### PR TITLE
Give each main commit its own CI concurrency group and take coverage off the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,17 @@ on:
 permissions:
   contents: read
 
+# The sha suffix is empty off main, so every pull request and merge-queue ref
+# keeps one group per ref and `cancel-in-progress` still supersedes an older
+# push exactly as before. On main it gives each commit its own group. That
+# matters because `cancel-in-progress: false` does not mean "never cancel":
+# GitHub holds at most one PENDING run per group and cancels the older one, so
+# consecutive pushes to main both serialised behind each other and deleted each
+# other. Four main-branch pushes in a 24h sample were cancelled having started
+# zero jobs, and release-tag.yml requires push-event provenance for every
+# required check, which left those four landed commits permanently unmintable.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
@@ -99,6 +108,12 @@ jobs:
     # Split out of the installer job: the debug test compile and the release
     # build share no artifacts (separate target profiles), so serialising them
     # only added wall clock. They run concurrently now.
+    #
+    # This job stays on every event on purpose, and the authority test enforces
+    # that it carries no job-level `if:`. It is the merge group's only proof of
+    # the Windows admission refusals, so taking it off the queue to reclaim its
+    # runner minutes would trade a reviewable pre-landing signal for a required
+    # context that first fails on main.
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -643,6 +658,16 @@ jobs:
         run: bash scripts/zero_file_search_guard.sh
 
       - name: Falsify Zero File-Search guards
+        # Both guards above still run on both platforms. Only this meta-proof,
+        # that the guards are not vacuous, is single-legged. Falsifiability is
+        # a property of the guards' logic, and neither the Python checker nor
+        # the shell guard branches on platform: they carry no `sys.platform` /
+        # `os.name` / `darwin` / `linux` test and no GNU-only shell construct.
+        # The harness is self-contained, poisoning a `mktemp -d` copy of
+        # `crates` and `scripts` rather than the checkout, so skipping it
+        # leaves no state for later steps and does not reorder them. It costs
+        # 5.9 min of the macOS leg, which is the merge queue's critical path.
+        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           poisoned="$(mktemp -d)"
@@ -858,7 +883,15 @@ jobs:
     # Not the critical path (the Windows jobs are longer), so gating this off
     # PRs costs no wall clock and reclaims ~23 min of billed compute per PR.
     # Coverage still runs on every push to main, so it still gates what lands.
-    if: github.event_name != 'pull_request'
+    #
+    # Off the merge queue for a stronger reason than cost. This is not a
+    # required context, so the queue never waits for it: across seven sampled
+    # landings the merge completed a median 34s after the last required check
+    # while this job was still running, finishing up to 7.1 min PAST the merge.
+    # A merge_group check-run that concludes after the merge lands on the exact
+    # sha release-tag.yml sweeps, where a non-required failure is terminal even
+    # though nothing gated on it. A job that never starts cannot conclude.
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -13,8 +13,15 @@ on:
 permissions:
   contents: read
 
+# Sha-scoped on main for the same reason as ci.yml: `cancel-in-progress: false`
+# keeps at most one PENDING run per group and cancels the older one, so two
+# quick pushes to main can delete the earlier commit's run outright. This
+# workflow publishes `cargo-deny`, a required context that release-tag.yml
+# demands with push-event provenance, so a dropped run here makes the commit
+# unmintable. The suffix is empty off main, leaving pull-request and
+# merge-queue supersession exactly as it was.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -7,8 +7,15 @@ on:
   push:
     branches: ["**"]
 
+# Sha-scoped on main for the same reason as ci.yml: `cancel-in-progress: false`
+# keeps at most one PENDING run per group and cancels the older one, so two
+# quick pushes to main can delete the earlier commit's run outright. This
+# workflow publishes `gitleaks (full history)`, a required context that
+# release-tag.yml demands with push-event provenance, so a dropped run here
+# makes the commit unmintable. The suffix is empty off main, leaving branch
+# and merge-queue supersession exactly as it was.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -202,7 +202,7 @@ DOCS_ONLY_WORKFLOW_HEADER = textwrap.dedent(
     permissions:
       contents: read
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
Three independent CI changes with the same thesis: stop paying for work that
participates in no decision, and stop letting a concurrency group destroy the
evidence a release is minted from. Each hunk carries its own evidence, so any
one can be dropped without disturbing the others.

Part-of FIR-1015.

## 1. Sha-scope the main-branch concurrency group

`ci.yml`, `sast.yml` and `secret-scan.yml` all grouped on
`${{ github.workflow }}-${{ github.ref }}` with
`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`. On main that
expression is false, and `false` does not mean "never cancel". GitHub keeps at
most one PENDING run per group and cancels the older one, so consecutive
landings both serialised behind each other and deleted each other's runs.

Measured over 24h (2026-07-30 to 07-31): 8 of 19 main CI runs waited on the
group before their first job started, mean 14.0 min, worst 20.9 min. The
07:23Z-09:02Z chain sits entirely outside that window's runner-supply
incident, so this is the group and not the pool.

The serialisation is the cheap half. The expensive half is that four
main-branch push CI runs were cancelled having started **zero jobs**:

| sha | run | created | cancelled | jobs started | only push CI run on that sha |
|---|---|---|---|---|---|
| `93ebf6a5` | 30555734743 | 15:14:58Z | 15:16:38Z | 0 | `cancelled` |
| `67f04432` | 30557230303 | 15:33:03Z | 15:40:05Z | 0 | `cancelled` |
| `2941af70` | 30589907380 | 23:15:03Z | 23:36:06Z | 0 | `cancelled` |
| `b72d2bca` | 30614166276 | 07:49:52Z | 07:58:58Z | 0 | `cancelled` |

Each cancellation lands 1-2 seconds after the next main push run was created.
All four are confirmed ancestors of `origin/main` by `git merge-base
--is-ancestor`, so they are landed commits, not abandoned tips. Querying
`actions/workflows/245803170/runs?event=push&head_sha=<sha>` returns exactly
one run for each, concluded `cancelled`.

`release-tag.yml` resolves each of its six required checks against an exact
workflow id, path, `push` event, and `main` branch (the `expected_provenance`
table). A sha whose push CI run never started a job has no such evidence and
never will, so **those four landed commits are permanently unmintable**. A
release can only be cut from a commit that happened to win the concurrency
race. The v0.4.3 cut was protected only by the release quiesce holding pushes
apart.

The fix appends the commit sha to the group **on main only**:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
```

The conditional is load-bearing. Scoping unconditionally would break pull
request supersession, because every PR push has a new sha and
`cancel-in-progress` would never find an existing group to cancel. Off main
the suffix evaluates to the empty string, so the group is one key per ref
exactly as before and supersession is unchanged. On main each commit gets its
own group, so main runs neither serialise nor cancel each other, and "one push
producer per sha" becomes structural rather than accidental.

Honest note: the group name for non-main refs gains a trailing `-`. The
partition into groups is identical, so supersession behaviour is unchanged,
but a run created before this lands and one created after are in different
groups. The only effect is one transition round where an in-flight PR run is
not superseded.

`sast.yml` and `secret-scan.yml` publish `cargo-deny` and
`gitleaks (full history)`, both required contexts in the same provenance
table, so they carry identical exposure and get identical treatment. Their
headers are not authority-pinned.

Tradeoff stated: concurrent main runs now consume more runner slots at once.
Over the same 24h sweep (2055 jobs) every job that queued more than 300s falls
inside a single 2026-07-30 20:48Z-23:30Z supply incident; outside it P90
queueing is ~10s. There is no chronic backlog this serialisation was buying
capacity against, and hunk 2 hands back an ubuntu slot per landing.

## 2. Skip `Code Coverage` on `merge_group`

`Code Coverage` is not a required context. It appears in none of: ruleset
19746451's six contexts, `release-tag.yml`'s `REQUIRED_CHECKS`, or its
`expected_provenance` table. The queue does not wait for it: across 7 of 7
sampled landings the merge completed a median 34 seconds after the last
*required* check went green with this job still running, finishing up to 7.1
min past the merge. It also cannot fail on its own terms; its tarpaulin
invocation downgrades failure to `::warning::`.

The reason to skip it is not the 25.9 runner-minutes. It is FIR-1769: a
trailing `merge_group` check-run concludes on the exact landing sha that
`release-tag.yml` sweeps, and that sweep walks **every** check-run on the sha,
not just required ones, treating anything outside `{success, skipped,
neutral}` as terminal. A job that never starts cannot conclude. FIR-1769's own
fix direction was to add these jobs to the queue's required set, costed there
as longer queue latency for every PR; this reaches the same safety from the
opposite side and makes the queue faster instead of slower.

Coverage still runs on every push to main, which is the run the release proof
reads.

Safety of the resulting shape is empirical, not inferred: sha `72149519`
minted successfully with a `skipped` merge_group twin of
`Windows installer + vector-free release build` sitting beside its green push
twin. `non_failing_optional` accepts `skipped`.

## 3. Run the Zero File-Search falsification harness on Linux only

`Falsify Zero File-Search guards` is the single largest step in `Check & Test`:
477s on ubuntu (40.8% of the job) and 356s on macOS (24.0%), against a
`cargo nextest run` of 333s / 609s. It runs up to 192 full-repo guard
invocations serially.

Both *guards* keep running on both platforms; only the meta-proof that they
are not vacuous becomes single-legged, and falsifiability is a property of the
guards' logic. Verified directly rather than assumed:
`verify-zero-file-search.py`, `falsify-zero-file-search.py`, and
`zero_file_search_guard.sh` contain zero occurrences of `platform`,
`sys.platform`, `os.name`, `darwin`, `linux`, or `win32`, and the shell guard
uses no GNU-only construct (`grep -P`, `sed -i`, `readlink -f`, `stat -c`,
`find -printf` all absent).

The step is self-contained. It creates its own `mktemp -d`, copies `crates`
and `scripts` into it, and `falsify-zero-file-search.py` resolves every read
and write under `os.path.abspath(sys.argv[1])`, so the checkout is never
poisoned. It cleans up on an EXIT trap. GitHub runs a job's steps strictly in
order and a skipped step neither reorders nor leaves state for the ones after
it, so the macOS leg's later steps see exactly what they see today.

This is 5.9 min off the macOS job, which is the merge queue's critical path,
on each of the PR, merge_group, and push rounds.

## What this PR does not change

- No required-context name changes. The diff touches no `name:` line;
  `Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)`,
  `DCO Sign-off`, `cargo-deny`, `gitleaks (full history)`, and
  `Windows installer + vector-free release build` are byte-identical.
- `release-tag.yml`, `release-train.yml` and `release.yml` are byte-identical
  to `HEAD`, verified by blob hash rather than by reading the diff.
- `Windows authority tests` **stays on `merge_group`**. The ci-speed analysis
  proposed skipping it too, on a mutation sandbox taken before #534 landed.
  #534 added an authority assertion requiring that job to carry no job-level
  `if:`, because it is the merge group's only proof of the Windows admission
  refusals. Skipping it would trade a reviewable pre-landing signal for a
  required context that first fails on main. Its 24.0 merge_group
  runner-minutes and its FIR-1769 exposure both remain, and that residual is
  deliberately left for a decision that weighs admission review against mint
  poisoning.

## Observed on this PR

All checks settled green. `Code Coverage` reports `skipping` (pre-existing PR
behaviour, preserved), `Windows authority tests` **runs and passes**, both
`Check & Test` legs pass, and the six required contexts are unchanged in name.

Hunk 4 confirmed at the step level:

| leg | Check ZFS Invariant | Check ZFS (answer modules) | **Falsify ZFS guards** | next step (Hydration falsify) |
|---|---|---|---|---|
| ubuntu-latest | success | success | **success**, 523s | success |
| macos-latest | success | success | **skipped** | success |

Both guards still run on both platforms. The step after the skipped one
completes normally on macOS, which is the "does skipping reorder or strand
anything" question answered by the runner rather than by reading the source.

## Verification

- `python3 scripts/test-release-workflow-authority.py` passes with **exactly
  one** line changed in `DOCS_ONLY_WORKFLOW_HEADER`, mirroring the ci.yml
  group line verbatim (`git diff --numstat` reports `1 1` for that file).
- `actionlint` clean on all three workflows.
- The mutation plan re-run against a clean `git archive` of this commit,
  9 of 9 matching expectation, controls included:

| exp | expect | got | mutation |
|---|---|---|---|
| baseline | PASS | PASS | this commit as shipped |
| C | FAIL | FAIL | `windows-authority-tests` gains a job-level `if:` |
| D *(control)* | FAIL | FAIL | `check` job `env:` gains `CARGO_NET_RETRY` |
| E *(control)* | PASS | PASS | `check` job gains a no-op step |
| F *(control)* | FAIL | FAIL | ci.yml group changed, needle reverted |
| G *(control)* | FAIL | FAIL | `name: CI` renamed |
| H | PASS | PASS | group and needle reverted together |
| I | PASS | PASS | falsify step `if:` removed |
| J | PASS | PASS | coverage `if:` reverted |

  D, F and G are the falsification: the test would visibly break if "not
  pinned" were false, and it breaks exactly where the pin is real. C is why
  hunk 3 of the original proposal is not in this PR.
- `test_install_optional_vfs.py`, `test_installer_parity.py`,
  `test-npm-automatic-release.py`, `test-verify-npm-release.py`,
  `test-install-checksum.py`, `test-homebrew-release-gate.py` all pass.
- `node --test` over the five suites the npm launcher job drives: 27/27 pass.
  `node --check` and `bash -n` clean on every script CI validates.
- No Rust changed, so fmt/clippy/build are unaffected.

## What to watch after this lands

The observable defect is directly checkable: over the next drain, no main push
CI run should be cancelled with zero jobs started, and two main CI runs should
be able to overlap rather than one waiting on the other's last job. On the
queue run, `Code Coverage` should report `skipped` and the six required
contexts should be unchanged in name and outcome.

## Expected effect

| Metric | Before | After |
|---|---|---|
| merge_group runner-min per landing | 93.5 | ~61.7 (−25.9 coverage, −5.9 macOS falsify) |
| Total CI runner-min per landing (merge_group + push) | 204.1 | ~166.4 |
| `Check & Test (macos-latest)` | 24.8m | 24.8m minus whatever the falsify step costs that round (313-356s observed) |
| main-CI concurrency wait | 0-20.9m on 42% of runs | 0 |
| Main push CI runs cancelled before starting | 4 per 24h | 0 |
| Trailing merge_group check-runs able to poison a mint | 2 | 1 (`Windows authority tests`, see above) |

**The one observed run does not confirm the macOS projection, and the honest
comparison says so.** This PR's `Check & Test (macos-latest)` took 22.9 min with
the falsify step `skipped`. Reference run 30628155734 (also `pull_request`) took
25.3 min with it at 313s. That is a 2.4 min delta, not 5.2, because every other
step on this PR's macOS runner was slower than the same step on the reference:

| step | ref 30628155734 | PR 540 | delta |
|---|---|---|---|
| Test | 615s | 722s | +107s |
| Doc tests | 54s | 67s | +13s |
| Test gcs feature | 185s | 196s | +11s |
| Build | 188s | 197s | +9s |
| Clippy | 87s | 89s | +2s |
| **Falsify Zero File-Search guards** | **313s** | **skipped** | **−313s** |

The same round's ubuntu falsify step took 523s against a 477s ten-run mean, so
this round was slower generally. The saving is exactly the cost of the step, and
a single sample cannot separate that from runner variance. Judge it over several
landings, not from this run.

Numbers are wall-clock and runner-slot capacity, not money: kin is public and
`/actions/runs/{id}/timing` returns `billable: 0` on every run sampled.
