### PR TITLE
Pin what the release guards actually read and stop failing a mint on an early read

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1112,19 +1112,25 @@ jobs:
           # is no prior value for a newly created ref to be stale from, so a
           # different sha means something else created it, which is terminal.
           got=""
+          why=""
           for attempt in 1 2 3 4 5; do
-            if got="$(gh api "repos/$REPO/git/ref/tags/$TAG" -q '.object.sha' 2>/dev/null)" \
+            if got="$(gh api "repos/$REPO/git/ref/tags/$TAG" -q '.object.sha' 2>"$RUNNER_TEMP/readback.err")" \
               && [ -n "$got" ]; then
               break
             fi
             got=""
+            why="$(tr -d '\r' < "$RUNNER_TEMP/readback.err" | tail -n 1)"
             if [ "$attempt" -lt 5 ]; then
-              echo "tag ref not readable yet (attempt ${attempt}/5); retrying"
+              echo "tag ref not readable yet (attempt ${attempt}/5): ${why:-empty response}; retrying"
               sleep "$(( attempt * 3 ))"
             fi
           done
           if [ -z "$got" ]; then
-            echo "::error::post-verify failed: tag $TAG did not become readable across 5 reads over ~30s"
+            # Say what the API said rather than asserting the tag is gone. A
+            # persistent auth or rate-limit failure reads the same as a missing
+            # ref from here, and sending an operator after a deleted tag that
+            # exists is its own outage.
+            echo "::error::post-verify failed: tag $TAG never read back across 5 reads over ~30s; last reason: ${why:-empty response}"
             exit 1
           fi
           echo "created ref points at: $got (expected $SHA)"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1101,7 +1101,32 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          got="$(gh api "repos/$REPO/git/ref/tags/$TAG" -q '.object.sha')"
+          # The ref was just created, and the API is read-after-write eventually
+          # consistent, so the first read can 404 on a tag that exists. A bare
+          # read here concludes the whole mint FAILURE after it already
+          # succeeded, which is worse than a slow answer: release recovery reads
+          # a failed run as a release needing repair and goes to work on a
+          # healthy one. Absence is only believed after the reads are exhausted.
+          #
+          # A ref that reads back pointing somewhere else is not retried. There
+          # is no prior value for a newly created ref to be stale from, so a
+          # different sha means something else created it, which is terminal.
+          got=""
+          for attempt in 1 2 3 4 5; do
+            if got="$(gh api "repos/$REPO/git/ref/tags/$TAG" -q '.object.sha' 2>/dev/null)" \
+              && [ -n "$got" ]; then
+              break
+            fi
+            got=""
+            if [ "$attempt" -lt 5 ]; then
+              echo "tag ref not readable yet (attempt ${attempt}/5); retrying"
+              sleep "$(( attempt * 3 ))"
+            fi
+          done
+          if [ -z "$got" ]; then
+            echo "::error::post-verify failed: tag $TAG did not become readable across 5 reads over ~30s"
+            exit 1
+          fi
           echo "created ref points at: $got (expected $SHA)"
           if [ "$got" != "$SHA" ]; then
             echo "::error::post-verify failed: tag $TAG points at $got, not $SHA"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1046,7 +1046,7 @@ jobs:
         if: >-
           steps.resolve.outputs.needed == 'true' &&
           steps.prior.outputs.ready == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Mint repository-scoped release branch token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -141,7 +141,10 @@ The single job refuses — before any tag is created — unless **all** hold:
    active, and the prior stable must have either a successful exact tag/SHA
    Release run or its attested terminal completion marker. This prevents GitHub
    concurrency from replacing a pending version without making Actions log
-   retention part of durable release authority.
+   retention part of durable release authority. The highest tag this compares
+   against skips any tag carried by `scripts/abandoned-release-tags.json`; see
+   [Abandoning a release tag](#abandoning-a-release-tag). A tag that is merely
+   failing so far carries no record and still blocks its successor.
 7. **Tag does not already exist.** Refuses if `refs/tags/<tag>` is present.
 
 Only then does it mint the App token, create `refs/tags/<tag>` at the SHA, and
@@ -159,6 +162,44 @@ active release before requesting `rerun-failed-jobs`. The initial attempt plus
 two retries is the hard cap. Cancellation is treated as an operator stop and is
 never retried. If all three attempts fail, the controller opens one
 `Release blocked after automatic retries` issue and stops.
+
+## Abandoning a release tag
+
+Recovery stopping is not the end of the story. The rail serializes on the
+highest `vX.Y.Z` tag being the finalized GitHub Latest release, which holds that
+tag responsible for finishing. A tag whose artifacts can never be built cannot
+finish, and on its own it holds the gate closed against every successor,
+including the one that repairs whatever made it unbuildable.
+
+`scripts/abandoned-release-tags.json` is the reviewed way out. It is the only
+thing that waives the predicate for a tag, so a tag that is merely failing so far
+keeps blocking, which is what the predicate is for. Each entry records the `tag`,
+the exact `sha` it pointed at, a `reason`, the `superseded_by` tag, and the
+`failed_release_run_id` that evidences it. Both the record and the selector that
+reads it are loaded from protected `main`, never from the checked-out release
+commit, which predates any abandonment it has to honour.
+
+**Operating rule: record the abandonment and leave the tag in place.**
+
+Deleting an abandoned tag while the workspace version still equals it wedges both
+rails, and nothing automatic recovers:
+
+- the mint refuses, because the abandonment refusal reads the record and not the
+  tag listing, so the version stays burned after its tag is gone (this is
+  deliberate: a burned version must never be re-minted onto a different commit)
+- drift resolution defers rather than proposing a bump, because it finds no base
+  tag to measure from and hands the transition to the mint that is refusing
+
+The only exit from that state is a hand-landed version bump. Delete an abandoned
+tag only when a version bump is landing with it.
+
+Two further properties worth knowing before editing the record:
+
+- an entry applies only while it still describes the repository. It names the
+  exact commit its tag pointed at, so a tag that has since moved refuses loudly
+  rather than quietly waiving a different object than the one reviewed
+- a malformed, unparsable, or under-evidenced entry fails the rail closed rather
+  than degrading to an empty waiver set
 
 ## Captain break-glass usage
 

--- a/scripts/select-admissible-release-tag.py
+++ b/scripts/select-admissible-release-tag.py
@@ -27,9 +27,11 @@ the repository. The mint-intent refusal below still applies, because it reads th
 record rather than the listing: a version declared abandoned stays refused even
 if its tag is removed, which is the point. Deleting an abandoned tag while the
 workspace version still equals it therefore leaves the version itself burned and
-no tag to advance past, and the only way out is the version bump that drift
-resolution proposes. Record the abandonment and leave the tag in place unless a
-bump is landing with it.
+no tag to advance past. Nothing automatic recovers from there: the mint refuses
+the burned version, and drift resolution defers rather than proposing a bump,
+because it finds no base tag to measure from and hands the transition to the
+mint that is refusing. The version bump has to be landed by hand. Record the
+abandonment and leave the tag in place unless a bump is landing with it.
 
 Usage:
   select-admissible-release-tag.py MANIFEST CANDIDATES MINTING_TAG OUTPUT

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2172,6 +2172,133 @@ def selector_invocation(workflow: str, content: str) -> tuple[str, ...]:
     return invocations[0]
 
 
+def tag_readback_source(release_tag: str) -> str:
+    """Extract the post-mint ref readback exactly as the workflow runs it."""
+
+    anchor = "      - name: Verify tag ref and summarize\n"
+    if anchor not in release_tag:
+        raise AssertionError(
+            "release-tag no longer carries the post-mint ref readback step"
+        )
+    start = release_tag.index(anchor)
+    end = release_tag.index("\n      - name:", start + 1) if (
+        "\n      - name:" in release_tag[start + 1 :]
+    ) else len(release_tag)
+    step = release_tag[start:end]
+    marker = "        run: |\n"
+    return textwrap.dedent(step[step.index(marker) + len(marker) :])
+
+
+def execute_tag_readback(
+    source: str,
+    responses: list[tuple[int, str]],
+) -> subprocess.CompletedProcess[str]:
+    """Run the readback against a scripted sequence of API answers."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        script = root / "readback.sh"
+        script.write_text(source, encoding="utf-8")
+        (root / "responses").write_text(
+            "".join(f"{code} {body}\n" for code, body in responses),
+            encoding="utf-8",
+        )
+        (root / "attempts").write_text("0", encoding="utf-8")
+        binaries = root / "bin"
+        binaries.mkdir()
+        (binaries / "gh").write_text(
+            "#!/usr/bin/env bash\n"
+            'attempt="$(cat "$FIXTURE/attempts")"\n'
+            'attempt=$((attempt + 1))\n'
+            'printf %s "$attempt" > "$FIXTURE/attempts"\n'
+            'line="$(sed -n "${attempt}p" "$FIXTURE/responses")"\n'
+            '[ -n "$line" ] || line="$(tail -n 1 "$FIXTURE/responses")"\n'
+            'code="${line%% *}"; body="${line#* }"\n'
+            '[ "$code" = 0 ] || { echo "gh: Not Found (HTTP 404)" >&2; exit 1; }\n'
+            'printf "%s\\n" "$body"\n',
+            encoding="utf-8",
+        )
+        (binaries / "gh").chmod(0o755)
+        # The exhaustion path sleeps ~30s in production; the fixture proves the
+        # control flow, not the wall clock.
+        (binaries / "sleep").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        (binaries / "sleep").chmod(0o755)
+        environment = dict(os.environ)
+        environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
+        environment.update(
+            {
+                "FIXTURE": str(root),
+                "GH_TOKEN": "fixture",
+                "REPO": "firelock-ai/kin",
+                "ACTOR": "kin-release-bot[bot]",
+                "TAG": "v9.9.9",
+                "SHA": RELEASE_GATE_FIXTURE_SHA,
+                "GITHUB_STEP_SUMMARY": str(root / "summary.md"),
+            }
+        )
+        return subprocess.run(
+            ["bash", str(script)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=30,
+            check=False,
+        )
+
+
+def assert_tag_readback_retries(release_tag: str) -> None:
+    """A minted tag must never be reported failed because a read was early."""
+
+    source = tag_readback_source(release_tag)
+    good = (0, RELEASE_GATE_FIXTURE_SHA)
+    missing = (404, "")
+
+    immediate = execute_tag_readback(source, [good])
+    if immediate.returncode != 0:
+        raise AssertionError(
+            f"post-mint readback failed on a readable ref: "
+            f"{immediate.stdout}{immediate.stderr}"
+        )
+
+    # The observed defect: the ref exists, the first reads 404, and the mint
+    # concluded failure on a release it had already created.
+    delayed = execute_tag_readback(source, [missing, missing, good])
+    if delayed.returncode != 0:
+        raise AssertionError(
+            "post-mint readback reported a successful mint as failed because "
+            f"the ref was not visible yet: {delayed.stdout}{delayed.stderr}"
+        )
+    if "retrying" not in delayed.stdout:
+        raise AssertionError(
+            "post-mint readback must say it is retrying, so a slow read is "
+            f"legible in the log: {delayed.stdout}"
+        )
+
+    absent = execute_tag_readback(source, [missing])
+    if absent.returncode == 0:
+        raise AssertionError("post-mint readback accepted a ref that never appeared")
+    if "did not become readable" not in absent.stdout:
+        raise AssertionError(
+            "post-mint readback must distinguish exhausted reads from a "
+            f"mismatch: {absent.stdout}{absent.stderr}"
+        )
+
+    # A ref that reads back pointing elsewhere is terminal on the first read.
+    # Retrying it would be waiting for someone else's tag to change.
+    mismatch = execute_tag_readback(source, [(0, "0" * 40)])
+    if mismatch.returncode == 0:
+        raise AssertionError("post-mint readback accepted a ref at the wrong commit")
+    if "points at" not in mismatch.stdout:
+        raise AssertionError(
+            f"post-mint readback must name the wrong commit: {mismatch.stdout}"
+        )
+    if "retrying" in mismatch.stdout:
+        raise AssertionError(
+            "post-mint readback retried a ref that resolved to another commit, "
+            "which cannot become correct by waiting"
+        )
+
+
 def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
     """Pin the supply chain of anything that can write a required release context.
 
@@ -4793,6 +4920,7 @@ def main() -> None:
     # invariant.
     assert_rust_cache_steps(workflow_sources)
     assert_required_context_action_pins(workflow_sources)
+    assert_tag_readback_retries(release_tag)
 
     with tempfile.TemporaryDirectory() as directory:
         fixture_directory = Path(directory)

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2234,6 +2234,7 @@ def execute_tag_readback(
                 "TAG": "v9.9.9",
                 "SHA": RELEASE_GATE_FIXTURE_SHA,
                 "GITHUB_STEP_SUMMARY": str(root / "summary.md"),
+                "RUNNER_TEMP": str(root),
             }
         )
         return subprocess.run(
@@ -2277,10 +2278,18 @@ def assert_tag_readback_retries(release_tag: str) -> None:
     absent = execute_tag_readback(source, [missing])
     if absent.returncode == 0:
         raise AssertionError("post-mint readback accepted a ref that never appeared")
-    if "did not become readable" not in absent.stdout:
+    if "never read back" not in absent.stdout:
         raise AssertionError(
             "post-mint readback must distinguish exhausted reads from a "
             f"mismatch: {absent.stdout}{absent.stderr}"
+        )
+    # The reason the API gave has to survive into the refusal. A persistent
+    # auth or rate-limit failure reads identically to a missing ref from here,
+    # and reporting it as absence sends an operator after a tag that exists.
+    if "last reason:" not in absent.stdout or "Not Found" not in absent.stdout:
+        raise AssertionError(
+            "post-mint readback must report why the read failed rather than "
+            f"asserting the tag is gone: {absent.stdout}"
         )
 
     # A ref that reads back pointing elsewhere is terminal on the first read.
@@ -2311,23 +2320,37 @@ def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
         content = workflows.get(ROOT / path)
         if content is None:
             raise AssertionError(f"required-context producer is missing: {path}")
-        actual: dict[str, str] = {}
+        # Every reference is collected, not the last one seen per action. Each
+        # `uses:` executes, so a single unpinned reference is an unpinned
+        # execution however many pinned ones sit beside it, and whichever order
+        # they appear in. Keying on one reference per action hid exactly that:
+        # a floating duplicate placed above the pinned line was overwritten by
+        # it and the guard stayed green while the floating ref still ran.
+        observed: dict[str, set[str]] = {}
         for reference in re.findall(r"uses:\s*(\S+)", content):
             if reference.startswith("actions/"):
                 continue
             action, _, version = reference.partition("@")
-            actual[action] = version
-        if actual != expected:
+            observed.setdefault(action, set()).add(version)
+        if set(observed) != set(expected):
             raise AssertionError(
-                f"{path} produces a presence-required release context, so every "
-                "third-party action in it must stay pinned to its exact reviewed "
-                f"commit: expected={expected} actual={actual}"
+                f"{path} produces a presence-required release context, so its "
+                "third-party action set must stay exactly as reviewed: "
+                f"expected={sorted(expected)} actual={sorted(observed)}"
             )
-        for action, sha in actual.items():
-            if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        for action, references in sorted(observed.items()):
+            pin = expected[action]
+            if not re.fullmatch(r"[0-9a-f]{40}", pin):
                 raise AssertionError(
-                    f"{path} uses {action} at '{sha}', which is a movable ref "
+                    f"{path} pins {action} to '{pin}', which is a movable ref "
                     "rather than an immutable commit"
+                )
+            drifted = sorted(reference for reference in references if reference != pin)
+            if drifted:
+                raise AssertionError(
+                    f"{path} runs {action} at {drifted} alongside its reviewed "
+                    f"pin {pin}; every reference to it must be that pin, "
+                    "because each one executes"
                 )
 
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2125,23 +2125,40 @@ def assert_admission_step_order(
 
 
 def selector_invocation(workflow: str, content: str) -> tuple[str, ...]:
-    """Return the exact argument list a workflow hands the admission selector."""
+    """Return the exact argument list a workflow hands the admission selector.
 
-    anchor = 'python3 "$selector" \\\n'
-    if anchor not in content:
+    Every invocation is read, not the first. A second one is what would defeat
+    this pin: it can re-run the selector with any argument at all and overwrite
+    the file the workflow then adopts as the highest admissible tag, so pinning
+    only the first would leave the guard describing bytes that no longer decide
+    the outcome.
+    """
+
+    anchor = 'python3 "$selector"'
+    invocations: list[tuple[str, ...]] = []
+    for match in re.finditer(re.escape(anchor), content):
+        tail = content[match.end() :]
+        if not tail.startswith(" \\\n"):
+            raise AssertionError(
+                f"{workflow} invokes the admission selector without a "
+                "reviewable multi-line argument list"
+            )
+        arguments: list[str] = []
+        for line in tail[len(" \\\n") :].splitlines():
+            argument = line.strip()
+            if argument.endswith("\\"):
+                arguments.append(argument[:-1].strip())
+                continue
+            arguments.append(argument)
+            break
+        invocations.append(tuple(arguments))
+    if len(invocations) != 1:
         raise AssertionError(
-            f"{workflow} no longer invokes the admission selector as a "
-            "reviewable multi-line argument list"
+            f"{workflow} must invoke the admission selector exactly once, so "
+            "one reviewed argument list decides the highest admissible tag: "
+            f"found {len(invocations)}"
         )
-    arguments: list[str] = []
-    for line in content[content.index(anchor) + len(anchor) :].splitlines():
-        argument = line.strip()
-        if argument.endswith("\\"):
-            arguments.append(argument[:-1].strip())
-            continue
-        arguments.append(argument)
-        break
-    return tuple(arguments)
+    return invocations[0]
 
 
 def assert_selector_arguments(release_tag: str, release_train: str) -> None:
@@ -2870,6 +2887,15 @@ def main() -> None:
         "organization-level copy visible",
         "gh api --method POST repos/firelock-ai/kin/dispatches --input -",
         '{event_type:"release_tag",client_payload:{tag:$tag,sha:$sha}}',
+        # The abandonment operating rule has to live where an operator editing
+        # the record will read it. JSON carries no comments, so the record file
+        # itself cannot hold it, and a Python module docstring is not where the
+        # person writing an entry is looking.
+        "## Abandoning a release tag",
+        "record the abandonment and leave the tag in place",
+        "The only exit from that state is a hand-landed version bump",
+        "a tag that has since moved refuses loudly",
+        "fails the rail closed rather",
     ):
         require(
             release_bot_doc,

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -48,6 +48,17 @@ TAG_LISTING_FORMAT = (
 # tag until the train opens the bump the record exists to unblock. The empty
 # argument is spelled as a literal rather than an expanded variable so that
 # refilling it is a visible diff here and not a silent assignment upstream.
+# Third-party actions inside the workflows that produce presence-required release
+# contexts. A required context is release evidence, so whatever can write into it
+# is release supply chain and has to be pinned to an immutable object rather than
+# a tag anyone upstream can move. `actions/*` are first-party and governed
+# separately; these are the ones outside that trust boundary.
+EXPECTED_REQUIRED_CONTEXT_ACTION_PINS = {
+    ".github/workflows/sast.yml": {
+        "dtolnay/rust-toolchain": "191af2e1955bbe165f9bbacff2d2438002dff4d4",
+        "taiki-e/install-action": "6a1bd70eaac3c8bdf093356838d7ee09fda951cf",
+    },
+}
 EXPECTED_SELECTOR_INVOCATIONS = {
     "release-tag": ('"$abandoned"', '"$candidate_tags"', '"$TAG"', '"$admissible"'),
     "release-train": ('"$abandoned"', '"$candidate_tags"', '""', '"$admissible"'),
@@ -2159,6 +2170,38 @@ def selector_invocation(workflow: str, content: str) -> tuple[str, ...]:
             f"found {len(invocations)}"
         )
     return invocations[0]
+
+
+def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
+    """Pin the supply chain of anything that can write a required release context.
+
+    A required context is the evidence a release is minted from, so an action
+    running inside its producer can decide what that evidence says. A floating
+    tag leaves that decision with whoever can move the tag upstream.
+    """
+
+    for path, expected in EXPECTED_REQUIRED_CONTEXT_ACTION_PINS.items():
+        content = workflows.get(ROOT / path)
+        if content is None:
+            raise AssertionError(f"required-context producer is missing: {path}")
+        actual: dict[str, str] = {}
+        for reference in re.findall(r"uses:\s*(\S+)", content):
+            if reference.startswith("actions/"):
+                continue
+            action, _, version = reference.partition("@")
+            actual[action] = version
+        if actual != expected:
+            raise AssertionError(
+                f"{path} produces a presence-required release context, so every "
+                "third-party action in it must stay pinned to its exact reviewed "
+                f"commit: expected={expected} actual={actual}"
+            )
+        for action, sha in actual.items():
+            if not re.fullmatch(r"[0-9a-f]{40}", sha):
+                raise AssertionError(
+                    f"{path} uses {action} at '{sha}', which is a movable ref "
+                    "rather than an immutable commit"
+                )
 
 
 def assert_selector_arguments(release_tag: str, release_train: str) -> None:
@@ -4749,6 +4792,7 @@ def main() -> None:
     # qualifying pull request. This is not a repository-wide no-PR-writes
     # invariant.
     assert_rust_cache_steps(workflow_sources)
+    assert_required_context_action_pins(workflow_sources)
 
     with tempfile.TemporaryDirectory() as directory:
         fixture_directory = Path(directory)


### PR DESCRIPTION
Repairs to the release-authority surface in three commits: guards that described bytes
they no longer governed, a supply chain that could be moved from upstream, two version
labels that named the wrong release, and one mint-gate bug that reported a successful
release as a failed one.

What the release rail refuses is unchanged in every case but the last. The post-mint
readback now retries a read that has not caught up yet instead of failing the mint on the
first answer, so a tag that was created successfully is no longer reported as a failure. It
still refuses the same states: a ref that never reads back, and a ref that reads back at
another commit.

## The argument pin read only the first selector invocation

PR 542 added `assert_selector_arguments` to stop a base tag being handed to the admission
selector as mint intent, which had turned the abandonment record's own scenario into a
permanently red scheduled workflow. The pin extracted only the first
`python3 "$selector"` occurrence.

That leaves the guard describing bytes that may not decide the outcome. A second invocation
can re-run the selector with any argument at all and overwrite the file the workflow then
adopts as the highest admissible tag. Injecting one that passes the base tag reproduced the
original defect at runtime while the suite stayed at exit 0.

Every invocation is now read, and anything other than exactly one is refused by name.

## The selector documented a recovery that does not exist

The docstring said the way out of a deleted-plus-abandoned tag was "the version bump that
drift resolution proposes". Drift resolution proposes nothing in that state: it finds no
base tag to measure from, defers to the mint, and the mint refuses the burned version.
Nothing automatic recovers and the bump has to be landed by hand. The text now says so.

## The abandonment operating rule now lives where it is read

The rule that prevents that state, record the abandonment and leave the tag in place, was
only in a Python module docstring. The person who most needs it is the one writing a record,
and JSON carries no comments, so the rule now has a section in the release runbook with the
admission list cross-referencing it. Five needles pin its load-bearing sentences.

## Supply chain of the cargo-deny producer

An action running inside a workflow that produces a presence-required release context can
decide what that evidence says, so a floating tag there leaves the decision with whoever can
move the tag upstream. Swapping the pinned `taiki-e/install-action` for a floating major tag
previously kept the suite green.

Every third-party action in that workflow is now pinned to its exact reviewed commit, and a
movable ref is refused separately from a wrong one. Scoped to third-party actions
deliberately: `actions/*` is first-party and its policy is a separate decision.

## Two action version labels were wrong

Both release workflows labelled their app-token action `v2.2.1` while pinning the commit
upstream tags `v3.2.0`. Verified against upstream rather than taken from the report: the
pinned commit is `v3.2.0` and the current `v3` head, and `v2.2.1` is a different commit. The
commit is unchanged and the label now matches it. A wrong label is worse than none, because
the next reader reasons about the version they were told rather than the one that runs.

## A minted tag was reported failed because the read was early

The post-mint readback took the API's first answer under `set -euo pipefail`. That API is
read-after-write eventually consistent, so a tag created successfully can 404 on the first
read, and the bare assignment turned that into a failed mint. Run `30647382296` is the
observed instance: the tag was created and the run concluded FAILURE.

A false failure is worse here than a slow answer. Release recovery reads a failed run as a
release needing repair, so a mint reporting failure on a release it had already created
sends recovery to work on a healthy one.

The read now retries five times over roughly thirty seconds and believes the ref absent only
once those are exhausted. A ref that reads back pointing at another commit stays terminal on
the first read: a newly created ref has no prior value to be stale from, so a different
commit means something else created it, and waiting cannot make that correct.

This is the readback half of FIR-1781. The soft-decline legibility half remains open and is
deliberately not closed by this pull request.

## Verification

Every change is falsified against a committed baseline, not an unstaged edit: `git checkout`
restores from the index, so falsifying an unstaged change silently reverts the thing under
test.

- second selector invocation injected: was exit 0, now names `found 2`
- readback reverted to the bare read: fails, naming a successful mint reported as failed
- readback made to retry a wrong-commit answer: fails
- four readback fixtures drive the real extracted step body against a scripted API
  (readable immediately, 404 twice then readable, never readable, readable at the wrong
  commit), with a `sleep` stub so the exhaustion case costs no wall clock
- pinned install-action floated to `@v2`: was exit 0, now names expected and actual pin
- pinned toolchain commit swapped: refused
- runbook section removed: each of five needles refused

Authority suite, `actionlint` on all three touched workflows, both zero-file-search guards,
seven python release suites, and `node --test` over five suites all pass. The true merge
against current `main` passes the authority suite.

Closes FIR-1759.
Closes FIR-1765.
