### PR TITLE
Report five first-touch failures with the detail the code already had

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -193,6 +193,35 @@ fn available_ram_gb() -> f64 {
     }
 }
 
+/// What the host can say about memory pressure, for a command that has to
+/// decide whether a failure it just saw was the machine running out of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryEvidence {
+    /// The ceiling this process actually runs under: the container limit when
+    /// one is set, otherwise the host's physical RAM.
+    pub limit_bytes: u64,
+    /// Kernel OOM kills accounted to this cgroup. `None` means no accounting
+    /// was readable, which is "not observed" and never "did not happen".
+    pub cgroup_oom_kills: Option<u64>,
+}
+
+/// Read what this host will say about memory pressure right now.
+pub fn memory_evidence() -> MemoryEvidence {
+    MemoryEvidence {
+        limit_bytes: effective_memory_limit_bytes(),
+        cgroup_oom_kills: cgroup_oom_kill_count(),
+    }
+}
+
+/// The memory ceiling a Kin process runs under, in bytes.
+fn effective_memory_limit_bytes() -> u64 {
+    let host = (host_ram_gb() * 1024.0 * 1024.0 * 1024.0) as u64;
+    match cgroup_memory_limit_bytes() {
+        Some(limit) => host.min(limit),
+        None => host,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Container (cgroup) quota detection — Linux only
 // ---------------------------------------------------------------------------
@@ -254,6 +283,48 @@ fn cgroup_memory_limit_bytes() -> Option<u64> {
 #[cfg(not(target_os = "linux"))]
 fn cgroup_memory_limit_bytes() -> Option<u64> {
     None
+}
+
+/// How many times the kernel OOM-killed a process accounted to this cgroup, or
+/// `None` when no accounting is readable (off Linux, or neither hierarchy's
+/// file is present).
+///
+/// Both hierarchies publish the counter under the same key, in different files:
+/// cgroup v2 in `memory.events`, v1 in `memory.oom_control`. The distinction
+/// that matters to a caller is `Some(0)` against `None`: the first is the
+/// kernel saying nothing was killed, the second is this process being unable
+/// to ask.
+#[cfg(target_os = "linux")]
+fn cgroup_oom_kill_count() -> Option<u64> {
+    for path in [
+        "/sys/fs/cgroup/memory.events",
+        "/sys/fs/cgroup/memory/memory.oom_control",
+    ] {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Some(count) = parse_oom_kill_count(&contents) {
+                return Some(count);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn cgroup_oom_kill_count() -> Option<u64> {
+    None
+}
+
+/// The `oom_kill` counter out of a cgroup key/value block, or `None` when the
+/// block carries no such key.
+#[cfg(any(target_os = "linux", test))]
+fn parse_oom_kill_count(contents: &str) -> Option<u64> {
+    contents.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        match (fields.next(), fields.next()) {
+            (Some("oom_kill"), Some(value)) => value.parse().ok(),
+            _ => None,
+        }
+    })
 }
 
 /// Whole-core count for a cgroup v2 `cpu.max` value ("<quota> <period>" in µs,
@@ -361,6 +432,26 @@ mod tests {
             Some(4 * 1024 * 1024 * 1024)
         );
         assert_eq!(parse_v2_memory_max("max"), None);
+    }
+
+    #[test]
+    fn oom_kill_count_is_read_from_either_cgroup_hierarchy() {
+        // cgroup v2 `memory.events`, which is where the 512 MB constrained
+        // profile's evidence came from.
+        assert_eq!(
+            parse_oom_kill_count("low 0\nhigh 0\nmax 3\noom 1\noom_kill 1\n"),
+            Some(1)
+        );
+        // cgroup v1 `memory.oom_control`, same key, different file.
+        assert_eq!(
+            parse_oom_kill_count("oom_kill_disable 0\nunder_oom 0\noom_kill 2\n"),
+            Some(2)
+        );
+        // A group that was never killed says so, which is not the same answer
+        // as a host that cannot be asked.
+        assert_eq!(parse_oom_kill_count("low 0\nhigh 0\nmax 0\noom 0\n"), None);
+        assert_eq!(parse_oom_kill_count("oom_kill 0\n"), Some(0));
+        assert_eq!(parse_oom_kill_count("oom_kill notanumber\n"), None);
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -173,6 +173,121 @@ fn format_duration_secs(total: u64) -> String {
     }
 }
 
+/// The embedding model `kin embed` downloads on first use.
+const EMBED_MODEL_ID: &str = "nomic-ai/nomic-embed-text-v1.5";
+
+/// What that download costs, which is also roughly what the model costs
+/// resident once the daemon has loaded it.
+const EMBED_MODEL_DOWNLOAD_BYTES: u64 = 522 * 1024 * 1024;
+
+/// The smallest memory ceiling a vector embed has been measured to complete a
+/// real repository under. At 1 GiB a tiny repository finishes exactly at the
+/// cap and a 512 MiB cgroup gets the daemon OOM-killed; 2 GiB peaks around
+/// 1.5 GiB, which is why that is the number the guidance names.
+const RECOMMENDED_EMBED_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Phrases a lost connection renders with, as distinct from a refusal the
+/// daemon stayed alive to answer with.
+///
+/// An HTTP status the daemon returned reaches the caller as `daemon embed error
+/// (HTTP ...)` and matches nothing here, and neither does a client-side
+/// timeout. That separation is the point: a disconnect is the only failure
+/// shape a process that was killed can produce, so anything else must keep its
+/// own diagnosis rather than inherit a memory one.
+const LOST_CONNECTION_MARKERS: &[&str] = &[
+    "connection closed before message completed",
+    "connection reset by peer",
+    "connection closed",
+    "broken pipe",
+    "IncompleteMessage",
+    "channel closed",
+    "error sending request",
+];
+
+fn lost_the_daemon_mid_request(rendered: &str) -> bool {
+    LOST_CONNECTION_MARKERS
+        .iter()
+        .any(|marker| rendered.contains(marker))
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else {
+        format!("{} MiB", bytes / MIB)
+    }
+}
+
+/// Guidance for an embed that lost the daemon under memory pressure, or `None`
+/// when this cannot honestly attribute the failure to memory.
+///
+/// The failure the ticket describes reaches the caller as a bare transport
+/// error: the daemon is OOM-killed mid-pass, the connection drops, and the CLI
+/// reports a closed connection while the cgroup records `oom_kill 1`. Nothing
+/// in that message names memory, the model that needs it, or the fact that
+/// lexical and graph retrieval never did.
+///
+/// Two grades are produced and they are labelled differently on purpose. A
+/// cgroup that recorded a kill is the kernel's own statement and is reported as
+/// observed. A ceiling below what an embed needs is a strong prior and nothing
+/// more, so it is reported as likely. A disconnect with neither is left alone:
+/// a daemon that died for another reason on a large machine keeps its own
+/// error rather than being told it ran out of memory.
+fn embed_resource_exhaustion(
+    rendered: &str,
+    evidence: &crate::capability::MemoryEvidence,
+) -> Option<String> {
+    if !lost_the_daemon_mid_request(rendered) {
+        return None;
+    }
+    let observed_kills = evidence.cgroup_oom_kills.filter(|count| *count > 0);
+    let under_recommendation = evidence.limit_bytes < RECOMMENDED_EMBED_MEMORY_BYTES;
+    let cause = match (observed_kills, under_recommendation) {
+        (Some(count), _) => format!(
+            "the daemon was lost during this embed pass and this container's kernel recorded \
+             {count} out-of-memory kill(s), so the embed ran out of memory"
+        ),
+        (None, true) => format!(
+            "the daemon was lost during this embed pass and only {} of memory is available to \
+             it, so it most likely ran out of memory",
+            human_bytes(evidence.limit_bytes)
+        ),
+        (None, false) => return None,
+    };
+    Some(format!(
+        "{cause}.\n\
+         `kin embed` loads the {} {EMBED_MODEL_ID} model and a real repository peaks well above \
+         that, so give this machine at least {}.\n\
+         Coverage already embedded is persisted, so re-running `kin embed` under a higher limit \
+         resumes rather than starting over.\n\
+         Lexical and graph retrieval need no model: `kin locate` and `kin search` keep answering \
+         without vectors.",
+        human_bytes(EMBED_MODEL_DOWNLOAD_BYTES),
+        human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
+    ))
+}
+
+/// What to tell a caller before an embed starts on a machine that cannot
+/// comfortably hold the model, or `None` when the ceiling is adequate.
+///
+/// The download and the ceiling are both knowable before any work begins, and
+/// a caller who learns them from a failed pass learns them too late.
+fn constrained_memory_notice(evidence: &crate::capability::MemoryEvidence) -> Option<String> {
+    if evidence.limit_bytes >= RECOMMENDED_EMBED_MEMORY_BYTES {
+        return None;
+    }
+    Some(format!(
+        "Note: {} of memory is available here. `kin embed` downloads and loads the {} \
+         {EMBED_MODEL_ID} model, and at least {} is recommended; below that the daemon can be \
+         killed mid-pass. Lexical and graph retrieval need no model.",
+        human_bytes(evidence.limit_bytes),
+        human_bytes(EMBED_MODEL_DOWNLOAD_BYTES),
+        human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
+    ))
+}
+
 /// Whether the drive-to-completion loop should issue another embed pass.
 ///
 /// Continue only while retrievable work remains AND the last pass actually
@@ -214,6 +329,12 @@ pub async fn run(
     )
     .entered();
     let layout = crate::commands::require_repository_layout()?;
+
+    if !json {
+        if let Some(notice) = constrained_memory_notice(&crate::capability::memory_evidence()) {
+            println!("{notice}");
+        }
+    }
 
     if let Some(seconds) = max_seconds {
         let response = run_daemon_embed(
@@ -344,10 +465,17 @@ async fn run_daemon_embed(
     // (or fail under KIN_STRICT_BEHAVIOR_ENV) if this command's environment
     // diverges from what that worker captured at start.
     client.warn_on_behavior_env_divergence().await?;
-    client
-        .embed(request)
-        .await
-        .map_err(|e| anyhow::anyhow!("daemon embed failed: {e:#}"))
+    client.embed(request).await.map_err(|e| {
+        let rendered = format!("{e:#}");
+        // The transport error stays in the message either way. A caller who
+        // needs to see what the connection actually did still can, and a
+        // failure this cannot attribute to memory is passed through untouched
+        // rather than being given a diagnosis nobody proved.
+        match embed_resource_exhaustion(&rendered, &crate::capability::memory_evidence()) {
+            Some(guidance) => anyhow::anyhow!("daemon embed failed: {rendered}\n\n{guidance}"),
+            None => anyhow::anyhow!("daemon embed failed: {rendered}"),
+        }
+    })
 }
 
 pub fn build_embed_response(
@@ -511,9 +639,10 @@ pub fn build_embed_response(
 #[cfg(test)]
 mod tests {
     use super::{
-        effective_batch_size, embed_pass_should_continue, eta_suffix, format_duration_secs,
-        resolve_total_budget, should_queue_missing_embedding_pass, throughput_per_sec, EmbedResult,
-        DEFAULT_BATCH_SIZE, DEFAULT_CONSTRAINED_TOTAL_SECONDS,
+        constrained_memory_notice, effective_batch_size, embed_pass_should_continue,
+        embed_resource_exhaustion, eta_suffix, format_duration_secs, resolve_total_budget,
+        should_queue_missing_embedding_pass, throughput_per_sec, EmbedResult, DEFAULT_BATCH_SIZE,
+        DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_ID, RECOMMENDED_EMBED_MEMORY_BYTES,
     };
 
     fn result_with(pending_entities: usize, pending_artifacts: usize) -> EmbedResult {
@@ -593,6 +722,106 @@ mod tests {
     #[test]
     fn skips_full_queue_when_embeddings_are_current() {
         assert!(!should_queue_missing_embedding_pass(5, 5));
+    }
+
+    fn evidence(limit_bytes: u64, oom_kills: Option<u64>) -> crate::capability::MemoryEvidence {
+        crate::capability::MemoryEvidence {
+            limit_bytes,
+            cgroup_oom_kills: oom_kills,
+        }
+    }
+
+    /// The exact failure a 512 MB cgroup produced: the daemon is OOM-killed
+    /// mid-pass and the CLI is handed a closed connection.
+    const OOM_KILLED_MID_PASS: &str =
+        "send daemon embed request: error sending request for url (http://127.0.0.1:7654/embed): \
+         connection closed before message completed";
+
+    #[test]
+    fn a_recorded_oom_kill_is_reported_as_observed_with_the_limit_and_the_remedy() {
+        let guidance =
+            embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(512 * 1024 * 1024, Some(1)))
+                .expect("a kernel OOM kill during an embed is not an opaque transport failure");
+
+        assert!(
+            guidance.contains("out-of-memory kill"),
+            "the kernel's own record is what makes this observed: {guidance}"
+        );
+        assert!(
+            guidance.contains("2.0 GiB"),
+            "the failure must name the limit that would fix it: {guidance}"
+        );
+        assert!(
+            guidance.contains(EMBED_MODEL_ID) && guidance.contains("522 MiB"),
+            "the failure must name what is consuming the memory: {guidance}"
+        );
+        assert!(
+            guidance.contains("kin locate") && guidance.contains("kin search"),
+            "a repository without vectors is not a repository without retrieval: {guidance}"
+        );
+        assert!(
+            guidance.contains("persisted"),
+            "the caller must know a re-run resumes rather than restarts: {guidance}"
+        );
+    }
+
+    #[test]
+    fn a_ceiling_below_the_recommendation_is_reported_as_likely_not_as_observed() {
+        // No cgroup accounting is readable, which is every non-Linux host. The
+        // ceiling still says the machine cannot hold the model, and saying so
+        // is not the same as claiming the kernel proved it.
+        let guidance = embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(1 << 29, None))
+            .expect("a lost daemon under the recommendation is a memory diagnosis");
+        assert!(
+            guidance.contains("most likely"),
+            "an inference from the ceiling alone must be labelled as one: {guidance}"
+        );
+        assert!(
+            !guidance.contains("kernel recorded"),
+            "nothing may claim a kill this host could not observe: {guidance}"
+        );
+    }
+
+    #[test]
+    fn a_non_memory_daemon_disconnect_keeps_its_own_error() {
+        // The distinguishability the acceptance asks for. A daemon that died
+        // for another reason on a machine with room to spare must not be told
+        // it ran out of memory, and a refusal the daemon stayed alive to answer
+        // with was never a disconnect at all.
+        assert!(
+            embed_resource_exhaustion(OOM_KILLED_MID_PASS, &evidence(64 << 30, Some(0))).is_none(),
+            "a large host with no recorded kill has no memory diagnosis to offer"
+        );
+        assert!(
+            embed_resource_exhaustion(
+                "daemon embed error (HTTP 500): Graph error: kindb foo",
+                &evidence(512 * 1024 * 1024, Some(3)),
+            )
+            .is_none(),
+            "an answered HTTP refusal is not a daemon that was killed, whatever the cgroup says"
+        );
+        assert!(
+            embed_resource_exhaustion(
+                "send daemon embed request: operation timed out",
+                &evidence(512 * 1024 * 1024, Some(3)),
+            )
+            .is_none(),
+            "a client-side timeout keeps its own diagnosis"
+        );
+    }
+
+    #[test]
+    fn a_constrained_machine_is_told_before_the_work_starts_and_a_roomy_one_is_not() {
+        let notice = constrained_memory_notice(&evidence(1 << 30, None))
+            .expect("a machine under the recommendation is warned before the download");
+        assert!(
+            notice.contains("522 MiB") && notice.contains("2.0 GiB"),
+            "{notice}"
+        );
+        assert!(
+            constrained_memory_notice(&evidence(RECOMMENDED_EMBED_MEMORY_BYTES, None)).is_none(),
+            "a machine at the recommendation gets no warning it does not need"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -176,9 +176,10 @@ fn format_duration_secs(total: u64) -> String {
 /// The embedding model `kin embed` downloads on first use.
 const EMBED_MODEL_ID: &str = "nomic-ai/nomic-embed-text-v1.5";
 
-/// What that download costs, which is also roughly what the model costs
-/// resident once the daemon has loaded it.
-const EMBED_MODEL_DOWNLOAD_BYTES: u64 = 522 * 1024 * 1024;
+/// What that download costs, as the model host reports it. Carried as the
+/// published figure rather than as a byte count, so the number a caller sees is
+/// the one they will see again when the download runs.
+const EMBED_MODEL_DOWNLOAD: &str = "522 MB";
 
 /// The smallest memory ceiling a vector embed has been measured to complete a
 /// real repository under. At 1 GiB a tiny repository finishes exactly at the
@@ -258,13 +259,12 @@ fn embed_resource_exhaustion(
     };
     Some(format!(
         "{cause}.\n\
-         `kin embed` loads the {} {EMBED_MODEL_ID} model and a real repository peaks well above \
-         that, so give this machine at least {}.\n\
+         `kin embed` loads the {EMBED_MODEL_DOWNLOAD} {EMBED_MODEL_ID} model and a real \
+         repository peaks well above that, so give this machine at least {}.\n\
          Coverage already embedded is persisted, so re-running `kin embed` under a higher limit \
          resumes rather than starting over.\n\
          Lexical and graph retrieval need no model: `kin locate` and `kin search` keep answering \
          without vectors.",
-        human_bytes(EMBED_MODEL_DOWNLOAD_BYTES),
         human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
     ))
 }
@@ -279,11 +279,10 @@ fn constrained_memory_notice(evidence: &crate::capability::MemoryEvidence) -> Op
         return None;
     }
     Some(format!(
-        "Note: {} of memory is available here. `kin embed` downloads and loads the {} \
-         {EMBED_MODEL_ID} model, and at least {} is recommended; below that the daemon can be \
-         killed mid-pass. Lexical and graph retrieval need no model.",
+        "Note: {} of memory is available here. `kin embed` downloads and loads the \
+         {EMBED_MODEL_DOWNLOAD} {EMBED_MODEL_ID} model, and at least {} is recommended; below \
+         that the daemon can be killed mid-pass. Lexical and graph retrieval need no model.",
         human_bytes(evidence.limit_bytes),
-        human_bytes(EMBED_MODEL_DOWNLOAD_BYTES),
         human_bytes(RECOMMENDED_EMBED_MEMORY_BYTES),
     ))
 }
@@ -642,7 +641,8 @@ mod tests {
         constrained_memory_notice, effective_batch_size, embed_pass_should_continue,
         embed_resource_exhaustion, eta_suffix, format_duration_secs, resolve_total_budget,
         should_queue_missing_embedding_pass, throughput_per_sec, EmbedResult, DEFAULT_BATCH_SIZE,
-        DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_ID, RECOMMENDED_EMBED_MEMORY_BYTES,
+        DEFAULT_CONSTRAINED_TOTAL_SECONDS, EMBED_MODEL_DOWNLOAD, EMBED_MODEL_ID,
+        RECOMMENDED_EMBED_MEMORY_BYTES,
     };
 
     fn result_with(pending_entities: usize, pending_artifacts: usize) -> EmbedResult {
@@ -752,7 +752,7 @@ mod tests {
             "the failure must name the limit that would fix it: {guidance}"
         );
         assert!(
-            guidance.contains(EMBED_MODEL_ID) && guidance.contains("522 MiB"),
+            guidance.contains(EMBED_MODEL_ID) && guidance.contains(EMBED_MODEL_DOWNLOAD),
             "the failure must name what is consuming the memory: {guidance}"
         );
         assert!(
@@ -815,7 +815,7 @@ mod tests {
         let notice = constrained_memory_notice(&evidence(1 << 30, None))
             .expect("a machine under the recommendation is warned before the download");
         assert!(
-            notice.contains("522 MiB") && notice.contains("2.0 GiB"),
+            notice.contains(EMBED_MODEL_DOWNLOAD) && notice.contains("2.0 GiB"),
             "{notice}"
         );
         assert!(

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -187,14 +187,17 @@ const EMBED_MODEL_DOWNLOAD: &str = "522 MB";
 /// 1.5 GiB, which is why that is the number the guidance names.
 const RECOMMENDED_EMBED_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
-/// Phrases a lost connection renders with, as distinct from a refusal the
-/// daemon stayed alive to answer with.
+/// Phrases an established connection renders with when it breaks partway, as
+/// distinct from a refusal the daemon stayed alive to answer with.
 ///
-/// An HTTP status the daemon returned reaches the caller as `daemon embed error
-/// (HTTP ...)` and matches nothing here, and neither does a client-side
-/// timeout. That separation is the point: a disconnect is the only failure
-/// shape a process that was killed can produce, so anything else must keep its
-/// own diagnosis rather than inherit a memory one.
+/// Every entry describes a connection that existed and then broke, which is the
+/// only failure shape a process killed mid-request can produce. The HTTP
+/// client's generic send-failure wrapper is deliberately not here: it also
+/// covers a connection that was refused outright, and a daemon that never
+/// accepted the request was not lost during this pass, whatever the machine's
+/// memory says. An HTTP status the daemon returned reaches the caller as
+/// `daemon embed error (HTTP ...)` and matches nothing here either, and neither
+/// does a client-side timeout, so each keeps its own diagnosis.
 const LOST_CONNECTION_MARKERS: &[&str] = &[
     "connection closed before message completed",
     "connection reset by peer",
@@ -202,7 +205,6 @@ const LOST_CONNECTION_MARKERS: &[&str] = &[
     "broken pipe",
     "IncompleteMessage",
     "channel closed",
-    "error sending request",
 ];
 
 fn lost_the_daemon_mid_request(rendered: &str) -> bool {
@@ -807,6 +809,16 @@ mod tests {
             )
             .is_none(),
             "a client-side timeout keeps its own diagnosis"
+        );
+        assert!(
+            embed_resource_exhaustion(
+                "send daemon embed request: error sending request for url \
+                 (http://127.0.0.1:7654/embed): tcp connect error: Connection refused (os error 61)",
+                &evidence(512 * 1024 * 1024, Some(3)),
+            )
+            .is_none(),
+            "a connection that was never accepted is not a daemon lost during this pass, whatever \
+             the machine's memory says"
         );
     }
 

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -59,12 +59,39 @@ fn author_name(author: &str) -> String {
         .to_string()
 }
 
-fn truncate(value: &str, width: usize) -> String {
-    if value.chars().count() <= width {
-        return value.to_string();
-    }
-    let kept: String = value.chars().take(width.saturating_sub(1)).collect();
-    format!("{kept}…")
+/// One rendered revision, before the author column has been sized.
+struct RevisionRow {
+    id: String,
+    when: String,
+    who: String,
+    subject: String,
+}
+
+/// Render the revision rows with an author column sized to the widest author
+/// present.
+///
+/// The column is measured rather than fixed because an author is an identity,
+/// and half an identity answers nobody. An MCP commit is authored by
+/// `{vendor}/{client_name}`, so a fixed column cut exactly the client name, the
+/// half that tells two sessions of one vendor apart, and an unregistered
+/// session left nineteen characters of a UUID. The date column stays fixed
+/// because a calendar date is always ten characters wide, and the subject is
+/// last so nothing after it needs padding: a wide terminal spends its extra
+/// columns on the message rather than on trailing space.
+fn render_revision_rows(rows: &[RevisionRow]) -> Vec<String> {
+    let author_width = rows
+        .iter()
+        .map(|row| row.who.chars().count())
+        .max()
+        .unwrap_or(0);
+    rows.iter()
+        .map(|row| {
+            format!(
+                "  {}  {:<10}  {:<author_width$}  {}",
+                row.id, row.when, row.who, row.subject
+            )
+        })
+        .collect()
 }
 
 pub async fn run(entity: String, reference: Option<String>) -> Result<()> {
@@ -130,6 +157,7 @@ pub fn execute_history_request(
     if revisions.is_empty() {
         lines.push("  No history recorded".to_string());
     } else {
+        let mut rows = Vec::with_capacity(revisions.len());
         for revision in &revisions {
             let change = graph.get_change(&revision.introduced_by)?;
             let (when, who, subject) = match change.as_ref() {
@@ -140,15 +168,94 @@ pub fn execute_history_request(
                 ),
                 None => ("?".to_string(), "?".to_string(), "unknown".to_string()),
             };
-            lines.push(format!(
-                "  {}  {:<10}  {:<20}  {}",
-                abbreviate_id(&revision.introduced_by.to_string()),
+            rows.push(RevisionRow {
+                id: abbreviate_id(&revision.introduced_by.to_string()),
                 when,
-                truncate(&who, 20),
-                subject
-            ));
+                who,
+                subject,
+            });
         }
+        lines.extend(render_revision_rows(&rows));
     }
 
     Ok(HistoryResponse { lines })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(who: &str, subject: &str) -> RevisionRow {
+        RevisionRow {
+            id: "0123456789ab".to_string(),
+            when: "2026-07-31".to_string(),
+            who: author_name(who),
+            subject: subject.to_string(),
+        }
+    }
+
+    /// Column each row's subject starts at, which is what "aligned" means here.
+    fn subject_column(line: &str, subject: &str) -> usize {
+        line.char_indices()
+            .position(|(offset, _)| line[offset..].starts_with(subject))
+            .expect("every rendered row carries its subject")
+    }
+
+    #[test]
+    fn an_agent_identity_is_never_cut_to_fit_the_author_column() {
+        // Both values are what `kin history` actually shows for an MCP commit:
+        // the registered `{vendor}/{client_name}`, and the session id an
+        // unregistered session falls back to. Neither fits twenty columns, and
+        // the part a fixed column removed was the part that identifies the
+        // session rather than the vendor.
+        let client = "claude-code/one-change-demo";
+        let session = "3f2a9c8e-7b41-4c2d-9e05-1a6b8c3d4e5f";
+        assert!(client.chars().count() > 20 && session.chars().count() > 20);
+
+        let rendered = render_revision_rows(&[
+            row(
+                &format!("{client} <mcp-agent:{session}>"),
+                "Rename the parser entry point",
+            ),
+            row(
+                &format!("{session} <mcp-agent:{session}>"),
+                "Seed the graph",
+            ),
+        ]);
+
+        for (line, who) in rendered.iter().zip([client, session]) {
+            assert!(
+                line.contains(who),
+                "the author column must carry the whole identity: {line}"
+            );
+        }
+        assert!(
+            !rendered.iter().any(|line| line.contains('…')),
+            "no identity may be ellipsized: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn the_author_column_is_sized_from_the_widest_author_so_subjects_stay_aligned() {
+        // Growing the column is only worth doing if the table still reads as a
+        // table: every subject has to start in the same place regardless of how
+        // long its row's author is.
+        let rendered = render_revision_rows(&[
+            row("kin <kin@firelock.ai>", "short author"),
+            row("claude-code/one-change-demo <mcp-agent:abc>", "long author"),
+        ]);
+
+        assert_eq!(
+            subject_column(&rendered[0], "short author"),
+            subject_column(&rendered[1], "long author"),
+            "subjects must line up: {rendered:?}"
+        );
+        // Nothing is padded past the widest author, so a history of short
+        // authors does not pay for a column no row needs.
+        assert!(
+            rendered[1].contains("claude-code/one-change-demo  long author"),
+            "the widest author must be followed by the column gap alone: {}",
+            rendered[1]
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -215,9 +215,10 @@ mod repository_refusal_tests {
     /// Keyed on the condition sentence rather than on any call spelling, which
     /// is what makes it blind to how the refusal is raised: `ok_or_else`,
     /// `context`, `bail!`, a `match`, or a `let ... else` all carry the same
-    /// sentence and are all caught. A test that wants to assert on the refusal
-    /// asserts against `NOT_A_KIN_REPOSITORY`, so a literal copy anywhere else
-    /// is a second home for the wording by construction.
+    /// sentence and are all caught. A test that needs the whole sentence reads
+    /// it from `NOT_A_KIN_REPOSITORY` rather than repeating it, so a literal
+    /// copy anywhere else is a second home for the wording rather than an
+    /// assertion about it.
     fn refusal_wording_restated(
         root: &std::path::Path,
         canonical: &std::path::Path,

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -105,16 +105,27 @@ pub(crate) fn require_repository_layout() -> anyhow::Result<kin_core::KinLayout>
 pub(crate) fn require_repository_layout_at(
     start: &std::path::Path,
 ) -> anyhow::Result<kin_core::KinLayout> {
-    kin_core::KinLayout::discover(start).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })
+    kin_core::KinLayout::discover(start).ok_or_else(not_a_kin_repository)
+}
+
+/// The one wording every "you are not in a Kin repository" refusal is raised
+/// with, so a command whose condition is its own still states the same remedy.
+///
+/// A few commands cannot phrase the condition as a discovery, because they hold
+/// a specific directory and ask whether that exact directory is a repository.
+/// Those raise this rather than restating it. The wording having one home is
+/// what the enforcement scan below checks, and it checks the wording rather than
+/// any one call spelling.
+pub(crate) const NOT_A_KIN_REPOSITORY: &str =
+    "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here";
+
+pub(crate) fn not_a_kin_repository() -> anyhow::Error {
+    anyhow::anyhow!(NOT_A_KIN_REPOSITORY)
 }
 
 #[cfg(test)]
 mod repository_refusal_tests {
-    use super::require_repository_layout_at;
+    use super::{require_repository_layout_at, NOT_A_KIN_REPOSITORY};
 
     #[test]
     fn refusing_outside_a_repository_names_the_command_that_creates_one() {
@@ -130,6 +141,29 @@ mod repository_refusal_tests {
             message.contains("kin init"),
             "refusal must name the remedy: {message}"
         );
+    }
+
+    /// Every `.rs` under `root`, other than `canonical`, paired with its text.
+    fn crate_sources(root: &std::path::Path, canonical: &std::path::Path) -> Vec<(String, String)> {
+        let mut found = Vec::new();
+        let mut pending = vec![root.to_path_buf()];
+        while let Some(directory) = pending.pop() {
+            let entries = std::fs::read_dir(&directory).expect("read crate sources");
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    pending.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || path == canonical
+                {
+                    continue;
+                }
+                let source = std::fs::read_to_string(&path).expect("read a crate source");
+                found.push((path.display().to_string(), source));
+            }
+        }
+        found
     }
 
     /// Byte offset just past the parenthesis closing the one at `open`.
@@ -150,57 +184,141 @@ mod repository_refusal_tests {
         None
     }
 
-    #[test]
-    fn no_command_hand_rolls_the_repository_refusal() {
-        // One home for the wording only holds while it stays the only home.
-        // The shape that produced 81 copies is a discovery immediately
-        // refused in place, so this crate's sources carry it in exactly one
-        // file: the one declaring the canonical refusal. A command reverting
-        // to a local refusal reads as an ordinary two-line diff and would
-        // otherwise pass every gate while dropping the remedy the caller
-        // needs. Deliberate exceptions refuse on their own condition rather
-        // than on discovery, so they are outside this shape by construction.
+    /// Where a discovery is refused in place: `discover(...)` handed straight
+    /// to `ok_or_else`. This is one call shape, and naming it is the point.
+    fn discovery_refused_in_place(
+        root: &std::path::Path,
+        canonical: &std::path::Path,
+    ) -> Vec<String> {
         const DISCOVERY: &str = "KinLayout::discover(";
         const REFUSAL: &str = ".ok_or_else(";
 
-        let sources = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut found = Vec::new();
+        for (path, source) in crate_sources(root, canonical) {
+            let mut cursor = 0;
+            while let Some(hit) = source[cursor..].find(DISCOVERY) {
+                let open = cursor + hit + DISCOVERY.len() - 1;
+                let closed = end_of_call(&source, open).unwrap_or(source.len());
+                if source[closed..].trim_start().starts_with(REFUSAL) {
+                    let line = source[..open].lines().count();
+                    found.push(format!("{path}:{line}"));
+                }
+                cursor = open + 1;
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// Where the refusal's own wording is written out again.
+    ///
+    /// Keyed on the condition sentence rather than on any call spelling, which
+    /// is what makes it blind to how the refusal is raised: `ok_or_else`,
+    /// `context`, `bail!`, a `match`, or a `let ... else` all carry the same
+    /// sentence and are all caught. A test that wants to assert on the refusal
+    /// asserts against `NOT_A_KIN_REPOSITORY`, so a literal copy anywhere else
+    /// is a second home for the wording by construction.
+    fn refusal_wording_restated(
+        root: &std::path::Path,
+        canonical: &std::path::Path,
+    ) -> Vec<String> {
+        let condition = NOT_A_KIN_REPOSITORY
+            .split('\n')
+            .next()
+            .expect("the refusal states its condition before its remedy");
+
+        let mut found = Vec::new();
+        for (path, source) in crate_sources(root, canonical) {
+            let mut cursor = 0;
+            while let Some(hit) = source[cursor..].find(condition) {
+                let at = cursor + hit;
+                let line = source[..at].lines().count();
+                found.push(format!("{path}:{line}"));
+                cursor = at + condition.len();
+            }
+        }
+        found.sort();
+        found
+    }
+
+    fn crate_source_root() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+    }
+
+    #[test]
+    fn no_command_hand_rolls_the_repository_refusal() {
+        // One home for the wording only holds while it stays the only home. A
+        // command reverting to a local refusal reads as an ordinary two-line
+        // diff and would otherwise pass every gate while dropping the remedy
+        // the caller needs. This scan reads the wording, so it does not care
+        // which combinator raised it; a command whose condition genuinely is
+        // its own still raises `not_a_kin_repository()` rather than restating
+        // the sentence.
+        let sources = crate_source_root();
         let canonical = sources.join("commands").join("mod.rs");
         assert!(canonical.is_file(), "canonical refusal file must exist");
 
-        let mut hand_rolled = Vec::new();
-        let mut pending = vec![sources];
-        while let Some(directory) = pending.pop() {
-            let entries = std::fs::read_dir(&directory).expect("read crate sources");
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    pending.push(path);
-                    continue;
-                }
-                if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || path == canonical
-                {
-                    continue;
-                }
-                let source = std::fs::read_to_string(&path).expect("read a crate source");
-                let mut cursor = 0;
-                while let Some(hit) = source[cursor..].find(DISCOVERY) {
-                    let open = cursor + hit + DISCOVERY.len() - 1;
-                    let closed = end_of_call(&source, open).unwrap_or(source.len());
-                    if source[closed..].trim_start().starts_with(REFUSAL) {
-                        let line = source[..open].lines().count();
-                        hand_rolled.push(format!("{}:{line}", path.display()));
-                    }
-                    cursor = open + 1;
-                }
-            }
-        }
-        hand_rolled.sort();
-
+        let restated = refusal_wording_restated(&sources, &canonical);
         assert!(
-            hand_rolled.is_empty(),
+            restated.is_empty(),
+            "the repository refusal has one home; raise it with \
+             require_repository_layout, require_repository_layout_at, or \
+             not_a_kin_repository rather than writing the wording again; restated at {restated:?}"
+        );
+    }
+
+    #[test]
+    fn no_command_refuses_a_discovery_in_place() {
+        // The narrower shape, kept because it is the one that produced 81
+        // copies and it catches a hand-rolled refusal even when the wording
+        // drifts too. Deliberate exceptions refuse on their own condition
+        // rather than on discovery, so they are outside this shape by
+        // construction.
+        let sources = crate_source_root();
+        let canonical = sources.join("commands").join("mod.rs");
+
+        let in_place = discovery_refused_in_place(&sources, &canonical);
+        assert!(
+            in_place.is_empty(),
             "a command refusing outside a repository must refuse through \
              require_repository_layout or require_repository_layout_at, so the condition and \
-             the remedy cannot drift apart again; hand-rolled at {hand_rolled:?}"
+             the remedy cannot drift apart again; hand-rolled at {in_place:?}"
+        );
+    }
+
+    #[test]
+    fn an_equivalent_spelling_is_caught_by_the_wording_scan_the_shape_scan_misses() {
+        // The falsification, run rather than described. A refusal spelled with
+        // `context` instead of `ok_or_else` is the same refusal, and a guard
+        // that only recognised one of the two would keep passing while the
+        // wording it exists to protect had quietly grown a second home.
+        let staged = tempfile::tempdir().expect("temp dir");
+        let commands = staged.path().join("commands");
+        std::fs::create_dir_all(&commands).expect("stage a crate source tree");
+        let canonical = commands.join("mod.rs");
+        std::fs::write(&canonical, "// the canonical refusal lives here\n")
+            .expect("stage the canonical file");
+
+        let hand_rolled = commands.join("invented.rs");
+        std::fs::write(
+            &hand_rolled,
+            format!(
+                "use anyhow::Context;\nfn run(cwd: &std::path::Path) -> anyhow::Result<()> {{\n    \
+                 let _layout = kin_core::KinLayout::discover(cwd).context({:?})?;\n    Ok(())\n}}\n",
+                NOT_A_KIN_REPOSITORY
+            ),
+        )
+        .expect("stage a hand-rolled refusal");
+
+        assert!(
+            discovery_refused_in_place(staged.path(), &canonical).is_empty(),
+            "the call-shape scan does not see a context() spelling, which is why it is not the \
+             only guard"
+        );
+        assert_eq!(
+            refusal_wording_restated(staged.path(), &canonical),
+            vec![format!("{}:3", hand_rolled.display())],
+            "the wording scan must name the file and line that restated the refusal"
         );
     }
 }

--- a/crates/kin-cli/src/commands/prepared_state.rs
+++ b/crates/kin-cli/src/commands/prepared_state.rs
@@ -68,9 +68,11 @@ pub async fn publish(target: PathBuf, json: bool) -> Result<()> {
     let repo_path = std::env::current_dir()?;
     let kin_dir = repo_path.join(".kin");
     if !kin_dir.exists() {
-        bail!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        );
+        // The condition is this exact directory rather than a discovery: a
+        // prepared state is published from the repository root it was built
+        // in, not from anywhere beneath it. The refusal is still the shared
+        // one, so the remedy cannot drift away from every other command's.
+        return Err(crate::commands::not_a_kin_repository());
     }
 
     let mut manifest = expected_manifest(&repo_path)?;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7794,7 +7794,9 @@ async fn pull_admitted_nothing(
     })
     .await;
     match behind {
-        Ok(Ok(Some(detail))) => WorkspaceFollow::Behind { detail },
+        Ok(Ok(Some(detail))) => WorkspaceFollow::Behind {
+            detail: format!("this pull admitted no history; {detail}"),
+        },
         Ok(Ok(None)) => WorkspaceFollow::NotApplicable {
             detail: "this pull admitted no history, so no ref moved for a working tree to follow"
                 .to_string(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7781,6 +7781,10 @@ async fn pull_admitted_nothing(
             detail: "hosted snapshot authority serves no local working tree".to_string(),
         };
     }
+    // Take the same gate a transition takes, for the same reason: a read that
+    // races a concurrent commit or branch switch would see the workspace before
+    // it moved and report a tree behind that is in the middle of catching up.
+    let _coordination = state.coordination_gate.lock().await;
     let state = Arc::clone(state);
     let destination_ref = destination_ref.clone();
     // The authority read blocks, so it must not run on the executor that also

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7719,9 +7719,9 @@ pub(crate) async fn pull_into_replica(
     // which is how a plain local edit came to be reported as authority having
     // moved. It also pays the whole branch-switch planner on every `kin pull`.
     //
-    // The cost of the guard is that a workspace an earlier pull left behind no
-    // longer completes on the next pull. That is the remedy the report already
-    // names: `kin branch switch` onto the pulled ref.
+    // A pull that admitted nothing can still find a tree behind, which is what
+    // the no-op path reports instead of planning a transition: see
+    // `pull_admitted_nothing`.
     let workspace = if outcome.moved_history() {
         pull_workspace_follow(
             &state,
@@ -7731,10 +7731,7 @@ pub(crate) async fn pull_into_replica(
         )
         .await
     } else {
-        WorkspaceFollow::NotApplicable {
-            detail: "this pull admitted no history, so no ref moved for a working tree to follow"
-                .to_string(),
-        }
+        pull_admitted_nothing(&state, local_derived_views, &outcome.destination_ref).await
     };
 
     Ok(kin_cli::commands::transfer::CommandTransferResponse {
@@ -7762,6 +7759,52 @@ fn interrupted_pull_report(admitted_packs: usize) -> Option<String> {
          it had before. Re-run the pull to resume from the last admitted pack; that run reports \
          and completes the workspace transition."
     ))
+}
+
+/// Report what a pull that admitted nothing found, rather than assuming that a
+/// run which moved nothing found nothing.
+///
+/// No ref moved here, so there is no transition to plan and none is planned:
+/// planning one is what made an ordinary no-op pull answer with whatever the
+/// planner found in the working copy. What a retry of a failed pull needs is
+/// narrower and costs one authority read. The run that admitted the history is
+/// the one whose transition did not complete, so the retry admits nothing and,
+/// before this, exited zero while the working tree was still on the old head.
+/// That is the exact case the exit-status contract exists to prevent.
+async fn pull_admitted_nothing(
+    state: &Arc<DaemonState>,
+    local_derived_views: bool,
+    destination_ref: &kin_model::RefName,
+) -> WorkspaceFollow {
+    if !local_derived_views {
+        return WorkspaceFollow::NotApplicable {
+            detail: "hosted snapshot authority serves no local working tree".to_string(),
+        };
+    }
+    let state = Arc::clone(state);
+    let destination_ref = destination_ref.clone();
+    // The authority read blocks, so it must not run on the executor that also
+    // serves this daemon's own transfer seam.
+    let behind = tokio::task::spawn_blocking(move || {
+        crate::repository_branch::workspace_behind_ref(&state, &destination_ref)
+    })
+    .await;
+    match behind {
+        Ok(Ok(Some(detail))) => WorkspaceFollow::Behind { detail },
+        Ok(Ok(None)) => WorkspaceFollow::NotApplicable {
+            detail: "this pull admitted no history, so no ref moved for a working tree to follow"
+                .to_string(),
+        },
+        // A check that could not run has not proved this tree current, and
+        // reporting NotApplicable would claim it looked. Behind is the honest
+        // fail-safe, and its detail says which of the two it is.
+        Ok(Err(error)) => WorkspaceFollow::Behind {
+            detail: format!("could not read whether this workspace follows the ref: {error:#}"),
+        },
+        Err(error) => WorkspaceFollow::Behind {
+            detail: format!("workspace follow check did not complete: {error}"),
+        },
+    }
 }
 
 /// Move the graph-owned workspace onto the head this pull admitted.
@@ -12397,10 +12440,20 @@ mod tests {
             "a workspace that cannot follow must not cost the caller the transfer"
         );
         match &pulled.workspace {
-            WorkspaceFollow::Behind { detail } => assert!(
-                detail.contains("diverge from the graph-owned workspace projection"),
-                "the report must name what blocked the transition: {detail}"
-            ),
+            WorkspaceFollow::Behind { detail } => {
+                assert!(
+                    detail.contains("diverge from the graph-owned workspace projection"),
+                    "the report must name what blocked the transition: {detail}"
+                );
+                assert!(
+                    !detail.contains("before switching branches"),
+                    "a caller who ran a pull is not part-way through a branch switch: {detail}"
+                );
+                assert!(
+                    detail.contains("follow the ref the transfer moved"),
+                    "the remedy must name the operation the caller actually ran: {detail}"
+                );
+            }
             other => panic!("an edited projection cannot be silently replaced, got {other:?}"),
         }
         assert_eq!(
@@ -12408,6 +12461,32 @@ mod tests {
             b"services:\n  api: { image: local }\n",
             "the caller's edit must survive a transfer that could not move the tree"
         );
+
+        // The retry. Every pack is durable, so this run has nothing left to
+        // admit and no ref moves under it, while the working tree is still on
+        // the head it had before, which is the state the caller is about to
+        // chain work onto. Reporting "no ref moved" here is true about the
+        // retry and silent about the workspace, and it exits zero.
+        let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let retried: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(
+            !retried.outcome.moved_history(),
+            "the first run already admitted everything the peer had"
+        );
+        match &retried.workspace {
+            WorkspaceFollow::Behind { detail } => {
+                assert!(
+                    detail.contains("kin branch switch"),
+                    "a workspace left behind is told how to catch up: {detail}"
+                );
+            }
+            other => panic!(
+                "a retry that admits nothing must still report the tree an earlier run left \
+                 behind, got {other:?}"
+            ),
+        }
     }
 
     /// The everyday invocation: up to date with the peer, one tracked file
@@ -12534,18 +12613,31 @@ mod tests {
             "the caller's uncommitted state must survive a transfer that could not move the tree"
         );
 
-        // The gap is closed now, so the next pull admits nothing. It must not
-        // repeat a refusal about a head that no longer moves.
+        // The history gap is closed, so the next pull admits nothing. The
+        // workspace gap is not: the tree is still on the head it had before the
+        // refusal. The retry stops repeating the transition refusal, which is
+        // about a head that no longer moves, and reports the state the replica
+        // actually holds instead.
         let (status, body) = transfer_command(Arc::clone(&fixture.state), "pull", &request).await;
         assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
         let repeated: kin_cli::commands::transfer::CommandTransferResponse =
             serde_json::from_slice(&body).unwrap();
         assert!(!repeated.outcome.moved_history());
-        assert!(
-            !repeated.workspace.is_behind(),
-            "a pull that admitted nothing reports no workspace behind it: {:?}",
-            repeated.workspace
-        );
+        match &repeated.workspace {
+            WorkspaceFollow::Behind { detail } => {
+                assert!(
+                    !detail.contains("has graph-owned changes"),
+                    "the retry planned no transition, so it cannot report one refusing: {detail}"
+                );
+                assert!(
+                    detail.contains("kin branch switch"),
+                    "a workspace left behind is told how to catch up: {detail}"
+                );
+            }
+            other => panic!(
+                "the working tree is still behind the ref an earlier pull moved, got {other:?}"
+            ),
+        }
     }
 
     /// An interrupted multi-pack pull left every pack it admitted durable, and

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2146,17 +2146,23 @@ mod tests {
             },
         )
         .unwrap();
-        // `kin history` gives the author column 20 characters and ellipsizes
-        // past that, so "claude-code/one-change-demo" (27) renders cut. Asserted
-        // in its rendered form rather than on a prefix, so the truncation is a
-        // stated property of this surface instead of an accident the assertion
-        // happens to survive.
+        // `kin history` sizes its author column to the widest author it is
+        // rendering, so a 27-character agent identity arrives whole. Asserted on
+        // the rendered line rather than on a prefix, so a column that started
+        // cutting the client name again would fail here: the client name is the
+        // half that tells two sessions of one vendor apart, and it is the half a
+        // fixed column removed.
         assert!(
             history
                 .lines
                 .iter()
-                .any(|line| line.contains("claude-code/one-cha\u{2026}")),
-            "history must name the committing agent, truncated to its column: {:#?}",
+                .any(|line| line.contains("claude-code/one-change-demo")),
+            "history must name the committing agent in full: {:#?}",
+            history.lines
+        );
+        assert!(
+            !history.lines.iter().any(|line| line.contains('\u{2026}')),
+            "no identity may be ellipsized: {:#?}",
             history.lines
         );
 

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -223,9 +223,9 @@ pub(crate) fn workspace_behind_ref(state: &DaemonState, name: &RefName) -> Resul
         None => "no admitted head".to_string(),
     };
     Ok(Some(format!(
-        "workspace {} stands at {standing} while {name} is at {}; this pull admitted nothing, so \
-         the gap is one an earlier pull admitted without completing its workspace transition. Run \
-         `kin branch switch {name}` to move this working tree onto it.",
+        "workspace {} stands at {standing} while {name} is at {}, so an earlier run moved that ref \
+         without this workspace following it. Run `kin branch switch {name}` to move this working \
+         tree onto it.",
         workspace.workspace_id,
         render_target(&target)
     )))

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -147,28 +147,88 @@ fn branch_bad_request(message: impl Into<String>) -> anyhow::Error {
     anyhow::Error::new(BranchBadRequest(message.into()))
 }
 
-/// Refuse a transition over uncommitted state that graph authority already
-/// owns. Only admitted state reaches this: unadmitted working-copy bytes are
-/// reported as projection drift instead, so the wording never describes host
-/// content that has not crossed the repository-v6 compare-and-swap.
+/// The clause a remedy ends with, naming what the caller actually asked for.
 ///
-/// The remedy names what the caller actually asked for. A caller who ran a pull
-/// is not switching branches, and telling them to finish doing so describes an
-/// operation they never started.
-fn graph_owned_changes(
-    workspace: &kin_model::WorkspaceState,
-    policy: TransitionPolicy,
-) -> anyhow::Error {
-    let remedy = match policy {
+/// A caller who ran a pull is not switching branches, and telling them to
+/// finish doing so describes an operation they never started. Every refusal
+/// this transition can raise reads its verb from here, so a new refusal cannot
+/// pick up branch language by copying a neighbour.
+fn transition_remedy(policy: TransitionPolicy) -> &'static str {
+    match policy {
         TransitionPolicy::Switch => "before switching branches",
         TransitionPolicy::FollowMovedRef => {
             "before this workspace can follow the ref the transfer moved"
         }
-    };
+    }
+}
+
+/// The same distinction as a bare operation noun, for refusals phrased as
+/// "reopen before {operation}".
+fn transition_operation(policy: TransitionPolicy) -> &'static str {
+    match policy {
+        TransitionPolicy::Switch => "switching branches",
+        TransitionPolicy::FollowMovedRef => "following the ref this transfer moved",
+    }
+}
+
+/// Refuse a transition over uncommitted state that graph authority already
+/// owns. Only admitted state reaches this: unadmitted working-copy bytes are
+/// reported as projection drift instead, so the wording never describes host
+/// content that has not crossed the repository-v6 compare-and-swap.
+fn graph_owned_changes(
+    workspace: &kin_model::WorkspaceState,
+    policy: TransitionPolicy,
+) -> anyhow::Error {
     branch_conflict(format!(
-        "workspace {} has graph-owned changes; commit or explicitly preserve them {remedy}",
-        workspace.workspace_id
+        "workspace {} has graph-owned changes; commit or explicitly preserve them {}",
+        workspace.workspace_id,
+        transition_remedy(policy)
     ))
+}
+
+/// Whether this replica's working tree stands behind `name`, decided from
+/// persisted authority on both sides and nothing else.
+///
+/// A pull that admitted nothing moved no ref, so nothing that pull did can have
+/// left a tree behind. It can still find one behind: the run that admitted the
+/// history is the one whose workspace transition did not complete, and its
+/// retry admits nothing precisely because the first attempt already admitted
+/// everything. Answering that retry with "no ref moved" is true about the retry
+/// and silent about the workspace, and the exit status a caller chains on then
+/// says the pull is complete while the working tree still shows the old head.
+///
+/// Reads the workspace's base target against the ref's current target. Both are
+/// graph truth, so this states what the replica holds rather than what this
+/// invocation did, and it never consults the working copy.
+pub(crate) fn workspace_behind_ref(state: &DaemonState, name: &RefName) -> Result<Option<String>> {
+    let authority = ActiveLocalRepositoryAuthority::open_bound(state)
+        .map_err(RepositoryAuthorityBindRefusal::into_error)
+        .context("open repository authority to report whether the workspace follows the ref")?;
+    let lease = authority.manager.read_authority();
+    let workspace = local_workspace(&authority, lease.metadata())?;
+    if !matches!(&workspace.head, WorkspaceHead::Symbolic { target } if target == name) {
+        return Ok(None);
+    }
+    let Some(target) = lease
+        .resolve_ref_target(name)
+        .with_context(|| format!("resolve repository branch {name} from one authority lease"))?
+    else {
+        return Ok(None);
+    };
+    if workspace.base_target.as_ref() == Some(&target) {
+        return Ok(None);
+    }
+    let standing = match &workspace.base_target {
+        Some(base) => render_target(base),
+        None => "no admitted head".to_string(),
+    };
+    Ok(Some(format!(
+        "workspace {} stands at {standing} while {name} is at {}; this pull admitted nothing, so \
+         the gap is one an earlier pull admitted without completing its workspace transition. Run \
+         `kin branch switch {name}` to move this working tree onto it.",
+        workspace.workspace_id,
+        render_target(&target)
+    )))
 }
 
 pub(crate) fn execute(
@@ -748,7 +808,7 @@ fn switch(
         state,
         &roots,
         &current_workspace_graph,
-        "switching branches",
+        transition_operation(policy),
     )
     .map_err(|error| branch_conflict(error.to_string()))?;
     let mut snapshot = lease.snapshot().clone();
@@ -886,12 +946,13 @@ fn switch(
         &workspace.tree,
         &authority.manager,
     )
-    .with_context(|| format!("validate exact workspace projection before switching to {name}"))?;
+    .with_context(|| format!("validate exact workspace projection before moving onto {name}"))?;
     if let Some(first) = drift.first() {
         return Err(kin_core::KinError::ProjectionConflict(format!(
             "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
-             reconcile them into graph authority or discard them before switching branches",
-            drift.len()
+             reconcile them into graph authority or discard them {}",
+            drift.len(),
+            transition_remedy(policy)
         ))
         .into());
     }

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -113,17 +113,25 @@ impl HttpRepositoryTransferTransport {
         )
     }
 
-    fn get_json<R: serde::de::DeserializeOwned>(&self, url: &str, what: &str) -> Result<R> {
+    fn get_json<R: serde::de::DeserializeOwned>(
+        &self,
+        repository_id: &RepositoryId,
+        url: &str,
+        what: &str,
+    ) -> Result<R> {
         let mut request = self.agent.get(url);
         if let Some(token) = &self.endpoint.auth_token {
             request = request.header("Authorization", &format!("Bearer {token}"));
         }
-        let response = request.call().map_err(|error| peer_error(error, what))?;
+        let response = request
+            .call()
+            .map_err(|error| peer_error(error, what, repository_id))?;
         read_json(response, what)
     }
 
     fn post_json<T: serde::Serialize, R: serde::de::DeserializeOwned>(
         &self,
+        repository_id: &RepositoryId,
         url: &str,
         body: &T,
         what: &str,
@@ -134,7 +142,7 @@ impl HttpRepositoryTransferTransport {
         }
         let response = request
             .send_json(body)
-            .map_err(|error| peer_error(error, what))?;
+            .map_err(|error| peer_error(error, what, repository_id))?;
         read_json(response, what)
     }
 }
@@ -182,7 +190,18 @@ fn body_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
 /// 422 for an invalid envelope, 409 for a lease or fast-forward conflict, 424
 /// for storage. Preserving that mapping is what lets a caller distinguish "this
 /// pack is malformed" from "the remote moved under us" without parsing prose.
-fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
+///
+/// The 404 arm names `repository_id` because 404 is the one class that says the
+/// peer does not know this repository at all, which makes the id itself the
+/// thing that may be wrong. A mistyped id is the most likely first mistake in
+/// team usage, and "this repository" gives the caller nothing to compare their
+/// spelling against. Every other class is the peer refusing on the state of a
+/// repository it does serve, where the id is not what the caller would correct.
+fn peer_error(
+    error: ureq::Error,
+    what: &str,
+    repository_id: &RepositoryId,
+) -> RepositoryTransferError {
     match error {
         ureq::Error::StatusCode(code) => match code {
             409 => RepositoryTransferError::Conflict(format!(
@@ -195,7 +214,9 @@ fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
                 "remote {what} failed on storage (HTTP 424)"
             )),
             404 => RepositoryTransferError::Invalid(format!(
-                "remote does not serve {what} for this repository (HTTP 404)"
+                "remote does not serve {what} for repository {:?} (HTTP 404); check the \
+                 repository id, or that the peer serves it",
+                repository_id.as_str()
             )),
             // The peer is intact and answered; the envelope is too large for
             // the bound both sides declare. That is the same refusal the
@@ -216,7 +237,11 @@ fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
 
 impl RepositoryTransferTransport for HttpRepositoryTransferTransport {
     fn advertise_refs(&self, repository_id: &RepositoryId) -> Result<RepositoryRefAdvertisement> {
-        self.get_json(&self.url(repository_id, "advertise"), "ref advertisement")
+        self.get_json(
+            repository_id,
+            &self.url(repository_id, "advertise"),
+            "ref advertisement",
+        )
     }
 
     fn transfer_status(
@@ -225,6 +250,7 @@ impl RepositoryTransferTransport for HttpRepositoryTransferTransport {
         destination_ref: &RefName,
     ) -> Result<RepositoryTransferStatus> {
         self.post_json(
+            repository_id,
             &self.url(repository_id, "status"),
             &serde_json::json!({ "destination_ref": destination_ref }),
             "transfer status",
@@ -238,6 +264,7 @@ impl RepositoryTransferTransport for HttpRepositoryTransferTransport {
         expectation: &RepositoryTransferExpectation,
     ) -> Result<RepositoryTransferPack> {
         self.post_json(
+            repository_id,
             &self.url(repository_id, "export"),
             &serde_json::json!({
                 "source_ref": source_ref,
@@ -254,6 +281,7 @@ impl RepositoryTransferTransport for HttpRepositoryTransferTransport {
         pack: &RepositoryTransferPack,
     ) -> Result<RepositoryTransferReceipt> {
         self.post_json(
+            repository_id,
             &self.url(repository_id, "receive"),
             &serde_json::json!({
                 "destination_ref": destination_ref,
@@ -305,28 +333,61 @@ mod tests {
         );
     }
 
+    fn asked_for() -> RepositoryId {
+        RepositoryId::new("kin").unwrap()
+    }
+
     #[test]
     fn peer_status_codes_keep_their_refusal_class() {
+        let asked_for = asked_for();
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(409), "transfer receive"),
+            peer_error(ureq::Error::StatusCode(409), "transfer receive", &asked_for),
             RepositoryTransferError::Conflict(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(422), "transfer receive"),
+            peer_error(ureq::Error::StatusCode(422), "transfer receive", &asked_for),
             RepositoryTransferError::Invalid(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(424), "transfer receive"),
+            peer_error(ureq::Error::StatusCode(424), "transfer receive", &asked_for),
             RepositoryTransferError::Storage(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(413), "transfer receive"),
+            peer_error(ureq::Error::StatusCode(413), "transfer receive", &asked_for),
             RepositoryTransferError::Invalid(_)
         ));
         assert!(matches!(
-            peer_error(ureq::Error::StatusCode(500), "transfer receive"),
+            peer_error(ureq::Error::StatusCode(500), "transfer receive", &asked_for),
             RepositoryTransferError::Storage(_)
         ));
+    }
+
+    #[test]
+    fn a_not_found_refusal_names_the_repository_that_was_asked_for() {
+        // A mistyped id is the first-touch mistake this refusal exists to
+        // answer, and it is answerable only if the caller can see what was
+        // sent. Every transfer call can raise it, so each of them carries the
+        // id it asked with rather than the transport naming it once.
+        let asked_for = RepositoryId::new("kin-esosystem").unwrap();
+        for what in [
+            "ref advertisement",
+            "transfer status",
+            "transfer export",
+            "transfer receive",
+        ] {
+            let error = peer_error(ureq::Error::StatusCode(404), what, &asked_for);
+            let RepositoryTransferError::Invalid(message) = error else {
+                panic!("a repository the peer does not serve is not a storage failure");
+            };
+            assert!(
+                message.contains("kin-esosystem"),
+                "a 404 must name the repository it asked for: {message}"
+            );
+            assert!(
+                message.contains(what),
+                "a 404 must still name the call it refused: {message}"
+            );
+        }
     }
 
     #[test]
@@ -408,7 +469,7 @@ mod tests {
         // A peer that cannot be reached has not refused anything. Reporting
         // this as Invalid or Conflict would let a caller conclude the remote
         // evaluated the transfer and said no.
-        let error = peer_error(ureq::Error::HostNotFound, "ref advertisement");
+        let error = peer_error(ureq::Error::HostNotFound, "ref advertisement", &asked_for());
         assert!(matches!(error, RepositoryTransferError::Storage(_)));
     }
 }

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -363,7 +363,7 @@
       "allow_match": [
         {
           "expr": ".metadata()",
-          "count": 9
+          "count": 10
         }
       ]
     },


### PR DESCRIPTION
Five first-touch failures that each told the caller less than the code already
knew. Batched because they are one class, not because they share code: four of
the five touch different crates.

## The repository refusal was enforced by one call shape

`crates/kin-cli/src/commands/mod.rs`, `crates/kin-cli/src/commands/prepared_state.rs`

The scan that keeps every command refusing through the shared helper matched a
`KinLayout::discover(...)` handed straight to `.ok_or_else(`. An equivalent
refusal spelled with `context`, `bail!`, a `match`, or a `let ... else` escaped
it, and one already had: `kin prepared-state publish` carried a second copy of
the wording.

The wording now has a named home (`NOT_A_KIN_REPOSITORY` /
`not_a_kin_repository()`) that both the discovery helper and a command whose
condition is its own directory raise. The enforcement test reads that wording
out of the crate's sources, which is spelling independent. The call-shape scan
is kept as its own test, because it also catches a hand-rolled refusal whose
wording drifted, and its name now states the shape it enforces.

Evidence, the ticket's falsification run rather than described:

- A staged-fixture test asserts in one run that the call-shape scan returns
  empty on a `context(...)` refusal and the wording scan names its file and
  line. It does not depend on real sources, so it cannot rot.
- By hand, a `context(...)` refusal injected into `commands/locate_cursor.rs`
  left `no_command_refuses_a_discovery_in_place` GREEN and turned
  `no_command_hand_rolls_the_repository_refusal` RED with
  `restated at [".../commands/locate_cursor.rs:63"]`. Injection reverted.

## kin history cut agent identities at twenty columns

`crates/kin-cli/src/commands/history.rs`, `crates/kin-daemon/src/mcp_commit.rs`

An MCP commit is authored by `{vendor}/{client_name}`, and the fixed column cut
exactly the client name, which is the half that tells two sessions of one
vendor apart. An unregistered session was worse: its display name is the
session id, so the column showed nineteen characters of a UUID.

The truncation is gone. Rows are built first, then rendered with an author
column measured from the widest author in that history. Width is decided from
data rather than terminal width on purpose: these lines are formatted in the
daemon and printed by the client, so the client's terminal is not knowable at
format time. The subject stays last, so a wide terminal spends its extra width
on the message rather than on trailing padding.

Evidence: two tests, one on identity survival and one on column alignment.
Reverting to the 20-column truncation turns both RED and reproduces the
ticket's exact `claude-code/one-cha…`. The attribution test in `mcp_commit.rs`
asserted that cut prefix, which stated the truncation as a property of the
surface rather than as the defect it was. It now asserts the identity arrives
whole and that no rendered line carries an ellipsis, so a column that starts
cutting the client name again fails there as well as in the renderer's own
tests.

## Pull exited clean over a tree an earlier pull left behind, and spoke branch language

`crates/kin-daemon/src/api.rs`, `crates/kin-daemon/src/repository_branch.rs`

The no-op guard traded a false positive for a false negative. It still plans no
transition, which is what stopped a plain local edit being reported as
authority having moved. It now answers the workspace question the cheap way the
reviewer identified: compare the workspace's `base_target` against the ref's
current target, both persisted graph truth, no filesystem. The run that admits
the history is the one whose transition can fail, so its retry admits nothing
precisely because the first attempt already admitted everything, and that retry
now reports `Behind` and exits non-zero instead of reporting a complete pull.
An ordinary no-op pull over an edited tree still reports clean, because that
workspace is at the ref. A check that could not run reports `Behind` naming the
failure, never `NotApplicable`, which would claim it looked.

The read takes the coordination gate the transition takes, so it cannot see a
concurrent commit or branch switch half-applied and call a tree behind that is
in the middle of catching up.

The reviewer's design question, whether `kin pull` may move a tree on an
invocation that admitted nothing, is answered NO and left that way. This
reports; it does not move. The remedy it names is `kin branch switch` onto the
pulled ref.

Second half: the projection-drift refusal, which is the more common Behind
case, still told a `kin pull` caller to "discard them before switching
branches". The remedy clause and the operation noun now both come from
`TransitionPolicy`, so every refusal this transition can raise names the
operation the caller actually ran. That covers the drift refusal, the
graph-owned-changes refusal that was already fixed, and the daemon-freshness
refusal that was still branch-only.

Evidence: two existing daemon tests extended in place. Reverting either half
turns them RED, and the drift failure prints the ticket's verbatim "discard them
before switching branches" on a pull.

One existing assertion was corrected rather than preserved:
`a_pull_over_graph_owned_changes_reports_the_workspace_behind_without_naming_a_switch`
asserted the retry reports nothing behind, with a comment claiming "the gap is
closed now". The history gap was closed; the workspace gap was not, which is
the bug.

## Native-transport 404 never named the repository

`crates/kin-remote/src/repository_transfer_http.rs`

A mistyped repository id is the most likely first mistake in team usage, and
the refusal named the call and the status but never the id, so a caller had
nothing to compare their spelling against. `get_json` / `post_json` now thread
the requested `RepositoryId` into `peer_error`, so all four transfer calls
(advertise, status, export, receive) carry the id they asked with.

Only the 404 arm names it, deliberately. That status is the peer saying it does
not know this repository at all, which is what makes the id itself the thing a
caller would correct; 409, 422, 424, and 413 are a peer refusing on the state of
a repository it does serve.

Evidence: a test over all four call labels. Reverting the message to the static
label turns it RED.

## kin embed reported a closed socket when the daemon was OOM-killed

`crates/kin-cli/src/capability.rs`, `crates/kin-cli/src/commands/embed.rs`

On a 512 MB ceiling the daemon is killed mid-pass and the CLI reported only
that the connection closed before the message completed. The cgroup recorded
the kill, the model that consumed the memory is known, and lexical and graph
retrieval never needed it, and none of that reached the caller.

`capability.rs` already owned cgroup limit detection, so the host memory
evidence went beside it: the effective ceiling (container limit, else host RAM)
plus the kernel's `oom_kill` counter, read from cgroup v2 `memory.events` or v1
`memory.oom_control`. `Some(0)` and `None` stay distinct, because "nothing was
killed" and "this host cannot be asked" are different answers.

`embed.rs` classifies purely, from the rendered error chain plus that evidence:

- lost connection plus a recorded kill: reported as observed;
- lost connection plus a ceiling under the recommendation: reported as likely,
  and it says "most likely" rather than claiming a kill it could not see;
- anything else: the original error passes through untouched, so a daemon that
  died for another reason on a large host is never told it ran out of memory,
  and an answered HTTP refusal or a client-side timeout keeps its own
  diagnosis.

What counts as a lost connection is drawn narrowly for the same reason. The
HTTP client wraps every send failure, including a connection refused outright,
in one generic phrase, so matching it would report a daemon that never accepted
the request as one that ran out of memory partway through a pass. The markers
name only a connection that existed and then broke, which is the only shape a
process killed mid-request produces.

The guidance names the model and its 522 MiB download, the 2 GiB ceiling to run
under, that persisted coverage resumes rather than restarting, and that
`kin locate` and `kin search` keep answering without vectors. A machine under
the recommendation is also told before the download starts rather than after the
failure.

Not claimed: this does not make the 512 MB vector path feasible. The
deterministic failure-injection tests are here; a Linux cgroup acceptance test
is not, because no host in this fleet or in CI runs under a ceiling low enough
to trigger the path.

## Guard pin

`scripts/zero-file-search-allowlist.json` bumps the exact-count
`.metadata()` pin on `crates/kin-daemon/src/repository_branch.rs` from 9 to 10.
That pin counts an authority-lease accessor that shares a method name with the
filesystem probe in the shared deny set; the workspace-follow read adds the
tenth call site. Exact counts are the point of that pin, so the new site is
counted rather than inherited. Both zero-file-search guards pass, at the same
146 scanned files as before.

Closes FIR-1748
Closes FIR-1699
Closes FIR-1763

FIR-1763's D3-D7 remainder (interrupted-pull formatter test, AlreadyCurrent race coverage, push note identity limit) is split into FIR-1821 so it survives this closure. The two capitalized marker shapes the narrowed list cannot match are recorded as FIR-1822.
Closes FIR-1775
Closes FIR-1479

