### PR TITLE
Stop test code mutating the shared process environment and umask

### DIFF
--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -93,6 +93,7 @@ unicode-normalization = "0.1"
 kin-spine = { version = "0.4.2", path = "../kin-spine" }
 
 [dev-dependencies]
+kin-core = { workspace = true, features = ["test-support"] }
 kin-git = { workspace = true, features = ["test-support"] }
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -504,20 +504,14 @@ mod tests {
         })
         .unwrap();
 
-        std::env::set_var("KINLAB_AUTH_PASSPHRASE", "test-passphrase");
-        let previous_hostname = std::env::var("HOSTNAME").ok();
-        std::env::set_var("HOSTNAME", "workstation");
+        let _env =
+            kin_core::test_env::EnvVarGuard::set("KINLAB_AUTH_PASSPHRASE", "test-passphrase")
+                .with("HOSTNAME", "workstation");
         write_encrypted_file(&path, &payload).unwrap();
 
         let actor_id = default_cli_actor_id(base_url);
         assert_eq!(actor_id, "cli:troy@firelock.ai:workstation");
 
         fs::remove_file(path).unwrap();
-        if let Some(hostname) = previous_hostname {
-            std::env::set_var("HOSTNAME", hostname);
-        } else {
-            std::env::remove_var("HOSTNAME");
-        }
-        std::env::remove_var("KINLAB_AUTH_PASSPHRASE");
     }
 }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1454,36 +1454,8 @@ fn check_retrieval_profile() -> HealthCheck {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
-    use std::ffi::{OsStr, OsString};
-
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-            let previous = env::var_os(key);
-            env::set_var(key, value.as_ref());
-            Self { key, previous }
-        }
-
-        fn remove(key: &'static str) -> Self {
-            let previous = env::var_os(key);
-            env::remove_var(key);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => env::set_var(self.key, value),
-                None => env::remove_var(self.key),
-            }
-        }
-    }
 
     fn write_file(path: &Path, bytes: &[u8]) {
         use std::io::Write;
@@ -1595,7 +1567,7 @@ mod tests {
         for path in [&registry, &lock] {
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
         }
-        let _registry_path = EnvGuard::set("KIN_REGISTRY_PATH", &registry);
+        let _registry_path = EnvVarGuard::set("KIN_REGISTRY_PATH", &registry);
 
         let check = check_registry_authority();
         assert!(matches!(check.status, HealthStatus::Misconfigured));
@@ -1637,14 +1609,14 @@ mod tests {
         )
         .unwrap();
 
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _kin_dir = EnvGuard::remove("KIN_DIR");
-        let _shell = EnvGuard::set("SHELL", "/bin/zsh");
-        let _ps_module_path = EnvGuard::remove("PSModulePath");
-        let _ps_version_table = EnvGuard::remove("PSVersionTable");
-        let _profile = EnvGuard::remove("PROFILE");
-        let _path = EnvGuard::set("PATH", "/usr/bin");
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvVarGuard::unset("KIN_DIR");
+        let _shell = EnvVarGuard::set("SHELL", "/bin/zsh");
+        let _ps_module_path = EnvVarGuard::unset("PSModulePath");
+        let _ps_version_table = EnvVarGuard::unset("PSVersionTable");
+        let _profile = EnvVarGuard::unset("PROFILE");
+        let _path = EnvVarGuard::set("PATH", "/usr/bin");
 
         let check = check_shell_path();
         assert_eq!(check.id, "shell_path");

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -16882,7 +16882,7 @@ mod tests {
     #[test]
     fn entity_page_size_honors_env_override() {
         // Default when unset; floor of 1 when set to 0.
-        std::env::remove_var("KIN_LOCATE_ENTITY_CAP");
+        let _cap = kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_ENTITY_CAP");
         assert_eq!(entity_page_size(), DEFAULT_ENTITY_PAGE_SIZE);
     }
 
@@ -17535,10 +17535,10 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
         admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
 
-        std::env::set_var("KIN_REQUIRE_COMPLETE_EMBEDDINGS", "1");
-        std::env::remove_var("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
+        let _coverage =
+            kin_core::test_env::EnvVarGuard::set("KIN_REQUIRE_COMPLETE_EMBEDDINGS", "1")
+                .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
         let result = run_with_graph_capture(&graph, "handler failure", true, 10, true);
-        std::env::remove_var("KIN_REQUIRE_COMPLETE_EMBEDDINGS");
 
         let err = match result {
             Ok(_) => panic!("strict mode should reject incomplete embeddings"),
@@ -17559,11 +17559,11 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
         admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
 
-        std::env::set_var("KIN_REQUIRE_COMPLETE_EMBEDDINGS", "1");
-        std::env::remove_var("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
+        let _coverage =
+            kin_core::test_env::EnvVarGuard::set("KIN_REQUIRE_COMPLETE_EMBEDDINGS", "1")
+                .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
         let result = run_with_graph_capture(&graph, "handler failure", true, 10, true)
             .expect("a vector-free build must still serve lexical and graph locate");
-        std::env::remove_var("KIN_REQUIRE_COMPLETE_EMBEDDINGS");
 
         let coverage = result
             .semantic_coverage
@@ -17591,8 +17591,8 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
         admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
 
-        std::env::remove_var("KIN_REQUIRE_COMPLETE_EMBEDDINGS");
-        std::env::remove_var("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
+        let _coverage = kin_core::test_env::EnvVarGuard::unset("KIN_REQUIRE_COMPLETE_EMBEDDINGS")
+            .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
         let result = run_with_graph_capture(&graph, "handler failure", true, 10, true)
             .expect("default locate must degrade gracefully, not error");
 
@@ -17618,8 +17618,8 @@ mod tests {
         // RRF ties on the rank term and breaks by name (the competitor sorts
         // first); a >1.0 embedding rank weight lifts the semantic-only gold above
         // its lexical peer — the buried-gold rank-lift lever.
-        let old_weight = std::env::var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT").ok();
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", "0.0");
+        let _weight =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", "0.0");
 
         let mut lists: Vec<Vec<(String, f32)>> = vec![Vec::new(); 10];
         lists[8] = vec![("src/aaa_comp.rs".to_string(), 1.0)];
@@ -17632,12 +17632,6 @@ mod tests {
         weights[9] = 2.0;
         let weighted = reciprocal_rank_fusion_weighted(&lists, 60.0, &weights, &[]);
         let first_weighted = weighted.first().map(|(p, _)| p.as_str());
-
-        if let Some(val) = old_weight {
-            std::env::set_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", val);
-        } else {
-            std::env::remove_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT");
-        }
 
         assert_eq!(
             first_unweighted,
@@ -17736,9 +17730,9 @@ mod tests {
         // The gated lever extends class-like head-truncation to any over-threshold
         // entity. Default OFF keeps the span byte-identical (no regression risk);
         // the precision↔recall trade is a ContextBench line-F1 call before flip.
-        std::env::remove_var("KIN_LOCATE_SPAN_FULL_EXTENT");
-        std::env::remove_var("KIN_LOCATE_SPAN_CLASS_HEAD_THRESHOLD");
-        std::env::remove_var("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG");
+        let mut span = kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_SPAN_FULL_EXTENT")
+            .without("KIN_LOCATE_SPAN_CLASS_HEAD_THRESHOLD")
+            .without("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG");
 
         let mut coarse = test_entity("whole_module", "src/big.rs", 0, 1500);
         coarse.kind = EntityKind::File;
@@ -17749,9 +17743,9 @@ mod tests {
             "default OFF: a coarse File-kind entity emits its full extent (unchanged)"
         );
 
-        std::env::set_var("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG", "1");
+        span.apply("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG", Some("1"));
         let tightened = entity_span_pair(&coarse);
-        std::env::remove_var("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG");
+        span.apply::<_, &str>("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG", None);
         assert_eq!(
             tightened,
             vec![[1, 5]],
@@ -18091,7 +18085,7 @@ mod tests {
     #[serial_test::serial]
     fn declaration_cutoff_env_gate_defaults_off_is_byte_identical() {
         use crate::retrieval_profile::RetrievalProfile;
-        std::env::remove_var("KIN_LOCATE_DECLARATION_CUTOFF");
+        let _cutoff = kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_DECLARATION_CUTOFF");
         // A decisive single-winner distribution the cutoff WOULD trim if enabled.
         let results = cutoff_list(&[10.0, 0.2, 0.1]);
         for profile in [RetrievalProfile::CompatV0, RetrievalProfile::AccuracyV1] {
@@ -18119,9 +18113,9 @@ mod tests {
     fn declaration_cutoff_env_override_forces_the_trim() {
         // The A/B path: an explicit env var wins over the (dark) profile default
         // and drives the trim, using the registered gap/min_keep defaults.
-        std::env::set_var("KIN_LOCATE_DECLARATION_CUTOFF", "1");
-        std::env::remove_var("KIN_LOCATE_DECLARATION_CUTOFF_GAP");
-        std::env::remove_var("KIN_LOCATE_DECLARATION_CUTOFF_MIN_KEEP");
+        let _cutoff = kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_DECLARATION_CUTOFF", "1")
+            .without("KIN_LOCATE_DECLARATION_CUTOFF_GAP")
+            .without("KIN_LOCATE_DECLARATION_CUTOFF_MIN_KEEP");
         let enabled = locate_env_bool("KIN_LOCATE_DECLARATION_CUTOFF", false);
         assert!(
             enabled,
@@ -18131,7 +18125,6 @@ mod tests {
         let min_keep = locate_env_usize("KIN_LOCATE_DECLARATION_CUTOFF_MIN_KEEP", 1);
         let results = cutoff_list(&[10.0, 0.2, 0.1]);
         assert_eq!(declaration_cutoff_len(&results, gap, min_keep), 1);
-        std::env::remove_var("KIN_LOCATE_DECLARATION_CUTOFF");
     }
 
     #[test]
@@ -21078,7 +21071,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn rerank_semantic_phase_paths_leaves_phase_anchors_dark_by_default() {
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
         let mut fused = vec![
             ("src/libponyc/pass/expr.h".to_string(), 0.158),
             ("src/libponyc/expr/reference.c".to_string(), 0.123),
@@ -21118,7 +21112,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn semantic_phase_anchor_floors_dark_by_default_even_with_full_signal_support() {
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
         let source_files = HashSet::from([String::from("engine/pass/typecheck.rs")]);
         let all_hits = vec![HashMap::from([(
             "engine/pass/typecheck.rs".to_string(),
@@ -21140,7 +21135,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn semantic_phase_anchor_floors_ranks_signal_supported_bucket_files_when_enabled() {
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
 
         // A fictional, non-Pony corpus: the mechanism must work from bucket +
         // cross-signal support alone, not from any hardcoded name or path.
@@ -21210,14 +21206,13 @@ mod tests {
                 ("engine/expr/closure_capture.rs", 6.4),
             ],
         );
-
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
     }
 
     #[test]
     #[serial_test::serial]
     fn semantic_phase_anchor_floors_is_deterministic() {
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
         let source_files = HashSet::from([
             String::from("engine/pass/typecheck.rs"),
             String::from("engine/pass/lower.rs"),
@@ -21237,14 +21232,13 @@ mod tests {
             "identical inputs must yield identical output"
         );
         assert!(!first.is_empty());
-
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
     }
 
     #[test]
     #[serial_test::serial]
     fn semantic_phase_distractor_cap_dark_by_default_even_with_zero_signal_support() {
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::unset("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
 
         let cap = semantic_phase_distractor_cap(
             "Fix return checking in constructors.",
@@ -21258,7 +21252,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn semantic_phase_distractor_cap_caps_unsupported_bucket_files_when_enabled() {
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
 
         // A fictional, non-Pony corpus: the mechanism must work from bucket +
         // cross-signal support alone, not from any hardcoded name or path.
@@ -21343,14 +21338,13 @@ mod tests {
             None,
             "a lambda query must never cap the pass bucket"
         );
-
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
     }
 
     #[test]
     #[serial_test::serial]
     fn semantic_phase_distractor_cap_is_deterministic() {
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
+        let _anchors =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS", "1");
         let all_hits: Vec<HashMap<String, Vec<FileHit>>> = vec![];
         let text = "Fix return checking in constructors with lambda captures.";
         let path = "engine/expr/closure.rs";
@@ -21362,8 +21356,6 @@ mod tests {
             "identical inputs must yield identical output"
         );
         assert!(first.is_some());
-
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PHASE_GRAPH_ANCHORS");
     }
 
     #[test]
@@ -22066,21 +22058,12 @@ mod tests {
             },
         )]);
 
-        let old_frontier = std::env::var("KIN_LOCATE_RESOLVE_ARTIFACT_FRONTIER").ok();
-        let old_graph_floor = std::env::var("KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR").ok();
-        std::env::set_var("KIN_LOCATE_RESOLVE_ARTIFACT_FRONTIER", "1");
-        std::env::set_var("KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR", "0.25");
-        let result = resolve_entities_to_files(&seeds, &graph, true, "text");
-        if let Some(value) = old_frontier {
-            std::env::set_var("KIN_LOCATE_RESOLVE_ARTIFACT_FRONTIER", value);
-        } else {
-            std::env::remove_var("KIN_LOCATE_RESOLVE_ARTIFACT_FRONTIER");
-        }
-        if let Some(value) = old_graph_floor {
-            std::env::set_var("KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR", value);
-        } else {
-            std::env::remove_var("KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR");
-        }
+        let result = {
+            let _frontier =
+                kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_RESOLVE_ARTIFACT_FRONTIER", "1")
+                    .with("KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR", "0.25");
+            resolve_entities_to_files(&seeds, &graph, true, "text")
+        };
         let (resolved, _, _, _, candidate_stages) = result.unwrap();
 
         assert!(
@@ -23671,7 +23654,8 @@ mod tests {
         // Several files tie on the rank term (each appears once at rank 0 in a
         // distinct list with equal score). Fusing repeatedly must yield exactly
         // the same ordering every time.
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", "0.0");
+        let _weight =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", "0.0");
         let lists: Vec<Vec<(String, f32)>> = vec![
             vec![("src/d.rs".to_string(), 1.0)],
             vec![("src/a.rs".to_string(), 1.0)],
@@ -23686,7 +23670,6 @@ mod tests {
                 "RRF output must be byte-identical across runs"
             );
         }
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT");
         // All-tied scores: ordering must be the canonical path-ascending order.
         let order: Vec<&str> = first.iter().map(|(p, _)| p.as_str()).collect();
         assert_eq!(order, vec!["src/a.rs", "src/b.rs", "src/c.rs", "src/d.rs"]);
@@ -23697,7 +23680,8 @@ mod tests {
         // The same tied candidates presented in different per-list orders (a
         // stand-in for HashMap iteration variance upstream) must fuse to the
         // same final ordering — the path tie-break, not arrival order, decides.
-        std::env::set_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", "0.0");
+        let _weight =
+            kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT", "0.0");
         let forward: Vec<Vec<(String, f32)>> = vec![vec![
             ("src/a.rs".to_string(), 5.0),
             ("src/b.rs".to_string(), 5.0),
@@ -23710,7 +23694,6 @@ mod tests {
         ]];
         let a = reciprocal_rank_fusion_weighted(&forward, 60.0, &[], &[]);
         let b = reciprocal_rank_fusion_weighted(&reversed, 60.0, &[], &[]);
-        std::env::remove_var("KIN_LOCATE_SEMANTIC_PRIMACY_WEIGHT");
         // Same RANK positions tie within one list, so the rank term is equal for
         // all three; only the within-list rank differs. The fused set and its
         // tie-broken order must be stable regardless of how the list was ordered.

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -303,40 +303,9 @@ mod tests {
         bind_daemon_for_repo_dir, bind_first_kin_repo_against, build_mcp_start_config,
         resolve_repo_override, session_authority_notice, start,
     };
+    use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
     use std::path::PathBuf;
-
-    /// RAII guard that saves and restores a single env var around a test, so
-    /// tests that mutate process-global env state (unavoidable — cwd/env are
-    /// how `kin mcp start` binds its repo) don't leak into other tests in this
-    /// binary.
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let previous = std::env::var(key).ok();
-            std::env::set_var(key, value);
-            Self { key, previous }
-        }
-
-        fn remove(key: &'static str) -> Self {
-            let previous = std::env::var(key).ok();
-            std::env::remove_var(key);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 
     #[test]
     fn daemon_available_notice_mentions_daemon_authority() {
@@ -385,7 +354,7 @@ mod tests {
     #[test]
     #[serial]
     fn repo_override_none_when_neither_flag_nor_env_set() {
-        let _guard = EnvVarGuard::remove("KIN_MCP_REPO");
+        let _guard = EnvVarGuard::unset("KIN_MCP_REPO");
         assert_eq!(resolve_repo_override(None), None);
     }
 
@@ -398,7 +367,7 @@ mod tests {
         // A directory with no .kin/ must produce an `Err` reason string for
         // the caller to log, never a panic or a process-killing error
         // propagated out of `start`.
-        let _daemon_guard = EnvVarGuard::remove("KIN_DAEMON_URL");
+        let _daemon_guard = EnvVarGuard::unset("KIN_DAEMON_URL");
         let tmp = tempfile::tempdir().unwrap();
         let reason = bind_daemon_for_repo_dir(tmp.path())
             .await
@@ -553,7 +522,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn roots_with_no_kin_repository_bind_nothing() {
-        let _daemon_guard = EnvVarGuard::remove("KIN_DAEMON_URL");
+        let _daemon_guard = EnvVarGuard::unset("KIN_DAEMON_URL");
         // No autostart: this test must never spawn a daemon process.
         let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
         let plain = tempfile::tempdir().unwrap();

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -1481,7 +1481,7 @@ mod tests {
     #[test]
     #[serial]
     fn precise_mode_rejects_broad_show_body_searches() {
-        std::env::set_var("KIN_SEARCH_MODE", "precise");
+        let _mode = kin_core::test_env::EnvVarGuard::set("KIN_SEARCH_MODE", "precise");
         let err = enforce_precise_search_mode(
             "parse|parseStrict|_parse|run",
             &["parse", "parseStrict", "_parse", "run"],
@@ -1492,13 +1492,12 @@ mod tests {
         .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("limited to `--limit 5`") || msg.contains("too many OR terms"));
-        std::env::remove_var("KIN_SEARCH_MODE");
     }
 
     #[test]
     #[serial]
     fn precise_mode_accepts_small_exact_or_searches() {
-        std::env::set_var("KIN_SEARCH_MODE", "precise");
+        let _mode = kin_core::test_env::EnvVarGuard::set("KIN_SEARCH_MODE", "precise");
         let result = enforce_precise_search_mode(
             "$MyType|$MyTypeInternals",
             &["$MyType", "$MyTypeInternals"],
@@ -1507,7 +1506,6 @@ mod tests {
             Some(5),
         );
         assert!(result.is_ok());
-        std::env::remove_var("KIN_SEARCH_MODE");
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12193,36 +12193,8 @@ pub fn uninstall(dry_run: bool, force: bool, json: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
-    use std::ffi::{OsStr, OsString};
-
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-            let previous = env::var_os(key);
-            env::set_var(key, value.as_ref());
-            Self { key, previous }
-        }
-
-        fn remove(key: &'static str) -> Self {
-            let previous = env::var_os(key);
-            env::remove_var(key);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => env::set_var(self.key, value),
-                None => env::remove_var(self.key),
-            }
-        }
-    }
 
     fn opts() -> WizardOptions {
         WizardOptions {
@@ -12584,8 +12556,8 @@ wait
         fs::create_dir_all(shim.parent().unwrap()).unwrap();
         fs::write(&shim, b"MANAGED_SHIM").unwrap();
 
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _kin_dir = EnvGuard::remove("KIN_DIR");
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvVarGuard::unset("KIN_DIR");
 
         assert_eq!(find_shim().as_deref(), Some(shim.as_path()));
     }
@@ -12884,15 +12856,14 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[test]
     #[serial]
     fn kin_dir_honors_kin_home_before_kin_dir() {
-        let _kin_home = EnvGuard::remove("KIN_HOME");
-        let _kin_dir = EnvGuard::remove("KIN_DIR");
+        let mut home = EnvVarGuard::unset("KIN_HOME").without("KIN_DIR");
         let fallback = PathBuf::from("/tmp/kin-dir-only");
         let preferred = PathBuf::from("/tmp/kin-home-preferred");
 
-        env::set_var("KIN_DIR", &fallback);
+        home.apply("KIN_DIR", Some(&fallback));
         assert_eq!(kin_dir().unwrap(), fallback);
 
-        env::set_var("KIN_HOME", &preferred);
+        home.apply("KIN_HOME", Some(&preferred));
         assert_eq!(kin_dir().unwrap(), preferred);
     }
 
@@ -12904,10 +12875,10 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let kin_home = tmp.path().join("kin-home");
         fs::create_dir_all(&home).unwrap();
 
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _kin_dir = EnvGuard::remove("KIN_DIR");
-        let _path = EnvGuard::set("PATH", "/usr/bin");
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvVarGuard::unset("KIN_DIR");
+        let _path = EnvVarGuard::set("PATH", "/usr/bin");
 
         install_shell_hook("zsh").unwrap();
         install_shell_hook("zsh").unwrap();
@@ -13020,7 +12991,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn merge_mcp_config_refuses_to_overwrite_corrupt_json() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let path = dir.path().join("config.json");
         std::fs::write(&path, b"this is not json {{{").unwrap();
 
@@ -13047,7 +13018,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn merge_mcp_config_merges_into_valid_existing_file() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let path = dir.path().join("config.json");
         std::fs::write(&path, r#"{"existingKey": true}"#).unwrap();
 
@@ -13066,7 +13037,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn merge_mcp_config_toml_refuses_to_overwrite_corrupt_toml() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let repo = dir.path().join("repo");
         fs::create_dir_all(repo.join(".kin")).unwrap();
         let path = dir.path().join("config.toml");
@@ -13095,7 +13066,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn merge_mcp_config_toml_preserves_existing_codex_config() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let repo = dir.path().join("repo");
         fs::create_dir_all(repo.join(".kin")).unwrap();
         let repo = repo.canonicalize().unwrap();
@@ -13143,7 +13114,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn merge_mcp_config_toml_creates_missing_file_and_is_idempotent() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let repo = dir.path().join("repo");
         fs::create_dir_all(repo.join(".kin")).unwrap();
         let repo = repo.canonicalize().unwrap();
@@ -13178,7 +13149,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn codex_merge_preserves_table_env_cwd_and_user_policy() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let repo = dir.path().join("repo");
         fs::create_dir_all(repo.join(".kin")).unwrap();
         let repo = repo.canonicalize().unwrap();
@@ -13209,7 +13180,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[serial]
     fn structurally_incompatible_configs_fail_closed_byte_for_byte() {
         let dir = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let json = dir.path().join("config.json");
         let json_bytes = br#"{"mcpServers":{"kin":{"env":"user-owned"}}}"#;
         fs::write(&json, json_bytes).unwrap();
@@ -13235,8 +13206,8 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let config = client.join("mcp.json");
         fs::write(&config, b"{}").unwrap();
         let alias = client.join("..").join(".cursor").join("mcp.json");
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", dir.path().join("kin-home"));
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", dir.path().join("kin-home"));
         let digest = crate::commands::setup_ledger::sha256_hex(b"{}");
         let cursor = McpRepairTarget {
             id: "cursor".to_string(),
@@ -15416,8 +15387,8 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let kin_home = dir.path().join("kin-home");
         fs::create_dir_all(home.join(".claude")).unwrap();
         fs::create_dir_all(kin_home.join("config")).unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         let digest = crate::commands::setup_ledger::sha256_hex(b"{}");
 
         let primary = home.join(".claude.json");
@@ -15484,8 +15455,8 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
             ),
         )
         .unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
 
         let captured = current_mcp_repair_targets().unwrap();
         let captured = captured
@@ -15525,8 +15496,8 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
             r#"{"mcpServers":{"kin":{"command":"/stale/kin","args":["mcp","start"]}}}"#,
         )
         .unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         let captured = current_mcp_repair_targets().unwrap();
         assert_eq!(captured.len(), 1);
 
@@ -15627,9 +15598,10 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
             .output()
             .unwrap();
         assert!(git.status.success());
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _scan_root = EnvGuard::set(crate::commands::managed_config_scope::SCAN_ROOT_ENV, &repo);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _scan_root =
+            EnvVarGuard::set(crate::commands::managed_config_scope::SCAN_ROOT_ENV, &repo);
         let previous = env::current_dir().unwrap();
         env::set_current_dir(&repo).unwrap();
         let _cwd = CurrentDirGuard(previous);
@@ -15704,10 +15676,10 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
             br#"{"mcpServers":{"kin":{"command":"/enclosing/kin","args":["mcp","start"]}}}"#;
         fs::write(&decoy, decoy_bytes).unwrap();
 
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         let _scan_root =
-            EnvGuard::set(crate::commands::managed_config_scope::SCAN_ROOT_ENV, &inner);
+            EnvVarGuard::set(crate::commands::managed_config_scope::SCAN_ROOT_ENV, &inner);
         let previous = env::current_dir().unwrap();
         env::set_current_dir(&inner).unwrap();
         let _cwd = CurrentDirGuard(previous);
@@ -15742,7 +15714,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let outside = dir.path().join("outside");
         fs::create_dir_all(&fixture).unwrap();
         fs::create_dir_all(&outside).unwrap();
-        let _fixture_root = EnvGuard::set(
+        let _fixture_root = EnvVarGuard::set(
             crate::commands::managed_config_scope::FIXTURE_ROOT_ENV,
             &fixture,
         );
@@ -15771,7 +15743,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
 }"#,
         )
         .unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         let target = McpRepairTarget {
             id: "antigravity".to_string(),
             path: config.clone(),

--- a/crates/kin-cli/src/commands/test_subprocess.rs
+++ b/crates/kin-cli/src/commands/test_subprocess.rs
@@ -1723,14 +1723,15 @@ mod tests {
         }
 
         if let Some(marker) = std::env::var_os(AUTHORITY_OUTER) {
+            let mut ambient = kin_core::test_env::EnvVarGuard::new();
             for key in HOSTILE_AUTHORITY_KEYS {
-                std::env::set_var(key, "ambient-hostile");
+                ambient.apply(key, Some("ambient-hostile"));
             }
             for (key, _) in ALLOWED_WORKER_INPUTS {
-                std::env::set_var(key, "ambient-hostile");
+                ambient.apply(key, Some("ambient-hostile"));
             }
-            std::env::set_var("KIN_DIR", "/ambient/legacy-home");
-            std::env::set_var("KIN_MCP_REPO", "/ambient/repository");
+            ambient.apply("KIN_DIR", Some("/ambient/legacy-home"));
+            ambient.apply("KIN_MCP_REPO", Some("/ambient/repository"));
 
             let mut command = Command::new(std::env::current_exe().unwrap());
             command

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -10107,30 +10107,8 @@ fn is_newer(latest: &str, current: &str) -> Result<bool> {
 mod tests {
     use super::*;
     use crate::commands::test_subprocess::{output_with_timeout, DEFAULT_TEST_SUBPROCESS_TIMEOUT};
+    use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
-    use std::ffi::{OsStr, OsString};
-
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-            let previous = std::env::var_os(key);
-            std::env::set_var(key, value.as_ref());
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 
     fn test_subprocess_output(command: Command, label: &str) -> Result<std::process::Output> {
         output_with_timeout(command, label, DEFAULT_TEST_SUBPROCESS_TIMEOUT)
@@ -11321,8 +11299,8 @@ cwd = {:?}
         let stage = tmp.path().join("stage");
         let home = tmp.path().join("home");
         fs::create_dir(&home).unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", &custom_home);
-        let _home = EnvGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &custom_home);
+        let _home = EnvVarGuard::set("HOME", &home);
         let _cwd = CwdGuard::set(tmp.path());
         write_bundle(&custom_home, LINUX_COMPONENTS, b"old-");
 
@@ -11540,8 +11518,8 @@ cwd = {:?}
             let stage = tmp.path().join("stage");
             let home = tmp.path().join("home");
             fs::create_dir(&home).unwrap();
-            let _home = EnvGuard::set("HOME", &home);
-            let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+            let _home = EnvVarGuard::set("HOME", &home);
+            let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
             write_bundle(&kin_home, LINUX_COMPONENTS, b"old-");
             let expected = bundle_snapshot(&kin_home, LINUX_COMPONENTS);
             stage_archive(
@@ -12814,8 +12792,8 @@ cwd = {:?}
         let home = tmp.path().join("home");
         fs::create_dir_all(&home).unwrap();
         fs::create_dir_all(&kin_home).unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _home = EnvGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
         let stage = tmp.path().join("stage");
         write_bundle(&kin_home, WINDOWS_COMPONENTS, b"old-");
         let archive = make_zip(&[("kin.exe", b"new-kin"), ("kin-daemon.exe", b"new-daemon")]);
@@ -12864,8 +12842,8 @@ cwd = {:?}
             .map(|entry| entry.unwrap().file_name())
             .collect();
         before.sort();
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _registry = EnvGuard::set("KIN_REGISTRY_PATH", &registry);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _registry = EnvVarGuard::set("KIN_REGISTRY_PATH", &registry);
 
         let error = run(false, None, None, None, None, true, true, false, Vec::new())
             .await
@@ -12903,7 +12881,7 @@ cwd = {:?}
         fs::set_permissions(&lock, fs::Permissions::from_mode(0o644)).unwrap();
         let before_registry = fs::read(&registry).unwrap();
         let before_lock = fs::read(&lock).unwrap();
-        let _registry = EnvGuard::set("KIN_REGISTRY_PATH", &registry);
+        let _registry = EnvVarGuard::set("KIN_REGISTRY_PATH", &registry);
 
         let error = registry_authority_preflight()
             .expect_err("updater must refuse unsafe registry authority");
@@ -12951,9 +12929,9 @@ cwd = {:?}
             ),
         )
         .unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _kin_dir = EnvGuard::set("KIN_DIR", tmp.path().join("wrong-install"));
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvVarGuard::set("KIN_DIR", tmp.path().join("wrong-install"));
 
         let repaired = crate::commands::setup::remerge_existing_mcp_configs();
         let normalized_config = crate::commands::setup::ConfigLock::normalized_path(&config)
@@ -13000,9 +12978,9 @@ cwd = {:?}
             let home = state.mcp_home.as_ref().unwrap();
             let repo = state.mcp_repo.as_ref().unwrap();
             let config = state.mcp_config.as_ref().unwrap();
-            let _home = EnvGuard::set("HOME", home);
-            let _kin_home = EnvGuard::set("KIN_HOME", &state.kin_home);
-            let _kin_dir = EnvGuard::set("KIN_DIR", state._tmp.path().join("wrong-install"));
+            let _home = EnvVarGuard::set("HOME", home);
+            let _kin_home = EnvVarGuard::set("KIN_HOME", &state.kin_home);
+            let _kin_dir = EnvVarGuard::set("KIN_DIR", state._tmp.path().join("wrong-install"));
             let _cwd = CwdGuard::set(&home);
 
             let lock = InstallRootLock::acquire_existing(&state.kin_home).unwrap();
@@ -13055,8 +13033,8 @@ cwd = {:?}
         fs::create_dir_all(config.parent().unwrap()).unwrap();
         let malformed = b"\xff\xfe[mcp_servers.kin\ncommand =";
         fs::write(&config, malformed).unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &state.kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &state.kin_home);
         let _cwd = CwdGuard::set(&home);
         enqueue_mcp_repair_targets(&[crate::commands::setup::McpRepairTarget {
             id: "codex".to_string(),
@@ -13095,8 +13073,8 @@ cwd = {:?}
             "[mcp_servers.kin]\ncommand = \"/stale/kin\"\nargs = [\"mcp\", \"start\"]\n",
         )
         .unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         enqueue_mcp_repair_targets(&[crate::commands::setup::McpRepairTarget {
             id: "codex".to_string(),
             path: config.clone(),
@@ -13169,8 +13147,8 @@ cwd = {:?}
             fs::write(&marker, &bytes).unwrap();
             let home = tmp.path().join("home");
             fs::create_dir_all(&home).unwrap();
-            let _home = EnvGuard::set("HOME", &home);
-            let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+            let _home = EnvVarGuard::set("HOME", &home);
+            let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
 
             let lock = InstallRootLock::acquire_existing(&kin_home).unwrap();
             assert!(attempt_pending_mcp_repair(&lock).is_err());
@@ -13216,8 +13194,8 @@ cwd = {:?}
         }))
         .unwrap();
         fs::write(&marker, &marker_bytes).unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
 
         let lock = InstallRootLock::acquire_existing(&kin_home).unwrap();
         let error = attempt_pending_mcp_repair(&lock)
@@ -13271,8 +13249,8 @@ cwd = {:?}
         }))
         .unwrap();
         fs::write(&marker, &marker_bytes).unwrap();
-        let _home = EnvGuard::set("HOME", tmp.path().join("home"));
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", tmp.path().join("home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
 
         let lock = InstallRootLock::acquire_existing(&kin_home).unwrap();
         let error = attempt_pending_mcp_repair(&lock)
@@ -13295,8 +13273,8 @@ cwd = {:?}
             write_bundle(&kin_home, LINUX_COMPONENTS, b"installed-");
             let home = tmp.path().join("home");
             fs::create_dir_all(home.join(".cursor")).unwrap();
-            let _home = EnvGuard::set("HOME", &home);
-            let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+            let _home = EnvVarGuard::set("HOME", &home);
+            let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
             let victim = match victim_kind {
                 "arbitrary_json" => home.join("victim.json"),
                 "restart_marker" => restart_pending_path(&kin_home),
@@ -13348,8 +13326,8 @@ cwd = {:?}
         let marker = mcp_repair_pending_path(&kin_home);
         let marker_bytes = br#"{"schema_version":99,"installed_version":"0.2.21","recorded_at":"2026-07-16T00:00:00Z","repair_required":true,"targets":[]}"#;
         fs::write(&marker, marker_bytes).unwrap();
-        let _home = EnvGuard::set("HOME", tmp.path().join("home"));
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", tmp.path().join("home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
 
         let error = install_staged_bundle(
             &kin_home,
@@ -13495,8 +13473,8 @@ cwd = {:?}
         let config_bytes =
             br#"{"mcpServers":{"kin":{"command":"/stale/kin","args":["mcp","start"]}}}"#;
         fs::write(&config, config_bytes).unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         let target = crate::commands::setup::McpRepairTarget {
             id: "cursor".to_string(),
             path: config,
@@ -13558,8 +13536,8 @@ cwd = {:?}
             path: existing_path,
             repo_root: None,
         };
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         let lock = InstallRootLock::acquire_existing(&kin_home).unwrap();
         persist_mcp_repair_record_at(
             lock.install().unwrap(),
@@ -13592,8 +13570,8 @@ cwd = {:?}
         fs::remove_file(&managed).unwrap();
         fs::hard_link(std::env::current_exe().unwrap(), &managed).unwrap();
         fs::set_permissions(&managed, fs::Permissions::from_mode(0o755)).unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _home = EnvGuard::set("HOME", tmp.path().join("home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", tmp.path().join("home"));
 
         assert!(UpdaterStartAuthority::capture(&kin_home, LINUX_COMPONENTS).is_ok());
         let replacement = kin_home.join("bin/.kin-identical-replacement");
@@ -13630,8 +13608,8 @@ cwd = {:?}
         )
         .into_bytes();
         fs::write(&config, &config_bytes).unwrap();
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
         enqueue_mcp_repair_targets(&[crate::commands::setup::McpRepairTarget {
             id: "codex".to_string(),
             path: config.clone(),
@@ -13725,8 +13703,8 @@ cwd = {:?}
         )
         .unwrap();
         let marker = mcp_repair_pending_path(&state.kin_home);
-        let _home = EnvGuard::set("HOME", &home);
-        let _kin_home = EnvGuard::set("KIN_HOME", &state.kin_home);
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &state.kin_home);
         let _cwd = CwdGuard::set(&home);
         enqueue_mcp_repair_targets(&[crate::commands::setup::McpRepairTarget {
             id: "codex".to_string(),
@@ -13790,8 +13768,8 @@ cwd = {:?}
         mark_restart_record_committed(&mut record, &kin_home, LINUX_COMPONENTS).unwrap();
         persist_restart_record_at(lock.install().unwrap(), &record).unwrap();
         drop(lock);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _home = EnvGuard::set("HOME", tmp.path().join("home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", tmp.path().join("home"));
 
         acknowledge_runtime_restart(&[]).unwrap();
 
@@ -13868,8 +13846,8 @@ cwd = {:?}
             fs::write(&marker, &marker_bytes).unwrap();
             fs::set_permissions(&marker, fs::Permissions::from_mode(0o600)).unwrap();
             drop(lock);
-            let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-            let _home = EnvGuard::set("HOME", tmp.path().join("home"));
+            let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+            let _home = EnvVarGuard::set("HOME", tmp.path().join("home"));
 
             let error = acknowledge_runtime_restart(&[])
                 .expect_err("unknown restart lifecycle fields must fail closed");
@@ -14286,8 +14264,8 @@ cwd = {:?}
         record.dependency_provenance = build.dependency_provenance.to_string();
         persist_restart_record_at(lock.install().unwrap(), &record).unwrap();
         drop(lock);
-        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
-        let _home = EnvGuard::set("HOME", tmp.path().join("home"));
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _home = EnvVarGuard::set("HOME", tmp.path().join("home"));
 
         let error = acknowledge_runtime_restart(&[])
             .expect_err("a different running build cannot acknowledge the marker");
@@ -14302,8 +14280,8 @@ cwd = {:?}
         let tmp = tempfile::tempdir().unwrap();
         let fallback = tmp.path().join("fallback");
         let preferred = tmp.path().join("preferred");
-        let _kin_dir = EnvGuard::set("KIN_DIR", &fallback);
-        let _kin_home = EnvGuard::set("KIN_HOME", &preferred);
+        let _kin_dir = EnvVarGuard::set("KIN_DIR", &fallback);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &preferred);
 
         assert_eq!(UpdateConfig::path().unwrap(), preferred.join("update.toml"));
     }
@@ -14312,7 +14290,7 @@ cwd = {:?}
     #[serial]
     fn check_only_channel_override_does_not_persist_state() {
         let tmp = tempfile::tempdir().unwrap();
-        let _kin_home = EnvGuard::set("KIN_HOME", tmp.path());
+        let _kin_home = EnvVarGuard::set("KIN_HOME", tmp.path());
 
         assert_eq!(
             resolve_channel(tmp.path(), Some(Channel::Alpha), true, false),
@@ -15031,7 +15009,7 @@ cwd = {:?}
 
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("observed-mode");
-        let _observe = EnvGuard::set("KIN_UPDATE_TEST_PRIVATE_CREATE_OBSERVE", &marker);
+        let _observe = EnvVarGuard::set("KIN_UPDATE_TEST_PRIVATE_CREATE_OBSERVE", &marker);
         // SAFETY: umask accepts every mode value and has no pointer arguments.
         let _umask = UmaskGuard(unsafe { libc::umask(0) });
         let root =

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -14993,36 +14993,65 @@ cwd = {:?}
         assert!(format!("{error:#}").contains("inspection bound"));
     }
 
+    /// A permissive umask must not widen the private updater root.
+    ///
+    /// The observation runs in a worker process because the file-creation mask
+    /// is process-global, exactly like the environment table: every directory
+    /// any concurrently running test creates while this one holds `umask(0)`
+    /// comes out world-writable, and Kin's own namespace-safety checks then
+    /// refuse those directories. The failures land on whatever test happened to
+    /// be creating a temporary directory in that window, which is why the set
+    /// moved run to run. `#[serial]` cannot prevent it: it orders a test only
+    /// against other serial tests, not against the thousand running beside it.
+    /// The restrictive-umask tests in `setup.rs` already take this shape.
     #[cfg(unix)]
     #[test]
-    #[serial]
     fn private_root_is_atomically_0700_even_with_umask_zero() {
         use std::os::unix::fs::PermissionsExt as _;
 
-        struct UmaskGuard(libc::mode_t);
-        impl Drop for UmaskGuard {
-            fn drop(&mut self) {
-                // SAFETY: umask accepts every mode value and has no pointer arguments.
-                unsafe { libc::umask(self.0) };
-            }
+        const WORKER_ROOT: &str = "KIN_UPDATE_TEST_PRIVATE_ROOT_UMASK_ROOT";
+
+        if let Some(root) = std::env::var_os(WORKER_ROOT) {
+            let root = PathBuf::from(root);
+            // SAFETY: umask accepts every mode value and has no pointer
+            // arguments. This process exists only to hold the permissive mask.
+            unsafe { libc::umask(0) };
+            let private =
+                PrivateUpdaterTempDir::create(&root, PREFLIGHT_TEMP_PREFIX, "atomic-mode-test")
+                    .unwrap();
+            assert_eq!(
+                fs::symlink_metadata(private.path())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            return;
         }
 
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("observed-mode");
-        let _observe = EnvVarGuard::set("KIN_UPDATE_TEST_PRIVATE_CREATE_OBSERVE", &marker);
-        // SAFETY: umask accepts every mode value and has no pointer arguments.
-        let _umask = UmaskGuard(unsafe { libc::umask(0) });
-        let root =
-            PrivateUpdaterTempDir::create(temp.path(), PREFLIGHT_TEMP_PREFIX, "atomic-mode-test")
-                .unwrap();
-        assert_eq!(fs::read_to_string(&marker).unwrap(), "700");
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "commands::update::tests::private_root_is_atomically_0700_even_with_umask_zero",
+                "--nocapture",
+            ])
+            .env(WORKER_ROOT, temp.path())
+            .env("KIN_UPDATE_TEST_PRIVATE_CREATE_OBSERVE", &marker);
+        let output = test_subprocess_output(command, "private updater root under umask 0").unwrap();
+        assert!(
+            output.status.success(),
+            "worker output: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         assert_eq!(
-            fs::symlink_metadata(root.path())
-                .unwrap()
-                .permissions()
-                .mode()
-                & 0o777,
-            0o700
+            fs::read_to_string(&marker).unwrap(),
+            "700",
+            "creation must request 0700 atomically rather than widen and repair"
         );
     }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -6849,15 +6849,11 @@ mod tests {
         let layout = KinLayout::new(dir.path().join(".kin"));
         std::fs::create_dir_all(layout.root()).unwrap();
         std::fs::write(layout.root().join("daemon.token"), "layout-token\n").unwrap();
-        let previous = std::env::var_os("KIN_DAEMON_AUTH_TOKEN");
-        std::env::set_var("KIN_DAEMON_AUTH_TOKEN", "explicit-token");
+        let _token =
+            kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_AUTH_TOKEN", "explicit-token");
 
         let resolved = resolve_daemon_auth_token_for_layout(&layout);
 
-        match previous {
-            Some(value) => std::env::set_var("KIN_DAEMON_AUTH_TOKEN", value),
-            None => std::env::remove_var("KIN_DAEMON_AUTH_TOKEN"),
-        }
         assert_eq!(resolved.as_deref(), Some("explicit-token"));
     }
 
@@ -7746,13 +7742,14 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn runtime_reexec_requires_prior_adoption_and_survives_launcher_drop() {
-        let prior = std::env::var_os(SUPERVISOR_STARTUP_GENERATION_ENV);
-
         let adopted_dir = tempfile::tempdir().unwrap();
         let adopted_launcher =
             try_acquire_supervisor_startup_lock_in_dir(adopted_dir.path()).unwrap();
         let adopted_generation = adopted_launcher.generation().to_string();
-        std::env::set_var(SUPERVISOR_STARTUP_GENERATION_ENV, &adopted_generation);
+        let mut generation = kin_core::test_env::EnvVarGuard::set(
+            SUPERVISOR_STARTUP_GENERATION_ENV,
+            &adopted_generation,
+        );
         let first_runtime = validate_supervisor_runtime_startup(adopted_dir.path()).unwrap();
         first_runtime.acknowledge().unwrap();
         drop(adopted_launcher);
@@ -7768,17 +7765,12 @@ mod tests {
         let crashed_dir = tempfile::tempdir().unwrap();
         let crashed_launcher =
             try_acquire_supervisor_startup_lock_in_dir(crashed_dir.path()).unwrap();
-        std::env::set_var(
+        generation.apply(
             SUPERVISOR_STARTUP_GENERATION_ENV,
-            crashed_launcher.generation(),
+            Some(crashed_launcher.generation()),
         );
         drop(crashed_launcher);
         let error = validate_supervisor_runtime_startup(crashed_dir.path()).unwrap_err();
-
-        match prior {
-            Some(value) => std::env::set_var(SUPERVISOR_STARTUP_GENERATION_ENV, value),
-            None => std::env::remove_var(SUPERVISOR_STARTUP_GENERATION_ENV),
-        }
 
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
         assert!(
@@ -7824,13 +7816,8 @@ mod tests {
             format!("pid={} acquired_at=legacy\n", std::process::id()),
         )
         .unwrap();
-        let prior = std::env::var_os(SUPERVISOR_STARTUP_GENERATION_ENV);
-        std::env::remove_var(SUPERVISOR_STARTUP_GENERATION_ENV);
+        let _generation = kin_core::test_env::EnvVarGuard::unset(SUPERVISOR_STARTUP_GENERATION_ENV);
         let error = validate_supervisor_runtime_startup(dir.path()).unwrap_err();
-        match prior {
-            Some(value) => std::env::set_var(SUPERVISOR_STARTUP_GENERATION_ENV, value),
-            None => std::env::remove_var(SUPERVISOR_STARTUP_GENERATION_ENV),
-        }
 
         assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
         assert!(

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -232,23 +232,24 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn profile_resolves_from_env_with_aliases_and_default() {
-        std::env::remove_var("KIN_PROFILE");
+        let mut profile = kin_core::test_env::EnvVarGuard::unset("KIN_PROFILE");
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
-        std::env::set_var("KIN_PROFILE", "compat-v0");
+        profile.apply("KIN_PROFILE", Some("compat-v0"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
-        std::env::set_var("KIN_PROFILE", "compat");
+        profile.apply("KIN_PROFILE", Some("compat"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
-        std::env::set_var("KIN_PROFILE", "ACCURACY-V1");
+        profile.apply("KIN_PROFILE", Some("ACCURACY-V1"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV1);
 
         // Unknown values must not silently select a different serving shape.
-        std::env::set_var("KIN_PROFILE", "warp-speed");
+        profile.apply("KIN_PROFILE", Some("warp-speed"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
-        std::env::remove_var("KIN_PROFILE");
+        profile.apply::<_, &str>("KIN_PROFILE", None);
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
     }
 
     #[test]

--- a/crates/kin-cli/tests/daemon_runtime_hermeticity.rs
+++ b/crates/kin-cli/tests/daemon_runtime_hermeticity.rs
@@ -15,28 +15,7 @@ use tempfile::tempdir;
 mod common;
 
 use common::Command;
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
-        let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
+use kin_core::test_env::EnvVarGuard;
 
 struct KillAndReapChild {
     child: Child,
@@ -219,12 +198,13 @@ fn generic_authority_worker() {
 fn generic_command_scrubs_ambient_and_command_local_authority() {
     let root = tempdir().expect("temp root");
     let marker = root.path().join("generic-authority.marker");
-    let _ambient_git = EnvGuard::set("GIT_DIR", std::ffi::OsStr::new("/ambient/git"));
-    let _ambient_kin = EnvGuard::set(
+    let _ambient_git = EnvVarGuard::set("GIT_DIR", std::ffi::OsStr::new("/ambient/git"));
+    let _ambient_kin = EnvVarGuard::set(
         "KIN_GCS_BUCKET",
         std::ffi::OsStr::new("ambient-production-bucket"),
     );
-    let _ambient_loader = EnvGuard::set("LD_AUDIT", std::ffi::OsStr::new("/ambient/libaudit.so"));
+    let _ambient_loader =
+        EnvVarGuard::set("LD_AUDIT", std::ffi::OsStr::new("/ambient/libaudit.so"));
 
     let output = Command::new(std::env::current_exe().expect("current test executable"))
         .args(["--exact", "generic_authority_worker", "--nocapture"])
@@ -330,10 +310,10 @@ fn isolated_runtime_lifecycle_does_not_claim_product_control_state() {
     let root = tempdir().expect("temp root");
     let repository = root.path().join("repository");
     std::fs::create_dir_all(&repository).expect("create fresh repository");
-    let _git_dir = EnvGuard::set("GIT_DIR", std::ffi::OsStr::new("/hostile/git-dir"));
-    let _git_config_count = EnvGuard::set("GIT_CONFIG_COUNT", std::ffi::OsStr::new("1"));
-    let _git_default_hash = EnvGuard::set("GIT_DEFAULT_HASH", std::ffi::OsStr::new("sha256"));
-    let _ld_custom = EnvGuard::set(
+    let _git_dir = EnvVarGuard::set("GIT_DIR", std::ffi::OsStr::new("/hostile/git-dir"));
+    let _git_config_count = EnvVarGuard::set("GIT_CONFIG_COUNT", std::ffi::OsStr::new("1"));
+    let _git_default_hash = EnvVarGuard::set("GIT_DEFAULT_HASH", std::ffi::OsStr::new("sha256"));
+    let _ld_custom = EnvVarGuard::set(
         "LD_CUSTOM_INJECTION",
         std::ffi::OsStr::new("/hostile/custom-loader"),
     );
@@ -367,16 +347,16 @@ fn runtime_command_rebinds_git_and_kin_authority_at_launch() {
     let root = tempdir().expect("temp root");
     let repository = root.path().join("repository");
     std::fs::create_dir_all(repository.join(".kin")).expect("create Kin control dir");
-    let _ambient_git = EnvGuard::set("GIT_DIR", std::ffi::OsStr::new("/ambient/git"));
+    let _ambient_git = EnvVarGuard::set("GIT_DIR", std::ffi::OsStr::new("/ambient/git"));
     let _ambient_worktree =
-        EnvGuard::set("GIT_WORK_TREE", std::ffi::OsStr::new("/ambient/worktree"));
-    let _ambient_config = EnvGuard::set("GIT_CONFIG_COUNT", std::ffi::OsStr::new("1"));
-    let _ambient_ceiling = EnvGuard::set(
+        EnvVarGuard::set("GIT_WORK_TREE", std::ffi::OsStr::new("/ambient/worktree"));
+    let _ambient_config = EnvVarGuard::set("GIT_CONFIG_COUNT", std::ffi::OsStr::new("1"));
+    let _ambient_ceiling = EnvVarGuard::set(
         "GIT_CEILING_DIRECTORIES",
         std::ffi::OsStr::new("/ambient/ceiling"),
     );
     let _ambient_discovery =
-        EnvGuard::set("GIT_DISCOVERY_ACROSS_FILESYSTEM", std::ffi::OsStr::new("0"));
+        EnvVarGuard::set("GIT_DISCOVERY_ACROSS_FILESYSTEM", std::ffi::OsStr::new("0"));
     let runtime = common::IsolatedDaemonRuntime::with_cleanup_command_for_test(
         &repository,
         std::env::current_exe().expect("current test executable"),
@@ -530,62 +510,65 @@ fn isolated_runtime_scrubs_ambient_authority_and_reaps_every_process() {
 
     // These values model a developer shell already bound to real runtime and
     // VFS authority. The fixture launcher must remove them from every child.
-    let _home = EnvGuard::set("HOME", sentinel_home.as_os_str());
-    let _registry = EnvGuard::set("KIN_REGISTRY_PATH", sentinel_registry.as_os_str());
-    let _daemon_url = EnvGuard::set("KIN_DAEMON_URL", std::ffi::OsStr::new("http://127.0.0.1:9"));
-    let _supervisor_url = EnvGuard::set(
+    let _home = EnvVarGuard::set("HOME", sentinel_home.as_os_str());
+    let _registry = EnvVarGuard::set("KIN_REGISTRY_PATH", sentinel_registry.as_os_str());
+    let _daemon_url =
+        EnvVarGuard::set("KIN_DAEMON_URL", std::ffi::OsStr::new("http://127.0.0.1:9"));
+    let _supervisor_url = EnvVarGuard::set(
         "KIN_SUPERVISOR_URL",
         std::ffi::OsStr::new("http://127.0.0.1:9"),
     );
     let _daemon_bind_host =
-        EnvGuard::set("KIN_DAEMON_BIND_HOST", std::ffi::OsStr::new("192.0.2.1"));
-    let _daemon_auth = EnvGuard::set(
+        EnvVarGuard::set("KIN_DAEMON_BIND_HOST", std::ffi::OsStr::new("192.0.2.1"));
+    let _daemon_auth = EnvVarGuard::set(
         "KIN_DAEMON_AUTH_TOKEN",
         std::ffi::OsStr::new("ambient-token"),
     );
     let _daemon_require_token =
-        EnvGuard::set("KIN_DAEMON_REQUIRE_TOKEN", std::ffi::OsStr::new("true"));
-    let _supervisor_bind_host = EnvGuard::set(
+        EnvVarGuard::set("KIN_DAEMON_REQUIRE_TOKEN", std::ffi::OsStr::new("true"));
+    let _supervisor_bind_host = EnvVarGuard::set(
         "KIN_SUPERVISOR_BIND_HOST",
         std::ffi::OsStr::new("192.0.2.1"),
     );
-    let _supervisor_auth = EnvGuard::set(
+    let _supervisor_auth = EnvVarGuard::set(
         "KIN_SUPERVISOR_AUTH_TOKEN",
         std::ffi::OsStr::new("ambient-token"),
     );
     let _supervisor_require_token =
-        EnvGuard::set("KIN_SUPERVISOR_REQUIRE_TOKEN", std::ffi::OsStr::new("true"));
-    let _vfs_workspace = EnvGuard::set("KIN_VFS_WORKSPACE", sentinel_home.as_os_str());
-    let _storage = EnvGuard::set("KIN_STORAGE", std::ffi::OsStr::new("gcs"));
-    let _gcs_bucket = EnvGuard::set(
+        EnvVarGuard::set("KIN_SUPERVISOR_REQUIRE_TOKEN", std::ffi::OsStr::new("true"));
+    let _vfs_workspace = EnvVarGuard::set("KIN_VFS_WORKSPACE", sentinel_home.as_os_str());
+    let _storage = EnvVarGuard::set("KIN_STORAGE", std::ffi::OsStr::new("gcs"));
+    let _gcs_bucket = EnvVarGuard::set(
         "KIN_GCS_BUCKET",
         std::ffi::OsStr::new("must-never-be-contacted"),
     );
-    let _gcs_prefix = EnvGuard::set("KIN_GCS_PREFIX", std::ffi::OsStr::new("hostile-prefix"));
-    let _unknown_kin = EnvGuard::set(
+    let _gcs_prefix = EnvVarGuard::set("KIN_GCS_PREFIX", std::ffi::OsStr::new("hostile-prefix"));
+    let _unknown_kin = EnvVarGuard::set(
         "KIN_TEST_HOSTILE_UNKNOWN_AUTHORITY",
         std::ffi::OsStr::new("must-be-scrubbed"),
     );
-    let _git_dir = EnvGuard::set("GIT_DIR", std::ffi::OsStr::new("/hostile/git-dir"));
-    let _git_config_count = EnvGuard::set("GIT_CONFIG_COUNT", std::ffi::OsStr::new("1"));
-    let _git_config_key = EnvGuard::set("GIT_CONFIG_KEY_0", std::ffi::OsStr::new("core.hooksPath"));
+    let _git_dir = EnvVarGuard::set("GIT_DIR", std::ffi::OsStr::new("/hostile/git-dir"));
+    let _git_config_count = EnvVarGuard::set("GIT_CONFIG_COUNT", std::ffi::OsStr::new("1"));
+    let _git_config_key =
+        EnvVarGuard::set("GIT_CONFIG_KEY_0", std::ffi::OsStr::new("core.hooksPath"));
     let _git_config_value =
-        EnvGuard::set("GIT_CONFIG_VALUE_0", std::ffi::OsStr::new("/hostile/hooks"));
-    let _git_default_hash = EnvGuard::set("GIT_DEFAULT_HASH", std::ffi::OsStr::new("sha256"));
-    let _dyld = EnvGuard::set(
+        EnvVarGuard::set("GIT_CONFIG_VALUE_0", std::ffi::OsStr::new("/hostile/hooks"));
+    let _git_default_hash = EnvVarGuard::set("GIT_DEFAULT_HASH", std::ffi::OsStr::new("sha256"));
+    let _dyld = EnvVarGuard::set(
         "DYLD_INSERT_LIBRARIES",
         std::ffi::OsStr::new("/hostile/libkin_vfs.dylib"),
     );
     let _dyld_library_path =
-        EnvGuard::set("DYLD_LIBRARY_PATH", std::ffi::OsStr::new("/hostile/dyld"));
-    let _ld_preload = EnvGuard::set("LD_PRELOAD", std::ffi::OsStr::new("/hostile/libkin_vfs.so"));
-    let _ld_audit = EnvGuard::set("LD_AUDIT", std::ffi::OsStr::new("/hostile/libaudit.so"));
-    let _ld_library_path = EnvGuard::set("LD_LIBRARY_PATH", std::ffi::OsStr::new("/hostile/ld"));
-    let _ld_custom = EnvGuard::set(
+        EnvVarGuard::set("DYLD_LIBRARY_PATH", std::ffi::OsStr::new("/hostile/dyld"));
+    let _ld_preload =
+        EnvVarGuard::set("LD_PRELOAD", std::ffi::OsStr::new("/hostile/libkin_vfs.so"));
+    let _ld_audit = EnvVarGuard::set("LD_AUDIT", std::ffi::OsStr::new("/hostile/libaudit.so"));
+    let _ld_library_path = EnvVarGuard::set("LD_LIBRARY_PATH", std::ffi::OsStr::new("/hostile/ld"));
+    let _ld_custom = EnvVarGuard::set(
         "LD_CUSTOM_INJECTION",
         std::ffi::OsStr::new("/hostile/custom-loader"),
     );
-    let _last_vfs_dir = EnvGuard::set(
+    let _last_vfs_dir = EnvVarGuard::set(
         "_KIN_VFS_LAST_DIR",
         std::ffi::OsStr::new("/hostile/workspace/src"),
     );

--- a/crates/kin-cli/tests/windows_authority_order.rs
+++ b/crates/kin-cli/tests/windows_authority_order.rs
@@ -67,33 +67,13 @@ const COMMAND_REGISTRY: &str = "KIN_REGISTRY_PATH";
 #[cfg(windows)]
 const COMMAND_OWNER_TOKEN: &str = "kIn_TeSt_RuNtImE_oWnEr_ToKeN";
 #[cfg(not(windows))]
+use kin_core::test_env::EnvVarGuard;
+
 const COMMAND_OWNER_TOKEN: &str = "KIN_TEST_RUNTIME_OWNER_TOKEN";
 #[cfg(windows)]
 const COMMAND_GIT_CONFIG_NOSYSTEM: &str = "gIt_cOnFiG_nOsYsTeM";
 #[cfg(not(windows))]
 const COMMAND_GIT_CONFIG_NOSYSTEM: &str = "GIT_CONFIG_NOSYSTEM";
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &OsStr) -> Self {
-        let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
 
 #[test]
 fn authority_order_worker() {
@@ -195,10 +175,12 @@ fn spawned_child_observes_case_insensitive_authority_order() {
     let git_date = "1600000000 +0000";
     let daemon_url = "http://127.0.0.1:9";
 
-    let _ambient_git = EnvGuard::set(AMBIENT_GIT_DIR, OsStr::new("ambient-git-authority"));
-    let _ambient_kin = EnvGuard::set(AMBIENT_KIN_BUCKET, OsStr::new("ambient-production-bucket"));
-    let _ambient_dyld = EnvGuard::set(AMBIENT_DYLD_INJECTION, OsStr::new("ambient-dyld-injection"));
-    let _ambient_ld = EnvGuard::set(AMBIENT_LD_INJECTION, OsStr::new("ambient-ld-injection"));
+    let _ambient_git = EnvVarGuard::set(AMBIENT_GIT_DIR, OsStr::new("ambient-git-authority"));
+    let _ambient_kin =
+        EnvVarGuard::set(AMBIENT_KIN_BUCKET, OsStr::new("ambient-production-bucket"));
+    let _ambient_dyld =
+        EnvVarGuard::set(AMBIENT_DYLD_INJECTION, OsStr::new("ambient-dyld-injection"));
+    let _ambient_ld = EnvVarGuard::set(AMBIENT_LD_INJECTION, OsStr::new("ambient-ld-injection"));
 
     let runtime = common::IsolatedDaemonRuntime::with_cleanup_command_for_test(
         &repository,

--- a/crates/kin-cli/tests/windows_authority_order.rs
+++ b/crates/kin-cli/tests/windows_authority_order.rs
@@ -7,6 +7,7 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use kin_core::test_env::EnvVarGuard;
 use serial_test::serial;
 use tempfile::tempdir;
 
@@ -67,8 +68,6 @@ const COMMAND_REGISTRY: &str = "KIN_REGISTRY_PATH";
 #[cfg(windows)]
 const COMMAND_OWNER_TOKEN: &str = "kIn_TeSt_RuNtImE_oWnEr_ToKeN";
 #[cfg(not(windows))]
-use kin_core::test_env::EnvVarGuard;
-
 const COMMAND_OWNER_TOKEN: &str = "KIN_TEST_RUNTIME_OWNER_TOKEN";
 #[cfg(windows)]
 const COMMAND_GIT_CONFIG_NOSYSTEM: &str = "gIt_cOnFiG_nOsYsTeM";

--- a/crates/kin-core/Cargo.toml
+++ b/crates/kin-core/Cargo.toml
@@ -12,6 +12,11 @@ repository.workspace = true
 [lib]
 doctest = false
 
+[features]
+# Test-only fixtures other workspace crates consume from their dev-dependencies.
+# Never enabled by a product dependency edge.
+test-support = []
+
 [dependencies]
 kin-model = { workspace = true }
 kin-db = { workspace = true }

--- a/crates/kin-core/env_mutation_allowlist.txt
+++ b/crates/kin-core/env_mutation_allowlist.txt
@@ -1,0 +1,13 @@
+# Sources allowed to write the process environment table directly, checked by
+# `kin_core::test_env` tests::no_source_outside_the_sanctioned_guard_writes_the_environment.
+#
+# One workspace-relative path per line. An entry belongs here only when the write
+# is product behavior. Test setup does not qualify: it goes through
+# `kin_core::test_env::EnvVarGuard`, or the configuration is taken by argument.
+#
+# `crates/kin-core/src/test_env.rs` is the guard itself and is exempt in code.
+
+# `kin mcp start` binds the process to the daemon it resolved, and drops the pin
+# when the workspace moves off the bound repository. The variable is the
+# published interface the MCP daemon delegate reads, so the write is the feature.
+crates/kin-cli/src/commands/mcp.rs

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -32,6 +32,12 @@ pub mod repository_authority;
 pub mod resolver;
 pub mod shims;
 pub mod sync_state;
+/// Scoped, restoring, serialized environment mutation for test code.
+///
+/// Compiled only for this crate's own tests and for consumers that request the
+/// `test-support` feature from a dev-dependency, so no product build carries it.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_env;
 pub mod tree;
 pub mod workspace_semantics;
 

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -2327,7 +2327,8 @@ mod tests {
             "failure-cleanup" => {
                 KinRegistry::default().save_to(&registry_path).unwrap();
                 let before = std::fs::read(&registry_path).unwrap();
-                std::env::set_var("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC", "1");
+                let mut fail_after_temp_sync =
+                    crate::test_env::EnvVarGuard::set("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC", "1");
                 let mut changed = KinRegistry::default();
                 changed.repos.push(RegisteredRepo {
                     id: "must-not-land".to_string(),
@@ -2337,7 +2338,7 @@ mod tests {
                     dependencies: Vec::new(),
                 });
                 assert!(changed.save_to(&registry_path).is_err());
-                std::env::remove_var("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC");
+                fail_after_temp_sync.apply::<_, &str>("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC", None);
                 assert_eq!(std::fs::read(&registry_path).unwrap(), before);
                 assert!(std::fs::read_dir(&work).unwrap().all(|entry| !entry
                     .unwrap()

--- a/crates/kin-core/src/test_env.rs
+++ b/crates/kin-core/src/test_env.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The workspace's one sanctioned mutation of the process environment from test
+//! code.
+//!
+//! `std::env::set_var` and `std::env::remove_var` write a single table shared by
+//! every thread in the process. `cargo test` runs a binary's tests as threads
+//! inside one process, so a variable one test sets is read by every test running
+//! beside it, and a test that returns early or panics before its cleanup line
+//! leaks the value into everything that follows. `cargo nextest` gives each test
+//! its own process, which makes the same defect structurally invisible there, so
+//! a green nextest run does not cover it. Plain `cargo test` is the authority
+//! when the two runners disagree.
+//!
+//! What this guard buys, stated exactly so it is not over-trusted:
+//!
+//! - the previous value is restored on drop, including on panic and on an early
+//!   `return`, so a mutation cannot outlive the test that made it
+//! - mutating tests are serialized against each other, so two tests holding
+//!   opposite expectations of one variable cannot interleave
+//!
+//! What no guard can buy: it does not hide the mutation from a test that merely
+//! *reads* the variable. The table is process-global, and a reader takes no
+//! lock. `#[serial_test::serial]` has the same ceiling, because it orders a test
+//! only against other serial tests and not against the rest of a suite running
+//! in parallel. So when the code under test resolves configuration that other
+//! code under test also resolves, the fix is to take that configuration by
+//! argument and leave the environment alone. Reach for this guard only when the
+//! behavior under test *is* the environment read itself.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard};
+
+/// Serialization domain for every environment mutation in one test process.
+static ENV_MUTATION_LOCK: Mutex<()> = Mutex::new(());
+
+thread_local! {
+    /// How many guards this thread holds, and the lock it took for the first.
+    ///
+    /// Reentrant on purpose: a test commonly holds several guards at once (a
+    /// home directory and a registry path, say), each a separate binding whose
+    /// lifetime the test controls. Taking the mutex once per thread rather than
+    /// once per guard is what keeps the second guard from deadlocking against
+    /// the first.
+    static HELD: RefCell<(usize, Option<MutexGuard<'static, ()>>)> =
+        const { RefCell::new((0, None)) };
+}
+
+fn enter_env_mutation_domain() {
+    HELD.with(|held| {
+        let mut held = held.borrow_mut();
+        if held.0 == 0 {
+            // A test that panics while holding the lock poisons it. The next
+            // test still needs the domain, and the environment it will find is
+            // whatever the panicking guard's Drop restored, so recover rather
+            // than cascade one failure into every later one.
+            held.1 = Some(
+                ENV_MUTATION_LOCK
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            );
+        }
+        held.0 += 1;
+    });
+}
+
+fn leave_env_mutation_domain() {
+    // `try_with` because a guard dropped during thread teardown may find the
+    // thread-local already destroyed, and a panic there would abort the process.
+    let _ = HELD.try_with(|held| {
+        let mut held = held.borrow_mut();
+        held.0 = held.0.saturating_sub(1);
+        if held.0 == 0 {
+            held.1 = None;
+        }
+    });
+}
+
+/// A scoped, restoring, serialized mutation of process-global environment
+/// variables.
+///
+/// The guard restores every name it touched when it drops, in the state that
+/// name had when the guard first touched it.
+pub struct EnvVarGuard {
+    restore: BTreeMap<OsString, Option<OsString>>,
+}
+
+impl EnvVarGuard {
+    /// Enter the serialization domain without changing anything yet.
+    ///
+    /// Useful for a test that needs the domain to itself while it reads the
+    /// environment, or that decides which names to touch at runtime.
+    pub fn new() -> Self {
+        enter_env_mutation_domain();
+        Self {
+            restore: BTreeMap::new(),
+        }
+    }
+
+    /// Enter the domain with `key` set to `value` for the guard's lifetime.
+    pub fn set(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Self {
+        Self::new().with(key, value)
+    }
+
+    /// Enter the domain with `key` removed for the guard's lifetime.
+    pub fn unset(key: impl AsRef<OsStr>) -> Self {
+        Self::new().without(key)
+    }
+
+    /// Also set `key` to `value` for the guard's lifetime.
+    pub fn with(mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Self {
+        self.apply(key, Some(value));
+        self
+    }
+
+    /// Also remove `key` for the guard's lifetime.
+    pub fn without(mut self, key: impl AsRef<OsStr>) -> Self {
+        self.apply::<_, &OsStr>(key, None);
+        self
+    }
+
+    /// Set or remove `key` inside an already-held guard.
+    ///
+    /// The restore value recorded is the one from before this guard first
+    /// touched `key`, so a loop that walks a name through several values still
+    /// restores what the process had on entry.
+    pub fn apply<K: AsRef<OsStr>, V: AsRef<OsStr>>(&mut self, key: K, value: Option<V>) {
+        let key = key.as_ref().to_os_string();
+        self.restore
+            .entry(key.clone())
+            .or_insert_with(|| std::env::var_os(&key));
+        match value {
+            Some(value) => std::env::set_var(&key, value.as_ref()),
+            None => std::env::remove_var(&key),
+        }
+    }
+}
+
+impl Default for EnvVarGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Install a value for the whole test process, deliberately without restoring.
+///
+/// A few fixtures have to hold for every test in a binary rather than for one
+/// scope: pointing the registry authority away from the developer's real
+/// `~/.kin`, for instance, where restoring the original between tests would
+/// expose the real home to whatever ran in that window. The honest shape for
+/// that is an override installed once, before any test observes the name, and
+/// never taken back.
+///
+/// This is not a lighter-weight [`EnvVarGuard`]. Anything scoped to one test
+/// belongs in a guard, because a value left behind is read by every test that
+/// follows.
+pub fn install_process_wide(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    let _domain = EnvVarGuard::new();
+    std::env::set_var(key.as_ref(), value.as_ref());
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for (key, previous) in std::mem::take(&mut self.restore) {
+            match previous {
+                Some(value) => std::env::set_var(&key, value),
+                None => std::env::remove_var(&key),
+            }
+        }
+        leave_env_mutation_domain();
+    }
+}
+
+/// Workspace-relative path of the one module allowed to write the environment
+/// table directly. Everything else in the workspace goes through the guard.
+pub const SANCTIONED_MUTATION_SITE: &str = "crates/kin-core/src/test_env.rs";
+
+/// Name of the allowlist beside `Cargo.toml` naming product code that writes the
+/// environment as real behavior rather than as test setup.
+pub const MUTATION_ALLOWLIST_FILE: &str = "env_mutation_allowlist.txt";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ABSENT: &str = "KIN_TEST_ENV_GUARD_ABSENT";
+    const PRESENT: &str = "KIN_TEST_ENV_GUARD_PRESENT";
+
+    #[test]
+    fn a_guard_restores_absence_and_a_prior_value() {
+        let mut outer = EnvVarGuard::new();
+        outer.apply(ABSENT, None::<&str>);
+        outer.apply(PRESENT, Some("original"));
+
+        {
+            let _inner = EnvVarGuard::set(ABSENT, "temporary").with(PRESENT, "overridden");
+            assert_eq!(std::env::var(ABSENT).as_deref(), Ok("temporary"));
+            assert_eq!(std::env::var(PRESENT).as_deref(), Ok("overridden"));
+        }
+
+        assert!(
+            std::env::var_os(ABSENT).is_none(),
+            "a name absent before the guard must be absent after it"
+        );
+        assert_eq!(
+            std::env::var(PRESENT).as_deref(),
+            Ok("original"),
+            "a name present before the guard must keep its original value"
+        );
+    }
+
+    #[test]
+    fn repeated_application_restores_the_value_from_before_the_guard() {
+        let mut outer = EnvVarGuard::new();
+        outer.apply(PRESENT, Some("entry"));
+
+        {
+            let mut inner = EnvVarGuard::new();
+            for value in ["one", "two", "three"] {
+                inner.apply(PRESENT, Some(value));
+                assert_eq!(std::env::var(PRESENT).as_deref(), Ok(value));
+            }
+            inner.apply(PRESENT, None::<&str>);
+            assert!(std::env::var_os(PRESENT).is_none());
+        }
+
+        assert_eq!(
+            std::env::var(PRESENT).as_deref(),
+            Ok("entry"),
+            "walking a name through several values must still restore the entry value"
+        );
+    }
+
+    #[test]
+    fn a_panicking_scope_still_restores() {
+        let mut outer = EnvVarGuard::new();
+        outer.apply(PRESENT, Some("survivor"));
+
+        let panicked = std::panic::catch_unwind(|| {
+            let _guard = EnvVarGuard::set(PRESENT, "doomed");
+            panic!("the scope under test panics");
+        });
+
+        assert!(panicked.is_err());
+        assert_eq!(
+            std::env::var(PRESENT).as_deref(),
+            Ok("survivor"),
+            "unwinding through a guard must restore, or a failing test poisons its neighbours"
+        );
+    }
+
+    /// Every `path:line` in `text` that writes the process environment table.
+    ///
+    /// The needles are assembled from fragments so this scanner's own source
+    /// never contains the pattern it searches for.
+    fn scan_env_mutations(text: &str) -> Vec<(usize, String)> {
+        let module = "env";
+        let needles = [
+            format!("{module}::set_{}", "var("),
+            format!("{module}::remove_{}", "var("),
+        ];
+        let mut found = Vec::new();
+        for needle in &needles {
+            let mut from = 0;
+            while let Some(offset) = text[from..].find(needle.as_str()) {
+                let at = from + offset;
+                found.push((text[..at].lines().count(), needle.clone()));
+                from = at + needle.len();
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// Workspace-relative paths exempted because the write is product behavior.
+    fn load_mutation_allowlist(manifest: &std::path::Path) -> std::collections::BTreeSet<String> {
+        let mut allowed = std::collections::BTreeSet::new();
+        allowed.insert(SANCTIONED_MUTATION_SITE.to_string());
+        if let Ok(text) = std::fs::read_to_string(manifest.join(MUTATION_ALLOWLIST_FILE)) {
+            for line in text.lines() {
+                let line = line.trim();
+                if !line.is_empty() && !line.starts_with('#') {
+                    allowed.insert(line.to_string());
+                }
+            }
+        }
+        allowed
+    }
+
+    /// No source in the workspace writes the environment table on its own.
+    ///
+    /// Two confirmed defects came from a test doing exactly that, and neither
+    /// could ever turn CI red: the test job runs nextest, which gives each test
+    /// its own process. The shape is invisible in review too, because a
+    /// `set_var` line reads as ordinary setup and its blast radius is every
+    /// other test in the binary. So the ban is on the shape rather than on any
+    /// one variable, and the exemptions are enumerated in a file a reviewer
+    /// sees change.
+    #[test]
+    fn no_source_outside_the_sanctioned_guard_writes_the_environment() {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let root = manifest.join("../..");
+        // Skip in a packaged single-crate context, where the sibling crates
+        // this scans are not present. Mirrors the env-read completeness scan.
+        if !root.join("crates/kin-cli/src").is_dir() {
+            eprintln!("workspace crates not present; skipping env-mutation scan");
+            return;
+        }
+        let allowed = load_mutation_allowlist(manifest);
+
+        let mut offenders = Vec::new();
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if path.is_dir() {
+                    if name == "target" || name == "node_modules" || name.starts_with('.') {
+                        continue;
+                    }
+                    stack.push(path);
+                    continue;
+                }
+                if !name.ends_with(".rs") {
+                    continue;
+                }
+                let relative = path
+                    .strip_prefix(&root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                if allowed.contains(relative.as_str()) {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                for (line, needle) in scan_env_mutations(&text) {
+                    offenders.push(format!("{relative}:{line} {needle}"));
+                }
+            }
+        }
+        offenders.sort();
+
+        assert!(
+            offenders.is_empty(),
+            "these sources write the process environment directly. Test code must go through \
+             kin_core::test_env::EnvVarGuard (or install_process_wide for a binary-wide fixture) \
+             so the write is restored and serialized, and code whose subject is configuration \
+             other code under test also reads must take that configuration by argument instead. \
+             Product code that writes the environment as real behavior belongs in \
+             crates/kin-core/{MUTATION_ALLOWLIST_FILE}. Offenders: {offenders:#?}"
+        );
+    }
+}

--- a/crates/kin-core/src/test_env.rs
+++ b/crates/kin-core/src/test_env.rs
@@ -86,6 +86,15 @@ fn leave_env_mutation_domain() {
 /// name had when the guard first touched it.
 pub struct EnvVarGuard {
     restore: BTreeMap<OsString, Option<OsString>>,
+    /// Binds the guard to the thread that created it.
+    ///
+    /// The domain's reentrancy count and the mutex guard behind it live in
+    /// thread-local storage, so a guard released on a different thread than the
+    /// one that took it would leave the mutex held forever and stall every
+    /// later env-mutating test. Being `!Send` makes that a compile error rather
+    /// than a hang, and it is also what stops a guard being held across an
+    /// `.await` in a future a runtime may move between threads.
+    _not_send: std::marker::PhantomData<*const ()>,
 }
 
 impl EnvVarGuard {
@@ -97,6 +106,7 @@ impl EnvVarGuard {
         enter_env_mutation_domain();
         Self {
             restore: BTreeMap::new(),
+            _not_send: std::marker::PhantomData,
         }
     }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3274,13 +3274,13 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         let mut driver = driver.spawn().unwrap();
-        wait_for_test_path(&report_path, Duration::from_secs(5));
-        wait_for_test_path(&stalled_path, Duration::from_secs(5));
-        let ids = std::fs::read_to_string(&report_path)
-            .unwrap()
-            .split_whitespace()
+        // Both fields, not merely the file: a partially written report reads
+        // back short and the parse below would fail on a loaded host.
+        let ids = wait_for_test_report_fields(&report_path, 2, Duration::from_secs(5))
+            .iter()
             .map(|value| value.parse::<libc::pid_t>().unwrap())
             .collect::<Vec<_>>();
+        wait_for_test_path(&stalled_path, Duration::from_secs(5));
         assert_eq!(ids.len(), 2, "malformed pre-exec stall report");
 
         driver.kill().unwrap();
@@ -3613,12 +3613,13 @@ mod tests {
             .stderr(Stdio::null());
         let mut relay = guardian.spawn(relay_command).unwrap();
         std::fs::write(&trigger_path, b"fork\n").unwrap();
-        wait_for_test_path(&report_path, Duration::from_secs(5));
-        let late_member_pid = std::fs::read_to_string(&report_path)
-            .unwrap()
-            .trim()
-            .parse::<libc::pid_t>()
-            .unwrap();
+        // Wait for the field, not merely for the file. A report the worker has
+        // created but not yet written reads back empty, and on a loaded host the
+        // reader wins that race often enough to fail the suite.
+        let late_member_pid = wait_for_test_report_fields(&report_path, 1, Duration::from_secs(5))
+            [0]
+        .parse::<libc::pid_t>()
+        .unwrap();
 
         guardian.request_cleanup();
         let status = relay.wait().unwrap();
@@ -3668,12 +3669,13 @@ mod tests {
             .stderr(Stdio::null());
         let mut relay = guardian.spawn(relay_command).unwrap();
         std::fs::write(&trigger_path, b"fork\n").unwrap();
-        wait_for_test_path(&report_path, Duration::from_secs(5));
-        let late_member_pid = std::fs::read_to_string(&report_path)
-            .unwrap()
-            .trim()
-            .parse::<libc::pid_t>()
-            .unwrap();
+        // Wait for the field, not merely for the file. A report the worker has
+        // created but not yet written reads back empty, and on a loaded host the
+        // reader wins that race often enough to fail the suite.
+        let late_member_pid = wait_for_test_report_fields(&report_path, 1, Duration::from_secs(5))
+            [0]
+        .parse::<libc::pid_t>()
+        .unwrap();
         assert!(relay.wait().unwrap().success());
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
         while unsafe { libc::getpgid(late_member_pid) } == target_group {
@@ -3891,13 +3893,14 @@ mod tests {
         let mut driver = driver.spawn().unwrap();
         let status = driver.wait().unwrap();
         assert!(status.success(), "owner-death driver failed: {status}");
-        wait_for_test_path(&report_path, Duration::from_secs(5));
-        let report = std::fs::read_to_string(&report_path).unwrap();
-        let pids = report
-            .split_whitespace()
+        // All three fields, not merely the file: a partially written report
+        // reads back short and the parse below would fail on a loaded host.
+        let fields = wait_for_test_report_fields(&report_path, 3, Duration::from_secs(5));
+        let pids = fields
+            .iter()
             .map(|value| value.parse::<libc::pid_t>().unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(pids.len(), 3, "malformed owner-death report: {report:?}");
+        assert_eq!(pids.len(), 3, "malformed owner-death report: {fields:?}");
 
         wait_for_test_pid_gone(pids[0], Duration::from_secs(5));
         wait_for_test_pid_gone(pids[1], Duration::from_secs(5));

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -85,6 +85,7 @@ kin-infer = { version = ">=0.2.1", registry = "kin", features = ["metal"] }
 
 [dev-dependencies]
 base64 = "0.22"
+kin-core = { workspace = true, features = ["test-support"] }
 kin-git = { workspace = true, features = ["test-support"] }
 http-body = "1"
 tempfile = { workspace = true }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -11045,7 +11045,7 @@ mod tests {
             path
         });
 
-        std::env::set_var("KIN_REGISTRY_PATH", path);
+        kin_core::test_env::install_process_wide("KIN_REGISTRY_PATH", path);
     }
 
     #[test]
@@ -17537,7 +17537,8 @@ mod tests {
         let server = tokio::spawn(async move {
             let _ = axum::serve(listener, app).await;
         });
-        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+        let _daemon_url =
+            kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_URL", format!("http://{addr}"));
 
         let projection =
             kin_cli::commands::session_run::materialize(state.layout.clone(), None, None)
@@ -17673,7 +17674,6 @@ mod tests {
             .artifact_at_path(&RepoPath::from_utf8("partial.txt").unwrap())
             .is_none());
 
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
@@ -17702,20 +17702,22 @@ mod tests {
         /// A guard puts them back even when an assertion unwinds.
         struct ProcessScope {
             working_dir: PathBuf,
-            path: Option<std::ffi::OsString>,
+            _search_path: kin_core::test_env::EnvVarGuard,
         }
 
         impl ProcessScope {
             fn enter(working_dir: &FsPath, editor_dir: &FsPath) -> Self {
+                let mut search = vec![editor_dir.to_path_buf()];
+                if let Some(existing) = std::env::var_os("PATH") {
+                    search.extend(std::env::split_paths(&existing));
+                }
                 let scope = Self {
                     working_dir: std::env::current_dir().unwrap(),
-                    path: std::env::var_os("PATH"),
+                    _search_path: kin_core::test_env::EnvVarGuard::set(
+                        "PATH",
+                        std::env::join_paths(search).unwrap(),
+                    ),
                 };
-                let mut search = vec![editor_dir.to_path_buf()];
-                if let Some(existing) = scope.path.as_ref() {
-                    search.extend(std::env::split_paths(existing));
-                }
-                std::env::set_var("PATH", std::env::join_paths(search).unwrap());
                 std::env::set_current_dir(working_dir).unwrap();
                 scope
             }
@@ -17724,10 +17726,6 @@ mod tests {
         impl Drop for ProcessScope {
             fn drop(&mut self) {
                 let _ = std::env::set_current_dir(&self.working_dir);
-                match self.path.take() {
-                    Some(path) => std::env::set_var("PATH", path),
-                    None => std::env::remove_var("PATH"),
-                }
             }
         }
 
@@ -17753,7 +17751,8 @@ mod tests {
         let server = tokio::spawn(async move {
             let _ = axum::serve(listener, app).await;
         });
-        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+        let _daemon_url =
+            kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_URL", format!("http://{addr}"));
 
         // `kin open` launches an allowlisted editor by name, so the stand-in
         // has to be reachable exactly the way the real one is.
@@ -17829,7 +17828,6 @@ mod tests {
             "the delta the editor left must reach repository authority"
         );
 
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
@@ -17936,7 +17934,8 @@ mod tests {
         let server = tokio::spawn(async move {
             let _ = axum::serve(listener, app).await;
         });
-        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+        let _daemon_url =
+            kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_URL", format!("http://{addr}"));
 
         let mut projection =
             kin_cli::commands::session_run::materialize(state.layout.clone(), None, None)
@@ -18000,7 +17999,6 @@ mod tests {
             "closing a session releases its lease"
         );
 
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
@@ -21330,7 +21328,7 @@ mod tests {
             let _ = axum::serve(listener, router(state)).await;
         });
         let base = format!("http://{addr}");
-        std::env::set_var("KIN_DAEMON_URL", &base);
+        let mut daemon_url = kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_URL", &base);
 
         let run_task_str = run_task_id.to_string();
         let do_work_str = do_work_id.to_string();
@@ -21457,7 +21455,7 @@ mod tests {
         // The agent-facing production route must project that real incoming
         // edge without looping back through KIN_DAEMON_URL. A foreign request
         // argument must not override DaemonState's repo binding.
-        std::env::remove_var("KIN_DAEMON_URL");
+        daemon_url.apply::<_, &str>("KIN_DAEMON_URL", None);
         let result: kin_mcp::ToolCallResult = http
             .post(format!("{base}/mcp/tools/call"))
             .json(&serde_json::json!({
@@ -21498,7 +21496,6 @@ mod tests {
             })
         }));
 
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
@@ -21835,7 +21832,8 @@ mod tests {
         let server = tokio::spawn(async move {
             let _ = axum::serve(listener, Router::new().fallback(always_unavailable)).await;
         });
-        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+        let _daemon_url =
+            kin_core::test_env::EnvVarGuard::set("KIN_DAEMON_URL", format!("http://{addr}"));
 
         let layout = test_state().layout.clone();
         let repo = "consumer";
@@ -21879,12 +21877,18 @@ mod tests {
             other => panic!("MCP impact must be Unavailable on 503, got {other:?}"),
         }
 
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
+    /// Names its repository and spine endpoint by argument on purpose. An
+    /// earlier version set `KIN_REPO_ID` and `KIN_DAEMON_URL`, which are
+    /// process-global, and under `cargo test` this binary's ~600 tests are
+    /// threads in one process, so every test that opened a daemon state while
+    /// this one held `KIN_REPO_ID=provider` was refused against its own
+    /// manifest authority. `#[serial]` cannot prevent that: it orders a test
+    /// only against other serial tests. Under nextest, which gives each test
+    /// its own process, the defect is structurally invisible.
     #[tokio::test]
-    #[serial_test::serial]
     async fn mcp_find_references_reports_legacy_xref_payload_as_unavailable() {
         async fn legacy_xref() -> Json<serde_json::Value> {
             Json(serde_json::json!({
@@ -21903,8 +21907,10 @@ mod tests {
         let server = tokio::spawn(async move {
             let _ = axum::serve(listener, Router::new().fallback(legacy_xref)).await;
         });
-        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
-        std::env::set_var("KIN_REPO_ID", "provider");
+        let binding = kin_mcp::handlers::entities::AmbientCrossRepoBinding::new(
+            Some("provider"),
+            Some(&format!("http://{addr}")),
+        );
 
         let target = test_entity("do_work", "src/lib.rs");
         let graph = kin_db::InMemoryGraph::new();
@@ -21913,9 +21919,11 @@ mod tests {
             "entity_id".to_string(),
             serde_json::json!(target.id.to_string()),
         )]);
-        let result = kin_mcp::handlers::entities::handle_find_references(&args, &graph, None)
-            .await
-            .unwrap();
+        let result = kin_mcp::handlers::entities::handle_find_references_with_ambient_binding(
+            &args, &graph, binding, None,
+        )
+        .await
+        .unwrap();
         let kin_mcp::types::ContentBlock::Text { text } = result
             .content
             .first()
@@ -21927,13 +21935,12 @@ mod tests {
             .is_some_and(|reason| reason.contains("malformed spine xref response")));
         assert_eq!(body["total_upstream"], 0);
 
-        std::env::remove_var("KIN_REPO_ID");
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
+    /// Names its binding by argument for the reason given on
+    /// `mcp_find_references_reports_legacy_xref_payload_as_unavailable`.
     #[tokio::test]
-    #[serial_test::serial]
     async fn mcp_find_references_rejects_unanchored_xref_as_inconclusive() {
         async fn legacy_xref() -> Json<serde_json::Value> {
             Json(serde_json::json!({
@@ -21947,8 +21954,10 @@ mod tests {
         let server = tokio::spawn(async move {
             let _ = axum::serve(listener, Router::new().fallback(legacy_xref)).await;
         });
-        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
-        std::env::set_var("KIN_REPO_ID", "provider");
+        let binding = kin_mcp::handlers::entities::AmbientCrossRepoBinding::new(
+            Some("provider"),
+            Some(&format!("http://{addr}")),
+        );
 
         let target = test_entity("do_work", "src/lib.rs");
         let graph = kin_db::InMemoryGraph::new();
@@ -21957,9 +21966,11 @@ mod tests {
             "entity_id".to_string(),
             serde_json::json!(target.id.to_string()),
         )]);
-        let result = kin_mcp::handlers::entities::handle_find_references(&args, &graph, None)
-            .await
-            .unwrap();
+        let result = kin_mcp::handlers::entities::handle_find_references_with_ambient_binding(
+            &args, &graph, binding, None,
+        )
+        .await
+        .unwrap();
         let result = kin_mcp::finalize_with_envelope(
             result,
             kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
@@ -21983,13 +21994,12 @@ mod tests {
             .as_str()
             .is_some_and(|reason| reason.contains("cross_repo_unavailable")));
 
-        std::env::remove_var("KIN_REPO_ID");
-        std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
 
+    /// Names its binding by argument for the reason given on
+    /// `mcp_find_references_reports_legacy_xref_payload_as_unavailable`.
     #[tokio::test]
-    #[serial_test::serial]
     async fn mcp_find_references_requires_nonblank_repo_binding() {
         let target = test_entity("do_work", "src/lib.rs");
         let graph = kin_db::InMemoryGraph::new();
@@ -22000,13 +22010,12 @@ mod tests {
         )]);
 
         for repo_id in [None, Some("   ")] {
-            match repo_id {
-                Some(value) => std::env::set_var("KIN_REPO_ID", value),
-                None => std::env::remove_var("KIN_REPO_ID"),
-            }
-            let result = kin_mcp::handlers::entities::handle_find_references(&args, &graph, None)
-                .await
-                .unwrap();
+            let binding = kin_mcp::handlers::entities::AmbientCrossRepoBinding::new(repo_id, None);
+            let result = kin_mcp::handlers::entities::handle_find_references_with_ambient_binding(
+                &args, &graph, binding, None,
+            )
+            .await
+            .unwrap();
             let result = kin_mcp::finalize_with_envelope(
                 result,
                 kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
@@ -22030,8 +22039,6 @@ mod tests {
                 .as_str()
                 .is_some_and(|reason| reason.contains("cross_repo_unavailable")));
         }
-
-        std::env::remove_var("KIN_REPO_ID");
     }
 
     // -----------------------------------------------------------------------
@@ -22275,15 +22282,8 @@ mod tests {
     // is process-global and read by `router_with_auth` at construction, so the
     // env-touching publish test serializes on this `tokio::sync::Mutex` (held
     // across `.await`, so a std guard would trip `clippy::await_holding_lock`)
-    // and restores the var via `RegistryEnvGuard`.
+    // and restores the var through the shared test-env guard.
     static REGISTRY_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    struct RegistryEnvGuard(&'static str);
-    impl Drop for RegistryEnvGuard {
-        fn drop(&mut self) {
-            std::env::remove_var(self.0);
-        }
-    }
 
     /// Build a minimal valid `.crate` blob (gzip-tar containing
     /// `{name}-{version}/Cargo.toml`) so the cargo publish path passes coordinate
@@ -22414,7 +22414,7 @@ mod tests {
 
         // (1) No KIN_REGISTRY_CARGO_TOKEN configured -> publish fails closed
         // (503) even with a daemon token set and a Bearer header present.
-        std::env::remove_var("KIN_REGISTRY_CARGO_TOKEN");
+        let mut cargo_token = kin_core::test_env::EnvVarGuard::unset("KIN_REGISTRY_CARGO_TOKEN");
         let app = router_with_auth(test_state(), Some("daemon-token".to_string()));
         let disabled = app
             .oneshot(
@@ -22429,8 +22429,7 @@ mod tests {
 
         // (2) KIN_REGISTRY_CARGO_TOKEN configured: publish without the matching
         // bearer -> 401 (the daemon token does NOT satisfy the registry gate).
-        let _env = RegistryEnvGuard("KIN_REGISTRY_CARGO_TOKEN");
-        std::env::set_var("KIN_REGISTRY_CARGO_TOKEN", "cargo-secret");
+        cargo_token.apply("KIN_REGISTRY_CARGO_TOKEN", Some("cargo-secret"));
         let app = router_with_auth(test_state(), Some("daemon-token".to_string()));
         let unauthorized = app
             .oneshot(
@@ -22460,9 +22459,9 @@ mod tests {
     async fn oci_writes_require_their_own_token_while_pulls_stay_public() {
         let _lock = REGISTRY_ENV_LOCK.lock().await;
 
-        std::env::remove_var("KIN_REGISTRY_OCI_WRITE_TOKEN");
-        let _cargo_env = RegistryEnvGuard("KIN_REGISTRY_CARGO_TOKEN");
-        std::env::set_var("KIN_REGISTRY_CARGO_TOKEN", "cargo-secret");
+        let mut registry_tokens =
+            kin_core::test_env::EnvVarGuard::unset("KIN_REGISTRY_OCI_WRITE_TOKEN")
+                .with("KIN_REGISTRY_CARGO_TOKEN", "cargo-secret");
         let disabled = router_with_auth(test_state(), Some("daemon-token".to_string()))
             .oneshot(
                 Request::post("/v2/demo/blobs/uploads/")
@@ -22474,8 +22473,7 @@ mod tests {
             .unwrap();
         assert_eq!(disabled.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        let _oci_env = RegistryEnvGuard("KIN_REGISTRY_OCI_WRITE_TOKEN");
-        std::env::set_var("KIN_REGISTRY_OCI_WRITE_TOKEN", "registry-secret");
+        registry_tokens.apply("KIN_REGISTRY_OCI_WRITE_TOKEN", Some("registry-secret"));
         let app = router_with_auth(test_state(), Some("daemon-token".to_string()));
 
         // The Cargo credential is deliberately not accepted on the OCI scope.
@@ -22981,8 +22979,8 @@ mod tests {
     #[tokio::test]
     async fn resolve_serve_auth_token_gates_enforcement() {
         let _env = env_test_lock();
-        std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
-        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
+        let mut tokens = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_AUTH_TOKEN")
+            .without("KIN_DAEMON_REQUIRE_TOKEN");
 
         let dir = std::env::temp_dir().join(format!("kin-daemon-serve-token-{}", Uuid::new_v4()));
         std::fs::create_dir_all(dir.join(".kin")).unwrap();
@@ -22999,30 +22997,27 @@ mod tests {
         // Escape hatch: an explicit falsy value opts back out of enforcement —
         // for a local client that cannot yet send the header — while the file
         // stays provisioned.
-        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "0");
+        tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("0"));
         assert!(resolve_serve_auth_token(&layout).is_none());
-        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "false");
+        tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("false"));
         assert!(resolve_serve_auth_token(&layout).is_none());
 
         // Explicit truthy values are equivalent to the default.
-        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "1");
+        tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("1"));
         assert_eq!(
             resolve_serve_auth_token(&layout).as_deref(),
             Some(provisioned.trim())
         );
-        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
+        tokens.apply::<_, &str>("KIN_DAEMON_REQUIRE_TOKEN", None);
 
         // An explicit KIN_DAEMON_AUTH_TOKEN override always wins over the gate,
         // even while the gate is opted out.
-        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "0");
-        std::env::set_var("KIN_DAEMON_AUTH_TOKEN", "explicit-override");
+        tokens.apply("KIN_DAEMON_REQUIRE_TOKEN", Some("0"));
+        tokens.apply("KIN_DAEMON_AUTH_TOKEN", Some("explicit-override"));
         assert_eq!(
             resolve_serve_auth_token(&layout).as_deref(),
             Some("explicit-override")
         );
-
-        std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
-        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
     }
 
     /// Round-trip proof of the default-on posture through the real production
@@ -23035,8 +23030,8 @@ mod tests {
     #[tokio::test]
     async fn daemon_enforces_loopback_token_by_default_end_to_end() {
         let _env = env_test_lock();
-        std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
-        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
+        let _tokens = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_AUTH_TOKEN")
+            .without("KIN_DAEMON_REQUIRE_TOKEN");
 
         let state = test_state();
         // Pre-provision deterministically so this test does not race the
@@ -23085,8 +23080,6 @@ mod tests {
         );
 
         server.abort();
-        std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
-        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -613,13 +613,9 @@ mod tests {
     }
 
     fn with_repo_ids<T>(value: Option<&str>, body: impl FnOnce() -> T) -> T {
-        match value {
-            Some(value) => env::set_var("KIN_REPO_IDS", value),
-            None => env::remove_var("KIN_REPO_IDS"),
-        }
-        let outcome = body();
-        env::remove_var("KIN_REPO_IDS");
-        outcome
+        let mut allowlist = kin_core::test_env::EnvVarGuard::new();
+        allowlist.apply("KIN_REPO_IDS", value);
+        body()
     }
 
     /// The identity a daemon advertises must be one it will route, in every

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1440,7 +1440,7 @@ mod tests {
                 .unwrap();
             path
         });
-        std::env::set_var("KIN_REGISTRY_PATH", path);
+        kin_core::test_env::install_process_wide("KIN_REGISTRY_PATH", path);
     }
 
     fn test_state() -> (tempfile::TempDir, Arc<DaemonState>) {

--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -2296,13 +2296,11 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn session_idle_ttl_is_configurable_and_rejects_nonsense() {
-        let restore = std::env::var(SESSION_IDLE_TTL_ENV).ok();
-
-        std::env::set_var(SESSION_IDLE_TTL_ENV, "60");
+        let mut ttl = kin_core::test_env::EnvVarGuard::set(SESSION_IDLE_TTL_ENV, "60");
         assert_eq!(configured_session_idle_ttl(), Duration::from_secs(60));
 
         for nonsense in ["0", "", "  ", "later", "-5"] {
-            std::env::set_var(SESSION_IDLE_TTL_ENV, nonsense);
+            ttl.apply(SESSION_IDLE_TTL_ENV, Some(nonsense));
             assert_eq!(
                 configured_session_idle_ttl(),
                 DEFAULT_SESSION_IDLE_TTL,
@@ -2310,13 +2308,13 @@ mod tests {
             );
         }
 
-        std::env::set_var(
+        ttl.apply(
             SESSION_IDLE_TTL_ENV,
-            MAX_SESSION_IDLE_TTL.as_secs().to_string(),
+            Some(MAX_SESSION_IDLE_TTL.as_secs().to_string()),
         );
         assert_eq!(configured_session_idle_ttl(), MAX_SESSION_IDLE_TTL);
         for past_ceiling in [MAX_SESSION_IDLE_TTL.as_secs() + 1, 18_000_000, u64::MAX] {
-            std::env::set_var(SESSION_IDLE_TTL_ENV, past_ceiling.to_string());
+            ttl.apply(SESSION_IDLE_TTL_ENV, Some(past_ceiling.to_string()));
             assert_eq!(
                 configured_session_idle_ttl(),
                 DEFAULT_SESSION_IDLE_TTL,
@@ -2324,11 +2322,8 @@ mod tests {
             );
         }
 
-        std::env::remove_var(SESSION_IDLE_TTL_ENV);
+        ttl.apply::<_, &str>(SESSION_IDLE_TTL_ENV, None);
         assert_eq!(configured_session_idle_ttl(), DEFAULT_SESSION_IDLE_TTL);
-        if let Some(restore) = restore {
-            std::env::set_var(SESSION_IDLE_TTL_ENV, restore);
-        }
     }
 
     /// A heartbeat extends the lease: the sweeper measures from the last

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5374,10 +5374,8 @@ mod tests {
         kin_core::registry::KinRegistry { repos: Vec::new() }
             .save_to(&registry_path)
             .unwrap();
-        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
-        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
-        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
-        std::env::remove_var("KIN_DISABLE_SPINE");
+        let _spine_env = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path)
+            .without("KIN_DISABLE_SPINE");
 
         let repo_dir = tempfile::tempdir().unwrap();
         let init = kin_core::init(repo_dir.path()).unwrap();
@@ -5400,15 +5398,6 @@ mod tests {
             None => (false, None, false),
         };
 
-        match prev_registry {
-            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
-            None => std::env::remove_var("KIN_REGISTRY_PATH"),
-        }
-        match prev_disable {
-            Some(value) => std::env::set_var("KIN_DISABLE_SPINE", value),
-            None => std::env::remove_var("KIN_DISABLE_SPINE"),
-        }
-
         assert!(deferred, "an active writer must defer spine initialization");
         assert!(
             once_lock_unpublished,
@@ -5429,10 +5418,8 @@ mod tests {
         kin_core::registry::KinRegistry { repos: Vec::new() }
             .save_to(&registry_path)
             .unwrap();
-        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
-        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
-        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
-        std::env::remove_var("KIN_DISABLE_SPINE");
+        let _spine_env = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path)
+            .without("KIN_DISABLE_SPINE");
 
         let repo_dir = tempfile::tempdir().unwrap();
         let init = kin_core::init(repo_dir.path()).unwrap();
@@ -5480,15 +5467,6 @@ mod tests {
             "second caller must reuse the published spine"
         );
 
-        match prev_registry {
-            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
-            None => std::env::remove_var("KIN_REGISTRY_PATH"),
-        }
-        match prev_disable {
-            Some(value) => std::env::set_var("KIN_DISABLE_SPINE", value),
-            None => std::env::remove_var("KIN_DISABLE_SPINE"),
-        }
-
         assert_eq!(
             calls_while_blocked, 1,
             "OnceLock publication alone must not allow duplicate O(graph) initializers"
@@ -5508,10 +5486,8 @@ mod tests {
         kin_core::registry::KinRegistry { repos: Vec::new() }
             .save_to(&registry_path)
             .unwrap();
-        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
-        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
-        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
-        std::env::remove_var("KIN_DISABLE_SPINE");
+        let _spine_env = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path)
+            .without("KIN_DISABLE_SPINE");
 
         let repo_dir = tempfile::tempdir().unwrap();
         let init = kin_core::init(repo_dir.path()).unwrap();
@@ -5552,15 +5528,6 @@ mod tests {
             ),
             None => (false, None, false),
         };
-
-        match prev_registry {
-            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
-            None => std::env::remove_var("KIN_REGISTRY_PATH"),
-        }
-        match prev_disable {
-            Some(value) => std::env::set_var("KIN_DISABLE_SPINE", value),
-            None => std::env::remove_var("KIN_DISABLE_SPINE"),
-        }
 
         assert!(
             stale_backend_unpublished,
@@ -5664,10 +5631,8 @@ mod tests {
         }
         .save_to(&registry_path)
         .unwrap();
-        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
-        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
-        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
-        std::env::remove_var("KIN_DISABLE_SPINE");
+        let _spine_env = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path)
+            .without("KIN_DISABLE_SPINE");
 
         // The primary repo: a caller entity plus an unresolved cross-repo call
         // tagged with the sibling repo as its import source.
@@ -5708,13 +5673,6 @@ mod tests {
 
         // Restore the process-global env before asserting so a failure can never
         // leak the override into other tests.
-        match prev_registry {
-            Some(v) => std::env::set_var("KIN_REGISTRY_PATH", v),
-            None => std::env::remove_var("KIN_REGISTRY_PATH"),
-        }
-        if let Some(v) = prev_disable {
-            std::env::set_var("KIN_DISABLE_SPINE", v);
-        }
 
         assert!(
             repo_count >= 2,
@@ -5832,10 +5790,8 @@ mod tests {
         kin_core::registry::KinRegistry { repos: Vec::new() }
             .save_to(&registry_path)
             .unwrap();
-        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
-        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
-        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
-        std::env::remove_var("KIN_DISABLE_SPINE");
+        let _spine_env = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path)
+            .without("KIN_DISABLE_SPINE");
 
         // ── Drive the production ingest route logic ───────────────────────
         // Sibling first (metadata only), then the anchor with edge refresh —
@@ -5857,13 +5813,6 @@ mod tests {
             .expect("primary ingest retries onto stable capture + cross-repo edge refresh");
 
         // Restore env before asserting so a failure cannot leak the override.
-        if let Some(v) = prev_disable {
-            std::env::set_var("KIN_DISABLE_SPINE", v);
-        }
-        match prev_registry {
-            Some(v) => std::env::set_var("KIN_REGISTRY_PATH", v),
-            None => std::env::remove_var("KIN_REGISTRY_PATH"),
-        }
 
         // The sibling was loaded purely from storage (it has no local `.kndb`).
         assert_eq!(

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -3295,7 +3295,7 @@ mod tests {
     #[test]
     fn supervisor_is_host_allowed_honors_bind_host_env() {
         let _env = env_test_lock();
-        std::env::remove_var("KIN_SUPERVISOR_BIND_HOST");
+        let mut bind_host = kin_core::test_env::EnvVarGuard::unset("KIN_SUPERVISOR_BIND_HOST");
 
         // Loopback always allowed; arbitrary hosts rejected by default.
         assert!(is_host_allowed("127.0.0.1"));
@@ -3305,15 +3305,13 @@ mod tests {
         assert!(!is_host_allowed("10.0.0.5"));
 
         // An explicit non-loopback bind host is allowed only for that host.
-        std::env::set_var("KIN_SUPERVISOR_BIND_HOST", "10.0.0.5");
+        bind_host.apply("KIN_SUPERVISOR_BIND_HOST", Some("10.0.0.5"));
         assert!(is_host_allowed("10.0.0.5"));
         assert!(!is_host_allowed("attacker.com"));
 
         // A wildcard bind allows any host (operator opted into exposure).
-        std::env::set_var("KIN_SUPERVISOR_BIND_HOST", "0.0.0.0");
+        bind_host.apply("KIN_SUPERVISOR_BIND_HOST", Some("0.0.0.0"));
         assert!(is_host_allowed("attacker.com"));
-
-        std::env::remove_var("KIN_SUPERVISOR_BIND_HOST");
     }
 
     #[test]
@@ -3327,8 +3325,8 @@ mod tests {
     #[tokio::test]
     async fn supervisor_loopback_token_provisioned_persisted_and_enforced() {
         let _env = env_test_lock();
-        std::env::remove_var("KIN_SUPERVISOR_AUTH_TOKEN");
-        std::env::remove_var("KIN_SUPERVISOR_REQUIRE_TOKEN");
+        let mut tokens = kin_core::test_env::EnvVarGuard::unset("KIN_SUPERVISOR_AUTH_TOKEN")
+            .without("KIN_SUPERVISOR_REQUIRE_TOKEN");
 
         // Hermetic per-test supervisor directory, passed explicitly to the token
         // helpers so the assertions never depend on the process-global
@@ -3359,21 +3357,18 @@ mod tests {
         assert!(resolve_serve_auth_token(&dir).is_none());
 
         // Opt-in via KIN_SUPERVISOR_REQUIRE_TOKEN returns the provisioned token.
-        std::env::set_var("KIN_SUPERVISOR_REQUIRE_TOKEN", "1");
+        tokens.apply("KIN_SUPERVISOR_REQUIRE_TOKEN", Some("1"));
         assert_eq!(
             resolve_serve_auth_token(&dir).as_deref(),
             Some(token.as_str())
         );
 
         // An explicit KIN_SUPERVISOR_AUTH_TOKEN override always wins.
-        std::env::set_var("KIN_SUPERVISOR_AUTH_TOKEN", "explicit-override");
+        tokens.apply("KIN_SUPERVISOR_AUTH_TOKEN", Some("explicit-override"));
         assert_eq!(
             resolve_serve_auth_token(&dir).as_deref(),
             Some("explicit-override")
         );
-
-        std::env::remove_var("KIN_SUPERVISOR_AUTH_TOKEN");
-        std::env::remove_var("KIN_SUPERVISOR_REQUIRE_TOKEN");
     }
 
     #[test]

--- a/crates/kin-mcp/Cargo.toml
+++ b/crates/kin-mcp/Cargo.toml
@@ -36,5 +36,6 @@ uuid = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]
+kin-core = { workspace = true, features = ["test-support"] }
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -162,6 +162,23 @@ pub async fn fetch_spine_impact_typed(
     let Ok(daemon_url) = daemon_url_from_env() else {
         return SpineQuery::NotConfigured;
     };
+    fetch_spine_impact_typed_at(&daemon_url, repo_id, entity_id, depth).await
+}
+
+/// Query an explicitly named daemon for federated impact analysis.
+///
+/// The endpoint is an argument so a caller that already knows it does not have
+/// to publish it through `KIN_DAEMON_URL`. That variable is process-global, and
+/// under `cargo test` a binary's tests are threads in one process, so a test
+/// setting it to reach its own stub server also repoints every other test that
+/// resolves a daemon. Endpoint resolution belongs at the entry boundary, where
+/// it happens once, rather than inside a request that other code shares.
+pub async fn fetch_spine_impact_typed_at(
+    daemon_url: &str,
+    repo_id: &str,
+    entity_id: &EntityId,
+    depth: u32,
+) -> SpineQuery<kin_spine::FederatedImpact> {
     let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
@@ -207,6 +224,17 @@ pub async fn fetch_spine_xref(
     let Ok(daemon_url) = daemon_url_from_env() else {
         return SpineQuery::NotConfigured;
     };
+    fetch_spine_xref_at(&daemon_url, repo_id, entity_id).await
+}
+
+/// Query an explicitly named daemon for cross-repo edges.
+///
+/// See [`fetch_spine_impact_typed_at`] for why the endpoint is an argument.
+pub async fn fetch_spine_xref_at(
+    daemon_url: &str,
+    repo_id: &str,
+    entity_id: &EntityId,
+) -> SpineQuery<kin_spine::SpineXrefResponse> {
     let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -825,14 +825,49 @@ fn normalize_cross_repo_repo_id(raw: Option<&str>) -> std::result::Result<String
         })
 }
 
-fn cross_repo_repo_id() -> std::result::Result<String, String> {
-    match std::env::var("KIN_REPO_ID") {
-        Ok(value) => normalize_cross_repo_repo_id(Some(&value)),
-        Err(std::env::VarError::NotPresent) => normalize_cross_repo_repo_id(None),
-        Err(std::env::VarError::NotUnicode(_)) => Err(
-            "KIN_REPO_ID is not valid Unicode; cross-repo authority cannot bind this graph to a repository"
-                .to_string(),
-        ),
+/// Cross-repository binding for a caller that has no daemon-owned authority.
+///
+/// The standalone MCP server resolves this from the process environment once,
+/// at its entry boundary. Holding the resolved values rather than re-reading
+/// `KIN_REPO_ID` and `KIN_DAEMON_URL` mid-request means one request cannot see
+/// two different bindings, and means a test can name a binding by argument
+/// instead of writing the process-global table that every thread in the binary
+/// shares.
+#[derive(Clone, Debug)]
+pub struct AmbientCrossRepoBinding {
+    repo_id: std::result::Result<String, String>,
+    daemon_url: Option<String>,
+}
+
+impl AmbientCrossRepoBinding {
+    /// Bind to an explicitly named repository and spine endpoint.
+    pub fn new(repo_id: Option<&str>, daemon_url: Option<&str>) -> Self {
+        Self {
+            repo_id: normalize_cross_repo_repo_id(repo_id),
+            daemon_url: daemon_url
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned),
+        }
+    }
+
+    /// Resolve the binding from the process environment.
+    pub fn from_env() -> Self {
+        let repo_id = match std::env::var("KIN_REPO_ID") {
+            Ok(value) => normalize_cross_repo_repo_id(Some(&value)),
+            Err(std::env::VarError::NotPresent) => normalize_cross_repo_repo_id(None),
+            Err(std::env::VarError::NotUnicode(_)) => Err(
+                "KIN_REPO_ID is not valid Unicode; cross-repo authority cannot bind this graph to a repository"
+                    .to_string(),
+            ),
+        };
+        Self {
+            repo_id,
+            daemon_url: std::env::var("KIN_DAEMON_URL")
+                .ok()
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty()),
+        }
     }
 }
 
@@ -850,7 +885,7 @@ pub struct FindReferencesAuthority<'a> {
 }
 
 enum FindReferencesAuthoritySource<'a> {
-    Environment,
+    Ambient(AmbientCrossRepoBinding),
     Daemon(FindReferencesAuthority<'a>),
 }
 
@@ -956,7 +991,29 @@ pub async fn handle_find_references<G: GraphStore>(
     handle_find_references_with_authority_source(
         args,
         store,
-        FindReferencesAuthoritySource::Environment,
+        FindReferencesAuthoritySource::Ambient(AmbientCrossRepoBinding::from_env()),
+        repository_authority,
+    )
+    .await
+}
+
+/// Serve `find_references` from an explicitly named ambient binding.
+///
+/// Same behavior as [`handle_find_references`], with the repository id and
+/// spine endpoint supplied rather than read from the process environment. A
+/// test covering the ambient path names its binding here instead of writing
+/// `KIN_REPO_ID` and `KIN_DAEMON_URL`, which are process-global and, under
+/// `cargo test`, visible to every other test in the binary.
+pub async fn handle_find_references_with_ambient_binding<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+    binding: AmbientCrossRepoBinding,
+    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+) -> Result<ToolCallResult> {
+    handle_find_references_with_authority_source(
+        args,
+        store,
+        FindReferencesAuthoritySource::Ambient(binding),
         repository_authority,
     )
     .await
@@ -1028,9 +1085,12 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         collect_graph_reference_rows(store, &target.id, &relation_kinds, repository_authority)?;
     // ── Federated Xrefs via Spine ─────────────────────────────────────
     let cross_repo_query = match authority_source {
-        FindReferencesAuthoritySource::Environment => match cross_repo_repo_id() {
+        FindReferencesAuthoritySource::Ambient(binding) => match binding.repo_id {
             Ok(repo_id) => {
-                let query = fetch_spine_xref(&repo_id, &target.id).await;
+                let query = match binding.daemon_url.as_deref() {
+                    Some(daemon_url) => fetch_spine_xref_at(daemon_url, &repo_id, &target.id).await,
+                    None => kin_spine::SpineQuery::NotConfigured,
+                };
                 Ok((repo_id, query))
             }
             Err(reason) => Err(reason),

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -163,6 +163,7 @@ mod tests {
     use super::common::*;
     use super::*;
     use base64::Engine as _;
+    use kin_core::test_env::EnvVarGuard;
     use kin_db::{InMemoryGraph, KinDbError, LocalFileBackend, RepositoryAuthorityManager};
     use kin_model::change::SemanticChange;
     use kin_model::entity::Entity;
@@ -4269,29 +4270,6 @@ mod tests {
             err.to_string().contains("missing payload"),
             "actionable stage-time message expected, got: {err}"
         );
-    }
-
-    struct EnvVarGuard {
-        key: &'static str,
-        old_val: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, val: &std::path::Path) -> Self {
-            let old_val = std::env::var_os(key);
-            std::env::set_var(key, val);
-            Self { key, old_val }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            if let Some(ref val) = self.old_val {
-                std::env::set_var(self.key, val);
-            } else {
-                std::env::remove_var(self.key);
-            }
-        }
     }
 
     use std::sync::{Mutex, OnceLock};

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1542,7 +1542,7 @@ mod tests {
             }
             Err(error) => panic!("failed to establish Kin repo fixture: {error}"),
         };
-        std::env::remove_var("KIN_DAEMON_URL");
+        let _daemon_url = kin_core::test_env::EnvVarGuard::unset("KIN_DAEMON_URL");
         let config = McpServerConfig::default();
         let sessions = SessionRegistry::new();
         let store = InMemoryGraph::default();

--- a/crates/kin-migrate/Cargo.toml
+++ b/crates/kin-migrate/Cargo.toml
@@ -44,6 +44,7 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [dev-dependencies]
+kin-core = { workspace = true, features = ["test-support"] }
 pretty_assertions = { workspace = true }
 # The descendant-reap acceptance test is cross-platform even though production
 # process-group enumeration uses sysinfo only on Unix.

--- a/crates/kin-migrate/src/finalize.rs
+++ b/crates/kin-migrate/src/finalize.rs
@@ -102,7 +102,7 @@ mod tests {
         // timeout, so a `kin` process holding that lock would block this test
         // forever.
         let registry_path = tmp.path().join("registry-home/registry.toml");
-        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
+        let _registry = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path);
 
         update_registry(tmp.path(), 42).unwrap();
 
@@ -110,6 +110,5 @@ mod tests {
             registry_path.exists(),
             "the registry authority must be created under the missing home"
         );
-        std::env::remove_var("KIN_REGISTRY_PATH");
     }
 }


### PR DESCRIPTION
Closes FIR-1766

`cargo test --workspace` was host-flaky because test code mutated two
process-global tables, and `cargo nextest` (which the CI test job runs) gives
every test its own process, so neither class can turn CI red. Plain `cargo test`
is the authority when the runners disagree.

## The environment table

Two `kin-daemon` tests set `KIN_REPO_ID=provider` for the length of their
bodies. `DaemonState::open` reads that variable and refuses when the override
disagrees with the manifest, so any of the ~600 sibling tests that opened a
daemon state in that window failed against its own authority.
`#[serial_test::serial]` was on both leakers and could not help: it orders a test
against other serial tests, not against the rest of a suite running in parallel.

Reproduced deterministically on the pre-fix binary: with `KIN_REPO_ID=provider`
present, `command_branch_source_cas_integrity_failures_are_internal_without_mutation`
and `mcp_semantic_locate_fused_serves_snippets_and_keeps_hits_when_declined`
both fail with the manifest-authority refusal; without it, both pass.

`find_references` now resolves its cross-repository binding once, at the entry
boundary, into an `AmbientCrossRepoBinding` the request carries. The standalone
MCP server still builds that from the environment; the tests name a repository
and a spine endpoint by argument. A single request can no longer observe two
different bindings either. `fetch_spine_xref` and `fetch_spine_impact_typed`
gain endpoint-taking variants for the same reason.

Where the behavior under test genuinely is the environment read, the mutation
goes through one shared guard in `kin-core` rather than six near-identical local
copies. It restores on drop including on panic, serializes mutators, and is
`!Send` so it cannot be released on a thread that did not take it. Its
documentation states plainly that it does not hide a mutation from a test that
merely reads the variable, because nothing can.

## The file-creation mask

The kin-cli crash-recovery pair contends on the process umask, not on the
environment and not on the install-root lock.
`private_root_is_atomically_0700_even_with_umask_zero` held `umask(0)` in the
test process; every directory a concurrently running test created came out
world-writable, and Kin's namespace-safety check then refused it, aborting
whichever crash worker happened to be starting: "existing Kin-home ancestor
permits unsafe namespace replacement", naming a temporary directory the worker
had no part in creating. That is why the failing set moved run to run.

Reproduced at 3 failures in 6 runs of the kin-cli suite under concurrent load,
on four different victims. The observation now runs in a worker process, which
is the shape the restrictive-umask tests in `setup.rs` already use, and every
other `libc::umask` call in the workspace already had.

## The guard

A source-scanning test walks the workspace and fails on the bare
`env::set_var` / `env::remove_var` idiom outside the sanctioned module (the scan
enforces that literal form; equivalent spellings such as an aliased import or
`libc::setenv` are a recorded follow-up), with product writes
enumerated in `crates/kin-core/env_mutation_allowlist.txt` (one entry: `kin mcp
start` binding the process to its resolved daemon). Falsified by planting a bare
`std::env::set_var` in a test module, which turns it red and names the file and
line. This is the only part of the work CI can enforce, which is the point.

## A third flake the acceptance surfaced

The first acceptance round went 0, 0, 101 on a `kin-daemon-spawn` test this
branch does not touch. Three guardian tests waited for a worker's report file to
*exist* and then parsed it; existence is not content, so a reader that won the
race got an empty report and aborted with a bare `ParseIntError`.
`wait_for_test_report_fields` already existed for exactly this and the
fork-boundary test already used it. Fixed, and fifteen consecutive runs of that
crate's suite pass.

## Gates

All at the final head, under `RUSTFLAGS="-D warnings"`: fmt, both
zero-file-search guards, clippy with the ci.yml allowlist, and
`cargo build --all-targets --locked` clean. **Three consecutive
`cargo test --workspace --locked` runs all exit 0**, plus `cargo test --doc` and
`cargo nextest run` (4606/4606), so both runners agree.

One nextest attempt before that retry failed
`stop_barrier_catches_repeated_forks_at_the_cleanup_boundary` on a fork-boundary
timeout. Recorded rather than hidden: this branch's kin-daemon-spawn hunks do
not include that test or its helper, the same code passed nextest in the
previous round, all three workspace runs passed it, and CI's nextest passed it on
both platforms. It is a residual load-dependent flake that wants its own ticket
and is not fixed here.


