### PR TITLE
Admit every path the release generator writes

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -274,7 +274,11 @@ jobs:
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             existing=true
             git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
-            allowed='^(Cargo\.toml|Cargo\.lock|CHANGELOG\.md|crates/kin-cli/Cargo\.toml|packages/(kin-mcp|kin|boundary-contracts)/package\.json)$'
+            # Every path prepare-release.mjs writes has to be listed here, or
+            # the train refuses the branch it just generated. The authority
+            # suite cross-checks this against the generator rather than trusting
+            # the two to stay in step by hand.
+            allowed='^(Cargo\.toml|Cargo\.lock|fuzz/Cargo\.lock|CHANGELOG\.md|crates/kin-cli/Cargo\.toml|packages/(kin-mcp|kin|boundary-contracts)/package\.json)$'
             branch_paths="$(git diff \
               --name-only \
               "refs/remotes/origin/main...refs/remotes/origin/${BRANCH}")"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -29,6 +29,9 @@ RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
+PREPARE_RELEASE = ROOT / "scripts" / "prepare-release.mjs"
+# A repo-relative file path as the release generator writes it.
+GENERATED_PATH_LITERAL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*\.[A-Za-z0-9]+$")
 INSTALL_SH = ROOT / "scripts" / "install.sh"
 INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 ABANDONED_TAGS = ROOT / "scripts" / "abandoned-release-tags.json"
@@ -1779,6 +1782,63 @@ def assert_merge_policy_gate(release_train: str) -> None:
         )
 
 
+def release_branch_allowlist(release_train: str) -> str:
+    """Return the regex the train uses to admit its own generated branch."""
+
+    match = re.search(r"^\s*allowed='(?P<pattern>[^']+)'", release_train, re.M)
+    if match is None:
+        raise AssertionError(
+            "release train no longer carries the generated-path allowlist that "
+            "admits its own release branch"
+        )
+    return match.group("pattern")
+
+
+def prepared_release_paths(generator: str) -> set[str]:
+    """Return every repo path the release generator writes."""
+
+    bindings = dict(re.findall(r"const\s+(\w+)\s*=\s*'([^']+)'\s*;", generator))
+    paths: set[str] = set()
+    # Array literals of paths, which is how the npm manifests are carried.
+    for block in re.findall(r"const\s+\w+\s*=\s*\[([^\]]*)\]\s*;", generator):
+        for literal in re.findall(r"'([^']+)'", block):
+            if GENERATED_PATH_LITERAL.match(literal):
+                paths.add(literal)
+    # Direct writes, whether the destination is a literal or a bound constant.
+    for argument in re.findall(r"fs\.writeFile\(\s*([^,\s]+)\s*,", generator):
+        candidate = argument[1:-1] if argument.startswith("'") else bindings.get(argument)
+        if candidate and GENERATED_PATH_LITERAL.match(candidate):
+            paths.add(candidate)
+    return paths
+
+
+def assert_release_branch_allowlist_covers_generator(release_train: str) -> None:
+    """The train must admit every path its own generator writes.
+
+    These two drifted apart once already: the generator learned to bump a
+    second lockfile and the allowlist did not, so the train refused the branch
+    it had just written and no release could be prepared at all. Neither side
+    is authority over the other, so the gate is that they agree.
+    """
+
+    allowed = re.compile(release_branch_allowlist(release_train))
+    generated = prepared_release_paths(
+        PREPARE_RELEASE.read_text(encoding="utf-8")
+    )
+    if not generated:
+        raise AssertionError(
+            "no generated release path could be resolved from "
+            "prepare-release.mjs, so this cross-check proves nothing"
+        )
+    refused = sorted(path for path in generated if not allowed.match(path))
+    if refused:
+        raise AssertionError(
+            "the release branch guard refuses paths the release generator "
+            "writes, so the train cannot open the bump it just prepared: "
+            f"{', '.join(refused)}"
+        )
+
+
 def release_check_gate_source(release_tag: str) -> str:
     """Extract the exact Python gate executed by the release-tag workflow."""
 
@@ -2983,6 +3043,7 @@ def main() -> None:
     ):
         require(release_train, policy, "coalescing protected release train")
     assert_merge_policy_gate(release_train)
+    assert_release_branch_allowlist_covers_generator(release_train)
     assert_abandoned_tag_admission(release_tag, release_train)
     # The release bump must never be resolvable from anything a merged pull
     # request can still change.


### PR DESCRIPTION
The release train writes its own bump branch, then refuses it if any changed path falls
outside a hand-maintained allowlist. That allowlist never learned the second lockfile the
generator gained when the version bump became a six-file lockstep, so the train wrote a
correct branch and declined it:

```
::error::release branch contains non-generated paths:
fuzz/Cargo.lock
```

Two consecutive `Reconcile release PR` runs failed that way, and no release could be
prepared at all. The branch was right and the guard was stale.

## The fix, and the part that matters more

Adding `fuzz/Cargo.lock` to the allowlist unblocks today. It is the recurrence that is
worth spending a test on: the generator and the guard are two hand-maintained lists that
must agree, with nothing checking that they do, so the next path the generator gains
breaks the train the same way.

The authority suite now resolves the paths `prepare-release.mjs` actually writes, by
reading its bound path constants, its manifest array, and its write call sites, and
requires the guard's allowlist to admit every one of them. Neither list is authority over
the other; the gate is that they agree.

Today that resolves exactly the eight paths a bump touches: `Cargo.toml`, `Cargo.lock`,
`fuzz/Cargo.lock`, `CHANGELOG.md`, `crates/kin-cli/Cargo.toml`, and the three
`packages/*/package.json` manifests.

## Falsification

Both directions of the drift fail the suite, verified against a committed baseline:

- allowlist reverted to its pre-fix form: refuses, naming `fuzz/Cargo.lock`, which is this
  outage reproduced as a test
- generator given a scratch path the allowlist does not list: refuses, naming
  `tools/scratch.toml`

The cross-check also refuses outright if it resolves no generated paths at all, so a future
refactor of the generator cannot turn it into a vacuous pass.

## Expected effect on landing

This lands through the normal path and the resulting `main` push re-fires the release
train on its usual trigger. The train should then get past the branch guard and open the
version bump PR with no dispatch or other manual step. The abandonment mechanism it depends
on already ran correctly in production ahead of this, waiving the abandoned base tag and
resolving a patch bump, so this guard was the only thing left in the way.

Scope is deliberately just the allowlist and its cross-check; nothing else rides along.

Closes FIR-1792.
