### PR TITLE
Move the workspace onto the head a native pull admits

### DIFF
--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -79,9 +79,9 @@ pub enum WorkspaceFollow {
     /// The responding daemon predates this report, so whether the working tree
     /// followed is unknown. Never produced by this build.
     Unreported,
-    /// No local workspace was in a position to follow: hosted snapshot
-    /// authority owns no working tree, or this replica's workspace does not
-    /// track the ref the pull moved.
+    /// No local workspace was in a position to follow: the pull admitted no
+    /// history so no ref moved, hosted snapshot authority owns no working tree,
+    /// or this replica's workspace does not track the ref the pull moved.
     NotApplicable { detail: String },
     /// The workspace already stood at the admitted head, so nothing moved.
     AlreadyCurrent { authority_generation: u64 },
@@ -340,7 +340,11 @@ fn render_plan(plan: &RepositoryTransferPlan) -> String {
 fn render_outcome(response: &CommandTransferResponse, json: bool) -> Result<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(response)?);
-        return Ok(());
+        // The exit contract is not a property of the human rendering. `--json`
+        // is the mode a caller chains work from, so it is the mode where an
+        // exit status that ignored a working tree left behind would do the most
+        // damage. The body still carries the state; this decides the status.
+        return workspace_follow_outcome(&response.workspace);
     }
     let outcome = &response.outcome;
     let verb = match outcome.direction {
@@ -382,11 +386,6 @@ fn render_outcome(response: &CommandTransferResponse, json: bool) -> Result<()> 
 
 /// Report what the working tree did, and fail the command when it did not
 /// follow a head that is now durable.
-///
-/// A caller that chains work onto a pull reads the exit status, not the prose.
-/// Succeeding after the workspace stayed behind would let that work run against
-/// the tree the pull was supposed to replace, which is the one outcome nobody
-/// can see from the files alone.
 fn render_workspace_follow(workspace: &WorkspaceFollow) -> Result<()> {
     match workspace {
         WorkspaceFollow::Unreported => {}
@@ -400,14 +399,27 @@ fn render_workspace_follow(workspace: &WorkspaceFollow) -> Result<()> {
             detail,
             authority_generation,
         } => println!("Workspace: {detail} (authority generation {authority_generation})"),
-        WorkspaceFollow::Behind { detail } => {
-            println!(
-                "Repository authority moved and is durable, but this workspace did not follow it: {detail}"
-            );
-            bail!(
-                "the admitted history is durable; the working tree still shows the head it had before. Resolve the reason above, then run `kin branch switch` onto the pulled ref to move it."
-            );
-        }
+        WorkspaceFollow::Behind { detail } => println!(
+            "Repository authority moved and is durable, but this workspace did not follow it: {detail}"
+        ),
+    }
+    workspace_follow_outcome(workspace)
+}
+
+/// Decide the command's exit status from what the working tree did, separately
+/// from how it was rendered.
+///
+/// A caller that chains work onto a pull reads the exit status, not the prose.
+/// Succeeding after the workspace stayed behind would let that work run against
+/// the tree the pull was supposed to replace, which is the one outcome nobody
+/// can see from the files alone. Keeping the decision out of the renderer is
+/// what makes it hold in every output mode rather than only the one a person
+/// reads.
+fn workspace_follow_outcome(workspace: &WorkspaceFollow) -> Result<()> {
+    if workspace.is_behind() {
+        bail!(
+            "the admitted history is durable; the working tree still shows the head it had before. Resolve the reason above, then run `kin branch switch` onto the pulled ref to move it."
+        );
     }
     Ok(())
 }
@@ -449,57 +461,12 @@ mod tests {
         assert_eq!(request.source_ref, Some(RefName::branch(b"main").unwrap()));
     }
 
-    /// A working tree that stayed behind must not exit clean. Anything chained
-    /// onto the pull would otherwise run against the head the pull replaced,
-    /// which is invisible from the files alone.
-    #[test]
-    fn a_workspace_that_stayed_behind_fails_the_command() {
-        let error = render_workspace_follow(&WorkspaceFollow::Behind {
-            detail: "workspace has graph-owned changes".to_string(),
-        })
-        .expect_err("a working tree that did not follow cannot report success");
-        assert!(
-            error.to_string().contains("still shows the head it had"),
-            "refusal must say what the working tree is showing: {error}"
-        );
-    }
-
-    /// Every other state is a success. A transfer that landed is not turned into
-    /// a failure by a workspace that had nothing to do.
-    #[test]
-    fn every_state_other_than_behind_succeeds() {
-        for follow in [
-            WorkspaceFollow::Unreported,
-            WorkspaceFollow::NotApplicable {
-                detail: "hosted snapshot authority serves no local working tree".to_string(),
-            },
-            WorkspaceFollow::AlreadyCurrent {
-                authority_generation: 7,
-            },
-            WorkspaceFollow::Advanced {
-                detail: "Followed refs/heads/main".to_string(),
-                authority_generation: 8,
-            },
-        ] {
-            assert!(
-                render_workspace_follow(&follow).is_ok(),
-                "{follow:?} is not a failed pull"
-            );
-            assert!(!follow.is_behind());
-        }
-        assert!(WorkspaceFollow::Behind {
-            detail: String::new()
-        }
-        .is_behind());
-    }
-
-    /// A daemon that predates this report says nothing about the working tree,
-    /// and the default must say exactly that rather than claim a transition
-    /// nobody observed.
-    #[test]
-    fn a_response_without_the_field_reads_as_unreported() {
+    /// One pull response carrying the workspace report under test. The transfer
+    /// itself is deliberately the boring one: what these tests decide is what a
+    /// caller reads back, not what the negotiation did.
+    fn pull_response(workspace: WorkspaceFollow) -> CommandTransferResponse {
         let main = RefName::branch(b"main").unwrap();
-        let current = CommandTransferResponse {
+        CommandTransferResponse {
             outcome: RepositoryTransferOutcome {
                 direction: RepositoryTransferDirection::Pull,
                 repository_id: kin_model::RepositoryId::new(
@@ -512,11 +479,71 @@ mod tests {
                 receipts: Vec::new(),
             },
             derived_views: DerivedViewRefresh::Current,
-            workspace: WorkspaceFollow::Advanced {
-                detail: "Followed refs/heads/main".to_string(),
-                authority_generation: 3,
+            workspace,
+        }
+    }
+
+    /// The non-zero exit is a contract of the command, not of the prose. A
+    /// caller that chains work onto a pull almost always asks for `--json`, so
+    /// an exit status that only held in the human path would fail exactly the
+    /// caller it exists for.
+    #[test]
+    fn a_workspace_that_stayed_behind_fails_the_command_in_every_output_mode() {
+        for json in [false, true] {
+            let error = render_outcome(
+                &pull_response(WorkspaceFollow::Behind {
+                    detail: "a tracked path was edited outside Kin".to_string(),
+                }),
+                json,
+            )
+            .expect_err("a working tree that did not follow cannot report success");
+            assert!(
+                error.to_string().contains("still shows the head it had"),
+                "refusal must say what the working tree is showing (json={json}): {error}"
+            );
+        }
+    }
+
+    /// The same contract read from the other side: no other state turns a
+    /// transfer that landed into a failed command, in either mode.
+    #[test]
+    fn every_other_state_exits_clean_in_every_output_mode() {
+        for workspace in [
+            WorkspaceFollow::Unreported,
+            WorkspaceFollow::NotApplicable {
+                detail: "this pull admitted no history".to_string(),
             },
-        };
+            WorkspaceFollow::AlreadyCurrent {
+                authority_generation: 7,
+            },
+            WorkspaceFollow::Advanced {
+                detail: "Followed refs/heads/main".to_string(),
+                authority_generation: 8,
+            },
+        ] {
+            assert!(!workspace.is_behind());
+            for json in [false, true] {
+                assert!(
+                    render_outcome(&pull_response(workspace.clone()), json).is_ok(),
+                    "{workspace:?} is not a failed pull (json={json})"
+                );
+            }
+        }
+        assert!(WorkspaceFollow::Behind {
+            detail: String::new()
+        }
+        .is_behind());
+    }
+
+    /// A daemon that predates this report says nothing about the working tree,
+    /// and the default must say exactly that rather than claim a transition
+    /// nobody observed.
+    #[test]
+    fn a_response_without_the_field_reads_as_unreported() {
+        let current = pull_response(WorkspaceFollow::Advanced {
+            detail: "Followed refs/heads/main".to_string(),
+            authority_generation: 3,
+        });
         let mut wire = serde_json::to_value(&current).unwrap();
         // Exactly what an older daemon's body looks like: the outcome, and
         // neither optional report.

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -64,6 +64,45 @@ impl DerivedViewRefresh {
     }
 }
 
+/// Whether the graph-owned workspace followed the head a pull admitted.
+///
+/// Admitting history and moving the working tree are two repository
+/// transactions, not one. The first is what a transfer publishes; the second is
+/// the same graph-derived projection `kin branch switch` commits, replanned
+/// against the ref the pull just moved. Reporting them separately is what keeps
+/// a caller from reading "pulled" as "the files on disk changed" when the
+/// workspace could not follow, and from reading a workspace that could not
+/// follow as a transfer that did not happen.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum WorkspaceFollow {
+    /// The responding daemon predates this report, so whether the working tree
+    /// followed is unknown. Never produced by this build.
+    Unreported,
+    /// No local workspace was in a position to follow: hosted snapshot
+    /// authority owns no working tree, or this replica's workspace does not
+    /// track the ref the pull moved.
+    NotApplicable { detail: String },
+    /// The workspace already stood at the admitted head, so nothing moved.
+    AlreadyCurrent { authority_generation: u64 },
+    /// The workspace transitioned to the admitted head in one repository
+    /// transaction.
+    Advanced {
+        detail: String,
+        authority_generation: u64,
+    },
+    /// Repository authority moved and is durable; the workspace did not follow
+    /// it, and the working tree still shows the head it had before.
+    Behind { detail: String },
+}
+
+impl WorkspaceFollow {
+    /// True when a working tree that was expected to follow did not.
+    pub fn is_behind(&self) -> bool {
+        matches!(self, Self::Behind { .. })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandTransferResponse {
     pub outcome: RepositoryTransferOutcome,
@@ -71,10 +110,19 @@ pub struct CommandTransferResponse {
     /// the state it in fact reported: a refresh it never surfaced.
     #[serde(default = "derived_views_current")]
     pub derived_views: DerivedViewRefresh,
+    /// Defaulted for the same reason as `derived_views`, to the variant that
+    /// says the responding daemon reported nothing rather than one that would
+    /// claim a transition nobody observed.
+    #[serde(default = "workspace_unreported")]
+    pub workspace: WorkspaceFollow,
 }
 
 fn derived_views_current() -> DerivedViewRefresh {
     DerivedViewRefresh::Current
+}
+
+fn workspace_unreported() -> WorkspaceFollow {
+    WorkspaceFollow::Unreported
 }
 
 /// A negotiated plan that moved nothing.
@@ -329,6 +377,38 @@ fn render_outcome(response: &CommandTransferResponse, json: bool) -> Result<()> 
             "Search and retrieval answer from behind the admitted head until those views are rebuilt. Restart the daemon to rebuild them."
         );
     }
+    render_workspace_follow(&response.workspace)
+}
+
+/// Report what the working tree did, and fail the command when it did not
+/// follow a head that is now durable.
+///
+/// A caller that chains work onto a pull reads the exit status, not the prose.
+/// Succeeding after the workspace stayed behind would let that work run against
+/// the tree the pull was supposed to replace, which is the one outcome nobody
+/// can see from the files alone.
+fn render_workspace_follow(workspace: &WorkspaceFollow) -> Result<()> {
+    match workspace {
+        WorkspaceFollow::Unreported => {}
+        WorkspaceFollow::NotApplicable { detail } => println!("Workspace: {detail}"),
+        WorkspaceFollow::AlreadyCurrent {
+            authority_generation,
+        } => println!(
+            "Workspace: already at the admitted head (authority generation {authority_generation})"
+        ),
+        WorkspaceFollow::Advanced {
+            detail,
+            authority_generation,
+        } => println!("Workspace: {detail} (authority generation {authority_generation})"),
+        WorkspaceFollow::Behind { detail } => {
+            println!(
+                "Repository authority moved and is durable, but this workspace did not follow it: {detail}"
+            );
+            bail!(
+                "the admitted history is durable; the working tree still shows the head it had before. Resolve the reason above, then run `kin branch switch` onto the pulled ref to move it."
+            );
+        }
+    }
     Ok(())
 }
 
@@ -367,6 +447,86 @@ mod tests {
         let request = build_request(peer, Some("main"), None).unwrap();
         assert_eq!(request.source_ref, request.destination_ref);
         assert_eq!(request.source_ref, Some(RefName::branch(b"main").unwrap()));
+    }
+
+    /// A working tree that stayed behind must not exit clean. Anything chained
+    /// onto the pull would otherwise run against the head the pull replaced,
+    /// which is invisible from the files alone.
+    #[test]
+    fn a_workspace_that_stayed_behind_fails_the_command() {
+        let error = render_workspace_follow(&WorkspaceFollow::Behind {
+            detail: "workspace has graph-owned changes".to_string(),
+        })
+        .expect_err("a working tree that did not follow cannot report success");
+        assert!(
+            error.to_string().contains("still shows the head it had"),
+            "refusal must say what the working tree is showing: {error}"
+        );
+    }
+
+    /// Every other state is a success. A transfer that landed is not turned into
+    /// a failure by a workspace that had nothing to do.
+    #[test]
+    fn every_state_other_than_behind_succeeds() {
+        for follow in [
+            WorkspaceFollow::Unreported,
+            WorkspaceFollow::NotApplicable {
+                detail: "hosted snapshot authority serves no local working tree".to_string(),
+            },
+            WorkspaceFollow::AlreadyCurrent {
+                authority_generation: 7,
+            },
+            WorkspaceFollow::Advanced {
+                detail: "Followed refs/heads/main".to_string(),
+                authority_generation: 8,
+            },
+        ] {
+            assert!(
+                render_workspace_follow(&follow).is_ok(),
+                "{follow:?} is not a failed pull"
+            );
+            assert!(!follow.is_behind());
+        }
+        assert!(WorkspaceFollow::Behind {
+            detail: String::new()
+        }
+        .is_behind());
+    }
+
+    /// A daemon that predates this report says nothing about the working tree,
+    /// and the default must say exactly that rather than claim a transition
+    /// nobody observed.
+    #[test]
+    fn a_response_without_the_field_reads_as_unreported() {
+        let main = RefName::branch(b"main").unwrap();
+        let current = CommandTransferResponse {
+            outcome: RepositoryTransferOutcome {
+                direction: RepositoryTransferDirection::Pull,
+                repository_id: kin_model::RepositoryId::new(
+                    "8e29a0d6-9f2f-4a1c-9a3d-2d5f6c7b8a90".to_string(),
+                )
+                .unwrap(),
+                source_ref: main.clone(),
+                destination_ref: main,
+                plan: RepositoryTransferPlan::UpToDate { head: None },
+                receipts: Vec::new(),
+            },
+            derived_views: DerivedViewRefresh::Current,
+            workspace: WorkspaceFollow::Advanced {
+                detail: "Followed refs/heads/main".to_string(),
+                authority_generation: 3,
+            },
+        };
+        let mut wire = serde_json::to_value(&current).unwrap();
+        // Exactly what an older daemon's body looks like: the outcome, and
+        // neither optional report.
+        let object = wire.as_object_mut().unwrap();
+        assert!(object.remove("workspace").is_some());
+        assert!(object.remove("derived_views").is_some());
+        let decoded: CommandTransferResponse = serde_json::from_value(wire).unwrap();
+        assert_eq!(decoded.workspace, WorkspaceFollow::Unreported);
+        assert_eq!(decoded.derived_views, DerivedViewRefresh::Current);
+        assert!(render_workspace_follow(&decoded.workspace).is_ok());
     }
 
     #[test]

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -584,7 +584,8 @@ enum Command {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
-    /// [OPEN GATE] Admit exact repository-v6 history from a native Kin remote
+    /// Admit exact repository-v6 history from a native Kin remote and move the
+    /// workspace onto it
     #[command(visible_alias = "fetch")]
     Pull {
         /// Remote name (defaults to the configured default native-kin remote)

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,7 +40,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 30);
+    assert_eq!(report["ready_commands"], 31);
     assert_eq!(report["command_total"], 33);
 
     let commands = report["commands"]
@@ -121,16 +121,16 @@ fn remaining_open_gate_commands_fail_before_repository_discovery() {
     assert!(stderr.contains("not a Kin repository"), "{stderr}");
 }
 
-/// Push is wired to the transfer surface, not to the gate.
+/// Both transfer verbs are wired to the transfer surface, not to the gate.
 ///
-/// The flip that exposed it is a fixture edit, so nothing in the fixture can
-/// prove the dispatch arm reaches anything. Driving the real binary is what
+/// The flip that exposed each one is a fixture edit, so nothing in the fixture
+/// can prove the dispatch arm reaches anything. Driving the real binary is what
 /// proves it: the gate message must be absent and the transfer surface's own
-/// discovery failure must be present. Pull is still gated and is asserted in
-/// the same pass, so a gate that stopped refusing anything at all cannot pass
-/// this as a connected command.
+/// discovery failure must be present. Asserting the discovery message, and not
+/// merely the absence of the gate message, is what keeps a gate that stopped
+/// refusing anything at all from passing this as a connected command.
 #[test]
-fn push_reaches_the_transfer_surface_instead_of_the_capability_gate() {
+fn push_and_pull_reach_the_transfer_surface_instead_of_the_capability_gate() {
     let root = tempdir().expect("temp root");
     let home = root.path().join("home");
     std::fs::create_dir_all(&home).expect("create home");
@@ -158,15 +158,19 @@ fn push_reaches_the_transfer_surface_instead_of_the_capability_gate() {
         .args(["pull"])
         .current_dir(root.path())
         .output()
-        .expect("run gated pull outside a repository");
+        .expect("run exposed pull outside a repository");
     assert!(
         !output.status.success(),
         "pull must fail outside a repository"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("is fail-closed on repository-v6"),
-        "pull is still gated and must answer from the capability gate: {stderr}"
+        !stderr.contains("is fail-closed on repository-v6"),
+        "pull must no longer answer from the capability gate: {stderr}"
+    );
+    assert!(
+        stderr.contains("not a Kin repository"),
+        "pull must reach the transfer surface and fail on discovery: {stderr}"
     );
 }
 

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -199,7 +199,7 @@
       "evidence_tests": [
         "crates/kin-cli/tests/init_json.rs"
       ],
-      "note": "Git clone uses Git only as transport; Kin authority is admitted atomically from the completed clone."
+      "note": "Git clone uses Git only as transport; Kin authority is admitted atomically from the completed clone. Native Kin transport is an explicit open gate, so a clone cannot yet adopt a remote replica's repository identity. Adopting it is what both sides of a native transfer require, which is why `push` and `pull` are reachable today only between replicas that already share a repository id."
     },
     {
       "command": "migrate",
@@ -283,7 +283,8 @@
         "carry a closure larger than one negotiated envelope as an ordered sequence of packs, resuming from the last one admitted",
         "report a derived-view refresh that fails after authority is durable as a typed partial success rather than a server error",
         "transition the graph-derived workspace onto the admitted head through the same projection transaction a branch switch commits, so the working tree shows what was pulled",
-        "report a working tree that could not follow, naming what blocked it, without revoking the history that is already durable"
+        "report a working tree that could not follow, naming what blocked it, without revoking the history that is already durable",
+        "plan no workspace transition for a pull that admitted no history, so an ordinary no-op pull reports no working tree behind a head that never moved and exits clean"
       ],
       "evidence_tests": [
         "kin_remote::repository_transfer_negotiation::tests::a_pull_past_the_negotiated_envelope_admits_the_whole_gap_across_continuation_packs",
@@ -294,11 +295,14 @@
         "kin_daemon::api::tests::a_pull_moves_the_graph_owned_workspace_onto_the_admitted_head",
         "kin_daemon::api::tests::a_pull_onto_an_untracked_ref_reports_no_workspace_to_move",
         "kin_daemon::api::tests::a_pull_over_an_edited_projection_admits_history_and_reports_the_workspace_behind",
-        "kin_cli::commands::transfer::tests::a_workspace_that_stayed_behind_fails_the_command",
+        "kin_daemon::api::tests::a_pull_over_graph_owned_changes_reports_the_workspace_behind_without_naming_a_switch",
+        "kin_daemon::api::tests::a_pull_that_admits_nothing_reports_no_transition_over_an_edited_tree",
+        "kin_cli::commands::transfer::tests::a_workspace_that_stayed_behind_fails_the_command_in_every_output_mode",
+        "kin_cli::commands::transfer::tests::every_other_state_exits_clean_in_every_output_mode",
         "kin_cli::commands::transfer::tests::a_response_without_the_field_reads_as_unreported",
         "crates/kin-cli/tests/command_capabilities.rs::push_and_pull_reach_the_transfer_surface_instead_of_the_capability_gate"
       ],
-      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified, including a gap past one envelope, and the graph-owned workspace now follows the admitted head. Admission and the workspace transition are two repository transactions, not one: publication is atomic per pack and durable first, then the workspace moves onto the ref's final target through the same projection transaction `kin branch switch` commits, so a gap carried by several packs moves the working tree once rather than walking it through every intermediate head. Every workspace outcome is reported and none of them revokes the transfer. A workspace standing on another ref is reported as inapplicable; one that cannot move, because graph authority owns uncommitted state or a tracked path was edited outside Kin's seams, is reported as behind and the CLI exits non-zero so work chained onto the pull does not run against the head the pull replaced. Nothing is ever materialized over a tree that did not follow. One bound is inherited from repository-v6 admission rather than introduced here, and it is shared with `push` and the inbound receive route: a Native change that INTRODUCES an artifact must be published with the workspace mutation that admits it, and a transfer's receive transaction carries no workspace mutation, so natively authored history that adds a path is refused by name on the receiving replica. Native edits and removals, and all Git-origin history, transfer normally. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
+      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified, including a gap past one envelope, and the graph-owned workspace now follows the admitted head. Admission and the workspace transition are two repository transactions, not one: publication is atomic per pack and durable first, then the workspace moves onto the ref's final target through the same projection transaction `kin branch switch` commits, so a gap carried by several packs moves the working tree once rather than walking it through every intermediate head. Every workspace outcome is reported and none of them revokes the transfer. A workspace standing on another ref is reported as inapplicable; one that cannot move, because graph authority owns uncommitted state or a tracked path was edited outside Kin's seams, is reported as behind and the CLI exits non-zero in every output mode, including `--json`, so work chained onto the pull does not run against the head the pull replaced. Nothing is ever materialized over a tree that did not follow. A pull that admits no history plans no transition at all: no ref moved, so no working tree can be behind one, and the command reports that and exits clean. The cost is that a workspace an earlier pull left behind is not moved by the next pull; the remedy is the one the report already names, `kin branch switch` onto the pulled ref. A native pull is reachable today only between replicas that already share a repository id: `kin init` mints a fresh one, the daemon refuses an id that differs from its manifest, and the ref advertisement refuses a transfer between different identities, so the only thing that establishes a shared identity right now is a raw storage copy, which is what this command's own fixture does. Establishing it from a remote is native clone, which `clone` records as an open gate. One bound is inherited from repository-v6 admission rather than introduced here, and it is shared with `push` and the inbound receive route: a Native change that INTRODUCES an artifact must be published with the workspace mutation that admits it, and a transfer's receive transaction carries no workspace mutation, so natively authored history that adds a path is refused by name on the receiving replica. Native edits and removals, and all Git-origin history, transfer normally. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
     },
     {
       "command": "merge",

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -266,32 +266,39 @@
         "kin_daemon::api::tests::a_divergent_remote_refuses_the_push_over_http_and_moves_nothing",
         "kin_remote::repository_transfer_negotiation::tests::a_step_that_cannot_be_split_is_refused_by_name_rather_than_replanned",
         "kin_remote::repository_transfer_negotiation::tests::a_peer_whose_envelope_cannot_carry_the_smallest_step_is_refused_rather_than_looped_on",
-        "crates/kin-cli/tests/command_capabilities.rs::push_reaches_the_transfer_surface_instead_of_the_capability_gate"
+        "crates/kin-cli/tests/command_capabilities.rs::push_and_pull_reach_the_transfer_surface_instead_of_the_capability_gate"
       ],
-      "note": "Runs end to end between two Kin daemons over HTTP, including a gap larger than one negotiated envelope, which is published as an ordered sequence of packs rather than refused. Nothing spans those packs and this protocol does not claim it does: each is atomic on its own, and an interruption leaves the remote on the last receipted head. The remaining bound is a step that cannot be split, either one change whose new bodies exceed the negotiated byte limit or the smallest step a merge leaves reachable when that step exceeds a negotiated bound, which is refused by name rather than replanned. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
+      "note": "Runs end to end between two Kin daemons over HTTP, including a gap larger than one negotiated envelope, which is published as an ordered sequence of packs rather than refused. Nothing spans those packs and this protocol does not claim it does: each is atomic on its own, and an interruption leaves the remote on the last receipted head. The remaining bound is a step that cannot be split, either one change whose new bodies exceed the negotiated byte limit or the smallest step a merge leaves reachable when that step exceeds a negotiated bound, which is refused by name rather than replanned. One bound is inherited from repository-v6 admission and is shared with `pull` and the inbound receive route: a Native change that INTRODUCES an artifact must be published with the workspace mutation that admits it, and a transfer's receive transaction carries no workspace mutation, so natively authored history that adds a path is refused by name on the receiving replica. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
     },
     {
       "command": "pull",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "repository-v6 remote capability and exact transport",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
-        "DONE: read the remote ref advertisement, adopt its default ref when this replica has none, and fetch the exact exported closure",
-        "DONE: admit each pack in one local authority transaction and refuse a receipt that does not bind it",
-        "DONE: refuse a remote this replica already contains, naming the remote head",
-        "DONE: carry a closure larger than one negotiated envelope as an ordered sequence of packs, resuming from the last one admitted",
-        "DONE: report a derived-view refresh that fails after authority is durable as a typed partial success rather than a server error",
-        "OPEN: graph-derived workspace transition after admission, so a working tree follows the new head"
+        "read the remote ref advertisement, adopt its default ref when this replica has none, and fetch the exact exported closure",
+        "admit each pack in one local authority transaction and refuse a receipt that does not bind it",
+        "refuse a remote this replica already contains, naming the remote head",
+        "carry a closure larger than one negotiated envelope as an ordered sequence of packs, resuming from the last one admitted",
+        "report a derived-view refresh that fails after authority is durable as a typed partial success rather than a server error",
+        "transition the graph-derived workspace onto the admitted head through the same projection transaction a branch switch commits, so the working tree shows what was pulled",
+        "report a working tree that could not follow, naming what blocked it, without revoking the history that is already durable"
       ],
       "evidence_tests": [
         "kin_remote::repository_transfer_negotiation::tests::a_pull_past_the_negotiated_envelope_admits_the_whole_gap_across_continuation_packs",
         "kin_remote::repository_transfer_negotiation::tests::pull_admits_the_same_gap_from_the_other_side",
         "kin_remote::repository_transfer_negotiation::tests::pull_refuses_a_remote_this_replica_already_contains",
         "kin_daemon::api::tests::a_pull_whose_derived_refresh_fails_reports_partial_success_not_a_server_error",
-        "kin_daemon::api::tests::native_push_and_pull_move_exact_history_between_two_daemons_over_http"
+        "kin_daemon::api::tests::native_push_and_pull_move_exact_history_between_two_daemons_over_http",
+        "kin_daemon::api::tests::a_pull_moves_the_graph_owned_workspace_onto_the_admitted_head",
+        "kin_daemon::api::tests::a_pull_onto_an_untracked_ref_reports_no_workspace_to_move",
+        "kin_daemon::api::tests::a_pull_over_an_edited_projection_admits_history_and_reports_the_workspace_behind",
+        "kin_cli::commands::transfer::tests::a_workspace_that_stayed_behind_fails_the_command",
+        "kin_cli::commands::transfer::tests::a_response_without_the_field_reads_as_unreported",
+        "crates/kin-cli/tests/command_capabilities.rs::push_and_pull_reach_the_transfer_surface_instead_of_the_capability_gate"
       ],
-      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified, including a gap past one envelope. It stays closed for one reason only: admitting history does not move the workspace to the admitted head, so a working tree after `kin pull` still shows the old one. That is what a caller expects this command to do, and until it does, exposing it would promise a transition that does not happen."
+      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified, including a gap past one envelope, and the graph-owned workspace now follows the admitted head. Admission and the workspace transition are two repository transactions, not one: publication is atomic per pack and durable first, then the workspace moves onto the ref's final target through the same projection transaction `kin branch switch` commits, so a gap carried by several packs moves the working tree once rather than walking it through every intermediate head. Every workspace outcome is reported and none of them revokes the transfer. A workspace standing on another ref is reported as inapplicable; one that cannot move, because graph authority owns uncommitted state or a tracked path was edited outside Kin's seams, is reported as behind and the CLI exits non-zero so work chained onto the pull does not run against the head the pull replaced. Nothing is ever materialized over a tree that did not follow. One bound is inherited from repository-v6 admission rather than introduced here, and it is shared with `push` and the inbound receive route: a Native change that INTRODUCES an artifact must be published with the workspace mutation that admits it, and a transfer's receive transaction carries no workspace mutation, so natively authored history that adds a path is refused by name on the receiving replica. Native edits and removals, and all Git-origin history, transfer normally. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
     },
     {
       "command": "merge",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7629,7 +7629,8 @@ async fn command_pull(
                 None => kin_remote::repository_transfer_negotiation::remote_default_ref(
                     &transport,
                     &repository_id,
-                )?,
+                )
+                .map_err(|error| (error, 0usize))?,
             };
             let destination_ref = requested_destination_ref.unwrap_or_else(|| source_ref.clone());
             // Admission runs here rather than inside the negotiation helper so
@@ -7638,7 +7639,8 @@ async fn command_pull(
             // past one envelope arrives as several packs, and each takes that
             // path in turn.
             let mut refresh = DerivedViewRefresh::Current;
-            let outcome = kin_remote::repository_transfer_negotiation::pull_from_remote_with(
+            let mut admitted_packs = 0usize;
+            let admitted = kin_remote::repository_transfer_negotiation::pull_from_remote_with(
                 &authority,
                 &transport,
                 &repository_id,
@@ -7652,6 +7654,7 @@ async fn command_pull(
                         kin_model::AuthorId::new("kin-daemon:repository-transfer-puller"),
                         pack,
                     )?;
+                    admitted_packs += 1;
                     if local_derived_views && !refresh.is_stale() {
                         if let Err(detail) = refresh_local_derived_views(
                             &blocking_state,
@@ -7664,13 +7667,28 @@ async fn command_pull(
                     }
                     Ok(receipt)
                 },
-            )?;
-            Ok::<_, kin_remote::repository_transfer::RepositoryTransferError>((outcome, refresh))
+            );
+            // Bound as its own statement so the admit closure, and the borrows
+            // it holds, are gone before the count it kept is read back.
+            let outcome = admitted.map_err(|error| (error, admitted_packs))?;
+            Ok::<
+                _,
+                (
+                    kin_remote::repository_transfer::RepositoryTransferError,
+                    usize,
+                ),
+            >((outcome, refresh))
         })
         .await
         .map_err(internal_error)?
     };
-    let (outcome, mut derived_views) = outcome.map_err(repository_transfer_error)?;
+    let (outcome, mut derived_views) = outcome.map_err(|(error, admitted_packs)| {
+        let (status, message) = repository_transfer_error(error);
+        match interrupted_pull_report(admitted_packs) {
+            Some(report) => (status, format!("{message} {report}")),
+            None => (status, message),
+        }
+    })?;
 
     if !local_derived_views && outcome.moved_history() {
         state.repo_graphs.write().await.remove(&repo_id);
@@ -7680,13 +7698,29 @@ async fn command_pull(
     }
     record_derived_view_staleness(&state, &derived_views).await;
 
-    let workspace = pull_workspace_follow(
-        &state,
-        local_derived_views,
-        &derived_views,
-        &outcome.destination_ref,
-    )
-    .await;
+    // A pull that admitted nothing moved no ref, so no working tree can be
+    // behind a head that did not move. Planning the transition anyway answers an
+    // ordinary no-op pull with whatever the planner finds in the working copy,
+    // which is how a plain local edit came to be reported as authority having
+    // moved. It also pays the whole branch-switch planner on every `kin pull`.
+    //
+    // The cost of the guard is that a workspace an earlier pull left behind no
+    // longer completes on the next pull. That is the remedy the report already
+    // names: `kin branch switch` onto the pulled ref.
+    let workspace = if outcome.moved_history() {
+        pull_workspace_follow(
+            &state,
+            local_derived_views,
+            &derived_views,
+            &outcome.destination_ref,
+        )
+        .await
+    } else {
+        WorkspaceFollow::NotApplicable {
+            detail: "this pull admitted no history, so no ref moved for a working tree to follow"
+                .to_string(),
+        }
+    };
 
     Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
         outcome,
@@ -7695,12 +7729,34 @@ async fn command_pull(
     }))
 }
 
+/// Name what a pull left durable when it failed partway through a multi-pack
+/// gap, so the caller is not told a transfer that partly landed did nothing.
+///
+/// The protocol supports this interruption on purpose: each pack is its own
+/// repository transaction, so the ones that landed are durable and the
+/// destination ref has already moved with them. The workspace transition never
+/// ran, which means the working tree is now behind that ref and no
+/// `WorkspaceFollow` report reached the caller to say so.
+fn interrupted_pull_report(admitted_packs: usize) -> Option<String> {
+    if admitted_packs == 0 {
+        return None;
+    }
+    Some(format!(
+        "{admitted_packs} pack(s) were admitted before this failed and are durable, so this \
+         replica's destination ref has already moved while its working tree still shows the head \
+         it had before. Re-run the pull to resume from the last admitted pack; that run reports \
+         and completes the workspace transition."
+    ))
+}
+
 /// Move the graph-owned workspace onto the head this pull admitted.
 ///
 /// Runs after admission rather than inside it, because admission is atomic per
 /// pack while a workspace transition is one mutation onto the ref's final
 /// target. A gap carried by several packs therefore moves the working tree once,
-/// at the end, instead of walking it through every intermediate head.
+/// at the end, instead of walking it through every intermediate head. Its caller
+/// runs it only for a pull that admitted history, so every state it reports is a
+/// statement about a ref that did move.
 ///
 /// Every outcome here is reported, never raised. The admitted history is already
 /// durable and receipted; answering a caller with a failure would describe a
@@ -11829,19 +11885,21 @@ mod tests {
         drop(lease);
         drop(authority);
 
-        // Re-running finds both halves already where they belong: no history to
-        // admit, and no tree to move.
+        // Re-running finds both halves already where they belong. Nothing is
+        // admitted, so no ref moves, and the report says exactly that instead of
+        // describing a working tree measured against a head that did not move.
         let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
         assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
         let repeated: kin_cli::commands::transfer::CommandTransferResponse =
             serde_json::from_slice(&body).unwrap();
         assert!(repeated.outcome.receipts.is_empty());
-        assert_eq!(
-            repeated.workspace,
-            WorkspaceFollow::AlreadyCurrent {
-                authority_generation: advanced_generation
-            }
-        );
+        match &repeated.workspace {
+            WorkspaceFollow::NotApplicable { detail } => assert!(
+                detail.contains("admitted no history"),
+                "the report must name why no transition was planned: {detail}"
+            ),
+            other => panic!("a pull that admitted nothing plans no transition, got {other:?}"),
+        }
         assert_eq!(
             std::fs::read(&fixture.projected).unwrap(),
             b"services:\n  api: { image: peer }\n"
@@ -11927,6 +11985,165 @@ mod tests {
             std::fs::read(&fixture.projected).unwrap(),
             b"services:\n  api: { image: local }\n",
             "the caller's edit must survive a transfer that could not move the tree"
+        );
+    }
+
+    /// The everyday invocation: up to date with the peer, one tracked file
+    /// edited in an editor, `kin pull` run out of habit.
+    ///
+    /// Nothing is admitted, so no ref moves and no working tree can be behind
+    /// one. Planning the transition anyway would find the edit and report a
+    /// workspace that failed to follow a head that never moved, which fails the
+    /// command and asserts two things that are both false.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pull_that_admits_nothing_reports_no_transition_over_an_edited_tree() {
+        let fixture = workspace_follow_fixture(
+            "pull-noop-edited",
+            b"services:\n  api: { image: baseline }\n",
+            b"services:\n  api: { image: peer }\n",
+        )
+        .await;
+        let request = pull_request(&fixture.peer_url, &fixture.state.cached_repo_id);
+
+        // Reach "up to date with the peer" the way a caller does.
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(
+            matches!(pulled.workspace, WorkspaceFollow::Advanced { .. }),
+            "the first pull moves the tree, got {:?}",
+            pulled.workspace
+        );
+
+        std::fs::write(&fixture.projected, b"services:\n  api: { image: local }\n").unwrap();
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let repeated: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(
+            !repeated.outcome.moved_history(),
+            "the second pull has nothing left to admit"
+        );
+        assert!(
+            !repeated.workspace.is_behind(),
+            "nothing moved for this working tree to be behind of: {:?}",
+            repeated.workspace
+        );
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: local }\n",
+            "a pull that admitted nothing may not touch the caller's edit"
+        );
+    }
+
+    /// The refusal a follow owes a workspace that holds uncommitted state graph
+    /// authority already owns: the history still lands, the tree does not move,
+    /// and the refusal names the operation the caller actually ran.
+    ///
+    /// Reaching that state means going through the daemon. Bytes edited on disk
+    /// are projection drift, which is a different branch with a different
+    /// refusal; a stash seal followed by a restore is how a real workspace comes
+    /// to hold changes the compare-and-swap owns.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pull_over_graph_owned_changes_reports_the_workspace_behind_without_naming_a_switch()
+    {
+        let fixture = workspace_follow_fixture(
+            "pull-graph-owned-changes",
+            b"services:\n  api: { image: baseline }\n",
+            b"services:\n  api: { image: peer }\n",
+        )
+        .await;
+        std::fs::write(&fixture.projected, b"services:\n  api: { image: staged }\n").unwrap();
+        let (status, body) = post_stash_request(Arc::clone(&fixture.state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let (status, body) = post_stash_request(Arc::clone(&fixture.state), &stash_pop()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        let layout = kin_core::KinLayout::discover(&fixture.working).unwrap();
+        let authority = ActiveApiRepositoryAuthority::open_layout_for_test(&layout).unwrap();
+        let lease = authority.manager.read_authority();
+        let dirty = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .unwrap()
+            .is_dirty();
+        drop(lease);
+        drop(authority);
+        assert!(
+            dirty,
+            "the fixture must reach uncommitted state graph authority owns, not host drift"
+        );
+
+        let request = pull_request(&fixture.peer_url, &fixture.state.cached_repo_id);
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            pulled
+                .outcome
+                .final_receipt()
+                .expect("history is admitted regardless of the working tree")
+                .destination_head,
+            fixture.peer_head,
+            "a workspace that cannot follow must not cost the caller the transfer"
+        );
+        match &pulled.workspace {
+            WorkspaceFollow::Behind { detail } => {
+                assert!(
+                    detail.contains("has graph-owned changes"),
+                    "the report must name what blocked the transition: {detail}"
+                );
+                assert!(
+                    detail.contains("follow the ref the transfer moved"),
+                    "a caller who ran a pull is not part-way through a branch switch: {detail}"
+                );
+            }
+            other => panic!("uncommitted graph-owned state cannot be discarded, got {other:?}"),
+        }
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: staged }\n",
+            "the caller's uncommitted state must survive a transfer that could not move the tree"
+        );
+
+        // The gap is closed now, so the next pull admits nothing. It must not
+        // repeat a refusal about a head that no longer moves.
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let repeated: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(!repeated.outcome.moved_history());
+        assert!(
+            !repeated.workspace.is_behind(),
+            "a pull that admitted nothing reports no workspace behind it: {:?}",
+            repeated.workspace
+        );
+    }
+
+    /// An interrupted multi-pack pull left every pack it admitted durable, and
+    /// the destination ref moved with them. The workspace report never runs on
+    /// that path, so the error is the only place that state can be named.
+    #[test]
+    fn an_interrupted_multi_pack_pull_names_what_it_left_durable() {
+        assert!(
+            interrupted_pull_report(0).is_none(),
+            "a pull that admitted nothing has nothing durable to report"
+        );
+        let report = interrupted_pull_report(2).expect("admitted packs are reported");
+        assert!(report.contains("2 pack(s)"), "{report}");
+        assert!(
+            report.contains("working tree still shows the head it had before"),
+            "the caller has to be told the tree is now behind the moved ref: {report}"
+        );
+        assert!(
+            report.contains("Re-run the pull"),
+            "the remedy is resumption, not repair: {report}"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7727,6 +7727,13 @@ async fn pull_workspace_follow(
             ),
         };
     }
+    // Take the gate every other command that mutates this workspace takes, in
+    // the same order, so a transition does not merely lose a race against a
+    // concurrent commit or branch switch and report itself behind. Admission
+    // has already happened and does not hold this, so the gate covers the
+    // transition alone; the workspace compare-and-swap is still what makes the
+    // outcome safe rather than this lock.
+    let _coordination = state.coordination_gate.lock().await;
     let state = Arc::clone(state);
     let destination_ref = destination_ref.clone();
     // Authority reads, projection IO, and the workspace commit all block, so

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -28,7 +28,7 @@ use kin_model::{
 };
 // One declared bound governs both directions: what these routes accept is what
 // the transfer client reads.
-use kin_cli::commands::transfer::DerivedViewRefresh;
+use kin_cli::commands::transfer::{DerivedViewRefresh, WorkspaceFollow};
 use kin_remote::repository_transfer_http::REPOSITORY_TRANSFER_HTTP_BODY_LIMIT;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -7586,8 +7586,12 @@ async fn command_push(
     Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
         outcome,
         // A push moves the remote's authority, not this replica's, so nothing
-        // derived from local authority is behind after it.
+        // derived from local authority is behind after it, and this replica's
+        // workspace has nothing to follow.
         derived_views: DerivedViewRefresh::Current,
+        workspace: WorkspaceFollow::NotApplicable {
+            detail: "a push moves the remote's authority; this workspace is unchanged".to_string(),
+        },
     }))
 }
 
@@ -7676,10 +7680,72 @@ async fn command_pull(
     }
     record_derived_view_staleness(&state, &derived_views).await;
 
+    let workspace = pull_workspace_follow(
+        &state,
+        local_derived_views,
+        &derived_views,
+        &outcome.destination_ref,
+    )
+    .await;
+
     Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
         outcome,
         derived_views,
+        workspace,
     }))
+}
+
+/// Move the graph-owned workspace onto the head this pull admitted.
+///
+/// Runs after admission rather than inside it, because admission is atomic per
+/// pack while a workspace transition is one mutation onto the ref's final
+/// target. A gap carried by several packs therefore moves the working tree once,
+/// at the end, instead of walking it through every intermediate head.
+///
+/// Every outcome here is reported, never raised. The admitted history is already
+/// durable and receipted; answering a caller with a failure would describe a
+/// transfer that did happen as one that did not.
+async fn pull_workspace_follow(
+    state: &Arc<DaemonState>,
+    local_derived_views: bool,
+    derived_views: &DerivedViewRefresh,
+    destination_ref: &kin_model::RefName,
+) -> WorkspaceFollow {
+    if !local_derived_views {
+        return WorkspaceFollow::NotApplicable {
+            detail: "hosted snapshot authority serves no local working tree".to_string(),
+        };
+    }
+    // The transition plans its target from the daemon's own graph, so a graph
+    // that did not follow authority cannot be the thing a working tree is
+    // materialized from. Refusing here keeps a stale derived view from being
+    // projected onto disk as if it were the admitted head.
+    if let DerivedViewRefresh::Stale { detail } = derived_views {
+        return WorkspaceFollow::Behind {
+            detail: format!(
+                "the views this transition plans from are behind the admitted head: {detail}"
+            ),
+        };
+    }
+    let state = Arc::clone(state);
+    let destination_ref = destination_ref.clone();
+    // Authority reads, projection IO, and the workspace commit all block, so
+    // they must not run on the executor that also serves this daemon's own
+    // transfer seam.
+    match tokio::task::spawn_blocking(move || {
+        crate::repository_branch::follow_moved_ref(
+            &state,
+            &destination_ref,
+            &kin_model::AuthorId::new("kin-daemon:repository-transfer-puller"),
+        )
+    })
+    .await
+    {
+        Ok(follow) => follow,
+        Err(error) => WorkspaceFollow::Behind {
+            detail: format!("workspace transition task did not complete: {error}"),
+        },
+    }
 }
 
 /// POST /commands/transfer-plan — negotiate a publication without moving any
@@ -11231,6 +11297,96 @@ mod tests {
         format!("http://127.0.0.1:{port}")
     }
 
+    /// Advance a peer replica by one exact native change that edits an artifact
+    /// the replica already holds, and move `branch` onto it.
+    ///
+    /// Deliberately an edit rather than an addition. Repository-v6 binds a
+    /// native change that INTRODUCES an artifact to the workspace mutation that
+    /// publishes it, and a transfer's receive transaction carries no workspace
+    /// mutation, so native history that introduces artifacts cannot be admitted
+    /// by any pull today. Editing an artifact the destination already holds is
+    /// what a native transfer can actually carry, so it is what this proves.
+    fn advance_peer_artifact(
+        storage: &FsPath,
+        repository_id: &RepositoryId,
+        branch: &[u8],
+        previous_head: kin_model::SemanticChangeId,
+        previous_target: kin_model::RefTarget,
+        artifact_id: kin_model::ArtifactId,
+        old: kin_model::LocatedEntry,
+        body: &[u8],
+    ) -> kin_model::SemanticChangeId {
+        use kin_model::{
+            compute_semantic_change_id, ChangeOrigin, LocatedEntry, RefExpectation, RefMutation,
+            RefTarget, RefUpdatePolicy, RepositoryTransaction, SemanticChange, TreeDelta,
+            TreeEntry, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        };
+
+        let manager = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(storage.to_path_buf())),
+        )
+        .unwrap();
+        let digest = Hash256::from_bytes(
+            <[u8; 32]>::try_from(<sha2::Sha256 as sha2::Digest>::digest(body).as_slice()).unwrap(),
+        );
+        manager.save_source_blob(digest, body).unwrap();
+        let branch_ref = kin_model::RefName::branch(branch).unwrap();
+        let mut change = SemanticChange {
+            id: kin_model::SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+            origin: ChangeOrigin::Native,
+            parents: vec![previous_head],
+            timestamp: kin_model::Timestamp::now(),
+            author: kin_model::AuthorId::new("transfer-workspace-e2e"),
+            message: "edit the projected artifact on the peer".to_string(),
+            entity_deltas: Vec::new(),
+            relation_deltas: Vec::new(),
+            tree_deltas: vec![TreeDelta::Updated {
+                artifact_id,
+                new: LocatedEntry::new(old.path.clone(), TreeEntry::blob(digest, false)),
+                old,
+            }],
+            admission_policy_delta: None,
+            projected_files: Vec::new(),
+            spec_link: None,
+            evidence: Vec::new(),
+            risk_summary: None,
+            external_reference_deltas: Vec::new(),
+        };
+        change.id = compute_semantic_change_id(&change).unwrap();
+
+        let lease = manager.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: kin_model::OperationId::new(),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: kin_model::AuthorId::new("transfer-workspace-e2e"),
+            reason: "edit the projected artifact on the peer".to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: vec![change.clone()],
+            aliases: Vec::new(),
+            ref_mutations: vec![RefMutation {
+                name: branch_ref,
+                expected: RefExpectation::MustEqual {
+                    target: previous_target,
+                },
+                new_target: Some(RefTarget::change(change.id)),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }],
+            default_ref_mutation: None,
+            workspace_mutation: None,
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+        };
+        drop(lease);
+        manager.commit_repository_transaction(transaction).unwrap();
+        change.id
+    }
+
     /// A daemon backed by its own empty repository-v6 storage under `repo_id`.
     fn replica_state(repo_id: &str) -> (Arc<DaemonState>, tempfile::TempDir, tempfile::TempDir) {
         install_test_registry_override();
@@ -11469,6 +11625,301 @@ mod tests {
         assert_eq!(
             pulled.derived_views,
             kin_cli::commands::transfer::DerivedViewRefresh::Current
+        );
+    }
+
+    /// Two replicas of ONE repository: a real local one with a graph-owned
+    /// workspace projecting into a working directory, and a peer that forked
+    /// from it and has since moved `refs/heads/main` ahead by one exact edit.
+    ///
+    /// The peer is a copy of this replica's own storage rather than a separate
+    /// repository, because a transfer only exists between replicas of the same
+    /// repository identity: the ref advertisement refuses anything else. This is
+    /// the local half of what a native clone will establish.
+    struct WorkspaceFollowFixture {
+        state: Arc<DaemonState>,
+        working: PathBuf,
+        projected: PathBuf,
+        peer_url: String,
+        peer_head: kin_model::SemanticChangeId,
+        _peer_storage: tempfile::TempDir,
+    }
+
+    #[cfg(unix)]
+    async fn workspace_follow_fixture(
+        label: &str,
+        first_body: &[u8],
+        second_body: &[u8],
+    ) -> WorkspaceFollowFixture {
+        const PATH: &str = "service/compose.yaml";
+
+        install_test_registry_override();
+        let working =
+            std::env::temp_dir().join(format!("kin-daemon-{label}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(working.join("service")).unwrap();
+        run_test_git(&working, ["init", "--initial-branch=main"]);
+        run_test_git(&working, ["config", "user.email", "kin@example.invalid"]);
+        run_test_git(&working, ["config", "user.name", "Kin Pull Route Test"]);
+        std::fs::write(working.join(PATH), first_body).unwrap();
+        run_test_git(&working, ["add", "--all"]);
+        run_test_git(&working, ["commit", "-s", "-m", "projected baseline"]);
+
+        let layout = kin_core::init_from_git(&working).unwrap().layout;
+        let repo_id = kin_core::manifest::KinManifest::load(&layout.manifest_path())
+            .unwrap()
+            .repo_id;
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        // Read the exact identity the peer's edit has to update. A native edit
+        // that invented a new artifact id would introduce an artifact, which is
+        // a different admission contract.
+        let authority = ActiveApiRepositoryAuthority::open_layout_for_test(&layout).unwrap();
+        let lease = authority.manager.read_authority();
+        let main = kin_model::RefName::branch(b"main").unwrap();
+        let target = lease.resolve_ref_target(&main).unwrap().unwrap();
+        let baseline = lease.resolve_target_change_id(&target).unwrap();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .unwrap()
+            .clone();
+        let baseline_artifact = workspace
+            .tree
+            .artifacts_by_path()
+            .find(|artifact| artifact.path.as_bytes() == PATH.as_bytes())
+            .expect("the admitted baseline projects the fixture path");
+        let artifact_id = baseline_artifact.artifact_id;
+        let old_entry =
+            kin_model::LocatedEntry::new(baseline_artifact.path.clone(), baseline_artifact.entry);
+        drop(lease);
+        drop(authority);
+
+        // Fork the peer from this replica's storage, then advance only the peer.
+        let peer_storage = tempfile::tempdir().unwrap();
+        let peer_root = peer_storage.path().join("kindb");
+        copy_test_directory(&layout.kindb_dir(), &peer_root);
+        let peer_head = advance_peer_artifact(
+            &peer_root,
+            &repository_id,
+            b"main",
+            baseline,
+            target,
+            artifact_id,
+            old_entry,
+            second_body,
+        );
+
+        let state = Arc::new(DaemonState::open_with_repo_id(layout, None).unwrap());
+        let peer_working = tempfile::tempdir().unwrap();
+        let peer_layout = kin_core::init(peer_working.path()).unwrap().layout;
+        let peer_state = Arc::new(
+            DaemonState::open_with_backend(
+                peer_layout,
+                Box::new(kin_db::LocalFileBackend::new(peer_root)),
+                &repo_id,
+                None,
+            )
+            .unwrap(),
+        );
+        let peer_url = serve_replica(peer_state).await;
+        // The peer working directory only exists so the peer daemon has a
+        // layout; nothing projects into it. Leaking it keeps it alive for the
+        // duration of the test.
+        std::mem::forget(peer_working);
+
+        WorkspaceFollowFixture {
+            projected: working.join(PATH),
+            working,
+            state,
+            peer_url,
+            peer_head,
+            _peer_storage: peer_storage,
+        }
+    }
+
+    fn pull_request(
+        url: &str,
+        repo_id: &str,
+    ) -> kin_cli::commands::transfer::CommandTransferRequest {
+        kin_cli::commands::transfer::CommandTransferRequest {
+            remote_base_url: url.to_string(),
+            remote_token: None,
+            repository_id: Some(repo_id.to_string()),
+            source_ref: None,
+            destination_ref: None,
+        }
+    }
+
+    /// The gate this command was held closed on: admitting history has to move
+    /// the working tree, not just the ref.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pull_moves_the_graph_owned_workspace_onto_the_admitted_head() {
+        let fixture = workspace_follow_fixture(
+            "pull-follows",
+            b"services:\n  api: { image: baseline }\n",
+            b"services:\n  api: { image: peer }\n",
+        )
+        .await;
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: baseline }\n",
+            "the replica starts on the head it admitted from Git"
+        );
+
+        let request = pull_request(&fixture.peer_url, &fixture.state.cached_repo_id);
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            pulled
+                .outcome
+                .final_receipt()
+                .expect("a moved head returns a receipt")
+                .destination_head,
+            fixture.peer_head
+        );
+        assert_eq!(
+            pulled.derived_views,
+            kin_cli::commands::transfer::DerivedViewRefresh::Current
+        );
+        let advanced_generation = match &pulled.workspace {
+            WorkspaceFollow::Advanced {
+                authority_generation,
+                ..
+            } => *authority_generation,
+            other => panic!("the working tree must follow the admitted head, got {other:?}"),
+        };
+
+        // The claim is bytes on disk, so the assertion is bytes on disk.
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: peer }\n",
+            "the working tree must show the head the pull admitted"
+        );
+
+        // Authority and the workspace agree, and both are what the response
+        // reported. A projection that matched by luck would not survive this.
+        let layout = kin_core::KinLayout::discover(&fixture.working).unwrap();
+        let authority = ActiveApiRepositoryAuthority::open_layout_for_test(&layout).unwrap();
+        let lease = authority.manager.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .unwrap()
+            .clone();
+        assert_eq!(lease.roots().generation, advanced_generation);
+        assert_eq!(
+            workspace.base_target,
+            Some(kin_model::RefTarget::change(fixture.peer_head))
+        );
+        assert!(!workspace.is_dirty());
+        drop(lease);
+        drop(authority);
+
+        // Re-running finds both halves already where they belong: no history to
+        // admit, and no tree to move.
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let repeated: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(repeated.outcome.receipts.is_empty());
+        assert_eq!(
+            repeated.workspace,
+            WorkspaceFollow::AlreadyCurrent {
+                authority_generation: advanced_generation
+            }
+        );
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: peer }\n"
+        );
+    }
+
+    /// A pull onto a ref nobody is standing on is not a working tree that fell
+    /// behind. Reporting it as one would train a caller to ignore the report
+    /// that matters.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pull_onto_an_untracked_ref_reports_no_workspace_to_move() {
+        let fixture = workspace_follow_fixture(
+            "pull-untracked-ref",
+            b"services:\n  api: { image: baseline }\n",
+            b"services:\n  api: { image: peer }\n",
+        )
+        .await;
+        let mut request = pull_request(&fixture.peer_url, &fixture.state.cached_repo_id);
+        request.source_ref = Some(kin_model::RefName::branch(b"main").unwrap());
+        request.destination_ref = Some(kin_model::RefName::branch(b"imported").unwrap());
+
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(
+            pulled.outcome.moved_history(),
+            "history still lands on the ref that was named"
+        );
+        match &pulled.workspace {
+            WorkspaceFollow::NotApplicable { detail } => assert!(
+                detail.contains("does not track"),
+                "the report must name why nothing moved: {detail}"
+            ),
+            other => panic!("an untracked ref moves no working tree, got {other:?}"),
+        }
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: baseline }\n",
+            "a ref this workspace does not follow may not touch the working tree"
+        );
+    }
+
+    /// History still lands, the caller's edited file survives untouched, and the
+    /// response says both instead of picking one of those truths to report.
+    ///
+    /// This is the case a transfer must never resolve by overwriting: the pull
+    /// carries bytes for a path the caller has since edited outside Kin's seams.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pull_over_an_edited_projection_admits_history_and_reports_the_workspace_behind() {
+        let fixture = workspace_follow_fixture(
+            "pull-edited-projection",
+            b"services:\n  api: { image: baseline }\n",
+            b"services:\n  api: { image: peer }\n",
+        )
+        .await;
+        std::fs::write(&fixture.projected, b"services:\n  api: { image: local }\n").unwrap();
+
+        let request = pull_request(&fixture.peer_url, &fixture.state.cached_repo_id);
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            pulled
+                .outcome
+                .final_receipt()
+                .expect("history is admitted regardless of the working tree")
+                .destination_head,
+            fixture.peer_head,
+            "a workspace that cannot follow must not cost the caller the transfer"
+        );
+        match &pulled.workspace {
+            WorkspaceFollow::Behind { detail } => assert!(
+                detail.contains("diverge from the graph-owned workspace projection"),
+                "the report must name what blocked the transition: {detail}"
+            ),
+            other => panic!("an edited projection cannot be silently replaced, got {other:?}"),
+        }
+        assert_eq!(
+            std::fs::read(&fixture.projected).unwrap(),
+            b"services:\n  api: { image: local }\n",
+            "the caller's edit must survive a transfer that could not move the tree"
         );
     }
 

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -28,13 +28,6 @@ const DELETE_REASON: &str = "delete exact repository branch";
 const SWITCH_REASON: &str = "switch exact repository workspace branch";
 const FOLLOW_REASON: &str = "follow exact repository ref admitted by transfer";
 
-/// Internal discriminator for "this workspace stands on another ref".
-///
-/// It never reaches a client. `follow_moved_ref` is the only caller that can
-/// raise the condition and the only one that reads this back, so the status is
-/// a typed channel between them rather than a wire contract.
-const WORKSPACE_TRACKS_ANOTHER_REF: StatusCode = StatusCode::NO_CONTENT;
-
 /// Why a workspace is being transitioned onto a ref's current target.
 ///
 /// Both transitions publish the same workspace mutation against the same
@@ -98,6 +91,43 @@ impl std::fmt::Display for WorkspaceTracksAnotherRef {
 
 impl std::error::Error for WorkspaceTracksAnotherRef {}
 
+/// How a planned workspace mutation refused.
+///
+/// The tracks-another-ref case is deliberately not carried as an HTTP status.
+/// It is not an answer any client can be given: it means a transfer moved a ref
+/// this workspace does not stand on, which only `follow_moved_ref` asks about
+/// and only it reads back. Giving it a status would let a branch route answer
+/// with it and still compile, and the status it needed to be distinguishable by
+/// was one that may not carry a body. Keeping it a variant instead of a code is
+/// what makes the illegal response unrepresentable rather than merely
+/// documented.
+enum WorkspaceMutationRefusal {
+    /// A refusal a client is told, as the status and message it is told with.
+    Client(StatusCode, String),
+    /// This workspace stands on a different ref than the one a transfer moved.
+    TracksAnotherRef(String),
+}
+
+impl From<(StatusCode, String)> for WorkspaceMutationRefusal {
+    fn from((status, message): (StatusCode, String)) -> Self {
+        Self::Client(status, message)
+    }
+}
+
+impl WorkspaceMutationRefusal {
+    /// Answer a client. A branch command always transitions under
+    /// `TransitionPolicy::Switch`, which never raises the tracks-another-ref
+    /// case, so this arm is unreachable from a branch route; it maps to a
+    /// conflict rather than panicking, because an answer that is merely wrong
+    /// beats one that takes the daemon down.
+    fn into_client_response(self) -> (StatusCode, String) {
+        match self {
+            Self::Client(status, message) => (status, message),
+            Self::TracksAnotherRef(detail) => (StatusCode::CONFLICT, detail),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct BranchBadRequest(String);
 
@@ -121,10 +151,22 @@ fn branch_bad_request(message: impl Into<String>) -> anyhow::Error {
 /// owns. Only admitted state reaches this: unadmitted working-copy bytes are
 /// reported as projection drift instead, so the wording never describes host
 /// content that has not crossed the repository-v6 compare-and-swap.
-fn graph_owned_changes(workspace: &kin_model::WorkspaceState) -> anyhow::Error {
+///
+/// The remedy names what the caller actually asked for. A caller who ran a pull
+/// is not switching branches, and telling them to finish doing so describes an
+/// operation they never started.
+fn graph_owned_changes(
+    workspace: &kin_model::WorkspaceState,
+    policy: TransitionPolicy,
+) -> anyhow::Error {
+    let remedy = match policy {
+        TransitionPolicy::Switch => "before switching branches",
+        TransitionPolicy::FollowMovedRef => {
+            "before this workspace can follow the ref the transfer moved"
+        }
+    };
     branch_conflict(format!(
-        "workspace {} has graph-owned changes; commit or explicitly preserve them before \
-         switching branches",
+        "workspace {} has graph-owned changes; commit or explicitly preserve them {remedy}",
         workspace.workspace_id
     ))
 }
@@ -164,6 +206,7 @@ pub(crate) fn execute(
             TransitionPolicy::Switch,
         ),
     })
+    .map_err(WorkspaceMutationRefusal::into_client_response)
 }
 
 /// Move the graph-owned workspace onto the current target of the ref it already
@@ -201,8 +244,10 @@ pub(crate) fn follow_moved_ref(
         Ok(response) => WorkspaceFollow::AlreadyCurrent {
             authority_generation: response.authority_generation.unwrap_or_default(),
         },
-        Err((WORKSPACE_TRACKS_ANOTHER_REF, detail)) => WorkspaceFollow::NotApplicable { detail },
-        Err((_, detail)) => WorkspaceFollow::Behind { detail },
+        Err(WorkspaceMutationRefusal::TracksAnotherRef(detail)) => {
+            WorkspaceFollow::NotApplicable { detail }
+        }
+        Err(WorkspaceMutationRefusal::Client(_, detail)) => WorkspaceFollow::Behind { detail },
     }
 }
 
@@ -211,13 +256,13 @@ pub(crate) fn follow_moved_ref(
 fn run_workspace_mutation<Plan>(
     state: &DaemonState,
     plan: Plan,
-) -> std::result::Result<BranchResponse, (StatusCode, String)>
+) -> std::result::Result<BranchResponse, WorkspaceMutationRefusal>
 where
     Plan: FnOnce(&DaemonState, &ActiveLocalRepositoryAuthority) -> Result<BranchCommandOutcome>,
 {
     let graph_mutation = state.begin_graph_authority_mutation();
     let persistence = state.persist_lock.lock().map_err(|_| {
-        (
+        WorkspaceMutationRefusal::Client(
             StatusCode::INTERNAL_SERVER_ERROR,
             "daemon persistence lock poisoned".to_string(),
         )
@@ -240,7 +285,7 @@ where
         .repository_command_fail_after_authority_once
         .swap(false, std::sync::atomic::Ordering::SeqCst)
     {
-        return Err((
+        return Err(WorkspaceMutationRefusal::Client(
             StatusCode::INTERNAL_SERVER_ERROR,
             "injected failure after branch authority commit".to_string(),
         ));
@@ -654,7 +699,7 @@ fn switch(
     // the history it would refuse over is already durable and a workspace that
     // is already at the moved ref has nothing to refuse about.
     if policy == TransitionPolicy::Switch && workspace.is_dirty() {
-        return Err(graph_owned_changes(&workspace));
+        return Err(graph_owned_changes(&workspace, policy));
     }
     if policy == TransitionPolicy::FollowMovedRef
         && !matches!(&workspace.head, WorkspaceHead::Symbolic { target } if target == name)
@@ -777,7 +822,7 @@ fn switch(
     // tree out from under it would discard work the compare-and-swap already
     // owns, so the transition stops here and the transfer reports it.
     if policy == TransitionPolicy::FollowMovedRef && workspace.is_dirty() {
-        return Err(graph_owned_changes(&workspace));
+        return Err(graph_owned_changes(&workspace, policy));
     }
     let transaction = RepositoryTransaction {
         schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
@@ -1199,14 +1244,18 @@ fn render_target(target: &RefTarget) -> String {
     }
 }
 
-fn classify_branch_error(error: anyhow::Error) -> (StatusCode, String) {
-    // Nothing to do is not a failure, and a follow tells the two apart by this
-    // status rather than by reading the message it would otherwise have to
-    // pattern-match. No branch command can produce it: the marker type is
-    // raised only under `TransitionPolicy::FollowMovedRef`.
+fn classify_branch_error(error: anyhow::Error) -> WorkspaceMutationRefusal {
+    // Nothing to do is not a failure, and a follow tells it apart from one by
+    // the variant rather than by reading a message it would have to
+    // pattern-match. It is raised only under `TransitionPolicy::FollowMovedRef`,
+    // and it carries no status because no client is ever answered with it.
     if error.downcast_ref::<WorkspaceTracksAnotherRef>().is_some() {
-        return (WORKSPACE_TRACKS_ANOTHER_REF, format!("{error:#}"));
+        return WorkspaceMutationRefusal::TracksAnotherRef(format!("{error:#}"));
     }
+    client_branch_refusal(error).into()
+}
+
+fn client_branch_refusal(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<BranchBadRequest>().is_some() {
         return (StatusCode::BAD_REQUEST, format!("{error:#}"));
     }

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -8,6 +8,7 @@ use axum::http::StatusCode;
 use kin_cli::commands::branch::{
     BranchListEntry, BranchListReport, BranchRequest, BranchResponse, BRANCH_LIST_SCHEMA,
 };
+use kin_cli::commands::transfer::WorkspaceFollow;
 use kin_db::{LocalFileBackend, LocalRepositoryAuthorityFreeze, RepositoryAuthorityManager};
 use kin_model::{
     compute_resolved_tree_hash, AuthorId, ChangeStore, EffectiveAdmissionPolicyStamp, EntityStore,
@@ -25,6 +26,35 @@ use crate::state::{DaemonEvent, DaemonState};
 const CREATE_REASON: &str = "create exact repository branch";
 const DELETE_REASON: &str = "delete exact repository branch";
 const SWITCH_REASON: &str = "switch exact repository workspace branch";
+const FOLLOW_REASON: &str = "follow exact repository ref admitted by transfer";
+
+/// Internal discriminator for "this workspace stands on another ref".
+///
+/// It never reaches a client. `follow_moved_ref` is the only caller that can
+/// raise the condition and the only one that reads this back, so the status is
+/// a typed channel between them rather than a wire contract.
+const WORKSPACE_TRACKS_ANOTHER_REF: StatusCode = StatusCode::NO_CONTENT;
+
+/// Why a workspace is being transitioned onto a ref's current target.
+///
+/// Both transitions publish the same workspace mutation against the same
+/// compare-and-swap; they differ in what a caller asked for, and therefore in
+/// which refusal is the honest one.
+///
+/// A switch is a request to leave the current head, so uncommitted graph-owned
+/// state is a reason to refuse before anything is resolved: the caller can
+/// commit and ask again, and nothing has happened in the meantime. A follow is
+/// the second half of a transfer whose history is already durable, so the same
+/// state is not a reason to refuse the transfer that already landed. It is
+/// reported once the transition is known to be needed, which is why the
+/// already-at-target case is settled first here and last there.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransitionPolicy {
+    /// A caller named the ref to stand on.
+    Switch,
+    /// A transfer moved the ref this workspace already tracks.
+    FollowMovedRef,
+}
 
 struct BranchExecution {
     response: BranchResponse,
@@ -51,6 +81,22 @@ impl std::fmt::Display for BranchConflict {
 }
 
 impl std::error::Error for BranchConflict {}
+
+/// The workspace stands on a different ref than the one a transfer moved.
+///
+/// Distinct from a conflict on purpose: nothing is wrong and nothing needs
+/// resolving, so a follow reports it as inapplicable rather than as a working
+/// tree that fell behind.
+#[derive(Debug)]
+struct WorkspaceTracksAnotherRef(String);
+
+impl std::fmt::Display for WorkspaceTracksAnotherRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for WorkspaceTracksAnotherRef {}
 
 #[derive(Debug)]
 struct BranchBadRequest(String);
@@ -93,6 +139,82 @@ pub(crate) fn execute(
         return list(&authority).map_err(internal_branch_error);
     }
 
+    run_workspace_mutation(state, |state, authority| match request {
+        BranchRequest::List => unreachable!("list returned before mutation gates"),
+        BranchRequest::Create {
+            name,
+            operation_id,
+            actor,
+        } => create(state, authority, name, *operation_id, actor).map(BranchCommandOutcome::Commit),
+        BranchRequest::Delete {
+            name,
+            operation_id,
+            actor,
+        } => delete(state, authority, name, *operation_id, actor).map(BranchCommandOutcome::Commit),
+        BranchRequest::Switch {
+            name,
+            operation_id,
+            actor,
+        } => switch(
+            state,
+            authority,
+            name,
+            *operation_id,
+            actor,
+            TransitionPolicy::Switch,
+        ),
+    })
+}
+
+/// Move the graph-owned workspace onto the current target of the ref it already
+/// tracks, after a transfer admitted history onto that ref.
+///
+/// Publication and the workspace transition are two repository transactions on
+/// purpose. The first is atomic per pack and is already durable when this runs,
+/// so this cannot revoke it and never reports a transition failure as a failed
+/// transfer. It answers only what the working tree did.
+pub(crate) fn follow_moved_ref(
+    state: &DaemonState,
+    name: &RefName,
+    actor: &AuthorId,
+) -> WorkspaceFollow {
+    // A fresh operation id every time is deliberate. Idempotence here is a
+    // property of state, not of a caller-stable identifier: the already-current
+    // check settles a repeated pull, and the workspace compare-and-swap settles
+    // a concurrent one. A retried pull is a new negotiation, so there is no
+    // earlier operation for it to replay.
+    let outcome = run_workspace_mutation(state, |state, authority| {
+        switch(
+            state,
+            authority,
+            name,
+            OperationId::new(),
+            actor,
+            TransitionPolicy::FollowMovedRef,
+        )
+    });
+    match outcome {
+        Ok(response) if response.mutated => WorkspaceFollow::Advanced {
+            detail: response.lines.join("; "),
+            authority_generation: response.authority_generation.unwrap_or_default(),
+        },
+        Ok(response) => WorkspaceFollow::AlreadyCurrent {
+            authority_generation: response.authority_generation.unwrap_or_default(),
+        },
+        Err((WORKSPACE_TRACKS_ANOTHER_REF, detail)) => WorkspaceFollow::NotApplicable { detail },
+        Err((_, detail)) => WorkspaceFollow::Behind { detail },
+    }
+}
+
+/// Run one planned workspace mutation under the daemon's authority, persistence,
+/// and graph-mutation gates, then finalize every view derived from it.
+fn run_workspace_mutation<Plan>(
+    state: &DaemonState,
+    plan: Plan,
+) -> std::result::Result<BranchResponse, (StatusCode, String)>
+where
+    Plan: FnOnce(&DaemonState, &ActiveLocalRepositoryAuthority) -> Result<BranchCommandOutcome>,
+{
     let graph_mutation = state.begin_graph_authority_mutation();
     let persistence = state.persist_lock.lock().map_err(|_| {
         (
@@ -103,28 +225,7 @@ pub(crate) fn execute(
     let previous_graph_root = hex::encode(state.graph.compute_root_hash());
     let authority =
         ActiveLocalRepositoryAuthority::open_bound(state).map_err(branch_bind_refusal)?;
-    let outcome =
-        match request {
-            BranchRequest::List => unreachable!("list returned before mutation gates"),
-            BranchRequest::Create {
-                name,
-                operation_id,
-                actor,
-            } => create(state, &authority, name, *operation_id, actor)
-                .map(BranchCommandOutcome::Commit),
-            BranchRequest::Delete {
-                name,
-                operation_id,
-                actor,
-            } => delete(state, &authority, name, *operation_id, actor)
-                .map(BranchCommandOutcome::Commit),
-            BranchRequest::Switch {
-                name,
-                operation_id,
-                actor,
-            } => switch(state, &authority, name, *operation_id, actor),
-        }
-        .map_err(classify_branch_error)?;
+    let outcome = plan(state, &authority).map_err(classify_branch_error)?;
     let execution = match outcome {
         BranchCommandOutcome::Commit(execution) => execution,
         BranchCommandOutcome::ReadOnly(response) => {
@@ -529,6 +630,7 @@ fn switch(
     name: &RefName,
     operation_id: OperationId,
     actor: &AuthorId,
+    policy: TransitionPolicy,
 ) -> Result<BranchCommandOutcome> {
     require_branch_ref(name)?;
     let lease = authority.manager.read_authority();
@@ -547,8 +649,21 @@ fn switch(
     // its base. Admission only ever moves members the workspace already
     // tracks, so untracked host content can never reach this refusal, and the
     // wording never describes bytes that have not crossed the compare-and-swap.
-    if workspace.is_dirty() {
+    //
+    // A follow defers this until the transition is known to be needed, because
+    // the history it would refuse over is already durable and a workspace that
+    // is already at the moved ref has nothing to refuse about.
+    if policy == TransitionPolicy::Switch && workspace.is_dirty() {
         return Err(graph_owned_changes(&workspace));
+    }
+    if policy == TransitionPolicy::FollowMovedRef
+        && !matches!(&workspace.head, WorkspaceHead::Symbolic { target } if target == name)
+    {
+        return Err(anyhow::Error::new(WorkspaceTracksAnotherRef(format!(
+            "workspace {} does not track {name}, so a head admitted onto that ref moves no working \
+             tree here",
+            workspace.workspace_id
+        ))));
     }
     let target = lease
         .resolve_ref_target(name)
@@ -657,6 +772,13 @@ fn switch(
             idempotent: true,
         }));
     }
+    // The workspace is genuinely behind the ref, so a follow now has to decide
+    // what to do with graph-owned state the caller never committed. Moving the
+    // tree out from under it would discard work the compare-and-swap already
+    // owns, so the transition stops here and the transfer reports it.
+    if policy == TransitionPolicy::FollowMovedRef && workspace.is_dirty() {
+        return Err(graph_owned_changes(&workspace));
+    }
     let transaction = RepositoryTransaction {
         schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
         operation_id,
@@ -664,7 +786,11 @@ fn switch(
         expected_generation: roots.generation,
         expected_roots: roots,
         actor: actor.clone(),
-        reason: SWITCH_REASON.to_string(),
+        reason: match policy {
+            TransitionPolicy::Switch => SWITCH_REASON,
+            TransitionPolicy::FollowMovedRef => FOLLOW_REASON,
+        }
+        .to_string(),
         external_objects: Vec::new(),
         git_authority_delta: None,
         changes: Vec::new(),
@@ -736,8 +862,15 @@ fn switch(
     Ok(BranchCommandOutcome::Commit(BranchExecution {
         response: BranchResponse {
             lines: vec![format!(
-                "Switched to {} at change {} ({} projected entries, authority generation {})",
-                name, target_change_id, materialized, receipt.generation
+                "{} {} at change {} ({} projected entries, authority generation {})",
+                match policy {
+                    TransitionPolicy::Switch => "Switched to",
+                    TransitionPolicy::FollowMovedRef => "Followed",
+                },
+                name,
+                target_change_id,
+                materialized,
+                receipt.generation
             )],
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
             report: None,
@@ -1067,6 +1200,13 @@ fn render_target(target: &RefTarget) -> String {
 }
 
 fn classify_branch_error(error: anyhow::Error) -> (StatusCode, String) {
+    // Nothing to do is not a failure, and a follow tells the two apart by this
+    // status rather than by reading the message it would otherwise have to
+    // pattern-match. No branch command can produce it: the marker type is
+    // raised only under `TransitionPolicy::FollowMovedRef`.
+    if error.downcast_ref::<WorkspaceTracksAnotherRef>().is_some() {
+        return (WORKSPACE_TRACKS_ANOTHER_REF, format!("{error:#}"));
+    }
     if error.downcast_ref::<BranchBadRequest>().is_some() {
         return (StatusCode::BAD_REQUEST, format!("{error:#}"));
     }


### PR DESCRIPTION
Admitting history left the graph-owned workspace where it was, so a working tree after `kin pull` still showed the head the pull replaced. The capability inventory recorded that as the single OPEN item on `pull`; everything else on its acceptance was already DONE. This closes it.

## What changed

**Two transactions in sequence, not one.** Each pack publishes atomically and becomes durable first, then the workspace moves onto the destination ref's *final* target through the same projection transaction `kin branch switch` commits. A gap carried by several packs therefore moves the working tree once, at the admitted head, rather than walking it through every intermediate head.

**One transition planner, two callers.** `repository_branch::switch` takes a `TransitionPolicy` rather than being copied. Both callers publish the same `WorkspaceMutation` against the same compare-and-swap, and the planning, gates, and materialization between them are identical. The policy selects which refusal is honest for the caller, and with it the persisted transaction reason, the rendered verb, whether the operation id is caller-supplied or minted per call, and whether the untracked-ref check runs. A switch refuses over uncommitted graph-owned state before resolving anything, because the caller can commit and ask again with nothing lost. A follow settles the already-at-target case first and reports that state afterward, because the history it would refuse over is already durable. `Switch` behaviour is unchanged and every existing branch test passes untouched.

**Nothing is raised, everything is reported.** New `WorkspaceFollow` on the transfer response, modelled on `DerivedViewRefresh`: `NotApplicable` (a pull that admitted no history, hosted authority, a push, or a ref this workspace does not track), `AlreadyCurrent`, `Advanced`, `Behind`. None of them revokes the transfer, because the history is durable and receipted before any of this runs. `Behind` also covers stale derived views, since the transition plans its target from the daemon graph and a stale graph must not be projected onto disk as the admitted head.

**A pull that admits nothing plans no transition.** No ref moved, so no working tree can be behind one. `command_pull` guards the follow on `outcome.moved_history()` and otherwise reports `NotApplicable`, which is what keeps an ordinary no-op `kin pull` over a locally edited tree from failing the command and asserting that authority moved. It also means the branch-switch planner no longer runs on every pull. The cost of the guard is that a workspace an earlier pull left behind is not moved by the next pull; the remedy is the one the report already names, `kin branch switch` onto the pulled ref.

**Non-zero exit on `Behind`, in every output mode.** The exit decision is taken from the reported state rather than from inside the human renderer, so `kin pull --json` applies it too. `--json` is the mode a caller chains work from, so it is the mode where exiting clean over a working tree left behind would do the most damage. `kin pull && cargo test` otherwise runs against the tree the pull was supposed to replace, which is invisible from the files alone.

The one new wire field defaults to a variant meaning the responding daemon reported nothing, so a body from a build without it cannot read as a transition nobody observed. No kin-model change, so no positional-encoding concern.

## Evidence

Five integration tests drive two daemons over real HTTP with a real local replica on the receiving side, and assert bytes on disk:

- the working tree follows and the file's content changes to the admitted head; authority generation, `base_target`, and the reported generation all agree
- an untracked destination ref reports `NotApplicable` and touches nothing
- a file edited outside Kin's seams makes the pull report `Behind`, admit the history anyway, and leave the caller's edit byte-for-byte intact
- a workspace holding uncommitted graph-owned state, reached through a real stash seal and restore rather than by side channel, reports `Behind` naming that state, keeps it, and is told to finish a pull rather than a branch switch
- a pull that admits nothing over an edited tree reports no transition, exits clean, and leaves the edit alone

The last one is the regression for a defect this branch carried: with the follow unguarded, both of the everyday states above (a tracked file edited outside Kin, and uncommitted graph-owned state) made a no-op `kin pull` fail and print that repository authority had moved. Both were reproduced against the fixture before the fix.

The receiving replica is a genuine `init_from_git` repo with its own authority and workspace, not the existing `replica_state` harness, which holds no startup workspace binding and so cannot follow anything. The peer is a copy of that replica's storage advanced by one exact edit, because a transfer only exists between replicas of one repository identity.

Plus CLI unit tests covering both output modes: `Behind` fails the command in text and in `--json`, every other state exits clean in both, and a response without the field reads as unreported. Plus a unit test on what an interrupted multi-pack pull reports.

## Recorded, not introduced: artifact introduction cannot cross a transfer

Found while building the fixture, previously unrecorded anywhere. `verify_native_change_admission` requires that a `Native` change which INTRODUCES an artifact be committed with the workspace mutation admitting it, and it is called unconditionally from `verify_transaction_admission`. A transfer's receive transaction carries `workspace_mutation: None`, so natively authored history that adds a path is refused by name on the receiving replica.

This applies equally to `push` and to the inbound receive route, both of which already ship `ready` with it. Native edits and removals and all Git-origin history transfer normally, so brownfield repos are largely unaffected. Both capability notes now say so rather than leaving the inventory silent. It deserves its own ticket and probably belongs with FIR-1590; I have not filed one.

## Recorded, not introduced: a native transfer needs a shared repository identity

`kin init` mints a fresh `RepositoryId`, the daemon refuses an id that differs from its manifest, and the ref advertisement refuses a transfer between different identities. So the only thing that establishes a shared identity today is a raw storage copy, which is what this command's own fixture does, and a native pull is therefore reachable only between replicas that already share one. Establishing it from a remote is native clone, which `clone` records as an open gate.

That limit was previously stated only in a clap help string. Both `pull`'s and `clone`'s capability notes now record it, so `kin capabilities --json` cannot report `pull` as `ready` without also reporting what it takes to reach it.

## Gate flip

`pull` goes `open_gate`/`fail_closed` to `ready`/`enabled`, with the acceptance rewritten, evidence tests added, and the `[OPEN GATE]` marker removed from the CLI so the marker set test stays consistent. `ready_commands` 30 to 31; the bounded-dogfood bar is untouched at 12/12, since `pull` is not required for it.

## Also in this round

**The tracks-another-ref signal is a type, not a status code.** It was carried between `follow_moved_ref` and the shared planner as `204 No Content`, which nothing but a doc comment stopped a future branch-side raise from turning into a 204 answered with a body. It is now a variant on a refusal enum that the branch route has no way to return, so the illegal response is unrepresentable rather than documented.

**A pull's dirty refusal names a pull.** The refusal over uncommitted graph-owned state was inherited verbatim from the branch command and told a caller who ran `kin pull` to finish switching branches. The switch wording is byte-unchanged; the follow gets its own.

**An interrupted multi-pack pull says what it left durable.** Each pack is its own transaction, so an interruption leaves the admitted ones durable and the destination ref moved, while the workspace report never runs. The failure now names the packs that landed and that the working tree stands behind the moved ref.

## Gates run

fmt clean; clippy `--all-targets --all-features` under `RUSTFLAGS=-Dwarnings` with the exact ci.yml allowlist, exit 0; `build --all-targets --locked` and `test --workspace --locked` green; both zero-file-search guards pass with 144 files scanned, unchanged from baseline, and the falsifier confirms both still fail when poisoned at every site; runtime-boundary and private-coupling checks pass. The `repository_branch.rs` allowlist entry pins `.metadata()` at an exact count of 9, re-verified against current `main` because an exact-count pin is a co-landing hazard, and still passes, which is what confirms no new filesystem primitive entered that module.

Draft while `main` is quiesced for the release tag.

## Tickets

Advances FIR-1606 (native replication stage 3: negotiation, transport, and CLI wiring). It does not close it: that ticket's recorded scope is native clone/push/pull/fetch end to end, and native clone is not delivered here. What this PR delivers is the workspace transition after a native pull's admission, which was the single OPEN acceptance item recorded against `pull`.
