### PR TITLE
Prove the state a test depends on instead of assuming a signal, a budget, or a feature

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -17786,6 +17786,12 @@ mod tests {
         );
     }
 
+    /// Vector-gated: the counts asserted below describe a build that HAS an
+    /// embedding pipeline and has not run it. A vector-free build reports
+    /// `supported = false` and counts different targets, which is correct
+    /// behaviour and not partial coverage, so the featureless contract is a
+    /// separate assertion rather than a looser version of this one.
+    #[cfg(feature = "vector")]
     #[test]
     #[serial_test::serial]
     fn locate_degrades_gracefully_on_incomplete_embeddings() {
@@ -17822,6 +17828,48 @@ mod tests {
         assert!(
             coverage.note.is_some(),
             "partial coverage must carry a degradation note"
+        );
+    }
+
+    /// The featureless half of the graceful-degradation contract. The
+    /// vector-gated case above covers the strict knob; this covers the default
+    /// path, where a build with no embedding pipeline must still answer and
+    /// must say plainly that the semantic signal is unavailable rather than
+    /// reporting it as merely incomplete.
+    #[cfg(not(feature = "vector"))]
+    #[test]
+    #[serial_test::serial]
+    fn vector_free_locate_degrades_gracefully_on_the_default_path() {
+        let graph = kin_db::InMemoryGraph::new();
+        let entity = test_entity("handler", "src/lib.py", 1, 5);
+        graph.upsert_entity(&entity).unwrap();
+        admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
+
+        let _coverage = kin_core::test_env::EnvVarGuard::unset("KIN_REQUIRE_COMPLETE_EMBEDDINGS")
+            .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
+        let result = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            true,
+            10,
+            true,
+            LocateBudget::unbounded(),
+        )
+        .expect("a vector-free build must degrade gracefully, not error");
+
+        let coverage = result
+            .semantic_coverage
+            .expect("semantic_coverage must be reported");
+        assert!(
+            !coverage.supported,
+            "a vector-free build must report semantic ranking as unsupported"
+        );
+        assert_eq!(coverage.indexed, 0, "no embeddings indexed in this graph");
+        assert!(!coverage.complete, "coverage must be marked incomplete");
+        assert!(
+            coverage.note.is_some(),
+            "unsupported coverage must carry its explanation"
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -646,43 +646,82 @@ struct LocateBudget {
     warnings: Vec<String>,
 }
 
+/// The budget-gated phases of the locate pipeline, with the environment knob
+/// and default that size each one. Named once so a budget built for a test
+/// covers exactly the phases a real query is gated on, rather than falling
+/// through to `phase_remaining`'s generic default for a phase this table
+/// forgot.
+const LOCATE_PHASE_BUDGETS: [(&str, &str, f64); 6] = [
+    (
+        "entity_discovery",
+        "KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS",
+        20.0,
+    ),
+    (
+        "entity_resolution",
+        "KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS",
+        20.0,
+    ),
+    ("multihop", "KIN_LOCATE_PHASE_MULTIHOP_SECS", 20.0),
+    ("text_search", "KIN_LOCATE_PHASE_TEXT_SEARCH_SECS", 10.0),
+    ("source_text", "KIN_LOCATE_PHASE_SOURCE_TEXT_SECS", 10.0),
+    ("scoring", "KIN_LOCATE_PHASE_SCORING_SECS", 10.0),
+];
+
 impl LocateBudget {
-    fn new() -> Self {
+    /// The budget a real query runs under, resolved from the environment.
+    fn from_env() -> Self {
         // Timeout/budget knobs: `0` means unbounded (disable the budget) rather
         // than a real 0 s deadline that would skip every phase and gut retrieval.
         // The unbounded sentinel (`f64::INFINITY`) flows harmlessly through the
         // `elapsed > total_secs` / `remaining_total` comparisons below.
         use kin_core::env_registry::env_secs_bound_f64 as secs_budget;
-        let total = secs_budget("KIN_LOCATE_TOTAL_TIMEOUT_SECS", 90.0);
-        let mut phase_budgets = HashMap::new();
-        phase_budgets.insert(
-            "entity_discovery",
-            secs_budget("KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS", 20.0),
-        );
-        phase_budgets.insert(
-            "entity_resolution",
-            secs_budget("KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS", 20.0),
-        );
-        phase_budgets.insert(
-            "multihop",
-            secs_budget("KIN_LOCATE_PHASE_MULTIHOP_SECS", 20.0),
-        );
-        phase_budgets.insert(
-            "text_search",
-            secs_budget("KIN_LOCATE_PHASE_TEXT_SEARCH_SECS", 10.0),
-        );
-        phase_budgets.insert(
-            "source_text",
-            secs_budget("KIN_LOCATE_PHASE_SOURCE_TEXT_SECS", 10.0),
-        );
-        phase_budgets.insert(
-            "scoring",
-            secs_budget("KIN_LOCATE_PHASE_SCORING_SECS", 10.0),
-        );
         Self {
             start: std::time::Instant::now(),
-            total_secs: total,
-            phase_budgets,
+            total_secs: secs_budget("KIN_LOCATE_TOTAL_TIMEOUT_SECS", 90.0),
+            phase_budgets: LOCATE_PHASE_BUDGETS
+                .iter()
+                .map(|(phase, knob, default)| (*phase, secs_budget(knob, *default)))
+                .collect(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// A budget that never truncates retrieval.
+    ///
+    /// Every budget-gated phase is a wall-clock decision, so a test that
+    /// asserts on WHAT locate finds is otherwise asserting on how much CPU the
+    /// host granted it. A stall long enough to exhaust the total budget makes
+    /// the pipeline skip entity discovery outright and return `Ok` with no
+    /// files, which is indistinguishable from a retrieval regression at the
+    /// assertion. Tests that mean to describe retrieval semantics take this and
+    /// leave scheduling out of the result.
+    #[cfg(test)]
+    fn unbounded() -> Self {
+        Self::uniform(f64::INFINITY)
+    }
+
+    /// A budget that is already spent before the pipeline starts.
+    ///
+    /// Deterministic where a small positive budget is not: the total is behind
+    /// the start instant, so the first phase gate is over budget however fast
+    /// the host is. This exists so the budget-truncation contract can be
+    /// asserted directly instead of being waited for.
+    #[cfg(test)]
+    fn already_exhausted() -> Self {
+        Self::uniform(-1.0)
+    }
+
+    /// Every gate in the pipeline, total and per phase, set to `secs`.
+    #[cfg(test)]
+    fn uniform(secs: f64) -> Self {
+        Self {
+            start: std::time::Instant::now(),
+            total_secs: secs,
+            phase_budgets: LOCATE_PHASE_BUDGETS
+                .iter()
+                .map(|(phase, _, _)| (*phase, secs))
+                .collect(),
             warnings: Vec::new(),
         }
     }
@@ -1578,6 +1617,75 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
 ) -> Result<LocateResult> {
+    run_with_graph_capture_budgeted(
+        graph,
+        workspace_root,
+        text,
+        explain,
+        max_files,
+        max_files_explicit,
+        extra_priority_files,
+        vector_source,
+        snippet_opts,
+        repository_authority,
+        source_scope,
+        LocateBudget::from_env(),
+    )
+}
+
+/// Locate over a workspace graph under an explicit retrieval budget.
+///
+/// The shape tests use when the assertion is about what retrieval returns. The
+/// production wrappers resolve the budget from the environment, which makes
+/// their results a function of how much wall clock the host granted; a test
+/// that asserts on found files and inherits that is asserting on scheduling.
+#[cfg(test)]
+fn run_with_graph_capture_in_workspace_budgeted(
+    graph: &kin_db::InMemoryGraph,
+    workspace_root: Option<&std::path::Path>,
+    text: &str,
+    explain: bool,
+    max_files: usize,
+    max_files_explicit: bool,
+    budget: LocateBudget,
+) -> Result<LocateResult> {
+    run_with_graph_capture_budgeted(
+        graph,
+        workspace_root,
+        text,
+        explain,
+        max_files,
+        max_files_explicit,
+        Vec::new(),
+        None,
+        SnippetOptions::default(),
+        None,
+        kin_mcp::handlers::common::EntitySourceScope::WorkspaceHead,
+        budget,
+    )
+}
+
+/// The locate pipeline, with its retrieval budget taken by argument.
+///
+/// The budget decides whether a phase runs at all, so it is an input to
+/// retrieval and not an ambient property of the process. Passing it in is what
+/// lets a caller that cares about WHAT locate finds separate that question from
+/// how much wall clock the host granted the query.
+#[allow(clippy::too_many_arguments)]
+fn run_with_graph_capture_budgeted(
+    graph: &kin_db::InMemoryGraph,
+    workspace_root: Option<&std::path::Path>,
+    text: &str,
+    explain: bool,
+    max_files: usize,
+    max_files_explicit: bool,
+    extra_priority_files: Vec<(String, f32)>,
+    vector_source: Option<&kin_db::InMemoryGraph>,
+    snippet_opts: SnippetOptions,
+    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
+    source_scope: kin_mcp::handlers::common::EntitySourceScope,
+    mut budget: LocateBudget,
+) -> Result<LocateResult> {
     let _span = tracing::info_span!(
         "kin.locate.run_with_graph",
         text_len = text.len(),
@@ -1603,7 +1711,6 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     // Per-stage prune attribution, recorded only under --explain.
     let mut prune_ledger: Vec<PruneEvent> = Vec::new();
 
-    let mut budget = LocateBudget::new();
     let pipeline_report = std::env::var("KIN_LOCATE_PIPELINE_REPORT").is_ok();
     let profile = LocateProfile::detect();
     // Surface a hardware-driven quality downgrade in-band: on a sub-Performance
@@ -3518,6 +3625,24 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
             warnings = ?budget.warnings,
             "locate pipeline completed with budget warnings"
         );
+        // A budget that truncated discovery returns FEWER results, not an error,
+        // so without this the caller cannot tell "nothing matched" from "the
+        // pipeline stopped looking". The early scoring-skip return already
+        // reports this; a phase skipped mid-pipeline has to report it as well
+        // or the same silence returns through the other door.
+        record_degradation(
+            &mut degradations,
+            RetrievalDegradation {
+                component: "pipeline".to_string(),
+                reason: "budget_exhausted".to_string(),
+                detail: format!(
+                    "locate budget exhausted after {:.1}s; {}",
+                    budget.elapsed_secs(),
+                    budget.warnings.join("; ")
+                ),
+                remediation: "raise KIN_LOCATE_TOTAL_TIMEOUT_SECS for this repo size".to_string(),
+            },
+        );
     }
 
     // D_empty lever (default ON — measurement-backed: 51/51 official scorer,
@@ -3669,6 +3794,7 @@ pub fn run_with_graph_capture_at_ref(
         max_files,
         max_files_explicit,
         snippet_opts,
+        LocateBudget::from_env(),
     )
 }
 
@@ -3683,6 +3809,7 @@ fn run_with_repository_authority_capture_at_ref<B>(
     max_files: usize,
     max_files_explicit: bool,
     snippet_opts: SnippetOptions,
+    budget: LocateBudget,
 ) -> Result<LocateResult>
 where
     B: kin_db::StorageBackend + ?Sized + 'static,
@@ -3699,7 +3826,7 @@ where
     let _ = crate::commands::cochange::refresh_from_changes(&historical, &changes);
     let extra_priority_files =
         discover_historical_test_artifact_priority_files(&historical, reference, text);
-    run_with_graph_capture_with_priority_files_and_vector_source(
+    run_with_graph_capture_budgeted(
         &historical,
         None,
         text,
@@ -3711,6 +3838,7 @@ where
         snippet_opts,
         repository_authority,
         kin_mcp::handlers::common::EntitySourceScope::At(*head),
+        budget,
     )
 }
 
@@ -17102,13 +17230,14 @@ mod tests {
         // `workspace_root = None` is a scoped-session daemon locate: the
         // workspace is off-limits, so every source-text resolution must be
         // satisfied from graph-owned bodies or reported as a gap.
-        let result = run_with_graph_capture_in_workspace(
+        let result = run_with_graph_capture_in_workspace_budgeted(
             &graph,
             None,
             "where is parse_config defined",
             true,
             10,
             true,
+            LocateBudget::unbounded(),
         )
         .unwrap();
 
@@ -17235,12 +17364,20 @@ mod tests {
         let renamed = tempfile::TempDir::new().unwrap();
 
         let answer = |root: Option<&std::path::Path>| {
-            run_with_graph_capture_in_workspace(&graph, root, query, false, 10, false)
-                .unwrap()
-                .files
-                .into_iter()
-                .map(|entry| entry.path)
-                .collect::<Vec<_>>()
+            run_with_graph_capture_in_workspace_budgeted(
+                &graph,
+                root,
+                query,
+                false,
+                10,
+                false,
+                LocateBudget::unbounded(),
+            )
+            .unwrap()
+            .files
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<_>>()
         };
 
         let present_answer = answer(Some(present.path()));
@@ -17538,7 +17675,15 @@ mod tests {
         let _coverage =
             kin_core::test_env::EnvVarGuard::set("KIN_REQUIRE_COMPLETE_EMBEDDINGS", "1")
                 .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
-        let result = run_with_graph_capture(&graph, "handler failure", true, 10, true);
+        let result = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            true,
+            10,
+            true,
+            LocateBudget::unbounded(),
+        );
 
         let err = match result {
             Ok(_) => panic!("strict mode should reject incomplete embeddings"),
@@ -17562,8 +17707,16 @@ mod tests {
         let _coverage =
             kin_core::test_env::EnvVarGuard::set("KIN_REQUIRE_COMPLETE_EMBEDDINGS", "1")
                 .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
-        let result = run_with_graph_capture(&graph, "handler failure", true, 10, true)
-            .expect("a vector-free build must still serve lexical and graph locate");
+        let result = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            true,
+            10,
+            true,
+            LocateBudget::unbounded(),
+        )
+        .expect("a vector-free build must still serve lexical and graph locate");
 
         let coverage = result
             .semantic_coverage
@@ -17580,6 +17733,59 @@ mod tests {
         assert!(!vector_degradations[0].remediation.contains("kin embed"));
     }
 
+    /// A budget that truncated retrieval must say so on the result.
+    ///
+    /// Over budget the pipeline skips discovery and returns `Ok` with fewer
+    /// files, so "found nothing" and "stopped looking" are the same value at
+    /// the assertion. That is what made a wall-clock stall read as a retrieval
+    /// regression. The degradation ledger is what tells them apart, and it has
+    /// to be populated on the completing path and not only on the early return.
+    #[test]
+    fn budget_truncated_locate_reports_the_truncation_rather_than_an_empty_result() {
+        let graph = kin_db::InMemoryGraph::new();
+        let entity = test_entity("handler", "src/lib.py", 1, 5);
+        graph.upsert_entity(&entity).unwrap();
+        admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
+
+        let starved = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            false,
+            10,
+            true,
+            LocateBudget::already_exhausted(),
+        )
+        .expect("an exhausted budget truncates retrieval, it does not error");
+        assert!(
+            starved.degradations.iter().any(|degradation| {
+                degradation.component == "pipeline" && degradation.reason == "budget_exhausted"
+            }),
+            "a truncated locate must carry its budget_exhausted degradation, got {:?}",
+            starved.degradations
+        );
+
+        // The control: the same query under a budget that cannot truncate must
+        // NOT claim truncation, or the marker means nothing.
+        let whole = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            false,
+            10,
+            true,
+            LocateBudget::unbounded(),
+        )
+        .expect("an unbounded budget runs the whole pipeline");
+        assert!(
+            !whole.degradations.iter().any(|degradation| {
+                degradation.component == "pipeline" && degradation.reason == "budget_exhausted"
+            }),
+            "an untruncated locate must not claim a budget was exhausted, got {:?}",
+            whole.degradations
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn locate_degrades_gracefully_on_incomplete_embeddings() {
@@ -17593,8 +17799,16 @@ mod tests {
 
         let _coverage = kin_core::test_env::EnvVarGuard::unset("KIN_REQUIRE_COMPLETE_EMBEDDINGS")
             .without("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK");
-        let result = run_with_graph_capture(&graph, "handler failure", true, 10, true)
-            .expect("default locate must degrade gracefully, not error");
+        let result = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            true,
+            10,
+            true,
+            LocateBudget::unbounded(),
+        )
+        .expect("default locate must degrade gracefully, not error");
 
         let coverage = result
             .semantic_coverage
@@ -23540,6 +23754,10 @@ mod tests {
         #[cfg(feature = "vector")]
         load_complete_test_vectors(&current_graph, &[entity_v2.clone()]);
 
+        // Unbounded on purpose: this asserts which files historical locate
+        // surfaces, and under the environment budget a slow enough host skips
+        // entity discovery outright and returns zero files, which reads at the
+        // assertion exactly like a retrieval regression.
         let historical = run_with_repository_authority_capture_at_ref(
             None,
             &authority,
@@ -23551,6 +23769,7 @@ mod tests {
             10,
             true,
             SnippetOptions::default(),
+            LocateBudget::unbounded(),
         )
         .unwrap();
         assert_eq!(
@@ -23574,6 +23793,7 @@ mod tests {
             10,
             true,
             SnippetOptions::default(),
+            LocateBudget::unbounded(),
         )
         .unwrap();
         assert!(

--- a/crates/kin-cli/src/commands/prepared_state.rs
+++ b/crates/kin-cli/src/commands/prepared_state.rs
@@ -627,6 +627,12 @@ mod tests {
         );
     }
 
+    /// Vector-gated: the message asserted here comes from opening the sidecar
+    /// and finding it invalid, which is work only a build with a vector index
+    /// can do. A vector-free build refuses the same prepared state earlier and
+    /// for a different reason, asserted separately below, so both builds are
+    /// held to a refusal rather than one of them being left unchecked.
+    #[cfg(feature = "vector")]
     #[test]
     fn validation_rejects_invalid_vector_sidecar_when_embeddings_expected() {
         let dir = tempfile::tempdir().unwrap();
@@ -638,6 +644,25 @@ mod tests {
         assert!(
             msg.contains("validate prepared vector index") && msg.contains("graph.kvec"),
             "error should explain coverage validation failed, got: {msg}"
+        );
+    }
+
+    /// A build with vector support compiled out cannot restore an embeddings
+    /// prepared state at all, so reuse must refuse it and say why. Silently
+    /// accepting it would reopen with an empty index, which is the dormant-index
+    /// trap the vector-gated case above guards from the other side.
+    #[cfg(not(feature = "vector"))]
+    #[test]
+    fn vector_free_validation_refuses_prepared_state_that_expects_embeddings() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = make_prepared_dir(dir.path(), true, true, /* with_vectors */ true);
+
+        let err = validate_prepared_state(dir.path(), &manifest)
+            .expect_err("a vector-free build must refuse an embeddings prepared state");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("vector support disabled"),
+            "error should explain the build cannot serve embeddings, got: {msg}"
         );
     }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3392,6 +3392,67 @@ mod tests {
         assert_test_child_reaped(sentinel_pid);
     }
 
+    /// A target that enters a second stop is exactly the shape a single
+    /// fire-and-forget `SIGCONT` cannot clear, so this pins the property the
+    /// fork-boundary handshake depends on: a release is complete only once the
+    /// target's own progress proves it is running, not once a signal has been
+    /// sent. Replace [`resume_test_pid_until`] with a bare `kill(SIGCONT)` and
+    /// the child never reaches its marker, so this goes red.
+    #[cfg(unix)]
+    #[test]
+    fn resuming_a_stopped_target_clears_every_stop_it_enters() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let marker = root.path().join("resumed");
+        // Built before the fork: the child runs between a fork and an `_exit`
+        // in a multi-threaded process, where allocating can deadlock against a
+        // lock another thread held at fork time.
+        let marker_path = std::ffi::CString::new(marker.as_os_str().as_bytes()).unwrap();
+
+        let child = unsafe { libc::fork() };
+        assert_ne!(child, -1, "fork resume-probe child");
+        if child == 0 {
+            unsafe {
+                libc::raise(libc::SIGSTOP);
+                libc::raise(libc::SIGSTOP);
+                let fd = libc::open(
+                    marker_path.as_ptr(),
+                    libc::O_CREAT | libc::O_WRONLY | libc::O_TRUNC,
+                    0o600 as libc::c_int,
+                );
+                if fd < 0 {
+                    libc::_exit(1);
+                }
+                let body = b"resumed\n";
+                let written = libc::write(fd, body.as_ptr().cast(), body.len());
+                libc::close(fd);
+                if written != body.len() as isize {
+                    libc::_exit(1);
+                }
+                // Park rather than exit, matching the worker this helper serves.
+                // A target that exits inside the helper's window would have its
+                // status collected there instead of by the caller.
+                loop {
+                    libc::pause();
+                }
+            }
+        }
+
+        wait_for_test_pid_stopped(child, Duration::from_secs(5));
+        // The marker is published only after BOTH stops are cleared, so its
+        // presence is the running-target proof the helper must deliver.
+        resume_test_pid_until(child, Duration::from_secs(5), || marker.is_file());
+
+        assert_eq!(unsafe { libc::kill(child, libc::SIGKILL) }, 0);
+        let mut status = 0;
+        assert_eq!(
+            unsafe { libc::waitpid(child, &mut status, 0) },
+            child,
+            "reap resume-probe child"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn stop_barrier_catches_repeated_forks_at_the_cleanup_boundary() {
@@ -3451,13 +3512,12 @@ mod tests {
             // publication, so completed-fork coverage is deterministic.
             std::fs::write(&race_path, b"fork-at-cleanup\n").unwrap();
             wait_for_test_pid_stopped(worker_pid, Duration::from_secs(5));
-            assert_eq!(unsafe { libc::kill(worker_pid, libc::SIGCONT) }, 0);
-            receive_fork_boundary_signal(
-                &fork_boundary_signal,
-                &mut round_owner.worker,
-                1,
-                Duration::from_secs(15),
-            );
+            // The signal the worker publishes on the far side of its stop IS the
+            // proof it resumed, so release it until that byte arrives rather
+            // than releasing once and then blaming the socket for 15s.
+            resume_test_pid_until(worker_pid, Duration::from_secs(15), || {
+                poll_fork_boundary_signal(&fork_boundary_signal, &mut round_owner.worker, 1)
+            });
             if round % 2 == 1 {
                 receive_fork_boundary_signal(
                     &fork_boundary_signal,
@@ -3986,6 +4046,55 @@ mod tests {
         }
     }
 
+    /// Release a process parked at a job-control stop, and keep releasing it
+    /// until it proves it is running.
+    ///
+    /// Every cheap observation available here is a proxy. `waitpid(WUNTRACED)`
+    /// reporting a stop says the parent was told a stop happened, not that the
+    /// target is parked where exactly one process-directed `SIGCONT` will move
+    /// it: `raise(SIGSTOP)` inside a test binary is thread-directed, and on a
+    /// contended host the stop can still be settling when that `SIGCONT`
+    /// arrives, so it is spent against a stop the target then completes.
+    /// `waitpid(WCONTINUED)` is no better, because it reports the continue that
+    /// was granted and says nothing about the pending stop that parks the
+    /// target again immediately afterwards. Measured on a loaded host, a single
+    /// release left the target parked in roughly 3% of rounds, and confirming
+    /// that release through `WIFCONTINUED` did not move the rate at all.
+    ///
+    /// The only trustworthy evidence is the target's own progress, so repeat
+    /// the release until `proved_running` observes it. That is the same shape
+    /// as the production cleanup barrier in this file, which repeats its signal
+    /// rather than trusting one delivery. `SIGCONT` to a process that is
+    /// already running carries no handler and is discarded, so repeating costs
+    /// nothing and cannot disturb a target that already resumed.
+    #[cfg(unix)]
+    fn resume_test_pid_until(
+        pid: libc::pid_t,
+        timeout: Duration,
+        mut proved_running: impl FnMut() -> bool,
+    ) {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if proved_running() {
+                return;
+            }
+            assert_eq!(
+                unsafe { libc::kill(pid, libc::SIGCONT) },
+                0,
+                "could not continue process {pid}: {}",
+                std::io::Error::last_os_error()
+            );
+            if proved_running() {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "process {pid} did not resume from its stop"
+            );
+            std::thread::sleep(PROCESS_GROUP_GUARDIAN_POLL_INTERVAL);
+        }
+    }
+
     #[cfg(unix)]
     struct ForkBoundaryRoundOwner {
         guardian: ProcessGroupGuardian,
@@ -4019,6 +4128,50 @@ mod tests {
         }
     }
 
+    /// One non-blocking attempt at the fork-boundary signal.
+    ///
+    /// `true` means the expected byte arrived. `false` means nothing was queued
+    /// yet and the worker is still alive to publish it. Everything else is a
+    /// protocol violation and panics here rather than being retried.
+    #[cfg(unix)]
+    fn poll_fork_boundary_signal(
+        signal_socket: &std::os::unix::net::UnixDatagram,
+        worker: &mut std::process::Child,
+        expected: u8,
+    ) -> bool {
+        let mut signal = [0_u8; 1];
+        match signal_socket.recv(&mut signal) {
+            Ok(1) => {
+                assert_eq!(
+                    signal,
+                    [expected],
+                    "fork-boundary worker published an out-of-order signal"
+                );
+                true
+            }
+            Ok(received) => {
+                panic!("fork-boundary worker published a {received}-byte signal")
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => false,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                match worker.try_wait() {
+                    Ok(Some(status)) => {
+                        panic!("fork-boundary worker exited before signal {expected}: {status}")
+                    }
+                    Ok(None) => false,
+                    Err(error) => {
+                        panic!(
+                            "failed to poll fork-boundary worker before signal {expected}: {error}"
+                        )
+                    }
+                }
+            }
+            Err(error) => {
+                panic!("failed to receive fork-boundary signal {expected}: {error}")
+            }
+        }
+    }
+
     #[cfg(unix)]
     fn receive_fork_boundary_signal(
         signal_socket: &std::os::unix::net::UnixDatagram,
@@ -4027,36 +4180,7 @@ mod tests {
         timeout: Duration,
     ) {
         let deadline = std::time::Instant::now() + timeout;
-        let mut signal = [0_u8; 1];
-        loop {
-            match signal_socket.recv(&mut signal) {
-                Ok(1) => {
-                    assert_eq!(
-                        signal,
-                        [expected],
-                        "fork-boundary worker published an out-of-order signal"
-                    );
-                    return;
-                }
-                Ok(received) => {
-                    panic!("fork-boundary worker published a {received}-byte signal")
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    match worker.try_wait() {
-                        Ok(Some(status)) => {
-                            panic!("fork-boundary worker exited before signal {expected}: {status}")
-                        }
-                        Ok(None) => {}
-                        Err(error) => {
-                            panic!("failed to poll fork-boundary worker before signal {expected}: {error}")
-                        }
-                    }
-                }
-                Err(error) => {
-                    panic!("failed to receive fork-boundary signal {expected}: {error}")
-                }
-            }
+        while !poll_fork_boundary_signal(signal_socket, worker, expected) {
             assert!(
                 std::time::Instant::now() < deadline,
                 "timed out waiting for fork-boundary signal {expected}"


### PR DESCRIPTION
Three CI test flakes, one batch. Each was reproduced before it was fixed and falsified after.

## The fork-boundary stop barrier

`stop_barrier_catches_repeated_forks_at_the_cleanup_boundary` released its worker from a job
control stop with one `kill(pid, SIGCONT)` and then assumed it was running. `raise(SIGSTOP)`
inside a test binary is thread-directed, so on a contended host the stop can still be settling
when that single process-directed `SIGCONT` arrives and the signal is spent against a stop the
target then completes. The worker stayed parked at its `SIGSTOP` and the parent burned its 15s
deadline blaming the signalling socket, which was never the problem.

Reproduced with concurrent copies of the test process plus CPU spinners, which is what
`cargo nextest run --workspace` produces on a loaded host. A single process under spinners does
not reproduce it; concurrent processes do, at roughly 3% of rounds. Instrumentation put the
worker inside `raise(SIGSTOP)` rather than inside its send: a marker written immediately after
the raise returns was absent, `waitpid` reported no pending transition, and a second `SIGCONT`
released it 8 times out of 8, after which it completed the whole remaining sequence.

Confirming the release with the kernel's `WIFCONTINUED` does not fix it, and the branch says so
rather than dropping the negative result: `WCONTINUED` reports the continue that was granted and
says nothing about the pending stop that re-parks the target immediately afterwards, measured at
16 of 448 on the same harness, the same rate as no confirmation at all. Every cheap observation
here is a proxy. The target's own progress is not, so the release now repeats until that progress
appears, which is the shape the production cleanup barrier in this file already uses. Same
harness: 0 of 448.

The new test parks a child in two consecutive stops, which is the shape a single fire-and-forget
`SIGCONT` cannot clear. Swap the helper for a bare `kill(SIGCONT)` and it goes red.

## The locate retrieval budget

The locate pipeline carries a wall-clock budget resolved from the environment, and over budget it
skips entity discovery outright and returns `Ok` with no files. A test asserting on which files
locate surfaces was therefore asserting on how much CPU the host granted it, which is how a stall
turned a historical-locate assertion red on an unrelated pull request whose crate that test cannot
even reach.

The budget is now an input to retrieval rather than an ambient property of the process. Public
entry points keep their signatures and supply the environment budget, so the daemon path is
unchanged, and assertions about what retrieval returns pass an unbounded one. Mutating the
environment variable was the other option and is correctly no longer available: that value is read
by code under test that runs beside other tests. Every in-crate call site that drives the pipeline
now names its budget, not only the two the report named.

Truncated retrieval also reports itself on the completing path and not only on the early scoring
return, because fewer results and no results were otherwise the same value to a caller.

The first attempt at this inside the branch was wrong and review caught it. It gated the report on
the budget's warning list, which mixes two events meaning opposite things: work that was skipped,
which truncates, and a phase that overran a soft budget and finished anyway, which does not. Since
a skipped phase implies the total was exceeded, and that condition only ever goes from false to
true, the scoring gate always returns early before the end of the pipeline. The block could
therefore only be reached on pure timing notes, so it told a whole answer it had been cut short on
exactly the slow-host path the rest of this work exists to stop conflating with retrieval
semantics, and never fired when something really was truncated.

The fact is now recorded where the cut happens rather than inferred afterwards. The budget carries
a truncation ledger written by the skip gate, and the completing path reports on that. This also
covers the one budget cut that legitimately reaches the end of the pipeline: the embedding
sub-phase is skipped on the per-phase remainder rather than the total, so it truncates retrieval
while every phase gate still passes, and it was previously visible nowhere a caller could look. It
carries its own reason, distinct from the early return's, because the total is not exhausted in
that case.

`LocateResult.degradations` and `RetrievalDegradation` are unchanged, so the response type is the
same; the new `budget_truncated` reason is a new value in an existing free-form field, which a
caller matching on reasons will see.

## The two featureless kin-cli tests

Both asserted vector-build behaviour without a feature gate, and neither failure was a defect in
the code under test. The coverage case counts embedding targets only a build with an embedding
pipeline has; a vector-free build reports semantic ranking as unsupported and counts differently,
which is correct. The prepared-state case demands the message from opening a vector sidecar and
finding it invalid; a vector-free build refuses the same prepared state earlier and correctly,
saying it cannot serve embeddings at all.

Each is gated on the feature it describes and each gained a featureless counterpart rather than
leaving that configuration unasserted. `cargo test --locked -p kin-cli --no-default-features
--all-targets` now reports 1003 passed, 0 failed. The Windows authority job builds without default
features, so a filter matching either name would have failed there for a reason unrelated to the
change under test.

## Gates at the final head

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` under the exact ci.yml
allow-list with `RUSTFLAGS=-D warnings`, `cargo build --all-targets --locked`,
`scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`,
`scripts/verify-zero-file-search.py` (146 source files scanned, the expected count after #537 added
`kin-core/src/test_env.rs`; this branch adds no source file), `scripts/zero_file_search_guard.sh`,
and `cargo test --locked -p kin-cli --no-default-features --all-targets` all exit 0.

`cargo test --workspace --locked` was run three consecutive times at this head and exited 0 each
time, with `cargo nextest run --workspace --locked` agreeing and `cargo test --doc --locked`
passing beside it.

## What this does not claim

0 of 448 on one harness on one host bounds the fork-boundary failure rate; it does not prove
absence, and the deterministic test is the durable guard. The observable chain behind that flake is
proven, but no claim is made about precisely which kernel state consumed the first signal. The
21-minute CI stall behind the original locate red remains unexplained; this removes the assertion's
dependence on wall clock, not the stall.

Closes FIR-1758
Closes FIR-1773
Closes FIR-1774

