### PR TITLE
Cut 0.4.4 on a graph engine that compiles for musl and compile the release targets before landing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,6 +827,33 @@ jobs:
       - name: Build
         run: cargo build --all-targets --locked
 
+      # Kin's Linux release binaries link against musl so a single archive runs
+      # on every distribution, and nothing else in CI compiles for that target.
+      # A `target_env` cfg is invisible to a glibc build, so a dependency that
+      # resolves a glibc-only libc entry point compiles clean through every
+      # required context, reaches a tag, and then fails in the release run,
+      # where the only remedy is another version cut. This compiles the exact
+      # packages the release builds, for the target it builds them for, so that
+      # break is a red pull request instead of a burned tag.
+      #
+      # Two deliberate bounds. It checks rather than builds, so it proves
+      # compilation and name resolution and not linking. And it covers
+      # x86_64 only: aarch64-unknown-linux-musl is also a release target, but
+      # its C dependencies need an aarch64 musl cross toolchain that musl-tools
+      # does not carry, and the gate that has broken selects on target_env
+      # rather than architecture, so one musl target exercises it.
+      - name: Check the Linux release target (musl)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          rustup target add x86_64-unknown-linux-musl
+          # ring, oniguruma, sqlite, and tree-sitter compile C against musl, so
+          # this needs the same musl-gcc the release legs install.
+          sudo apt-get update
+          sudo apt-get install --yes musl-tools
+          cargo check --locked --target x86_64-unknown-linux-musl \
+            -p kin-cli -p kin-daemon
+
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.3] - 2026-07-31
+## [0.4.4] - 2026-07-31
 
 v0.4.0 was never published. Its release commit was refused by the mint gate
 because the release rail read the repository merge policy through a token that
@@ -25,6 +25,17 @@ slice had already replaced, and that check runs only on the landing push, so no
 pull request could have caught it. This release aligns the assertion with the
 behavior that shipped and mirrors it into a job that runs before a change can
 land.
+
+v0.4.3 was never published either, and it is the first of these that reached its
+tag. What refused it was the Linux artifact build. Kin's Linux binaries link
+against musl so that one archive runs on every distribution, and the pinned
+graph engine published local directory namespaces through a rename entry point
+that the libc bindings declare only for glibc, so both Linux legs stopped at a
+compile error and the release published nothing. This release moves to a graph
+engine that performs the same no-replace publication through the raw kernel
+syscall on musl, and it compiles the release targets on every pull request so
+that a target the artifacts need can no longer break where only a tag can see
+it.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,25 @@ it.
   local cache before fetching, and an instance whose cache already covers the
   tree does no remote work at all, where every open previously re-fetched every
   body before checking.
+- The release rail installs its dependency scanner from a pinned release
+  artifact instead of building a container image on every run, so a public
+  container-registry outage no longer refuses a release commit on a required
+  check that has nothing to say about the dependency graph (#529).
+- Embedding checkpoints reuse an authority match they have already proved
+  instead of reopening repository authority after every batch. Reopening
+  recovers the snapshot, revalidates every semantic change id, re-verifies every
+  stored body against its content address, and builds a second in-memory graph,
+  and that cost scales with the store rather than with the batch. A generation
+  bump or any live-tree mutation still misses the retained pair and reopens in
+  full, so the refusal it guards is unchanged (#530).
+- The Windows admission refusals Kin ships are now asserted by a job that runs
+  before a change can land, rather than only on the landing push where no pull
+  request could review them. The same slice reserves a Windows main-thread stack
+  large enough to parse the command tree, so a Windows build of the CLI starts
+  instead of aborting before it reaches any command (#534).
+- kin-model moves from 0.7.1 to 0.7.2. This is a version-only move forced by the
+  graph engine's own requirement; the two published crates carry identical
+  source.
 
 
 ## [0.3.6] - 2026-07-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.6"
+version = "0.7.8"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1c6429d44f30f92d3c9582befe066966cd06293be011ac8c9cf3c45dfa255c8b"
+checksum = "54f65a602410862f1b0b9b6e21682f748f22b26976eca9213d362dd61cdf4c7a"
 dependencies = [
  "bincode",
  "bstr",
@@ -3471,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.1"
+version = "0.7.2"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "4c3a35cfb62580592442c3413ae74a3382b81b24eff209e719a8d68502a8f212"
+checksum = "b3dbb23717e2682e4df5f51aed04123333a9d0667423a312a795c28abe3fceb3"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,14 +3054,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "age",
  "anyhow",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-model",
  "serde",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-stream",
  "axum",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.6", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.8", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.1", registry = "kin" }
+kin-model = { version = "=0.7.2", registry = "kin" }
 kin-blobs = { version = "0.1.3", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -90,7 +90,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.4.3", path = "../kin-spine" }
+kin-spine = { version = "0.4.4", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-git = { workspace = true, features = ["test-support"] }

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -2929,7 +2929,7 @@ mod tests {
         // This worker is deliberately killed as a process-group member. Moving
         // the handle out of Drop makes that intentional non-wait explicit.
         std::mem::forget(child);
-        std::fs::write(&report, format!("{child_id}\n")).expect("publish late inherited member");
+        publish_test_report(&report, format!("{child_id}\n"));
         if std::env::var_os(LATE_RELAY_ESCAPE_CHILD_ENV).is_some() {
             return;
         }
@@ -2983,11 +2983,10 @@ mod tests {
         // The hard `_exit` below intentionally bypasses Rust cleanup so the
         // watcher, rather than this driver, must reap the containment tree.
         std::mem::forget(member);
-        std::fs::write(
-            report_path,
+        publish_test_report(
+            &report_path,
             format!("{watcher_id} {process_group} {member_id}\n"),
-        )
-        .expect("publish owner-death process ids");
+        );
 
         // Do not unwind and do not run `ProcessGroupGuardian::drop`. Exact PPID
         // change (with ownership EOF as a secondary trigger) is under test.
@@ -3024,15 +3023,14 @@ mod tests {
                 |_| {},
             )
             .expect("spawn pre-exec stall guardian");
-        std::fs::write(
+        publish_test_report(
             &report_path,
             format!(
                 "{} {}\n",
                 guardian.watcher_id().expect("owned watcher"),
                 guardian.process_group()
             ),
-        )
-        .expect("publish pre-exec stall guardian ids");
+        );
 
         let stalled_path =
             CString::new(stalled_path.as_os_str().as_bytes()).expect("NUL-free stall marker");
@@ -3902,6 +3900,20 @@ mod tests {
         wait_for_test_pid_gone(pids[0], Duration::from_secs(5));
         wait_for_test_pid_gone(pids[1], Duration::from_secs(5));
         wait_for_test_pid_gone(pids[2], Duration::from_secs(5));
+    }
+
+    // A report file is a rendezvous: a worker publishes process ids and the
+    // test polls for the path and parses what it finds. `fs::write` creates the
+    // file before it writes any bytes, so a poller can observe the path and
+    // read an empty file, which surfaces as a parse error on a value the worker
+    // did produce. Publish through a temporary sibling and one rename, the same
+    // way the guardian publishes its own readiness, so the path appears only
+    // once its contents are complete.
+    #[cfg(unix)]
+    fn publish_test_report(path: &Path, contents: impl AsRef<[u8]>) {
+        let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+        std::fs::write(&temporary, contents).expect("stage test report");
+        std::fs::rename(&temporary, path).expect("publish test report");
     }
 
     #[cfg(unix)]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "kin-model",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.1"
+version = "0.7.2"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "4c3a35cfb62580592442c3413ae74a3382b81b24eff209e719a8d68502a8f212"
+checksum = "b3dbb23717e2682e4df5f51aed04123333a9d0667423a312a795c28abe3fceb3"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2680,6 +2680,48 @@ def main() -> None:
             "refusals are asserted before a release commit can carry them"
         )
 
+    # The Linux release artifacts are the only musl compilation Kin performs,
+    # and until this guard existed no required context compiled for that target.
+    # A target_env cfg is invisible to a glibc build, so a dependency resolving
+    # a glibc-only libc entry point passed every check, reached a tag, and then
+    # failed the release run, where the only remedy is another version cut. Pin
+    # the guard to the release matrix so it cannot drift off the target whose
+    # artifacts it protects, and pin its package set so it cannot shrink below
+    # what the release builds. It lives in the required Check & Test job on
+    # purpose: a guard in a context no ruleset requires cannot refuse a merge.
+    release_musl_targets = {
+        match.group("target")
+        for match in re.finditer(
+            r"(?m)^\s+target: (?P<target>\S+-linux-musl)$",
+            workflow_job_blocks(release)["build"],
+        )
+    }
+    if not release_musl_targets:
+        raise AssertionError(
+            "the release build matrix must name at least one musl target for "
+            "the pull-request release-target compile guard to protect"
+        )
+    for policy in (
+        "- name: Check the Linux release target (musl)",
+        "rustup target add x86_64-unknown-linux-musl",
+        "musl-tools",
+        "cargo check --locked --target x86_64-unknown-linux-musl",
+        "-p kin-cli -p kin-daemon",
+    ):
+        require(ci_jobs["check"], policy, "pull-request Linux release-target compile guard")
+    if "x86_64-unknown-linux-musl" not in release_musl_targets:
+        raise AssertionError(
+            "the pull-request compile guard must build a target the release "
+            "workflow actually ships; release musl targets="
+            f"{sorted(release_musl_targets)}"
+        )
+    for package in ("-p kin-cli", "-p kin-daemon"):
+        require(
+            workflow_job_blocks(release)["build"],
+            package,
+            "release core binary package set the compile guard mirrors",
+        )
+
     for policy in (
         'workflows: ["Release"]',
         "types: [completed]",


### PR DESCRIPTION
v0.4.3's tag exists but its Linux artifacts could not build, because the pinned
graph engine could not compile for musl; this release moves to kin-db 0.7.8 and
adds the musl compile to pull-request CI.

Kin's Linux release binaries target musl so a single archive runs on every
distribution. kin-db 0.7.6 published local directory namespaces through
`libc::renameat2`, behind a cfg selecting `target_os = "linux"`, and musl matches
that cfg while the libc bindings declare the function only for glibc and Android.
Every required context compiled for glibc, Darwin, or MSVC, so the arm that
breaks had never been compiled anywhere before a tag existed. Both Linux legs of
the v0.4.3 release run stopped at `error[E0425]`, the run never reached its
publish step, and there is no GitHub release, npm version, or image behind that
tag.

### The version cut

Every version surface and both lockfiles move to 0.4.4. The pending changelog
section is retitled with its accumulated content kept, plus a paragraph recording
what refused v0.4.3.

### The dependency move

`kin-db` goes to `=0.7.8`, which performs the same no-replace directory
publication through the raw kernel syscall on musl and therefore forces no libc
floor bump. The workspace's `libc` stays at 0.2.186.

`kin-model` moves `=0.7.1` to `=0.7.2` because it has to: kin-db 0.7.7 raised its
own requirement to `=0.7.2` and kin was still on 0.7.6, so the two exact
requirements cannot both be satisfied. This is a version-only move. The published
0.7.1 and 0.7.2 crates have **byte-identical `src/` trees**; their manifests
differ only in the version and in a `kin-blobs` requirement that this workspace
already locks at 0.1.3. The lock diff is four lines, two versions and two
checksums.

### The class guard

`Check & Test` now compiles the Linux release target on its Linux leg, using the
same package set, target, and musl C toolchain the release build uses. It extends
that job rather than adding a new one because `Check & Test (ubuntu-latest)` is a
required context and a guard in a context no ruleset requires cannot refuse a
merge. The release-workflow authority suite pins the step against the release
build matrix, so it cannot drift off the target it protects or shrink below the
packages the release ships.

The guard is falsified rather than assumed. Against kin's own locked libc
0.2.186 and the pinned toolchain, a musl check of kin-db `=0.7.6` fails with the
same `error[E0425]: cannot find function renameat2 in crate libc` the release run
produced, and the same check against `=0.7.8` exits clean.

Two coverage bounds are stated in the workflow comment rather than left implicit.
The guard checks rather than builds, so it proves compilation and name resolution
and not linking. And it covers x86_64 only: `aarch64-unknown-linux-musl` is also
a release target, but its C dependencies need an aarch64 musl cross toolchain
that `musl-tools` does not carry, and the gate that broke selects on `target_env`
rather than architecture, so one musl target exercises it.

### One unrelated repair

The process-group guardian tests handed process ids between a worker and its
parent through a file written with `fs::write`, which creates the file before it
writes any bytes, so a poller could observe the path and read nothing. That
surfaced as `ParseIntError { kind: Empty }` on a required context. The three
workers now publish through a temporary sibling and one rename, which is how the
guardian already publishes its own readiness.

Closes FIR-1772
Part-of FIR-1015
