### PR TITLE
Let a reviewed abandonment record retire a release tag that can never finish

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -349,13 +349,44 @@ jobs:
 
           latest="$(gh api "repos/${REPO}/releases/latest")"
           latest_tag="$(jq -er .tag_name <<< "$latest")"
-          highest_tag=""
-          while IFS= read -r candidate_tag; do
-            if [[ "$candidate_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              highest_tag="$candidate_tag"
-              break
-            fi
-          done < <(git tag --list --sort=-v:refname)
+          # Serialization is owed to a release that can still finish. A tag
+          # whose artifacts can never be built cannot, and on its own it holds
+          # this lane closed against every successor, including the one that
+          # repairs the defect. A reviewed abandonment record is the only
+          # waiver, so a tag that is merely failing so far still blocks. Both
+          # the record and the selector come from protected main rather than the
+          # checked-out release commit, which predates the abandonment it has to
+          # honour and would otherwise re-deadlock the lane it unblocks.
+          lane_policy="$RUNNER_TEMP/release-lane-policy"
+          mkdir -p "$lane_policy"
+          abandoned="$lane_policy/abandoned-release-tags.json"
+          selector="$lane_policy/select-admissible-release-tag.py"
+          if ! git show \
+            "refs/remotes/origin/main:scripts/abandoned-release-tags.json" \
+            > "$abandoned"; then
+            echo "::error::protected main carries no abandoned release-tag record"
+            exit 1
+          fi
+          if ! git show \
+            "refs/remotes/origin/main:scripts/select-admissible-release-tag.py" \
+            > "$selector"; then
+            echo "::error::protected main carries no release-lane tag selector"
+            exit 1
+          fi
+          test -s "$abandoned"
+          test -s "$selector"
+          candidate_tags="$lane_policy/release-tags"
+          git for-each-ref \
+            --sort=-v:refname \
+            --format='%(refname:strip=2) %(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)' \
+            refs/tags > "$candidate_tags"
+          admissible="$lane_policy/highest-admissible-tag"
+          python3 "$selector" \
+            "$abandoned" \
+            "$candidate_tags" \
+            "$TAG" \
+            "$admissible"
+          highest_tag="$(cat "$admissible")"
           if [ -z "$highest_tag" ] || [ "$highest_tag" != "$latest_tag" ]; then
             if [ "$AUTOMATIC" = true ]; then
               echo "::notice::highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}; release recovery will reconcile it."

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -161,6 +161,15 @@ jobs:
           # from ever opening, so the version never moves and the mint has
           # nothing new to tag. Only a reviewed abandonment record skips a tag,
           # read from protected main together with the selector that reads it.
+          #
+          # The selector's mint-intent argument is empty here on purpose. This
+          # step resolves drift and opens a version bump PR; it never creates a
+          # tag, and $tag below is the pre-existing base it measures drift from.
+          # Handing that base over as mint intent would refuse precisely when a
+          # record covers it, and a record always covers it: the mint only
+          # creates v$(workspace version), so main's version equals the stuck
+          # tag and cannot move until this step opens the bump that a record is
+          # written to unblock.
           train_policy="$RUNNER_TEMP/release-train-policy"
           mkdir -p "$train_policy"
           abandoned="$train_policy/abandoned-release-tags.json"
@@ -182,7 +191,7 @@ jobs:
           python3 "$selector" \
             "$abandoned" \
             "$candidate_tags" \
-            "$tag" \
+            "" \
             "$admissible"
           highest_tag="$(cat "$admissible")"
           latest_tag="$(gh api "repos/${REPO}/releases/latest" --jq .tag_name)"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -155,13 +155,36 @@ jobs:
           print(tomllib.loads(sys.stdin.read())["workspace"]["package"]["version"])
           ')"
           tag="v${version}"
-          highest_tag=""
-          while IFS= read -r candidate_tag; do
-            if [[ "$candidate_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              highest_tag="$candidate_tag"
-              break
-            fi
-          done < <(git tag --list --sort=-v:refname)
+          # The same serialization predicate the tag mint admits against, and
+          # the same waiver. Fixing only the mint would leave this side wedged:
+          # an abandoned tag that stays highest here stops the version bump PR
+          # from ever opening, so the version never moves and the mint has
+          # nothing new to tag. Only a reviewed abandonment record skips a tag,
+          # read from protected main together with the selector that reads it.
+          train_policy="$RUNNER_TEMP/release-train-policy"
+          mkdir -p "$train_policy"
+          abandoned="$train_policy/abandoned-release-tags.json"
+          selector="$train_policy/select-admissible-release-tag.py"
+          git show \
+            "refs/remotes/origin/main:scripts/abandoned-release-tags.json" \
+            > "$abandoned"
+          git show \
+            "refs/remotes/origin/main:scripts/select-admissible-release-tag.py" \
+            > "$selector"
+          test -s "$abandoned"
+          test -s "$selector"
+          candidate_tags="$train_policy/release-tags"
+          git for-each-ref \
+            --sort=-v:refname \
+            --format='%(refname:strip=2) %(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)' \
+            refs/tags > "$candidate_tags"
+          admissible="$train_policy/highest-admissible-tag"
+          python3 "$selector" \
+            "$abandoned" \
+            "$candidate_tags" \
+            "$tag" \
+            "$admissible"
+          highest_tag="$(cat "$admissible")"
           latest_tag="$(gh api "repos/${REPO}/releases/latest" --jq .tag_name)"
           if [ -z "$highest_tag" ] || [ "$highest_tag" != "$latest_tag" ]; then
             echo "::notice::highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}; release recovery owns this state."

--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "abandoned": [
+    {
+      "tag": "v0.4.3",
+      "sha": "72149519de5451fcbd441bfb0641a6224a57268d",
+      "reason": "The tagged lockfile immutably pins kin-db 0.7.6, which cannot compile for the musl release targets, so no Linux artifact can ever be produced from this commit. Automatic release recovery exhausted its bounded retries, no GitHub Release object was ever published, and the tag produced zero artifacts.",
+      "superseded_by": "v0.4.4",
+      "failed_release_run_id": "30627672394"
+    }
+  ]
+}

--- a/scripts/select-admissible-release-tag.py
+++ b/scripts/select-admissible-release-tag.py
@@ -18,9 +18,18 @@ precisely the case the predicate exists to serialize.
 
 A record is honoured only while it still describes the repository. It names the
 exact commit its tag pointed at, so a tag that has since moved refuses loudly
-instead of silently waiving a different object than the one that was reviewed. A
-record naming a tag that no longer exists is inert, because a deleted tag
-already blocks nothing.
+instead of silently waiving a different object than the one that was reviewed.
+
+A record outlives the tag it names, and it is not inert when the tag is deleted.
+Ranking stops being affected, because nothing in the listing can match it and so
+nothing is skipped, and the recorded commit can no longer be validated against
+the repository. The mint-intent refusal below still applies, because it reads the
+record rather than the listing: a version declared abandoned stays refused even
+if its tag is removed, which is the point. Deleting an abandoned tag while the
+workspace version still equals it therefore leaves the version itself burned and
+no tag to advance past, and the only way out is the version bump that drift
+resolution proposes. Record the abandonment and leave the tag in place unless a
+bump is landing with it.
 
 Usage:
   select-admissible-release-tag.py MANIFEST CANDIDATES MINTING_TAG OUTPUT

--- a/scripts/select-admissible-release-tag.py
+++ b/scripts/select-admissible-release-tag.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+"""Select the highest release tag the serialized release rail must wait on.
+
+The rail serializes on one predicate: the highest `vX.Y.Z` tag in the repository
+must already be the finalized GitHub Latest release before a newer tag is minted
+or a newer version is prepared. That predicate exists so an in-flight release is
+never leapfrogged, and it holds the highest tag responsible for finishing.
+
+A tag whose artifacts can never be built cannot finish. Left alone it holds the
+predicate closed against every successor forever, including the successor that
+repairs whatever made it unbuildable. Abandonment is the explicit way out, and
+it is a reviewed record in tracked source rather than a runtime inference from
+how a build happens to be going. Only a record waives the predicate for a tag; a
+tag that is merely failing so far carries none and keeps blocking, which is
+precisely the case the predicate exists to serialize.
+
+A record is honoured only while it still describes the repository. It names the
+exact commit its tag pointed at, so a tag that has since moved refuses loudly
+instead of silently waiving a different object than the one that was reviewed. A
+record naming a tag that no longer exists is inert, because a deleted tag
+already blocks nothing.
+
+Usage:
+  select-admissible-release-tag.py MANIFEST CANDIDATES MINTING_TAG OUTPUT
+
+MANIFEST    the abandonment record, read from protected main
+CANDIDATES  `<tag> <commit>` lines, version-descending, from git for-each-ref
+MINTING_TAG the tag this release is about to produce, or empty when none is
+OUTPUT      file receiving the highest admissible tag, empty when there is none
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+SCHEMA_VERSION = 1
+RELEASE_TAG = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+WORKFLOW_RUN_ID = re.compile(r"^[1-9][0-9]*$")
+# Every field is required. `reason` and `superseded_by` carry no machine
+# meaning, and that is the point: an abandonment is a claim a reviewer has to be
+# able to judge in the diff, so the record cannot be reduced to a bare tag.
+RECORD_FIELDS = (
+    "tag",
+    "sha",
+    "reason",
+    "superseded_by",
+    "failed_release_run_id",
+)
+MANIFEST_FIELDS = ("schema_version", "abandoned")
+
+
+def refuse(message: str) -> NoReturn:
+    """Fail the release rail loudly rather than degrading to a silent skip."""
+
+    print(f"::error::{message}")
+    raise SystemExit(1)
+
+
+def load_abandonments(path: Path) -> dict[str, str]:
+    """Return the reviewed tag-to-commit waivers, refusing anything malformed."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        refuse(f"abandoned release-tag record is unreadable: {error}")
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as error:
+        refuse(f"abandoned release-tag record is not valid JSON: {error}")
+    if not isinstance(manifest, dict):
+        refuse("abandoned release-tag record must be a JSON object")
+    unreviewed = sorted(set(manifest) - set(MANIFEST_FIELDS))
+    if unreviewed:
+        refuse(
+            "abandoned release-tag record carries unreviewed keys: "
+            f"{', '.join(unreviewed)}"
+        )
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        refuse(
+            "abandoned release-tag record must declare schema_version "
+            f"{SCHEMA_VERSION}"
+        )
+    records = manifest.get("abandoned")
+    if not isinstance(records, list):
+        refuse("abandoned release-tag record must carry an 'abandoned' array")
+
+    abandoned: dict[str, str] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            refuse("every abandonment entry must be a JSON object")
+        unreviewed = sorted(set(record) - set(RECORD_FIELDS))
+        if unreviewed:
+            refuse(
+                "abandonment entry carries unreviewed fields: "
+                f"{', '.join(unreviewed)}"
+            )
+        missing = [
+            field
+            for field in RECORD_FIELDS
+            if not isinstance(record.get(field), str) or not record[field].strip()
+        ]
+        if missing:
+            refuse(
+                "abandonment entry is missing required evidence: "
+                f"{', '.join(missing)}"
+            )
+        tag = record["tag"]
+        if not RELEASE_TAG.match(tag):
+            refuse(f"abandoned tag '{tag}' is not a vX.Y.Z release tag")
+        if tag in abandoned:
+            refuse(f"release tag {tag} is recorded as abandoned more than once")
+        if not COMMIT_SHA.match(record["sha"]):
+            refuse(
+                f"abandonment of {tag} must record the exact 40-hex commit it "
+                "waives"
+            )
+        superseded_by = record["superseded_by"]
+        if not RELEASE_TAG.match(superseded_by):
+            refuse(f"abandonment of {tag} must name a vX.Y.Z superseding tag")
+        if superseded_by == tag:
+            refuse(f"abandonment of {tag} cannot name itself as its successor")
+        if not WORKFLOW_RUN_ID.match(record["failed_release_run_id"]):
+            refuse(f"abandonment of {tag} must cite the Release run id that failed")
+        abandoned[tag] = record["sha"]
+    return abandoned
+
+
+def load_candidates(path: Path) -> list[tuple[str, str]]:
+    """Return `(tag, commit)` pairs in the order git already ranked them."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as error:
+        refuse(f"release tag listing is unreadable: {error}")
+    candidates: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        fields = line.split(" ")
+        if len(fields) != 2 or not fields[0] or not COMMIT_SHA.match(fields[1]):
+            refuse(f"release tag listing carries an unreadable record: {line}")
+        candidates.append((fields[0], fields[1]))
+    return candidates
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 5:
+        refuse(
+            "usage: select-admissible-release-tag.py MANIFEST CANDIDATES "
+            "MINTING_TAG OUTPUT"
+        )
+    manifest_path, candidates_path, minting_tag, output_path = argv[1:]
+    abandoned = load_abandonments(Path(manifest_path))
+    candidates = load_candidates(Path(candidates_path))
+
+    present: dict[str, str] = {}
+    for tag, commit in candidates:
+        if present.get(tag, commit) != commit:
+            refuse(f"release tag {tag} was listed against two different commits")
+        present[tag] = commit
+
+    for tag, commit in sorted(abandoned.items()):
+        listed = present.get(tag)
+        if listed is not None and listed != commit:
+            refuse(
+                f"abandonment of {tag} waives {commit} but the tag now names "
+                f"{listed}; correct the reviewed record before releasing"
+            )
+
+    if minting_tag and minting_tag in abandoned:
+        refuse(
+            f"{minting_tag} is recorded as an abandoned release tag and must "
+            "not be released"
+        )
+
+    highest = ""
+    for tag, commit in candidates:
+        if not RELEASE_TAG.match(tag):
+            continue
+        if abandoned.get(tag) == commit:
+            print(f"::notice::skipping abandoned release tag {tag} at {commit}")
+            continue
+        highest = tag
+        break
+
+    Path(output_path).write_text(highest, encoding="utf-8")
+    print(f"highest admissible release tag: {highest or '<none>'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -31,6 +31,11 @@ INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
 INSTALL_SH = ROOT / "scripts" / "install.sh"
 INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
+ABANDONED_TAGS = ROOT / "scripts" / "abandoned-release-tags.json"
+TAG_SELECTOR = ROOT / "scripts" / "select-admissible-release-tag.py"
+ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
+TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
+TRUSTED_POLICY_PREFIX = "refs/remotes/origin/main:"
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
@@ -1953,6 +1958,385 @@ def assert_release_check_accepted(
         )
 
 
+def run_tag_selector(
+    manifest: str,
+    candidates: str,
+    minting_tag: str = "",
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Execute the shipped admission selector against fixture inputs."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        fixture = Path(directory)
+        manifest_path = fixture / "abandoned-release-tags.json"
+        manifest_path.write_text(manifest, encoding="utf-8")
+        candidates_path = fixture / "release-tags"
+        candidates_path.write_text(candidates, encoding="utf-8")
+        selected_path = fixture / "highest-admissible-tag"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(TAG_SELECTOR),
+                str(manifest_path),
+                str(candidates_path),
+                minting_tag,
+                str(selected_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        selected = ""
+        if selected_path.exists():
+            selected = selected_path.read_text(encoding="utf-8")
+    return completed, selected
+
+
+def assert_admissible_tag(
+    label: str,
+    manifest: str,
+    candidates: str,
+    expected: str,
+    *,
+    minting_tag: str = "",
+) -> None:
+    """Require the selector to name exactly the tag the rail must wait on."""
+
+    completed, selected = run_tag_selector(manifest, candidates, minting_tag)
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"release-lane admission refused {label}: "
+            f"{completed.stdout}{completed.stderr}"
+        )
+    if selected != expected:
+        raise AssertionError(
+            f"release-lane admission selected {selected or '<none>'} for "
+            f"{label}, expected {expected or '<none>'}"
+        )
+
+
+def assert_tag_selection_refused(
+    label: str,
+    manifest: str,
+    candidates: str,
+    expected_error: str,
+    *,
+    minting_tag: str = "",
+) -> None:
+    """Require a loud, named refusal rather than a silently degraded skip."""
+
+    completed, selected = run_tag_selector(manifest, candidates, minting_tag)
+    output = completed.stdout + completed.stderr
+    if completed.returncode == 0:
+        raise AssertionError(f"release-lane admission accepted {label}: {output}")
+    if expected_error not in output:
+        raise AssertionError(
+            f"release-lane admission refused {label} for the wrong reason: {output}"
+        )
+    if selected:
+        raise AssertionError(
+            f"release-lane admission named {selected} while refusing {label}"
+        )
+
+
+def abandonment_manifest(*records: dict[str, str]) -> str:
+    """Serialize an abandonment record the way the tracked file carries it."""
+
+    return json.dumps({"schema_version": 1, "abandoned": list(records)})
+
+
+def workflow_step_source(workflow: str, content: str, step_anchor: str) -> str:
+    """Extract one named workflow step so its internal order can be judged."""
+
+    if step_anchor not in content:
+        raise AssertionError(
+            f"{workflow} no longer carries the step that owns release-lane "
+            f"admission: {step_anchor.strip()}"
+        )
+    start = content.index(step_anchor)
+    if "\n      - name:" not in content[start + 1 :]:
+        raise AssertionError(
+            f"{workflow} admission step is no longer followed by another step, "
+            "so its boundary cannot be resolved"
+        )
+    return content[start : content.index("\n      - name:", start + 1)]
+
+
+def assert_trusted_abandonment_reads(workflow: str, content: str) -> None:
+    """Both admission policies must come from protected main, nowhere else."""
+
+    for policy in (ABANDONED_TAGS_POLICY, TAG_SELECTOR_POLICY):
+        index = content.find(policy)
+        if index < 0:
+            raise AssertionError(f"{workflow} never reads {policy}")
+        while index >= 0:
+            prefix = content[max(0, index - len(TRUSTED_POLICY_PREFIX)) : index]
+            if prefix != TRUSTED_POLICY_PREFIX:
+                raise AssertionError(
+                    f"{workflow} reads {policy} from something other than "
+                    "protected main. The release commit under admission can "
+                    "predate the abandonment it must honour, so reading either "
+                    "policy from the checkout re-deadlocks the lane it unblocks"
+                )
+            index = content.find(policy, index + 1)
+
+
+def assert_admission_step_order(
+    workflow: str,
+    content: str,
+    step_anchor: str,
+    comparison: str,
+) -> None:
+    """The waiver must be read, then applied, before the lane predicate runs."""
+
+    step = workflow_step_source(workflow, content, step_anchor)
+    manifest_read = step.index(f"{TRUSTED_POLICY_PREFIX}{ABANDONED_TAGS_POLICY}")
+    selector_read = step.index(f"{TRUSTED_POLICY_PREFIX}{TAG_SELECTOR_POLICY}")
+    selection = step.index('python3 "$selector"')
+    adoption = step.index('highest_tag="$(cat "$admissible")"')
+    predicate = step.index(comparison)
+    if not manifest_read < selector_read < selection < adoption < predicate:
+        raise AssertionError(
+            f"{workflow} must read the reviewed abandonment record and its "
+            "selector from protected main, resolve the highest admissible tag, "
+            "and only then admit against finalized GitHub Latest"
+        )
+    if "git tag --list" in step:
+        raise AssertionError(
+            f"{workflow} still ranks release tags without consulting the "
+            "reviewed abandonment record"
+        )
+
+
+def assert_abandoned_tag_admission(release_tag: str, release_train: str) -> None:
+    """Only a reviewed record may waive release-lane serialization."""
+
+    for workflow, content, step_anchor, comparison in (
+        (
+            "release-tag",
+            release_tag,
+            "      - name: Admit the serialized release lane\n",
+            '[ "$highest_tag" != "$latest_tag" ]',
+        ),
+        (
+            "release-train",
+            release_train,
+            "      - name: Resolve releasable drift and SemVer intent\n",
+            '[ "$highest_tag" != "$latest_tag" ]',
+        ),
+    ):
+        assert_trusted_abandonment_reads(workflow, content)
+        assert_admission_step_order(workflow, content, step_anchor, comparison)
+
+    unbuildable = "1" * 40
+    superseding = "2" * 40
+    stable = "3" * 40
+    older = "4" * 40
+    unversioned = "5" * 40
+    # A non-release tag ahead of every version tag, because the version filter
+    # has to survive whatever else the repository has tagged.
+    candidates = (
+        f"nightly {unversioned}\n"
+        f"v0.4.3 {unbuildable}\n"
+        f"v0.3.6 {stable}\n"
+        f"v0.3.5 {older}\n"
+    )
+    record = {
+        "tag": "v0.4.3",
+        "sha": unbuildable,
+        "reason": "the tagged lockfile pins a dependency that cannot build",
+        "superseded_by": "v0.4.4",
+        "failed_release_run_id": "30627672394",
+    }
+
+    # The invariant this whole gate exists for: a tag that is only failing so
+    # far is not skippable, so it still holds its successor. Nothing but a
+    # reviewed record changes that, and a record that does not describe the tag
+    # in the repository is not one.
+    assert_admissible_tag(
+        "an unlisted tag whose release keeps failing",
+        abandonment_manifest(),
+        candidates,
+        "v0.4.3",
+    )
+    assert_admissible_tag(
+        "an abandonment naming a different tag",
+        abandonment_manifest({**record, "tag": "v0.3.5", "sha": older}),
+        candidates,
+        "v0.4.3",
+    )
+    assert_admissible_tag(
+        "an abandonment of a tag that no longer exists",
+        abandonment_manifest({**record, "tag": "v0.9.9"}),
+        candidates,
+        "v0.4.3",
+    )
+    assert_tag_selection_refused(
+        "an abandonment whose tag has since moved",
+        abandonment_manifest({**record, "sha": superseding}),
+        candidates,
+        f"abandonment of v0.4.3 waives {superseding} but the tag now names",
+    )
+
+    # With the record present the unbuildable tag stops holding the lane, and
+    # ranking otherwise stays exactly what git already decided.
+    assert_admissible_tag(
+        "a reviewed abandonment",
+        abandonment_manifest(record),
+        candidates,
+        "v0.3.6",
+    )
+    assert_admissible_tag(
+        "consecutive reviewed abandonments",
+        abandonment_manifest(
+            record,
+            {**record, "tag": "v0.3.6", "sha": stable, "superseded_by": "v0.4.4"},
+        ),
+        candidates,
+        "v0.3.5",
+    )
+    assert_admissible_tag(
+        "an abandonment of every version tag",
+        abandonment_manifest(
+            record,
+            {**record, "tag": "v0.3.6", "sha": stable, "superseded_by": "v0.4.4"},
+            {**record, "tag": "v0.3.5", "sha": older, "superseded_by": "v0.4.4"},
+        ),
+        candidates,
+        "",
+    )
+    assert_tag_selection_refused(
+        "minting a tag that is itself recorded as abandoned",
+        abandonment_manifest(record),
+        candidates,
+        "v0.4.3 is recorded as an abandoned release tag and must not be released",
+        minting_tag="v0.4.3",
+    )
+
+    for label, manifest, expected_error in (
+        ("a manifest that is not JSON", "{not json", "is not valid JSON"),
+        ("a manifest that is a JSON array", "[]", "must be a JSON object"),
+        (
+            "a manifest declaring another schema",
+            json.dumps({"schema_version": 2, "abandoned": []}),
+            "must declare schema_version 1",
+        ),
+        (
+            "a manifest carrying an unreviewed key",
+            json.dumps({"schema_version": 1, "abandoned": [], "waive_all": True}),
+            "unreviewed keys: waive_all",
+        ),
+        (
+            "a manifest with no abandonment array",
+            json.dumps({"schema_version": 1}),
+            "must carry an 'abandoned' array",
+        ),
+        (
+            "a manifest whose abandonments are an object",
+            json.dumps({"schema_version": 1, "abandoned": {}}),
+            "must carry an 'abandoned' array",
+        ),
+        (
+            "an abandonment that is a bare tag string",
+            json.dumps({"schema_version": 1, "abandoned": ["v0.4.3"]}),
+            "every abandonment entry must be a JSON object",
+        ),
+        (
+            "an abandonment carrying an unreviewed field",
+            abandonment_manifest({**record, "force": "yes"}),
+            "unreviewed fields: force",
+        ),
+        (
+            "an abandonment with no reason",
+            abandonment_manifest(
+                {key: value for key, value in record.items() if key != "reason"}
+            ),
+            "missing required evidence: reason",
+        ),
+        (
+            "an abandonment whose reason is blank",
+            abandonment_manifest({**record, "reason": "   "}),
+            "missing required evidence: reason",
+        ),
+        (
+            "an abandonment with no superseding tag",
+            abandonment_manifest(
+                {
+                    key: value
+                    for key, value in record.items()
+                    if key != "superseded_by"
+                }
+            ),
+            "missing required evidence: superseded_by",
+        ),
+        (
+            "an abandonment that is not a release tag",
+            abandonment_manifest({**record, "tag": "0.4.3"}),
+            "abandoned tag '0.4.3' is not a vX.Y.Z release tag",
+        ),
+        (
+            "an abandonment with an abbreviated commit",
+            abandonment_manifest({**record, "sha": unbuildable[:12]}),
+            "must record the exact 40-hex commit it waives",
+        ),
+        (
+            "an abandonment superseded by a non-release tag",
+            abandonment_manifest({**record, "superseded_by": "main"}),
+            "must name a vX.Y.Z superseding tag",
+        ),
+        (
+            "an abandonment superseded by itself",
+            abandonment_manifest({**record, "superseded_by": record["tag"]}),
+            "cannot name itself as its successor",
+        ),
+        (
+            "an abandonment citing no failed run",
+            abandonment_manifest({**record, "failed_release_run_id": "0"}),
+            "must cite the Release run id that failed",
+        ),
+        (
+            "an abandonment recorded twice",
+            abandonment_manifest(record, record),
+            "v0.4.3 is recorded as abandoned more than once",
+        ),
+    ):
+        assert_tag_selection_refused(label, manifest, candidates, expected_error)
+
+    assert_tag_selection_refused(
+        "a tag listing with no commit",
+        abandonment_manifest(record),
+        "v0.4.3\n",
+        "release tag listing carries an unreadable record",
+    )
+    assert_tag_selection_refused(
+        "a tag listed against two commits",
+        abandonment_manifest(record),
+        f"v0.3.6 {stable}\nv0.3.6 {older}\n",
+        "release tag v0.3.6 was listed against two different commits",
+    )
+
+    # The tracked record itself is release authority, so it is exercised rather
+    # than trusted: every entry it carries must survive the same validation and
+    # actually stop holding the lane.
+    shipped = ABANDONED_TAGS.read_text(encoding="utf-8")
+    entries = json.loads(shipped)["abandoned"]
+    if not entries:
+        raise AssertionError(
+            "the tracked abandonment record must stay a reviewed ledger of "
+            "every tag the release rail has given up on"
+        )
+    floor = "v0.0.1"
+    shipped_candidates = "".join(
+        f"{entry['tag']} {entry['sha']}\n" for entry in entries
+    )
+    assert_admissible_tag(
+        "the tracked abandonment record",
+        shipped,
+        f"{shipped_candidates}{floor} {'9' * 40}\n",
+        floor,
+    )
+
+
 def main() -> None:
     retired = (
         "auto-tag-release.yml",
@@ -2228,6 +2612,11 @@ def main() -> None:
         "markerless logless fallback is retired",
         "matching_count",
         "highest_tag",
+        "refs/remotes/origin/main:scripts/abandoned-release-tags.json",
+        "refs/remotes/origin/main:scripts/select-admissible-release-tag.py",
+        "git for-each-ref",
+        'python3 "$selector"',
+        'highest_tag="$(cat "$admissible")"',
         "REQUIRED_CHECKS:",
         'GITHUB_ACTIONS_APP_ID: "15368"',
         "GITHUB_ACTIONS_APP_SLUG: github-actions",
@@ -2338,6 +2727,11 @@ def main() -> None:
         '.headRepositoryOwner.login == "firelock-ai"',
         '.headRepository.nameWithOwner == "firelock-ai/kin"',
         "highest_tag",
+        "refs/remotes/origin/main:scripts/abandoned-release-tags.json",
+        "refs/remotes/origin/main:scripts/select-admissible-release-tag.py",
+        "git for-each-ref",
+        'python3 "$selector"',
+        'highest_tag="$(cat "$admissible")"',
         "git merge --signoff --no-edit -X ours refs/remotes/origin/main",
         'gh pr merge "$PR"',
         "GH_TOKEN: ${{ steps.app-token.outputs.token }}",
@@ -2366,6 +2760,7 @@ def main() -> None:
     ):
         require(release_train, policy, "coalescing protected release train")
     assert_merge_policy_gate(release_train)
+    assert_abandoned_tag_admission(release_tag, release_train)
     # The release bump must never be resolvable from anything a merged pull
     # request can still change.
     for forbidden in (

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -36,6 +36,22 @@ TAG_SELECTOR = ROOT / "scripts" / "select-admissible-release-tag.py"
 ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
 TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
 TRUSTED_POLICY_PREFIX = "refs/remotes/origin/main:"
+TAG_LISTING_FORMAT = (
+    "--format='%(refname:strip=2) "
+    "%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)'"
+)
+# Which tag each workflow declares it is about to create. Only the mint creates
+# one, so only the mint names it. The train resolves drift from a base tag it
+# never mints, and handing that base over as mint intent refuses exactly when a
+# record covers it, which is always the moment a record is written: the mint
+# only ever creates `v$(workspace version)`, so main's version equals the stuck
+# tag until the train opens the bump the record exists to unblock. The empty
+# argument is spelled as a literal rather than an expanded variable so that
+# refilling it is a visible diff here and not a silent assignment upstream.
+EXPECTED_SELECTOR_INVOCATIONS = {
+    "release-tag": ('"$abandoned"', '"$candidate_tags"', '"$TAG"', '"$admissible"'),
+    "release-train": ('"$abandoned"', '"$candidate_tags"', '""', '"$admissible"'),
+}
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
@@ -2108,8 +2124,49 @@ def assert_admission_step_order(
         )
 
 
+def selector_invocation(workflow: str, content: str) -> tuple[str, ...]:
+    """Return the exact argument list a workflow hands the admission selector."""
+
+    anchor = 'python3 "$selector" \\\n'
+    if anchor not in content:
+        raise AssertionError(
+            f"{workflow} no longer invokes the admission selector as a "
+            "reviewable multi-line argument list"
+        )
+    arguments: list[str] = []
+    for line in content[content.index(anchor) + len(anchor) :].splitlines():
+        argument = line.strip()
+        if argument.endswith("\\"):
+            arguments.append(argument[:-1].strip())
+            continue
+        arguments.append(argument)
+        break
+    return tuple(arguments)
+
+
+def assert_selector_arguments(release_tag: str, release_train: str) -> None:
+    """Pin which tag each workflow declares it is about to mint."""
+
+    actual = {
+        "release-tag": selector_invocation("release-tag", release_tag),
+        "release-train": selector_invocation("release-train", release_train),
+    }
+    if actual != EXPECTED_SELECTOR_INVOCATIONS:
+        raise AssertionError(
+            "each release workflow must hand the admission selector its own "
+            "reviewed arguments. The mint-intent argument names the tag that "
+            "workflow is about to create, and only the mint creates one. The "
+            "train resolves drift from a base tag it never mints, so naming "
+            "that base as mint intent refuses exactly when a record covers it, "
+            f"which is every abandonment: expected={EXPECTED_SELECTOR_INVOCATIONS} "
+            f"actual={actual}"
+        )
+
+
 def assert_abandoned_tag_admission(release_tag: str, release_train: str) -> None:
     """Only a reviewed record may waive release-lane serialization."""
+
+    assert_selector_arguments(release_tag, release_train)
 
     for workflow, content, step_anchor, comparison in (
         (
@@ -2205,12 +2262,27 @@ def assert_abandoned_tag_admission(release_tag: str, release_train: str) -> None
         candidates,
         "",
     )
+    # The mint-intent contract, in the state that actually occurs. A record is
+    # written the moment a release is stuck, and main's version still equals the
+    # stuck tag then, because the mint only ever creates `v$(workspace version)`
+    # and the bump that moves main past it is the thing being unblocked. So the
+    # tag under a fresh record IS the tag both workflows are holding. Naming it
+    # as mint intent must refuse, and resolving drift without naming it must
+    # walk past it. Getting this backwards turns the record's own scenario into
+    # a permanently failing scheduled workflow.
     assert_tag_selection_refused(
         "minting a tag that is itself recorded as abandoned",
         abandonment_manifest(record),
         candidates,
         "v0.4.3 is recorded as an abandoned release tag and must not be released",
         minting_tag="v0.4.3",
+    )
+    assert_admissible_tag(
+        "resolving drift in the same state, declaring no mint intent",
+        abandonment_manifest(record),
+        candidates,
+        "v0.3.6",
+        minting_tag="",
     )
 
     for label, manifest, expected_error in (
@@ -2615,6 +2687,7 @@ def main() -> None:
         "refs/remotes/origin/main:scripts/abandoned-release-tags.json",
         "refs/remotes/origin/main:scripts/select-admissible-release-tag.py",
         "git for-each-ref",
+        TAG_LISTING_FORMAT,
         'python3 "$selector"',
         'highest_tag="$(cat "$admissible")"',
         "REQUIRED_CHECKS:",
@@ -2730,6 +2803,7 @@ def main() -> None:
         "refs/remotes/origin/main:scripts/abandoned-release-tags.json",
         "refs/remotes/origin/main:scripts/select-admissible-release-tag.py",
         "git for-each-ref",
+        TAG_LISTING_FORMAT,
         'python3 "$selector"',
         'highest_tag="$(cat "$admissible")"',
         "git merge --signoff --no-edit -X ours refs/remotes/origin/main",


### PR DESCRIPTION
The release rail serializes on one predicate, in the tag mint's lane admission
and again in the version-bump train: the highest `vX.Y.Z` tag must already be
the finalized GitHub Latest release before a newer tag is minted or a newer
version prepared. It stops an in-flight release from being leapfrogged, by
holding the highest tag responsible for finishing.

A tag whose artifacts can never be built cannot finish, and no value of GitHub
Latest resolves it. Keeping Latest older fails the highest-tag comparison;
moving Latest onto the unbuildable tag then fails the separate proof that its
release ever succeeded. Deleting the failed run is worse still: the count of
preserved attempts drops to zero and admission falls through to a markerless
legacy fallback hard-pinned to `v0.3.6`, which hard-errors for any other tag.
The rail had no way to say a tag is over.

## What this adds

`scripts/abandoned-release-tags.json` is a tracked record of tags the rail has
given up on. Each entry carries the tag, the exact commit it named, the reason,
the tag that supersedes it, and the failed Release run id. It is seeded with
`v0.4.3`, whose lockfile immutably pins a graph engine that cannot compile for
the musl release targets, which never published a Release object, and whose
automatic recovery exhausted its retries.

`scripts/select-admissible-release-tag.py` ranks the tag universe the way git
already ordered it and skips only what the record waives. Both workflows read
the record and the selector from protected main rather than from the checked-out
release commit, which can predate the abandonment it has to honour; reading
either from the checkout would re-deadlock the lane it is meant to unblock.

## What the invariant still refuses

Only a record waives the predicate. A tag that is merely failing so far carries
none and keeps blocking its successor, which is the case the predicate exists to
serialize. A record applies only while it still describes the repository: it
names the exact commit its tag pointed at, so a tag that has since moved refuses
loudly rather than silently waiving a different object than the one reviewed. A record
outlives the tag it names and is not inert once that tag is deleted: ranking stops
being affected because nothing in the listing can match it, but the mint-intent
refusal reads the record rather than the listing, so a version stays refused after
its tag is removed. Minting a tag that is itself recorded as abandoned is refused. A
malformed, unparsable, or under-evidenced record fails the rail closed instead of
degrading to an empty waiver set.

## Why the train changes too

The mint and the train share the predicate, so they share the waiver. Repairing
only the mint leaves the train wedged: an abandoned tag that stays highest there
stops the version-bump PR from ever opening, so the version never moves and the
mint has nothing new to tag.

The two sides do not take the same argument. Only the mint creates a tag, so only
the mint declares one. Drift resolution measures from a pre-existing base tag and
declares no mint intent, because that base always equals the abandoned tag at the
moment a record is written and declaring it would refuse exactly there. The
authority suite pins the argument list each workflow passes.

## Coverage

`scripts/test-release-workflow-authority.py` executes the shipped selector
against fixtures rather than reading it: an abandoned tag is skipped, an unlisted
failing tag still blocks, consecutive abandonments walk down, a moved tag refuses,
minting an abandoned tag refuses, and seventeen malformed-record shapes each
refuse by name. The tracked record itself is run through the same validation, so
it is exercised rather than trusted. Source-level assertions pin that both
workflows read each policy only from protected main, that the waiver is resolved
before the finalized-Latest comparison, and that raw tag ranking cannot creep
back into either step.

No version bump: this is workflow and policy only, so the resolver still
normalizes to the same commit.

Closes FIR-1780.
