### PR TITLE
Report hosted identity, resolve work-item rollback, and narrow the rename refusal

### DIFF
--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -48,11 +48,20 @@ fn project_dirs() -> Result<ProjectDirs> {
         .ok_or_else(|| anyhow::anyhow!("failed to resolve Kin config directory"))
 }
 
+fn fallback_credential_root() -> Result<PathBuf> {
+    Ok(project_dirs()?.data_local_dir().join("auth"))
+}
+
 fn fallback_credential_path(base_url: &str) -> Result<PathBuf> {
-    let dirs = project_dirs()?;
-    let root = dirs.data_local_dir().join("auth");
+    let root = fallback_credential_root()?;
     fs::create_dir_all(&root)?;
     Ok(root.join(format!("{}.json.age", account_key(base_url))))
+}
+
+/// The same path without creating the directory, for read-only probes that
+/// must not leave a directory behind on a machine that never logged in.
+fn fallback_credential_probe_path(base_url: &str) -> Result<PathBuf> {
+    Ok(fallback_credential_root()?.join(format!("{}.json.age", account_key(base_url))))
 }
 
 fn read_passphrase() -> Result<String> {
@@ -155,6 +164,61 @@ fn load_credential(base_url: &str, allow_keyring: bool) -> Result<Option<StoredC
     }
 
     Ok(None)
+}
+
+/// What this machine knows about a KinLab identity, without unlocking it.
+///
+/// The first-run surface reports hosted state, and a report must never raise a
+/// passphrase prompt, so a credential that exists only as an encrypted file is
+/// reported as present and locked rather than decrypted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostedCredentialState {
+    /// Nothing on this machine claims an identity for the workspace.
+    Absent,
+    /// An encrypted credential file exists; reading it needs the passphrase.
+    Locked,
+    /// A credential is readable without a prompt.
+    Ready {
+        user_email: String,
+        expires_at: String,
+    },
+}
+
+/// The workspace URL a hosted command would talk to, resolved the same way
+/// every auth subcommand resolves it.
+pub fn hosted_base_url(base_url: Option<String>) -> String {
+    normalized_base_url(base_url)
+}
+
+/// Report the stored identity for a workspace without prompting or writing.
+pub fn hosted_credential_state(base_url: &str) -> Result<HostedCredentialState> {
+    let key = account_key(base_url);
+    if keyring_enabled() {
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, &key) {
+            if let Ok(value) = entry.get_password() {
+                let credential: StoredCredential = serde_json::from_str(&value)?;
+                return Ok(HostedCredentialState::Ready {
+                    user_email: credential.user_email,
+                    expires_at: credential.expires_at,
+                });
+            }
+        }
+    }
+
+    let encrypted_path = fallback_credential_probe_path(base_url)?;
+    let plaintext_path = encrypted_path.with_extension("json");
+    if plaintext_path.exists() {
+        let bytes = fs::read(&plaintext_path)?;
+        let credential: StoredCredential = serde_json::from_slice(&bytes)?;
+        return Ok(HostedCredentialState::Ready {
+            user_email: credential.user_email,
+            expires_at: credential.expires_at,
+        });
+    }
+    if encrypted_path.exists() {
+        return Ok(HostedCredentialState::Locked);
+    }
+    Ok(HostedCredentialState::Absent)
 }
 
 fn delete_credential(base_url: &str) -> Result<()> {
@@ -312,7 +376,7 @@ pub(crate) fn default_base_url_for_health() -> String {
 /// block a non-interactive health probe. A keyring-only credential therefore
 /// reads as absent rather than risk hanging.
 pub(crate) fn has_stored_credential(base_url: &str) -> bool {
-    if let Ok(encrypted_path) = fallback_credential_path(base_url) {
+    if let Ok(encrypted_path) = fallback_credential_probe_path(base_url) {
         let plaintext_path = encrypted_path.with_extension("json");
         if plaintext_path.exists() || encrypted_path.exists() {
             return true;

--- a/crates/kin-cli/src/commands/auth.rs
+++ b/crates/kin-cli/src/commands/auth.rs
@@ -151,8 +151,11 @@ fn load_credential(base_url: &str, allow_keyring: bool) -> Result<Option<StoredC
         }
     }
 
-    // Fall back to plaintext then encrypted file.
-    let encrypted_path = fallback_credential_path(base_url)?;
+    // Fall back to plaintext then encrypted file. Reading resolves the probe
+    // path: `kin auth status`, `whoami`, and every actor-id lookup reach here,
+    // and none of them may create the auth directory on a machine that never
+    // logged in.
+    let encrypted_path = fallback_credential_probe_path(base_url)?;
     let plaintext_path = encrypted_path.with_extension("json");
     if plaintext_path.exists() {
         let bytes = fs::read(&plaintext_path)?;
@@ -175,6 +178,11 @@ fn load_credential(base_url: &str, allow_keyring: bool) -> Result<Option<StoredC
 pub enum HostedCredentialState {
     /// Nothing on this machine claims an identity for the workspace.
     Absent,
+    /// No credential file names an identity, and the platform keyring was not
+    /// read, so a keyring-stored identity would not have been seen. Reporting
+    /// this as [`HostedCredentialState::Absent`] would state something false
+    /// about a machine that is signed in.
+    AbsentKeyringNotRead,
     /// An encrypted credential file exists; reading it needs the passphrase.
     Locked,
     /// A credential is readable without a prompt.
@@ -190,10 +198,34 @@ pub fn hosted_base_url(base_url: Option<String>) -> String {
     normalized_base_url(base_url)
 }
 
+/// What a probe reports when neither source named an identity.
+///
+/// The two cases are not the same statement. A probe that read the keyring and
+/// found nothing knows the machine is signed out; a probe that never read it
+/// knows only that no file names an identity.
+fn absent_state(keyring_read: bool) -> HostedCredentialState {
+    if keyring_read {
+        HostedCredentialState::Absent
+    } else {
+        HostedCredentialState::AbsentKeyringNotRead
+    }
+}
+
 /// Report the stored identity for a workspace without prompting or writing.
-pub fn hosted_credential_state(base_url: &str) -> Result<HostedCredentialState> {
-    let key = account_key(base_url);
-    if keyring_enabled() {
+///
+/// `allow_keyring` must be false whenever nothing can answer a prompt. A
+/// `get_password` call raises an interactive Keychain authorization dialog on
+/// macOS whenever the item's ACL does not already authorize the calling binary,
+/// which is routine for a rebuilt unsigned binary or after a relock, and that
+/// dialog blocks the process for as long as nobody clicks it. Reading the file
+/// probes alone cannot hang.
+pub fn hosted_credential_state(
+    base_url: &str,
+    allow_keyring: bool,
+) -> Result<HostedCredentialState> {
+    let keyring_read = allow_keyring && keyring_enabled();
+    if keyring_read {
+        let key = account_key(base_url);
         if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, &key) {
             if let Ok(value) = entry.get_password() {
                 let credential: StoredCredential = serde_json::from_str(&value)?;
@@ -218,7 +250,7 @@ pub fn hosted_credential_state(base_url: &str) -> Result<HostedCredentialState> 
     if encrypted_path.exists() {
         return Ok(HostedCredentialState::Locked);
     }
-    Ok(HostedCredentialState::Absent)
+    Ok(absent_state(keyring_read))
 }
 
 fn delete_credential(base_url: &str) -> Result<()> {
@@ -577,5 +609,18 @@ mod tests {
         assert_eq!(actor_id, "cli:troy@firelock.ai:workstation");
 
         fs::remove_file(path).unwrap();
+    }
+
+    /// A probe that never read the keyring has not learned that the machine is
+    /// signed out, and the two answers must not collapse into one: the default
+    /// install stores the credential in the keyring, so reporting the
+    /// unread case as `Absent` would deny an identity this machine holds.
+    #[test]
+    fn an_unread_keyring_is_not_an_absent_credential() {
+        assert_eq!(absent_state(true), HostedCredentialState::Absent);
+        assert_eq!(
+            absent_state(false),
+            HostedCredentialState::AbsentKeyringNotRead
+        );
     }
 }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1276,8 +1276,9 @@ fn check_kinlab_connect() -> HealthCheck {
             HealthStatus::Unsupported,
             format!("no stored credential for {base_url}"),
         )
-        .with_platform_note("hosted connect is not yet a first-run flow")
-        .with_manual_fix("run `kin auth login` once hosted connect is available")
+        .with_manual_fix(format!(
+            "run `kin auth login` to connect this machine to {base_url}, or `kin auth login --base-url <url>` for another workspace"
+        ))
     }
 }
 

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -47,6 +47,26 @@ pub fn available_today(symbol: &str) -> Vec<String> {
     ]
 }
 
+/// The gate refusal with the reachable surfaces appended.
+///
+/// Both the CLI and the daemon path answer with this, so the agent-facing
+/// refusal carries the same guidance a person gets at the terminal. The `Ok`
+/// arm is the tripwire for a fixture that flips `rename` to ready without an
+/// executor behind it.
+fn refusal_with_guidance(symbol: &str) -> anyhow::Error {
+    let refusal = match super::capabilities::require_ready("rename") {
+        Ok(()) => unreachable!("a ready rename capability must replace the fail-closed executor"),
+        Err(refusal) => refusal,
+    };
+    let mut message = refusal.to_string();
+    message.push_str("\nwhat works today:");
+    for line in available_today(symbol) {
+        message.push_str("\n  - ");
+        message.push_str(&line);
+    }
+    anyhow::anyhow!(message)
+}
+
 pub async fn run(
     symbol: String,
     _new_name: String,
@@ -55,26 +75,15 @@ pub async fn run(
     _column: Option<u32>,
     _json: bool,
 ) -> Result<()> {
-    let refusal = match super::capabilities::require_ready("rename") {
-        Ok(()) => unreachable!("a ready rename capability must replace the fail-closed executor"),
-        Err(refusal) => refusal,
-    };
-    let mut message = refusal.to_string();
-    message.push_str("\nwhat works today:");
-    for line in available_today(&symbol) {
-        message.push_str("\n  - ");
-        message.push_str(&line);
-    }
-    Err(anyhow::anyhow!(message))
+    Err(refusal_with_guidance(&symbol))
 }
 
 pub fn build_rename_response(
     _layout: &kin_core::KinLayout,
     _graph: &kin_db::InMemoryGraph,
-    _request: &RenameRequest,
+    request: &RenameRequest,
 ) -> Result<RenameResponse> {
-    super::capabilities::require_ready("rename")?;
-    unreachable!("ready rename capability must replace the fail-closed executor")
+    Err(refusal_with_guidance(&request.symbol))
 }
 
 #[cfg(test)]
@@ -96,10 +105,66 @@ mod tests {
         );
     }
 
-    /// The executor stays fail-closed; guidance must not read as a partial
-    /// rename having happened.
+    fn rename_request(symbol: &str) -> RenameRequest {
+        RenameRequest {
+            symbol: symbol.to_string(),
+            new_name: "parse_settings".to_string(),
+            file: None,
+            line: None,
+            column: None,
+            json: false,
+        }
+    }
+
+    /// The daemon answers `/rename` through this function, so asserting on the
+    /// capability fixture instead would leave an executor that fabricated a
+    /// response passing a test named for the executor.
     #[test]
     fn build_rename_response_stays_fail_closed() {
-        assert!(super::super::capabilities::require_ready("rename").is_err());
+        let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/nonexistent/.kin"));
+        let graph = kin_db::InMemoryGraph::new();
+        let error = build_rename_response(&layout, &graph, &rename_request("parse_config"))
+            .expect_err("the rename executor must refuse while the gate is closed");
+        let message = error.to_string();
+        for expected in [
+            "`kin rename`",
+            "open acceptance gates:",
+            "kin refs parse_config",
+        ] {
+            assert!(
+                message.contains(expected),
+                "the wire refusal must carry {expected}: {message}"
+            );
+        }
+    }
+
+    /// The composed CLI refusal states the gate and then the reachable
+    /// surfaces. Nothing else asserts on the composition, so a change that
+    /// dropped either half would otherwise only show up in a manual run.
+    #[tokio::test]
+    async fn run_refuses_with_the_gate_and_the_reachable_surfaces() {
+        let error = run(
+            "parse_config".to_string(),
+            "parse_settings".to_string(),
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect_err("`kin rename` must refuse while the gate is closed");
+        let message = error.to_string();
+        for expected in [
+            "`kin rename`",
+            "open acceptance gates:",
+            "what works today:",
+            "kin refs parse_config",
+            "kin locate parse_config",
+        ] {
+            assert!(
+                message.contains(expected),
+                "the refusal must carry {expected}: {message}"
+            );
+        }
     }
 }

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -32,15 +32,40 @@ pub struct RenameResponse {
     pub json: Option<String>,
 }
 
+/// What a caller can reach today, named at the point the gate refuses.
+///
+/// The gate text states the two acceptance conditions, which says what Kin
+/// cannot do without saying what it can. Every reference a rename would have to
+/// touch is already a graph answer, so the refusal points at it.
+pub fn available_today(symbol: &str) -> Vec<String> {
+    vec![
+        format!("`kin refs {symbol}` lists every reference the graph holds for this symbol."),
+        format!("`kin locate {symbol}` finds the declaration to edit."),
+        "Editing and committing by hand keeps graph truth exact; the gate is the planner and the \
+         single-transaction apply, not the rename itself."
+            .to_string(),
+    ]
+}
+
 pub async fn run(
-    _symbol: String,
+    symbol: String,
     _new_name: String,
     _file: Option<String>,
     _line: Option<u32>,
     _column: Option<u32>,
     _json: bool,
 ) -> Result<()> {
-    super::capabilities::require_ready("rename")
+    let refusal = match super::capabilities::require_ready("rename") {
+        Ok(()) => unreachable!("a ready rename capability must replace the fail-closed executor"),
+        Err(refusal) => refusal,
+    };
+    let mut message = refusal.to_string();
+    message.push_str("\nwhat works today:");
+    for line in available_today(&symbol) {
+        message.push_str("\n  - ");
+        message.push_str(&line);
+    }
+    Err(anyhow::anyhow!(message))
 }
 
 pub fn build_rename_response(
@@ -50,4 +75,31 @@ pub fn build_rename_response(
 ) -> Result<RenameResponse> {
     super::capabilities::require_ready("rename")?;
     unreachable!("ready rename capability must replace the fail-closed executor")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A gate that only states what is missing leaves a first-time caller with
+    /// nowhere to go. The refusal has to name a command that works now.
+    #[test]
+    fn refusal_guidance_names_the_reachable_surfaces() {
+        let lines = available_today("parse_config").join("\n");
+        assert!(
+            lines.contains("kin refs parse_config"),
+            "guidance must name the reference surface for the symbol asked about: {lines}"
+        );
+        assert!(
+            lines.contains("kin locate parse_config"),
+            "guidance must name the declaration surface: {lines}"
+        );
+    }
+
+    /// The executor stays fail-closed; guidance must not read as a partial
+    /// rename having happened.
+    #[test]
+    fn build_rename_response_stays_fail_closed() {
+        assert!(super::super::capabilities::require_ready("rename").is_err());
+    }
 }

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -69,6 +69,18 @@ pub struct WorkItemRollbackPlan {
     pub reverted: Vec<SemanticChangeId>,
 }
 
+/// One change on the branch line, carrying the parent list its immutable
+/// change published rather than only the first-parent link.
+///
+/// A merge publishes `[ours, theirs]` and only `ours` continues the line, so a
+/// plan given the bare line could not tell a merge from an ordinary change and
+/// would discard everything the merge brought in without ever naming it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineChange {
+    pub change: SemanticChangeId,
+    pub parents: Vec<SemanticChangeId>,
+}
+
 /// Why a work item cannot be rolled back as a unit. Each case names something
 /// the caller can act on rather than reporting a bare failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,6 +92,13 @@ pub enum WorkItemRollbackRefusal {
     /// Changes published after the work item's earliest change that the work
     /// item does not claim. Rolling back would silently discard them.
     InterveningChanges(Vec<SemanticChangeId>),
+    /// A claimed change is a merge that brought in ancestry the work item does
+    /// not claim. That ancestry is reachable but absent from the line, so a
+    /// restore would discard it without the line ever showing it.
+    MergedWorkNotClaimed {
+        merge: SemanticChangeId,
+        unclaimed_parents: Vec<SemanticChangeId>,
+    },
     /// The earliest recorded change is the first change on the line, so there
     /// is no earlier state to restore.
     ReachesRepositoryRoot,
@@ -98,25 +117,41 @@ impl std::fmt::Display for WorkItemRollbackRefusal {
             ),
             Self::NotOnBranchLine(changes) => write!(
                 f,
-                "these recorded changes are not on the current branch line: {}; switch to the \
-                 branch that carries them, or roll back to an explicit change",
+                "these recorded changes are not on the first-parent line of the current branch: \
+                 {}; a change merged in from elsewhere stays reachable without sitting on this \
+                 line, so `kin log` shows where it sits and `kin rollback <change-id>` restores an \
+                 explicit change",
                 render_change_list(changes)
             ),
             Self::InterveningChanges(changes) => write!(
                 f,
-                "rolling this work item back would also discard {}, which it does not claim; roll \
-                 back to an explicit change if that is what you intend",
+                "rolling this work item back would also discard {}, which it does not claim; \
+                 restore an explicit change with `kin rollback <change-id>` if that is what you \
+                 intend",
                 render_change_list(changes)
+            ),
+            Self::MergedWorkNotClaimed {
+                merge,
+                unclaimed_parents,
+            } => write!(
+                f,
+                "change {merge} merged {} into this line, and this work item does not claim that \
+                 side of the merge, so restoring an earlier state would discard everything it \
+                 brought in; `kin log` shows what the merge carries, and `kin rollback \
+                 <change-id>` restores an explicit change if that is what you intend",
+                render_change_list(unclaimed_parents)
             ),
             Self::ReachesRepositoryRoot => write!(
                 f,
                 "the earliest change this work item records is the first change on this line, so \
-                 there is no earlier state to restore"
+                 there is no earlier state to restore; `kin log` shows the whole line, and `kin \
+                 rollback <change-id>` restores any change on it"
             ),
             Self::HistoryWindowExhausted => write!(
                 f,
                 "not every change this work item records was found within the {} changes read, so \
-                 the branch line cannot be decided; roll back to an explicit change instead",
+                 the branch line cannot be decided; restore an explicit change with `kin rollback \
+                 <change-id>` instead",
                 WORK_ITEM_HISTORY_WINDOW
             ),
         }
@@ -137,8 +172,15 @@ fn render_change_list(changes: &[SemanticChangeId]) -> String {
 /// the content of one earlier change, so a work item can only be rolled back as
 /// a unit when its changes are exactly the newest run of that line; anything
 /// else would discard work the item never claimed.
+///
+/// The line alone is not enough to decide that. The daemon accepts a target on
+/// full-DAG reachability and computes the correction from the whole current
+/// state, so a merge inside the claimed run also discards its second-parent
+/// ancestry, which no position on the line reveals. Each line entry therefore
+/// carries its full parent list and a merge that brought in unclaimed work is
+/// refused.
 pub fn plan_work_item_rollback(
-    line: &[SemanticChangeId],
+    line: &[LineChange],
     line_truncated: bool,
     recorded: &[SemanticChangeId],
 ) -> Result<WorkItemRollbackPlan, WorkItemRollbackRefusal> {
@@ -149,7 +191,10 @@ pub fn plan_work_item_rollback(
     let mut positions = Vec::new();
     let mut absent = Vec::new();
     for change in recorded {
-        match line.iter().position(|candidate| candidate == change) {
+        match line
+            .iter()
+            .position(|candidate| &candidate.change == change)
+        {
             Some(index) => positions.push(index),
             None if absent.contains(change) => {}
             None => absent.push(*change),
@@ -167,16 +212,36 @@ pub fn plan_work_item_rollback(
     let newest_run = positions.len();
     let intervening: Vec<SemanticChangeId> = (0..=positions[positions.len() - 1])
         .filter(|index| !positions.contains(index))
-        .map(|index| line[index])
+        .map(|index| line[index].change)
         .collect();
     if !intervening.is_empty() {
         return Err(WorkItemRollbackRefusal::InterveningChanges(intervening));
     }
 
+    // Every position above the oldest claimed one is claimed by here, so the
+    // claimed run is exactly what a restore drops from this line. What it also
+    // drops is whatever a merge in that run brought in from another line, and
+    // that is invisible in the line itself.
+    for entry in positions.iter().map(|index| &line[*index]) {
+        let unclaimed: Vec<SemanticChangeId> = entry
+            .parents
+            .iter()
+            .skip(1)
+            .filter(|parent| !recorded.contains(parent))
+            .copied()
+            .collect();
+        if !unclaimed.is_empty() {
+            return Err(WorkItemRollbackRefusal::MergedWorkNotClaimed {
+                merge: entry.change,
+                unclaimed_parents: unclaimed,
+            });
+        }
+    }
+
     match line.get(newest_run) {
         Some(target) => Ok(WorkItemRollbackPlan {
-            target: *target,
-            reverted: positions.iter().map(|index| line[*index]).collect(),
+            target: target.change,
+            reverted: positions.iter().map(|index| line[*index].change).collect(),
         }),
         None if line_truncated => Err(WorkItemRollbackRefusal::HistoryWindowExhausted),
         None => Err(WorkItemRollbackRefusal::ReachesRepositoryRoot),
@@ -189,7 +254,10 @@ pub fn plan_work_item_rollback(
 /// entry list is not the branch order. The first-parent chain is the line the
 /// branch actually advanced along, which is the only order a rollback target
 /// can be read off.
-pub fn first_parent_line(report: &crate::commands::log::LogReport) -> Vec<SemanticChangeId> {
+///
+/// Each entry keeps every parent, not just the one the walk followed, so a
+/// caller can tell a merge from an ordinary change.
+pub fn first_parent_line(report: &crate::commands::log::LogReport) -> Vec<LineChange> {
     let mut by_id = std::collections::HashMap::new();
     for entry in &report.entries {
         by_id.insert(entry.change_id, entry);
@@ -201,10 +269,15 @@ pub fn first_parent_line(report: &crate::commands::log::LogReport) -> Vec<Semant
         if !seen.insert(change_id) {
             break;
         }
-        line.push(change_id);
-        cursor = by_id
+        let parents = by_id
             .get(&change_id)
-            .and_then(|entry| entry.parents.first().copied());
+            .map(|entry| entry.parents.clone())
+            .unwrap_or_default();
+        cursor = parents.first().copied();
+        line.push(LineChange {
+            change: change_id,
+            parents,
+        });
     }
     line
 }
@@ -317,11 +390,23 @@ mod tests {
         SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([seed; 32]))
     }
 
+    /// A line with no merges, head first, each change parented on the next.
+    fn linear_line(changes: &[SemanticChangeId]) -> Vec<LineChange> {
+        changes
+            .iter()
+            .enumerate()
+            .map(|(index, change)| LineChange {
+                change: *change,
+                parents: changes.get(index + 1).copied().into_iter().collect(),
+            })
+            .collect()
+    }
+
     /// The newest run of the line is the only shape rollback can restore as a
     /// unit, and it resolves to the change just before that run.
     #[test]
     fn tip_run_resolves_to_the_change_before_it() {
-        let line = vec![change(4), change(3), change(2), change(1)];
+        let line = linear_line(&[change(4), change(3), change(2), change(1)]);
         let plan = plan_work_item_rollback(&line, false, &[change(3), change(4)]).unwrap();
         assert_eq!(plan.target, change(2));
         assert_eq!(plan.reverted, vec![change(4), change(3)]);
@@ -330,7 +415,7 @@ mod tests {
     /// A work item that recorded nothing must not be answered with a guess.
     #[test]
     fn no_recorded_changes_refuses() {
-        let line = vec![change(2), change(1)];
+        let line = linear_line(&[change(2), change(1)]);
         assert_eq!(
             plan_work_item_rollback(&line, false, &[]),
             Err(WorkItemRollbackRefusal::NoRecordedChanges)
@@ -341,7 +426,7 @@ mod tests {
     /// would be discarded by the restore, so the refusal names it.
     #[test]
     fn intervening_change_is_named_rather_than_discarded() {
-        let line = vec![change(9), change(3), change(2), change(1)];
+        let line = linear_line(&[change(9), change(3), change(2), change(1)]);
         assert_eq!(
             plan_work_item_rollback(&line, false, &[change(3), change(2)]),
             Err(WorkItemRollbackRefusal::InterveningChanges(vec![change(9)]))
@@ -351,7 +436,7 @@ mod tests {
     /// A recorded change on another branch is not silently ignored.
     #[test]
     fn change_off_this_line_is_named() {
-        let line = vec![change(2), change(1)];
+        let line = linear_line(&[change(2), change(1)]);
         assert_eq!(
             plan_work_item_rollback(&line, false, &[change(7)]),
             Err(WorkItemRollbackRefusal::NotOnBranchLine(vec![change(7)]))
@@ -361,7 +446,7 @@ mod tests {
     /// Restoring the state before the first change on the line has no target.
     #[test]
     fn reaching_the_first_change_refuses() {
-        let line = vec![change(2), change(1)];
+        let line = linear_line(&[change(2), change(1)]);
         assert_eq!(
             plan_work_item_rollback(&line, false, &[change(2), change(1)]),
             Err(WorkItemRollbackRefusal::ReachesRepositoryRoot)
@@ -372,7 +457,7 @@ mod tests {
     /// reports the window rather than claiming a root.
     #[test]
     fn truncated_window_is_reported_as_a_window() {
-        let line = vec![change(2), change(1)];
+        let line = linear_line(&[change(2), change(1)]);
         assert_eq!(
             plan_work_item_rollback(&line, true, &[change(2), change(1)]),
             Err(WorkItemRollbackRefusal::HistoryWindowExhausted)
@@ -386,30 +471,104 @@ mod tests {
     /// Duplicate scope entries describe one change, not two.
     #[test]
     fn repeated_scope_entries_count_once() {
-        let line = vec![change(3), change(2), change(1)];
+        let line = linear_line(&[change(3), change(2), change(1)]);
         let plan =
             plan_work_item_rollback(&line, false, &[change(3), change(3), change(3)]).unwrap();
         assert_eq!(plan.target, change(2));
         assert_eq!(plan.reverted, vec![change(3)]);
     }
 
-    /// Every refusal has to name something the caller can do next; a bare
-    /// statement of the condition is the first-touch failure this avoids.
+    /// A merge inside the claimed run brought in a line the first-parent walk
+    /// never visits, and the daemon accepts the target on full-DAG
+    /// reachability, so restoring the change before the run would discard that
+    /// whole side without naming it.
     #[test]
-    fn every_refusal_names_a_remedy_or_a_change() {
+    fn merge_of_unclaimed_work_inside_the_run_refuses() {
+        let mut line = linear_line(&[change(5), change(4), change(3)]);
+        line[0].parents = vec![change(4), change(9)];
+        assert_eq!(
+            plan_work_item_rollback(&line, false, &[change(5)]),
+            Err(WorkItemRollbackRefusal::MergedWorkNotClaimed {
+                merge: change(5),
+                unclaimed_parents: vec![change(9)],
+            })
+        );
+    }
+
+    /// The refusal is about unclaimed work, not about merges. A merge whose
+    /// every extra parent the work item also claims discards nothing the item
+    /// did not ask to discard, so it still plans.
+    #[test]
+    fn merge_whose_every_parent_is_claimed_still_plans() {
+        let mut line = linear_line(&[change(5), change(4), change(3), change(2)]);
+        line[0].parents = vec![change(4), change(3)];
+        let plan =
+            plan_work_item_rollback(&line, false, &[change(5), change(4), change(3)]).unwrap();
+        assert_eq!(plan.target, change(2));
+    }
+
+    /// A merge older than the claimed run is part of the state being restored
+    /// rather than something the restore discards, so it does not refuse.
+    #[test]
+    fn merge_below_the_claimed_run_does_not_refuse() {
+        let mut line = linear_line(&[change(5), change(4), change(3)]);
+        line[2].parents = vec![change(2), change(9)];
+        let plan = plan_work_item_rollback(&line, false, &[change(5)]).unwrap();
+        assert_eq!(plan.target, change(4));
+    }
+
+    /// Commands each refusal must name. The match is exhaustive, so a refusal
+    /// cannot be added without declaring what the caller can run next.
+    fn required_commands(refusal: &WorkItemRollbackRefusal) -> &'static [&'static str] {
+        match refusal {
+            WorkItemRollbackRefusal::NoRecordedChanges => {
+                &["kin work link", "kin rollback <change-id>"]
+            }
+            WorkItemRollbackRefusal::NotOnBranchLine(_) => &["kin log", "kin rollback <change-id>"],
+            WorkItemRollbackRefusal::InterveningChanges(_) => &["kin rollback <change-id>"],
+            WorkItemRollbackRefusal::MergedWorkNotClaimed { .. } => {
+                &["kin log", "kin rollback <change-id>"]
+            }
+            WorkItemRollbackRefusal::ReachesRepositoryRoot => {
+                &["kin log", "kin rollback <change-id>"]
+            }
+            WorkItemRollbackRefusal::HistoryWindowExhausted => &["kin rollback <change-id>"],
+        }
+    }
+
+    /// Every refusal has to name something the caller can run next; a bare
+    /// statement of the condition is the first-touch failure this avoids.
+    ///
+    /// Asserting on the word "change" would not catch that: every one of these
+    /// messages is about changes, so descriptive prose alone would satisfy it
+    /// and a refusal naming no command at all would pass. Each case declares
+    /// the exact commands its text must carry instead.
+    #[test]
+    fn every_refusal_names_the_commands_it_declares() {
         let refusals = [
             WorkItemRollbackRefusal::NoRecordedChanges,
             WorkItemRollbackRefusal::NotOnBranchLine(vec![change(1)]),
             WorkItemRollbackRefusal::InterveningChanges(vec![change(1)]),
+            WorkItemRollbackRefusal::MergedWorkNotClaimed {
+                merge: change(5),
+                unclaimed_parents: vec![change(9)],
+            },
             WorkItemRollbackRefusal::ReachesRepositoryRoot,
             WorkItemRollbackRefusal::HistoryWindowExhausted,
         ];
         for refusal in refusals {
             let rendered = refusal.to_string();
+            let commands = required_commands(&refusal);
             assert!(
-                rendered.contains("kin ") || rendered.contains("change"),
-                "refusal must point somewhere: {rendered}"
+                !commands.is_empty(),
+                "every refusal must declare a command it names: {rendered}"
             );
+            for command in commands {
+                assert!(
+                    rendered.contains(command),
+                    "refusal must name `{command}`: {rendered}"
+                );
+            }
         }
     }
 }

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -246,9 +246,9 @@ async fn resolve_feature_target(work_id: &str) -> Result<String> {
 
 pub async fn run(change_id: Option<String>, feature: Option<String>) -> Result<()> {
     let change_id = match (change_id, feature) {
-        (Some(_), Some(_)) => anyhow::bail!(
-            "name a change to roll back to, or a work item with --feature, not both"
-        ),
+        (Some(_), Some(_)) => {
+            anyhow::bail!("name a change to roll back to, or a work item with --feature, not both")
+        }
         (None, None) => anyhow::bail!(
             "name the change to roll back to, or the work item whose changes to roll back with \
              --feature <work-id>; `kin log` lists the changes on this line"

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -115,8 +115,8 @@ impl std::fmt::Display for WorkItemRollbackRefusal {
             ),
             Self::HistoryWindowExhausted => write!(
                 f,
-                "the earliest change this work item records is further back than the {} changes \
-                 read; roll back to an explicit change instead",
+                "not every change this work item records was found within the {} changes read, so \
+                 the branch line cannot be decided; roll back to an explicit change instead",
                 WORK_ITEM_HISTORY_WINDOW
             ),
         }

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -10,7 +10,7 @@
 //! target already had, so no source is rewritten and no CAS entry is created.
 
 use anyhow::Result;
-use kin_model::{AuthorId, OperationId, RefName, RepositoryId};
+use kin_model::{AuthorId, OperationId, RefName, RepositoryId, SemanticChangeId};
 use serde::{Deserialize, Serialize};
 
 pub const ROLLBACK_SCHEMA: &str = "kin.rollback.v1";
@@ -56,13 +56,206 @@ pub struct RollbackResponse {
     pub report: Option<RollbackReport>,
 }
 
-pub async fn run(change_id: String, feature: Option<String>) -> Result<()> {
-    if feature.is_some() {
-        anyhow::bail!(
-            "rolling back every change linked to a work item is not implemented; roll back to an \
-             explicit change instead"
-        );
+/// How far back to read the change line when resolving a work item. A work
+/// item's changes are the recent tip of a branch in every case this serves, and
+/// an exhausted window refuses rather than guessing.
+const WORK_ITEM_HISTORY_WINDOW: usize = 4096;
+
+/// The change a work-item rollback resolves to: the state immediately before
+/// the work item's earliest recorded change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkItemRollbackPlan {
+    pub target: SemanticChangeId,
+    pub reverted: Vec<SemanticChangeId>,
+}
+
+/// Why a work item cannot be rolled back as a unit. Each case names something
+/// the caller can act on rather than reporting a bare failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkItemRollbackRefusal {
+    /// The work item records no change scopes at all.
+    NoRecordedChanges,
+    /// Recorded changes that are not on this branch line.
+    NotOnBranchLine(Vec<SemanticChangeId>),
+    /// Changes published after the work item's earliest change that the work
+    /// item does not claim. Rolling back would silently discard them.
+    InterveningChanges(Vec<SemanticChangeId>),
+    /// The earliest recorded change is the first change on the line, so there
+    /// is no earlier state to restore.
+    ReachesRepositoryRoot,
+    /// The read window ended before the earliest recorded change.
+    HistoryWindowExhausted,
+}
+
+impl std::fmt::Display for WorkItemRollbackRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoRecordedChanges => write!(
+                f,
+                "this work item records no changes, so there is nothing to roll back; link one \
+                 with `kin work link <work-id> change:<change-id>`, or roll back to an explicit \
+                 change with `kin rollback <change-id>`"
+            ),
+            Self::NotOnBranchLine(changes) => write!(
+                f,
+                "these recorded changes are not on the current branch line: {}; switch to the \
+                 branch that carries them, or roll back to an explicit change",
+                render_change_list(changes)
+            ),
+            Self::InterveningChanges(changes) => write!(
+                f,
+                "rolling this work item back would also discard {}, which it does not claim; roll \
+                 back to an explicit change if that is what you intend",
+                render_change_list(changes)
+            ),
+            Self::ReachesRepositoryRoot => write!(
+                f,
+                "the earliest change this work item records is the first change on this line, so \
+                 there is no earlier state to restore"
+            ),
+            Self::HistoryWindowExhausted => write!(
+                f,
+                "the earliest change this work item records is further back than the {} changes \
+                 read; roll back to an explicit change instead",
+                WORK_ITEM_HISTORY_WINDOW
+            ),
+        }
     }
+}
+
+fn render_change_list(changes: &[SemanticChangeId]) -> String {
+    changes
+        .iter()
+        .map(|change| change.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Resolve a work item's recorded changes against a branch line.
+///
+/// `line` is the first-parent ancestry with the head first. Rollback restores
+/// the content of one earlier change, so a work item can only be rolled back as
+/// a unit when its changes are exactly the newest run of that line; anything
+/// else would discard work the item never claimed.
+pub fn plan_work_item_rollback(
+    line: &[SemanticChangeId],
+    line_truncated: bool,
+    recorded: &[SemanticChangeId],
+) -> Result<WorkItemRollbackPlan, WorkItemRollbackRefusal> {
+    if recorded.is_empty() {
+        return Err(WorkItemRollbackRefusal::NoRecordedChanges);
+    }
+
+    let mut positions = Vec::new();
+    let mut absent = Vec::new();
+    for change in recorded {
+        match line.iter().position(|candidate| candidate == change) {
+            Some(index) => positions.push(index),
+            None if absent.contains(change) => {}
+            None => absent.push(*change),
+        }
+    }
+    if !absent.is_empty() {
+        if line_truncated {
+            return Err(WorkItemRollbackRefusal::HistoryWindowExhausted);
+        }
+        return Err(WorkItemRollbackRefusal::NotOnBranchLine(absent));
+    }
+
+    positions.sort_unstable();
+    positions.dedup();
+    let newest_run = positions.len();
+    let intervening: Vec<SemanticChangeId> = (0..=positions[positions.len() - 1])
+        .filter(|index| !positions.contains(index))
+        .map(|index| line[index])
+        .collect();
+    if !intervening.is_empty() {
+        return Err(WorkItemRollbackRefusal::InterveningChanges(intervening));
+    }
+
+    match line.get(newest_run) {
+        Some(target) => Ok(WorkItemRollbackPlan {
+            target: *target,
+            reverted: positions.iter().map(|index| line[*index]).collect(),
+        }),
+        None if line_truncated => Err(WorkItemRollbackRefusal::HistoryWindowExhausted),
+        None => Err(WorkItemRollbackRefusal::ReachesRepositoryRoot),
+    }
+}
+
+/// The first-parent ancestry of a log report, head first.
+///
+/// History is a DAG and the log walk is breadth first, so position in the
+/// entry list is not the branch order. The first-parent chain is the line the
+/// branch actually advanced along, which is the only order a rollback target
+/// can be read off.
+pub fn first_parent_line(report: &crate::commands::log::LogReport) -> Vec<SemanticChangeId> {
+    let mut by_id = std::collections::HashMap::new();
+    for entry in &report.entries {
+        by_id.insert(entry.change_id, entry);
+    }
+    let mut line = Vec::new();
+    let mut cursor = report.start_change;
+    let mut seen = std::collections::HashSet::new();
+    while let Some(change_id) = cursor {
+        if !seen.insert(change_id) {
+            break;
+        }
+        line.push(change_id);
+        cursor = by_id
+            .get(&change_id)
+            .and_then(|entry| entry.parents.first().copied());
+    }
+    line
+}
+
+async fn resolve_work_item_changes(work_id: &str) -> Result<Vec<SemanticChangeId>> {
+    let response = crate::commands::work::request_work_scopes(work_id).await?;
+    let report = response.scopes.ok_or_else(|| {
+        anyhow::anyhow!("work item read returned no scopes for {work_id}; the daemon and this CLI disagree on the work protocol")
+    })?;
+    Ok(report
+        .scopes
+        .iter()
+        .filter_map(|scope| match scope {
+            kin_model::WorkScope::Change(change_id) => Some(*change_id),
+            _ => None,
+        })
+        .collect())
+}
+
+async fn resolve_feature_target(work_id: &str) -> Result<String> {
+    let recorded = resolve_work_item_changes(work_id).await?;
+    let layout = crate::commands::require_repository_layout()?;
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
+    let report = crate::commands::log::inspect(&binding, WORK_ITEM_HISTORY_WINDOW)?;
+    let line = first_parent_line(&report);
+    match plan_work_item_rollback(&line, report.truncated, &recorded) {
+        Ok(plan) => {
+            println!(
+                "Work item {} records {} change(s) at the tip of this line.",
+                work_id,
+                plan.reverted.len()
+            );
+            println!("Restoring the content of change {}.", plan.target);
+            Ok(plan.target.to_string())
+        }
+        Err(refusal) => anyhow::bail!("cannot roll back work item {work_id}: {refusal}"),
+    }
+}
+
+pub async fn run(change_id: Option<String>, feature: Option<String>) -> Result<()> {
+    let change_id = match (change_id, feature) {
+        (Some(_), Some(_)) => anyhow::bail!(
+            "name a change to roll back to, or a work item with --feature, not both"
+        ),
+        (None, None) => anyhow::bail!(
+            "name the change to roll back to, or the work item whose changes to roll back with \
+             --feature <work-id>; `kin log` lists the changes on this line"
+        ),
+        (Some(change_id), None) => change_id,
+        (None, Some(work_id)) => resolve_feature_target(&work_id).await?,
+    };
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
@@ -114,4 +307,109 @@ pub fn render_lines(report: &RollbackReport) -> Vec<String> {
             report.authority_generation, report.workspace_generation
         ),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change(seed: u8) -> SemanticChangeId {
+        SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([seed; 32]))
+    }
+
+    /// The newest run of the line is the only shape rollback can restore as a
+    /// unit, and it resolves to the change just before that run.
+    #[test]
+    fn tip_run_resolves_to_the_change_before_it() {
+        let line = vec![change(4), change(3), change(2), change(1)];
+        let plan = plan_work_item_rollback(&line, false, &[change(3), change(4)]).unwrap();
+        assert_eq!(plan.target, change(2));
+        assert_eq!(plan.reverted, vec![change(4), change(3)]);
+    }
+
+    /// A work item that recorded nothing must not be answered with a guess.
+    #[test]
+    fn no_recorded_changes_refuses() {
+        let line = vec![change(2), change(1)];
+        assert_eq!(
+            plan_work_item_rollback(&line, false, &[]),
+            Err(WorkItemRollbackRefusal::NoRecordedChanges)
+        );
+    }
+
+    /// Someone else's change published after the work item's earliest change
+    /// would be discarded by the restore, so the refusal names it.
+    #[test]
+    fn intervening_change_is_named_rather_than_discarded() {
+        let line = vec![change(9), change(3), change(2), change(1)];
+        assert_eq!(
+            plan_work_item_rollback(&line, false, &[change(3), change(2)]),
+            Err(WorkItemRollbackRefusal::InterveningChanges(vec![change(9)]))
+        );
+    }
+
+    /// A recorded change on another branch is not silently ignored.
+    #[test]
+    fn change_off_this_line_is_named() {
+        let line = vec![change(2), change(1)];
+        assert_eq!(
+            plan_work_item_rollback(&line, false, &[change(7)]),
+            Err(WorkItemRollbackRefusal::NotOnBranchLine(vec![change(7)]))
+        );
+    }
+
+    /// Restoring the state before the first change on the line has no target.
+    #[test]
+    fn reaching_the_first_change_refuses() {
+        let line = vec![change(2), change(1)];
+        assert_eq!(
+            plan_work_item_rollback(&line, false, &[change(2), change(1)]),
+            Err(WorkItemRollbackRefusal::ReachesRepositoryRoot)
+        );
+    }
+
+    /// A truncated read cannot tell the first change from an unread one, so it
+    /// reports the window rather than claiming a root.
+    #[test]
+    fn truncated_window_is_reported_as_a_window() {
+        let line = vec![change(2), change(1)];
+        assert_eq!(
+            plan_work_item_rollback(&line, true, &[change(2), change(1)]),
+            Err(WorkItemRollbackRefusal::HistoryWindowExhausted)
+        );
+        assert_eq!(
+            plan_work_item_rollback(&line, true, &[change(7)]),
+            Err(WorkItemRollbackRefusal::HistoryWindowExhausted)
+        );
+    }
+
+    /// Duplicate scope entries describe one change, not two.
+    #[test]
+    fn repeated_scope_entries_count_once() {
+        let line = vec![change(3), change(2), change(1)];
+        let plan =
+            plan_work_item_rollback(&line, false, &[change(3), change(3), change(3)]).unwrap();
+        assert_eq!(plan.target, change(2));
+        assert_eq!(plan.reverted, vec![change(3)]);
+    }
+
+    /// Every refusal has to name something the caller can do next; a bare
+    /// statement of the condition is the first-touch failure this avoids.
+    #[test]
+    fn every_refusal_names_a_remedy_or_a_change() {
+        let refusals = [
+            WorkItemRollbackRefusal::NoRecordedChanges,
+            WorkItemRollbackRefusal::NotOnBranchLine(vec![change(1)]),
+            WorkItemRollbackRefusal::InterveningChanges(vec![change(1)]),
+            WorkItemRollbackRefusal::ReachesRepositoryRoot,
+            WorkItemRollbackRefusal::HistoryWindowExhausted,
+        ];
+        for refusal in refusals {
+            let rendered = refusal.to_string();
+            assert!(
+                rendered.contains("kin ") || rendered.contains("change"),
+                "refusal must point somewhere: {rendered}"
+            );
+        }
+    }
 }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -11152,7 +11152,7 @@ pub async fn run_wizard(opts: WizardOptions) -> Result<()> {
 
     let configured_assistants = apply_plan(&plan, &assistants, shell_name).await?;
 
-    print_intent_followups(&plan);
+    print_intent_followups(&plan, interactive);
 
     request_notification_authorization(interactive);
 
@@ -11707,7 +11707,7 @@ fn configure_assistant_by_index(idx: usize) -> Option<Result<PathBuf>> {
 
 /// Intent-specific guidance shown before the health checklist, driven by the
 /// applied [`SetupPlan`].
-fn print_intent_followups(plan: &SetupPlan) {
+fn print_intent_followups(plan: &SetupPlan, interactive: bool) {
     if plan.show_editor_hint {
         println!();
         println!("Editor extension:");
@@ -11721,7 +11721,7 @@ fn print_intent_followups(plan: &SetupPlan) {
         println!();
         println!("Hosted / KinLab:");
         let base_url = super::auth::hosted_base_url(None);
-        match super::auth::hosted_credential_state(&base_url) {
+        match super::auth::hosted_credential_state(&base_url, interactive) {
             Ok(state) => {
                 for line in hosted_followup_lines(&base_url, &state) {
                     println!("  {} {}", style("→").cyan(), line);
@@ -11763,6 +11763,14 @@ fn hosted_followup_lines(
             "`kin auth login` connects this machine, then `kin remote add <name> <url>`."
                 .to_string(),
             "Another workspace: `kin auth login --base-url <url>`, or set KINLAB_URL.".to_string(),
+        ],
+        super::auth::HostedCredentialState::AbsentKeyringNotRead => vec![
+            format!("No stored credential file for {base_url} on this machine."),
+            "This run cannot answer a keychain prompt, so the platform keyring was not read; \
+             `kin auth status` reports a keyring-stored credential."
+                .to_string(),
+            "`kin auth login` connects this machine, then `kin remote add <name> <url>`."
+                .to_string(),
         ],
     }
 }
@@ -13017,6 +13025,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     fn hosted_followups_never_deny_the_shipped_connect_command() {
         let states = [
             super::super::auth::HostedCredentialState::Absent,
+            super::super::auth::HostedCredentialState::AbsentKeyringNotRead,
             super::super::auth::HostedCredentialState::Locked,
             super::super::auth::HostedCredentialState::Ready {
                 user_email: "dev@example.com".to_string(),
@@ -13079,6 +13088,37 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         assert!(
             ready.contains("dev@example.com") && ready.contains("2026-12-31T00:00:00Z"),
             "a signed-in machine must be told which identity and until when: {ready}"
+        );
+    }
+
+    /// A run that cannot answer a keychain prompt does not read the keyring, so
+    /// it does not know whether this machine is signed in. Saying it is not
+    /// would be false on the default install, where the keyring is where a
+    /// credential lands.
+    #[test]
+    fn hosted_followups_do_not_claim_signed_out_when_the_keyring_went_unread() {
+        let unread = hosted_followup_lines(
+            "https://kinlab.example",
+            &super::super::auth::HostedCredentialState::AbsentKeyringNotRead,
+        )
+        .join("\n");
+        assert!(
+            !unread.to_lowercase().contains("not signed in"),
+            "an unread keyring cannot support a signed-out claim: {unread}"
+        );
+        assert!(
+            unread.contains("kin auth status"),
+            "the report must name the command that does read the keyring: {unread}"
+        );
+
+        let read = hosted_followup_lines(
+            "https://kinlab.example",
+            &super::super::auth::HostedCredentialState::Absent,
+        )
+        .join("\n");
+        assert!(
+            read.to_lowercase().contains("not signed in"),
+            "a probe that did read the keyring states the machine is signed out: {read}"
         );
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -967,7 +967,9 @@ impl SetupIntent {
             Self::LocalOnly => "shell integration + auto-daemon; no AI client config",
             Self::AgentOnly => "configure Kin's MCP server for detected AI clients + auto-daemon",
             Self::Editor => "local-only, plus how to install the kin-editor extension",
-            Self::Hosted => "local setup, plus the sign-in state and commands for a KinLab workspace",
+            Self::Hosted => {
+                "local setup, plus the sign-in state and commands for a KinLab workspace"
+            }
             Self::Advanced => "choose shell, per-client MCP, and daemon options yourself",
         }
     }
@@ -13024,8 +13026,12 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         for state in states {
             let rendered = hosted_followup_lines("https://kinlab.example", &state).join("\n");
             let lowered = rendered.to_lowercase();
-            for denial in ["coming soon", "no public", "not a first-run flow", "no first-run flow"]
-            {
+            for denial in [
+                "coming soon",
+                "no public",
+                "not a first-run flow",
+                "no first-run flow",
+            ] {
                 assert!(
                     !lowered.contains(denial),
                     "hosted wording for {state:?} must not deny a shipped command: {rendered}"
@@ -13080,9 +13086,12 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     /// promise less than the command surface delivers.
     #[test]
     fn hosted_intent_menu_entry_does_not_deny_the_connect_command() {
-        let entry =
-            format!("{} {}", SetupIntent::Hosted.title(), SetupIntent::Hosted.description())
-                .to_lowercase();
+        let entry = format!(
+            "{} {}",
+            SetupIntent::Hosted.title(),
+            SetupIntent::Hosted.description()
+        )
+        .to_lowercase();
         for denial in ["coming soon", "no first-run flow yet", "not yet"] {
             assert!(
                 !entry.contains(denial),

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -933,7 +933,8 @@ pub enum SetupIntent {
     AgentOnly,
     /// Local-only plus a pointer to the kin-editor VS Code extension.
     Editor,
-    /// Hosted / KinLab — not yet a first-run flow (honest gap).
+    /// Local setup plus the real KinLab sign-in state and the commands that
+    /// change it.
     Hosted,
     /// Expose the granular toggles (shell, per-client MCP, daemon).
     Advanced,
@@ -956,7 +957,7 @@ impl SetupIntent {
             Self::LocalOnly => "Local-only (CLI development)",
             Self::AgentOnly => "AI agents (the wedge)",
             Self::Editor => "Editor (VS Code + kin-editor)",
-            Self::Hosted => "Hosted / KinLab (coming soon)",
+            Self::Hosted => "Hosted / KinLab (connect this machine)",
             Self::Advanced => "Advanced / manual (all toggles)",
         }
     }
@@ -966,7 +967,7 @@ impl SetupIntent {
             Self::LocalOnly => "shell integration + auto-daemon; no AI client config",
             Self::AgentOnly => "configure Kin's MCP server for detected AI clients + auto-daemon",
             Self::Editor => "local-only, plus how to install the kin-editor extension",
-            Self::Hosted => "connect to a KinLab workspace (no first-run flow yet)",
+            Self::Hosted => "local setup, plus the sign-in state and commands for a KinLab workspace",
             Self::Advanced => "choose shell, per-client MCP, and daemon options yourself",
         }
     }
@@ -11717,12 +11718,50 @@ fn print_intent_followups(plan: &SetupPlan) {
     if plan.show_hosted_hint {
         println!();
         println!("Hosted / KinLab:");
-        println!(
-            "  {} Hosted connect is not a first-run flow yet. There is no public",
-            style("!").yellow()
-        );
-        println!("    `kin login`/connect command shipped. This is coming soon —");
-        println!("    your local setup above is fully functional in the meantime.");
+        let base_url = super::auth::hosted_base_url(None);
+        match super::auth::hosted_credential_state(&base_url) {
+            Ok(state) => {
+                for line in hosted_followup_lines(&base_url, &state) {
+                    println!("  {} {}", style("→").cyan(), line);
+                }
+            }
+            Err(error) => {
+                println!(
+                    "  {} could not read the stored KinLab credential for {base_url}: {error}",
+                    style("!").yellow()
+                );
+                println!("    `kin auth status` reports the same state directly.");
+            }
+        }
+    }
+}
+
+/// Hosted follow-ups, rendered from what this machine actually knows about a
+/// KinLab identity. Kept separate from printing so the wording is testable
+/// without touching a credential store.
+fn hosted_followup_lines(
+    base_url: &str,
+    state: &super::auth::HostedCredentialState,
+) -> Vec<String> {
+    match state {
+        super::auth::HostedCredentialState::Ready {
+            user_email,
+            expires_at,
+        } => vec![
+            format!("Signed in to {base_url} as {user_email} (credential expires {expires_at})."),
+            "`kin auth whoami` confirms the account the workspace sees.".to_string(),
+            "Add a native remote with `kin remote add <name> <url>`, then `kin push`.".to_string(),
+        ],
+        super::auth::HostedCredentialState::Locked => vec![
+            format!("A stored credential for {base_url} is encrypted on this machine."),
+            "`kin auth status` unlocks and reports it; `kin auth login` replaces it.".to_string(),
+        ],
+        super::auth::HostedCredentialState::Absent => vec![
+            format!("Not signed in to {base_url}."),
+            "`kin auth login` connects this machine, then `kin remote add <name> <url>`."
+                .to_string(),
+            "Another workspace: `kin auth login --base-url <url>`, or set KINLAB_URL.".to_string(),
+        ],
     }
 }
 
@@ -12967,6 +13006,89 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         assert!(plan.show_editor_hint);
         assert!(!plan.configure_mcp);
         assert!(plan.install_shell_hook);
+    }
+
+    /// The hosted surface is where a first-time caller learns whether they can
+    /// connect at all. `kin auth login` ships, so no hosted wording may say a
+    /// connect command is missing or still on the way.
+    #[test]
+    fn hosted_followups_never_deny_the_shipped_connect_command() {
+        let states = [
+            super::super::auth::HostedCredentialState::Absent,
+            super::super::auth::HostedCredentialState::Locked,
+            super::super::auth::HostedCredentialState::Ready {
+                user_email: "dev@example.com".to_string(),
+                expires_at: "2026-12-31T00:00:00Z".to_string(),
+            },
+        ];
+        for state in states {
+            let rendered = hosted_followup_lines("https://kinlab.example", &state).join("\n");
+            let lowered = rendered.to_lowercase();
+            for denial in ["coming soon", "no public", "not a first-run flow", "no first-run flow"]
+            {
+                assert!(
+                    !lowered.contains(denial),
+                    "hosted wording for {state:?} must not deny a shipped command: {rendered}"
+                );
+            }
+            assert!(
+                rendered.contains("kin auth"),
+                "hosted wording for {state:?} must name a real auth command: {rendered}"
+            );
+        }
+    }
+
+    /// Each state answers the only question the caller has: am I connected, and
+    /// what do I type next.
+    #[test]
+    fn hosted_followups_report_the_state_this_machine_is_in() {
+        let absent = hosted_followup_lines(
+            "https://kinlab.example",
+            &super::super::auth::HostedCredentialState::Absent,
+        )
+        .join("\n");
+        assert!(
+            absent.contains("https://kinlab.example") && absent.contains("kin auth login"),
+            "a machine with no credential must be told where it is not signed in and how: {absent}"
+        );
+
+        let locked = hosted_followup_lines(
+            "https://kinlab.example",
+            &super::super::auth::HostedCredentialState::Locked,
+        )
+        .join("\n");
+        assert!(
+            locked.contains("kin auth status"),
+            "a locked credential must name the command that unlocks it: {locked}"
+        );
+
+        let ready = hosted_followup_lines(
+            "https://kinlab.example",
+            &super::super::auth::HostedCredentialState::Ready {
+                user_email: "dev@example.com".to_string(),
+                expires_at: "2026-12-31T00:00:00Z".to_string(),
+            },
+        )
+        .join("\n");
+        assert!(
+            ready.contains("dev@example.com") && ready.contains("2026-12-31T00:00:00Z"),
+            "a signed-in machine must be told which identity and until when: {ready}"
+        );
+    }
+
+    /// The intent menu is read before anything runs, so its own line cannot
+    /// promise less than the command surface delivers.
+    #[test]
+    fn hosted_intent_menu_entry_does_not_deny_the_connect_command() {
+        let entry =
+            format!("{} {}", SetupIntent::Hosted.title(), SetupIntent::Hosted.description())
+                .to_lowercase();
+        for denial in ["coming soon", "no first-run flow yet", "not yet"] {
+            assert!(
+                !entry.contains(denial),
+                "hosted menu entry must not deny a shipped command: {entry}"
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -875,7 +875,11 @@ pub fn execute_work_request(
                 status: item.status,
                 scopes: item.scopes.clone(),
             };
-            let mut out = format!("{} scope(s) recorded for {}\n", report.scopes.len(), work_id);
+            let mut out = format!(
+                "{} scope(s) recorded for {}\n",
+                report.scopes.len(),
+                work_id
+            );
             for scope in &report.scopes {
                 writeln!(out, "  - {scope}")?;
             }

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -51,15 +51,32 @@ pub enum WorkRequest {
     Verify {
         work_id: String,
     },
+    /// Read a work item's recorded scopes as data rather than rendered text.
+    /// Commands that act on what a work item covers need the scopes typed, and
+    /// parsing the rendered listing back would make the display format load
+    /// bearing.
+    Scopes {
+        work_id: String,
+    },
     TodoImport {
         path: Option<String>,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkScopesReport {
+    pub work_id: WorkId,
+    pub title: String,
+    pub status: WorkStatus,
+    pub scopes: Vec<WorkScope>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkResponse {
     #[serde(default)]
     pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<WorkScopesReport>,
 }
 
 #[derive(Debug, Clone)]
@@ -82,6 +99,15 @@ async fn run_daemon_work(request: &WorkRequest) -> Result<WorkResponse> {
     })?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.work(request).await.context("daemon work failed")
+}
+
+/// Read a work item's scopes as data. Callers that act on what a work item
+/// covers use this rather than the rendered listing.
+pub async fn request_work_scopes(work_id: &str) -> Result<WorkResponse> {
+    run_daemon_work(&WorkRequest::Scopes {
+        work_id: work_id.to_string(),
+    })
+    .await
 }
 
 fn print_work_response(response: WorkResponse) {
@@ -640,6 +666,7 @@ pub fn execute_work_request(
     request: WorkRequest,
 ) -> Result<WorkExecution> {
     let mut mutated = false;
+    let mut scopes = None;
     let text = match request {
         WorkRequest::Create {
             kind,
@@ -837,6 +864,24 @@ pub fn execute_work_request(
             out
         }
         WorkRequest::Verify { work_id } => render_work_verification(graph, work_id)?,
+        WorkRequest::Scopes { work_id } => {
+            let id = parse_work_id(&work_id)?;
+            let item = graph
+                .get_work_item(&id)?
+                .ok_or_else(|| anyhow::anyhow!("work item not found: {}", work_id))?;
+            let report = WorkScopesReport {
+                work_id: item.work_id,
+                title: item.title.clone(),
+                status: item.status,
+                scopes: item.scopes.clone(),
+            };
+            let mut out = format!("{} scope(s) recorded for {}\n", report.scopes.len(), work_id);
+            for scope in &report.scopes {
+                writeln!(out, "  - {scope}")?;
+            }
+            scopes = Some(report);
+            out
+        }
         WorkRequest::TodoImport { path } => {
             let scan_root = path
                 .map(std::path::PathBuf::from)
@@ -916,7 +961,7 @@ pub fn execute_work_request(
     };
 
     Ok(WorkExecution {
-        response: WorkResponse { text },
+        response: WorkResponse { text, scopes },
         mutated,
     })
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2505,7 +2505,14 @@ fn main() -> Result<()> {
                     rebuild,
                     json,
                 } => commands::embed::run(batch_size, json, max_seconds, rebuild).await,
-                Command::Rename { .. } => commands::capabilities::require_ready("rename"),
+                Command::Rename {
+                    symbol,
+                    new_name,
+                    file,
+                    line,
+                    column,
+                    json,
+                } => commands::rename::run(symbol, new_name, file, line, column, json).await,
                 Command::Refs {
                     entity,
                     kind,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -740,9 +740,9 @@ enum Command {
     /// Publish an exact restoration of a previous change
     #[command(visible_alias = "revert")]
     Rollback {
-        /// Change ID to rollback to
-        change_id: String,
-        /// Rollback all changes linked to a work item ID
+        /// Change ID to rollback to. Omit when naming a work item with --feature.
+        change_id: Option<String>,
+        /// Roll back every change the named work item records
         #[arg(long)]
         feature: Option<String>,
     },
@@ -3729,6 +3729,34 @@ mod tests {
                 } if output.as_path() == std::path::Path::new("../export.git")
             ));
             assert!(Cli::try_parse_from(["kin", "git", "export", "--in-place"]).is_err());
+        });
+    }
+
+    /// A work item names the changes to roll back, so requiring a change on the
+    /// same invocation made the flag unreachable: the caller had to already know
+    /// the answer the flag exists to compute.
+    #[test]
+    fn work_item_rollback_parses_without_a_change_argument() {
+        on_cli_test_stack(|| {
+            let cli = Cli::try_parse_from(["kin", "rollback", "--feature", "some-work-id"])
+                .expect("naming a work item must be a complete rollback invocation");
+            assert!(matches!(
+                cli.command,
+                Command::Rollback {
+                    change_id: None,
+                    feature: Some(ref work_id),
+                } if work_id == "some-work-id"
+            ));
+
+            let cli = Cli::try_parse_from(["kin", "rollback", "abc123"])
+                .expect("naming a change stays a complete rollback invocation");
+            assert!(matches!(
+                cli.command,
+                Command::Rollback {
+                    change_id: Some(ref change),
+                    feature: None,
+                } if change == "abc123"
+            ));
         });
     }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,7 +92,7 @@ bag of independent toggles:
 | **AI agents** (default) | Kin's MCP server for every detected AI client, plus shell integration and daemon auto-start. The smallest path to value. |
 | **Local-only** | Shell integration + daemon auto-start; no AI client config. |
 | **Editor** | Local-only, plus how to install the `kin-editor` VS Code extension. |
-| **Hosted / KinLab** | Local setup, plus a note that hosted connect is coming soon (see below). |
+| **Hosted / KinLab** | Local setup, plus this machine's KinLab sign-in state and the commands that change it (see below). |
 | **Advanced / manual** | Choose shell, per-client MCP, and daemon options yourself. |
 
 You can pre-select non-interactively (handy in scripts / CI):
@@ -112,9 +112,11 @@ Other flags (`global`, honored across every intent):
 When the wizard finishes, it prints the **health checklist** (the same engine as
 `kin setup status`, see step 8) and your next steps.
 
-> **Hosted / KinLab is not yet a first-run flow.** There is no public `kin login` /
-> connect command shipped today. The wizard is honest about this; your local setup is
-> fully functional in the meantime.
+> **Hosted / KinLab.** The wizard reads the credential this machine already holds and
+> reports it: signed in as an account with its expiry, present but encrypted, or not
+> signed in. Connecting is `kin auth login` (`--base-url <url>`, or `KINLAB_URL`, for a
+> workspace other than the default), and `kin auth whoami` confirms the account the
+> workspace sees. Local setup does not depend on any of it.
 
 ---
 
@@ -347,7 +349,7 @@ The checks (IDs as emitted in `--json`):
 | `shell_path` | The `kin-vfs` shell hook is installed and sourced from your rc, and the managed `~/.kin/bin` directory is on PATH now or will be after shell restart. |
 | `mcp_client_*` (e.g. `mcp_client_claude`) | A detected AI client has the `kin` MCP server with the `agent-default` profile. With no client configs present, a single `mcp_clients` check reports ok ("nothing to configure"). |
 | `editor` | The `kin-editor` VS Code extension is detected in `~/.vscode/extensions`. **n/a** if not found / non-VS Code. |
-| `kinlab_connect` | A stored KinLab credential is present. **n/a** today — hosted connect is not yet a first-run flow. |
+| `kinlab_connect` | A stored KinLab credential is present. **n/a** when nothing is stored; `kin auth login` connects this machine. |
 | `semantic_query_readiness` | The daemon is reachable and the vector index exists. **yellow/STALE** until you run `kin embed`; **MISSING** if the daemon isn't running. |
 
 ### When a check is yellow or red


### PR DESCRIPTION
Three commands on the M8 not-ready list stopped short of what a first-time caller needs. Two of them told the caller something untrue; the third refused without saying what it could do instead. This lane fixes the two false surfaces with real functionality and narrows the third refusal, deliberately leaving its gate closed.

## `kin setup` hosted intent, and the doctor check beside it

The hosted intent said connecting was not possible yet. The menu entry read "Hosted / KinLab (coming soon)", the follow-up block printed "There is no public `kin login`/connect command shipped. This is coming soon", `kin doctor` gave the remedy "run `kin auth login` once hosted connect is available", and the quickstart repeated it in three places. None of it is true: `kin auth login`, `logout`, `whoami`, and `status` are implemented and dispatched, and login is a real PKCE browser flow that stores a credential in the keyring or an age-encrypted file.

Hosted follow-ups are now rendered from what this machine actually holds. `commands/auth.rs` gained `HostedCredentialState`, `hosted_base_url`, and `hosted_credential_state`, which reads the plaintext fallback and reports an encrypted-only credential as locked rather than prompting. A first-run report must never raise a passphrase prompt. `setup.rs` gained `hosted_followup_lines(base_url, state)` as a pure renderer, so the wording is testable without a credential store, and each state names the command that moves to the next one. A probe error prints the error and points at `kin auth status` rather than silently degrading to "not signed in".

The probe reads the platform keyring only when the wizard is interactive. On macOS `get_password` raises a Keychain authorization dialog whenever the item's ACL does not already authorize the calling binary, which is routine for a rebuilt unsigned binary or after a relock, and that dialog blocks the process; `kin setup --intent hosted --no-interactive` in a script would otherwise finish all its work and then never print the checklist and never exit. Dropping the keyring read outright would have been worse than the hang, because the keyring is where the default install puts the credential, so a report that skipped it would tell a signed-in machine it is not signed in. The two answers are therefore distinct states: a probe that read the keyring and found nothing says the machine is signed out, and a probe that did not read it says so and names `kin auth status` as the command that does.

Same read found a write on a read path: `has_stored_credential` resolved through `fallback_credential_path`, which calls `create_dir_all`, so probing created the auth directory on a machine that never logged in. Loading a credential resolved through the same path, so `kin auth status`, `whoami`, and every actor-id lookup wrote on a read too. Both now use the non-creating probe path.

**Evidence.** Falsification captured before and after, in the lane scratchpad. With the pre-fix wording behind the new renderer, three of four hosted tests fail and name the exact false strings; after the wording is corrected, four of four pass. For the keyring gate, both wrong shapes were run red: collapsing the two absent answers into one fails `an_unread_keyring_is_not_an_absent_credential`, and rendering the unread case with the signed-out wording fails `hosted_followups_do_not_claim_signed_out_when_the_keyring_went_unread` on the literal string "Not signed in".

## `kin rollback --feature <work-item>`

The flag was unreachable and unimplemented at once. `change_id` was a required positional, so `kin rollback --feature X` died in clap with "the following required arguments were not provided: <CHANGE_ID>", and a caller who also passed a change got "rolling back every change linked to a work item is not implemented". The flag could not be typed without already knowing the answer it exists to compute.

A work item records its changes as `WorkScope::Change` entries, so resolving them is a graph read. `commands/work.rs` gained a read-only `WorkRequest::Scopes` that returns those scopes as data on the response instead of leaving callers to parse the rendered listing; the daemon forwards `/work` into `execute_work_request`, which lives in kin-cli, so no daemon route changed and the new variant stays outside the mutating set. `commands/rollback.rs` gained `first_parent_line` and `plan_work_item_rollback`. History is a DAG and the log walk is breadth first, so entry order is not branch order: the first-parent chain is the line the branch advanced along and the only order a rollback target can be read off. History comes from `LocalRepositoryAuthorityBinding` and `log::inspect`, which walk the immutable change DAG under an authority lease.

Rollback restores one earlier state, so a work item can be rolled back as a unit only when its changes are exactly the newest run of that line. Every other shape refuses and names what stopped it: nothing recorded, changes off the first-parent line, changes the item does not claim that a restore would discard, a merge inside the claimed run, the first change of the line, and a read window that ended too early. `change_id` is now optional, and naming both a change and a work item, or neither, refuses with the two valid forms.

The merge case is why each line entry carries its full parent list rather than only the link the walk followed. A merge publishes both parents and only the first continues the line, while the daemon accepts a rollback target on full-DAG reachability and computes the correction from the whole current state. A planner given the bare line could not see the merged-in branch and would restore a state that never contained it, dropping it without ever naming it. A claimed change whose extra parents the work item does not also claim is now refused. Merges below the claimed run are part of the state being restored and still plan, as do merges whose every parent is claimed.

Every refusal names a command the caller can run, and each case declares through an exhaustive match which commands its text must carry, so a refusal that stated only its condition would fail the check rather than pass it on the word "change".

**Evidence.** A binary built from the pre-fix sources produced the clap error and the not-implemented bail; the rebuilt binary answers both invocation mistakes specifically and refuses outside a repository with the remedy. Eleven planner unit tests cover the tip run, the empty case, an intervening change, an off-line change, the root boundary, a truncated window, duplicate scopes, three merge shapes, and the commands each refusal declares. Removing the merge refusal turns the merge test red with the planner returning a plan that restores the change before the run, which is the silent discard itself. Stripping the root refusal down to a bare condition turns the command check red while the assertion it replaced still passes. `work_item_rollback_parses_without_a_change_argument` is red on the pre-fix clap definition by construction.

## `kin rename`, gate deliberately left closed

The gate is not closed here, and the capability inventory still reports 31 of 33 ready.

A plan needs an exact edit span per reference. Today `collect_graph_references` reports the referring entity's own span and never reads `Relation.evidence[].source_span`. Call-site spans exist in the model, but whether the parsers populate them across languages is an unrun measurement that needs an admitted repository and the daemon lock. The apply half needs a single repository transaction carrying workspace tree and semantic deltas for a non-commit caller, which is likewise unverified. A planner built on unverified spans silently misses edit sites, which is worse than a refusal.

What changed instead: the refusal stated its two acceptance conditions and stopped, which says what Kin cannot do without saying what it can. Rename stays fail-closed, the capability fixture is untouched, and the refusal now also names the surfaces that answer the same question today (`kin refs <symbol>`, `kin locate <symbol>`) and states plainly that the gate is the planner and the single-transaction apply. Both the command path and the daemon path compose that refusal through one function, so the agent-facing surface carries the same guidance a person gets at the terminal. The measurement that would open the gate is filed separately.

**Evidence.** The fail-closed test calls the executor the daemon routes to and asserts on what it returns, rather than asserting a property of the capability fixture; an executor rewritten to fabricate a response turns it red and would have passed the assertion it replaces. A second test covers the composed refusal on the command path.

## Files this branch owns

- `crates/kin-cli/src/commands/auth.rs`
- `crates/kin-cli/src/commands/setup.rs`, intent title and description, `print_intent_followups`, new `hosted_followup_lines`, hosted tests
- `crates/kin-cli/src/commands/health.rs`, the `check_kinlab_connect` remedy only
- `crates/kin-cli/src/commands/work.rs`
- `crates/kin-cli/src/commands/rollback.rs`
- `crates/kin-cli/src/commands/rename.rs`
- `crates/kin-cli/src/main.rs`, the Rollback clap definition, the Rollback and Rename dispatch arms, one parse test
- `docs/quickstart.md`, three hosted claims

Not touched on purpose: `crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json`, which carries both open gates and belongs to the sibling lane closing `doctor --heal`; `setup.rs::doctor` and the heal path; and the first-touch bug set in `history.rs`, the pull path, the transport refusals, and the refusal-enforcement scan.

`kin doctor` is implemented inside `setup.rs`, so a concurrent heal change will also touch this file. The hunks are far apart, the intent region against the doctor function, but a reviewer should expect the overlap.

## Gates

fmt, clippy with the ci.yml allowlist, `build --all-targets --locked`, both zero-file-search guards, the runtime-boundaries check, `cargo nextest run --workspace` with `cargo test --doc` beside it, and `cargo test --workspace` as the authority, all run through the lane wrapper against an isolated target directory and under the workflow-level `-D warnings` that ci.yml sets.

One known flake sits outside this diff. `commands::setup_ledger::tests::verify_whole_file_detects_all_three_states` carries a plain `#[test]` while the test that sets the process-global `KIN_MCP_FIXTURE_ROOT` is `#[serial]`, and `serial_test` serializes only among serial-marked tests, so the ledger test can observe that global and fail with "managed config path escaped its fixture". It is nondeterministic, it is in files this branch does not touch, and the one-line fix is owned by another lane. If a queue run ejects on that test alone, it is this and not the diff.

Closes FIR-1813
Closes FIR-1814
Closes FIR-1811

