### PR TITLE
Diagnose a supervisor startup timeout instead of always blaming contention

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -451,15 +451,22 @@ fn check_supervisor_startup_protocol() -> HealthCheck {
     // Enumerating and probing installs is boundary IO and belongs to
     // daemon_client. Probing costs a subprocess per install, so it is requested
     // only in the state whose answer can change the verdict.
-    let installed: Vec<InstalledKin> =
-        if matches!(sentinel, SupervisorStartupSentinel::ProtocolDirectory) {
-            crate::daemon_client::installed_kin_startup_protocols()
-                .into_iter()
-                .map(|(path, protocol)| InstalledKin { path, protocol })
-                .collect()
-        } else {
-            Vec::new()
-        };
+    //
+    // Never under test. This runs inside the unit suite through
+    // `run_health_checks`, where spawning the host's installed kin-daemon would
+    // make a unit test depend on whatever is installed on the machine and add
+    // subprocesses to a thousand-test parallel run. The verdict logic is
+    // exercised directly against constructed inputs instead.
+    let probe_installs =
+        matches!(sentinel, SupervisorStartupSentinel::ProtocolDirectory) && !cfg!(test);
+    let installed: Vec<InstalledKin> = if probe_installs {
+        crate::daemon_client::installed_kin_startup_protocols()
+            .into_iter()
+            .map(|(path, protocol)| InstalledKin { path, protocol })
+            .collect()
+    } else {
+        Vec::new()
+    };
     supervisor_startup_protocol_check(sentinel, &sentinel_path, &installed)
 }
 

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -16,6 +16,7 @@ use crate::commands::auth::default_base_url_for_health;
 use crate::commands::setup::{
     check_binary_in_path, detect_shell, hook_filename, kin_dir, shell_rc, shim_filename,
 };
+use crate::daemon_client::{InstalledStartupProtocol, SupervisorStartupSentinel};
 
 /// Outcome of a single probed health check.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -143,6 +144,7 @@ pub async fn run_health_checks() -> HealthReport {
     let mut checks = vec![
         check_kin_binary(),
         check_kin_daemon_binary(),
+        check_supervisor_startup_protocol(),
         check_daemon_running().await,
         check_vfs_projection(),
         check_repo_init(),
@@ -348,6 +350,147 @@ fn check_kin_daemon_binary() -> HealthCheck {
         )
         .with_manual_fix("reinstall Kin so kin-daemon is installed alongside kin"),
     }
+}
+
+/// One installed kin other than the running binary, with its probed verdict on
+/// the supervisor startup protocol.
+#[derive(Debug, Clone)]
+struct InstalledKin {
+    path: PathBuf,
+    protocol: InstalledStartupProtocol,
+}
+
+/// Installed kin binaries on this host that are not the running one.
+///
+/// Only install locations are considered, meaning what PATH resolves plus the
+/// Kin home's `bin`, so a build tree is never mistaken for an install.
+fn other_installed_kin_binaries() -> Vec<PathBuf> {
+    let running = env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok());
+    let mut candidates = Vec::new();
+    if let Some(path) = check_binary_in_path("kin") {
+        candidates.push(path);
+    }
+    if let Ok(home) = kin_dir() {
+        candidates.push(home.join("bin").join("kin"));
+    }
+
+    let mut found: Vec<PathBuf> = Vec::new();
+    for candidate in candidates {
+        let Ok(resolved) = candidate.canonicalize() else {
+            continue;
+        };
+        if running.as_ref() == Some(&resolved) || found.contains(&resolved) {
+            continue;
+        }
+        found.push(resolved);
+    }
+    found
+}
+
+/// Report an installed kin that cannot start a supervisor against the on-disk
+/// startup sentinel because it predates the current startup protocol.
+///
+/// This is the diagnosis a stuck operator never gets from the stuck binary
+/// itself: a pre-v2 kin meeting the v2 sentinel sleeps to its startup deadline
+/// and then blames lock contention. The running binary can see both halves, the
+/// sentinel on disk and the other install's own protocol answer, so it is the
+/// surface that can name binary age as the cause.
+///
+/// A pre-v2 install is `Stale`, not `Misconfigured`: it does not block the
+/// binary running this check, so it must not flip the report's readiness. A
+/// legacy marker file is `Misconfigured`, because the current binary refuses to
+/// start a supervisor at all while one exists.
+fn supervisor_startup_protocol_check(
+    sentinel: SupervisorStartupSentinel,
+    sentinel_path: &Path,
+    installed: &[InstalledKin],
+) -> HealthCheck {
+    let protocol = crate::daemon_client::supervisor_startup_protocol();
+    let update = format!("update kin: {}", crate::daemon_client::KIN_INSTALL_COMMAND);
+    let sentinel_path = sentinel_path.display();
+
+    match sentinel {
+        SupervisorStartupSentinel::LegacyMarker => HealthCheck::new(
+            "supervisor_startup_protocol",
+            "Supervisor protocol",
+            HealthStatus::Misconfigured,
+            format!(
+                "{sentinel_path} is a protocol-v1 marker file, which only a kin older than \
+                 startup protocol v{protocol} creates; this binary refuses to start a supervisor \
+                 against it"
+            ),
+        )
+        .with_manual_fix(update),
+        SupervisorStartupSentinel::Unreadable => HealthCheck::new(
+            "supervisor_startup_protocol",
+            "Supervisor protocol",
+            HealthStatus::Stale,
+            format!("{sentinel_path} exists but is neither a directory nor a regular file"),
+        )
+        .with_manual_fix(
+            "inspect the supervisor startup sentinel; it must be an ordinary directory",
+        ),
+        SupervisorStartupSentinel::Absent => HealthCheck::new(
+            "supervisor_startup_protocol",
+            "Supervisor protocol",
+            HealthStatus::Healthy,
+            format!("startup protocol v{protocol}; no sentinel written yet"),
+        ),
+        SupervisorStartupSentinel::ProtocolDirectory => {
+            let outdated: Vec<String> = installed
+                .iter()
+                .filter_map(|kin| match &kin.protocol {
+                    InstalledStartupProtocol::Predates(reason) => {
+                        Some(format!("{} ({reason})", kin.path.display()))
+                    }
+                    InstalledStartupProtocol::Current
+                    | InstalledStartupProtocol::Undetermined(_) => None,
+                })
+                .collect();
+            if outdated.is_empty() {
+                return HealthCheck::new(
+                    "supervisor_startup_protocol",
+                    "Supervisor protocol",
+                    HealthStatus::Healthy,
+                    format!("startup protocol v{protocol}; {sentinel_path} matches it"),
+                );
+            }
+            let detail = outdated.join(", ");
+            HealthCheck::new(
+                "supervisor_startup_protocol",
+                "Supervisor protocol",
+                HealthStatus::Stale,
+                format!(
+                    "your installed kin predates the current supervisor protocol: {detail}. \
+                     While {sentinel_path} exists, that binary cannot start a supervisor and \
+                     waits out its full startup deadline in silence before reporting a lock \
+                     timeout that names contention it is not hitting"
+                ),
+            )
+            .with_manual_fix(update)
+        }
+    }
+}
+
+fn check_supervisor_startup_protocol() -> HealthCheck {
+    let sentinel = crate::daemon_client::supervisor_startup_sentinel();
+    let sentinel_path = crate::daemon_client::supervisor_startup_sentinel_path();
+    // Probing costs a subprocess per install, so it runs only in the state whose
+    // answer can change the verdict.
+    let installed = if matches!(sentinel, SupervisorStartupSentinel::ProtocolDirectory) {
+        other_installed_kin_binaries()
+            .into_iter()
+            .map(|path| InstalledKin {
+                protocol: crate::daemon_client::probe_installed_startup_protocol(&path),
+                path,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    supervisor_startup_protocol_check(sentinel, &sentinel_path, &installed)
 }
 
 /// Probe whether the daemon is actually *running* (reachable) for the current
@@ -1850,6 +1993,120 @@ mod tests {
         )
         .unwrap();
         assert!(evaluate_codex_binding_for(&path, &expected).is_some());
+    }
+
+    fn installed_kin(path: &str, protocol: InstalledStartupProtocol) -> InstalledKin {
+        InstalledKin {
+            path: PathBuf::from(path),
+            protocol,
+        }
+    }
+
+    /// The doctor is the surface that can name binary age, because the stuck
+    /// binary blames lock contention instead. It must say so only when an
+    /// install actually answers that it predates the protocol.
+    #[test]
+    fn doctor_names_binary_age_when_an_install_predates_the_startup_protocol() {
+        let sentinel = PathBuf::from("/home/dev/.kin/supervisor.start.lock");
+        let outdated = installed_kin(
+            "/usr/local/bin/kin",
+            InstalledStartupProtocol::Predates(
+                "it reports compat schema kin.daemon.compat.v1 and no supervisor startup protocol \
+                 at all"
+                    .to_string(),
+            ),
+        );
+
+        let check = supervisor_startup_protocol_check(
+            SupervisorStartupSentinel::ProtocolDirectory,
+            &sentinel,
+            std::slice::from_ref(&outdated),
+        );
+        assert_eq!(check.id, "supervisor_startup_protocol");
+        assert!(matches!(check.status, HealthStatus::Stale), "{check:?}");
+        assert!(
+            check
+                .detail
+                .contains("your installed kin predates the current supervisor protocol")
+                && check.detail.contains("/usr/local/bin/kin")
+                && check.detail.contains("kin.daemon.compat.v1"),
+            "the diagnosis must name the binary and the evidence: {}",
+            check.detail
+        );
+        assert!(
+            check
+                .manual_fix
+                .as_deref()
+                .is_some_and(|fix| fix.contains(crate::daemon_client::KIN_INSTALL_COMMAND)),
+            "the remedy must be the exact install command: {:?}",
+            check.manual_fix
+        );
+        assert!(
+            !blocks_readiness(&check),
+            "another install's age does not stop this binary from working, so it must not flip \
+             the report's readiness"
+        );
+    }
+
+    #[test]
+    fn doctor_stays_quiet_when_no_install_answers_that_it_predates_the_protocol() {
+        let sentinel = PathBuf::from("/home/dev/.kin/supervisor.start.lock");
+        for installed in [
+            vec![],
+            vec![installed_kin(
+                "/usr/local/bin/kin",
+                InstalledStartupProtocol::Current,
+            )],
+            vec![installed_kin(
+                "/usr/local/bin/kin",
+                InstalledStartupProtocol::Undetermined("no kin-daemon beside it".to_string()),
+            )],
+        ] {
+            let check = supervisor_startup_protocol_check(
+                SupervisorStartupSentinel::ProtocolDirectory,
+                &sentinel,
+                &installed,
+            );
+            assert!(
+                matches!(check.status, HealthStatus::Healthy),
+                "an unanswered probe is not evidence of age: {check:?}"
+            );
+        }
+
+        let absent = supervisor_startup_protocol_check(
+            SupervisorStartupSentinel::Absent,
+            &sentinel,
+            &[installed_kin(
+                "/usr/local/bin/kin",
+                InstalledStartupProtocol::Predates("older".to_string()),
+            )],
+        );
+        assert!(
+            matches!(absent.status, HealthStatus::Healthy),
+            "with no sentinel written there is nothing for an older binary to stall on: {absent:?}"
+        );
+    }
+
+    /// A legacy marker file is different in kind: the running binary refuses to
+    /// start a supervisor at all against one, so it blocks readiness.
+    #[test]
+    fn doctor_treats_a_legacy_marker_as_blocking_and_names_the_update() {
+        let sentinel = PathBuf::from("/home/dev/.kin/supervisor.start.lock");
+        let check = supervisor_startup_protocol_check(
+            SupervisorStartupSentinel::LegacyMarker,
+            &sentinel,
+            &[],
+        );
+        assert!(
+            matches!(check.status, HealthStatus::Misconfigured),
+            "{check:?}"
+        );
+        assert!(blocks_readiness(&check));
+        assert!(check.detail.contains("protocol-v1 marker file"));
+        assert!(check
+            .manual_fix
+            .as_deref()
+            .is_some_and(|fix| fix.contains(crate::daemon_client::KIN_INSTALL_COMMAND)));
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -360,35 +360,6 @@ struct InstalledKin {
     protocol: InstalledStartupProtocol,
 }
 
-/// Installed kin binaries on this host that are not the running one.
-///
-/// Only install locations are considered, meaning what PATH resolves plus the
-/// Kin home's `bin`, so a build tree is never mistaken for an install.
-fn other_installed_kin_binaries() -> Vec<PathBuf> {
-    let running = env::current_exe()
-        .ok()
-        .and_then(|path| path.canonicalize().ok());
-    let mut candidates = Vec::new();
-    if let Some(path) = check_binary_in_path("kin") {
-        candidates.push(path);
-    }
-    if let Ok(home) = kin_dir() {
-        candidates.push(home.join("bin").join("kin"));
-    }
-
-    let mut found: Vec<PathBuf> = Vec::new();
-    for candidate in candidates {
-        let Ok(resolved) = candidate.canonicalize() else {
-            continue;
-        };
-        if running.as_ref() == Some(&resolved) || found.contains(&resolved) {
-            continue;
-        }
-        found.push(resolved);
-    }
-    found
-}
-
 /// Report an installed kin that cannot start a supervisor against the on-disk
 /// startup sentinel because it predates the current startup protocol.
 ///
@@ -477,19 +448,18 @@ fn supervisor_startup_protocol_check(
 fn check_supervisor_startup_protocol() -> HealthCheck {
     let sentinel = crate::daemon_client::supervisor_startup_sentinel();
     let sentinel_path = crate::daemon_client::supervisor_startup_sentinel_path();
-    // Probing costs a subprocess per install, so it runs only in the state whose
-    // answer can change the verdict.
-    let installed = if matches!(sentinel, SupervisorStartupSentinel::ProtocolDirectory) {
-        other_installed_kin_binaries()
-            .into_iter()
-            .map(|path| InstalledKin {
-                protocol: crate::daemon_client::probe_installed_startup_protocol(&path),
-                path,
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
+    // Enumerating and probing installs is boundary IO and belongs to
+    // daemon_client. Probing costs a subprocess per install, so it is requested
+    // only in the state whose answer can change the verdict.
+    let installed: Vec<InstalledKin> =
+        if matches!(sentinel, SupervisorStartupSentinel::ProtocolDirectory) {
+            crate::daemon_client::installed_kin_startup_protocols()
+                .into_iter()
+                .map(|(path, protocol)| InstalledKin { path, protocol })
+                .collect()
+        } else {
+            Vec::new()
+        };
     supervisor_startup_protocol_check(sentinel, &sentinel_path, &installed)
 }
 

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -369,10 +369,13 @@ struct InstalledKin {
 /// sentinel on disk and the other install's own protocol answer, so it is the
 /// surface that can name binary age as the cause.
 ///
-/// A pre-v2 install is `Stale`, not `Misconfigured`: it does not block the
-/// binary running this check, so it must not flip the report's readiness. A
-/// legacy marker file is `Misconfigured`, because the current binary refuses to
-/// start a supervisor at all while one exists.
+/// Severity follows one rule: a state blocks readiness exactly when it stops
+/// the binary running this check from starting a supervisor. A pre-v2 *other*
+/// install is `Stale`, because another install's age does not stop this one. The
+/// two sentinel shapes `ensure_supervisor_startup_namespace` refuses on are
+/// `Misconfigured`: a legacy marker file, and a symlink or reparse point the
+/// protocol will not follow. Metadata that simply cannot be read proves nothing
+/// either way and stays advisory.
 fn supervisor_startup_protocol_check(
     sentinel: SupervisorStartupSentinel,
     sentinel_path: &Path,
@@ -394,11 +397,25 @@ fn supervisor_startup_protocol_check(
             ),
         )
         .with_manual_fix(update),
+        SupervisorStartupSentinel::RefusedLink => HealthCheck::new(
+            "supervisor_startup_protocol",
+            "Supervisor protocol",
+            HealthStatus::Misconfigured,
+            format!(
+                "{sentinel_path} is a symlink rather than a directory; startup protocol \
+                 v{protocol} refuses to follow one, so this binary cannot start a supervisor at \
+                 all while it is there"
+            ),
+        )
+        .with_manual_fix(
+            "remove the link at the supervisor startup sentinel path; kin recreates it as an \
+             ordinary directory",
+        ),
         SupervisorStartupSentinel::Unreadable => HealthCheck::new(
             "supervisor_startup_protocol",
             "Supervisor protocol",
             HealthStatus::Stale,
-            format!("{sentinel_path} exists but is neither a directory nor a regular file"),
+            format!("{sentinel_path} exists but its metadata could not be read"),
         )
         .with_manual_fix(
             "inspect the supervisor startup sentinel; it must be an ordinary directory",
@@ -449,8 +466,11 @@ fn check_supervisor_startup_protocol() -> HealthCheck {
     let sentinel = crate::daemon_client::supervisor_startup_sentinel();
     let sentinel_path = crate::daemon_client::supervisor_startup_sentinel_path();
     // Enumerating and probing installs is boundary IO and belongs to
-    // daemon_client. Probing costs a subprocess per install, so it is requested
-    // only in the state whose answer can change the verdict.
+    // daemon_client. The probe is requested only in the state whose answer can
+    // change the verdict, but that state is the steady one for every current
+    // user, so this runs on essentially every invocation rather than rarely.
+    // What keeps it acceptable is its bound, not its frequency: at most two
+    // deduped candidates, each capped by the daemon probe timeout.
     //
     // Never under test. This runs inside the unit suite through
     // `run_health_checks`, where spawning the host's installed kin-daemon would
@@ -2084,6 +2104,64 @@ mod tests {
             .manual_fix
             .as_deref()
             .is_some_and(|fix| fix.contains(crate::daemon_client::KIN_INSTALL_COMMAND)));
+    }
+
+    /// A link at the sentinel path is a hard block in fact: startup refuses to
+    /// follow one, so a report that stayed healthy would print "first-run
+    /// ready" on a host where no supervisor can start. The two contrasts are
+    /// the point of the severity rule, so they are asserted beside it:
+    /// unreadable metadata proves nothing, and a pre-v2 sibling install does
+    /// not stop the binary running the check.
+    #[test]
+    fn doctor_blocks_on_a_refused_link_but_not_on_states_that_do_not_stop_this_binary() {
+        let sentinel = PathBuf::from("/home/dev/.kin/supervisor.start.lock");
+
+        let linked = supervisor_startup_protocol_check(
+            SupervisorStartupSentinel::RefusedLink,
+            &sentinel,
+            &[],
+        );
+        assert!(
+            matches!(linked.status, HealthStatus::Misconfigured),
+            "a sentinel startup refuses to follow blocks readiness in fact: {linked:?}"
+        );
+        assert!(
+            blocks_readiness(&linked),
+            "doctor must not report readiness on a host where no supervisor can start"
+        );
+        assert!(
+            linked.detail.contains("symlink")
+                && linked.detail.contains("cannot start a supervisor"),
+            "the detail must name the actual refusal, not just an odd file type: {}",
+            linked.detail
+        );
+        assert!(linked.manual_fix.is_some(), "{linked:?}");
+
+        let unreadable = supervisor_startup_protocol_check(
+            SupervisorStartupSentinel::Unreadable,
+            &sentinel,
+            &[],
+        );
+        assert!(
+            !blocks_readiness(&unreadable),
+            "metadata that cannot be read proves nothing either way: {unreadable:?}"
+        );
+
+        let sibling = supervisor_startup_protocol_check(
+            SupervisorStartupSentinel::ProtocolDirectory,
+            &sentinel,
+            &[installed_kin(
+                "/usr/local/bin/kin",
+                InstalledStartupProtocol::Predates(
+                    "no supervisor startup protocol at all".to_string(),
+                ),
+            )],
+        );
+        assert!(
+            !blocks_readiness(&sibling),
+            "another install's age does not stop this binary, so it must not share the blocking \
+             severity: {sibling:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -2838,6 +2838,34 @@ const SUPERVISOR_STARTUP_PROTOCOL: u32 = 2;
 const SUPERVISOR_STARTUP_CAPABILITY: &str = "generation-adoption-ack-v2";
 const SUPERVISOR_LEGACY_SENTINEL_CAPABILITY: &str = "legacy-directory-sentinel-v1";
 const SUPERVISOR_BOUNDED_ROLLBACK_CAPABILITY: &str = "bounded-legacy-rollback-v1";
+/// Plain-text notice a current launcher leaves inside the startup sentinel.
+///
+/// The sentinel path is the only channel a current binary has to the operator
+/// of a binary too old to speak this protocol: that binary's timeout message
+/// names the path, so listing it is the first thing anyone does after the wait.
+const SUPERVISOR_STARTUP_NOTICE_FILE: &str = "README-UPDATE-KIN.txt";
+/// Canonical one-line install used by every remedy this crate prints.
+pub const KIN_INSTALL_COMMAND: &str = "curl -fsSL https://get.kinlab.dev/install | sh";
+/// Byte-stable contents of [`SUPERVISOR_STARTUP_NOTICE_FILE`]. Stability is
+/// load-bearing: refresh compares before writing, so an unchanged notice never
+/// rewrites the file and never touches the sentinel directory's mtime.
+const SUPERVISOR_STARTUP_NOTICE: &str = "\
+This directory is the Kin supervisor startup sentinel for startup protocol v2.
+
+A kin binary older than protocol v2 cannot start a supervisor while it exists.
+Such a binary sleeps until its startup deadline (300 seconds by default,
+KIN_DAEMON_READY_TIMEOUT_SECS) and then reports a startup lock timeout that
+names lock contention. There is no contention. Nothing holds a lock here, and
+no amount of waiting or retrying can succeed, because that binary cannot speak
+the protocol this directory requires.
+
+Update kin, then run `kin doctor` to confirm:
+
+    curl -fsSL https://get.kinlab.dev/install | sh
+
+Deleting this directory does not help. A current kin recreates it on the next
+command, and an older kin still cannot start a supervisor.
+";
 /// Internal handoff from the current CLI launcher to the supervisor child.
 ///
 /// This is scrubbed from every daemon command and set only on a supervisor
@@ -3898,6 +3926,25 @@ fn preserve_bounded_legacy_rollback(
     Ok(identity)
 }
 
+/// Leave the protocol-upgrade notice inside the startup sentinel.
+///
+/// Written only when the bytes differ, so a refresh is a no-op rather than a
+/// rewrite, and always before the sentinel is stamped, so the first write's
+/// effect on the directory mtime is overwritten by the compatibility stamp.
+fn refresh_supervisor_startup_notice(sentinel: &Path) -> std::io::Result<()> {
+    let path = sentinel.join(SUPERVISOR_STARTUP_NOTICE_FILE);
+    let mut file = open_startup_regular_file(&path, true, false, true)?;
+    let mut existing = String::new();
+    file.read_to_string(&mut existing)?;
+    if existing == SUPERVISOR_STARTUP_NOTICE {
+        return Ok(());
+    }
+    file.rewind()?;
+    file.set_len(0)?;
+    file.write_all(SUPERVISOR_STARTUP_NOTICE.as_bytes())?;
+    file.flush()
+}
+
 fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<SupervisorStartupNamespace> {
     std::fs::create_dir_all(dir)?;
     let sentinel = dir.join(SUPERVISOR_STARTUP_FILE);
@@ -3946,6 +3993,16 @@ fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<Supervisor
         false,
         true,
     )?);
+    // The notice is an operator aid, not a protocol element. A filesystem that
+    // refuses it must not take startup down with it, so the failure is reported
+    // and startup continues rather than being swallowed or fatal.
+    if let Err(error) = refresh_supervisor_startup_notice(&sentinel) {
+        warn!(
+            sentinel = %sentinel.display(),
+            %error,
+            "could not leave the supervisor startup protocol notice; startup continues without it"
+        );
+    }
     let records = sentinel.join(SUPERVISOR_STARTUP_RECORDS_DIR);
     loop {
         match std::fs::symlink_metadata(&records) {
@@ -4206,8 +4263,12 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
                 }
                 if Instant::now() >= deadline {
                     bail!(
-                        "timed out waiting for daemon startup lock at {}",
-                        path.display()
+                        "timed out waiting for daemon startup lock at {} after {}s: another kin \
+                         command in this repository still holds it. Wait for it to finish, or \
+                         raise KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS (it defaults from \
+                         KIN_DAEMON_READY_TIMEOUT_SECS) to wait longer.",
+                        path.display(),
+                        timeout.as_secs()
                     );
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;
@@ -4286,6 +4347,113 @@ enum SupervisorStartupAcquisition {
     Connected(String),
 }
 
+/// Why a supervisor startup-lock wait reached its deadline.
+///
+/// The old message named lock contention unconditionally, which is the one
+/// explanation that is false in the case that actually reaches users: an
+/// installed binary predating startup protocol v2 sleeps out this same deadline
+/// against a sentinel nothing is holding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupervisorStartupTimeoutCause {
+    /// A live launcher holds the kernel authority lock. The kernel releases an
+    /// `flock` when its holder dies, so a contended lock is proof of a live
+    /// holder: this is the only cause that is genuine contention.
+    Contention,
+    /// Nothing holds the lock, no supervisor is running, and the sentinel is
+    /// the protocol-v2 directory carrying its deliberate far-future stamp. That
+    /// is exactly the state a pre-v2 launcher waits out in silence.
+    LegacyProtocolExclusion,
+    /// Neither of the above: startup is slower than this caller's patience.
+    SlowStartup,
+}
+
+/// Probed state behind a startup-lock timeout, kept separate from the
+/// classification so the three-way distinction is testable without racing a
+/// live filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SupervisorStartupTimeoutState {
+    authority_held: bool,
+    sentinel_is_protocol_directory: bool,
+    sentinel_stamp_is_future: bool,
+    supervisor_may_be_alive: bool,
+}
+
+fn classify_supervisor_startup_timeout(
+    state: SupervisorStartupTimeoutState,
+) -> SupervisorStartupTimeoutCause {
+    if state.authority_held {
+        return SupervisorStartupTimeoutCause::Contention;
+    }
+    // A future stamp exists only where a current launcher set and read one back,
+    // so it also stands in for a well-formed v2 namespace: without it this falls
+    // through to the plain slow-startup wording rather than guessing.
+    if state.sentinel_is_protocol_directory
+        && state.sentinel_stamp_is_future
+        && !state.supervisor_may_be_alive
+    {
+        return SupervisorStartupTimeoutCause::LegacyProtocolExclusion;
+    }
+    SupervisorStartupTimeoutCause::SlowStartup
+}
+
+fn probe_supervisor_startup_timeout_state(dir: &Path) -> SupervisorStartupTimeoutState {
+    let sentinel = dir.join(SUPERVISOR_STARTUP_FILE);
+    let sentinel_is_protocol_directory = std::fs::symlink_metadata(&sentinel)
+        .map(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+        .unwrap_or(false);
+    let sentinel_stamp_is_future = std::fs::symlink_metadata(&sentinel)
+        .and_then(|metadata| metadata.modified())
+        .map(|modified| modified.elapsed().is_err())
+        .unwrap_or(false);
+    let recorded = supervisor_endpoint_snapshot(dir);
+    SupervisorStartupTimeoutState {
+        authority_held: supervisor_startup_authority_is_held(&sentinel).unwrap_or(false),
+        sentinel_is_protocol_directory,
+        sentinel_stamp_is_future,
+        supervisor_may_be_alive: recorded
+            .pid
+            .map(|pid| process_liveness(pid).may_be_alive())
+            .unwrap_or(recorded.pid_exists),
+    }
+}
+
+/// Render a startup-lock timeout so the caller is pointed at the real cause.
+///
+/// Every branch names `KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS` and the
+/// `KIN_DAEMON_READY_TIMEOUT_SECS` it defaults from, because a timeout whose
+/// bound is unnamed cannot be raised by the person hitting it.
+fn supervisor_startup_timeout_message(
+    path: &Path,
+    waited_secs: u64,
+    cause: SupervisorStartupTimeoutCause,
+) -> String {
+    let path = path.display();
+    let knob = "raise KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS (it defaults from \
+                KIN_DAEMON_READY_TIMEOUT_SECS) to wait longer";
+    match cause {
+        SupervisorStartupTimeoutCause::Contention => format!(
+            "timed out waiting for supervisor startup lock at {path} after {waited_secs}s: \
+             another kin launcher holds supervisor startup authority and is still alive, so this \
+             is real contention. Wait for it to finish, or stop it with `kin daemon stop`; {knob}."
+        ),
+        SupervisorStartupTimeoutCause::LegacyProtocolExclusion => format!(
+            "timed out waiting for supervisor startup lock at {path} after {waited_secs}s, but \
+             nothing holds that lock and no supervisor is running, so this is not contention. \
+             {path} is the startup protocol v{SUPERVISOR_STARTUP_PROTOCOL} sentinel: a directory \
+             carrying a deliberate far-future timestamp. A kin binary older than protocol \
+             v{SUPERVISOR_STARTUP_PROTOCOL} cannot start a supervisor while it exists and waits \
+             out this same deadline in silence instead of failing. If an older kin is installed \
+             on this host, update it with `{KIN_INSTALL_COMMAND}` and run `kin doctor`; {knob} if \
+             startup is merely slow."
+        ),
+        SupervisorStartupTimeoutCause::SlowStartup => format!(
+            "timed out waiting for supervisor startup lock at {path} after {waited_secs}s: \
+             supervisor startup did not complete inside this deadline. Run `kin doctor` and check \
+             the supervisor log; {knob}."
+        ),
+    }
+}
+
 async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupAcquisition> {
     let dir = supervisor_dir();
     acquire_supervisor_startup_lock_in_dir_with_timeout(
@@ -4293,6 +4461,124 @@ async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupAcquisitio
         Duration::from_secs(startup_lock_timeout_secs()),
     )
     .await
+}
+
+/// Startup protocol this binary speaks, for diagnostics that report it.
+pub fn supervisor_startup_protocol() -> u32 {
+    SUPERVISOR_STARTUP_PROTOCOL
+}
+
+/// Path of the per-user supervisor startup sentinel.
+pub fn supervisor_startup_sentinel_path() -> PathBuf {
+    supervisor_dir().join(SUPERVISOR_STARTUP_FILE)
+}
+
+/// What the shared startup sentinel looks like to a diagnostic caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupervisorStartupSentinel {
+    /// Nothing on disk: no launcher has run against this Kin home yet.
+    Absent,
+    /// The current protocol's permanent directory. A binary older than the
+    /// current protocol cannot start a supervisor while it exists.
+    ProtocolDirectory,
+    /// A protocol-v1 marker file, which only a pre-v2 launcher creates. Its
+    /// presence is proof that a binary too old for this protocol ran here.
+    LegacyMarker,
+    /// Present but unclassifiable (a symlink, or unreadable metadata).
+    Unreadable,
+}
+
+/// Classify the shared startup sentinel without taking any authority.
+pub fn supervisor_startup_sentinel() -> SupervisorStartupSentinel {
+    match std::fs::symlink_metadata(supervisor_startup_sentinel_path()) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            SupervisorStartupSentinel::Absent
+        }
+        Err(_) => SupervisorStartupSentinel::Unreadable,
+        Ok(metadata) if metadata.file_type().is_symlink() => SupervisorStartupSentinel::Unreadable,
+        Ok(metadata) if metadata.is_dir() => SupervisorStartupSentinel::ProtocolDirectory,
+        Ok(_) => SupervisorStartupSentinel::LegacyMarker,
+    }
+}
+
+/// Verdict on whether some other installed kin speaks the current startup
+/// protocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstalledStartupProtocol {
+    /// The install acknowledges the current supervisor startup protocol.
+    Current,
+    /// The install answers, and its answer proves it predates the current
+    /// protocol. The string is the exact mismatch, for the operator.
+    Predates(String),
+    /// No answer could be obtained, so nothing is claimed either way.
+    Undetermined(String),
+}
+
+/// Ask an installed kin whether it speaks the current supervisor startup
+/// protocol, by probing the `kin-daemon` shipped beside it.
+///
+/// The CLI has no protocol probe of its own; the daemon's `--compat-json` does,
+/// and an install ships and version-locks the two together, so the daemon's
+/// answer is the available proof. A pre-v2 install answers with the v1 compat
+/// schema and no supervisor protocol field at all, which is a positive
+/// discriminator rather than an absence of evidence.
+pub fn probe_installed_startup_protocol(kin_binary: &Path) -> InstalledStartupProtocol {
+    let daemon = kin_binary.with_file_name(if cfg!(windows) {
+        "kin-daemon.exe"
+    } else {
+        "kin-daemon"
+    });
+    if !daemon.is_file() {
+        return InstalledStartupProtocol::Undetermined(format!(
+            "no kin-daemon beside {}",
+            kin_binary.display()
+        ));
+    }
+    let mut command = Command::new(&daemon);
+    command.arg("--compat-json");
+    let label = format!("{} --compat-json", daemon.display());
+    let output =
+        match probe_process::output_with_timeout(command, &label, DAEMON_BINARY_PROBE_TIMEOUT) {
+            Ok(output) if output.status.success() => output,
+            Ok(output) => {
+                // A binary predating the flag itself exits non-zero on it. That
+                // is consistent with age but is not the protocol's own answer,
+                // so it is reported as undetermined rather than asserted.
+                return InstalledStartupProtocol::Undetermined(format!(
+                    "compat probe exited with {} ({})",
+                    output.status,
+                    compact_probe_output(&output)
+                ));
+            }
+            Err(error) => {
+                return InstalledStartupProtocol::Undetermined(format!(
+                    "compat probe failed to execute: {error}"
+                ))
+            }
+        };
+    let compat: DaemonCompatResponse = match serde_json::from_slice(&output.stdout) {
+        Ok(compat) => compat,
+        Err(error) => {
+            return InstalledStartupProtocol::Undetermined(format!(
+                "compat probe returned invalid JSON: {error}"
+            ))
+        }
+    };
+    match compat.supervisor_startup_protocol {
+        Some(SUPERVISOR_STARTUP_PROTOCOL) => InstalledStartupProtocol::Current,
+        Some(protocol) => InstalledStartupProtocol::Predates(format!(
+            "it reports supervisor startup protocol v{protocol}, not \
+             v{SUPERVISOR_STARTUP_PROTOCOL}"
+        )),
+        None => InstalledStartupProtocol::Predates(format!(
+            "it reports compat schema {} and no supervisor startup protocol at all",
+            if compat.schema.is_empty() {
+                "<none>"
+            } else {
+                &compat.schema
+            }
+        )),
+    }
 }
 
 async fn acquire_supervisor_startup_lock_in_dir_with_timeout(
@@ -4323,10 +4609,13 @@ async fn acquire_supervisor_startup_lock_in_dir_with_timeout(
                     }
                 }
                 if Instant::now() >= deadline {
-                    bail!(
-                        "timed out waiting for supervisor startup lock at {}",
-                        path.display()
-                    );
+                    bail!(supervisor_startup_timeout_message(
+                        &path,
+                        timeout.as_secs(),
+                        classify_supervisor_startup_timeout(
+                            probe_supervisor_startup_timeout_state(dir)
+                        ),
+                    ));
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
@@ -4727,7 +5016,8 @@ async fn wait_for_daemon_ready(
          wait for it, or stop it with `kin daemon stop`"
     };
     Err(DaemonReadinessError::Timeout(format!(
-        "waited {:.1}s: {}; {}; recent log:\n{}",
+        "waited {:.1}s: {}; {}; raise KIN_DAEMON_READY_TIMEOUT_SECS if this repository needs \
+         longer to load; recent log:\n{}",
         timeout.as_secs_f64(),
         last_error,
         fate,
@@ -5179,7 +5469,8 @@ async fn follow_existing_supervisor_publication(
             ExistingSupervisor::Starting(detail) => {
                 return ExistingSupervisor::LiveNotReady(format!(
                     "kin supervisor startup is serialized but endpoint publication did not \
-                     complete within {}s: {detail}. Kin will not start a second supervisor",
+                     complete within {}s: {detail}. Kin will not start a second supervisor; raise \
+                     KIN_DAEMON_READY_TIMEOUT_SECS to wait longer",
                     timeout.as_secs()
                 ));
             }
@@ -5251,7 +5542,9 @@ async fn wait_for_supervisor_ready(
     let _ = child.kill();
     let _ = child.wait();
     bail!(
-        "supervisor failed to become ready within {:.1}s: {}",
+        "supervisor failed to become ready within {:.1}s: {}. Raise \
+         KIN_DAEMON_READY_TIMEOUT_SECS if this host needs longer, and check the supervisor log \
+         under the Kin registry directory.",
         timeout.as_secs_f64(),
         last_error
     )
@@ -7039,6 +7332,201 @@ mod tests {
             namespace.is_dir(),
             "no Drop edge removes the old-client-blocking directory sentinel"
         );
+    }
+
+    /// The startup-lock deadline has three distinct causes, and the old message
+    /// named the one that is false in the case that reaches users. Each state
+    /// below must reach its own cause, so a wrong diagnosis fails here.
+    #[test]
+    fn startup_timeout_diagnosis_separates_contention_from_legacy_exclusion() {
+        let contended = SupervisorStartupTimeoutState {
+            authority_held: true,
+            sentinel_is_protocol_directory: true,
+            sentinel_stamp_is_future: true,
+            supervisor_may_be_alive: false,
+        };
+        assert_eq!(
+            classify_supervisor_startup_timeout(contended),
+            SupervisorStartupTimeoutCause::Contention,
+            "a held authority lock proves a live holder, because the kernel drops an flock when \
+             its holder dies"
+        );
+
+        let excluded = SupervisorStartupTimeoutState {
+            authority_held: false,
+            ..contended
+        };
+        assert_eq!(
+            classify_supervisor_startup_timeout(excluded),
+            SupervisorStartupTimeoutCause::LegacyProtocolExclusion
+        );
+
+        assert_eq!(
+            classify_supervisor_startup_timeout(SupervisorStartupTimeoutState {
+                supervisor_may_be_alive: true,
+                ..excluded
+            }),
+            SupervisorStartupTimeoutCause::SlowStartup,
+            "a running supervisor means the wait was about startup, not about protocol age"
+        );
+        assert_eq!(
+            classify_supervisor_startup_timeout(SupervisorStartupTimeoutState {
+                sentinel_stamp_is_future: false,
+                ..excluded
+            }),
+            SupervisorStartupTimeoutCause::SlowStartup,
+            "without the compatibility stamp there is no evidence of the excluding state"
+        );
+        assert_eq!(
+            classify_supervisor_startup_timeout(SupervisorStartupTimeoutState {
+                sentinel_is_protocol_directory: false,
+                ..excluded
+            }),
+            SupervisorStartupTimeoutCause::SlowStartup
+        );
+    }
+
+    /// A timeout whose bound is unnamed cannot be raised by whoever hits it, and
+    /// only one of these paths used to name it.
+    #[test]
+    fn every_startup_timeout_message_names_its_knob_and_its_own_cause() {
+        let path = Path::new("/home/dev/.kin/supervisor.start.lock");
+        let contention = supervisor_startup_timeout_message(
+            path,
+            300,
+            SupervisorStartupTimeoutCause::Contention,
+        );
+        let exclusion = supervisor_startup_timeout_message(
+            path,
+            300,
+            SupervisorStartupTimeoutCause::LegacyProtocolExclusion,
+        );
+        let slow = supervisor_startup_timeout_message(
+            path,
+            300,
+            SupervisorStartupTimeoutCause::SlowStartup,
+        );
+
+        for message in [&contention, &exclusion, &slow] {
+            assert!(
+                message.contains("KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS")
+                    && message.contains("KIN_DAEMON_READY_TIMEOUT_SECS"),
+                "every timeout must name the knob that bounds it: {message}"
+            );
+            assert!(
+                message.contains("timed out waiting for supervisor startup lock")
+                    && message.contains("300s"),
+                "every timeout must stay identifiable and say how long it waited: {message}"
+            );
+        }
+
+        assert!(contention.contains("real contention"));
+        assert!(
+            !contention.contains(KIN_INSTALL_COMMAND),
+            "real contention must not be blamed on binary age: {contention}"
+        );
+        assert!(
+            exclusion.contains("not contention")
+                && exclusion.contains("older than protocol v2")
+                && exclusion.contains(KIN_INSTALL_COMMAND),
+            "the excluding state must name binary age and the update remedy: {exclusion}"
+        );
+        assert!(
+            !slow.contains("contention") && !slow.contains(KIN_INSTALL_COMMAND),
+            "plain slowness must not be diagnosed as either of the other two: {slow}"
+        );
+    }
+
+    /// The sentinel path is the only channel a current binary has to the
+    /// operator of a binary too old to speak this protocol, and the far-future
+    /// stamp that keeps such a binary bounded must survive using it.
+    #[test]
+    fn startup_notice_reaches_the_sentinel_without_aging_its_compatibility_stamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let notice = launcher.path().join(SUPERVISOR_STARTUP_NOTICE_FILE);
+
+        assert_eq!(
+            std::fs::read_to_string(&notice).unwrap(),
+            SUPERVISOR_STARTUP_NOTICE
+        );
+        assert!(
+            SUPERVISOR_STARTUP_NOTICE.contains(KIN_INSTALL_COMMAND)
+                && SUPERVISOR_STARTUP_NOTICE.contains("KIN_DAEMON_READY_TIMEOUT_SECS"),
+            "the notice must carry the remedy an older binary's operator needs"
+        );
+        assert!(
+            !startup_lock_is_stale(launcher.path(), Duration::ZERO),
+            "writing the notice must not age the stamp that keeps a legacy launcher bounded"
+        );
+
+        let written_at = std::fs::metadata(&notice).unwrap().modified().unwrap();
+        drop(launcher);
+        let refreshed = take_supervisor_startup_authority_after_release(dir.path());
+        assert_eq!(
+            std::fs::metadata(&notice).unwrap().modified().unwrap(),
+            written_at,
+            "an unchanged notice must not be rewritten on every launch"
+        );
+        assert!(!startup_lock_is_stale(refreshed.path(), Duration::ZERO));
+
+        std::fs::write(&notice, "clobbered by something else\n").unwrap();
+        drop(refreshed);
+        let repaired = take_supervisor_startup_authority_after_release(dir.path());
+        assert_eq!(
+            std::fs::read_to_string(&notice).unwrap(),
+            SUPERVISOR_STARTUP_NOTICE,
+            "a damaged notice must be restored rather than left wrong"
+        );
+        assert!(!startup_lock_is_stale(repaired.path(), Duration::ZERO));
+    }
+
+    /// The doctor's sentinel classification decides which diagnosis it prints,
+    /// so a directory must never read as a legacy marker or the reverse.
+    #[test]
+    #[serial_test::serial]
+    fn sentinel_classification_separates_the_protocol_directory_from_a_legacy_marker() {
+        struct RegistryPathGuard(Option<std::ffi::OsString>);
+        impl Drop for RegistryPathGuard {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
+                    None => std::env::remove_var("KIN_REGISTRY_PATH"),
+                }
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("kin-home");
+        std::fs::create_dir_all(&home).unwrap();
+        let _guard = RegistryPathGuard(std::env::var_os("KIN_REGISTRY_PATH"));
+        std::env::set_var("KIN_REGISTRY_PATH", home.join("registry.toml"));
+
+        let sentinel = supervisor_startup_sentinel_path();
+        assert_eq!(
+            sentinel,
+            home.join(SUPERVISOR_STARTUP_FILE),
+            "the classifier must read the same sentinel the launcher writes"
+        );
+        assert_eq!(
+            supervisor_startup_sentinel(),
+            SupervisorStartupSentinel::Absent
+        );
+
+        std::fs::write(&sentinel, "legacy v1 marker").unwrap();
+        assert_eq!(
+            supervisor_startup_sentinel(),
+            SupervisorStartupSentinel::LegacyMarker,
+            "only a launcher older than this protocol writes a regular file here"
+        );
+
+        std::fs::remove_file(&sentinel).unwrap();
+        drop(try_acquire_supervisor_startup_lock_in_dir(&home).unwrap());
+        assert_eq!(
+            supervisor_startup_sentinel(),
+            SupervisorStartupSentinel::ProtocolDirectory
+        );
+        assert_eq!(supervisor_startup_protocol(), SUPERVISOR_STARTUP_PROTOCOL);
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4490,7 +4490,18 @@ pub enum SupervisorStartupSentinel {
 
 /// Classify the shared startup sentinel without taking any authority.
 pub fn supervisor_startup_sentinel() -> SupervisorStartupSentinel {
-    match std::fs::symlink_metadata(supervisor_startup_sentinel_path()) {
+    supervisor_startup_sentinel_in_dir(&supervisor_dir())
+}
+
+/// Classify the startup sentinel under an explicit supervisor directory.
+///
+/// Split out so a test can point at a temporary directory by argument. Reaching
+/// the same behavior by setting the registry-path variable would mutate
+/// process-global state that every other test in the binary shares, which under
+/// `cargo test` (threads in one process, unlike nextest's process per test) is
+/// visible to unrelated tests resolving the Kin home.
+fn supervisor_startup_sentinel_in_dir(dir: &Path) -> SupervisorStartupSentinel {
+    match std::fs::symlink_metadata(dir.join(SUPERVISOR_STARTUP_FILE)) {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             SupervisorStartupSentinel::Absent
         }
@@ -7531,47 +7542,43 @@ mod tests {
 
     /// The doctor's sentinel classification decides which diagnosis it prints,
     /// so a directory must never read as a legacy marker or the reverse.
+    /// Takes its directory by argument on purpose. An earlier version set
+    /// `KIN_REGISTRY_PATH` instead, and because environment variables are
+    /// process-global while `cargo test` runs the binary's tests as threads in
+    /// one process, unrelated tests resolving the Kin home saw the temporary
+    /// path and failed. `#[serial]` does not help: it orders a test only against
+    /// other serial tests, not against the rest of the suite running in
+    /// parallel. Under nextest, which gives each test its own process, the same
+    /// bug is invisible.
     #[test]
-    #[serial_test::serial]
     fn sentinel_classification_separates_the_protocol_directory_from_a_legacy_marker() {
-        struct RegistryPathGuard(Option<std::ffi::OsString>);
-        impl Drop for RegistryPathGuard {
-            fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
-                    None => std::env::remove_var("KIN_REGISTRY_PATH"),
-                }
-            }
-        }
-
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path().join("kin-home");
         std::fs::create_dir_all(&home).unwrap();
-        let _guard = RegistryPathGuard(std::env::var_os("KIN_REGISTRY_PATH"));
-        std::env::set_var("KIN_REGISTRY_PATH", home.join("registry.toml"));
+        let sentinel = home.join(SUPERVISOR_STARTUP_FILE);
 
-        let sentinel = supervisor_startup_sentinel_path();
         assert_eq!(
-            sentinel,
-            home.join(SUPERVISOR_STARTUP_FILE),
-            "the classifier must read the same sentinel the launcher writes"
-        );
-        assert_eq!(
-            supervisor_startup_sentinel(),
+            supervisor_startup_sentinel_in_dir(&home),
             SupervisorStartupSentinel::Absent
         );
 
         std::fs::write(&sentinel, "legacy v1 marker").unwrap();
         assert_eq!(
-            supervisor_startup_sentinel(),
+            supervisor_startup_sentinel_in_dir(&home),
             SupervisorStartupSentinel::LegacyMarker,
             "only a launcher older than this protocol writes a regular file here"
         );
 
         std::fs::remove_file(&sentinel).unwrap();
-        drop(try_acquire_supervisor_startup_lock_in_dir(&home).unwrap());
+        let launcher = try_acquire_supervisor_startup_lock_in_dir(&home).unwrap();
         assert_eq!(
-            supervisor_startup_sentinel(),
+            launcher.path(),
+            sentinel,
+            "the classifier must read the same sentinel the launcher writes"
+        );
+        drop(launcher);
+        assert_eq!(
+            supervisor_startup_sentinel_in_dir(&home),
             SupervisorStartupSentinel::ProtocolDirectory
         );
         assert_eq!(supervisor_startup_protocol(), SUPERVISOR_STARTUP_PROTOCOL);

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4514,6 +4514,54 @@ pub enum InstalledStartupProtocol {
     Undetermined(String),
 }
 
+/// Installed kin binaries on this host that are not the running one.
+///
+/// Only install locations are considered, meaning what PATH resolves plus the
+/// Kin home's `bin`, so a build tree is never mistaken for an install. Paths are
+/// canonicalized so one binary reachable by two names is probed once and the
+/// running binary is excluded even when it was invoked through a symlink.
+fn other_installed_kin_binaries() -> Vec<PathBuf> {
+    let running = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok());
+    let mut candidates = Vec::new();
+    if let Some(path) = crate::commands::setup::check_binary_in_path("kin") {
+        candidates.push(path);
+    }
+    if let Ok(home) = crate::commands::setup::kin_dir() {
+        candidates.push(home.join("bin").join("kin"));
+    }
+
+    let mut found: Vec<PathBuf> = Vec::new();
+    for candidate in candidates {
+        let Ok(resolved) = candidate.canonicalize() else {
+            continue;
+        };
+        if running.as_ref() == Some(&resolved) || found.contains(&resolved) {
+            continue;
+        }
+        found.push(resolved);
+    }
+    found
+}
+
+/// Every installed kin other than the running one, with its probed verdict on
+/// the supervisor startup protocol.
+///
+/// Enumeration and probing both live here rather than in the health reporter,
+/// because this module is the declared process and install boundary: resolving
+/// installed binaries is boundary IO, and a diagnostic surface should consume
+/// the verdict rather than reach for the filesystem to compute it.
+pub fn installed_kin_startup_protocols() -> Vec<(PathBuf, InstalledStartupProtocol)> {
+    other_installed_kin_binaries()
+        .into_iter()
+        .map(|path| {
+            let protocol = probe_installed_startup_protocol(&path);
+            (path, protocol)
+        })
+        .collect()
+}
+
 /// Ask an installed kin whether it speaks the current supervisor startup
 /// protocol, by probing the `kin-daemon` shipped beside it.
 ///

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -6,6 +6,12 @@
 //! Used by CLI commands to query the daemon's live graph instead of
 //! opening a snapshot directly. Also owns the repo-scoped daemon
 //! auto-start logic so the CLI does not need to depend on `kin-daemon`.
+//!
+//! This module is the process and install boundary for the CLI, so locating
+//! installed kin binaries and probing them is boundary IO that belongs here:
+//! it resolves what to execute and executes it, and never answers a question
+//! about repository content. Diagnostic surfaces consume the verdict rather
+//! than reaching for the filesystem to compute one.
 
 use anyhow::{anyhow, bail, Context, Result};
 use fs2::FileExt;
@@ -3929,8 +3935,13 @@ fn preserve_bounded_legacy_rollback(
 /// Leave the protocol-upgrade notice inside the startup sentinel.
 ///
 /// Written only when the bytes differ, so a refresh is a no-op rather than a
-/// rewrite, and always before the sentinel is stamped, so the first write's
-/// effect on the directory mtime is overwritten by the compatibility stamp.
+/// rewrite, and before the sentinel is stamped, so namespace setup never hands
+/// back an aged compatibility stamp.
+///
+/// That ordering is hygiene, not the mechanism. What actually keeps the stamp
+/// safe is that every acquisition re-stamps the sentinel and fails closed
+/// unless the timestamp reads back in the future, so any dir-mtime bump taken
+/// while the namespace is built is repaired before a caller holds the lock.
 fn refresh_supervisor_startup_notice(sentinel: &Path) -> std::io::Result<()> {
     let path = sentinel.join(SUPERVISOR_STARTUP_NOTICE_FILE);
     let mut file = open_startup_regular_file(&path, true, false, true)?;
@@ -4349,10 +4360,10 @@ enum SupervisorStartupAcquisition {
 
 /// Why a supervisor startup-lock wait reached its deadline.
 ///
-/// The old message named lock contention unconditionally, which is the one
-/// explanation that is false in the case that actually reaches users: an
-/// installed binary predating startup protocol v2 sleeps out this same deadline
-/// against a sentinel nothing is holding.
+/// The old message named lock contention unconditionally. Contention is only one
+/// of the states this deadline is reachable from, and asserting it sends the
+/// caller looking for a competing launcher that may no longer exist, or never
+/// did. Each cause below is named only from evidence that distinguishes it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SupervisorStartupTimeoutCause {
     /// A live launcher holds the kernel authority lock. The kernel releases an
@@ -4372,7 +4383,11 @@ enum SupervisorStartupTimeoutCause {
 /// live filesystem.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SupervisorStartupTimeoutState {
-    authority_held: bool,
+    /// `None` where the probe could not decide. A filesystem whose `flock` is
+    /// unsupported or emulated answers that way on every attempt, and reading
+    /// it as "not held" would convert "contention cannot be observed here" into
+    /// "there is no contention".
+    authority_held: Option<bool>,
     sentinel_is_protocol_directory: bool,
     sentinel_stamp_is_future: bool,
     supervisor_may_be_alive: bool,
@@ -4381,8 +4396,13 @@ struct SupervisorStartupTimeoutState {
 fn classify_supervisor_startup_timeout(
     state: SupervisorStartupTimeoutState,
 ) -> SupervisorStartupTimeoutCause {
-    if state.authority_held {
-        return SupervisorStartupTimeoutCause::Contention;
+    match state.authority_held {
+        Some(true) => return SupervisorStartupTimeoutCause::Contention,
+        // An undecidable probe is not evidence of absence, so it falls through
+        // to the classifier's safe default rather than to a diagnosis that
+        // tells the caller their binary is the problem.
+        None => return SupervisorStartupTimeoutCause::SlowStartup,
+        Some(false) => {}
     }
     // A future stamp exists only where a current launcher set and read one back,
     // so it also stands in for a well-formed v2 namespace: without it this falls
@@ -4407,7 +4427,7 @@ fn probe_supervisor_startup_timeout_state(dir: &Path) -> SupervisorStartupTimeou
         .unwrap_or(false);
     let recorded = supervisor_endpoint_snapshot(dir);
     SupervisorStartupTimeoutState {
-        authority_held: supervisor_startup_authority_is_held(&sentinel).unwrap_or(false),
+        authority_held: supervisor_startup_authority_is_held(&sentinel).ok(),
         sentinel_is_protocol_directory,
         sentinel_stamp_is_future,
         supervisor_may_be_alive: recorded
@@ -4484,7 +4504,12 @@ pub enum SupervisorStartupSentinel {
     /// A protocol-v1 marker file, which only a pre-v2 launcher creates. Its
     /// presence is proof that a binary too old for this protocol ran here.
     LegacyMarker,
-    /// Present but unclassifiable (a symlink, or unreadable metadata).
+    /// A symlink, or on Windows a reparse point, where the sentinel belongs.
+    /// The startup protocol refuses to follow one, so no supervisor can start
+    /// against this Kin home until it is replaced by an ordinary directory.
+    RefusedLink,
+    /// Present, but its metadata could not be read, so nothing is claimed
+    /// either way about whether a supervisor could start here.
     Unreadable,
 }
 
@@ -4506,7 +4531,15 @@ fn supervisor_startup_sentinel_in_dir(dir: &Path) -> SupervisorStartupSentinel {
             SupervisorStartupSentinel::Absent
         }
         Err(_) => SupervisorStartupSentinel::Unreadable,
-        Ok(metadata) if metadata.file_type().is_symlink() => SupervisorStartupSentinel::Unreadable,
+        // Deliberately the same predicate `ensure_supervisor_startup_namespace`
+        // refuses on, so a state that hard-blocks supervisor startup can never
+        // be reported as one startup would accept.
+        Ok(metadata)
+            if metadata.file_type().is_symlink()
+                || startup_metadata_is_reparse_point(&metadata) =>
+        {
+            SupervisorStartupSentinel::RefusedLink
+        }
         Ok(metadata) if metadata.is_dir() => SupervisorStartupSentinel::ProtocolDirectory,
         Ok(_) => SupervisorStartupSentinel::LegacyMarker,
     }
@@ -4527,10 +4560,13 @@ pub enum InstalledStartupProtocol {
 
 /// Installed kin binaries on this host that are not the running one.
 ///
-/// Only install locations are considered, meaning what PATH resolves plus the
-/// Kin home's `bin`, so a build tree is never mistaken for an install. Paths are
-/// canonicalized so one binary reachable by two names is probed once and the
-/// running binary is excluded even when it was invoked through a symlink.
+/// Candidates are whatever `PATH` resolves for `kin`, plus the Kin home's
+/// `bin`. That is deliberately the set an operator actually invokes rather than
+/// a filtered notion of an install: `PATH` is what decides which binary runs, so
+/// a build tree reachable through it is probed like any other install and
+/// diagnosed on the same evidence. Paths are canonicalized so one binary
+/// reachable by two names is probed once, and so the running binary is excluded
+/// even when it was invoked through a symlink.
 fn other_installed_kin_binaries() -> Vec<PathBuf> {
     let running = std::env::current_exe()
         .ok()
@@ -7399,7 +7435,7 @@ mod tests {
     #[test]
     fn startup_timeout_diagnosis_separates_contention_from_legacy_exclusion() {
         let contended = SupervisorStartupTimeoutState {
-            authority_held: true,
+            authority_held: Some(true),
             sentinel_is_protocol_directory: true,
             sentinel_stamp_is_future: true,
             supervisor_may_be_alive: false,
@@ -7412,7 +7448,7 @@ mod tests {
         );
 
         let excluded = SupervisorStartupTimeoutState {
-            authority_held: false,
+            authority_held: Some(false),
             ..contended
         };
         assert_eq!(
@@ -7442,6 +7478,15 @@ mod tests {
                 ..excluded
             }),
             SupervisorStartupTimeoutCause::SlowStartup
+        );
+        assert_eq!(
+            classify_supervisor_startup_timeout(SupervisorStartupTimeoutState {
+                authority_held: None,
+                ..excluded
+            }),
+            SupervisorStartupTimeoutCause::SlowStartup,
+            "a filesystem that cannot report contention must not have its silence read as proof \
+             of absence and turned into a verdict on the caller's binary"
         );
     }
 
@@ -7499,10 +7544,41 @@ mod tests {
     /// The sentinel path is the only channel a current binary has to the
     /// operator of a binary too old to speak this protocol, and the far-future
     /// stamp that keeps such a binary bounded must survive using it.
+    ///
+    /// The guarded property is stamp survival, not write ordering.
+    /// `ensure_supervisor_startup_namespace` does write the notice before it
+    /// stamps, and the first block below pins that directly, but the ordering is
+    /// hygiene rather than the mechanism. Every acquisition stamps the sentinel
+    /// again and fails closed unless the timestamp reads back in the future, so
+    /// a dir-mtime bump taken while the namespace is built is repaired before
+    /// any caller holds the lock. The aged-sentinel block asserts that repair on
+    /// its own, which is the property that holds whatever order the writes
+    /// happen in.
     #[test]
     fn startup_notice_reaches_the_sentinel_without_aging_its_compatibility_stamp() {
+        // Observed at the seam rather than only after a full acquire, because
+        // the outer re-stamp would otherwise mask a notice write moved after
+        // the inner one.
+        let fresh = tempfile::tempdir().unwrap();
+        let namespace = ensure_supervisor_startup_namespace(fresh.path()).unwrap();
+        assert!(
+            namespace
+                .sentinel
+                .join(SUPERVISOR_STARTUP_NOTICE_FILE)
+                .is_file(),
+            "the notice must be written while the namespace is built, not afterwards"
+        );
+        assert!(
+            !startup_lock_is_stale(&namespace.sentinel, Duration::ZERO),
+            "namespace setup must hand back a sentinel already stamped into the future, so no \
+             write it performs can leave the stamp aged even momentarily"
+        );
+        drop(namespace);
+        drop(fresh);
+
         let dir = tempfile::tempdir().unwrap();
         let launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let sentinel = launcher.path().to_path_buf();
         let notice = launcher.path().join(SUPERVISOR_STARTUP_NOTICE_FILE);
 
         assert_eq!(
@@ -7538,6 +7614,27 @@ mod tests {
             "a damaged notice must be restored rather than left wrong"
         );
         assert!(!startup_lock_is_stale(repaired.path(), Duration::ZERO));
+
+        // Aging the sentinel by hand reaches the same end state as any write
+        // ordered after a stamp, without depending on where in setup that write
+        // sits. An acquisition owes the future stamp back either way.
+        drop(repaired);
+        filetime::set_file_mtime(
+            &sentinel,
+            filetime::FileTime::from_system_time(
+                std::time::SystemTime::now() - Duration::from_secs(3600),
+            ),
+        )
+        .unwrap();
+        assert!(
+            startup_lock_is_stale(&sentinel, Duration::ZERO),
+            "the aging must be visible here, or the repair assertion below could not fail"
+        );
+        let restamped = take_supervisor_startup_authority_after_release(dir.path());
+        assert!(
+            !startup_lock_is_stale(restamped.path(), Duration::ZERO),
+            "an acquisition must restore a compatibility stamp it finds aged, whatever aged it"
+        );
     }
 
     /// The doctor's sentinel classification decides which diagnosis it prints,
@@ -7582,6 +7679,35 @@ mod tests {
             SupervisorStartupSentinel::ProtocolDirectory
         );
         assert_eq!(supervisor_startup_protocol(), SUPERVISOR_STARTUP_PROTOCOL);
+    }
+
+    /// A link at the sentinel path hard-blocks supervisor startup, so it must
+    /// classify as its own state rather than as the directory it points at or
+    /// as merely unreadable. The refusal is asserted in fact, not assumed: the
+    /// classification is only honest while startup really does refuse.
+    #[cfg(unix)]
+    #[test]
+    fn sentinel_classification_marks_a_link_the_startup_protocol_refuses_to_follow() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("kin-home");
+        let elsewhere = dir.path().join("elsewhere");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        std::os::unix::fs::symlink(&elsewhere, home.join(SUPERVISOR_STARTUP_FILE)).unwrap();
+
+        assert_eq!(
+            supervisor_startup_sentinel_in_dir(&home),
+            SupervisorStartupSentinel::RefusedLink,
+            "a symlink must not be reported as the protocol directory it points at"
+        );
+
+        let refusal = ensure_supervisor_startup_namespace(&home).unwrap_err();
+        assert_eq!(
+            refusal.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "no supervisor can start against this sentinel: {refusal}"
+        );
+        assert!(refusal.to_string().contains("refuses symlink"), "{refusal}");
     }
 
     #[test]


### PR DESCRIPTION
## The defect

A `kin` built before 2026-07-29 can never start a supervisor once any newer
binary has run against the same `~/.kin`. `preserve_bounded_legacy_rollback`
makes `supervisor.start.lock` a permanent protocol-v2 directory stamped a
hundred years into the future, deliberately, so a legacy launcher's
`modified().elapsed()` check returns `Err` and it waits out its deadline instead
of busy-looping on a directory it cannot `remove_file`.

That bounded wait is correct and is not changed here. The **diagnosis** was the
defect. The caller got 300 seconds of silence and then:

```
timed out waiting for supervisor startup lock at ~/.kin/supervisor.start.lock
```

which names lock contention. Nothing holds a lock, nothing is contended, and no
amount of waiting can succeed. The message pointed at the one explanation that
is false, which is how it was first booked as machine load.

## What changed

**Three-way timeout diagnosis.** `classify_supervisor_startup_timeout` decides
from probed state rather than assuming:

- a contended authority `flock` proves a live holder, because the kernel
  releases an flock when its holder dies, so that alone is real contention;
- a protocol directory carrying the far-future compatibility stamp, with nothing
  holding the lock and no supervisor running, is the pre-v2 exclusion state, and
  the message says it is not contention and names the update command;
- anything else is plain slow startup.

The classification is separated from the IO probe so it is testable without
racing a live filesystem. The authority probe is tri-state: a filesystem whose
`flock` is unsupported or emulated answers neither held nor free, and that
silence falls through to slow startup rather than being read as proof of absence
and turned into a verdict on the caller's binary.

**Every timeout names its knob.** `KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS` and the
`KIN_DAEMON_READY_TIMEOUT_SECS` it defaults from are now named by the supervisor
startup lock, the daemon startup lock, `wait_for_daemon_ready`,
`wait_for_supervisor_ready`, and `follow_existing_supervisor_publication`.
Previously only `live_daemon_not_ready_message` did.

**On-disk breadcrumb.** A current launcher leaves `README-UPDATE-KIN.txt` inside
the sentinel directory. That path is the only channel a current binary has to a
stuck old binary's operator, because the old binary's own error names the path.
The notice is byte-stable, so refreshing it rewrites nothing, and it is written
before the sentinel is stamped so namespace setup never hands back an aged
stamp. The durable guarantee is not that ordering: every acquisition re-stamps
the sentinel and fails closed unless the timestamp reads back in the future, so
a directory-mtime bump taken while the namespace is built is repaired before any
caller holds the lock.

**`kin doctor` detection.** A new `supervisor_startup_protocol` check classifies
the sentinel, and when the protocol directory exists asks each other installed
kin whether it speaks the current protocol, by probing the `kin-daemon` shipped
beside it. Candidates are whatever `PATH` resolves plus `~/.kin/bin`, which is
deliberately the set an operator actually invokes rather than a filtered notion
of an install: `PATH` decides which binary runs, so a build tree reachable
through it is probed on the same evidence as any other install. A pre-v2 install
answers with the v1 compat schema and no supervisor protocol field, which is
positive evidence rather than an absence of it.

Severity follows one rule: a state blocks readiness exactly when it stops the
binary running the check from starting a supervisor. A pre-v2 *other* install is
`Stale` and advisory, because another install's age does not stop this one. The
two sentinel shapes `ensure_supervisor_startup_namespace` refuses on are both
`Misconfigured` and both block: a legacy v1 marker file, and a symlink or
reparse point the protocol will not follow. Metadata that simply cannot be read
proves nothing either way and stays advisory.

Enumerating and probing installs lives in `daemon_client`, the declared process
and install boundary that already owns daemon binary discovery and the compat
probe, so the health module consumes a verdict instead of reaching for the
filesystem to compute one. The module doc states that boundary explicitly.

The year-2126 stamp, the directory sentinel, the structural exclusion, and the
bounded-not-unbounded property are all unchanged.

## Live proof on the affected host

This machine is in the exact failing state (installed `~/.kin/bin/kin` is
`1d016b02`, dated 2026-07-28; the sentinel is stamped `Oct 14 2126`). The new
binary's `kin doctor --json`:

```json
{
  "id": "supervisor_startup_protocol",
  "status": "stale",
  "detail": "your installed kin predates the current supervisor protocol: /Users/…/.kin/bin/kin (it reports compat schema kin.daemon.compat.v1 and no supervisor startup protocol at all). While /Users/…/.kin/supervisor.start.lock exists, that binary cannot start a supervisor and waits out its full startup deadline in silence before reporting a lock timeout that names contention it is not hitting",
  "manual_fix": "update kin: curl -fsSL https://get.kinlab.dev/install | sh"
}
```

Confirmed independently: `~/.kin/bin/kin-daemon --compat-json` returns
`"schema":"kin.daemon.compat.v1"` with no `supervisor_startup_protocol` field,
while the current daemon emits `kin.daemon.compat.v2` with protocol 2.

## Tests

Nine tests cover this change, each falsified before being trusted rather than
merely observed passing.

`daemon_client`:

- `startup_timeout_diagnosis_separates_contention_from_legacy_exclusion` covers
  all three causes, the three states that must fall back to slow startup, and
  the undecidable authority probe. Letting the undecidable case fall through
  instead of stopping at slow startup fails it.
- `every_startup_timeout_message_names_its_knob_and_its_own_cause` asserts each
  branch names both knobs, stays identifiable, and does not borrow another
  branch's diagnosis (contention must not blame binary age; slow startup must
  claim neither).
- `startup_notice_reaches_the_sentinel_without_aging_its_compatibility_stamp`
  guards stamp survival rather than write ordering. It observes the sentinel at
  the namespace seam, where an outer re-stamp cannot mask a moved write; after a
  full acquisition; and after the stamp is aged by hand, which reaches the same
  end state any write ordered after a stamp would. Three separate mutations turn
  it red: moving the notice write after the inner stamp, dropping the stamp and
  its readback entirely, and repairing only recent drift so an aged sentinel is
  left aged. Forcing an unconditional rewrite still fails it on the mtime
  assertion.
- `sentinel_classification_separates_the_protocol_directory_from_a_legacy_marker`
  takes its directory by argument rather than through the environment.
- `sentinel_classification_marks_a_link_the_startup_protocol_refuses_to_follow`
  asserts the refusal in fact, not by assumption: it classifies the link and
  then requires `ensure_supervisor_startup_namespace` to reject the same path
  with `PermissionDenied`.

`kin doctor`: an install that answers "predates" is named with its evidence and
the exact install command and does not block readiness; an absent, current, or
undetermined answer stays healthy, so an unanswered probe is never treated as
evidence of age; a legacy marker blocks readiness; and a refused link blocks
while unreadable metadata and a pre-v2 sibling do not, which is the severity
rule stated with both of its contrasts beside it.

## Two self-caught failures worth reading

**Zero-file-search.** The first push went red: `health.rs` is scanned with
per-expression pins precisely so a newly added filesystem primitive fails the
guard, and the `canonicalize` calls added for binary enumeration tripped it. The
fix was not another pin. Enumeration moved to `daemon_client`, a declared
boundary module, which is where install discovery belonged anyway.

**A green CI that was wrong.** With CI fully green, `cargo test -p kin-cli --lib`
failed locally while the exact merge base passed. The sentinel test had been
setting `KIN_REGISTRY_PATH`; environment variables are process-global and
`cargo test` runs a binary's tests as threads in one process, so unrelated
`commands::update` tests resolving the Kin home saw a temporary path and failed.
`#[serial]` cannot prevent that, since it orders a test only against other serial
tests. Nextest gives each test its own process, so CI could not observe the
defect at all. Classification now takes its directory as an argument, and the
install probe is skipped under `cfg!(test)` so a unit test never spawns the
host's installed daemon.

## Gates

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| clippy, full ci.yml allowlist with `RUSTFLAGS=-D warnings` | 0 errors, 0 lint warnings (only the pre-existing `block v0.1.6` future-incompat note) |
| `cargo build --all-targets --locked` | clean |
| `cargo test -p kin-cli --lib` | **1003 passed, 0 failed** |
| `cargo test -p kin-cli --tests` | 36 binaries, **1389 passed, 0 failed** |
| `cargo test -p kin-cli --doc` | 1 passed, 1 ignored |
| `cargo test -p kin-daemon --lib supervisor` | **74 passed, 0 failed**, including `current_protocol_directory_sentinel_blocks_legacy_respawn_without_heartbeat` |
| `python3 scripts/verify-zero-file-search.py` | PASSED, **144 source files scanned** (5 function-scoped exemptions, 4 whole-file), the expected count |
| `bash scripts/zero_file_search_guard.sh` | passed, answer paths graph-clean |
| ci.yml `Falsify Zero File-Search guards`, extracted and run verbatim | passed, every probe caught at every site |
| `python3 scripts/verify-hydration-semantics.py` | passed, 13 guarded functions at version 7 |
| `bash scripts/check_runtime_boundaries.sh` | passed |
| `bash scripts/check_private_repo_coupling.sh` | passed |
| `cargo check -p kin-cli --no-default-features --lib` | clean, the shape the Windows job compiles |

Every exit code was captured to a variable separately from the output, because a piped
`cargo test` hides both earlier FAILED lines and the status. The load-bearing function was
re-checked by hash rather than by reading the diff: the extracted body of
`preserve_bounded_legacy_rollback` is byte-identical at the merge base, at the reviewed
head, and here (`3b94ea91297dee9a4c8b053da2ab31371f3208d44d681375c8487a29920aaabe`).

## Not claiming

The pre-v2 binaries already shipped cannot be fixed from here; their own code is
immutable, so their 300-second wait is unchanged and still happens. The legacy
launcher's own wait cannot be changed from this side, and FIR-1741's acceptance
was re-scoped accordingly on the ticket. What changes is that the current
binary's messages, the on-disk notice, and `kin doctor` now name binary age and
the remedy instead of pointing at contention.

The classifier's exclusion branch is reached only from probed state, and one
narrow window remains where that state can be reached without a legacy binary
being involved: a holder that releases or dies between the last acquisition
attempt and the probe, with no supervisor pid yet published. That window is
recorded rather than closed here, because closing it changes what the branch is
for rather than repairing it.

Closes FIR-1741
