### PR TITLE
Give each main-branch push its own CI concurrency group

### DIFF
--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -9,8 +9,17 @@ on:
   pull_request:
     branches: [main]
 
+# The sha suffix is empty off main, so every pull request and merge-queue ref
+# keeps one group per ref and `cancel-in-progress` supersedes an older push
+# exactly as it did before. On main each commit gets its own group, because
+# `cancel-in-progress: false` does not mean "never cancel": GitHub keeps at
+# most one PENDING run per group and cancels the older one. Two landings in
+# quick succession therefore delete the earlier commit's run before it starts
+# a job, and a run that started no jobs leaves the commit with its checks
+# absent rather than failed. The hosted merge queue lands PRs back to back, so
+# that window is the ordinary case here, not a rare one.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,8 +9,17 @@ on:
   pull_request:
     branches: [main]
 
+# The sha suffix is empty off main, so every pull request and merge-queue ref
+# keeps one group per ref and `cancel-in-progress` supersedes an older push
+# exactly as it did before. On main each commit gets its own group, because
+# `cancel-in-progress: false` does not mean "never cancel": GitHub keeps at
+# most one PENDING run per group and cancels the older one. Two landings in
+# quick succession therefore delete the earlier commit's run before it starts
+# a job, and a run that started no jobs leaves the commit with its checks
+# absent rather than failed. The hosted merge queue lands PRs back to back, so
+# that window is the ordinary case here, not a rare one.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,8 +28,17 @@ on:
 permissions:
   contents: read
 
+# The sha suffix is empty off main, so every pull request and merge-queue ref
+# keeps one group per ref and `cancel-in-progress` supersedes an older push
+# exactly as it did before. On main each commit gets its own group, because
+# `cancel-in-progress: false` does not mean "never cancel": GitHub keeps at
+# most one PENDING run per group and cancels the older one. Two landings in
+# quick succession therefore delete the earlier commit's run before it starts
+# a job, and a run that started no jobs leaves the commit with its checks
+# absent rather than failed. The hosted merge queue lands PRs back to back, so
+# that window is the ordinary case here, not a rare one.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
Completes the sha-scoped concurrency group across this repo's workflows. The
three touched here are the ones left alone when `ci.yml`, `sast.yml` and
`secret-scan.yml` were changed, and they carry the identical expression:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
```

`cancel-in-progress` is already false on `main`, but that only prevents an
in-flight run being cancelled. GitHub keeps at most one PENDING run per group
and cancels the older one, so a second landing inside the first run's queue
window deletes the earlier commit's run before it starts a job. A run dropped
that way contributes no check runs at all, so the commit ends up with its
checks absent rather than failed, and nothing retries it.

Unlike the three already changed, none of these publish a required context or
release evidence, so the cost of a dropped run here is a lost signal rather
than a commit that cannot be tagged. They are rolled anyway because the same
defect deserves the same fix in every workflow that serialises `main`, and
because the exception is not visible from the file that carries it.

Workflows changed:

- `.github/workflows/daemon-smoke.yml`
- `.github/workflows/docker.yml`
- `.github/workflows/link-check.yml`

Verified locally:

- `python3 scripts/test-release-workflow-authority.py` passes with the change
  applied, so the required-context map and the pinned workflow headers are
  unaffected
- `actionlint` passes on all three
- the only non-comment line changed is the `group:` line in each file
- `release-tag.yml`, `release-train.yml`, `release.yml`, `ci.yml`, `sast.yml`
  and `secret-scan.yml` are untouched

Known behaviour change off `main`: group names gain a trailing `-`, so the
first round after this lands does not supersede runs started before it. The
partition into groups is otherwise identical.
