### PR TITLE
Report retrieval truncation from where it was cut, not from an advisory log

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -643,7 +643,15 @@ struct LocateBudget {
     start: std::time::Instant,
     total_secs: f64,
     phase_budgets: HashMap<&'static str, f64>,
+    /// Advisory notes for the log and the explain surface. Mixed on purpose:
+    /// this holds both work that was skipped and work that merely overran a
+    /// soft per-phase budget and finished anyway. Do NOT infer truncation from
+    /// it; the second kind truncates nothing, so a caller that reads emptiness
+    /// here as "the answer is whole" is reading the wrong field.
     warnings: Vec<String>,
+    /// Retrieval that was actually cut short, recorded at the point it was cut.
+    /// This is the only sound basis for telling a caller the answer is partial.
+    truncations: Vec<String>,
 }
 
 /// The budget-gated phases of the locate pipeline, with the environment knob
@@ -684,6 +692,7 @@ impl LocateBudget {
                 .map(|(phase, knob, default)| (*phase, secs_budget(knob, *default)))
                 .collect(),
             warnings: Vec::new(),
+            truncations: Vec::new(),
         }
     }
 
@@ -712,6 +721,22 @@ impl LocateBudget {
         Self::uniform(-1.0)
     }
 
+    /// A generous total with specific phases overridden.
+    ///
+    /// `uniform` cannot express the one budget cut that reaches the end of the
+    /// pipeline, because that cut depends on a phase remainder being small
+    /// while the total is not exhausted. Setting them independently is what
+    /// lets a test drive a real truncation all the way to the completing path
+    /// instead of bailing at the scoring gate.
+    #[cfg(test)]
+    fn with_phase_overrides(total_secs: f64, overrides: &[(&'static str, f64)]) -> Self {
+        let mut budget = Self::uniform(total_secs);
+        for (phase, secs) in overrides {
+            budget.phase_budgets.insert(phase, *secs);
+        }
+        budget
+    }
+
     /// Every gate in the pipeline, total and per phase, set to `secs`.
     #[cfg(test)]
     fn uniform(secs: f64) -> Self {
@@ -723,6 +748,7 @@ impl LocateBudget {
                 .map(|(phase, _, _)| (*phase, secs))
                 .collect(),
             warnings: Vec::new(),
+            truncations: Vec::new(),
         }
     }
 
@@ -743,6 +769,10 @@ impl LocateBudget {
     /// Check if a phase should be skipped entirely (no budget left).
     fn phase_should_skip(&mut self, phase: &str) -> bool {
         if self.total_exceeded() {
+            self.record_truncation(format!(
+                "skipped {phase}: total budget exhausted ({:.1}s elapsed)",
+                self.start.elapsed().as_secs_f64()
+            ));
             self.warnings.push(format!(
                 "skipped {phase}: total budget exhausted ({:.1}s elapsed)",
                 self.start.elapsed().as_secs_f64()
@@ -757,6 +787,9 @@ impl LocateBudget {
         false
     }
 
+    /// Note a phase that overran its soft budget. Deliberately NOT a truncation:
+    /// every call site fires in the branch where the phase already ran to
+    /// completion, so the result is whole and only the timing was poor.
     fn warn_phase_timeout(&mut self, phase: &str, elapsed: std::time::Duration) {
         self.warnings.push(format!(
             "{phase} exceeded budget ({:.1}s)",
@@ -767,6 +800,17 @@ impl LocateBudget {
             elapsed_ms = elapsed.as_millis(),
             "locate phase exceeded budget, returning partial results"
         );
+    }
+
+    /// Record retrieval that was cut short. Called at the cut, never inferred
+    /// after the fact.
+    fn record_truncation(&mut self, what: String) {
+        self.truncations.push(what);
+    }
+
+    /// Whether any retrieval was cut short for this query.
+    fn truncated(&self) -> bool {
+        !self.truncations.is_empty()
     }
 
     fn elapsed_secs(&self) -> f64 {
@@ -1766,6 +1810,14 @@ fn run_with_graph_capture_budgeted(
         let embedding = if budget.phase_remaining("entity_discovery") < 2.0 {
             tracing::info!(
                 "skipping embedding sub-phase: entity_discovery budget nearly exhausted"
+            );
+            // The one budget cut that does NOT imply the total was exceeded: it
+            // fires on the per-phase remainder, so the pipeline runs to
+            // completion with the embedding signal missing. Before this it was
+            // recorded nowhere the caller could see, which is precisely the
+            // silent partial answer the degradation ledger exists to prevent.
+            budget.record_truncation(
+                "embedding sub-phase skipped: entity_discovery budget nearly exhausted".to_string(),
             );
             if explain {
                 prune_ledger.push(PruneEvent {
@@ -3625,22 +3677,31 @@ fn run_with_graph_capture_budgeted(
             warnings = ?budget.warnings,
             "locate pipeline completed with budget warnings"
         );
-        // A budget that truncated discovery returns FEWER results, not an error,
-        // so without this the caller cannot tell "nothing matched" from "the
-        // pipeline stopped looking". The early scoring-skip return already
-        // reports this; a phase skipped mid-pipeline has to report it as well
-        // or the same silence returns through the other door.
+    }
+    // Gated on truncation, NOT on `warnings`. A phase that overran its soft
+    // budget and still produced its full result writes a warning and truncates
+    // nothing, so reporting that as a degradation would tell a caller its whole
+    // answer was partial, on exactly the slow-host path this file otherwise
+    // works to stop conflating with retrieval semantics.
+    //
+    // Reaching here with a truncation means the per-phase embedding cut above:
+    // a skipped PHASE implies the total was exceeded, and `total_exceeded` only
+    // ever goes from false to true, so the scoring gate would have returned
+    // early with its own report before this line.
+    if budget.truncated() {
         record_degradation(
             &mut degradations,
             RetrievalDegradation {
                 component: "pipeline".to_string(),
-                reason: "budget_exhausted".to_string(),
+                reason: "budget_truncated".to_string(),
                 detail: format!(
-                    "locate budget exhausted after {:.1}s; {}",
+                    "retrieval truncated after {:.1}s; {}",
                     budget.elapsed_secs(),
-                    budget.warnings.join("; ")
+                    budget.truncations.join("; ")
                 ),
-                remediation: "raise KIN_LOCATE_TOTAL_TIMEOUT_SECS for this repo size".to_string(),
+                remediation:
+                    "raise KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS, or the total budget, for this repo size"
+                        .to_string(),
             },
         );
     }
@@ -17733,40 +17794,49 @@ mod tests {
         assert!(!vector_degradations[0].remediation.contains("kin embed"));
     }
 
-    /// A budget that truncated retrieval must say so on the result.
+    /// Truncated retrieval must say so on the result, and untruncated retrieval
+    /// must not.
     ///
-    /// Over budget the pipeline skips discovery and returns `Ok` with fewer
-    /// files, so "found nothing" and "stopped looking" are the same value at
-    /// the assertion. That is what made a wall-clock stall read as a retrieval
-    /// regression. The degradation ledger is what tells them apart, and it has
-    /// to be populated on the completing path and not only on the early return.
+    /// Over budget the pipeline returns `Ok` with fewer files, so "found
+    /// nothing" and "stopped looking" are the same value at the assertion. The
+    /// degradation ledger is what separates them.
+    ///
+    /// The positive case drives the ONE budget cut that reaches the end of the
+    /// pipeline: a tiny `entity_discovery` phase budget under a generous total
+    /// skips the embedding sub-phase without ever exhausting the total, so no
+    /// phase gate fires and the run completes normally. Revert the
+    /// `budget.truncated()` block and this goes red, which the previous version
+    /// of this test could not do: it drove an exhausted TOTAL, which bails at
+    /// the scoring gate and is reported by code that predates this branch.
     #[test]
-    fn budget_truncated_locate_reports_the_truncation_rather_than_an_empty_result() {
+    fn truncated_retrieval_is_reported_and_whole_retrieval_is_not() {
         let graph = kin_db::InMemoryGraph::new();
         let entity = test_entity("handler", "src/lib.py", 1, 5);
         graph.upsert_entity(&entity).unwrap();
         admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
 
-        let starved = run_with_graph_capture_in_workspace_budgeted(
+        let truncated_marker = |result: &LocateResult| {
+            result.degradations.iter().any(|degradation| {
+                degradation.component == "pipeline" && degradation.reason == "budget_truncated"
+            })
+        };
+
+        let truncated = run_with_graph_capture_in_workspace_budgeted(
             &graph,
             None,
             "handler failure",
             false,
             10,
             true,
-            LocateBudget::already_exhausted(),
+            LocateBudget::with_phase_overrides(f64::INFINITY, &[("entity_discovery", 0.0)]),
         )
-        .expect("an exhausted budget truncates retrieval, it does not error");
+        .expect("a truncating budget cuts retrieval, it does not error");
         assert!(
-            starved.degradations.iter().any(|degradation| {
-                degradation.component == "pipeline" && degradation.reason == "budget_exhausted"
-            }),
-            "a truncated locate must carry its budget_exhausted degradation, got {:?}",
-            starved.degradations
+            truncated_marker(&truncated),
+            "retrieval cut short must carry its truncation, got {:?}",
+            truncated.degradations
         );
 
-        // The control: the same query under a budget that cannot truncate must
-        // NOT claim truncation, or the marker means nothing.
         let whole = run_with_graph_capture_in_workspace_budgeted(
             &graph,
             None,
@@ -17778,11 +17848,40 @@ mod tests {
         )
         .expect("an unbounded budget runs the whole pipeline");
         assert!(
-            !whole.degradations.iter().any(|degradation| {
-                degradation.component == "pipeline" && degradation.reason == "budget_exhausted"
-            }),
-            "an untruncated locate must not claim a budget was exhausted, got {:?}",
+            !truncated_marker(&whole),
+            "whole retrieval must not claim truncation, got {:?}",
             whole.degradations
+        );
+    }
+
+    /// The distinction the truncation marker rests on, asserted directly.
+    ///
+    /// `warnings` mixes two events that mean opposite things to a caller: work
+    /// that was skipped, and work that overran a soft budget and finished
+    /// anyway. Gating a "your answer is partial" signal on that vector reports
+    /// a whole answer as truncated every time a slow host trips the second
+    /// kind, which is the inversion this pins against returning.
+    #[test]
+    fn a_phase_that_overran_its_budget_but_completed_is_not_a_truncation() {
+        let mut overran = LocateBudget::unbounded();
+        overran.warn_phase_timeout("entity_discovery", std::time::Duration::from_secs(30));
+        assert!(
+            !overran.warnings.is_empty(),
+            "the advisory warning is still recorded for the log and explain surface"
+        );
+        assert!(
+            !overran.truncated(),
+            "a phase that produced its full result truncated nothing"
+        );
+
+        let mut exhausted = LocateBudget::already_exhausted();
+        assert!(
+            exhausted.phase_should_skip("entity_discovery"),
+            "an exhausted total must skip the phase"
+        );
+        assert!(
+            exhausted.truncated(),
+            "a skipped phase IS a truncation and must be recorded as one"
         );
     }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3396,8 +3396,15 @@ mod tests {
     /// fire-and-forget `SIGCONT` cannot clear, so this pins the property the
     /// fork-boundary handshake depends on: a release is complete only once the
     /// target's own progress proves it is running, not once a signal has been
-    /// sent. Replace [`resume_test_pid_until`] with a bare `kill(SIGCONT)` and
-    /// the child never reaches its marker, so this goes red.
+    /// sent.
+    ///
+    /// Falsify it by replacing the repeat loop INSIDE [`resume_test_pid_until`]
+    /// with a single `kill(SIGCONT)`: the child stays parked at its second stop,
+    /// never publishes its marker, and the assertion below fails. That
+    /// assertion is deliberately outside the helper, because the closure the
+    /// helper takes is its own success condition, and a test whose only
+    /// observation lives inside the thing under test cannot fail when that
+    /// thing stops working.
     #[cfg(unix)]
     #[test]
     fn resuming_a_stopped_target_clears_every_stop_it_enters() {
@@ -3439,18 +3446,42 @@ mod tests {
             }
         }
 
-        wait_for_test_pid_stopped(child, Duration::from_secs(5));
-        // The marker is published only after BOTH stops are cleared, so its
-        // presence is the running-target proof the helper must deliver.
-        resume_test_pid_until(child, Duration::from_secs(5), || marker.is_file());
+        // The child's terminal state is `pause()`, so it never exits on its
+        // own: if the helper below trips its deadline assert, an unguarded
+        // cleanup line would never run and would leave a permanently stopped,
+        // reparented child pinning this lane's target directory. The neighbouring
+        // multi-process tests take an owner for the same reason.
+        let child = StoppedProbeChild(child);
 
-        assert_eq!(unsafe { libc::kill(child, libc::SIGKILL) }, 0);
-        let mut status = 0;
-        assert_eq!(
-            unsafe { libc::waitpid(child, &mut status, 0) },
-            child,
-            "reap resume-probe child"
+        wait_for_test_pid_stopped(child.0, Duration::from_secs(5));
+        resume_test_pid_until(child.0, Duration::from_secs(5), || marker.is_file());
+        // Outside the helper on purpose: the closure above is the helper's own
+        // success condition, so observing the marker only there would leave this
+        // test green if the helper stopped proving anything.
+        assert!(
+            marker.is_file(),
+            "the target must have cleared both stops and published its marker"
         );
+    }
+
+    /// Kills and reaps a probe child that cannot terminate on its own, however
+    /// the test leaves its scope.
+    #[cfg(unix)]
+    struct StoppedProbeChild(libc::pid_t);
+
+    #[cfg(unix)]
+    impl Drop for StoppedProbeChild {
+        fn drop(&mut self) {
+            // SIGCONT first: SIGKILL is delivered to a stopped process, but a
+            // stopped process that is never continued is not reaped promptly on
+            // every platform, and the point of this guard is to leave nothing.
+            unsafe {
+                libc::kill(self.0, libc::SIGCONT);
+                libc::kill(self.0, libc::SIGKILL);
+            }
+            let mut status = 0;
+            unsafe { libc::waitpid(self.0, &mut status, 0) };
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Forward fix for a defect that shipped in #547. The three tickets that PR closed are otherwise
intact; this repairs one block inside the FIR-1773 stretch goal, which an adversarial review
caught after the PR had already merged.

## What shipped wrong

The completing-path degradation added by #547 (`locate.rs:3622` on current main) is gated on
`budget.warnings`, and that vector has two writers meaning opposite things to a caller.
`phase_should_skip` records work that was skipped and truncates. `warn_phase_timeout` records a
phase that overran a soft budget, and every one of its six call sites fires in the branch where
that phase already ran to completion, so it truncates nothing and only logs.

Worse, the block cannot fire when something really was truncated. `total_exceeded` compares a
monotonic elapsed against a value fixed at construction, so it only ever goes from false to true.
The scoring gate that consults it is an unconditional statement whose taken branch returns. Any
skipped phase therefore guarantees an early return, with its own report, long before the end of
the pipeline.

The result is a signal that is inverted wherever it is observable: a query that ran whole on a
slow host is told its answer was cut short, on exactly the wall-clock path the rest of that work
existed to stop conflating with retrieval semantics, and a query that really was truncated never
reaches the block at all.

## The fix

Record the fact where the cut happens rather than inferring it afterwards. The budget carries a
truncation ledger written by the skip gate, and the completing path reports on that. `warnings`
keeps its existing advisory role for the log and the explain surface, with its two-kinds hazard
now documented at the field.

This also covers the one budget cut that legitimately reaches the end of the pipeline, which had
no report anywhere before. The embedding sub-phase is skipped on the per-phase remainder rather
than the total, so it truncates retrieval while every phase gate still passes. It carries its own
reason, distinct from the early return's, because the total is not exhausted in that case and
reusing that reason would repeat the same false claim in a new place.

`LocateResult.degradations` and `RetrievalDegradation` are unchanged, so the response type is the
same. The new `budget_truncated` reason is a new value in an existing free-form field, which a
caller matching on reasons will see.

## Tests that depend on the code they guard

The guard test in #547 could not have caught this: it drove an exhausted TOTAL, which bails at the
scoring gate and is reported by code predating that branch, so it passed with the new block
absent. It now drives a small per-phase budget under an unbounded total, reaching the production
path. Removing the reporting block turns it red, verified. A second test pins the distinction
directly: a phase that overran its budget but completed is not a truncation, while a skipped phase
is.

The fork-boundary test from FIR-1758 gains the assertion its own doc comment claimed. That comment
said substituting a bare `kill(SIGCONT)` would turn the test red; read literally it was false,
because the test's only observation of the marker was the closure passed into the helper, which is
the helper's own success condition. The marker is now also asserted after the helper returns, so
gutting the helper's repeat loop fails the test as documented, verified. That ticket stays closed;
this is test truthfulness, not a behaviour change.

Its probe child cannot exit on its own, so an owner now kills and reaps it however the test leaves
scope. A deadline assert previously leaked a permanently stopped child, and one such orphan was
found live on the development host, pinning a lane target directory.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` under the exact ci.yml
allow-list with `RUSTFLAGS=-D warnings`, `cargo build --all-targets --locked`, both zero-file-search
guards, both boundary scripts, `cargo test --locked -p kin-cli --no-default-features --all-targets`,
three consecutive `cargo test --workspace --locked` runs, `cargo nextest run --workspace --locked`
and `cargo test --doc --locked` all exit 0.

## What this does not claim

The inverted block was proven by reading the code, not by observing a production query carry the
false degradation; the failure needs a phase to overrun a soft budget on a loaded host, which the
new unit test pins deterministically instead. No claim is made that `warnings` has no other
consumer worth auditing: the explain surface still reads it, deliberately, because there its mixed
contents are the intended content.

Closes FIR-1773
