### PR TITLE
Keep the install proof's init log out of the worktree it admits

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -372,7 +372,17 @@ jobs:
           git init -q && git config user.email ci@firelock.ai && git config user.name ci
           printf 'def hello():\n    return 42\n' > probe.py
           git add -A && git commit -qm "probe"
-          kin init 2>&1 | tee kin-init.txt
+          # kin init admits this worktree exactly and repeats that proof across
+          # publication, so a report file must neither exist in it nor grow
+          # while init runs. Capture outside the admitted tree and copy the log
+          # back afterwards, on success and on failure alike, so a refusal still
+          # reaches the uploaded proof reports.
+          init_log="$RUNNER_TEMP/kin-init.txt"
+          init_status=0
+          kin init > "$init_log" 2>&1 || init_status=$?
+          cat "$init_log"
+          cp "$init_log" kin-init.txt
+          if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi
           # Do not pipe this command through tee. On Windows, the daemon child
           # inherits the pipe and keeps it open until idle shutdown, which makes
           # the shell wait for the daemon and then tests a process that just exited.

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -699,6 +699,42 @@ def workflow_active_header_source(workflow: str) -> str:
     return classifier_active_job_source(workflow.split(marker, 1)[0])
 
 
+def assert_install_proof_init_log_authority(first_run: str) -> None:
+    """Keep the install proof's own report files out of the worktree kin init admits.
+
+    kin init proves the Git worktree exactly, repeats that proof immediately
+    before publication, and repeats it again afterwards, refusing when the two
+    differ. A report file written into that worktree therefore breaks admission
+    twice over: it is an untracked non-ignored path, and an ignored one would
+    still change size between the repeats.
+    """
+
+    active = [
+        line.strip()
+        for line in first_run.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    init_lines = [line for line in active if line.startswith("kin init")]
+    if len(init_lines) != 1:
+        raise AssertionError(
+            "install proof must invoke kin init exactly once in the first-run step"
+        )
+    if init_lines[0] != 'kin init > "$init_log" 2>&1 || init_status=$?':
+        raise AssertionError(
+            "kin init must write its log outside the worktree it admits rather "
+            f"than through a relative redirect or pipe: {init_lines[0]}"
+        )
+    for policy in (
+        'init_log="$RUNNER_TEMP/kin-init.txt"',
+        'cp "$init_log" kin-init.txt',
+        'if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi',
+    ):
+        if policy not in active:
+            raise AssertionError(
+                f"install-proof init log capture lost an active line: {policy}"
+            )
+
+
 def assert_docs_only_classifier_guard(workflow: str) -> None:
     """Require the exact workflow header, classifier job, and classifier shell."""
 
@@ -3486,6 +3522,42 @@ def main() -> None:
         'printf \'SHELL=%s\\n\' "$SHELL" >> "$GITHUB_ENV"',
     ):
         require(first_run, policy, "cross-step install-proof shell pin")
+    assert_install_proof_init_log_authority(first_run)
+    expect_assertion(
+        "kin init writes its log into the worktree it admits",
+        "outside the worktree it admits",
+        lambda: assert_install_proof_init_log_authority(
+            first_run.replace(
+                'kin init > "$init_log" 2>&1 || init_status=$?',
+                "kin init 2>&1 | tee kin-init.txt",
+                1,
+            )
+        ),
+    )
+    expect_assertion(
+        "a second kin init escapes the admitted-worktree contract",
+        "exactly once",
+        lambda: assert_install_proof_init_log_authority(
+            f"{first_run}\n          kin init\n"
+        ),
+    )
+    for label, active_line in (
+        (
+            "the captured init log never reaches the proof reports",
+            'cp "$init_log" kin-init.txt',
+        ),
+        (
+            "a refused init stops failing the install proof",
+            'if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi',
+        ),
+    ):
+        expect_assertion(
+            label,
+            "install-proof init log capture",
+            lambda mutated=first_run.replace(
+                active_line, f"# {active_line}", 1
+            ): assert_install_proof_init_log_authority(mutated),
+        )
     for policy in (
         "PROOF_SHELL: ${{ matrix.setup-shell }}",
         'case "$PROOF_SHELL" in',


### PR DESCRIPTION
## What broke

The v0.4.5 release run failed Public Install Proof on all five platforms in roughly 175 milliseconds, identically:

```
Error: admit exact reachable Git repository authority
Caused by:
    prove mutable Git workspace: Git migration preflight failed: worktree contains untracked non-ignored path kin-init.txt
```

The harness writes that file itself. `.github/workflows/install-proof.yml:375` ran `kin init 2>&1 | tee kin-init.txt` from inside `kin-install-proof/`, which is the worktree `kin init` is being asked to admit. The shell builds the pipeline before either process does any work, so `tee` creates `kin-init.txt` while the binary is still starting, and admission then refuses the file the step created a moment earlier.

## Why ignoring the file would not have worked

`kin init` runs the preflight three times: before staging (`crates/kin-core/src/git_init.rs:220`), again immediately before publication (line 260, "repeat final Git source proof"), and once more after publication (line 270). The last two compare the proof for exact equality and refuse on any difference. Ignored entries are part of that proof and carry their byte length (`IgnoredLocalEntry` in `crates/kin-git/src/preflight.rs:120`), so a `.gitignore` entry would only move the failure: `tee` grows the file between the repeats and init would refuse with "Git source proof changed before repository publication" instead. Writing the log outside the admitted worktree is the only shape that holds.

## The change

Capture outside, copy back afterwards, keep the exit code:

```bash
init_log="$RUNNER_TEMP/kin-init.txt"
init_status=0
kin init > "$init_log" 2>&1 || init_status=$?
cat "$init_log"
cp "$init_log" kin-init.txt
if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi
```

The worktree is byte-identical to its commit while init runs. The log reaches `kin-install-proof/` afterwards, so the existing upload glob still collects it, and a refusal still reaches the uploaded reports. `kin init`'s own exit code still fails the step, so the proof still fails when admission genuinely breaks.

Windows path handling is proven by the identical operation, not by analogy. `ci.yml:328-334` ("Assert the Windows admission contract", `shell: bash`, Windows runner, every pull request) runs `scripts/assert-windows-init-contract.sh` with its scratch root at `"$RUNNER_TEMP/kin-windows-admission"`, and that script's line 131 is `(cd "$dir" && "$kin_bin" init) > "$log" 2>&1` with the log under that scratch root. Redirecting `kin init`'s output into a `$RUNNER_TEMP` path from MSYS bash on Windows is therefore already a green required check. `ci.yml:428-429` does the same shape with `kin.exe` and reads the file back, and `$RUNNER_TEMP` is used with bash `mkdir` and `cp` twelve lines below this change in the very same step. Redirecting rather than piping also brings `kin init` in line with the guidance directly below it about Windows daemon children inheriting a tee pipe, and with `scripts/assert-windows-init-contract.sh:131`, which already writes its init log to a sibling of the directory under test. That script was doing this correctly; the install proof was the outlier. Every other `kin init` in CI, scripts, and docs was checked and none redirects into the worktree.

## Why this needs a guard

The strict preflight landed in #447 (merged 2026-07-27) and nothing caught the interaction for four days. Install Proof runs on a release and on a weekly schedule, and the scheduled run installs the latest promoted public release, which is still v0.3.6 and predates #447. A regression introduced after a promotion is therefore invisible to it until the next release attempt. The v0.4.3 runs died earlier still, in the installer.

So the guard goes where it can run per pull request: `assert_install_proof_init_log_authority` in `scripts/test-release-workflow-authority.py`, which CI already executes at `ci.yml:86` and `ci.yml:634`. It requires exactly one `kin init` in the first-run step, requires its exact capture form, and requires the copy-back and status-propagation lines as active non-comment lines, so commenting them out fails the guard instead of satisfying a raw substring match. Four falsifications cover restoring the `tee` form, adding a second `kin init`, and commenting out either of the two lines.

## Evidence

- `python3 scripts/test-release-workflow-authority.py` passes.
- Falsified against the real workflow file, not only in-script fixtures. Restoring `kin init 2>&1 | tee kin-init.txt` in `install-proof.yml` fails with "kin init must write its log outside the worktree it admits"; commenting out the copy-back fails with "install-proof init log capture lost an active line". File restored, suite green again.
- Rehearsed locally under the runner's exact shell options with a stub `kin` that reports `git status --porcelain --untracked-files=all` from inside the worktree at init time. The old form makes the stub see `?? kin-init.txt`, reproducing the failure rather than asserting it. The new form makes it see nothing. With the stub exiting 7, the step exits 7 rather than a flattened 1, and the log is still copied back.
- `actionlint .github/workflows/install-proof.yml` reports nothing.
- The sibling python gates CI runs alongside this one all pass: `test_install_optional_vfs.py`, `test_installer_parity.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, `test-install-checksum.py`, `test-homebrew-release-gate.py`.

## Effect on the blocked v0.4.5 run

This cannot unblock run 30678146368. `release.yml:1555` calls the proof as `uses: ./.github/workflows/install-proof.yml`, which resolves from the same commit as the caller, and re-running a run replays the workflow files at that run's ref (`head_sha` 93a74a91af929a340d9ec90999601843d0b325b1). The failing logic is inline shell in tag-pinned content and nothing in that job is fetched from a mutable ref at runtime, so `rerun-failed-jobs`, which is what the recovery controller uses, replays the same defect. Release also triggers only on a tag push, with manual dispatch deliberately disabled. What happens to v0.4.5 is a separate decision for the release captain; this change is the fix that has to exist first either way.
