### PR TITLE
Assert the shipped Windows admission refusal from a pre-landing job and cut v0.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           node --check ./scripts/verify-npm-attestation.mjs
           bash -n ./scripts/publish-npm-release.sh
           bash -n ./scripts/verify-npm-release.sh
+          bash -n ./scripts/assert-windows-init-refusals.sh
 
   windows-authority-tests:
     name: Windows authority tests
@@ -99,7 +100,7 @@ jobs:
     # build share no artifacts (separate target profiles), so serialising them
     # only added wall clock. They run concurrently now.
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Preserve tracked bytes on Windows
         shell: bash
@@ -278,6 +279,27 @@ jobs:
             --locked --target x86_64-pc-windows-msvc \
             -p kin-cli --no-default-features --test repository_merge_resolution
 
+      # The two steps below are the pull-request half of the Windows admission
+      # contract. The installer leg asserts the same refusals against the
+      # release binary, but it runs only on the landing push, so on its own it
+      # can report an admission change no earlier than a required check
+      # failing on a release commit. The feature set matches the installer
+      # leg's so both legs drive the same build of the command.
+      - name: Build the Windows CLI the admission assertions drive
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --target x86_64-pc-windows-msvc \
+            -p kin-cli --no-default-features --bin kin
+
+      - name: Assert Windows admission refusals
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash ./scripts/assert-windows-init-refusals.sh \
+            "$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/debug/kin.exe" \
+            "$RUNNER_TEMP/kin-windows-admission"
+
   windows-installer:
     name: Windows installer + vector-free release build
     needs: changes
@@ -410,44 +432,19 @@ jobs:
           }
           NODE
 
-      - name: Reopen a fresh Windows graph through the daemon
+      # Both admission boundaries still refuse on Windows, and the shared
+      # script is the only statement of what they refuse. The pull-request
+      # authority job runs the same assertions against a debug binary, so an
+      # admission change that moves the refusal turns a pull request red
+      # instead of first turning a release commit red here. Daemon reopen
+      # assertions live in the Linux daemon smoke until the Windows ports land.
+      - name: Assert Windows admission refusals
         shell: bash
         run: |
           set -euo pipefail
-          trap 'taskkill.exe /F /IM kin-daemon.exe >/dev/null 2>&1 || true' EXIT
-          bin_dir="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release"
-          export PATH="$bin_dir:$PATH"
-          repo_dir="$RUNNER_TEMP/kin-windows-daemon-reopen"
-          mkdir -p "$repo_dir"
-          cd "$repo_dir"
-          git init -q
-          git config user.email ci@firelock.ai
-          git config user.name ci
-          printf 'fn probe() {}\n' > probe.rs
-          git add probe.rs
-          git commit -qm "probe"
-          # Exact Git admission needs the byte-exact executable-mode proof,
-          # which is a unix capability; Windows must refuse loudly, naming
-          # the gate, instead of admitting without the proof.
-          if kin.exe init > "$RUNNER_TEMP/kin-init-git.txt" 2>&1; then
-            echo "::error::Windows exact Git admission unexpectedly succeeded"
-            exit 1
-          fi
-          grep -q "byte-exact executable-mode proof is unsupported" "$RUNNER_TEMP/kin-init-git.txt"
-          # Fresh non-Git bootstrap is also gated off Windows today: repository
-          # config publication requires capability-owned atomic replacement,
-          # a unix capability. The refusal must be loud and name that gate;
-          # daemon reopen assertions live in the Linux daemon smoke until the
-          # Windows ports land.
-          boot_dir="$RUNNER_TEMP/kin-windows-daemon-boot"
-          mkdir -p "$boot_dir"
-          cd "$boot_dir"
-          if kin.exe init > "$RUNNER_TEMP/kin-init.txt" 2>&1; then
-            echo "::error::Windows non-Git bootstrap unexpectedly succeeded"
-            exit 1
-          fi
-          grep -q "atomic repository config replacement is unsupported" "$RUNNER_TEMP/kin-init.txt"
-          test ! -e "$boot_dir/.kin/kindb/head-generation"
+          bash ./scripts/assert-windows-init-refusals.sh \
+            "$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release/kin.exe" \
+            "$RUNNER_TEMP/kin-windows-admission"
 
   # Classify the PR diff so documentation-only and workflow-only changes can
   # satisfy the heavy required checks without a toolchain or registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ land.
 
 ### Fixed
 
+- The Windows `kin` binary reserves a main thread large enough to parse its own
+  command tree. Windows reserves 1 MiB where Unix reserves 8, fixed at link
+  time, and building the command tree recurses over every subcommand, so an
+  unoptimized Windows build overflowed its stack before reaching any command at
+  all, `--version` included. Reserved address space is not committed memory, so
+  matching the 16 MiB the CLI's own tests already use costs nothing at runtime.
 - A daemon that refuses to start can no longer take the running daemon's
   endpoint down with it. `.kin/daemon.pid` and `.kin/daemon.port` are now
   attributed by a `.kin/daemon.owner` record naming the exact process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2] - 2026-07-31
+## [0.4.3] - 2026-07-31
 
 v0.4.0 was never published. Its release commit was refused by the mint gate
 because the release rail read the repository merge policy through a token that
@@ -19,6 +19,13 @@ timeouts rather than on anything in the dependency graph, and this release
 removes that dependency by installing the scanner from its own pinned release
 artifact instead of building a container image on every run.
 
+v0.4.2 was never published either. Its release commit was refused when a
+required Windows check asserted a refusal message that a landed Windows-support
+slice had already replaced, and that check runs only on the landing push, so no
+pull request could have caught it. This release aligns the assertion with the
+behavior that shipped and mirrors it into a job that runs before a change can
+land.
+
 ### Breaking
 
 - Repository-v6 authority replaces the legacy Git-compatibility command path.
@@ -26,11 +33,11 @@ artifact instead of building a container image on every run.
   daemon exec endpoint are removed.
 - Graph storage moves to on-disk snapshot format 13. A Kin binary accepts
   exactly one on-disk format, so no repository initialized by v0.3.6, which
-  wrote format 12, opens under v0.4.0. Re-initialize the repository against its
-  source of truth. This is the standing pre-release storage posture rather than
-  something this release introduces: v0.3.6 accepted only the one format it
-  wrote, and so does this one. The accepted range widens when the format is
-  declared stable, not before.
+  wrote format 12, opens under this release. Re-initialize the repository
+  against its source of truth. This is the standing pre-release storage posture
+  rather than something this release introduces: v0.3.6 accepted only the one
+  format it wrote, and so does this one. The accepted range widens when the
+  format is declared stable, not before.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,14 +3054,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "age",
  "anyhow",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-model",
  "serde",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-stream",
  "axum",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -90,7 +90,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.4.2", path = "../kin-spine" }
+kin-spine = { version = "0.4.3", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-git = { workspace = true, features = ["test-support"] }

--- a/crates/kin-cli/build.rs
+++ b/crates/kin-cli/build.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Give the Windows `kin` binaries a main thread that can parse their own
+//! command tree.
+//!
+//! Windows reserves 1 MiB for a binary's main thread where Unix reserves 8, and
+//! it is fixed at link time rather than raised at runtime. Building the command
+//! tree recurses over every subcommand, and this crate's own tests already run
+//! that recursion on a dedicated 16 MiB thread because the 2 MiB a test thread
+//! gets is not enough. So an unoptimized Windows build overflows before `main`
+//! reaches any command at all, including `--version`, and an optimized one
+//! survives only on smaller frames, one command-tree growth away from the same
+//! cliff.
+//!
+//! Reserved address space is not committed memory, so matching the 16 MiB the
+//! tests already use costs nothing at runtime and removes the cliff from both
+//! profiles.
+//!
+//! This has to be a link argument emitted here rather than `rustflags` in
+//! `.cargo/config.toml`: a `RUSTFLAGS` value in the environment replaces the
+//! config key outright, and CI sets `RUSTFLAGS` for every job.
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        println!("cargo::rustc-link-arg-bins=/STACK:16777216");
+    }
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/assert-windows-init-refusals.sh
+++ b/scripts/assert-windows-init-refusals.sh
@@ -52,13 +52,19 @@ CONFIG_CAUSE="an atomic exchanging or no-replace directory rename"
 # materialization replaced.
 SOURCE_PROOF_STAGE="prove mutable Git workspace"
 
+# Every assertion reports and the script exits once at the end. One CI round on
+# a Windows runner is expensive, so a run that stops at the first failure buys a
+# second round to learn what the second boundary did.
+failures=0
+
 fail() {
   local message="$1"
   local log="$2"
+  failures=$((failures + 1))
   echo "::error::$message"
   echo "--- captured kin init output: $log ---"
   cat "$log" || true
-  exit 1
+  echo "--- end $log ---"
 }
 
 # `grep -c` exits 1 on zero matches, which `set -e` would otherwise treat as a
@@ -100,6 +106,16 @@ require_refused() {
   fi
 }
 
+# What a command refuses means nothing until it can start. Windows gives the
+# main thread a 1 MiB stack where Unix gives 8 MiB, and this repository already
+# records that the CLI's own command tree needs more room than a 2 MiB thread
+# gives it, so "the binary died before it reached admission" is a real and
+# distinct outcome that must not be read as a missing refusal.
+startup_log="$scratch/kin-version.txt"
+if ! "$kin_bin" --version > "$startup_log" 2>&1; then
+  fail "kin --version did not run, so nothing below reports on admission" "$startup_log"
+fi
+
 git_boundary="$scratch/exact-git"
 git_log="$scratch/kin-init-exact-git.txt"
 mkdir -p "$git_boundary"
@@ -129,4 +145,8 @@ require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_lo
 require_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL" "$native_log"
 require_text "Windows native-unborn bootstrap" "$CONFIG_CAUSE" "$native_log"
 
+if [ "$failures" -ne 0 ]; then
+  echo "::error::Windows admission did not behave as asserted ($failures check(s) failed)"
+  exit 1
+fi
 echo "Windows admission refused on both boundaries and published no repository."

--- a/scripts/assert-windows-init-refusals.sh
+++ b/scripts/assert-windows-init-refusals.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# What `kin init` refuses on Windows, stated once.
+#
+# Both CI legs that own a Windows `kin` executable run this script: the
+# pull-request authority job and the landing-push installer proof. They cannot
+# disagree, because there is only one set of assertions. That matters because
+# the installer leg is off the pull-request path, so an admission change that
+# moved the refusal used to be unreviewable until it had already failed a
+# required check on a release commit.
+#
+# Usage: assert-windows-init-refusals.sh <kin executable> <scratch directory>
+
+set -euo pipefail
+
+usage() {
+  echo "usage: assert-windows-init-refusals.sh <kin executable> <scratch directory>" >&2
+  exit 2
+}
+
+kin_bin="${1-}"
+scratch="${2-}"
+if [ -z "$kin_bin" ] || [ -z "$scratch" ]; then
+  usage
+fi
+if [ ! -x "$kin_bin" ]; then
+  echo "::error::not an executable kin binary: $kin_bin"
+  exit 1
+fi
+
+# Every assertion runs from inside a fixture directory, so both arguments have
+# to survive the `cd`.
+kin_bin="$(cd "$(dirname "$kin_bin")" && pwd)/$(basename "$kin_bin")"
+mkdir -p "$scratch"
+scratch="$(cd "$scratch" && pwd)"
+
+# Admission refuses before it publishes anything, so no daemon should start.
+# Reap one anyway rather than leaving a runner process behind if that changes.
+trap 'taskkill.exe /F /IM kin-daemon.exe >/dev/null 2>&1 || true' EXIT
+
+# Publishing repository config is where both admission boundaries stop today.
+# Exact-Git admission proves executable modes from the Git index and link
+# targets from what `core.symlinks` says the worktree holds, so it runs past
+# the mutable-source proof and reaches this writer; native-unborn admission
+# reaches the same writer with no Git work in front of it.
+CONFIG_REFUSAL="cannot publish repository config"
+CONFIG_CAUSE="an atomic exchanging or no-replace directory rename"
+# Naming the mutable-source proof would mean exact-Git admission stopped in
+# front of the config writer, which is the behavior platform-resolved
+# materialization replaced.
+SOURCE_PROOF_STAGE="prove mutable Git workspace"
+
+fail() {
+  local message="$1"
+  local log="$2"
+  echo "::error::$message"
+  echo "--- captured kin init output: $log ---"
+  cat "$log" || true
+  exit 1
+}
+
+# `grep -c` exits 1 on zero matches, which `set -e` would otherwise treat as a
+# fatal error rather than the answer.
+occurrences() {
+  grep -Fc -- "$1" "$2" || true
+}
+
+require_text() {
+  local label="$1"
+  local needle="$2"
+  local log="$3"
+  if [ "$(occurrences "$needle" "$log")" -eq 0 ]; then
+    fail "$label did not report its refusal: $needle" "$log"
+  fi
+}
+
+refute_text() {
+  local label="$1"
+  local needle="$2"
+  local log="$3"
+  if [ "$(occurrences "$needle" "$log")" -ne 0 ]; then
+    fail "$label stopped at an earlier gate: $needle" "$log"
+  fi
+}
+
+require_refused() {
+  local label="$1"
+  local dir="$2"
+  local log="$3"
+  if (cd "$dir" && "$kin_bin" init) > "$log" 2>&1; then
+    fail "$label unexpectedly succeeded" "$log"
+  fi
+  # Both boundaries stage into a sibling `.kin.init-<uuid>` and publish only
+  # at the end, so a `.kin` of any shape means a refusal published authority
+  # anyway. This subsumes probing the authority store inside it.
+  if [ -e "$dir/.kin" ]; then
+    fail "$label left a half-created repository at $dir/.kin" "$log"
+  fi
+}
+
+git_boundary="$scratch/exact-git"
+git_log="$scratch/kin-init-exact-git.txt"
+mkdir -p "$git_boundary"
+(
+  cd "$git_boundary"
+  git init -q
+  git config user.email ci@firelock.ai
+  git config user.name ci
+  printf 'fn probe() {}\n' > probe.rs
+  git add probe.rs
+  # Hooks and signing are neutralized for this one invocation and NOT written
+  # into the fixture's config. A recorded `core.hooksPath` is itself a local
+  # compatibility blocker that admission refuses on before it ever reaches the
+  # config writer, so persisting one would prove a different refusal than the
+  # one under test.
+  git -c core.hooksPath= -c commit.gpgsign=false commit -qm probe
+)
+require_refused "Windows exact-Git admission" "$git_boundary" "$git_log"
+refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE" "$git_log"
+require_text "Windows exact-Git admission" "$CONFIG_REFUSAL" "$git_log"
+require_text "Windows exact-Git admission" "$CONFIG_CAUSE" "$git_log"
+
+native_boundary="$scratch/native-unborn"
+native_log="$scratch/kin-init-native-unborn.txt"
+mkdir -p "$native_boundary"
+require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log"
+require_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL" "$native_log"
+require_text "Windows native-unborn bootstrap" "$CONFIG_CAUSE" "$native_log"
+
+echo "Windows admission refused on both boundaries and published no repository."

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2632,13 +2632,53 @@ def main() -> None:
     ):
         require(release, policy, "Kin and pinned kin-vfs release compatibility gate")
 
+    # Windows admission refusals are stated once and asserted from one script.
+    # The installer leg proves them on the landing push, which is the commit
+    # release proof reads. The authority job proves the same assertions against
+    # the same command on every pull request and merge group, which is the only
+    # place an admission change is still reviewable. Pin both invocations and
+    # the assertions themselves: dropping the pull-request half restores a
+    # behavior change no one can see until it fails a required check on a
+    # release commit, and letting the two legs carry their own copies restores
+    # the drift that made the copies disagree.
+    windows_admission = (ROOT / "scripts" / "assert-windows-init-refusals.sh").read_text(
+        encoding="utf-8"
+    )
     for policy in (
-        "Reopen a fresh Windows graph through the daemon",
-        'grep -q "byte-exact executable-mode proof is unsupported"',
-        'grep -q "atomic repository config replacement is unsupported"',
-        'test ! -e "$boot_dir/.kin/kindb/head-generation"',
+        '"$kin_bin" init',
+        'CONFIG_REFUSAL="cannot publish repository config"',
+        'CONFIG_CAUSE="an atomic exchanging or no-replace directory rename"',
+        'SOURCE_PROOF_STAGE="prove mutable Git workspace"',
+        'refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE"',
+        'require_text "Windows exact-Git admission" "$CONFIG_REFUSAL"',
+        'require_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL"',
+        'fail "$label unexpectedly succeeded" "$log"',
+        'if [ -e "$dir/.kin" ]; then',
     ):
-        require(ci_workflow, policy, "Windows daemon reopen regression")
+        require(windows_admission, policy, "Windows admission refusal assertions")
+
+    ci_jobs = workflow_job_blocks(ci_workflow)
+    for job_id in ("windows-authority-tests", "windows-installer"):
+        for policy in (
+            "- name: Assert Windows admission refusals",
+            "bash ./scripts/assert-windows-init-refusals.sh",
+        ):
+            require(ci_jobs[job_id], policy, f"shared Windows admission proof in {job_id}")
+    require(
+        ci_jobs["windows-authority-tests"],
+        "target/x86_64-pc-windows-msvc/debug/kin.exe",
+        "pull-request Windows admission proof",
+    )
+    require(
+        ci_jobs["windows-installer"],
+        "target/x86_64-pc-windows-msvc/release/kin.exe",
+        "landing-push Windows admission proof",
+    )
+    if re.search(r"(?m)^    if:", ci_jobs["windows-authority-tests"]) is not None:
+        raise AssertionError(
+            "the Windows authority job must stay on every event, so admission "
+            "refusals are asserted before a release commit can carry them"
+        )
 
     for policy in (
         'workflows: ["Release"]',


### PR DESCRIPTION
> **Verified on Windows.** `Windows authority tests` is green on this head and
> its assertion step printed, on a real Windows host,
> `Windows admission refused on both boundaries and published no repository.`
> The binary starts, both admission boundaries refuse with the message derived
> below, and neither publishes a `.kin`. The build step costs 56 seconds and the
> assertion step 1 second.
>
> **The mirror this PR adds found a shipped Windows defect on its first run.**
> The Windows `kin.exe` it built aborted with
> `thread 'main' has overflowed its stack` before reaching any command at all.
> An unoptimized Windows build of `kin` could not run `--version`, and no CI job
> could report that, because the only job that holds a Windows `kin` binary runs
> on the landing push and only ever built the release profile. Reproduced here
> by lowering the stack limit: the unoptimized binary aborts at 1 MiB (the
> Windows default) and at 2 MiB, and runs at 4 MiB, with the same message.
> `kin-daemon` starts fine at 1 MiB and is left alone. Fixed in the third commit
> by reserving 16 MiB for the Windows `kin` main thread, which is what the CLI's
> own tests already use because
> `crates/kin-cli/src/main.rs` records that this command tree outgrew a 2 MiB
> thread.

v0.4.2 was never published. Its release commit `653d21d0` was refused because
`Windows installer + vector-free release build`, a required release context that
`ci.yml` deliberately skips on `pull_request` and `merge_group` and runs only on
the landing push, asserted a refusal message that PR #525 had already replaced
when it cleared the Windows executable-mode and symlink blockers on exact-Git
admission. Nothing about that change was visible to any pull request, because
the only job that asserts Windows `kin init` behavior never runs on one.

## What this changes

**The assertions now match the behavior that landed.** Both `kin init` admission
boundaries stop at the same place on Windows today, and it is not the
executable-mode proof any more. Exact-Git admission resolves the executable bit
from the Git index and link materialization from `core.symlinks`, so it runs
past `preflight_git_migration` and stops in `prepare_repository_layout_at` at
`KinConfig::save_initialization_stage`, whose non-Apple/Linux/Android arm returns
`cannot publish repository config <path> on this platform: capability-owned
replacement needs an atomic exchanging or no-replace directory rename and a
durable directory flush ...`. The native-unborn boundary reaches the same writer
with no Git work in front of it. Both greps in the installer leg were stale: PR
#525 rewrote the config-writer message too, so the non-Git assertion was one
landing away from burning a release commit by itself.

The refusal was derived by reading the call chain in source at `main`
(`git_init.rs` `init_from_git_with_hooks` -> `init.rs:528`
`config.save_initialization_stage` -> `config.rs` `save_config_atomically_scoped`
-> `unsupported_config_replacement`), not from the message text alone, and the
Windows leg on this head has since confirmed it by execution.

**The class is closed, not just the instance.** The assertions moved into
`scripts/assert-windows-init-refusals.sh`, and both legs run it: the installer
leg against the release binary on the landing push, and `Windows authority
tests` against a debug binary built with the same `--no-default-features`
feature set on every pull request and merge group. There is one set of
assertions, so the two legs cannot drift apart, and an admission change now
turns a pull request red before it can turn a release commit red. The
landing-push leg is not weakened: the shared script asserts strictly more than
the inline shell it replaces, adding the `.kin` absence check to both boundaries
and a refutation that admission stopped in front of the config writer.

`scripts/test-release-workflow-authority.py` pins both invocations, the binary
each leg drives, the assertions inside the script, and the fact that the
authority job carries no `if:` and therefore stays on every event. Three
mutations were applied and reverted to prove those pins can fail.

**Version cut 0.4.2 to 0.4.3** across the six surfaces plus both lockfiles.
`scripts/prepare-release.mjs` still cannot cut a release whose predecessor tag
was never minted (it verifies `v0.4.2^{commit}` before its first write), so the
lockfiles went through its own exported `updateWorkspaceLock` and the npm
manifests through the same parse/stringify path `main()` uses.
`node scripts/release-intent.mjs` reports v0.4.3 coherent with `should_tag=true`.

`release-tag.yml` and `release-train.yml` are byte-identical to `origin/main`
(blobs `ca4d5c98` and `8d37dce3`).

**Windows main-thread reservation.** `crates/kin-cli/build.rs` emits
`cargo::rustc-link-arg-bins=/STACK:16777216` for the MSVC target. It has to be a
build-script link argument rather than `[target.*].rustflags` in
`.cargo/config.toml`, because a `RUSTFLAGS` value in the environment replaces
that config key outright and `ci.yml` sets one for every job. Reserved address
space is not committed memory, so this costs nothing at runtime and it takes
both profiles off the cliff rather than only the one that was already over it.

## What this does not claim

- **No claim that v0.4.3 will mint.** Every required context has to go green on
  the merged sha, and the mint gate additionally refuses any non-green check-run
  on it.
- **No claim that the release-profile Windows binary ever crashed.** Pre-525
  release runs started fine and produced a refusal, so release startup was never
  the problem. What is claimed is that the unoptimized build could not start,
  that the optimized one was one command-tree growth from the same cliff, and
  that both are now off it.
- **No claim about what the release binary does at `kin init` today.** The
  installer leg is off the pull-request path and its `grep -q` printed nothing,
  so the 653d21d0 step cannot be read either way. The next landing push is the
  first place it can be observed, and this PR is what makes it readable.
- **No claim that `kin init` works on Windows.** It does not, and this does not
  make it. The atomic config writer is still the standing blocker.
- **No claim beyond the pull-request board.** It is settled green (23 pass,
  0 fail, 3 skip-by-design), but `Windows installer + vector-free release build`
  cannot run from a pull request, so the release-profile behavior is first
  observable on the landing push.
- **No claim that this removes every landing-push-only assertion from CI.** It
  moves the Windows admission assertions and nothing else.
- No benchmark, retrieval, or performance claim is made or affected.

Part-of FIR-1015.
