### PR TITLE
Admit the macOS notification bundle into the release archive shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
             ./scripts/check-release-version.test.mjs \
             ./scripts/prepare-release.test.mjs \
             ./scripts/read-update-build-identity.test.cjs \
+            ./scripts/release-archive-shape.test.cjs \
             ./scripts/release-order.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs
           node --check ./scripts/read-update-build-identity.cjs
@@ -632,7 +633,8 @@ jobs:
           python3 scripts/test-release-workflow-authority.py
           node --test \
             scripts/check-release-version.test.mjs \
-            scripts/prepare-release.test.mjs
+            scripts/prepare-release.test.mjs \
+            scripts/release-archive-shape.test.cjs
           node --check scripts/check-release-version.mjs
           node --check scripts/prepare-release.mjs
           node --check scripts/release-intent.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -862,18 +862,24 @@ jobs:
             cp -R "target/${TARGET}/release/KinNotifier.app" "$ARTIFACT/"
           fi
           tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
+          # Take the listing once into a file. Piping it into `grep -q` lets grep
+          # exit on its first match, and under `pipefail` the SIGPIPE that raises
+          # on `tar` fails the pipeline, which reads exactly like the member being
+          # absent. Reading a file cannot invert the guard that way.
+          ARCHIVE_LISTING="$RUNNER_TEMP/${ARTIFACT}.listing.txt"
+          tar tzf "${ARTIFACT}.tar.gz" > "$ARCHIVE_LISTING"
           # All supported Unix surfaces are mandatory release contents.
           for required in kin kin-daemon kin-vfs "$SHIM_NAME"; do
-            if ! tar tzf "${ARTIFACT}.tar.gz" | grep -q "/${required}$"; then
+            if ! grep -q "/${required}$" "$ARCHIVE_LISTING"; then
               echo "::error::$required missing from ${ARTIFACT}.tar.gz"
               exit 1
             fi
           done
-          # The notifier is mandatory on macOS. Without it the CLI still runs
-          # but every notification is credited to Script Editor, which is a
-          # silent downgrade rather than a visible failure — so assert it.
+          # The notifier is mandatory on macOS. Without it the CLI still runs but
+          # every notification is credited to Script Editor, which is a silent
+          # downgrade rather than a visible failure, so assert it here.
           if [ "$RUNNER_OS" = "macOS" ]; then
-            if ! tar tzf "${ARTIFACT}.tar.gz" | grep -q "KinNotifier.app/Contents/MacOS/KinNotifier$"; then
+            if ! grep -q "KinNotifier.app/Contents/MacOS/KinNotifier$" "$ARCHIVE_LISTING"; then
               echo "::error::KinNotifier.app missing from ${ARTIFACT}.tar.gz"
               exit 1
             fi
@@ -928,6 +934,7 @@ jobs:
 
           const artifact = process.env.ARTIFACT;
           const { readUpdateBuildIdentity } = require("./scripts/read-update-build-identity.cjs");
+          const { classifyReleaseArchiveRoot } = require("./scripts/release-archive-shape.cjs");
           const target = process.env.TARGET;
           const root = process.cwd();
           const authorityNames = new Set(
@@ -964,16 +971,22 @@ jobs:
             throw new Error(`expected exactly one final archive for ${artifact}, found ${archives.join(", ") || "none"}`);
           }
           const archive = archives[0];
-          const contents = fs.readdirSync(artifact, { withFileTypes: true })
-            .filter((entry) => entry.isFile())
-            .map((entry) => {
-              const file = path.join(artifact, entry.name);
+          // The content inventory covers the archive's component files. The macOS
+          // notification bundle is a sealed directory rather than a component, so
+          // it is classified and shape-checked here but stays out of the manifest:
+          // an installed updater refuses any inventory name outside its managed
+          // component list, and the bundle's bytes are already covered by the
+          // archive digest, its code signature, and its stapled notarization.
+          const contents = classifyReleaseArchiveRoot(artifact, { target })
+            .files
+            .map((name) => {
+              const file = path.join(artifact, name);
               const record = {
-                name: entry.name,
+                name,
                 sha256: sha256(file),
                 size_bytes: fs.statSync(file).size,
               };
-              if (authorityNames.has(entry.name)) {
+              if (authorityNames.has(name)) {
                 record.build_identity = readUpdateBuildIdentity(file);
               }
               return record;
@@ -1249,6 +1262,10 @@ jobs:
           const os = require("os");
           const path = require("path");
           const { readUpdateBuildIdentity } = require("./scripts/read-update-build-identity.cjs");
+          const {
+            assertReleaseArchiveMemberPaths,
+            classifyReleaseArchiveRoot,
+          } = require("./scripts/release-archive-shape.cjs");
 
           const root = process.cwd();
           const sha256 = (file) =>
@@ -1337,6 +1354,16 @@ jobs:
             fail(manifest.workflow?.run_attempt === process.env.GITHUB_RUN_ATTEMPT,
               `${manifestPath} run attempt does not match this run`);
 
+            // Judge the archive's declared member paths before extracting it. A
+            // member that escapes the extraction root has already been written
+            // somewhere else by the time the extracted tree can be inspected.
+            const listing = spec.archive.endsWith(".zip")
+              ? childProcess.execFileSync("unzip", ["-Z1", spec.archive], { encoding: "utf8" })
+              : childProcess.execFileSync("tar", ["-tzf", spec.archive], { encoding: "utf8" });
+            assertReleaseArchiveMemberPaths(
+              listing.split("\n").filter((member) => member !== ""),
+              { artifact: spec.artifact, target: spec.target }
+            );
             const extractRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${spec.artifact}-`));
             try {
               if (spec.archive.endsWith(".zip")) {
@@ -1346,9 +1373,12 @@ jobs:
               }
               const nested = path.join(extractRoot, spec.artifact);
               const contentRoot = fs.existsSync(nested) ? nested : extractRoot;
-              const entries = fs.readdirSync(contentRoot, { withFileTypes: true });
-              fail(entries.every((entry) => entry.isFile()), `${spec.archive} has unexpected nested content`);
-              const actualNames = entries.map((entry) => entry.name).sort();
+              // Component files carry per-file provenance; the macOS notification
+              // bundle is admitted as a sealed directory and is inventoried by the
+              // archive digest instead. Everything else is refused.
+              const actualNames = classifyReleaseArchiveRoot(contentRoot, {
+                target: spec.target,
+              }).files;
               const manifestNames = manifest.archive_contents.map((entry) => entry.name).sort();
               fail(JSON.stringify(actualNames) === JSON.stringify(manifestNames),
                 `${manifestPath} content inventory does not match ${spec.archive}`);

--- a/scripts/release-archive-shape.cjs
+++ b/scripts/release-archive-shape.cjs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Directory name of the macOS notification bundle inside a release archive.
+//
+// Every other release component is a bare executable or shared library. This one
+// cannot be: macOS reads a notification's sender name, icon, and grouping from
+// the posting process's bundle, and codesign seals Info.plist and Resources
+// alongside the executable, so flattening the bundle into loose files destroys
+// both the identity and the signature. It therefore travels as a directory, and
+// the release archive's shape rules have to say so explicitly rather than
+// treating every directory as a tarbomb.
+const NOTIFIER_BUNDLE_DIR = "KinNotifier.app";
+
+// Bundle members whose absence leaves nothing to launch or nothing to attribute
+// the notification to. A bundle missing either is broken in a way that only
+// shows up as a wrong sender name at runtime, so it is rejected at release time.
+const NOTIFIER_BUNDLE_EXECUTABLE = ["Contents", "MacOS", "KinNotifier"];
+const NOTIFIER_BUNDLE_PLIST = ["Contents", "Info.plist"];
+
+// A release archive is assembled from a fixed component list plus one bundle, so
+// its shape is bounded. These caps turn "the archive grew something unexpected"
+// into a failure rather than an unbounded walk over attacker-chosen structure.
+const MAX_ARCHIVE_MEMBERS = 256;
+const MAX_BUNDLE_ENTRIES = 64;
+const MAX_BUNDLE_DEPTH = 6;
+
+// Whether a target triple is one whose archive may carry the notification
+// bundle. Only macOS has a bundle concept, so every other leg must stay flat.
+function targetCarriesNotifierBundle(target) {
+  if (typeof target !== "string" || target === "") {
+    throw new Error("release archive shape requires a target triple");
+  }
+  return target.endsWith("-apple-darwin");
+}
+
+// Split an archive member path into its segments, rejecting the encodings that
+// let a member escape the extraction root.
+//
+// This runs against the archive listing rather than the extracted tree, because
+// by the time a traversing member has been materialized it has already been
+// written outside the directory under inspection.
+function memberSegments(member, label) {
+  if (typeof member !== "string" || member === "") {
+    throw new Error(`${label} contains an empty member path`);
+  }
+  if (member.includes("\\")) {
+    throw new Error(`${label} member '${member}' uses a backslash separator`);
+  }
+  if (member.startsWith("/")) {
+    throw new Error(`${label} member '${member}' is an absolute path`);
+  }
+  if (/^[A-Za-z]:/.test(member)) {
+    throw new Error(`${label} member '${member}' carries a drive prefix`);
+  }
+  const isDirectory = member.endsWith("/");
+  const segments = (isDirectory ? member.slice(0, -1) : member).split("/");
+  for (const segment of segments) {
+    if (segment === "") {
+      throw new Error(`${label} member '${member}' has an empty path segment`);
+    }
+    if (segment === "." || segment === "..") {
+      throw new Error(`${label} member '${member}' traverses its archive root`);
+    }
+  }
+  return { segments, isDirectory };
+}
+
+// Assert that an archive listing declares only the sanctioned release shape.
+//
+// Unix archives wrap their contents in a single `<artifact>/` directory; the
+// Windows zip is built from `<artifact>/*` and so is flat. Both are accepted,
+// but not mixed: an archive that is partly prefixed is describing two roots.
+function assertReleaseArchiveMemberPaths(memberPaths, options) {
+  const { artifact, target } = options ?? {};
+  if (typeof artifact !== "string" || artifact === "") {
+    throw new Error("release archive shape requires an artifact name");
+  }
+  const bundleAllowed = targetCarriesNotifierBundle(target);
+  const label = `${artifact} archive listing`;
+  if (!Array.isArray(memberPaths) || memberPaths.length === 0) {
+    throw new Error(`${label} is empty`);
+  }
+  if (memberPaths.length > MAX_ARCHIVE_MEMBERS) {
+    throw new Error(
+      `${label} declares ${memberPaths.length} members, above the limit of ${MAX_ARCHIVE_MEMBERS}`
+    );
+  }
+
+  const parsed = memberPaths.map((member) => ({
+    member,
+    ...memberSegments(member, label),
+  }));
+  const prefixed = parsed.filter((entry) => entry.segments[0] === artifact);
+  if (prefixed.length !== 0 && prefixed.length !== parsed.length) {
+    throw new Error(`${label} mixes prefixed and unprefixed members`);
+  }
+  const hasPrefix = prefixed.length === parsed.length;
+
+  let sawBundle = false;
+  for (const { member, segments, isDirectory } of parsed) {
+    const relative = hasPrefix ? segments.slice(1) : segments;
+    if (relative.length === 0) {
+      if (!isDirectory) {
+        throw new Error(`${label} declares its root '${member}' as a file`);
+      }
+      continue;
+    }
+    if (relative[0] === NOTIFIER_BUNDLE_DIR) {
+      if (!bundleAllowed) {
+        throw new Error(
+          `${label} carries ${NOTIFIER_BUNDLE_DIR} on non-macOS target ${target}`
+        );
+      }
+      if (relative.length > MAX_BUNDLE_DEPTH) {
+        throw new Error(`${label} member '${member}' is nested past the bundle depth limit`);
+      }
+      sawBundle = true;
+      continue;
+    }
+    if (relative.length > 1) {
+      throw new Error(`${label} member '${member}' nests content below the archive root`);
+    }
+    if (isDirectory) {
+      throw new Error(`${label} declares unexpected directory '${member}'`);
+    }
+  }
+
+  if (bundleAllowed && !sawBundle) {
+    throw new Error(`${label} is missing ${NOTIFIER_BUNDLE_DIR}`);
+  }
+}
+
+// Walk a materialized notification bundle and reject anything that is not a
+// plain file or directory beneath it.
+//
+// The archive listing check cannot see what extraction actually produced, so
+// this is the second half of the same guard: an entry that arrived as a
+// symbolic link, a device node, or a second application bundle is refused here
+// even if its declared path looked ordinary.
+function assertNotifierBundle(bundleRoot, bundleName) {
+  const seen = new Set();
+  const stack = [{ dir: bundleRoot, relative: [], depth: 0 }];
+  let count = 0;
+  while (stack.length > 0) {
+    const { dir, relative, depth } = stack.pop();
+    if (depth > MAX_BUNDLE_DEPTH) {
+      throw new Error(`${bundleName} nests past the depth limit of ${MAX_BUNDLE_DEPTH}`);
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      count += 1;
+      if (count > MAX_BUNDLE_ENTRIES) {
+        throw new Error(`${bundleName} holds more than ${MAX_BUNDLE_ENTRIES} entries`);
+      }
+      const entryRelative = [...relative, entry.name];
+      const printable = entryRelative.join("/");
+      if (entry.isSymbolicLink()) {
+        throw new Error(`${bundleName} entry '${printable}' is a symbolic link`);
+      }
+      if (entry.isDirectory()) {
+        if (entry.name.endsWith(".app")) {
+          throw new Error(`${bundleName} nests another application bundle at '${printable}'`);
+        }
+        stack.push({
+          dir: path.join(dir, entry.name),
+          relative: entryRelative,
+          depth: depth + 1,
+        });
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new Error(`${bundleName} entry '${printable}' is not a regular file`);
+      }
+      seen.add(printable);
+    }
+  }
+
+  for (const member of [NOTIFIER_BUNDLE_EXECUTABLE, NOTIFIER_BUNDLE_PLIST]) {
+    const printable = member.join("/");
+    if (!seen.has(printable)) {
+      throw new Error(`${bundleName} is missing '${printable}'`);
+    }
+  }
+  const executable = path.join(bundleRoot, ...NOTIFIER_BUNDLE_EXECUTABLE);
+  if ((fs.statSync(executable).mode & 0o111) === 0) {
+    throw new Error(
+      `${bundleName} entry '${NOTIFIER_BUNDLE_EXECUTABLE.join("/")}' is not executable`
+    );
+  }
+}
+
+// Classify the extracted root of a release archive into its component files and
+// its sanctioned bundles, refusing every other shape.
+//
+// The returned file list is the release's content inventory: it is what the
+// build job hashes into the per-artifact provenance manifest and what the
+// publish job compares that manifest against, so both sides agree on which
+// entries carry per-file provenance and which travel as a sealed bundle.
+function classifyReleaseArchiveRoot(contentRoot, options) {
+  const { target } = options ?? {};
+  const bundleAllowed = targetCarriesNotifierBundle(target);
+  const files = [];
+  const bundles = [];
+  for (const entry of fs.readdirSync(contentRoot, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      throw new Error(`release archive root entry '${entry.name}' is a symbolic link`);
+    }
+    if (entry.isFile()) {
+      files.push(entry.name);
+      continue;
+    }
+    if (!entry.isDirectory()) {
+      throw new Error(`release archive root entry '${entry.name}' is not a regular file`);
+    }
+    if (entry.name !== NOTIFIER_BUNDLE_DIR) {
+      throw new Error(`release archive root holds unexpected directory '${entry.name}'`);
+    }
+    if (!bundleAllowed) {
+      throw new Error(
+        `release archive root carries ${NOTIFIER_BUNDLE_DIR} on non-macOS target ${target}`
+      );
+    }
+    assertNotifierBundle(path.join(contentRoot, entry.name), entry.name);
+    bundles.push(entry.name);
+  }
+
+  if (bundleAllowed && bundles.length === 0) {
+    throw new Error(`release archive root for ${target} is missing ${NOTIFIER_BUNDLE_DIR}`);
+  }
+  files.sort();
+  bundles.sort();
+  return { files, bundles };
+}
+
+module.exports = {
+  MAX_ARCHIVE_MEMBERS,
+  MAX_BUNDLE_DEPTH,
+  MAX_BUNDLE_ENTRIES,
+  NOTIFIER_BUNDLE_DIR,
+  assertReleaseArchiveMemberPaths,
+  classifyReleaseArchiveRoot,
+  targetCarriesNotifierBundle,
+};

--- a/scripts/release-archive-shape.test.cjs
+++ b/scripts/release-archive-shape.test.cjs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  MAX_BUNDLE_ENTRIES,
+  NOTIFIER_BUNDLE_DIR,
+  assertReleaseArchiveMemberPaths,
+  classifyReleaseArchiveRoot,
+  targetCarriesNotifierBundle,
+} = require("./release-archive-shape.cjs");
+
+const MACOS_TARGET = "x86_64-apple-darwin";
+const LINUX_TARGET = "x86_64-unknown-linux-musl";
+const WINDOWS_TARGET = "x86_64-pc-windows-msvc";
+const MACOS_ARTIFACT = "kin-macos-x86_64";
+const LINUX_ARTIFACT = "kin-linux-x86_64";
+const WINDOWS_ARTIFACT = "kin-windows-x86_64";
+
+// Verbatim `tar -tzf kin-macos-x86_64.tar.gz` output from the release build that
+// this guard rejected, including its interleaved directory records and the
+// bundle's signature payload. Fixtures are derived from it rather than from an
+// idealized listing so the accepted shape is the shape a release actually has.
+const MACOS_LISTING = [
+  "kin-macos-x86_64/",
+  "kin-macos-x86_64/kin",
+  "kin-macos-x86_64/kin-vfs",
+  "kin-macos-x86_64/libkin_vfs_shim.dylib",
+  "kin-macos-x86_64/KinNotifier.app/",
+  "kin-macos-x86_64/kin-daemon",
+  "kin-macos-x86_64/KinNotifier.app/Contents/",
+  "kin-macos-x86_64/KinNotifier.app/Contents/CodeResources",
+  "kin-macos-x86_64/KinNotifier.app/Contents/_CodeSignature/",
+  "kin-macos-x86_64/KinNotifier.app/Contents/MacOS/",
+  "kin-macos-x86_64/KinNotifier.app/Contents/Resources/",
+  "kin-macos-x86_64/KinNotifier.app/Contents/Info.plist",
+  "kin-macos-x86_64/KinNotifier.app/Contents/Resources/Kin.icns",
+  "kin-macos-x86_64/KinNotifier.app/Contents/MacOS/KinNotifier",
+  "kin-macos-x86_64/KinNotifier.app/Contents/_CodeSignature/CodeResources",
+];
+
+// The same archive one release earlier, before the notification bundle shipped.
+const LINUX_LISTING = [
+  "kin-linux-x86_64/",
+  "kin-linux-x86_64/kin",
+  "kin-linux-x86_64/kin-vfs",
+  "kin-linux-x86_64/libkin_vfs_shim.so",
+  "kin-linux-x86_64/kin-daemon",
+];
+
+// The Windows zip is compressed from `<artifact>/*`, so its members carry no
+// artifact prefix at all.
+const WINDOWS_LISTING = ["kin.exe", "kin-daemon.exe", "kin-vfs.exe"];
+
+const MACOS_FILES = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"];
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "release-archive-shape-"));
+}
+
+function writeFile(root, relative, mode = 0o644) {
+  const file = path.join(root, ...relative);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, relative.join("/"));
+  fs.chmodSync(file, mode);
+  return file;
+}
+
+// Materialize the extracted content root of a real macOS release archive.
+function macosRoot(options = {}) {
+  const { bundle = true, executableMode = 0o755 } = options;
+  const root = tempRoot();
+  for (const name of MACOS_FILES) {
+    writeFile(root, [name], 0o755);
+  }
+  if (bundle) {
+    writeFile(root, [NOTIFIER_BUNDLE_DIR, "Contents", "Info.plist"]);
+    writeFile(root, [NOTIFIER_BUNDLE_DIR, "Contents", "CodeResources"]);
+    writeFile(root, [NOTIFIER_BUNDLE_DIR, "Contents", "Resources", "Kin.icns"]);
+    writeFile(root, [NOTIFIER_BUNDLE_DIR, "Contents", "_CodeSignature", "CodeResources"]);
+    writeFile(root, [NOTIFIER_BUNDLE_DIR, "Contents", "MacOS", "KinNotifier"], executableMode);
+  }
+  return root;
+}
+
+function linuxRoot() {
+  const root = tempRoot();
+  for (const name of ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"]) {
+    writeFile(root, [name], 0o755);
+  }
+  return root;
+}
+
+test("a macOS target carries the bundle and no other target does", () => {
+  assert.equal(targetCarriesNotifierBundle(MACOS_TARGET), true);
+  assert.equal(targetCarriesNotifierBundle("aarch64-apple-darwin"), true);
+  assert.equal(targetCarriesNotifierBundle(LINUX_TARGET), false);
+  assert.equal(targetCarriesNotifierBundle(WINDOWS_TARGET), false);
+  assert.throws(() => targetCarriesNotifierBundle(""), /requires a target triple/);
+});
+
+test("the released macOS archive listing is accepted whole", () => {
+  assertReleaseArchiveMemberPaths(MACOS_LISTING, {
+    artifact: MACOS_ARTIFACT,
+    target: MACOS_TARGET,
+  });
+});
+
+test("prefixed Unix and unprefixed Windows listings are both accepted", () => {
+  assertReleaseArchiveMemberPaths(LINUX_LISTING, {
+    artifact: LINUX_ARTIFACT,
+    target: LINUX_TARGET,
+  });
+  assertReleaseArchiveMemberPaths(WINDOWS_LISTING, {
+    artifact: WINDOWS_ARTIFACT,
+    target: WINDOWS_TARGET,
+  });
+});
+
+test("a listing that escapes or renames its archive root is rejected", () => {
+  const cases = [
+    [["/etc/passwd"], /is an absolute path/],
+    [["C:/Windows/system32/kin.exe"], /carries a drive prefix/],
+    [[`${LINUX_ARTIFACT}/../kin`], /traverses its archive root/],
+    [[`${LINUX_ARTIFACT}/./kin`], /traverses its archive root/],
+    [[`${LINUX_ARTIFACT}\\kin`], /uses a backslash separator/],
+    [[`${LINUX_ARTIFACT}//kin`], /has an empty path segment/],
+    [[""], /contains an empty member path/],
+    [[], /is empty/],
+    [[`${LINUX_ARTIFACT}`], /declares its root .* as a file/],
+    [[...LINUX_LISTING, "kin-daemon"], /mixes prefixed and unprefixed members/],
+  ];
+  for (const [listing, expected] of cases) {
+    assert.throws(
+      () =>
+        assertReleaseArchiveMemberPaths(listing, {
+          artifact: LINUX_ARTIFACT,
+          target: LINUX_TARGET,
+        }),
+      expected,
+      `listing ${JSON.stringify(listing)} should have been refused`
+    );
+  }
+});
+
+test("a listing nesting anything but the sanctioned bundle is rejected", () => {
+  assert.throws(
+    () =>
+      assertReleaseArchiveMemberPaths([...LINUX_LISTING, `${LINUX_ARTIFACT}/payload/kin`], {
+        artifact: LINUX_ARTIFACT,
+        target: LINUX_TARGET,
+      }),
+    /nests content below the archive root/
+  );
+  assert.throws(
+    () =>
+      assertReleaseArchiveMemberPaths([...LINUX_LISTING, `${LINUX_ARTIFACT}/payload/`], {
+        artifact: LINUX_ARTIFACT,
+        target: LINUX_TARGET,
+      }),
+    /declares unexpected directory/
+  );
+  assert.throws(
+    () =>
+      assertReleaseArchiveMemberPaths(
+        [...MACOS_LISTING, `${MACOS_ARTIFACT}/KinNotifier.appx/payload`],
+        { artifact: MACOS_ARTIFACT, target: MACOS_TARGET }
+      ),
+    /nests content below the archive root/
+  );
+});
+
+test("the bundle is required on macOS listings and refused on every other target", () => {
+  assert.throws(
+    () =>
+      assertReleaseArchiveMemberPaths(
+        MACOS_LISTING.filter((member) => !member.includes(NOTIFIER_BUNDLE_DIR)),
+        { artifact: MACOS_ARTIFACT, target: MACOS_TARGET }
+      ),
+    /is missing KinNotifier\.app/
+  );
+  assert.throws(
+    () =>
+      assertReleaseArchiveMemberPaths(
+        [...LINUX_LISTING, `${LINUX_ARTIFACT}/KinNotifier.app/Contents/Info.plist`],
+        { artifact: LINUX_ARTIFACT, target: LINUX_TARGET }
+      ),
+    /carries KinNotifier\.app on non-macOS target/
+  );
+});
+
+test("the extracted macOS root yields exactly the four provenance-bearing files", () => {
+  const root = macosRoot();
+  const { files, bundles } = classifyReleaseArchiveRoot(root, { target: MACOS_TARGET });
+  assert.deepEqual(files, MACOS_FILES);
+  assert.deepEqual(bundles, [NOTIFIER_BUNDLE_DIR]);
+});
+
+test("the extracted Linux root yields its files and no bundle", () => {
+  const { files, bundles } = classifyReleaseArchiveRoot(linuxRoot(), { target: LINUX_TARGET });
+  assert.deepEqual(files, ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"]);
+  assert.deepEqual(bundles, []);
+});
+
+test("an extracted root holding an unsanctioned directory is rejected", () => {
+  const root = macosRoot();
+  fs.mkdirSync(path.join(root, "payload"));
+  assert.throws(
+    () => classifyReleaseArchiveRoot(root, { target: MACOS_TARGET }),
+    /holds unexpected directory 'payload'/
+  );
+});
+
+test("an extracted root is rejected for a missing or misplaced bundle", () => {
+  assert.throws(
+    () => classifyReleaseArchiveRoot(macosRoot({ bundle: false }), { target: MACOS_TARGET }),
+    /is missing KinNotifier\.app/
+  );
+  const linux = linuxRoot();
+  fs.mkdirSync(path.join(linux, NOTIFIER_BUNDLE_DIR, "Contents", "MacOS"), { recursive: true });
+  assert.throws(
+    () => classifyReleaseArchiveRoot(linux, { target: LINUX_TARGET }),
+    /carries KinNotifier\.app on non-macOS target/
+  );
+});
+
+test("symbolic links are refused at the archive root and inside the bundle", () => {
+  const root = macosRoot();
+  fs.symlinkSync(path.join(root, "kin"), path.join(root, "kin-link"));
+  assert.throws(
+    () => classifyReleaseArchiveRoot(root, { target: MACOS_TARGET }),
+    /root entry 'kin-link' is a symbolic link/
+  );
+
+  const disguised = macosRoot({ bundle: false });
+  const real = macosRoot();
+  fs.symlinkSync(path.join(real, NOTIFIER_BUNDLE_DIR), path.join(disguised, NOTIFIER_BUNDLE_DIR));
+  assert.throws(
+    () => classifyReleaseArchiveRoot(disguised, { target: MACOS_TARGET }),
+    /root entry 'KinNotifier\.app' is a symbolic link/
+  );
+
+  const nested = macosRoot();
+  fs.symlinkSync(
+    path.join(nested, "kin"),
+    path.join(nested, NOTIFIER_BUNDLE_DIR, "Contents", "MacOS", "shortcut")
+  );
+  assert.throws(
+    () => classifyReleaseArchiveRoot(nested, { target: MACOS_TARGET }),
+    /entry 'Contents\/MacOS\/shortcut' is a symbolic link/
+  );
+});
+
+test("a bundle missing a required member or its executable bit is rejected", () => {
+  const noExecutable = macosRoot();
+  fs.rmSync(path.join(noExecutable, NOTIFIER_BUNDLE_DIR, "Contents", "MacOS", "KinNotifier"));
+  assert.throws(
+    () => classifyReleaseArchiveRoot(noExecutable, { target: MACOS_TARGET }),
+    /is missing 'Contents\/MacOS\/KinNotifier'/
+  );
+
+  const noPlist = macosRoot();
+  fs.rmSync(path.join(noPlist, NOTIFIER_BUNDLE_DIR, "Contents", "Info.plist"));
+  assert.throws(
+    () => classifyReleaseArchiveRoot(noPlist, { target: MACOS_TARGET }),
+    /is missing 'Contents\/Info\.plist'/
+  );
+
+  assert.throws(
+    () => classifyReleaseArchiveRoot(macosRoot({ executableMode: 0o644 }), { target: MACOS_TARGET }),
+    /entry 'Contents\/MacOS\/KinNotifier' is not executable/
+  );
+});
+
+test("a bundle hiding another bundle or exceeding its entry budget is rejected", () => {
+  const nestedApp = macosRoot();
+  fs.mkdirSync(path.join(nestedApp, NOTIFIER_BUNDLE_DIR, "Contents", "Payload.app"), {
+    recursive: true,
+  });
+  assert.throws(
+    () => classifyReleaseArchiveRoot(nestedApp, { target: MACOS_TARGET }),
+    /nests another application bundle at 'Contents\/Payload\.app'/
+  );
+
+  const overfull = macosRoot();
+  for (let index = 0; index <= MAX_BUNDLE_ENTRIES; index += 1) {
+    writeFile(overfull, [NOTIFIER_BUNDLE_DIR, "Contents", "Resources", `filler-${index}`]);
+  }
+  assert.throws(
+    () => classifyReleaseArchiveRoot(overfull, { target: MACOS_TARGET }),
+    new RegExp(`holds more than ${MAX_BUNDLE_ENTRIES} entries`)
+  );
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3136,6 +3136,49 @@ def main() -> None:
         "./scripts/read-update-build-identity.test.cjs",
         "static release build identity parser regression",
     )
+
+    # The archive that carries the release and the manifest that describes it are
+    # produced by one job and judged by another. Both must decide what a release
+    # archive is allowed to contain from the same rules, or a shape one side
+    # emits is a shape the other refuses at publish time.
+    for policy in (
+        'require("./scripts/release-archive-shape.cjs")',
+        "classifyReleaseArchiveRoot(artifact, { target })",
+    ):
+        require(build_job, policy, "sanctioned release archive shape at packaging")
+    for policy in (
+        'require("./scripts/release-archive-shape.cjs")',
+        "assertReleaseArchiveMemberPaths(",
+        "classifyReleaseArchiveRoot(contentRoot, {",
+    ):
+        require(publish_job, policy, "sanctioned release archive shape at publish")
+    for forbidden in (
+        "entries.every((entry) => entry.isFile())",
+        ".filter((entry) => entry.isFile())",
+    ):
+        if forbidden in publish_job or forbidden in build_job:
+            raise AssertionError(
+                "release archive shape must be judged by the shared classifier, not by "
+                f"an inline entry-type filter: {forbidden}"
+            )
+    member_path_check = publish_job.index("assertReleaseArchiveMemberPaths(")
+    archive_extraction = publish_job.index("fs.mkdtempSync(path.join(os.tmpdir()")
+    if member_path_check >= archive_extraction:
+        raise AssertionError(
+            "release archive member paths must be judged before extraction, because a "
+            "member that escapes the extraction root has already been written by then"
+        )
+    if 'tar tzf "${ARTIFACT}.tar.gz" | grep' in build_job:
+        raise AssertionError(
+            "release packaging must read the archive listing from a file: piping it into "
+            "grep lets an early grep exit fail the pipeline under pipefail, which is "
+            "indistinguishable from the member being absent"
+        )
+    require(
+        ci_workflow,
+        "./scripts/release-archive-shape.test.cjs",
+        "release archive shape regression",
+    )
     archive_attestation_start = publish_job.index(
         "      - name: Attest final release archives and provenance"
     )


### PR DESCRIPTION
## What broke

`v0.4.4`'s release run failed at Publish Release with `kin-macos-x86_64.tar.gz has unexpected nested content`. The publish job asserted that every entry at a release archive's root is a regular file. macOS archives carry `KinNotifier.app`, a directory, and have since the notification bundle shipped.

Neither side was wrong on its own. The flat-file assertion landed in "Enforce public release proof gate" on 2026-07-10; the bundle landed in "Give Kin its own macOS notification identity" on 2026-07-26. `v0.3.6`, the last published release, was cut about seven hours before the bundle commit, so the guard and the bundle had never been exercised together until a real tag reached the publish job.

Confirmed against the real artifacts of run 30647442701. Both macOS legs carry the bundle; the four flat files are unchanged from `v0.3.6`.

```
kin-macos-x86_64/kin
kin-macos-x86_64/kin-vfs
kin-macos-x86_64/libkin_vfs_shim.dylib
kin-macos-x86_64/kin-daemon
kin-macos-x86_64/KinNotifier.app/Contents/Info.plist
kin-macos-x86_64/KinNotifier.app/Contents/CodeResources
kin-macos-x86_64/KinNotifier.app/Contents/MacOS/KinNotifier
kin-macos-x86_64/KinNotifier.app/Contents/Resources/Kin.icns
kin-macos-x86_64/KinNotifier.app/Contents/_CodeSignature/CodeResources
```

Relaxing the one assertion would not have been enough. The build job builds `archive_contents` with `.filter(entry => entry.isFile())`, so the manifest omits the bundle while the verifier's `actualNames` includes it, which fails the inventory comparison next; the per-name hash loop then calls `readFileSync` on a directory.

## Why the packaging is not what changed

Every consuming surface was read before choosing a direction.

| Surface | Behavior with a `KinNotifier.app/` entry |
| --- | --- |
| `scripts/install.sh:239-257` | Installs it. Moves the bundle whole to `~/.kin/lib/KinNotifier.app`, chmods the executable, registers it with LaunchServices. |
| `crates/kin-cli/src/commands/update.rs:5529-5538` | Skips it by design. `is_notifier_bundle_entry` keeps a macOS archive stageable; `update.rs:8225` hard-rejects any `archive_contents` name outside the managed component list. |
| `packages/kin/lib/provision.mjs:146-184` | Ignored. Extracts to a temp dir, copies enumerated names, deletes the temp dir. |
| `homebrew-kin/Formula/kin.rb:41-45` | Ignored. Literal-name `bin.install` only. |
| `.github/workflows/install-proof.yml:316-323` | Ignored. Compares two named components. |
| `scripts/install.ps1` | Not applicable. The Windows zip never carries the bundle. |

The bundle already installs and functions through the primary install path. The only surface that breaks is the publish verifier, so the verifier is what changed.

## What this does

`scripts/release-archive-shape.cjs` owns the sanctioned shape, and both the packaging job and the publish job consult it, so the archive's producer and its judge decide what an archive may contain from one set of rules.

- `assertReleaseArchiveMemberPaths` judges the archive listing before extraction. Absolute paths, drive prefixes, `..` and `.` traversal, backslash separators, empty segments, and archives that mix prefixed and unprefixed roots are refused. A member that escapes the extraction root has already been written somewhere else by the time the extracted tree can be inspected, which is why this runs first.
- `classifyReleaseArchiveRoot` judges the extracted tree and returns the component files. Only a macOS target may carry `KinNotifier.app`, and a macOS archive without it is refused, because a missing notifier is a silent downgrade to notifications credited to Script Editor rather than a visible failure. Any other directory, a symbolic link at the root or inside the bundle, a nested application bundle, a missing `Contents/MacOS/KinNotifier` or `Contents/Info.plist`, an executable without its executable bit, and anything past the entry and depth budgets are all refused.

The bundle stays out of `archive_contents` deliberately. `update.rs:8225` refuses any inventory name outside its managed component list, so naming the bundle there would break `kin update` for every already-installed version. Its bytes are covered by the archive digest, by its own code signature, and by the notarization ticket stapled inside it.

Packaging also now reads the archive listing from a file rather than piping it into `grep -q`. An early `grep` exit raises SIGPIPE on `tar`, and under `pipefail` that fails the pipeline, which reads exactly like the member being absent. The listing is short enough that this has not fired, but the guard cannot be allowed to invert.

## Evidence

- `node --test scripts/release-archive-shape.test.cjs`: 13 tests, fixtures derived from the real `v0.4.4` listing including its interleaved directory records and signature payload. Wired into both `node --test` blocks in `ci.yml`.
- `python3 scripts/test-release-workflow-authority.py`: passes, and now pins that both jobs require the shared module, that neither reintroduces an inline entry-type filter, that member paths are judged before extraction, that packaging does not pipe its listing into grep, and that CI runs the regression.
- Replayed the repaired verifier against all four real artifacts of run 30647442701. Every one passes, and each computed inventory matches its shipped provenance manifest exactly, including the flat Windows zip that carries no artifact prefix.

```
kin-macos-x86_64.tar.gz: inventory ["kin","kin-daemon","kin-vfs","libkin_vfs_shim.dylib"] matches manifest
kin-macos-aarch64.tar.gz: inventory ["kin","kin-daemon","kin-vfs","libkin_vfs_shim.dylib"] matches manifest
kin-linux-x86_64.tar.gz: inventory ["kin","kin-daemon","kin-vfs","libkin_vfs_shim.so"] matches manifest
kin-windows-x86_64.zip: inventory ["kin-daemon.exe","kin.exe"] matches manifest
```

- Falsification: 22 mutations, one per guard and per authority pin. Each was applied, the suite run, and the file restored. All 14 shape-module mutations turn the covering subtest red, including reinstating the flat-file refusal, which reddens the test that accepts the real macOS shape. All 8 authority-pin mutations are refused with the intended message.
- Also green locally: the full release `node --test` set (40 tests), `test_install_optional_vfs.py`, `test_installer_parity.py`, `test-install-checksum.py`, `test-homebrew-release-gate.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, both npm package suites, `verify-zero-file-search.py`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`.

`v0.4.4` itself stays unpublishable: its workflow snapshot is frozen at the tag. This targets `main` and takes effect on the next tag.

Closes FIR-1783.
