### PR TITLE
Give the release container two registries and compile both musl release targets before landing

### DIFF
--- a/.github/workflows/base-image-pins.yml
+++ b/.github/workflows/base-image-pins.yml
@@ -3,16 +3,31 @@
 
 name: Base Image Pins
 
-# Scheduled and manual only, deliberately. A pull_request or push trigger would
-# publish a check-run against the commits that reach main, and release-tag.yml's
-# second sweep refuses a release commit carrying any non-green check-run whether
-# or not a ruleset requires it. A registry-reachability probe is exactly the
-# kind of job whose transient failure must never be able to refuse a release:
-# adding one to the release sha would recreate the failure class this workflow
-# exists to watch. Pre-landing coverage is already there without a new context.
-# `Docker Image Build (no push)` pulls both pinned digests on every pull request
-# and every push to main, and the release-authority suite refuses an unpinned
-# FROM inside the required Check & Test job.
+# A scheduled run's check-runs DO land on a commit. GitHub binds a check suite
+# to every workflow run, and for a `schedule` event `github.sha` is the default
+# branch HEAD at fire time, so a red scheduled run publishes a failure check-run
+# on a main commit. release-tag.yml's second sweep refuses a release commit
+# carrying any non-green check-run whether or not a ruleset requires it, and a
+# quiesced main during a release train holds HEAD still across exactly the
+# window that matters. This repo already carries a live instance of that shape:
+# fuzz.yml's scheduled run left two `failure` check-runs on a main sha.
+#
+# Dropping the push and pull_request triggers therefore does NOT make this job
+# safe on its own. What makes it safe is that the scheduled path is
+# structurally incapable of concluding failure: the prover's exit status is
+# captured rather than propagated, and the step exits 0 whatever it found. A
+# registry-reachability probe must never be able to refuse a release, because
+# that is the failure class this workflow exists to watch.
+#
+# Loudness comes from a surface that cannot poison a mint. When a pin is
+# definitively unreachable the run opens or updates a tracking issue, which
+# persists until someone acts on it, unlike a red check nobody is paged for.
+#
+# A `workflow_dispatch` run may fail hard, because an operator asked a direct
+# question and deserves a direct answer. The residual is real and is theirs to
+# own: dispatching against main during a release train can publish a failure
+# check-run on the candidate sha. Prefer the schedule unless you need the
+# answer now.
 on:
   schedule:
     - cron: "23 5 * * 1"
@@ -30,16 +45,103 @@ jobs:
     name: Verify base image pins
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      # The tracking issue is the alarm. It is the only write this job performs.
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      # Fails when a pinned digest has stopped resolving from either registry,
-      # which is the state that turns the fallback into a single point of
-      # failure again while every build still looks healthy. Upstream tag drift
-      # is reported rather than failed: a base image moving is normal, and a
-      # scheduled job that is red every week is a job nobody reads.
+      # Exit status is captured, never propagated. `set -e` is deliberately
+      # absent so a non-zero prover status reaches the capture instead of
+      # killing the step, and the explicit `exit 0` makes the green conclusion
+      # a property of the step rather than of what the prover happened to find.
+      #
+      # 1 means a pin is definitively gone or wrong, which is the alarm. 2 means
+      # the probe could not reach a verdict, which is reported and nothing more:
+      # a throttled lookup is not evidence about a digest, and `Docker Image
+      # Build (no push)` already proves buildability on every pull request and
+      # every push to main.
       - name: Verify base image pins resolve from both registries
-        run: bash scripts/verify-base-image-pins.sh Dockerfile
+        id: verify
+        run: |
+          set -uo pipefail
+          bash scripts/verify-base-image-pins.sh Dockerfile 2>&1 | tee /tmp/base-image-pins.log
+          status="${PIPESTATUS[0]}"
+          # A status outside the documented set means the prover itself broke,
+          # which would otherwise route to neither the alarm nor the all-clear
+          # and leave this job quietly doing nothing for weeks.
+          case "$status" in
+            0 | 1 | 2) ;;
+            *)
+              echo "::warning::the pin prover exited ${status}, which is not one of its documented statuses; no conclusion drawn"
+              ;;
+          esac
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # The alarm must not become the thing that reds a main sha. An API hiccup
+      # while filing it is the same hazard as a registry hiccup while probing,
+      # so it is reported and tolerated rather than propagated.
+      - name: Open or update the tracking issue
+        if: steps.verify.outputs.status == '1'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ALARM_TITLE: "Base image pin unreachable: the release build has lost a registry"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo "A base image pinned by \`Dockerfile\` is no longer served at that digest by"
+            echo "one of the two registries the release build resolves through, so the build"
+            echo "has lost its second door and a registry blip can refuse a release again."
+            echo ""
+            echo "Detected by [this run](${RUN_URL})."
+            echo ""
+            echo '```'
+            cat /tmp/base-image-pins.log
+            echo '```'
+            echo ""
+            echo "Remedy: repin the affected \`FROM\` in \`Dockerfile\` to a digest both"
+            echo "registries serve, then rerun this workflow to confirm and close."
+          } > /tmp/alarm-body.md
+
+          # Match on the exact title rather than a search expression so the
+          # lookup cannot widen into an unrelated issue.
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            --jq '[.[] | select(.title == env.ALARM_TITLE)] | .[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file /tmp/alarm-body.md
+            echo "updated tracking issue #${existing}"
+          else
+            gh issue create --title "$ALARM_TITLE" --body-file /tmp/alarm-body.md
+          fi
+
+      - name: Close the tracking issue once the pins are healthy
+        if: steps.verify.outputs.status == '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ALARM_TITLE: "Base image pin unreachable: the release build has lost a registry"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            --jq '[.[] | select(.title == env.ALARM_TITLE)] | .[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "Every pin resolves from both registries again, verified by [this run](${RUN_URL})."
+            echo "closed tracking issue #${existing}"
+          fi
+
+      # Only a dispatched run may go red, and only after the alarm above has
+      # already been raised, so the operator's answer never costs the alarm.
+      - name: Report the failure to the operator who asked
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.verify.outputs.status != '0' }}
+        run: |
+          echo "::error::base image pin verification exited ${{ steps.verify.outputs.status }}; see the log above"
+          exit 1

--- a/.github/workflows/base-image-pins.yml
+++ b/.github/workflows/base-image-pins.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Base Image Pins
+
+# Scheduled and manual only, deliberately. A pull_request or push trigger would
+# publish a check-run against the commits that reach main, and release-tag.yml's
+# second sweep refuses a release commit carrying any non-green check-run whether
+# or not a ruleset requires it. A registry-reachability probe is exactly the
+# kind of job whose transient failure must never be able to refuse a release:
+# adding one to the release sha would recreate the failure class this workflow
+# exists to watch. Pre-landing coverage is already there without a new context.
+# `Docker Image Build (no push)` pulls both pinned digests on every pull request
+# and every push to main, and the release-authority suite refuses an unpinned
+# FROM inside the required Check & Test job.
+on:
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  verify-pins:
+    name: Verify base image pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Fails when a pinned digest has stopped resolving from either registry,
+      # which is the state that turns the fallback into a single point of
+      # failure again while every build still looks healthy. Upstream tag drift
+      # is reported rather than failed: a base image moving is normal, and a
+      # scheduled job that is red every week is a job nobody reads.
+      - name: Verify base image pins resolve from both registries
+        run: bash scripts/verify-base-image-pins.sh Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -919,6 +919,11 @@ jobs:
         run: |
           set -euo pipefail
           rustup target add aarch64-unknown-linux-musl
+          # Self-contained rather than relying on the step above having
+          # refreshed the index. This is a required context, so an implicit
+          # ordering dependency between two steps is a way for a reorder to
+          # turn a stale index into a red Check & Test.
+          sudo apt-get update
           sudo apt-get install --yes gcc-aarch64-linux-gnu
           CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc \
           AR_aarch64_unknown_linux_musl=aarch64-linux-gnu-ar \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           bash -n ./scripts/publish-npm-release.sh
           bash -n ./scripts/verify-npm-release.sh
           bash -n ./scripts/assert-windows-init-contract.sh
+          bash -n ./scripts/verify-base-image-pins.sh
 
   windows-authority-tests:
     name: Windows authority tests
@@ -879,12 +880,8 @@ jobs:
       # packages the release builds, for the target it builds them for, so that
       # break is a red pull request instead of a burned tag.
       #
-      # Two deliberate bounds. It checks rather than builds, so it proves
-      # compilation and name resolution and not linking. And it covers
-      # x86_64 only: aarch64-unknown-linux-musl is also a release target, but
-      # its C dependencies need an aarch64 musl cross toolchain that musl-tools
-      # does not carry, and the gate that has broken selects on target_env
-      # rather than architecture, so one musl target exercises it.
+      # One deliberate bound: it checks rather than builds, so it proves
+      # compilation and name resolution and not linking.
       - name: Check the Linux release target (musl)
         if: runner.os == 'Linux'
         run: |
@@ -896,6 +893,37 @@ jobs:
           sudo apt-get install --yes musl-tools
           cargo check --locked --target x86_64-unknown-linux-musl \
             -p kin-cli -p kin-daemon
+
+      # The second Linux release target. The step above proves any break that
+      # selects on the C environment, because that selection is identical on
+      # both architectures. It cannot prove a break that selects on the
+      # architecture, and until this step existed that class first compiled
+      # inside the release run, after the tag exists, which is the shape that
+      # burned a cut.
+      #
+      # The Rust half is exact: rustc type-checks the release package set for
+      # the real target triple, which is where the defect class lives. A
+      # dependency resolving a libc entry point that libc declares for some
+      # architectures and not others fails here rather than after the tag.
+      #
+      # The C half is bounded and stays bounded on purpose. Ubuntu ships no
+      # aarch64 musl C toolchain, so the C sources that dependency build
+      # scripts compile are built by the aarch64 glibc cross compiler: right
+      # architecture, wrong C library headers. That is enough for the build
+      # scripts to produce objects and let the Rust check run, and it is not a
+      # proof that those C sources compile against musl headers. The release
+      # leg proves that natively on ubuntu-24.04-arm, where musl-tools does
+      # supply an aarch64 musl-gcc, which is why nothing here is a cross build.
+      - name: Check the aarch64 Linux release target (musl)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          rustup target add aarch64-unknown-linux-musl
+          sudo apt-get install --yes gcc-aarch64-linux-gnu
+          CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc \
+          AR_aarch64_unknown_linux_musl=aarch64-linux-gnu-ar \
+            cargo check --locked --target aarch64-unknown-linux-musl \
+              -p kin-cli -p kin-daemon
 
       - name: Install nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,8 +33,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Resolve the Dockerfile's digest-pinned base images through a mirror
+      # first. This job publishes a check-run against every commit that reaches
+      # main, and release-tag.yml's second sweep refuses a release commit
+      # carrying any non-green check-run, required or not, so minutes of
+      # registry unavailability refuse a release permanently. BuildKit tries
+      # each mirror in order and falls back to the canonical registry, so the
+      # two are independent front doors rather than a redirect: verified
+      # locally by building the pinned bases with a deliberately unreachable
+      # mirror host, which still completed against docker.io.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       # Build-only gate: this job NEVER pushes an image. It proves the
       # multi-stage Dockerfile still builds end to end — kin-* dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,8 +146,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Same mirror-first base image resolution the pull-request build uses. The
+      # shipped image is built here, so the registry serving its base layers is
+      # part of the release path: mirror first, canonical registry on failure,
+      # and the Dockerfile pins both bases by digest so neither door can serve
+      # different bytes.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Publish or verify immutable commit image
         id: publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM rust:slim AS builder
+# Both base images are pinned by digest and reachable through two independent
+# registries. The tag is kept for review; the digest is what gets pulled, and a
+# digest cannot serve different bytes whichever registry answers. The build
+# configures BuildKit to try mirror.gcr.io before docker.io (see docker.yml and
+# release.yml), and falls back to docker.io when the mirror cannot serve the
+# digest, so neither registry is a single point of failure.
+#
+# This matters beyond reproducibility. `Docker Image Build (no push)` publishes
+# a check-run against every commit that reaches main, and release-tag.yml's
+# second sweep refuses a release commit carrying any non-green check-run,
+# required or not. A registry blip lasting minutes therefore refuses a release
+# permanently, which is how one cut was already lost.
+#
+# scripts/verify-base-image-pins.sh proves both registries still serve both
+# pinned digests, and reports when the upstream tag has moved past the pin.
+FROM docker.io/library/rust:slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c AS builder
 RUN apt-get update && apt-get install -y git pkg-config libssl-dev g++ && rm -rf /var/lib/apt/lists/*
 ARG KIN_DB_REF=main
 ARG KIN_BUILD_GIT_SHA=""
@@ -35,7 +50,7 @@ RUN if [ -n "$KIN_BUILD_GIT_SHA" ] || [ -n "$KIN_BUILD_DIRTY" ] || [ -n "$KIN_BU
       cargo build --locked --release --features gcs --bin kin-daemon --bin kin; \
     fi
 
-FROM debian:trixie-slim
+FROM docker.io/library/debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates curl libssl3 && rm -rf /var/lib/apt/lists/*
 RUN groupadd -r kin \
     && useradd -r -g kin -d /home/kin -m kin \

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -56,7 +56,9 @@ HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 DOCKERFILE = ROOT / "Dockerfile"
 BASE_IMAGE_REGISTRY = "docker.io"
 BASE_IMAGE_MIRROR = 'mirrors = ["mirror.gcr.io"]'
+BASE_IMAGE_MIRROR_INPUT = "buildkitd-config-inline:"
 BASE_IMAGE_PIN = re.compile(r"(?m)^FROM\s+(?P<reference>\S+)")
+SETUP_BUILDX_ACTION = "docker/setup-buildx-action@"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
 MAIN_ONLY_CACHE_SAVE_VALUE = "${{ github.ref == 'refs/heads/main' }}"
@@ -2463,8 +2465,99 @@ def assert_container_base_image_authority(
             raise AssertionError(
                 f"{label} no longer declares the {job} job that builds the Dockerfile"
             )
+        mirror_input = setup_buildx_mirror_input(block, f"{label}:{job}")
         for needle in (f'[registry."{BASE_IMAGE_REGISTRY}"]', BASE_IMAGE_MIRROR):
-            require(block, needle, f"{label}:{job} base image mirror")
+            require(mirror_input, needle, f"{label}:{job} base image mirror")
+
+
+def comment_out_mirror_input(workflow: str) -> str:
+    """Comment out the buildx mirror input while leaving its text in the file."""
+
+    lines = workflow.splitlines(keepends=True)
+    mutated: list[str] = []
+    commenting = False
+    input_indent = 0
+    for line in lines:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if stripped.startswith(BASE_IMAGE_MIRROR_INPUT):
+            commenting = True
+            input_indent = indent
+            mutated.append(f"{' ' * indent}# {line.lstrip()}")
+            continue
+        if commenting:
+            if not stripped or indent > input_indent:
+                mutated.append(f"{' ' * indent}# {line.lstrip()}" if stripped else line)
+                continue
+            commenting = False
+        mutated.append(line)
+    return "".join(mutated)
+
+
+def setup_buildx_mirror_input(job_block: str, label: str) -> str:
+    """Return the active `buildkitd-config-inline` the buildx action receives.
+
+    Asserting the mirror against the job body as raw text accepts a config that
+    was commented out and left behind, which is the shape a debugging session
+    produces and the one shape a delete-the-string falsification cannot catch.
+    Binding the assertion to the input of the step whose `uses:` is the buildx
+    action, with comment lines dropped, means only a configuration the action
+    is actually handed can satisfy it.
+    """
+
+    lines = job_block.splitlines()
+    uses = [
+        index
+        for index, line in enumerate(lines)
+        if SETUP_BUILDX_ACTION in line and not line.lstrip().startswith("#")
+    ]
+    if len(uses) != 1:
+        raise AssertionError(
+            f"{label} base image mirror expects exactly one buildx setup step, "
+            f"found {len(uses)}"
+        )
+
+    start = uses[0]
+    while start >= 0 and re.match(r"^\s*-\s", lines[start]) is None:
+        start -= 1
+    if start < 0:
+        raise AssertionError(
+            f"{label} base image mirror could not find the buildx step's start"
+        )
+    step_indent = len(lines[start]) - len(lines[start].lstrip())
+
+    active: list[str] = []
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= step_indent:
+            break
+        if line.lstrip().startswith("#"):
+            continue
+        active.append(line)
+
+    input_index = next(
+        (
+            index
+            for index, line in enumerate(active)
+            if line.strip().startswith(BASE_IMAGE_MIRROR_INPUT)
+        ),
+        None,
+    )
+    if input_index is None:
+        raise AssertionError(
+            f"{label} base image mirror is missing required policy: "
+            f"{BASE_IMAGE_MIRROR_INPUT}"
+        )
+
+    input_indent = len(active[input_index]) - len(active[input_index].lstrip())
+    body: list[str] = []
+    for line in active[input_index + 1 :]:
+        if len(line) - len(line.lstrip()) <= input_indent:
+            break
+        body.append(line)
+    return "\n".join(body)
 
 
 def main() -> None:
@@ -3334,6 +3427,29 @@ def main() -> None:
             release.replace(BASE_IMAGE_MIRROR, ""),
         ),
     )
+    # Deleting the string is the one mutation shape a raw-text assertion always
+    # catches, so it proves the least. These comment the config out instead and
+    # leave the strings in the file, which is what a debugging session actually
+    # leaves behind, and which a raw-text assertion passes.
+    for label, mutated_docker, mutated_release in (
+        (
+            "the pull-request image build's mirror is commented out",
+            comment_out_mirror_input(docker_workflow),
+            release,
+        ),
+        (
+            "the released image build's mirror is commented out",
+            docker_workflow,
+            comment_out_mirror_input(release),
+        ),
+    ):
+        expect_assertion(
+            label,
+            f"base image mirror is missing required policy: {BASE_IMAGE_MIRROR_INPUT}",
+            lambda docker=mutated_docker, source=mutated_release: (
+                assert_container_base_image_authority(dockerfile, docker, source)
+            ),
+        )
 
     for policy in (
         'workflows: ["Release"]',

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1982,8 +1982,6 @@ def assert_release_check_accepted(
             f"{check_name}={conclusion}: {result.stdout}{result.stderr}"
         )
 
-
-<<<<<<< HEAD
 def run_tag_selector(
     manifest: str,
     candidates: str,

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -53,6 +53,10 @@ EXPECTED_SELECTOR_INVOCATIONS = {
     "release-train": ('"$abandoned"', '"$candidate_tags"', '""', '"$admissible"'),
 }
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
+DOCKERFILE = ROOT / "Dockerfile"
+BASE_IMAGE_REGISTRY = "docker.io"
+BASE_IMAGE_MIRROR = 'mirrors = ["mirror.gcr.io"]'
+BASE_IMAGE_PIN = re.compile(r"(?m)^FROM\s+(?P<reference>\S+)")
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
 MAIN_ONLY_CACHE_SAVE_VALUE = "${{ github.ref == 'refs/heads/main' }}"
@@ -412,6 +416,9 @@ CI_JOB_DISPLAY_NAMES = {
 EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/approve-to-merge.yml": {
         "gate": None,
+    },
+    ".github/workflows/base-image-pins.yml": {
+        "verify-pins": "Verify base image pins",
     },
     ".github/workflows/ci.yml": CI_JOB_DISPLAY_NAMES,
     ".github/workflows/daemon-smoke.yml": {
@@ -1974,6 +1981,7 @@ def assert_release_check_accepted(
         )
 
 
+<<<<<<< HEAD
 def run_tag_selector(
     manifest: str,
     candidates: str,
@@ -2407,6 +2415,56 @@ def assert_abandoned_tag_admission(release_tag: str, release_train: str) -> None
         f"{shipped_candidates}{floor} {'9' * 40}\n",
         floor,
     )
+
+
+def assert_container_base_image_authority(
+    dockerfile: str,
+    docker_workflow: str,
+    release: str,
+) -> None:
+    """Keep one registry from being able to refuse a release on its own.
+
+    `Docker Image Build (no push)` publishes a check-run against every commit
+    that reaches main, and release-tag.yml's second sweep refuses a release
+    commit carrying any non-green check-run whether or not a ruleset requires
+    it. Minutes of registry unavailability therefore refuse a release
+    permanently, which has already cost a cut. Two properties remove that: the
+    build resolves base images through a mirror before the canonical registry,
+    and every base image is pinned by digest so the two doors cannot serve
+    different bytes.
+    """
+
+    references = [
+        match.group("reference") for match in BASE_IMAGE_PIN.finditer(dockerfile)
+    ]
+    if not references:
+        raise AssertionError(
+            "the release container Dockerfile must declare at least one base image"
+        )
+    for reference in references:
+        if re.search(r"@sha256:[0-9a-f]{64}$", reference) is None:
+            raise AssertionError(
+                "release container base images must be pinned by digest, so a "
+                "mirror cannot serve different bytes than the canonical "
+                f"registry: {reference}"
+            )
+        if not reference.startswith(f"{BASE_IMAGE_REGISTRY}/"):
+            raise AssertionError(
+                "release container base images must name their registry, so the "
+                f"reviewed mirror rewrite applies to them: {reference}"
+            )
+
+    for label, source, job in (
+        ("docker.yml", docker_workflow, "build-image"),
+        ("release.yml", release, "build_daemon_image"),
+    ):
+        block = workflow_job_blocks(source).get(job)
+        if block is None:
+            raise AssertionError(
+                f"{label} no longer declares the {job} job that builds the Dockerfile"
+            )
+        for needle in (f'[registry."{BASE_IMAGE_REGISTRY}"]', BASE_IMAGE_MIRROR):
+            require(block, needle, f"{label}:{job} base image mirror")
 
 
 def main() -> None:
@@ -3202,17 +3260,34 @@ def main() -> None:
         )
     for policy in (
         "- name: Check the Linux release target (musl)",
-        "rustup target add x86_64-unknown-linux-musl",
         "musl-tools",
-        "cargo check --locked --target x86_64-unknown-linux-musl",
         "-p kin-cli -p kin-daemon",
     ):
         require(ci_jobs["check"], policy, "pull-request Linux release-target compile guard")
-    if "x86_64-unknown-linux-musl" not in release_musl_targets:
-        raise AssertionError(
-            "the pull-request compile guard must build a target the release "
-            "workflow actually ships; release musl targets="
-            f"{sorted(release_musl_targets)}"
+    # Every musl target the release workflow ships must compile before a merge,
+    # not first inside the tagged release run. Deriving the requirement from the
+    # release matrix rather than naming one target keeps the two from drifting
+    # apart in the direction that costs a version cut: a release target that no
+    # required context compiles. The aarch64 leg needs a C compiler for the same
+    # dependency build scripts, and Ubuntu carries no aarch64 musl one, so it
+    # compiles those C sources with the aarch64 glibc cross toolchain and proves
+    # the Rust half exactly; the native ubuntu-24.04-arm release leg is what
+    # proves the C half against musl.
+    for target in sorted(release_musl_targets):
+        for policy in (
+            f"rustup target add {target}",
+            f"cargo check --locked --target {target}",
+        ):
+            require(
+                ci_jobs["check"],
+                policy,
+                f"pull-request compile guard coverage of release musl target {target}",
+            )
+    if "aarch64-unknown-linux-musl" in release_musl_targets:
+        require(
+            ci_jobs["check"],
+            "gcc-aarch64-linux-gnu",
+            "aarch64 release-target compile guard C toolchain",
         )
     for package in ("-p kin-cli", "-p kin-daemon"):
         require(
@@ -3220,6 +3295,45 @@ def main() -> None:
             package,
             "release core binary package set the compile guard mirrors",
         )
+
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    assert_container_base_image_authority(dockerfile, docker_workflow, release)
+    expect_assertion(
+        "a floating base image tag reaches the release container",
+        "must be pinned by digest",
+        lambda: assert_container_base_image_authority(
+            re.sub(r"@sha256:[0-9a-f]{64}", "", dockerfile, count=1),
+            docker_workflow,
+            release,
+        ),
+    )
+    expect_assertion(
+        "a base image with no registry escapes the reviewed mirror rewrite",
+        "must name their registry",
+        lambda: assert_container_base_image_authority(
+            dockerfile.replace(f"FROM {BASE_IMAGE_REGISTRY}/", "FROM ", 1),
+            docker_workflow,
+            release,
+        ),
+    )
+    expect_assertion(
+        "the pull-request image build loses its second registry",
+        "docker.yml:build-image base image mirror",
+        lambda: assert_container_base_image_authority(
+            dockerfile,
+            docker_workflow.replace(BASE_IMAGE_MIRROR, ""),
+            release,
+        ),
+    )
+    expect_assertion(
+        "the released image build loses its second registry",
+        "release.yml:build_daemon_image base image mirror",
+        lambda: assert_container_base_image_authority(
+            dockerfile,
+            docker_workflow,
+            release.replace(BASE_IMAGE_MIRROR, ""),
+        ),
+    )
 
     for policy in (
         'workflows: ["Release"]',

--- a/scripts/verify-base-image-pins.sh
+++ b/scripts/verify-base-image-pins.sh
@@ -13,9 +13,21 @@
 # build right up to the outage it was supposed to survive. This asserts each
 # door independently.
 #
-# Drift is reported, not failed. The pinned digest going stale relative to the
-# upstream tag is a maintenance signal a human acts on; the pinned digest
-# becoming unreachable is the failure.
+# Three outcomes, deliberately distinct, because the caller acts differently on
+# each and because reporting one as another is how a prover lies:
+#
+#   0  every pin verified from both registries
+#   1  a pin is DEFINITIVELY gone or wrong at a registry
+#   2  verification could not be completed (throttled or otherwise transient)
+#
+# A registry throttle is not a missing digest. Docker Hub's anonymous manifest
+# limit is per IP and hosted runners share heavily used egress, so treating an
+# exhausted retry as "no longer serves" would raise a false alarm far more often
+# than a true one. release.yml's own inspect_digest retries against the same
+# reality; this mirrors that rather than inventing a second policy.
+#
+# Upstream tag drift is reported, never failed, and a drift lookup that does not
+# answer must not stop the remaining pins from being checked.
 
 set -euo pipefail
 
@@ -24,13 +36,46 @@ canonical_registry="docker.io"
 mirror_registry="mirror.gcr.io"
 
 if [ ! -f "$dockerfile" ]; then
-  echo "::error::no Dockerfile at $dockerfile" >&2
+  echo "::error::no Dockerfile at $dockerfile"
   exit 1
 fi
 
-# Resolve one reference to the digest its registry reports, or print nothing.
+# resolve_digest runs inside a command substitution, so anything it assigns to a
+# variable dies with that subshell. The diagnostic has to survive in a file for
+# the caller to be able to say WHY a lookup did not answer.
+resolve_error_file="$(mktemp)"
+trap 'rm -f "$resolve_error_file"' EXIT
+
+# Resolve one reference to the digest its registry reports.
+#
+#   0   digest printed on stdout
+#   44  the registry answered definitively that it does not have it
+#   2   no usable answer within the retry budget
+#
+# Distinguishing 44 from 2 is the point: only 44 justifies claiming a registry
+# no longer serves a pin.
 resolve_digest() {
-  docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}' 2>/dev/null
+  local reference="$1"
+  local output=""
+  local attempt
+  : > "$resolve_error_file"
+  for attempt in 1 2 3 4 5; do
+    if output="$(docker buildx imagetools inspect "$reference" \
+      --format '{{.Manifest.Digest}}' 2>&1)"; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+    printf '%s' "$output" > "$resolve_error_file"
+    case "$output" in
+      *"not found"* | *404* | *MANIFEST_UNKNOWN* | *"manifest unknown"*)
+        return 44
+        ;;
+    esac
+    if [ "$attempt" -lt 5 ]; then
+      sleep $(( attempt * 3 ))
+    fi
+  done
+  return 2
 }
 
 summary() {
@@ -39,8 +84,40 @@ summary() {
   fi
 }
 
+# Probe one door. Reports through a global rather than stdout so its own log
+# lines cannot be captured into the state it is reporting, and always returns 0
+# so a probe result can never terminate the caller under errexit.
+probe_state=""
+probe_registry() {
+  local registry="$1"
+  local path="$2"
+  local pinned_digest="$3"
+  local resolved=""
+  local status=0
+
+  resolved="$(resolve_digest "${registry}/${path}@${pinned_digest}")" || status=$?
+  if [ "$status" -eq 0 ]; then
+    if [ "$resolved" = "$pinned_digest" ]; then
+      probe_state=ok
+    else
+      echo "::error::${registry} served ${path} as ${resolved}, not the pinned ${pinned_digest}"
+      probe_state=mismatch
+    fi
+    return 0
+  fi
+  if [ "$status" -eq 44 ]; then
+    echo "::error::${registry} no longer serves ${path} at ${pinned_digest}: $(cat "$resolve_error_file")"
+    probe_state=gone
+    return 0
+  fi
+  echo "::warning::${registry} did not answer for ${path} at ${pinned_digest} within the retry budget; this is not a claim that it is gone: $(cat "$resolve_error_file")"
+  probe_state=unverified
+  return 0
+}
+
 pins_found=0
-failures=0
+broken=0
+unverified=0
 drifted=0
 
 summary "## Base image pins"
@@ -51,13 +128,26 @@ summary "| --- | --- | --- | --- | --- |"
 # Read FROM lines from the Dockerfile itself so the pins cannot be checked
 # against a second copy that drifts from the one the build uses.
 while IFS= read -r from_line; do
-  reference="$(printf '%s\n' "$from_line" | awk '{print $2}')"
+  # `FROM` accepts flags before the reference (`--platform=`) and a trailing
+  # `AS <stage>` after it. Take the first token that is neither.
+  reference=""
+  for token in $from_line; do
+    case "$token" in
+      FROM | --*) continue ;;
+      *) reference="$token"; break ;;
+    esac
+  done
+  if [ -z "$reference" ]; then
+    echo "::error::could not read a base image reference from: ${from_line}"
+    broken=$((broken + 1))
+    continue
+  fi
 
   case "$reference" in
     *@sha256:*) ;;
     *)
-      echo "::error::base image is not digest-pinned: ${reference}" >&2
-      failures=$((failures + 1))
+      echo "::error::base image is not digest-pinned: ${reference}"
+      broken=$((broken + 1))
       continue
       ;;
   esac
@@ -65,45 +155,52 @@ while IFS= read -r from_line; do
   pins_found=$((pins_found + 1))
   pinned_digest="${reference##*@}"
   name_with_tag="${reference%@*}"
-  repository="${name_with_tag%%:*}"
-  tag="${name_with_tag##*:}"
+
+  # Split the tag off only when the colon follows the last slash: a registry
+  # host may carry a port, and a reference may be pinned with no tag at all.
+  repository="$name_with_tag"
+  tag=""
+  case "${name_with_tag##*/}" in
+    *:*)
+      tag="${name_with_tag##*:}"
+      repository="${name_with_tag%:*}"
+      ;;
+  esac
 
   case "$repository" in
     "${canonical_registry}/"*)
       path="${repository#"${canonical_registry}/"}"
       ;;
     *)
-      echo "::error::base image must name ${canonical_registry} explicitly so the mirror rewrite is reviewable: ${reference}" >&2
-      failures=$((failures + 1))
+      echo "::error::base image must name ${canonical_registry} explicitly so the mirror rewrite is reviewable: ${reference}"
+      broken=$((broken + 1))
       continue
       ;;
   esac
 
-  canonical_state=fail
-  if [ "$(resolve_digest "${canonical_registry}/${path}@${pinned_digest}")" = "$pinned_digest" ]; then
-    canonical_state=ok
-  else
-    echo "::error::${canonical_registry} no longer serves ${path} at ${pinned_digest}" >&2
-    failures=$((failures + 1))
-  fi
+  probe_registry "$canonical_registry" "$path" "$pinned_digest"
+  canonical_state="$probe_state"
+  probe_registry "$mirror_registry" "$path" "$pinned_digest"
+  mirror_state="$probe_state"
+  for state in "$canonical_state" "$mirror_state"; do
+    case "$state" in
+      gone | mismatch) broken=$((broken + 1)) ;;
+      unverified) unverified=$((unverified + 1)) ;;
+    esac
+  done
 
-  mirror_state=fail
-  if [ "$(resolve_digest "${mirror_registry}/${path}@${pinned_digest}")" = "$pinned_digest" ]; then
-    mirror_state=ok
-  else
-    echo "::error::${mirror_registry} no longer serves ${path} at ${pinned_digest}; the build has lost its second registry" >&2
-    failures=$((failures + 1))
-  fi
-
-  upstream_digest="$(resolve_digest "${canonical_registry}/${path}:${tag}")"
-  tag_state="unresolved"
-  if [ -n "$upstream_digest" ]; then
-    if [ "$upstream_digest" = "$pinned_digest" ]; then
-      tag_state="current"
-    else
-      tag_state="moved to ${upstream_digest}"
-      drifted=$((drifted + 1))
-      echo "::warning::${path}:${tag} has moved past the pin; bump the Dockerfile digest to ${upstream_digest}"
+  tag_state="untagged"
+  if [ -n "$tag" ]; then
+    upstream_digest=""
+    tag_state="unresolved"
+    if upstream_digest="$(resolve_digest "${canonical_registry}/${path}:${tag}")"; then
+      if [ "$upstream_digest" = "$pinned_digest" ]; then
+        tag_state="current"
+      else
+        tag_state="moved to ${upstream_digest}"
+        drifted=$((drifted + 1))
+        echo "::warning::${path}:${tag} has moved past the pin; bump the Dockerfile digest to ${upstream_digest}"
+      fi
     fi
   fi
 
@@ -112,16 +209,20 @@ while IFS= read -r from_line; do
 done < <(grep -E '^FROM[[:space:]]' "$dockerfile")
 
 if [ "$pins_found" -eq 0 ]; then
-  echo "::error::no digest-pinned base image was found in ${dockerfile}; this check would pass an unpinned build" >&2
+  echo "::error::no digest-pinned base image was found in ${dockerfile}; this check would pass an unpinned build"
   exit 1
 fi
 
 summary ""
-summary "${pins_found} pinned base image(s), ${drifted} behind the upstream tag."
+summary "${pins_found} pinned base image(s): ${broken} unreachable or wrong, ${unverified} unverified, ${drifted} behind the upstream tag."
 
-if [ "$failures" -gt 0 ]; then
-  echo "::error::${failures} base image pin check(s) failed" >&2
+if [ "$broken" -gt 0 ]; then
+  echo "::error::${broken} base image pin check(s) failed definitively"
   exit 1
+fi
+if [ "$unverified" -gt 0 ]; then
+  echo "::warning::${unverified} base image pin check(s) could not be completed; no conclusion is being drawn about them"
+  exit 2
 fi
 
 echo "all ${pins_found} base image pin(s) resolve from ${canonical_registry} and ${mirror_registry}"

--- a/scripts/verify-base-image-pins.sh
+++ b/scripts/verify-base-image-pins.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Prove the container base images the release image is built FROM are still
+# served, at the exact digests the Dockerfile pins, by both registries the
+# build can reach.
+#
+# The build resolves docker.io through a mirror and falls back to the canonical
+# registry, which only removes the single point of failure while both doors
+# stay open. Nothing in the build reports which door answered, so a mirror that
+# silently stopped carrying a pinned digest would look identical to a healthy
+# build right up to the outage it was supposed to survive. This asserts each
+# door independently.
+#
+# Drift is reported, not failed. The pinned digest going stale relative to the
+# upstream tag is a maintenance signal a human acts on; the pinned digest
+# becoming unreachable is the failure.
+
+set -euo pipefail
+
+dockerfile="${1:-Dockerfile}"
+canonical_registry="docker.io"
+mirror_registry="mirror.gcr.io"
+
+if [ ! -f "$dockerfile" ]; then
+  echo "::error::no Dockerfile at $dockerfile" >&2
+  exit 1
+fi
+
+# Resolve one reference to the digest its registry reports, or print nothing.
+resolve_digest() {
+  docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}' 2>/dev/null
+}
+
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+pins_found=0
+failures=0
+drifted=0
+
+summary "## Base image pins"
+summary ""
+summary "| image | pinned digest | ${canonical_registry} | ${mirror_registry} | upstream tag |"
+summary "| --- | --- | --- | --- | --- |"
+
+# Read FROM lines from the Dockerfile itself so the pins cannot be checked
+# against a second copy that drifts from the one the build uses.
+while IFS= read -r from_line; do
+  reference="$(printf '%s\n' "$from_line" | awk '{print $2}')"
+
+  case "$reference" in
+    *@sha256:*) ;;
+    *)
+      echo "::error::base image is not digest-pinned: ${reference}" >&2
+      failures=$((failures + 1))
+      continue
+      ;;
+  esac
+
+  pins_found=$((pins_found + 1))
+  pinned_digest="${reference##*@}"
+  name_with_tag="${reference%@*}"
+  repository="${name_with_tag%%:*}"
+  tag="${name_with_tag##*:}"
+
+  case "$repository" in
+    "${canonical_registry}/"*)
+      path="${repository#"${canonical_registry}/"}"
+      ;;
+    *)
+      echo "::error::base image must name ${canonical_registry} explicitly so the mirror rewrite is reviewable: ${reference}" >&2
+      failures=$((failures + 1))
+      continue
+      ;;
+  esac
+
+  canonical_state=fail
+  if [ "$(resolve_digest "${canonical_registry}/${path}@${pinned_digest}")" = "$pinned_digest" ]; then
+    canonical_state=ok
+  else
+    echo "::error::${canonical_registry} no longer serves ${path} at ${pinned_digest}" >&2
+    failures=$((failures + 1))
+  fi
+
+  mirror_state=fail
+  if [ "$(resolve_digest "${mirror_registry}/${path}@${pinned_digest}")" = "$pinned_digest" ]; then
+    mirror_state=ok
+  else
+    echo "::error::${mirror_registry} no longer serves ${path} at ${pinned_digest}; the build has lost its second registry" >&2
+    failures=$((failures + 1))
+  fi
+
+  upstream_digest="$(resolve_digest "${canonical_registry}/${path}:${tag}")"
+  tag_state="unresolved"
+  if [ -n "$upstream_digest" ]; then
+    if [ "$upstream_digest" = "$pinned_digest" ]; then
+      tag_state="current"
+    else
+      tag_state="moved to ${upstream_digest}"
+      drifted=$((drifted + 1))
+      echo "::warning::${path}:${tag} has moved past the pin; bump the Dockerfile digest to ${upstream_digest}"
+    fi
+  fi
+
+  echo "${path}:${tag} pinned=${pinned_digest} ${canonical_registry}=${canonical_state} ${mirror_registry}=${mirror_state} tag=${tag_state}"
+  summary "| \`${path}:${tag}\` | \`${pinned_digest}\` | ${canonical_state} | ${mirror_state} | ${tag_state} |"
+done < <(grep -E '^FROM[[:space:]]' "$dockerfile")
+
+if [ "$pins_found" -eq 0 ]; then
+  echo "::error::no digest-pinned base image was found in ${dockerfile}; this check would pass an unpinned build" >&2
+  exit 1
+fi
+
+summary ""
+summary "${pins_found} pinned base image(s), ${drifted} behind the upstream tag."
+
+if [ "$failures" -gt 0 ]; then
+  echo "::error::${failures} base image pin check(s) failed" >&2
+  exit 1
+fi
+
+echo "all ${pins_found} base image pin(s) resolve from ${canonical_registry} and ${mirror_registry}"


### PR DESCRIPTION
Two hardenings of the paths a release commit has to survive, batched because
both are release-path build changes with independent evidence.

Part-of FIR-1762.
Closes FIR-1779.

## 1. The release container no longer depends on one registry

`Docker Image Build (no push)` publishes a check-run against every commit that
reaches main, and release-tag.yml's second sweep refuses a release commit
carrying any non-green check-run whether or not a ruleset requires it. The root
Dockerfile pulled `rust:slim` and `debian:trixie-slim` by floating tag from
docker.io, so minutes of registry unavailability refuse that release
permanently rather than delaying it. That is the cargo-deny failure class of
the v0.4.1 burn, in the one job PR 529 did not reach.

What changed:

- both `FROM`s are digest-pinned and name their registry explicitly
- both jobs that build the Dockerfile (`docker.yml:build-image` and
  `release.yml:build_daemon_image`) configure BuildKit to resolve `docker.io`
  through `mirror.gcr.io` first, falling back to `docker.io`
- `.github/workflows/base-image-pins.yml` (schedule + dispatch only) proves
  both pinned digests still resolve from **both** registries
- the release-authority suite refuses an unpinned base image, a base image that
  does not name its registry, and either build job losing its mirror

### Why not the GHCR mirror the ticket preferred

Verified and rejected on a specific fact, not on effort. GHCR container
packages are private by default, **do not inherit repository visibility**, and
visibility is changeable only through the org UI ([GitHub
docs](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility):
"a package automatically inherits the access permissions (but not the
visibility) of the linked repository"). `firelock-ai/kin` is public with 4
forks and ships a `docker-compose.yml` with a `build:` section, so a private
mirror in the `FROM` would break fork pull requests and every external `docker
build`, and would make the release-critical path depend on a one-time manual org
UI action nothing in the repo can assert. Pushing itself is not the blocker:
`build_daemon_image` already pushes `ghcr.io/firelock-ai/kin` with the standard
`GITHUB_TOKEN`.

The sanctioned fallback is what landed, implemented at the registry-resolution
layer rather than as a shell retry, so it applies to every consumer of the
Dockerfile including forks and external builders.

### Evidence

Run locally against the exact BuildKit configuration in the diff:

- `mirror.gcr.io` returns **byte-identical digests** to `docker.io` for both
  images (`sha256:5c6f46a6...` rust:slim, `sha256:020c0d20...`
  debian:trixie-slim), so the pin is satisfiable from either door
- the pinned bases build through a mirror-first BuildKit builder: builder stage
  (pinned rust base, apt layer, tracked `[registries.kin]` assertion) rc=0, and
  runtime stage (pinned debian base, apt layer, non-root user) rc=0
- **fallback falsified**: the same build with the mirror host set to an
  unreachable name still completes against `docker.io`, rc=0, so the mirror is
  an additional door and not a redirect
- `scripts/verify-base-image-pins.sh` run against the committed Dockerfile:
  both pins `docker.io=ok mirror.gcr.io=ok tag=current`

`mirror.gcr.io` is hosted on Artifact Registry and is unaffected by the
Container Registry shutdown. It is a pull-through cache, so the honest claim is
two independent front doors, not our own copy of the bytes.

## 2. aarch64-unknown-linux-musl compiles before the tag exists

PR 541 closed the x86_64 half. The remaining gap: the second shipped Linux
release target first compiled inside `release.yml`, after the tag, which is the
shape that burned v0.4.3.

`Check & Test` now also runs `cargo check --locked --target
aarch64-unknown-linux-musl -p kin-cli -p kin-daemon`. Option (a) from the
ticket, not (b): a native `ubuntu-24.04-arm` leg would add a new context name,
which needs a ruleset change and perturbs the census release-tag.yml pins.

**The bound, stated plainly.** Ubuntu carries no aarch64 musl C toolchain, so
dependency build scripts compile their C sources with `gcc-aarch64-linux-gnu`:
right architecture, glibc headers. The Rust half is exact, and that is where
the recorded defect class lives. The C half against musl headers stays proven
by the native `ubuntu-24.04-arm` release leg, where `musl-tools` does supply an
aarch64 `musl-gcc`, which is why the release build is not a cross build either.

### Falsification against the recorded defect

`libc` declares the `renameat2` wrapper only for `target_env = "gnu"`, android
and redox, and kin-db 0.7.6 called it unconditionally on Linux. Run in a
container at the workspace `libc` pin (`=0.2.186`):

| scratch resolve | target | result |
| --- | --- | --- |
| `kin-db =0.7.6` | `aarch64-unknown-linux-musl` | `error[E0425]: cannot find function renameat2 in crate libc`, rc=101 |
| minimal `libc::renameat2` repro | `aarch64-unknown-linux-musl` | E0425, rc=101 |
| minimal `libc::renameat2` repro | `x86_64-unknown-linux-musl` | E0425, rc=101 |
| minimal `libc::renameat2` repro | `x86_64-unknown-linux-gnu` | **rc=0** |

The gnu control compiles, so the target selection is what catches it. Two facts
worth recording: `SYS_renameat2` (the constant the 0.7.8 fix uses) **is**
declared for aarch64 musl at this pin, so the fixed code is correct on the new
target; and `libc` 0.2.188 added the musl `renameat2` wrapper, so an
unconstrained scratch resolve silently stops reproducing the defect. The
workspace pin is 0.2.186.

### Cost

On the run this branched from (30641500854, main): the existing x86_64 musl
step cost **90s**, the ubuntu leg ran **23.2 min**, and the longest required leg
(`Windows authority tests`) ran **29.1 min**, leaving 5.9 min of slack behind
the critical path. The measured cost of the new step on this PR's own run is
reported in a comment below.

## Gates

- release-authority suite: green, with 4 new in-suite falsifications
  (unpinned base, registry-less base, each build job losing its mirror)
- 5 external falsifications, each confirmed to fail for the right reason and
  the control confirmed green after each: aarch64 `cargo check` removed,
  aarch64 `rustup target` removed, aarch64 C toolchain removed, new workflow
  missing from the census, new workflow job renamed to a required context name
- `bash -n scripts/verify-base-image-pins.sh` green, and wired into the
  existing ci.yml syntax step
- both zero-file-search guards green (146 files scanned)
- `actionlint`: 1 finding, byte-identical to the finding on `main` before this
  branch (pre-existing SC2034 in `registry-index-migrate.yml`, untouched here)
- no Rust changed, so fmt/clippy/build carry no delta from this diff

## What this does not fix

- **FIR-1762 fix 2, the policy half.** release-tag.yml's second sweep still
  terminally refuses any non-green check-run on the release sha, required or
  not. This change removes one producer's dependence on a single registry; it
  does not change what the sweep does with a failure. That is a release-
  authority change and needs its own adversarial review, which is why this is
  Part-of and not Closes.
- **We do not own the base image bytes.** `mirror.gcr.io` is a pull-through
  cache. If Docker Hub is unreachable *and* the mirror has never cached a
  pinned digest, both doors fail. For these two images (official, extremely
  popular, and now warm at the pinned digests) that is remote, and the
  scheduled job makes it observable rather than a surprise. Owning the bytes
  needs the GHCR mirror, which needs the visibility decision above.
- **The aarch64 C half.** Bounded on purpose and documented in the step, not
  hidden. Closing it would need either an aarch64 musl sysroot built in CI or
  the native arm leg that option (b) describes.
