### PR TITLE
feat(status): plumb embedding coverage into status.v2 semantic enrichment

### DIFF
--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -91,6 +91,9 @@ pub struct SemanticEnrichmentStatus {
     pub entity_count: usize,
     pub relation_count: usize,
     pub semantic_change_count: usize,
+    pub embeddings_indexed: usize,
+    pub embeddings_pending: usize,
+    pub embeddings_total: usize,
     /// There is no repository-v6 completion attestation yet. Counts are exact;
     /// completeness is deliberately not inferred from them.
     pub completion_attested: bool,
@@ -106,6 +109,9 @@ struct SemanticEnrichmentStatusWire {
     entity_count: usize,
     relation_count: usize,
     semantic_change_count: usize,
+    embeddings_indexed: usize,
+    embeddings_pending: usize,
+    embeddings_total: usize,
     #[serde(deserialize_with = "deserialize_status_unattested")]
     completion_attested: bool,
 }
@@ -124,6 +130,9 @@ impl<'de> Deserialize<'de> for SemanticEnrichmentStatus {
             entity_count: wire.entity_count,
             relation_count: wire.relation_count,
             semantic_change_count: wire.semantic_change_count,
+            embeddings_indexed: wire.embeddings_indexed,
+            embeddings_pending: wire.embeddings_pending,
+            embeddings_total: wire.embeddings_total,
             completion_attested: wire.completion_attested,
         };
         enrichment.validate().map_err(serde::de::Error::custom)?;
@@ -147,6 +156,9 @@ impl SemanticEnrichmentStatus {
             entity_count: summary.entity_count,
             relation_count: summary.relation_count,
             semantic_change_count: summary.semantic_change_count,
+            embeddings_indexed: summary.embeddings_indexed,
+            embeddings_pending: summary.embeddings_pending,
+            embeddings_total: summary.embeddings_total,
             completion_attested: false,
         }
     }
@@ -162,7 +174,15 @@ impl SemanticEnrichmentStatus {
                 "semantic_enrichment.presence is present despite zero entity/relation counts"
                     .to_string(),
             ),
-            _ => Ok(()),
+            _ => {
+                if self.embeddings_indexed > self.embeddings_total {
+                    return Err(format!(
+                        "embeddings_indexed ({}) exceeds embeddings_total ({})",
+                        self.embeddings_indexed, self.embeddings_total
+                    ));
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -751,6 +771,9 @@ mod tests {
             entity_count: 7,
             relation_count: 4,
             semantic_change_count: 2,
+            embeddings_indexed: 5,
+            embeddings_pending: 2,
+            embeddings_total: 7,
             completion_attested: false,
         };
 
@@ -758,6 +781,9 @@ mod tests {
         assert_eq!(encoded["view"], "durable_repository_authority");
         assert_eq!(encoded["authority_generation"], 9);
         assert_eq!(encoded["workspace_generation"], 3);
+        assert_eq!(encoded["embeddings_indexed"], 5);
+        assert_eq!(encoded["embeddings_pending"], 2);
+        assert_eq!(encoded["embeddings_total"], 7);
         assert_eq!(
             serde_json::from_value::<SemanticEnrichmentStatus>(encoded).unwrap(),
             enrichment

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -86,18 +86,18 @@ pub fn durable_semantic_enrichment_summary(
         "workspace semantic overlay",
     )?;
 
-    let (embeddings_indexed, embeddings_pending, embeddings_total) =
-        if let Some(snapshot) = authority
+    let (embeddings_indexed, embeddings_pending, embeddings_total) = if let Some(snapshot) =
+        authority
             .workspace_graph_snapshot(workspace_id)
             .map_err(|error| KinError::Graph(error.to_string()))?
-        {
-            let graph = kin_db::InMemoryGraph::from_snapshot(snapshot)
-                .map_err(|error| KinError::Graph(error.to_string()))?;
-            let status = graph.embedding_status();
-            (status.indexed, status.pending, status.total)
-        } else {
-            (0, 0, 0)
-        };
+    {
+        let graph = kin_db::InMemoryGraph::from_snapshot(snapshot)
+            .map_err(|error| KinError::Graph(error.to_string()))?;
+        let status = graph.embedding_status();
+        (status.indexed, status.pending, status.total)
+    } else {
+        (0, 0, 0)
+    };
 
     Ok(DurableSemanticEnrichmentSummary {
         authority_generation: authority.roots().generation,

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -37,6 +37,9 @@ pub struct DurableSemanticEnrichmentSummary {
     /// Repository-wide immutable semantic changes sealed by this authority
     /// generation. Entity and relation counts remain workspace-scoped.
     pub semantic_change_count: usize,
+    pub embeddings_indexed: usize,
+    pub embeddings_pending: usize,
+    pub embeddings_total: usize,
 }
 
 /// Summarize one durable workspace without materializing its complete query graph.
@@ -83,12 +86,28 @@ pub fn durable_semantic_enrichment_summary(
         "workspace semantic overlay",
     )?;
 
+    let (embeddings_indexed, embeddings_pending, embeddings_total) =
+        if let Some(snapshot) = authority
+            .workspace_graph_snapshot(workspace_id)
+            .map_err(|error| KinError::Graph(error.to_string()))?
+        {
+            let graph = kin_db::InMemoryGraph::from_snapshot(snapshot)
+                .map_err(|error| KinError::Graph(error.to_string()))?;
+            let status = graph.embedding_status();
+            (status.indexed, status.pending, status.total)
+        } else {
+            (0, 0, 0)
+        };
+
     Ok(DurableSemanticEnrichmentSummary {
         authority_generation: authority.roots().generation,
         workspace_generation: workspace.generation,
         entity_count: entity_ids.len(),
         relation_count: relation_ids.len(),
         semantic_change_count: authority.snapshot().changes.len(),
+        embeddings_indexed,
+        embeddings_pending,
+        embeddings_total,
     })
 }
 


### PR DESCRIPTION
Plumbs embedding coverage (`embeddings_indexed`, `embeddings_pending`, `embeddings_total`) from graph-owned authority truth into `SemanticEnrichmentStatus` on `kin status --json` (`kin.status.v2`). Restores progress visibility for MCP, kin-editor, and benchmark agents.

Closes FIR-1785