### PR TITLE
Open the automated release pull request as the release App

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -368,7 +368,16 @@ jobs:
         id: pr
         if: steps.plan.outputs.needed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Open the PR as the release App rather than GITHUB_TOKEN. GitHub
+          # refuses `createPullRequest` from an Actions token wherever the
+          # organization withholds pull-request creation from workflows, and
+          # granting it back would let every workflow in the repository open
+          # pull requests. The App identity is also what makes the new pull
+          # request emit the events that start its own protected checks. The
+          # installation is scoped to this repository and carries contents,
+          # issues, and pull-requests write, which covers creating, editing,
+          # and labelling the release PR.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.branch.outputs.branch }}
           TAG: ${{ steps.branch.outputs.tag }}
           BUMP: ${{ steps.plan.outputs.bump }}
@@ -476,8 +485,11 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           set -euo pipefail
-          # A GITHUB_TOKEN-created PR starts in GitHub's approval-required
-          # recursion state. This App-authored synchronize event is the narrow,
+          # An App-opened pull request starts its own checks, so this step is
+          # the fallback for a head that has none: a run GitHub had not yet
+          # registered when the poll above gave up, or a head carrying only the
+          # approval-required run a GITHUB_TOKEN-created pull request leaves
+          # behind. This App-authored synchronize event is the narrow,
           # unattended handoff into the ordinary protected PR checks.
           git commit --allow-empty --signoff \
             -m "Activate protected checks for the automated release PR"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -43,6 +43,10 @@ TAG_LISTING_FORMAT = (
     "--format='%(refname:strip=2) "
     "%(if)%(*objectname)%(then)%(*objectname)%(else)%(objectname)%(end)'"
 )
+RELEASE_PR_STEP_ANCHOR = "      - name: Open the protected release PR"
+RELEASE_APP_TOKEN = "${{ steps.app-token.outputs.token }}"
+DEFAULT_WORKFLOW_TOKEN = "${{ github.token }}"
+STEP_ENV_TOKEN_BINDING = re.compile(r"(?m)^\s+GH_TOKEN:\s*(?P<token>\S.*?)\s*$")
 # Which tag each workflow declares it is about to create. Only the mint creates
 # one, so only the mint names it. The train resolves drift from a base tag it
 # never mints, and handing that base over as mint intent refuses exactly when a
@@ -1782,6 +1786,58 @@ def assert_merge_policy_gate(release_train: str) -> None:
         )
 
 
+def rebind_release_pr_token(release_train: str, token: str) -> str:
+    """Rewrite only the release-PR opener's own GH_TOKEN binding."""
+
+    step = workflow_step_source(
+        "release train", release_train, RELEASE_PR_STEP_ANCHOR
+    )
+    return release_train.replace(
+        step,
+        STEP_ENV_TOKEN_BINDING.sub(
+            lambda _: f"          GH_TOKEN: {token}", step, count=1
+        ),
+        1,
+    )
+
+
+def assert_release_pr_author_identity(release_train: str) -> None:
+    """The release pull request must be opened by the App, not by Actions.
+
+    GitHub refuses `createPullRequest` from an Actions token wherever the
+    organization withholds pull-request creation from workflows, so a train
+    reaching this step on GITHUB_TOKEN dies holding a prepared release branch
+    and no pull request to merge it. The App identity is load bearing a second
+    time: only an App-authored pull request emits the events that start its own
+    protected checks, which is what the activation fallback below it exists to
+    supply when nothing else does. The binding is therefore behavior under
+    test, not an incidental credential choice, and the alternative repair is
+    the repository-wide toggle that would let any workflow open pull requests.
+    """
+
+    step = workflow_step_source(
+        "release train", release_train, RELEASE_PR_STEP_ANCHOR
+    )
+    require(step, "gh pr create", "protected release PR opener")
+    bindings = [
+        match.group("token") for match in STEP_ENV_TOKEN_BINDING.finditer(step)
+    ]
+    if bindings != [RELEASE_APP_TOKEN]:
+        raise AssertionError(
+            "the step that opens the protected release PR must bind GH_TOKEN "
+            f"to the minted App installation token {RELEASE_APP_TOKEN} exactly "
+            f"once, and binds {bindings or '<nothing>'}. GitHub Actions is not "
+            "permitted to create pull requests, so an Actions token here "
+            "leaves every prepared release branch unopened"
+        )
+    if "GH_TOKEN=" in step:
+        raise AssertionError(
+            "the step that opens the protected release PR must not override "
+            "GH_TOKEN inline, because a per-command token re-authors the pull "
+            "request as an identity the step's environment no longer describes"
+        )
+
+
 def release_branch_allowlist(release_train: str) -> str:
     """Return the regex the train uses to admit its own generated branch."""
 
@@ -2130,18 +2186,18 @@ def abandonment_manifest(*records: dict[str, str]) -> str:
 
 
 def workflow_step_source(workflow: str, content: str, step_anchor: str) -> str:
-    """Extract one named workflow step so its internal order can be judged."""
+    """Extract one named workflow step so its internals can be judged."""
 
     if step_anchor not in content:
         raise AssertionError(
-            f"{workflow} no longer carries the step that owns release-lane "
-            f"admission: {step_anchor.strip()}"
+            f"{workflow} no longer carries the step this gate is anchored to: "
+            f"{step_anchor.strip()}"
         )
     start = content.index(step_anchor)
     if "\n      - name:" not in content[start + 1 :]:
         raise AssertionError(
-            f"{workflow} admission step is no longer followed by another step, "
-            "so its boundary cannot be resolved"
+            f"{workflow} step {step_anchor.strip()} is no longer followed by "
+            "another step, so its boundary cannot be resolved"
         )
     return content[start : content.index("\n      - name:", start + 1)]
 
@@ -3043,6 +3099,36 @@ def main() -> None:
     ):
         require(release_train, policy, "coalescing protected release train")
     assert_merge_policy_gate(release_train)
+    assert_release_pr_author_identity(release_train)
+    # The reverts this pin has to survive, in the order they are reachable: the
+    # binding falling back to the default token, a per-command token quietly
+    # restoring it while the environment still reads as the App, and creation
+    # moving out from under the step the pin is anchored to.
+    expect_assertion(
+        "the release PR opener falls back to the Actions token",
+        f"must bind GH_TOKEN to the minted App installation token {RELEASE_APP_TOKEN}",
+        lambda: assert_release_pr_author_identity(
+            rebind_release_pr_token(release_train, DEFAULT_WORKFLOW_TOKEN)
+        ),
+    )
+    expect_assertion(
+        "the release PR opener overrides its token for the create call",
+        "must not override GH_TOKEN inline",
+        lambda: assert_release_pr_author_identity(
+            release_train.replace(
+                "            gh pr create \\",
+                '            GH_TOKEN="$FALLBACK" gh pr create \\',
+                1,
+            )
+        ),
+    )
+    expect_assertion(
+        "pull-request creation leaves the step whose token the pin binds",
+        "protected release PR opener is missing required policy: gh pr create",
+        lambda: assert_release_pr_author_identity(
+            release_train.replace("gh pr create \\", "gh pr view \\", 1)
+        ),
+    )
     assert_release_branch_allowlist_covers_generator(release_train)
     assert_abandoned_tag_admission(release_tag, release_train)
     # The release bump must never be resolvable from anything a merged pull


### PR DESCRIPTION
The release train reached its final step for the first time on 2026-07-31 and
died there. Run 30670614429 resolved TAG v0.4.5 and BUMP patch, passed the
merge-policy gate and the branch-content guard, wrote `automation/release-next`,
and then failed at `Open the protected release PR` with
`pull request create failed: GraphQL: GitHub Actions is not permitted to create
or approve pull requests (createPullRequest)`. Every step before it succeeded.
The prepared branch had nothing to merge it.

## What changed

The opener's `GH_TOKEN` moves from `${{ github.token }}` to
`${{ steps.app-token.outputs.token }}`, the repository-scoped kin-release-bot
installation token the job already mints at its first step and already uses for
checkout, the merge-policy read, and auto-merge arming. The restriction GitHub
enforces is on Actions tokens, not on App installation tokens, so the App can
open the pull request that the workflow token cannot. Nothing about the
organization or repository Actions settings was touched; granting creation back
to workflows would have let every workflow in the repository open pull requests
to fix one step that already had a stronger identity available to it.

The App covers every call in the step. Its installation permissions are
`contents: write`, `issues: write`, `metadata: read`, `pull_requests: write`,
and the mint passes `owner` and `repositories` with no `permissions:` input, so
the minted token narrows repository scope and keeps that full set. Creating and
editing the pull request need `pull_requests: write`; setting its labels through
`PUT /issues/{n}/labels` needs `issues: write`. Both are held.

One call in the step is covered by neither token's permissions. The workflow's
`permissions:` block names only contents, issues, and pull-requests, so
`github.token` carries `actions: none`, and kin-release-bot holds no `actions`
permission either, yet the activation poll reads
`GET /actions/workflows/ci.yml/runs`. That read works because this repository is
public and the endpoint serves public resources without the permission, which an
unauthenticated request confirms with HTTP 200. It is unchanged by this PR
rather than fixed by it, and it would need `actions: read` if kin ever went
private.

## What needs_activation now means

`steps.pr.outputs.needs_activation` has exactly one consumer, the `if:` on
`Activate ordinary PR checks with the release App`. No later step branches on
it.

Its `false` case was previously unreachable. A pull request created by
`github.token` emits no events, so no `ci.yml` run ever appeared for the head,
the poll always exhausted its six attempts, and the empty-commit push was the
only way protected checks ever started. An App-created pull request does trigger
`pull_request`, so the poll can now observe a real run and the `false` case
becomes reachable for the first time.

The `true` branch is not dead code and is deliberately unchanged. It stays
reachable and correct when GitHub has not registered the run inside the poll
window of six attempts, and when the head carries only the `action_required` run
that the poll's jq filter already excludes, which is what a `github.token`
created pull request leaves behind. In both cases the fallback does what it
always did, pushing an App-authored empty commit that starts the checks, and
`Arm protected auto-merge` re-reads `headRefOid` afterwards so it arms against
whichever head resulted. The cost of the fallback firing unnecessarily is one
empty commit and one superseded CI run. Only the comment above it changed, since
it claimed the approval-required state is where every automated release pull
request starts, which is no longer true.

## The pin and its falsification

`assert_release_pr_author_identity` in the authority suite anchors on the
`Open the protected release PR` step, requires it to still contain
`gh pr create`, collects every `GH_TOKEN:` binding inside that step, and
requires the list to be exactly the minted App token. It also refuses an inline
`GH_TOKEN=` override in the step body, which would otherwise re-author the pull
request while the step's environment still read as the App.

Three falsifications run in the suite itself through the existing
`expect_assertion` idiom: the binding reverted to `${{ github.token }}`, a
per-command `GH_TOKEN="$FALLBACK" gh pr create`, and `gh pr create` moving out
of the anchored step. The first mutates the extracted step rather than the file,
so reordering the `env:` block cannot make the falsification silently stop
applying.

Falsified externally as well. With the fix staged, reverting the opener to
`${{ github.token }}` in the worktree turns the suite red naming the defect:

```
AssertionError: the step that opens the protected release PR must bind GH_TOKEN
to the minted App installation token ${{ steps.app-token.outputs.token }}
exactly once, and binds ['${{ github.token }}']. GitHub Actions is not
permitted to create pull requests, so an Actions token here leaves every
prepared release branch unopened
```

`workflow_step_source` gained a second caller, so its two failure messages were
generalized from release-lane-admission wording to naming the step they are
anchored to. No falsification pinned the old strings.

## Same-class sweep

`gh pr create` appears exactly once in the repository, and that was the defect.
release-tag.yml is clean: its only write, `Create release tag ref`, already
presents the App token for the same two reasons, and its four `github.token`
steps are pure reads. base-image-pins.yml opens and closes issues on
`github.token`, which is not the same class, since the restriction covers pull
requests only and that job mints no App token.

Two findings are listed without being fixed here because they are not the same
defect. `Create or coalesce the release branch` declares
`GH_TOKEN: ${{ github.token }}` and invokes no `gh` command at all, its
`git push` authenticating with the App checkout credential, so the binding is
vestigial rather than wrong. `steps.pr.outputs.created` is written and read by
nothing.

## Gates

`python3 scripts/test-release-workflow-authority.py`, `actionlint` on the
workflow, `bash -n` over all seven step bodies,
`python3 scripts/verify-zero-file-search.py` at 146 files scanned,
`bash scripts/zero_file_search_guard.sh`, and
`bash scripts/check_runtime_boundaries.sh` all pass at this head. The diff
contains no Rust.

No executable step-body line changed, which matters because these bodies run
under `bash -e {0}` and a capture-then-inspect pattern can change meaning under
errexit. Rather than assert it from reading, stripping comment lines from every
`run:` body in HEAD and in this branch and comparing per step reports no step
whose executable lines differ. The single body edit is the activation comment,
which is inert under any shell, and the opener's body is untouched with only its
`env:` changed.

Closes FIR-1808.
