### PR TITLE
Make the pin prover green on what it finds, and prove it on the substrate rather than in a comment

### DIFF
--- a/.github/workflows/base-image-pins.yml
+++ b/.github/workflows/base-image-pins.yml
@@ -6,28 +6,58 @@ name: Base Image Pins
 # A scheduled run's check-runs DO land on a commit. GitHub binds a check suite
 # to every workflow run, and for a `schedule` event `github.sha` is the default
 # branch HEAD at fire time, so a red scheduled run publishes a failure check-run
-# on a main commit. release-tag.yml's second sweep refuses a release commit
-# carrying any non-green check-run whether or not a ruleset requires it, and a
-# quiesced main during a release train holds HEAD still across exactly the
-# window that matters. This repo already carries a live instance of that shape:
-# fuzz.yml's scheduled run left two `failure` check-runs on a main sha.
+# on a main commit. release-tag.yml's second sweep treats only `success`,
+# `skipped` and `neutral` as non-failing, so anything else on a release
+# candidate refuses that release terminally. A quiesced main during a release
+# train holds HEAD still across exactly that window. fuzz.yml is the standing
+# example: its scheduled run left two `failure` check-runs on a main sha.
 #
-# Dropping the push and pull_request triggers therefore does NOT make this job
-# safe on its own. What makes it safe is that the scheduled path is
-# structurally incapable of concluding failure: the prover's exit status is
-# captured rather than propagated, and the step exits 0 whatever it found. A
-# registry-reachability probe must never be able to refuse a release, because
-# that is the failure class this workflow exists to watch.
+# So this job must not conclude non-green on what it FINDS. What follows is the
+# measured posture, not the intended one. An earlier version of this file
+# claimed the same protection and did not have it, because a `run:` step's
+# script is executed by `bash -e {0}`: `set -e` was never absent, and adding
+# `set -o pipefail` is what armed it. Every claim below was checked by running
+# the shapes on a scratch branch and reading the check-run conclusions off the
+# commit.
 #
-# Loudness comes from a surface that cannot poison a mint. When a pin is
-# definitively unreachable the run opens or updates a tracking issue, which
-# persists until someone acts on it, unlike a red check nobody is paged for.
+# What IS guaranteed:
 #
-# A `workflow_dispatch` run may fail hard, because an operator asked a direct
-# question and deserves a direct answer. The residual is real and is theirs to
-# own: dispatching against main during a release train can publish a failure
-# check-run on the candidate sha. Prefer the schedule unless you need the
-# answer now.
+#   - No result the prover can report concludes non-green. The step runs under
+#     a shell carrying no `-e`, disarms errexit again in its own body, captures
+#     the prover's status instead of propagating it, and ends in `exit 0`.
+#     Measured: that shape publishes `success` with a prover exit of 1, and the
+#     alarm step still runs.
+#   - A failed checkout does not fail the job: step-level `continue-on-error`.
+#
+# What is NOT guaranteed, stated rather than claimed away:
+#
+#   - Runner or infrastructure failure still concludes non-green. Nothing in a
+#     workflow can prevent that.
+#   - Exceeding `timeout-minutes` concludes `cancelled`, which the sweep also
+#     treats as non-green. That is made unreachable by bounding the work rather
+#     than by tolerating it: every registry call is wall-clock capped, the
+#     retry budget is fixed, and the worst case is roughly a third of the limit.
+#
+# Job-level `continue-on-error: true` is deliberately NOT used. It is the
+# obvious remedy and it does not work: measured, a job carrying it that fails
+# still publishes a `failure` check-run on the sha, and one that times out
+# publishes `cancelled`. It only stops the workflow RUN being marked failed,
+# which is not what the sweep reads. Adding it would look like protection while
+# changing nothing.
+#
+# The complete fix for the residual is the sweep learning to ignore
+# non-required producers, which is release-authority work tracked separately
+# and deliberately out of scope here.
+#
+# Loudness lives on a surface that cannot poison a mint: a definitively
+# unreachable pin opens or updates a tracking issue, which persists until
+# someone acts on it.
+#
+# A `workflow_dispatch` run still fails hard, because an operator asked a direct
+# question and deserves a direct answer. The residual is theirs to own:
+# dispatching against main during a release train can publish a failure
+# check-run on the candidate sha. Prefer the schedule unless you need the answer
+# now.
 on:
   schedule:
     - cron: "23 5 * * 1"
@@ -44,50 +74,75 @@ jobs:
   verify-pins:
     name: Verify base image pins
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom, not a deadline. Worst case is 6 registry references at 3
+    # attempts, each call capped at 20s, with 15s of backoff per reference:
+    # about 7.5 minutes. Exceeding this concludes `cancelled`, so the budget is
+    # sized so that finishing is never in question.
+    timeout-minutes: 20
     permissions:
       contents: read
       # The tracking issue is the alarm. It is the only write this job performs.
       issues: write
     steps:
+      # A checkout that fails is a step failure, and a failed step fails the job
+      # whatever the later steps do. The prover cannot run without a checkout,
+      # but a green run reporting nothing beats a red one refusing a release.
       - name: Checkout
+        continue-on-error: true
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      # Exit status is captured, never propagated. `set -e` is deliberately
-      # absent so a non-zero prover status reaches the capture instead of
-      # killing the step, and the explicit `exit 0` makes the green conclusion
-      # a property of the step rather than of what the prover happened to find.
-      #
-      # 1 means a pin is definitively gone or wrong, which is the alarm. 2 means
-      # the probe could not reach a verdict, which is reported and nothing more:
-      # a throttled lookup is not evidence about a digest, and `Docker Image
-      # Build (no push)` already proves buildability on every pull request and
-      # every push to main.
+      # The shell is declared explicitly and carries no `-e`, because the
+      # default (`bash -e {0}`) does, and the `set -o pipefail` below is exactly
+      # what turns a non-zero prover status into a killed step under it.
+      # `set +e` then disarms errexit a second time in the body, so removing the
+      # `shell:` line later cannot silently re-arm the trap. Either layer alone
+      # is sufficient; both are here because this file already shipped once with
+      # a remedy that read correctly and did nothing.
       - name: Verify base image pins resolve from both registries
         id: verify
+        shell: bash --noprofile --norc {0}
         run: |
           set -uo pipefail
+          set +e
           bash scripts/verify-base-image-pins.sh Dockerfile 2>&1 | tee /tmp/base-image-pins.log
           status="${PIPESTATUS[0]}"
-          # A status outside the documented set means the prover itself broke,
-          # which would otherwise route to neither the alarm nor the all-clear
-          # and leave this job quietly doing nothing for weeks.
           case "$status" in
-            0 | 1 | 2) ;;
+            0)
+              echo "Every pinned base image resolves from both registries." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            1)
+              echo "::error::a pinned base image is unreachable; the release build has lost a registry"
+              echo "A pinned base image is unreachable. Tracking issue opened." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            2)
+              # Reported rather than silent. A permanently throttled probe is
+              # the most likely steady state for anonymous registry lookups from
+              # shared runner egress, and without an annotation a run that
+              # verified nothing is indistinguishable from a healthy one.
+              echo "::warning::base image pins could not be verified this run; no conclusion is being drawn"
+              echo "Pins could not be verified this run (throttled or unreachable registry)." >> "$GITHUB_STEP_SUMMARY"
+              ;;
             *)
+              # Includes the prover being missing entirely, which is what a
+              # failed checkout looks like from here.
               echo "::warning::the pin prover exited ${status}, which is not one of its documented statuses; no conclusion drawn"
+              echo "Pin prover exited ${status}; no conclusion drawn." >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
           echo "status=${status}" >> "$GITHUB_OUTPUT"
           exit 0
 
-      # The alarm must not become the thing that reds a main sha. An API hiccup
-      # while filing it is the same hazard as a registry hiccup while probing,
-      # so it is reported and tolerated rather than propagated.
+      # `always()` so the alarm does not depend on every earlier step having
+      # succeeded. A bare `if:` implies `success()`, which would tie the alarm
+      # to exactly the conditions under which it is most needed.
+      #
+      # The alarm must also not become the thing that reds a main sha, so filing
+      # it is tolerated rather than propagated: an API hiccup while raising an
+      # alarm is the same hazard as a registry hiccup while probing.
       - name: Open or update the tracking issue
-        if: steps.verify.outputs.status == '1'
+        if: ${{ always() && steps.verify.outputs.status == '1' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -122,7 +177,7 @@ jobs:
           fi
 
       - name: Close the tracking issue once the pins are healthy
-        if: steps.verify.outputs.status == '0'
+        if: ${{ always() && steps.verify.outputs.status == '0' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -141,7 +196,7 @@ jobs:
       # Only a dispatched run may go red, and only after the alarm above has
       # already been raised, so the operator's answer never costs the alarm.
       - name: Report the failure to the operator who asked
-        if: ${{ github.event_name == 'workflow_dispatch' && steps.verify.outputs.status != '0' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && steps.verify.outputs.status != '0' }}
         run: |
           echo "::error::base image pin verification exited ${{ steps.verify.outputs.status }}; see the log above"
           exit 1

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -59,6 +59,7 @@ BASE_IMAGE_MIRROR = 'mirrors = ["mirror.gcr.io"]'
 BASE_IMAGE_MIRROR_INPUT = "buildkitd-config-inline:"
 BASE_IMAGE_PIN = re.compile(r"(?m)^FROM\s+(?P<reference>\S+)")
 SETUP_BUILDX_ACTION = "docker/setup-buildx-action@"
+BASE_IMAGE_PINS = WORKFLOWS / "base-image-pins.yml"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
 MAIN_ONLY_CACHE_SAVE_VALUE = "${{ github.ref == 'refs/heads/main' }}"
@@ -2468,6 +2469,85 @@ def assert_container_base_image_authority(
             require(mirror_input, needle, f"{label}:{job} base image mirror")
 
 
+def assert_pin_prover_cannot_refuse_a_release(pins_workflow: str) -> None:
+    """Keep the scheduled pin prover unable to red the sha it runs against.
+
+    A `schedule` run's check-runs land on the default branch HEAD, and the
+    release sweep treats anything but success, skipped or neutral as a terminal
+    refusal. This job therefore must not conclude on what it finds. That held by
+    accident once and then stopped holding, because a `run:` step is executed by
+    `bash -e {0}` and the step's own `set -o pipefail` is what armed errexit
+    against the prover's non-zero status. The remedy read correctly and did
+    nothing for a full review round, so the properties it depends on are pinned
+    here rather than left to the next reader to re-derive.
+    """
+
+    verify = job_step_active_lines(pins_workflow, "verify-pins", "id: verify")
+    shell = next(
+        (line for line in verify if line.strip().startswith("shell:")),
+        None,
+    )
+    if shell is None:
+        raise AssertionError(
+            "the pin prover step must declare its shell explicitly; the default "
+            "carries -e, which kills the step on the prover status it exists to "
+            "capture"
+        )
+    if re.search(r"(?<![\w-])-\w*e", shell.split("shell:", 1)[1]) is not None:
+        raise AssertionError(
+            f"the pin prover step's shell must not carry errexit: {shell.strip()}"
+        )
+    for policy in ("set +e", "exit 0"):
+        require(
+            "\n".join(verify),
+            policy,
+            "pin prover step that must not conclude on what it finds",
+        )
+
+    checkout = job_step_active_lines(pins_workflow, "verify-pins", "actions/checkout@")
+    require(
+        "\n".join(checkout),
+        "continue-on-error: true",
+        "pin prover checkout, whose failure would fail the job regardless of "
+        "the guard below it",
+    )
+
+
+def job_step_active_lines(workflow: str, job: str, marker: str) -> list[str]:
+    """Return the active lines of the step in `job` that contains `marker`."""
+
+    block = workflow_job_blocks(workflow).get(job)
+    if block is None:
+        raise AssertionError(f"workflow no longer declares the {job} job")
+    lines = block.splitlines()
+    hits = [
+        index
+        for index, line in enumerate(lines)
+        if marker in line and not line.lstrip().startswith("#")
+    ]
+    if len(hits) != 1:
+        raise AssertionError(
+            f"{job} must contain exactly one step matching {marker!r}, "
+            f"found {len(hits)}"
+        )
+    start = hits[0]
+    while start >= 0 and re.match(r"^\s*-\s", lines[start]) is None:
+        start -= 1
+    if start < 0:
+        raise AssertionError(f"{job} step matching {marker!r} has no step start")
+    step_indent = len(lines[start]) - len(lines[start].lstrip())
+    active = [lines[start]]
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip()) <= step_indent:
+            break
+        if line.lstrip().startswith("#"):
+            continue
+        active.append(line)
+    return active
+
+
 def comment_out_mirror_input(workflow: str) -> str:
     """Comment out the buildx mirror input while leaving its text in the file."""
 
@@ -3388,6 +3468,58 @@ def main() -> None:
         )
 
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    # P3-4's content landed without a guard, so a deliberate deletion of the
+    # index refresh was invisible to the suite.
+    require(
+        ci_jobs["check"],
+        "sudo apt-get update",
+        "aarch64 release-target compile guard apt index refresh",
+    )
+
+    base_image_pins = BASE_IMAGE_PINS.read_text(encoding="utf-8")
+    assert_pin_prover_cannot_refuse_a_release(base_image_pins)
+    expect_assertion(
+        "the pin prover step loses its explicit errexit-free shell",
+        "must declare its shell explicitly",
+        lambda: assert_pin_prover_cannot_refuse_a_release(
+            re.sub(r"(?m)^\s+shell: bash --noprofile --norc \{0\}\n", "", base_image_pins)
+        ),
+    )
+    expect_assertion(
+        "the pin prover step's shell is given errexit back",
+        "must not carry errexit",
+        lambda: assert_pin_prover_cannot_refuse_a_release(
+            base_image_pins.replace(
+                "shell: bash --noprofile --norc {0}",
+                "shell: bash --noprofile --norc -e {0}",
+            )
+        ),
+    )
+    expect_assertion(
+        "the pin prover step stops disarming errexit in its own body",
+        "missing required policy: set +e",
+        lambda: assert_pin_prover_cannot_refuse_a_release(
+            base_image_pins.replace("          set +e\n", "")
+        ),
+    )
+    expect_assertion(
+        "the pin prover step stops forcing a green conclusion",
+        "missing required policy: exit 0",
+        lambda: assert_pin_prover_cannot_refuse_a_release(
+            base_image_pins.replace("          exit 0\n", "")
+        ),
+    )
+    expect_assertion(
+        "a failed checkout is allowed to fail the pin prover job",
+        "missing required policy: continue-on-error: true",
+        lambda: assert_pin_prover_cannot_refuse_a_release(
+            base_image_pins.replace(
+                "      - name: Checkout\n        continue-on-error: true\n",
+                "      - name: Checkout\n",
+            )
+        ),
+    )
+
     assert_container_base_image_authority(dockerfile, docker_workflow, release)
     expect_assertion(
         "a floating base image tag reaches the release container",

--- a/scripts/verify-base-image-pins.sh
+++ b/scripts/verify-base-image-pins.sh
@@ -59,20 +59,34 @@ resolve_digest() {
   local output=""
   local attempt
   : > "$resolve_error_file"
-  for attempt in 1 2 3 4 5; do
-    if output="$(docker buildx imagetools inspect "$reference" \
+  for attempt in 1 2 3; do
+    # Each call is wall-clock bounded. A registry outage is exactly when a
+    # connect hangs rather than refusing, and this job's whole reason to exist
+    # is registry outages, so an unbounded call would let the job run past its
+    # timeout during the one event it is watching for. A job that exceeds
+    # timeout-minutes concludes `cancelled`, which the release sweep treats as
+    # non-green just like `failure`.
+    if output="$(timeout 20 docker buildx imagetools inspect "$reference" \
       --format '{{.Manifest.Digest}}' 2>&1)"; then
       printf '%s\n' "$output"
       return 0
     fi
     printf '%s' "$output" > "$resolve_error_file"
+    # Match an HTTP status token or a whole phrase, never a bare "404". The
+    # error text embeds the reference, so the pinned digest is part of what is
+    # searched, and roughly one digest in seventy contains "404" somewhere in
+    # its hex. A bare substring match would turn any error, a throttle
+    # included, into "the registry answered definitively that it does not have
+    # it" for those digests, which is the exact false alarm the three-state
+    # design exists to prevent.
     case "$output" in
-      *"not found"* | *404* | *MANIFEST_UNKNOWN* | *"manifest unknown"*)
+      *": not found"* | *"404 Not Found"* | *"status 404"* \
+        | *MANIFEST_UNKNOWN* | *"manifest unknown"*)
         return 44
         ;;
     esac
-    if [ "$attempt" -lt 5 ]; then
-      sleep $(( attempt * 3 ))
+    if [ "$attempt" -lt 3 ]; then
+      sleep $(( attempt * 5 ))
     fi
   done
   return 2


### PR DESCRIPTION
The P1-1 remedy that landed in #545 was inert. This makes it real and proves it
on the substrate instead of asserting it in a comment.

Closes FIR-1794.

Spec: `.kin-coord/reports/audit-kin-pr545-postmerge-20260731.md` (VERDICT UNSOUND).

**Nothing has broken.** `base-image-pins.yml` is `schedule` + `workflow_dispatch`
only, `cron: "23 5 * * 1"`, and has **never run** (`total_count=0`). First fire
is Monday 05:23 UTC.

## What was wrong

The workflow claimed the scheduled path could not conclude non-green, and gave
as its reason that `set -e` was absent. It was never absent: a `run:` step's
script is executed by **`bash -e {0}`**, and the step's own `set -o pipefail` is
what completed the trap by making the pipeline carry the prover's non-zero
status for errexit to act on. The capture, the `$GITHUB_OUTPUT` write, the
tracking issue and the dispatch reporter were all unreachable. Net effect: worse
than before the fix, because a broken pin would produce a red check-run on a
main sha **and** no alarm.

Reproduced verbatim (landed body, documented shell, stub prover exiting 2):

```
STEP RC=2                       <- red
GITHUB_OUTPUT contents: []      <- never written
```

## The obvious remedy does not work, and is measured not to

Both the original review and the audit recommended job-level
`continue-on-error: true`. I ran the shapes on a scratch branch in this repo and
read the **check-run conclusions off the commit**, which is what
`release-tag.yml` sweeps (`non_failing_optional = {success, skipped, neutral}`):

| shape | check-run conclusion |
| --- | --- |
| job `continue-on-error: true` + failing step | **failure** |
| no `continue-on-error` + failing step | failure |
| job `continue-on-error: true` + exceeded `timeout-minutes` | **cancelled** |
| the step body in this PR, prover exit 1 | **success** |

Job-level `continue-on-error` only stops the *workflow run* being marked failed.
It would have looked like protection while changing nothing, so it is
deliberately **not** used, and the header records why.

## What this PR does

**P1-1 + N1 (load-bearing).** The verify step declares its shell explicitly with
no `-e`, calls `set +e` in its own body, captures the status, and ends in
`exit 0`. Either layer alone suffices; both exist because the second is what
survives someone deleting the first. `$GITHUB_OUTPUT` is written on every path,
and the alarm steps run under `always()` so they do not depend on earlier steps
having succeeded.

**N2 (job-level paths), honestly bounded rather than claimed away.**

- failed checkout: neutralised with step-level `continue-on-error`
- timeout: made *unreachable* by bounding work, not by tolerating it. Every
  registry call is `timeout 20`, retries drop 5 → 3, worst case ≈ 7.5 min
  against `timeout-minutes: 20`
- runner/infrastructure failure: **irreducible**, and the header says so. The
  complete fix is the sweep ignoring non-required producers, which is
  release-authority work and out of scope here

**N3.** The header now states the measured posture, separated into what is
guaranteed and what is not, and names the errexit mistake so the next reader
does not repeat it.

**N4.** `status == 2` emits a `::warning::` and a job-summary line, so a
permanently throttled probe cannot masquerade as a healthy one.

**N5.** The `*404*` match is anchored to a status token or whole phrase. The
error text embeds the reference, so a pinned digest containing `404` in its hex
(~1 in 70) turned *any* error, a throttle included, into a definitive absence.

**N7**: an authority-suite line for the aarch64 `sudo apt-get update` was added,
but it matches at job scope rather than pinning the intended step, so it does not
yet prove that guard. Proper scoping is recorded as follow-up.

## Acceptance, end to end on the real substrate

A probe branch ran the workflow with the step body, its shell, every
`continue-on-error` and every `if:` **verbatim**, changing only the trigger and
stubbing the prover to exit 1:

| criterion | result |
| --- | --- |
| check-run conclusion on the sha | **`success`** |
| tracking issue filed | **yes** (#554, since closed) |
| `Close the tracking issue` step | correctly skipped |
| dispatch reporter, event clause satisfied | **`failure`**, still fails hard |

Also verified locally that the fixed body survives `bash -e` (the shell that
killed the previous version) with `STEP_RC=0`, `status=1` written and the
summary line emitted, so the `set +e` layer alone is sufficient.

## Regression guard

The properties this depends on are now pinned by the release-authority suite,
because this mechanism has now been wrong twice and a guard whose green is
untested is exactly the shape being fixed. Five in-suite falsifications: the
shell regaining `-e`, the shell declaration vanishing, the body losing `set +e`,
the body losing `exit 0`, and the checkout losing its tolerance.

## Gates

`test-release-workflow-authority.py` rc=0 · `py_compile` rc=0 ·
`bash -n` rc=0 · `shellcheck -x` rc=0 · both zero-file-search guards pass ·
`actionlint` findings byte-identical to `main` · live prover run against the
committed Dockerfile: both pins `docker.io=ok mirror.gcr.io=ok tag=current`,
rc=0 · no `.rs`, no required-context names touched, no census change.

## Claims not being made

- Not claiming the job cannot conclude non-green. Runner/infrastructure failure
  still can, and `workflow_dispatch` still fails hard by design.
- Not claiming the timeout path was executed. It is made unreachable by budget,
  and the `cancelled` conclusion it would produce was measured separately.
- Not claiming anything about the Dockerfile pins, the BuildKit mirror wiring,
  or the aarch64 step, which are unchanged and were cleared by both prior passes.

