### PR TITLE
Read the release merge policy through a push-scoped token and cut v0.4.1

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -111,6 +111,10 @@ jobs:
             exit 1
           fi
           merge_policy="$(GH_TOKEN="$MERGE_POLICY_TOKEN" gh api "repos/${REPO}")"
+          if ! jq -e 'type == "object"' <<< "$merge_policy" > /dev/null; then
+            echo "::error::repository merge policy response was not a JSON object, so the policy was never read"
+            exit 1
+          fi
           absent="$(jq -r '
             . as $repo
             | [

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -90,6 +90,7 @@ jobs:
         id: plan
         env:
           GH_TOKEN: ${{ github.token }}
+          MERGE_POLICY_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -97,16 +98,49 @@ jobs:
           # only reaches them because this repository merges by squash with the
           # pull-request body as the message. Assert that before trusting the
           # resolution rather than discovering a rewritten message later.
-          jq -e '
-            .allow_squash_merge == true and
-            .allow_merge_commit == false and
-            .allow_rebase_merge == false and
-            .squash_merge_commit_title == "PR_TITLE" and
-            .squash_merge_commit_message == "PR_BODY"
-          ' <<< "$(gh api "repos/${REPO}")" >/dev/null || {
-            echo "::error::immutable PR-body release intent requires enforced PR_TITLE + PR_BODY squash-only merging"
+          #
+          # GitHub returns the merge-policy fields only to a token that holds
+          # push-level repository access, and this workflow's GITHUB_TOKEN is
+          # deliberately read-scoped. Read the policy through the same
+          # repository-scoped App installation token that already writes the
+          # release branch, and keep the two failures apart: a response that
+          # never carried the fields cannot disprove the policy, so reporting it
+          # as a wrong setting sends recovery after a correct repository.
+          if [ -z "$MERGE_POLICY_TOKEN" ]; then
+            echo "::error::reading repository merge policy requires the release App installation token"
             exit 1
-          }
+          fi
+          merge_policy="$(GH_TOKEN="$MERGE_POLICY_TOKEN" gh api "repos/${REPO}")"
+          absent="$(jq -r '
+            . as $repo
+            | [
+                "allow_squash_merge",
+                "allow_merge_commit",
+                "allow_rebase_merge",
+                "squash_merge_commit_title",
+                "squash_merge_commit_message"
+              ]
+            | map(. as $field | select(($repo | has($field)) | not))
+            | join(", ")
+          ' <<< "$merge_policy")"
+          if [ -n "$absent" ]; then
+            echo "::error::repository merge policy is unreadable, not disproven: ${absent} absent from the API response, which happens when the reading token lacks push-level repository access"
+            exit 1
+          fi
+          violations="$(jq -r '
+            [
+              (select(.allow_squash_merge == true | not) | "allow_squash_merge"),
+              (select(.allow_merge_commit == false | not) | "allow_merge_commit"),
+              (select(.allow_rebase_merge == false | not) | "allow_rebase_merge"),
+              (select(.squash_merge_commit_title == "PR_TITLE" | not) | "squash_merge_commit_title"),
+              (select(.squash_merge_commit_message == "PR_BODY" | not) | "squash_merge_commit_message")
+            ]
+            | join(", ")
+          ' <<< "$merge_policy")"
+          if [ -n "$violations" ]; then
+            echo "::error::immutable PR-body release intent requires enforced PR_TITLE + PR_BODY squash-only merging; offending repository settings: ${violations}"
+            exit 1
+          fi
           git fetch origin \
             "+refs/heads/main:refs/remotes/origin/main" \
             "+refs/tags/*:refs/tags/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-07-30
+## [0.4.1] - 2026-07-31
+
+v0.4.0 was never published. Its release commit was refused by the mint gate
+because the release rail read the repository merge policy through a token that
+could not see those settings, and that defect is fixed in this release.
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,14 +3054,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "age",
  "anyhow",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-model",
  "serde",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -90,7 +90,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.4.0", path = "../kin-spine" }
+kin-spine = { version = "0.4.1", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-git = { workspace = true, features = ["test-support"] }

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -73,7 +73,14 @@ resolution is stable and monotone.
 
 The release App has repository Contents permission but no `main` bypass. It can
 only update `automation/release-next`; the repository `GITHUB_TOKEN` opens the
-PR, while the App activates ordinary checks and registers protected auto-merge.
+PR, while the App reads the repository merge policy, activates ordinary checks,
+and registers protected auto-merge. GitHub returns the merge-policy settings
+only to a token holding push-level repository access, so the deliberately
+read-scoped `GITHUB_TOKEN` receives a response with those fields absent rather
+than wrong. The train therefore reads that policy through the App token and
+reports an unreadable policy separately from a violated one, because blaming
+the repository settings for a policy no token ever read sends recovery after a
+correctly configured repository.
 That App identity is important: GitHub suppresses most workflow events caused
 by `GITHUB_TOKEN`, whereas the App-owned merge emits the `main` push that starts
 CI and automatic tag admission. Main must require up-to-date checks so new

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1556,6 +1556,135 @@ def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
         raise AssertionError("no pinned rust-cache steps found")
 
 
+def release_train_merge_policy_source(release_train: str) -> str:
+    """Extract the exact merge-policy gate executed by the release train."""
+
+    step_start = release_train.index(
+        "      - name: Resolve releasable drift and SemVer intent"
+    )
+    step_end = release_train.index("\n      - name:", step_start + 1)
+    step = release_train[step_start:step_end]
+    source_start = step.index('          if [ -z "$MERGE_POLICY_TOKEN" ]; then')
+    source_end = step.index("\n          git fetch origin", source_start)
+    return textwrap.dedent(step[source_start:source_end])
+
+
+def execute_merge_policy_gate(
+    source: str,
+    repository: dict[str, object],
+    *,
+    token: str = "fixture-installation-token",
+) -> subprocess.CompletedProcess[str]:
+    """Execute the real merge-policy gate against a fixture API response."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        gate = root / "merge-policy-gate.sh"
+        gate.write_text(source, encoding="utf-8")
+        fixture = root / "repository.json"
+        fixture.write_text(json.dumps(repository), encoding="utf-8")
+        binaries = root / "bin"
+        binaries.mkdir()
+        shim = binaries / "gh"
+        shim.write_text(
+            '#!/usr/bin/env bash\nset -euo pipefail\ncat "$MERGE_POLICY_FIXTURE"\n',
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+        environment = dict(os.environ)
+        environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
+        environment["MERGE_POLICY_FIXTURE"] = str(fixture)
+        environment["MERGE_POLICY_TOKEN"] = token
+        environment["REPO"] = "firelock-ai/kin"
+        return subprocess.run(
+            ["bash", "-euo", "pipefail", str(gate)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            check=False,
+        )
+
+
+def assert_merge_policy_gate(release_train: str) -> None:
+    """Keep an unreadable merge policy distinct from a violated one."""
+
+    gate = release_train_merge_policy_source(release_train)
+    enforced: dict[str, object] = {
+        "allow_squash_merge": True,
+        "allow_merge_commit": False,
+        "allow_rebase_merge": False,
+        "squash_merge_commit_title": "PR_TITLE",
+        "squash_merge_commit_message": "PR_BODY",
+    }
+    accepted = execute_merge_policy_gate(gate, enforced)
+    if accepted.returncode != 0:
+        raise AssertionError(
+            "release train merge-policy gate refused the enforced squash "
+            f"policy: {accepted.stdout}{accepted.stderr}"
+        )
+
+    # A response carrying none of the policy fields is exactly what a token
+    # without push-level repository access receives. It cannot disprove the
+    # policy, and calling it a violation sends recovery after a correct
+    # repository instead of after the token that could not read it.
+    unreadable = execute_merge_policy_gate(
+        gate,
+        {"full_name": "firelock-ai/kin", "permissions": {"push": False}},
+    )
+    if unreadable.returncode == 0:
+        raise AssertionError(
+            "release train merge-policy gate accepted a response that carried "
+            "no merge policy at all"
+        )
+    if "absent from the API response" not in unreadable.stdout:
+        raise AssertionError(
+            "release train merge-policy gate must refuse an unreadable policy "
+            f"as absent fields: {unreadable.stdout}{unreadable.stderr}"
+        )
+    if "immutable PR-body release intent" in unreadable.stdout:
+        raise AssertionError(
+            "release train merge-policy gate blamed the repository settings "
+            "for a policy it never read"
+        )
+
+    for field, drift in (
+        ("allow_squash_merge", False),
+        ("allow_merge_commit", True),
+        ("allow_rebase_merge", True),
+        ("squash_merge_commit_title", "COMMIT_OR_PR_TITLE"),
+        ("squash_merge_commit_message", "COMMIT_MESSAGES"),
+    ):
+        drifted = dict(enforced)
+        drifted[field] = drift
+        refused = execute_merge_policy_gate(gate, drifted)
+        if refused.returncode == 0:
+            raise AssertionError(
+                f"release train merge-policy gate accepted drifted {field}"
+            )
+        if "immutable PR-body release intent" not in refused.stdout:
+            raise AssertionError(
+                f"release train merge-policy gate must refuse drifted {field} "
+                f"as a policy violation: {refused.stdout}{refused.stderr}"
+            )
+        if field not in refused.stdout:
+            raise AssertionError(
+                "release train merge-policy gate must name the offending "
+                f"setting {field}: {refused.stdout}"
+            )
+        if "absent from the API response" in refused.stdout:
+            raise AssertionError(
+                f"release train merge-policy gate reported present {field} "
+                "as absent"
+            )
+
+    unscoped = execute_merge_policy_gate(gate, enforced, token="")
+    if unscoped.returncode == 0:
+        raise AssertionError(
+            "release train merge-policy gate read the merge policy without "
+            "the release App installation token"
+        )
+
+
 def release_check_gate_source(release_tag: str) -> str:
     """Extract the exact Python gate executed by the release-tag workflow."""
 
@@ -2162,8 +2291,16 @@ def main() -> None:
         '.squash_merge_commit_message == "PR_BODY"',
         "immutable PR-body release intent requires enforced PR_TITLE + PR_BODY "
         "squash-only merging",
+        # GitHub withholds the merge-policy fields from a token without
+        # push-level repository access, so the read must stay bound to the
+        # repository-scoped App installation token rather than the read-scoped
+        # GITHUB_TOKEN that the rest of the step uses.
+        "MERGE_POLICY_TOKEN: ${{ steps.app-token.outputs.token }}",
+        'GH_TOKEN="$MERGE_POLICY_TOKEN" gh api "repos/${REPO}"',
+        "absent from the API response",
     ):
         require(release_train, policy, "coalescing protected release train")
+    assert_merge_policy_gate(release_train)
     # The release bump must never be resolvable from anything a merged pull
     # request can still change.
     for forbidden in (

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1559,42 +1559,79 @@ def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
 def release_train_merge_policy_source(release_train: str) -> str:
     """Extract the exact merge-policy gate executed by the release train."""
 
-    step_start = release_train.index(
-        "      - name: Resolve releasable drift and SemVer intent"
-    )
+    step_anchor = "      - name: Resolve releasable drift and SemVer intent"
+    if step_anchor not in release_train:
+        raise AssertionError(
+            "release train no longer carries the step that owns the "
+            f"merge-policy gate: {step_anchor.strip()}"
+        )
+    step_start = release_train.index(step_anchor)
+    if "\n      - name:" not in release_train[step_start + 1 :]:
+        raise AssertionError(
+            "release train merge-policy step is no longer followed by another "
+            "step, so its boundary cannot be resolved"
+        )
     step_end = release_train.index("\n      - name:", step_start + 1)
     step = release_train[step_start:step_end]
-    source_start = step.index('          if [ -z "$MERGE_POLICY_TOKEN" ]; then')
-    source_end = step.index("\n          git fetch origin", source_start)
+    open_anchor = '          if [ -z "$MERGE_POLICY_TOKEN" ]; then'
+    if open_anchor not in step:
+        raise AssertionError(
+            "release train merge-policy gate no longer opens with its "
+            "installation-token guard, so the executed gate cannot be extracted"
+        )
+    source_start = step.index(open_anchor)
+    close_anchor = "\n          git fetch origin"
+    if close_anchor not in step[source_start:]:
+        raise AssertionError(
+            "release train merge-policy gate no longer ends before the origin "
+            "fetch, so the executed gate cannot be extracted"
+        )
+    source_end = step.index(close_anchor, source_start)
     return textwrap.dedent(step[source_start:source_end])
 
 
 def execute_merge_policy_gate(
     source: str,
-    repository: dict[str, object],
+    repository: dict[str, object] | None,
     *,
     token: str = "fixture-installation-token",
+    raw: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Execute the real merge-policy gate against a fixture API response."""
 
+    if (repository is None) == (raw is None):
+        raise AssertionError(
+            "merge-policy fixture needs exactly one of a repository object or "
+            "a raw response body"
+        )
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         gate = root / "merge-policy-gate.sh"
         gate.write_text(source, encoding="utf-8")
         fixture = root / "repository.json"
-        fixture.write_text(json.dumps(repository), encoding="utf-8")
+        fixture.write_text(
+            json.dumps(repository) if raw is None else raw, encoding="utf-8"
+        )
         binaries = root / "bin"
         binaries.mkdir()
         shim = binaries / "gh"
         shim.write_text(
-            '#!/usr/bin/env bash\nset -euo pipefail\ncat "$MERGE_POLICY_FIXTURE"\n',
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            'if [ "${GH_TOKEN:-}" != "$MERGE_POLICY_EXPECTED_TOKEN" ]; then\n'
+            '  echo "policy read presented the wrong token" >&2\n'
+            "  exit 77\n"
+            "fi\n"
+            'cat "$MERGE_POLICY_FIXTURE"\n',
             encoding="utf-8",
         )
         shim.chmod(0o755)
         environment = dict(os.environ)
+        environment.pop("GH_TOKEN", None)
         environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
         environment["MERGE_POLICY_FIXTURE"] = str(fixture)
         environment["MERGE_POLICY_TOKEN"] = token
+        environment["MERGE_POLICY_EXPECTED_TOKEN"] = token
         environment["REPO"] = "firelock-ai/kin"
         return subprocess.run(
             ["bash", "-euo", "pipefail", str(gate)],
@@ -1622,6 +1659,33 @@ def assert_merge_policy_gate(release_train: str) -> None:
             "release train merge-policy gate refused the enforced squash "
             f"policy: {accepted.stdout}{accepted.stderr}"
         )
+
+    # Both refusals below read the emptiness of a jq result, and jq emits
+    # nothing at all for a body that is not a JSON object, so a gate that
+    # judged only those results would pass having read no policy whatsoever.
+    for label, body in (
+        ("an empty", ""),
+        ("a whitespace-only", "   \n"),
+        ("a JSON array", "[]"),
+        ("a bare JSON string", '"not-an-object"'),
+    ):
+        unread = execute_merge_policy_gate(gate, None, raw=body)
+        if unread.returncode == 0:
+            raise AssertionError(
+                f"release train merge-policy gate accepted {label} API "
+                "response, so it passed without reading any policy"
+            )
+        if "was not a JSON object" not in unread.stdout:
+            raise AssertionError(
+                f"release train merge-policy gate must refuse {label} API "
+                f"response by naming the response shape: "
+                f"{unread.stdout}{unread.stderr}"
+            )
+        if "immutable PR-body release intent" in unread.stdout:
+            raise AssertionError(
+                "release train merge-policy gate blamed the repository "
+                f"settings for {label} response it could not read"
+            )
 
     # A response carrying none of the policy fields is exactly what a token
     # without push-level repository access receives. It cannot disprove the
@@ -2298,6 +2362,7 @@ def main() -> None:
         "MERGE_POLICY_TOKEN: ${{ steps.app-token.outputs.token }}",
         'GH_TOKEN="$MERGE_POLICY_TOKEN" gh api "repos/${REPO}"',
         "absent from the API response",
+        "repository merge policy response was not a JSON object",
     ):
         require(release_train, policy, "coalescing protected release train")
     assert_merge_policy_gate(release_train)


### PR DESCRIPTION
The release train refused to reconcile on the v0.4.0 release commit even though this repository's merge settings are exactly what it asks for. Its squash-policy assertion read `repos/{owner}/{repo}` with `GH_TOKEN: ${{ github.token }}` under a workflow-level `permissions: contents: read` block, and GitHub includes `allow_squash_merge`, `allow_merge_commit`, `allow_rebase_merge`, `squash_merge_commit_title`, and `squash_merge_commit_message` only for a token holding push-level repository access. The run log does not print the response body, so what that body carried is diagnosed rather than observed, and only one shape fits both the live settings and the visibility rule. The read-scoped token received a response without any of those keys, every `==` comparison therefore ran against `null`, and the train reported enforced squash-only merging as violated. Run 30596642361 failed exactly this way on `84223e65`, which left a terminally failed check-run on the release sha, and `release-tag.yml`'s present-check sweep refuses any non-green check-run there other than its own mint attempts. That is what made v0.4.0 unmintable.

The visibility rule was falsified rather than assumed. A repository the reader has pull access to but not push (`cli/cli`, `rust-lang/rust`) omits the fields; two repositories with `push: true` and `admin: false` include them, which separates push from admin and shows push is the gate. The `kin-release-bot` installation carries `contents: write`, which is push access, so by that same rule its repository-scoped installation token receives the fields. Minting a real installation token needs the App private key held only in the `release-tag` environment, so that last step stays inference until the first post-merge run exercises it. If the App turns out to be narrower than believed, the presence refusal below fails loud naming token scope rather than blaming a correctly configured repository.

The policy read now runs under that installation token, which the job already mints as its first step for the release branch write. It is passed to the single elevated call through `MERGE_POLICY_TOKEN`, so the rest of the step keeps the read-scoped `GITHUB_TOKEN` and the workflow `permissions:` block is unchanged.

The assertion is also presence-aware and stays fail-closed, in four ordered refusals. An absent installation token is refused before any read. A response that is not a JSON object, including an empty or whitespace-only body, is refused by naming the response shape, because the two refusals after it read the emptiness of a jq result and jq emits nothing at all for such a body. Fields missing from a response that is an object are refused as an unreadable policy that names token scope and lists the absent fields, never as a wrong setting. Fields present but wrong are refused as a policy violation carrying the original message plus the exact offending field names. A run that cannot read the policy no longer sends recovery after a correctly configured repository.

`scripts/test-release-workflow-authority.py` gains a falsification that extracts the shipped gate from `release-train.yml` and executes it against fixture API responses. The enforced policy is accepted; an empty body, a whitespace-only body, a JSON array, and a bare JSON string are each refused by naming the response shape; a response carrying none of the fields is refused as absent and must not emit the policy-violation message; each of the five fields drifted individually is refused as a violation naming that field; a run without the installation token is refused. The fixture `gh` shim asserts the token presented to the read, so the executed half proves the installation-token binding rather than leaving that to a pinned string, and the extractor names each missing anchor instead of raising a bare substring error. The new assertions were themselves falsified. Keeping every pinned string while making the presence branch unreachable still fails the suite with the old wrong diagnosis as the recorded failure; keeping every pinned string while making the response-shape branch unreachable fails on the empty-body fixture; and dropping the elevated token from the read call fails the executed enforced-policy case even with its pinned string removed.

`docs/release-bot.md` described the App as activating checks and registering auto-merge. That enumeration was incomplete once the App also reads merge policy, so it now names that read and the push-level visibility rule behind it.

Since v0.4.0 was never published, this cuts v0.4.1 in its place across the workspace version, the kin-cli `kin-spine` path pin, the three npm manifests, both lockfiles, and the changelog section, which keeps all of its v0.4.0 content and gains one line recording why that version does not exist. `node scripts/release-intent.mjs` reports v0.4.1 coherent and ready to tag and holds the path-resolved `kin-parser` entry in `fuzz/Cargo.lock` to the workspace version, `cargo build --all-targets --locked` proves the root lockfile resolves, and the `cargo-fuzz` jobs prove the fuzz lockfile resolves, which the root build never reads because `fuzz` declares its own workspace.

Closes FIR-1751
