### PR TITLE
Pin the Rust toolchain action to a reachable commit sha in every workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -313,7 +313,7 @@ jobs:
         run: ./scripts/test-install-checksum.ps1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -610,7 +610,7 @@ jobs:
           node --check scripts/release-intent.mjs
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
         with:
           components: clippy, rustfmt
 
@@ -868,7 +868,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
 
       - name: Verify kin cargo registry config
         # Same tracked config the check job verifies.

--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
 
       - name: Verify kin cargo registry config
         # Preserve the tracked config because it carries public Git [patch.kin]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,7 +431,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@c0e9df88980754dd93e5833b8dcb1b304c1fe173 # 1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
         with:
           # On the Linux legs the core (kin, kin-daemon) targets musl and the VFS
           # leg targets gnu (vfs_target), so both targets must be installed.

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
 
       - name: Verify kin cargo registry config
         # cargo-deny resolves the full dependency graph via `cargo metadata`.


### PR DESCRIPTION
Six workflow uses of dtolnay/rust-toolchain referenced the mutable 1.96.0 branch, which was rebuilt upstream on 2026-07-16, and release.yml pinned a revision that is no longer reachable from any upstream ref. Every use now pins a full commit sha that is reachable today, with identity comments naming the branch and date rather than a tag the action does not have.

The toolchain each job installs is unchanged; the comments now state where each sha comes from so the next roll is checked against upstream instead of trusted from the label.

Closes FIR-1749.
Part-of FIR-1015.