### PR TITLE
Reuse a proved authority match across embed batches instead of reopening authority per batch

### DIFF
--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -872,19 +872,29 @@ impl Drop for GraphAuthorityMutationGuard {
 /// workspace authority has already been derived for a vector checkpoint.
 ///
 /// A vector checkpoint is refused when the live exact tree diverges from
-/// committed authority. Deriving that answer costs a full authority reopen —
-/// recovering the snapshot, revalidating every semantic change id, and
-/// re-verifying every stored body — which is linear in store size, not in the
-/// batch being checkpointed. Paid once per embed batch, it dominates a long
-/// embed: on a 2 GB store it is minutes of reopen for seconds of inference,
-/// and it re-derives a conclusion about bytes that have not moved.
+/// committed authority. Deriving that answer costs a full authority reopen,
+/// which recovers the snapshot, revalidates every semantic change id, and
+/// re-verifies every stored body against its content address. That cost is
+/// linear in store size rather than in the batch being checkpointed, so paid
+/// once per embed batch it dominates a long embed. On a 2 GB store it is
+/// minutes of reopen for seconds of inference, re-deriving a conclusion about
+/// bytes that have not moved.
 ///
 /// Both inputs to the conclusion are exact and cheap to compare. Committed
 /// authority is immutable at a generation, so the authority side is a function
-/// of `generation` alone; the live side is the tree itself. Retaining the
-/// derived pair therefore skips only re-derivation, never a real check: a
-/// generation bump or any live-tree mutation misses the retained pair and
-/// reopens authority in full.
+/// of `generation` alone, and the live side is the tree itself. A generation
+/// bump or any live-tree mutation misses the retained pair and reopens
+/// authority in full, with the same refusal.
+///
+/// What the retained pair does narrow is the incidental tripwire a reopen
+/// carried. The on-disk generation assertion and the content-address
+/// re-verification of every authority body ran once per batch as a side effect
+/// of opening authority, and while the pair holds they run at the next real
+/// reopen instead, which is the next generation change, the next live-tree
+/// change, or the next daemon open. The vector index is a pure derived sidecar
+/// that is not in the merkle root, and the stamp it carries is re-verified
+/// wherever it is reused, so nothing downstream accepts a checkpoint on weaker
+/// evidence than before.
 #[cfg(feature = "embeddings")]
 #[derive(Debug, Default)]
 struct VectorCheckpointAuthorityMatch {
@@ -1034,6 +1044,14 @@ pub struct DaemonState {
     /// regression tests. Production initialization has no injected hook.
     #[cfg(test)]
     spine_initialization_test_hook: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    /// Deterministic seam inside the vector-checkpoint authority reopen, fired
+    /// at the last moment that window is still open. The reopen takes no lock
+    /// on the live graph, so a mutation can land while it runs; a test hook
+    /// here reproduces that arrival without racing it, and also counts how many
+    /// reopens a sequence of flushes actually paid for. Production installs no
+    /// hook.
+    #[cfg(all(test, feature = "embeddings"))]
+    vector_checkpoint_reopen_test_hook: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
     /// Serializes hosted repo registration and all-repo edge refresh passes.
     /// The backend independently keeps a pass-wide incomplete lease; this gate
     /// prevents daemon request paths from racing that lease with a new ingest.
@@ -1921,6 +1939,8 @@ impl DaemonState {
             spine_warming: AtomicBool::new(false),
             #[cfg(test)]
             spine_initialization_test_hook: Mutex::new(None),
+            #[cfg(all(test, feature = "embeddings"))]
+            vector_checkpoint_reopen_test_hook: Mutex::new(None),
             spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()),
             allowed_repo_ids: None,
@@ -2120,6 +2140,8 @@ impl DaemonState {
             spine_warming: AtomicBool::new(false),
             #[cfg(test)]
             spine_initialization_test_hook: Mutex::new(None),
+            #[cfg(all(test, feature = "embeddings"))]
+            vector_checkpoint_reopen_test_hook: Mutex::new(None),
             spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()), // populated below
             allowed_repo_ids,
@@ -2342,6 +2364,29 @@ impl DaemonState {
             .spine_initialization_test_hook
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = hook;
+    }
+
+    #[cfg(all(test, feature = "embeddings"))]
+    pub(crate) fn set_vector_checkpoint_reopen_test_hook(
+        &self,
+        hook: Option<Arc<dyn Fn() + Send + Sync>>,
+    ) {
+        *self
+            .vector_checkpoint_reopen_test_hook
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = hook;
+    }
+
+    #[cfg(all(test, feature = "embeddings"))]
+    fn run_vector_checkpoint_reopen_hook(&self) {
+        let hook = self
+            .vector_checkpoint_reopen_test_hook
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(hook) = hook {
+            hook();
+        }
     }
 
     fn load_registered_workspace_graph(
@@ -4082,6 +4127,14 @@ impl DaemonState {
             .holds(generation, &live_tree)
         {
             let authority_graph = self.load_committed_authority_graph(generation)?;
+            // The reopen is linear in store size, and this path holds only
+            // `persist_lock` while commit and reconcile exclude on the
+            // coordination gate, so the live graph can move while it runs.
+            // Sample again after it, so the tree proved against authority is
+            // the tree this call goes on to retain and checkpoint.
+            #[cfg(test)]
+            self.run_vector_checkpoint_reopen_hook();
+            let live_tree = self.graph.resolved_tree();
             if live_tree != authority_graph.resolved_tree() {
                 return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
                     format!(
@@ -4760,6 +4813,116 @@ mod tests {
         retained.record(0, empty.clone());
         assert!(retained.holds(0, &empty));
         assert!(!retained.holds(0, &tree_with_path("src/lib.rs")));
+    }
+
+    /// The two tests above prove the retained pair's algebra in isolation, and
+    /// prove nothing about whether the flush consults it. Drive the real flush
+    /// against a real workspace-authority store: the first call has nothing
+    /// retained and must derive the answer by reopening authority, and the next
+    /// call over an unchanged batch must answer from the retained pair without
+    /// reopening at all. Reuse across unchanged batches is the entire mechanism,
+    /// so a flush that quietly kept reopening would be indistinguishable from
+    /// the unfixed path by any test of the type alone.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn flush_embed_progress_derives_the_authority_match_once_and_then_reuses_it() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+
+        let reopens = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&reopens);
+        state.set_vector_checkpoint_reopen_test_hook(Some(Arc::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        })));
+
+        let generation = state.snapshot_generation.load(Ordering::SeqCst);
+        state
+            .flush_embed_progress()
+            .expect("a live tree matching committed authority must checkpoint");
+        assert_eq!(
+            reopens.load(Ordering::SeqCst),
+            1,
+            "the first flush has nothing retained, so it must reopen authority"
+        );
+        assert!(
+            state
+                .vector_checkpoint_authority_match
+                .holds(generation, &state.graph.resolved_tree()),
+            "the retained pair must cover the tree this flush actually checkpointed"
+        );
+
+        state
+            .flush_embed_progress()
+            .expect("an unchanged batch must still checkpoint");
+        assert_eq!(
+            reopens.load(Ordering::SeqCst),
+            1,
+            "an unchanged batch must answer from the retained pair, not a second reopen"
+        );
+    }
+
+    /// The reopen is linear in store size and this path holds only
+    /// `persist_lock`, while commit and reconcile exclude on the coordination
+    /// gate, so the live graph can move while the reopen runs. A tree sampled
+    /// before the reopen is therefore a statement about a repository state the
+    /// checkpoint may no longer be writing. What the flush proves against
+    /// authority, retains, and then serializes must all be the same tree, so a
+    /// mutation landing inside that window has to be refused and has to leave
+    /// nothing retained.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn flush_embed_progress_refuses_a_live_tree_that_moved_during_the_reopen() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+
+        let generation = state.snapshot_generation.load(Ordering::SeqCst);
+        let tree_before = state.graph.resolved_tree();
+
+        let moving_graph = Arc::clone(&state.graph);
+        state.set_vector_checkpoint_reopen_test_hook(Some(Arc::new(move || {
+            moving_graph
+                .apply_transaction_delta(&kin_model::TransactionDelta {
+                    tree_deltas: vec![TreeDelta::Added {
+                        artifact_id: ArtifactId::new(),
+                        new: LocatedEntry::new(
+                            RepoPath::from_utf8("src/arrived_during_reopen.rs").unwrap(),
+                            TreeEntry::blob(Hash256::from_bytes([9u8; 32]), false),
+                        ),
+                    }],
+                    ..Default::default()
+                })
+                .expect("the live graph must accept the concurrent mutation under test");
+        })));
+
+        let error = state
+            .flush_embed_progress()
+            .expect_err("a live tree that moved away from authority must be refused");
+        assert!(
+            error
+                .to_string()
+                .contains("live exact tree does not match workspace authority"),
+            "expected the authority-mismatch refusal, got: {error}"
+        );
+
+        let tree_after = state.graph.resolved_tree();
+        assert_ne!(
+            tree_before, tree_after,
+            "the seam must actually have moved the live tree"
+        );
+        assert!(
+            !state
+                .vector_checkpoint_authority_match
+                .holds(generation, &tree_before),
+            "a tree the checkpoint is no longer writing must not be retained as proved"
+        );
+        assert!(
+            !state
+                .vector_checkpoint_authority_match
+                .holds(generation, &tree_after),
+            "a refused flush must retain nothing"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -868,6 +868,52 @@ impl Drop for GraphAuthorityMutationGuard {
     }
 }
 
+/// The `(generation, live exact tree)` pair whose match against committed
+/// workspace authority has already been derived for a vector checkpoint.
+///
+/// A vector checkpoint is refused when the live exact tree diverges from
+/// committed authority. Deriving that answer costs a full authority reopen —
+/// recovering the snapshot, revalidating every semantic change id, and
+/// re-verifying every stored body — which is linear in store size, not in the
+/// batch being checkpointed. Paid once per embed batch, it dominates a long
+/// embed: on a 2 GB store it is minutes of reopen for seconds of inference,
+/// and it re-derives a conclusion about bytes that have not moved.
+///
+/// Both inputs to the conclusion are exact and cheap to compare. Committed
+/// authority is immutable at a generation, so the authority side is a function
+/// of `generation` alone; the live side is the tree itself. Retaining the
+/// derived pair therefore skips only re-derivation, never a real check: a
+/// generation bump or any live-tree mutation misses the retained pair and
+/// reopens authority in full.
+#[cfg(feature = "embeddings")]
+#[derive(Debug, Default)]
+struct VectorCheckpointAuthorityMatch {
+    derived: Mutex<Option<(u64, ResolvedTree)>>,
+}
+
+#[cfg(feature = "embeddings")]
+impl VectorCheckpointAuthorityMatch {
+    /// True when this exact pair has already been derived. A poisoned lock
+    /// answers false, so the caller reopens authority rather than trusting an
+    /// unreadable record.
+    fn holds(&self, generation: u64, live_tree: &ResolvedTree) -> bool {
+        self.derived.lock().is_ok_and(|derived| {
+            derived
+                .as_ref()
+                .is_some_and(|(derived_generation, derived_tree)| {
+                    *derived_generation == generation && derived_tree == live_tree
+                })
+        })
+    }
+
+    /// Retain a freshly derived pair, replacing any earlier one.
+    fn record(&self, generation: u64, live_tree: ResolvedTree) {
+        if let Ok(mut derived) = self.derived.lock() {
+            *derived = Some((generation, live_tree));
+        }
+    }
+}
+
 /// Shared daemon state. All mutable state is behind RwLock for
 /// concurrent access from the reconciliation loop and API handlers.
 pub struct DaemonState {
@@ -1016,6 +1062,10 @@ pub struct DaemonState {
     /// entering this derived finalization path. Held only for the synchronous
     /// critical section — never across an `.await` or another lock.
     pub persist_lock: Mutex<()>,
+    /// Last `(generation, live exact tree)` pair proved to match committed
+    /// workspace authority for a vector checkpoint. Read under `persist_lock`.
+    #[cfg(feature = "embeddings")]
+    vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch,
     /// When the last successful background save completed.
     pub last_save: std::sync::Mutex<Instant>,
     /// When the graph was last mutated (`mark_dirty`). The background
@@ -1878,6 +1928,8 @@ impl DaemonState {
             mutation_epoch: AtomicU64::new(0),
             embedding_work: Mutex::new(()),
             persist_lock: Mutex::new(()),
+            #[cfg(feature = "embeddings")]
+            vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch::default(),
             last_save: std::sync::Mutex::new(Instant::now()),
             last_mutation: std::sync::Mutex::new(Instant::now()),
             active_embed_passes: AtomicU32::new(0),
@@ -2075,6 +2127,8 @@ impl DaemonState {
             mutation_epoch: AtomicU64::new(0),
             embedding_work: Mutex::new(()),
             persist_lock: Mutex::new(()),
+            #[cfg(feature = "embeddings")]
+            vector_checkpoint_authority_match: VectorCheckpointAuthorityMatch::default(),
             last_save: std::sync::Mutex::new(Instant::now()),
             last_mutation: std::sync::Mutex::new(Instant::now()),
             active_embed_passes: AtomicU32::new(0),
@@ -4022,13 +4076,21 @@ impl DaemonState {
             .lock()
             .map_err(|_| DaemonError::Io(std::io::Error::other("persist lock poisoned")))?;
         let generation = self.snapshot_generation.load(Ordering::SeqCst);
-        let authority_graph = self.load_committed_authority_graph(generation)?;
-        if self.graph.resolved_tree() != authority_graph.resolved_tree() {
-            return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                format!(
-                    "refusing vector checkpoint at repository generation {generation}: live exact tree does not match workspace authority"
-                ),
-            )));
+        let live_tree = self.graph.resolved_tree();
+        if !self
+            .vector_checkpoint_authority_match
+            .holds(generation, &live_tree)
+        {
+            let authority_graph = self.load_committed_authority_graph(generation)?;
+            if live_tree != authority_graph.resolved_tree() {
+                return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                    format!(
+                        "refusing vector checkpoint at repository generation {generation}: live exact tree does not match workspace authority"
+                    ),
+                )));
+            }
+            self.vector_checkpoint_authority_match
+                .record(generation, live_tree);
         }
         let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
         kin_db::SnapshotManager::checkpoint_vector_index_for_graph(
@@ -4642,6 +4704,62 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         sync_directory_metadata(directory.path())
             .expect("directory metadata sync must not reject a valid host directory");
+    }
+
+    #[cfg(feature = "embeddings")]
+    fn tree_with_path(path: &str) -> ResolvedTree {
+        ResolvedTree::from_artifacts([ResolvedArtifact::new(
+            ArtifactId::new(),
+            RepoPath::from_utf8(path).unwrap(),
+            TreeEntry::blob(Hash256::from_bytes([7u8; 32]), false),
+        )])
+        .unwrap()
+    }
+
+    /// The retained authority match must skip re-derivation for the exact pair
+    /// it derived, and for nothing else. An embed batch that changes neither the
+    /// committed generation nor the live exact tree is the whole reason a long
+    /// embed is not dominated by authority reopens; a batch that changes either
+    /// must still pay for a full reopen, because the retained answer is no
+    /// longer about the state being checkpointed.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn vector_checkpoint_authority_match_holds_only_for_the_derived_pair() {
+        let tree = tree_with_path("src/lib.rs");
+        let other_tree = tree_with_path("src/main.rs");
+        let retained = VectorCheckpointAuthorityMatch::default();
+
+        // Nothing derived yet: every pair reopens.
+        assert!(!retained.holds(1, &tree));
+
+        retained.record(1, tree.clone());
+        assert!(retained.holds(1, &tree));
+
+        // A generation bump invalidates: committed authority moved.
+        assert!(!retained.holds(2, &tree));
+        // A live-tree mutation invalidates: the checkpointed state moved.
+        assert!(!retained.holds(1, &other_tree));
+
+        // Re-deriving replaces rather than accumulates, so the superseded pair
+        // never keeps answering for a state that has moved on.
+        retained.record(2, other_tree.clone());
+        assert!(retained.holds(2, &other_tree));
+        assert!(!retained.holds(1, &tree));
+    }
+
+    /// An empty tree is a real repository state (a workspace with no admitted
+    /// artifacts), not a "nothing derived yet" sentinel, so it must be told
+    /// apart from the un-derived state above.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn vector_checkpoint_authority_match_distinguishes_empty_tree_from_no_record() {
+        let retained = VectorCheckpointAuthorityMatch::default();
+        let empty = ResolvedTree::default();
+
+        assert!(!retained.holds(0, &empty));
+        retained.record(0, empty.clone());
+        assert!(retained.holds(0, &empty));
+        assert!(!retained.holds(0, &tree_with_path("src/lib.rs")));
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

`DaemonState::flush_embed_progress` runs after every embed batch and refuses a
vector checkpoint whose live exact tree diverges from committed workspace
authority. Deriving that answer reopens repository authority in full, which
recovers the snapshot, revalidates every semantic change id, re-verifies every
stored body against its content address, and constructs a second complete
`InMemoryGraph`.

That cost is linear in store size, not in the batch being checkpointed, and it
was paid once per batch of 64 entities.

This retains the `(generation, live ResolvedTree)` pair whose match has already
been derived, and reopens authority only on a miss. On the miss path the live
tree is sampled again after the reopen returns, so the tree that is proved
against authority is the same tree the call then retains and checkpoints.

## Why the retained pair is sound

Both inputs to the guard's conclusion are exact. Committed authority is immutable
at a generation, so the authority side is a function of the generation alone, and
the live side is the resolved tree itself. A generation bump or any live-tree
mutation misses the retained pair and reopens authority in full, with the same
refusal. A poisoned lock answers "no match" and reopens. Embeddings are
unaffected, because this is a guard-skip rather than a change to what is computed
or written.

This path also holds no lock the mutators take. `flush_embed_progress` holds
only `persist_lock`, while exact-tree admission, commit, and checkout exclude on
the coordination gate, so the live graph can move while a reopen runs. The live
tree is therefore sampled after the reopen rather than before it, which keeps the
window between proof and checkpoint at microseconds instead of the length of the
reopen. A mutation that lands inside that window is refused, exactly as it was
before this change.

## What does narrow

The reopen carried two checks beyond re-deriving the tree comparison, and both
ran once per batch as a side effect of opening authority. It asserted that the
on-disk authority generation equals the daemon's cached cursor, and the open
re-verified every stored body against its content address. While the retained
pair holds, neither runs.

**Tamper posture.** On-disk tamper of an authority body was re-detected every
batch. It is now detected at the next real reopen, which is the next generation
change, the next live-tree change, or the next daemon open, rather than the next
batch of 64 entities. The vector index is a pure derived sidecar that is not in
the merkle root, it is stamped with the retrieval authority hash and the embedder
identity, and a stamp mismatch is a hard error where the sidecar is reused, so
the fail-closed guarantee at publish is unchanged. The narrowing is real and
worth naming rather than eliding.

**In-process authority-move window.** `record_repository_authority_commit`
advances the daemon's cursor after the durable CAS returns
(`crates/kin-daemon/src/api.rs:3664-3672`), and neither step holds `persist_lock`.
Between the CAS landing and the cursor advancing, on-disk authority is at G+1
while the daemon still reads G. A flush in that window used to hit the
generation assertion and hard-fail the embed pass. While the retained pair holds
it now proceeds. That is arguably better, since the abort was caused by the
daemon's own non-atomic bookkeeping rather than by any divergence, but it is a
behavior change and this PR should say so.

## Measured

Stack sample of the embedding thread on a 2 GB store, 45 s window, 3780 samples:

```
3766  DaemonState::flush_embed_progress                          (99.6%)
 1945    load_committed_authority_graph → materialize_workspace_graph_snapshot
 1068      → InMemoryGraph::from_snapshot_inner → validate_storage_admission
 1068        → kin_model::identity::validate_semantic_change_id
 1821    load_committed_authority_graph → RepositoryAuthorityManager::open
 1103      → LocalFileBackend::with_verified_source_blob_batch
  963        → validate_all_authority_bodies → load_verified_authority_body
```

Zero samples in the GPU forward the batch exists to run.

A/B on two `cp -c` copies of the same sealed store, identical 420 s bounded pass,
identical env:

| | before | after |
| --- | --- | --- |
| entities embedded in 420 s | 256 | **5,632** |
| end-to-end rate | 0.61 ent/s | **13.41 ent/s** |
| GPU dispatches | 16 | 362 |
| total forward wall | 8.65 s | 253.90 s |
| forward share of the pass | 2.1% | **60.5%** |
| padded/real token ratio | 1.37 | 1.38 |

22.0x end to end. The pass goes from 2.1% GPU-bound to 60.5% GPU-bound. On the
Go-26 corpus that is roughly 37 minutes of embedding instead of roughly 20 hours.

Two caveats on the arms. The control run cited here is the one with a sampler
attached; a second control run on the same store embedded 128 entities in the
same window, so control run-to-run spread is about 2x and the arm quoted is the
faster of the two, which understates the speedup. And these are DEV-LOCAL n=1
timings on one host. Nothing here is citable.

Not in scope: the unconditional per-open validation lives in kin-db. This stops
calling it 465 times per corpus, and does not change what one call does.

## Tests

Two new tests drive `flush_embed_progress` itself against a real
workspace-authority store, because the pre-existing flush test covers sidecar
persistence rather than the guard, and the retained-pair tests below cover the
type in isolation rather than the wiring.

- `flush_embed_progress_derives_the_authority_match_once_and_then_reuses_it`
  asserts the first flush reopens authority exactly once and retains the pair
  covering the tree it checkpointed, and that a second flush over an unchanged
  batch reopens zero more times. Reuse across unchanged batches is the entire
  mechanism, so this is the test that would notice it silently not engaging.
- `flush_embed_progress_refuses_a_live_tree_that_moved_during_the_reopen` moves
  the live tree through a deterministic seam placed inside the reopen window and
  asserts the flush refuses with the authority-mismatch error and retains
  nothing, for either the pre-window or the post-window tree. Removing the
  post-reopen re-sample makes this test fail, so the ordering is pinned rather
  than assumed.

The two retained-pair tests are unchanged.

- `vector_checkpoint_authority_match_holds_only_for_the_derived_pair` holds for
  the derived pair, misses on a generation bump, misses on a live-tree mutation,
  and re-deriving replaces rather than accumulates.
- `vector_checkpoint_authority_match_distinguishes_empty_tree_from_no_record`
  treats an empty tree as a real repository state rather than a sentinel.

## Gates

- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features` with the ci.yml 45-lint allowlist, clean
- `cargo build --all-targets --locked` clean
- `cargo test -p kin-daemon --all-targets --locked` 633 passed, 0 failed
- `cargo nextest run --locked` green, which is the runner CI uses
- `verify-zero-file-search.py` PASSED (144 files scanned)
- `zero_file_search_guard.sh` PASSED
- `check_runtime_boundaries.sh` / `check_private_repo_coupling.sh` PASSED

One honest divergence, pre-existing and unrelated to this change. Plain
`cargo test --workspace --locked` on this host is flaky, and the failing set
differs run to run. One run failed two kin-daemon tests
(`command_branch_source_cas_integrity_failures_are_internal_without_mutation`,
`mcp_semantic_locate_fused_serves_snippets_and_keeps_hits_when_declined`); a
second run passed those and instead failed two kin-cli update crash-recovery
tests (`crash_recovery_worker`,
`subprocess_crashes_after_commit_recover_the_new_bundle_and_marker`). Neither
pair touches any path this PR changes.

The kin-daemon pair is diagnosed and reproducible on demand. `DaemonState::open`
reads the process-global `KIN_REPO_ID`, and two `#[serial_test::serial]` tests in
`crates/kin-daemon/src/api.rs` set `KIN_REPO_ID=provider` for the length of their
body. `serial` excludes only other `serial` tests, so a non-serial test opening a
daemon state concurrently reads the leaked value and refuses. Both setters and
both non-serial victims are on `origin/main` unchanged, and running the two
victims with `KIN_REPO_ID=provider` present reproduces the identical failure at
the identical lines every time. nextest gives each test its own process, which is
why the same code is green under the CI runner. Both pairs deserve their own
ticket and neither belongs to this change.

Closes FIR-1760
