### PR TITLE
Record v0.4.4 as an abandoned release tag

### DIFF
--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -7,6 +7,13 @@
       "reason": "The tagged lockfile immutably pins kin-db 0.7.6, which cannot compile for the musl release targets, so no Linux artifact can ever be produced from this commit. Automatic release recovery exhausted its bounded retries, no GitHub Release object was ever published, and the tag produced zero artifacts.",
       "superseded_by": "v0.4.4",
       "failed_release_run_id": "30627672394"
+    },
+    {
+      "tag": "v0.4.4",
+      "sha": "405c78f439705f757ee9fed7bfd738f2b31dc187",
+      "reason": "The workflow snapshot frozen at this tag verifies a published archive by asserting that every entry at its root is a regular file, and the same snapshot packages KinNotifier.app, the signed and stapled macOS notification bundle, into both macOS archives as a directory. Every macOS leg is therefore refused at the Publish Release step by the tag's own workflow, which no later change to main can alter. All three attempts of the cited run failed and no GitHub Release object was ever created.",
+      "superseded_by": "v0.4.5",
+      "failed_release_run_id": "30647442701"
     }
   ]
 }


### PR DESCRIPTION
Appends the `v0.4.4` abandonment record to `scripts/abandoned-release-tags.json`. One file, seven lines, no fixture changes required.

## Why the tag can never finish

The workflow snapshot frozen at `v0.4.4` contains both halves of a contradiction, and a tag runs the workflow it was cut with, so no change to `main` can resolve it:

- `release.yml:1350` at the tag: `fail(entries.every((entry) => entry.isFile()), ...)`
- the same snapshot carries 13 `KinNotifier.app` references, packaging the signed and stapled macOS notification bundle into both macOS archives as a directory

Verified:

```
$ git show v0.4.4:.github/workflows/release.yml | grep -n 'entries.every((entry) => entry.isFile())'
1350:              fail(entries.every((entry) => entry.isFile()), ...)
$ git show v0.4.4:.github/workflows/release.yml | grep -c KinNotifier
13
$ gh release view v0.4.4 --repo firelock-ai/kin
release not found
$ gh api repos/firelock-ai/kin/actions/runs/30647442701
attempts=3 status=completed conclusion=failure head_sha=405c78f4... event=push
```

The recorded sha matches the tag exactly (`git ls-remote --tags origin refs/tags/v0.4.4` gives `405c78f439705f757ee9fed7bfd738f2b31dc187`), which is what the selector requires before it will honour a record.

## Why it has to be recorded

The rail requires the highest `vX.Y.Z` tag to be the finalized GitHub Latest release before a newer tag is minted. `v0.4.4` is the highest tag and can never become Latest, so unrecorded it holds the lane closed against every successor, including the one carrying the repair.

Exercised against the repository's real tag listing (`git for-each-ref --sort=-v:refname`), not a fixture:

| Case | Result |
| --- | --- |
| With this record, minting `v0.4.5` | `skipping abandoned release tag v0.4.4 at 405c78f4...` then `highest admissible release tag: v0.3.6`, exit 0 |
| Counterfactual, same listing against `origin/main`'s record | `highest admissible release tag: v0.4.4`, so the lane stays blocked |
| Attempting to re-mint `v0.4.4` | refused, `v0.4.4 is recorded as an abandoned release tag and must not be released` |
| Record checked against a moved `v0.4.4` | refused, `abandonment of v0.4.4 waives 405c78f4... but the tag now names ...` |

GitHub Latest is currently `v0.3.6` (`draft=false`, `prerelease=false`), so with this record the rail's `highest_tag == latest_tag` comparison at `release-tag.yml:390` is satisfied and the train can cut `v0.4.5`.

## Fixtures

None needed. The shipped-record test at `scripts/test-release-workflow-authority.py:2393` derives its candidate listing from the record's own entries and asserts the selector falls through every one of them to a `v0.0.1` floor, so a second entry is covered automatically. Every other `v0.4.3` reference in that suite is a synthetic fixture built from placeholder shas, not read from the tracked file.

## Evidence

`python3 scripts/test-release-workflow-authority.py` passes. Also green locally: `test_install_optional_vfs.py`, `test_installer_parity.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, `test-install-checksum.py`, `test-homebrew-release-gate.py`, the release `node --test` set, `verify-zero-file-search.py`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`. No daemon or GPU work; the diff is one JSON file.

The verifier repair for the same defect ships separately in #546, which carries the closing reference for the ticket; this PR is the release-rail bookkeeping half and deliberately touches none of the same files.
