### PR TITLE
Install cargo-deny from its pinned release artifact and cut 0.4.2

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -77,11 +77,24 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed — kin-* resolve from the Kin registry"; exit 1; fi
 
-      - name: Read pinned toolchain channel
-        id: toolchain
-        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
+      # Install the release binary directly instead of running
+      # EmbarkStudios/cargo-deny-action, which is a Docker action whose image is
+      # built from docker.io on every run. A Docker Hub outage therefore failed
+      # this job for reasons unrelated to the dependency graph, and because
+      # cargo-deny is a required context the failure permanently refused the
+      # release commit it ran against. taiki-e/install-action fetches the same
+      # upstream release artifact the action's Dockerfile downloads, verifies it
+      # against a checksum pinned in the action at the sha below, and touches no
+      # container registry.
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+        with:
+          tool: cargo-deny@0.20.2
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          rust-version: ${{ steps.toolchain.outputs.channel }}
+        # Byte-for-byte the argv the replaced action's entrypoint assembled from
+        # its input defaults, so the check set is unchanged. A bare `check` with
+        # no subset still runs advisories, bans, licenses, and sources, and
+        # `--all-features` keeps resolving the full feature graph rather than
+        # the narrower one deny.toml's [graph] section would select.
+        run: cargo deny --log-level warn --manifest-path ./Cargo.toml --all-features check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-07-31
+## [0.4.2] - 2026-07-31
 
 v0.4.0 was never published. Its release commit was refused by the mint gate
 because the release rail read the repository merge policy through a token that
 could not see those settings, and that defect is fixed in this release.
+
+v0.4.1 was never published either. Its release commit was refused by the same
+gate after the required `cargo-deny` check failed on registry-infrastructure
+timeouts rather than on anything in the dependency graph, and this release
+removes that dependency by installing the scanner from its own pinned release
+artifact instead of building a container image on every run.
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,14 +3054,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "age",
  "anyhow",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-model",
  "serde",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -90,7 +90,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.4.1", path = "../kin-spine" }
+kin-spine = { version = "0.4.2", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-git = { workspace = true, features = ["test-support"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Two release commits in a row have now been permanently refused by the mint gate, so this change carries both the recut and the fix for what refused the second one. v0.4.0 was refused because the release rail read the repository merge policy through a token that could not see those settings, and v0.4.1 was refused when the required `cargo-deny` context failed after three sixty-second i/o timeouts pulling `docker.io/library/rust:1.85.0-alpine3.20` for the container action's image build, which means cargo-deny never examined a single dependency on that sha.

The mint gate said so itself. Run 30611766801 on `1bd53b82` printed exactly three refusals and nothing else:

```
  - required check not green: cargo-deny (conclusion=failure)
  - required check workflow not green: cargo-deny (conclusion=failure)
  - check not green: cargo-deny (conclusion=failure)
```

Which also means the v0.4.0 defect is genuinely fixed. `Reconcile release PR` went **green on that same sha** for the first time in this repository's history (run 30611766807, `##[notice]v0.4.1 is already staged on main; tag reconciliation owns the next transition`), so the merge-policy gate and the whole post-gate resolve path have now executed for real. An unreachable container registry was the only thing standing between `1bd53b82` and a minted tag.

## Remove the container-registry dependency from `cargo-deny`

`EmbarkStudios/cargo-deny-action` is a Docker action, so GitHub builds its image from `docker.io` on every run before any dependency is looked at. `.github/workflows/sast.yml` now installs the scanner with `taiki-e/install-action` pinned at `6a1bd70eaac3c8bdf093356838d7ee09fda951cf` (v2.85.5) and runs it directly, which reaches only GitHub release assets.

Parity is exact rather than approximate, because both paths install the same binary and run the same argv.

- The action's `Dockerfile` pins `deny_version="0.20.2"` and downloads `https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-x86_64-unknown-linux-musl.tar.gz`. install-action's manifest for `cargo-deny@0.20.2` at the pinned sha resolves `x86_64_linux_musl` to that identical URL, so the ubuntu runner receives the same artifact. I fetched that tarball and its macOS sibling and both hashed to exactly the values the pinned manifest carries, `9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f` and `fe67d82a10d8597a3549364cb733a3f9cc1bfff9031b7ae46384a9f2a72090c3`, which is also the checksum install-action verifies before installing.
- The action's `entrypoint.sh` shifts its four positional inputs and execs `cargo-deny --log-level warn --manifest-path ./Cargo.toml --all-features check`, assembled from the defaults in its `action.yml` because the job passed only `rust-version`. The new run step passes that argv verbatim, so the check set (advisories, bans, licenses, sources), the manifest scope, and the full-feature graph resolution are unchanged.
- Falsified on this tree with cargo-deny 0.20.2 rather than reasoned about. The replaced invocation and the new one produced byte-identical stdout and stderr, 10706 stderr lines each, and both reported `advisories ok, bans ok, licenses ok, sources ok`. Dropping `--all-features` moves stderr to 9360 lines and dropping the subcommand exits 2, so the comparison is one that can fail.

The job keeps the exact name `cargo-deny`, which is a required status check in the `main` ruleset and a pinned required context in `release-tag.yml`. `scripts/test-release-workflow-authority.py` passes unchanged, and that pass is evidence rather than silence: renaming the job, breaking the canonical step grammar, and widening the workflow token each make the suite fail against this very file. `release-tag.yml` and `release-train.yml` are byte-identical to `origin/main` by blob hash, so the mint path is untouched.

The `Read pinned toolchain channel` step is removed because it existed only to feed the action's `rust-version` input. `dtolnay/rust-toolchain@1.96.0` and the tracked `rust-toolchain.toml` still pin the toolchain that `cargo metadata` resolves the graph under, which is the same shape the Code Coverage job already uses.

Because this pull request touches `Cargo.lock`, the diff classifier reports `docs_only=false` and `cargo-deny` runs on it, so the new mechanism proved itself before the captain lands it. Job `91097291101` on this head concluded success in 23 seconds against 68 seconds for the container path's last green run on the same day, every step green, `advisories ok, bans ok, licenses ok, sources ok` on stdout, and the string `docker.io` appears zero times in its 11128 line log against twelve lines carrying fifteen occurrences in the job it replaces. The log also shows the download URL matching the replaced `Dockerfile`'s character for character, `verifying sha256 checksum` on it, and rustup reporting that `rust-toolchain.toml` still governs the toolchain, which is why the now-dead channel-reading step could be dropped without loosening anything.

### What this does not fix

The exposure is narrowed, not eliminated. `Docker Image Build (no push)` builds the root `Dockerfile`, whose `rust:slim` and `debian:trixie-slim` base images come from the same registry, and `release-tag.yml`'s second sweep refuses any non-green check-run on the release sha rather than only the named required contexts. A Docker Hub outage during that job would still poison a release commit. Fixing that means a decision about base-image sourcing for a shipped product image, which does not belong in a release recut, so it wants its own ticket.

## Cut 0.4.2

`scripts/prepare-release.mjs` cannot cut this release and was not used for the manifests. Its `main()` derives the base version from `origin/main:Cargo.toml`, which is now 0.4.1, forces `baseTag` to `v0.4.1`, and then runs `git rev-parse --verify v0.4.1^{commit}`, which fails with `fatal: Needed a single revision` because that tag was never minted. The refusal happens before any write, so nothing is left half-applied. Both lockfiles were still rewritten by the repo's own tested helper, `updateWorkspaceLock` imported from `prepare-release.mjs`, at 23 root replacements and 1 fuzz replacement, and only the five single-line manifest values were set directly. The release rail still has no first-class path for re-cutting a staged version whose commit was refused.

| surface | value |
| --- | --- |
| `Cargo.toml` `[workspace.package]` | 0.4.2 |
| `crates/kin-cli/Cargo.toml` kin-spine pin | 0.4.2 |
| `packages/kin/package.json` | 0.4.2 |
| `packages/kin-mcp/package.json` | 0.4.2 |
| `packages/boundary-contracts/package.json` | 0.4.2 |
| `fuzz/Cargo.lock` path-resolved `kin-parser` | 0.4.2 |
| root `Cargo.lock` | 23 local `kin-*` entries at 0.4.2 |

The lockfile diffs are version lines only. Filtering the root diff for anything that is not `-version = "0.4.1"` or `+version = "0.4.2"` returns nothing, so no `source` or `checksum` line moved, and the five third-party crates that legitimately sit at 0.4.1 (`dirs-sys`, `jni-sys`, `jni-sys-macros`, `rustc_version`, `windows-result`) are untouched, which a naive version sweep would have bumped. `node scripts/release-intent.mjs` reports v0.4.2 coherent with `should_tag=true`. `cargo build --all-targets --locked` proves the root lockfile resolves, `release-intent.mjs` holds the path-resolved `kin-parser` entry to the workspace version, and the `cargo-fuzz` jobs prove `fuzz/Cargo.lock`, which the root build never reads because `fuzz` declares its own workspace.

`CHANGELOG.md`'s pending section is retitled `## [0.4.2] - 2026-07-31` with its content kept, and a second paragraph records that v0.4.1 was never published either and why.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` under the full ci.yml allow-list, `cargo build --all-targets --locked`, and `cargo test --workspace --locked` all pass with `RUSTFLAGS="-D warnings"`. So do `scripts/test-release-workflow-authority.py`, `scripts/verify-zero-file-search.py` at 144 files scanned, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`, `scripts/verify-hydration-semantics.py`, both npm launcher packages with their lints, `test_install_optional_vfs.py`, `test_installer_parity.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, `test-homebrew-release-gate.py`, `test-install-checksum.py`, the `node --test` release suites, every `node --check` and `bash -n` the CI job runs, and `actionlint` on the changed workflow.

`Windows installer + vector-free release build` reports skipping on a pull request by design and runs on the landing push, which is the commit release proof reads.

## Claims not being made

No claim that v0.4.2 will mint. That needs every required context green on the merged sha, and every non-required check-run on it to be non-failing too, which is the captain's gate. The reconcile path is no longer the open question it was for v0.4.1, since it has now gone green once, but it still has to go green again on the merged sha.

No claim that a Docker Hub outage was the only thing wrong with the replaced action. The narrower claim is that the container image build is a dependency the security check does not need, and that it failed closed on a required release context.

No claim that this removes every container-registry dependency from the release path. It removes it from `cargo-deny` only; see "What this does not fix" above.

No benchmark, performance, retrieval, or proof claim is made or affected.

Part-of FIR-1015.

