### PR TITLE
Guard the kin-cli featureless contract by running its tests with default features off

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,6 +954,25 @@ jobs:
       - name: Test gcs feature
         run: cargo nextest run -p kin-daemon --features gcs --locked
 
+      # Nothing else on these legs resolves kin-cli without its default
+      # features, so a break that appears only with `vector` and `embeddings`
+      # off compiles clean here and reaches main behind a green required
+      # context. The Windows job covers that configuration for the msvc target
+      # and runs three filtered subsets of the library, so the cases asserting
+      # the vector-free path execute in this step and nowhere else.
+      # `RUSTFLAGS: -D warnings` is set at workflow level, so the unused-import
+      # shape this class first took fails the step rather than warning.
+      #
+      # The whole package runs rather than the library alone. The regressions
+      # this is here to catch are library unit tests, but the featureless
+      # configuration is a build configuration before it is a test one: 30 of
+      # the 33 integration targets compile without default features nowhere
+      # else, and scoping to `--lib` would stop compiling exactly the targets
+      # where a test that assumes a feature can next appear.
+      #
+      # `cargo test` rather than the `cargo nextest run` the steps above use.
+      # It is the authority when the two runners disagree, and it covers the
+      # package's doctests in the same pass instead of needing a second step.
       - name: Test featureless kin-cli
         run: cargo test -p kin-cli --no-default-features --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,6 +954,9 @@ jobs:
       - name: Test gcs feature
         run: cargo nextest run -p kin-daemon --features gcs --locked
 
+      - name: Test featureless kin-cli
+        run: cargo test -p kin-cli --no-default-features --locked
+
   # Security audit moved to sast.yml (cargo-deny: advisories + licenses + bans + sources)
 
   coverage:


### PR DESCRIPTION
`kin-cli` ships on Windows built without its default features, and until now nothing on
the Unix legs ever resolved that configuration. A break appearing only with `vector` and
`embeddings` off compiled clean through every pass in `Check & Test` and reached main
behind a green required context. This adds the missing pass as the last step of that job,
with the rationale comment the other non-obvious steps in the job carry.

## What the guard proves

It is not a second spelling of the default `Test` pass. The two
`#[cfg(feature = "vector")]` / `#[cfg(not(feature = "vector"))]` pairs added in #547
invert between the two steps, identically on both legs, which is what a genuinely
featureless resolution looks like:

| Test | gate | default `Test` | this step |
|---|---|---|---|
| `vector_free_locate_degrades_gracefully_on_the_default_path` | `not(vector)` | absent | present |
| `vector_free_validation_refuses_prepared_state_that_expects_embeddings` | `not(vector)` | absent | present |
| `locate_degrades_gracefully_on_incomplete_embeddings` | `vector` | present | absent |
| `validation_rejects_invalid_vector_sidecar_when_embeddings_expected` | `vector` | present | absent |

The macOS `[target.'cfg(target_os = "macos")'.dependencies]` block activates a `kin-db`
feature rather than `kin-cli`'s own `vector`, so the gates stay off on that leg too and
the guard is not vacuous there. `RUSTFLAGS: -D warnings` is set at workflow level, so the
unused-import shape this class first took fails the step rather than warning, and the step
carries no `continue-on-error`, so a failure fails a required context.

The Windows job already compiles this configuration, but only for the msvc target, and it
runs three filtered subsets of the library and compiles 3 of the 33 integration targets.
Everything else featureless executes in this step and nowhere else.

Counts at this head, summed from the step's own log: ubuntu reports 1381 passed, 0 failed,
1 ignored across 37 test binaries, of which the library contributes 1001; macOS reports
1386 passed, 0 failed, 1 ignored across the same 37 binaries, with 1004 in the library.
The ticket anticipated 1003, so the real figures are recorded here instead. The spread
between the legs is platform-gated cases, and nothing fails on either.

## Measured cost

Measured per step, which the ticket makes an acceptance condition. Two rounds are recorded
because a single round cannot separate the step's cost from runner variance. Durations
come from the Actions jobs API for runs 30663790105 and 30680101087, so every cell is
reproducible:

| Leg | Round | This step | Job total | Job without the step | Delta |
|---|---|---|---|---|---|
| ubuntu-latest | 1 | 447s (7m27s) | 1987s (33m07s) | 1540s (25m40s) | +29% |
| ubuntu-latest | 2 | 441s (7m21s) | 1774s (29m34s) | 1333s (22m13s) | +33% |
| macos-latest | 1 | 474s (7m54s) | 1382s (23m02s) | 908s (15m08s) | +52% |
| macos-latest | 2 | 475s (7m55s) | 1394s (23m14s) | 919s (15m19s) | +52% |

Billed total: 921s (15.4 min) in round 1, 916s (15.3 min) in round 2, per CI round.

The step's own cost is the stable figure, reproducing within 1.4% on ubuntu and 0.2% on
macOS. The percentage delta is the unstable one, because the job total moves with cache
warmth: the same ubuntu job took 33m07s and 29m34s across the two rounds while its
featureless step barely moved. Read the seconds, not the percentage.

`Check & Test (ubuntu-latest)` is the longest required context in the repo, so this lands
on the critical path. The job also runs on `merge_group`, which is correct for a
pre-landing guard but means a landing pays the step twice: roughly +14.8 min of critical
path and +30.6 min of billed compute per landing. `timeout-minutes: 60` leaves the worst
observed ubuntu round at 33m07s, 55% of budget, down from about 34 min of headroom to
about 27 min.

Round 1's ubuntu step is 84s of compile across 84 crates plus 363s of test execution, of
which the library is 252.7s and the 33 integration binaries are 107.9s. Scoping the run to
`--lib` would recover about 6.6 min of the billed total and is deliberately not done: 30
of those 33 integration targets compile without default features nowhere else, so `--lib`
would stop compiling exactly the targets where a test that assumes a feature can next
appear. The `Test gcs feature` step above it already records the same reasoning for the
same reason.

## Not claiming

The minutes come from two CI rounds per leg with cache restored from main. That bounds the
step's own cost, which reproduced closely, and it does not characterize the tail: two
rounds cannot rule out a slow round, and the job total already moved 3.5 min between them.
Nothing here claims the step is free of flake risk: running
the whole package does re-run the daemon-spawning integration suites a second time per leg
on a required context, which is a real second exposure to that class, accepted for the
compile coverage above rather than dismissed.

Closes FIR-1791
