### PR TITLE
Record v0.4.5 as abandoned and reconcile release recovery through the shipped selector

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -178,12 +178,15 @@ jobs:
           persist-credentials: false
 
       # Recovery is the alarm, so nothing weaker than the reviewed record may
-      # quiet it. A tag is reconciled only when the record abandons that exact
-      # tag at the exact commit the failed release ran, which is the same pair
-      # select-admissible-release-tag.py requires before it will skip a tag.
-      # Every other outcome, including an unreadable record or a checkout that
-      # is not the run's own default-branch commit, leaves the tag unrecorded
-      # and the alert armed.
+      # quiet it. The question is the one the release rail already answers,
+      # so this asks select-admissible-release-tag.py rather than reading the
+      # record a second way. Two readers of one record is how an alarm gets
+      # disarmed in the state that needs it most: a reader that accepts an
+      # entry the selector refuses would stand recovery down for a record too
+      # malformed to waive the mint, leaving the rail hard stuck while the
+      # check-run that would say so went green. Every other outcome, including
+      # an unreadable record or a checkout that is not the run's own
+      # default-branch commit, leaves the tag unrecorded and the alert armed.
       - name: Reconcile against the tracked abandonment record
         id: record
         if: steps.resolve.outputs.needed == 'true'
@@ -206,27 +209,47 @@ jobs:
             echo "::warning::the record checkout resolved '${head}' rather than this run's default-branch commit ${GITHUB_SHA}; no abandonment is honoured from an unverified tree."
             exit 0
           fi
-          if [ ! -f "$RECORD" ]; then
+          selector="scripts/select-admissible-release-tag.py"
+          if [ ! -f "$RECORD" ] || [ ! -f "$selector" ]; then
             echo "abandoned=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::${RECORD} is absent from ${GITHUB_SHA}; recovery stays responsible for ${TAG}."
+            echo "::warning::${RECORD} or ${selector} is absent from ${GITHUB_SHA}; recovery stays responsible for ${TAG}."
             exit 0
           fi
-          # jq exits non-zero on a tag the record does not carry, which is an
-          # ordinary answer here rather than an error.
-          waived=""
-          status=0
-          waived="$(jq -er --arg tag "$TAG" '
-            [.abandoned[] | select(.tag == $tag) | .sha]
-            | if length == 1 then .[0] else empty end
-          ' "$RECORD")" || status=$?
-          if [ "$status" -ne 0 ] || [ -z "$waived" ]; then
+          # The candidate listing is the one pair this reconcile is about, in
+          # the `<tag> <commit>` form the selector reads from git. The resolve
+          # step has already peeled the tag and required this commit to be what
+          # it names, so the selector is told the truth about the repository and
+          # its tag-moved refusal keeps its meaning here. Mint intent is empty
+          # because recovery creates no tag: naming this tag as intent would
+          # make the selector refuse precisely the recorded tag it is being
+          # asked about, and invert the answer.
+          work="${RUNNER_TEMP:-/tmp}"
+          candidate="$work/release-recovery-candidate-tag"
+          admissible="$work/release-recovery-highest-admissible"
+          printf '%s %s\n' "$TAG" "$SHA" > "$candidate"
+          # Seeded, so a selector run that leaves no answer behind reads as "not
+          # abandoned" rather than as a waiver.
+          printf 'unresolved' > "$admissible"
+          if ! python3 "$selector" \
+            "$RECORD" \
+            "$candidate" \
+            "" \
+            "$admissible"
+          then
             echo "abandoned=false" >> "$GITHUB_OUTPUT"
-            echo "${TAG} carries no reviewed abandonment record; recovery stays responsible for it."
+            echo "::warning::${RECORD} does not pass the release lane's own record validation, so it waives nothing for the mint and quiets nothing here; recovery stays responsible for ${TAG}. The selector's refusal above names what is wrong with the record."
             exit 0
           fi
-          if [ "$waived" != "$SHA" ]; then
+          # The selector answers by ranking, dropping a candidate its record
+          # abandons at the commit under review, so an empty ranking of a
+          # one-tag listing is that drop. It drops a candidate that is not a
+          # vX.Y.Z release tag for its own reasons, which is why resolve proves
+          # that shape before it declares a reconcile needed and the authority
+          # suite pins that order: an empty ranking waives a tag only when the
+          # tag was one the selector would rank at all.
+          if [ ! -f "$admissible" ] || [ -s "$admissible" ]; then
             echo "abandoned=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::${RECORD} abandons ${TAG} at ${waived}, but the failed release ran it at ${SHA}; the record does not cover this failure."
+            echo "${TAG} at ${SHA} carries no reviewed abandonment record; recovery stays responsible for it."
             exit 0
           fi
           echo "abandoned=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -153,10 +153,80 @@ jobs:
             echo "exhausted=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # An abandonment is a fact about the default branch, never about the tag
+      # it retires: a tag's tree is frozen before the failure that abandons it,
+      # so the record can only ever exist on main. Both triggers here resolve
+      # GITHUB_SHA to the last commit on the default branch, and checkout with
+      # no `ref:` input fetches exactly that commit, so the record is read from
+      # one immutable main snapshot instead of from whatever main becomes while
+      # the job runs. Nothing from the failed tag's own head is trusted.
+      - name: Checkout the abandonment record from the default-branch commit
+        if: steps.resolve.outputs.needed == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts
+          persist-credentials: false
+
+      # Recovery is the alarm, so nothing weaker than the reviewed record may
+      # quiet it. A tag is reconciled only when the record abandons that exact
+      # tag at the exact commit the failed release ran, which is the same pair
+      # select-admissible-release-tag.py requires before it will skip a tag.
+      # Every other outcome, including an unreadable record or a checkout that
+      # is not the run's own default-branch commit, leaves the tag unrecorded
+      # and the alert armed.
+      - name: Reconcile against the tracked abandonment record
+        id: record
+        if: steps.resolve.outputs.needed == 'true'
+        env:
+          RECORD: scripts/abandoned-release-tags.json
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Nothing in this step may end in a non-zero status of its own. The
+          # check-run it would publish is the one the mint gate refuses a
+          # release commit for, so every status is captured rather than left to
+          # the step's implicit errexit, and every unhappy path degrades to "not
+          # abandoned", which leaves the alert armed to fail for the real reason.
+          head=""
+          status=0
+          head="$(git rev-parse HEAD)" || status=$?
+          if [ "$status" -ne 0 ] || [ "$head" != "$GITHUB_SHA" ]; then
+            echo "abandoned=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::the record checkout resolved '${head}' rather than this run's default-branch commit ${GITHUB_SHA}; no abandonment is honoured from an unverified tree."
+            exit 0
+          fi
+          if [ ! -f "$RECORD" ]; then
+            echo "abandoned=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::${RECORD} is absent from ${GITHUB_SHA}; recovery stays responsible for ${TAG}."
+            exit 0
+          fi
+          # jq exits non-zero on a tag the record does not carry, which is an
+          # ordinary answer here rather than an error.
+          waived=""
+          status=0
+          waived="$(jq -er --arg tag "$TAG" '
+            [.abandoned[] | select(.tag == $tag) | .sha]
+            | if length == 1 then .[0] else empty end
+          ' "$RECORD")" || status=$?
+          if [ "$status" -ne 0 ] || [ -z "$waived" ]; then
+            echo "abandoned=false" >> "$GITHUB_OUTPUT"
+            echo "${TAG} carries no reviewed abandonment record; recovery stays responsible for it."
+            exit 0
+          fi
+          if [ "$waived" != "$SHA" ]; then
+            echo "abandoned=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::${RECORD} abandons ${TAG} at ${waived}, but the failed release ran it at ${SHA}; the record does not cover this failure."
+            exit 0
+          fi
+          echo "abandoned=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::${TAG} at ${SHA} is reconciled by abandonment: ${RECORD} retires it in favour of its recorded successor, so no retry is dispatched, no alert is filed, and this reconcile concludes success."
+
       - name: Re-run failed jobs
         if: >-
           steps.resolve.outputs.needed == 'true' &&
-          steps.resolve.outputs.retry == 'true'
+          steps.resolve.outputs.retry == 'true' &&
+          steps.record.outputs.abandoned != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -172,7 +242,8 @@ jobs:
       - name: Alert after automatic retries are exhausted
         if: >-
           steps.resolve.outputs.needed == 'true' &&
-          steps.resolve.outputs.exhausted == 'true'
+          steps.resolve.outputs.exhausted == 'true' &&
+          steps.record.outputs.abandoned != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -160,8 +160,18 @@ jobs:
       # no `ref:` input fetches exactly that commit, so the record is read from
       # one immutable main snapshot instead of from whatever main becomes while
       # the job runs. Nothing from the failed tag's own head is trusted.
+      #
+      # Reading the record is tolerated rather than propagated, on the same
+      # ground base-image-pins.yml states: the alarm must not become the thing
+      # that reds a main sha. Without this a network hiccup fetching the record
+      # would fail the job and publish exactly the check-run that refuses a
+      # release, which is the hazard this step exists to remove. A failed
+      # checkout instead leaves no HEAD for the next step to verify, so it reads
+      # as "not abandoned" and recovery behaves as it did before the record
+      # existed.
       - name: Checkout the abandonment record from the default-branch commit
         if: steps.resolve.outputs.needed == 'true'
+        continue-on-error: true
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: scripts

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -163,6 +163,18 @@ two retries is the hard cap. Cancellation is treated as an operator stop and is
 never retried. If all three attempts fail, the controller opens one
 `Release blocked after automatic retries` issue and stops.
 
+There is one exception, and only one: a tag the reviewed record has already
+retired is reconciled instead of alerted. Before retrying or alerting, the
+controller reads `scripts/abandoned-release-tags.json` from the run's own
+default-branch commit and asks the same selector the mint asks. A tag that
+record waives at exactly the commit the failed release ran gets no retry, no
+issue, and a notice saying so, and that reconcile concludes success.
+
+Every other outcome leaves the tag unrecorded and the alert armed, including a
+record that cannot be read or is under-evidenced: an undiagnosed failure
+still opens the issue and still fails the reconcile. See
+[Abandoning a release tag](#abandoning-a-release-tag).
+
 ## Abandoning a release tag
 
 Recovery stopping is not the end of the story. The rail serializes on the
@@ -178,6 +190,11 @@ the exact `sha` it pointed at, a `reason`, the `superseded_by` tag, and the
 `failed_release_run_id` that evidences it. Both the record and the selector that
 reads it are loaded from protected `main`, never from the checked-out release
 commit, which predates any abandonment it has to honour.
+
+Three consumers read it through that selector: the mint refuses to create a tag
+it names, drift resolution skips that tag when it ranks the highest release the
+rail must wait on, and automatic recovery stands down for it rather than
+retrying and alerting on a release nobody intends to finish.
 
 **Operating rule: record the abandonment and leave the tag in place.**
 
@@ -199,7 +216,8 @@ Two further properties worth knowing before editing the record:
   exact commit its tag pointed at, so a tag that has since moved refuses loudly
   rather than quietly waiving a different object than the one reviewed
 - a malformed, unparsable, or under-evidenced entry fails the rail closed rather
-  than degrading to an empty waiver set
+  than degrading to an empty waiver set, and recovery decides through that same
+  selector, so an entry that cannot waive the rail cannot quiet the alarm either
 
 ## Captain break-glass usage
 

--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -14,6 +14,13 @@
       "reason": "The workflow snapshot frozen at this tag verifies a published archive by asserting that every entry at its root is a regular file, and the same snapshot packages KinNotifier.app, the signed and stapled macOS notification bundle, into both macOS archives as a directory. Every macOS leg is therefore refused at the Publish Release step by the tag's own workflow, which no later change to main can alter. All three attempts of the cited run failed and no GitHub Release object was ever created.",
       "superseded_by": "v0.4.5",
       "failed_release_run_id": "30647442701"
+    },
+    {
+      "tag": "v0.4.5",
+      "sha": "93a74a91af929a340d9ec90999601843d0b325b1",
+      "reason": "The public install proof frozen at this tag pipes kin init through tee into kin-init.txt inside the worktree it asks kin to admit, so an untracked non-ignored path exists before admission runs and admission is refused on every platform. The proof is called as a local reusable workflow and therefore resolves from the tag rather than from main, so no later change to main can reach the failing step. All three attempts of the cited run failed on all five platforms, and the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, so the tag never became the finalized Latest release and nothing downstream of admission ever ran.",
+      "superseded_by": "v0.4.6",
+      "failed_release_run_id": "30678146368"
     }
   ]
 }

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3458,6 +3458,17 @@ def main() -> None:
         "The only exit from that state is a hand-landed version bump",
         "a tag that has since moved refuses loudly",
         "fails the rail closed rather",
+        # No CI job executes a line of release-recovery.yml: it triggers on
+        # schedule and workflow_run only, so this prose is the whole of what an
+        # operator has when a reconcile goes green while a release is visibly
+        # broken. Each clause is pinned because each is separately droppable:
+        # that the stand-down exists, that it is narrow, that recovery is a
+        # consumer of the record at all, and that a record too weak for the rail
+        # is too weak to quiet the alarm.
+        "is reconciled instead of alerted",
+        "still opens the issue and still fails the reconcile",
+        "automatic recovery stands down for it",
+        "cannot quiet the alarm either",
     ):
         require(
             release_bot_doc,

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3434,8 +3434,33 @@ def main() -> None:
         "rerun-failed-jobs",
         '[ "$attempt" -ge 3 ]',
         "Release blocked after automatic retries",
+        "scripts/abandoned-release-tags.json",
+        '[ "$head" != "$GITHUB_SHA" ]',
+        "reconciled by abandonment",
     ):
         require(release_recovery, policy, "bounded automatic release recovery")
+
+    # Recovery's failing check-run lands on the default branch head, and the
+    # mint gate refuses a release commit carrying any check-run outside
+    # success/skipped/neutral. An hourly tick that alerts on a tag the reviewed
+    # record has already retired therefore kills the very release that
+    # supersedes it. Both consumers of the record decision are pinned here
+    # rather than trusting one substring: the retry must not spend runners on an
+    # abandoned tag, and the alert must not stamp failure on one.
+    for step, duty in (
+        ("      - name: Re-run failed jobs\n", "bounded retry"),
+        (
+            "      - name: Alert after automatic retries are exhausted\n",
+            "exhausted-retry alert",
+        ),
+    ):
+        start = release_recovery.index(step)
+        end = release_recovery.index("\n        env:", start)
+        if "steps.record.outputs.abandoned != 'true'" not in release_recovery[start:end]:
+            raise AssertionError(
+                f"release recovery's {duty} must stand down for a tag the "
+                "tracked abandonment record already retired"
+            )
     for forbidden in (
         "workflow_dispatch:",
         "contents: write",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -69,6 +69,13 @@ EXPECTED_REQUIRED_CONTEXT_ACTION_PINS = {
 EXPECTED_SELECTOR_INVOCATIONS = {
     "release-tag": ('"$abandoned"', '"$candidate_tags"', '"$TAG"', '"$admissible"'),
     "release-train": ('"$abandoned"', '"$candidate_tags"', '""', '"$admissible"'),
+    # Recovery asks the same question about one tag, so its candidate listing is
+    # the single pair the failed release ran rather than the whole tag listing,
+    # and its mint intent is empty for a blunter reason than the train's: naming
+    # the tag under reconcile as intent makes the selector refuse exactly the
+    # recorded tag recovery is asking about, so recovery would read a waived tag
+    # as unwaived and re-arm the alert the record exists to stand down.
+    "release-recovery": ('"$RECORD"', '"$candidate"', '""', '"$admissible"'),
 }
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 DOCKERFILE = ROOT / "Dockerfile"
@@ -2478,29 +2485,95 @@ def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
                 )
 
 
-def assert_selector_arguments(release_tag: str, release_train: str) -> None:
+def assert_selector_arguments(
+    release_tag: str,
+    release_train: str,
+    release_recovery: str,
+) -> None:
     """Pin which tag each workflow declares it is about to mint."""
 
     actual = {
         "release-tag": selector_invocation("release-tag", release_tag),
         "release-train": selector_invocation("release-train", release_train),
+        "release-recovery": selector_invocation(
+            "release-recovery", release_recovery
+        ),
     }
     if actual != EXPECTED_SELECTOR_INVOCATIONS:
         raise AssertionError(
             "each release workflow must hand the admission selector its own "
             "reviewed arguments. The mint-intent argument names the tag that "
             "workflow is about to create, and only the mint creates one. The "
-            "train resolves drift from a base tag it never mints, so naming "
-            "that base as mint intent refuses exactly when a record covers it, "
+            "train resolves drift from a base tag it never mints, and recovery "
+            "reconciles a tag it never mints either, so naming that tag as "
+            "mint intent refuses exactly when a record covers it, "
             f"which is every abandonment: expected={EXPECTED_SELECTOR_INVOCATIONS} "
             f"actual={actual}"
         )
 
 
-def assert_abandoned_tag_admission(release_tag: str, release_train: str) -> None:
+def assert_recovery_record_authority(release_recovery: str) -> None:
+    """Recovery must decide abandonment through the rail's own selector.
+
+    Two readers of one record is how an alarm gets disarmed in the state that
+    needs it most. A reader of its own accepts entries the selector refuses, so
+    recovery would stand down for a record too malformed to waive the mint: the
+    rail hard stuck, and the check-run that would say so green. Recovery
+    therefore asks the selector the same question the mint asks, and this pins
+    that it keeps asking rather than reading the record itself.
+
+    Recovery is deliberately absent from the protected-main read above. The mint
+    and the train run on a release commit that predates the abandonment it has
+    to honour, so they must reach past their checkout; recovery checks out
+    GITHUB_SHA, which is the default-branch commit itself, and honours no
+    abandonment from a tree whose HEAD is not that commit.
+    """
+
+    step = workflow_step_source(
+        "release-recovery",
+        release_recovery,
+        "      - name: Reconcile against the tracked abandonment record\n",
+    )
+    for policy in (TAG_SELECTOR_POLICY, 'python3 "$selector"'):
+        require(step, policy, "record-aware release recovery")
+    for reader in ("jq ", "python3 -c"):
+        if reader in step:
+            raise AssertionError(
+                "release recovery must decide abandonment through "
+                f"{TAG_SELECTOR_POLICY} and not read the record a second way, "
+                "because a second reader accepts what the rail refuses and "
+                f"quiets the alarm the refusal exists to raise: {reader.strip()}"
+            )
+    # The selector answers by ranking, and it drops a candidate that is not a
+    # vX.Y.Z release tag for the same reason it drops an abandoned one. An empty
+    # ranking therefore means "waived" only while the tag handed to it is known
+    # to be a release tag, which resolve establishes before it declares the
+    # reconcile needed. The order is what makes it true at the ranking.
+    resolve = workflow_step_source(
+        "release-recovery",
+        release_recovery,
+        "      - name: Resolve exact retry candidate\n",
+    )
+    shape = resolve.index(r'[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]')
+    declared = resolve.index('echo "needed=true"')
+    if shape > declared:
+        raise AssertionError(
+            "release recovery must prove its retry candidate is a vX.Y.Z "
+            "release tag before it declares a reconcile needed, because the "
+            "admission selector drops anything else from its ranking and "
+            "recovery reads an empty ranking as a reviewed waiver"
+        )
+
+
+def assert_abandoned_tag_admission(
+    release_tag: str,
+    release_train: str,
+    release_recovery: str,
+) -> None:
     """Only a reviewed record may waive release-lane serialization."""
 
-    assert_selector_arguments(release_tag, release_train)
+    assert_selector_arguments(release_tag, release_train, release_recovery)
+    assert_recovery_record_authority(release_recovery)
 
     for workflow, content, step_anchor, comparison in (
         (
@@ -3340,7 +3413,7 @@ def main() -> None:
         ),
     )
     assert_release_branch_allowlist_covers_generator(release_train)
-    assert_abandoned_tag_admission(release_tag, release_train)
+    assert_abandoned_tag_admission(release_tag, release_train, release_recovery)
     # The release bump must never be resolvable from anything a merged pull
     # request can still change.
     for forbidden in (
@@ -3435,6 +3508,7 @@ def main() -> None:
         '[ "$attempt" -ge 3 ]',
         "Release blocked after automatic retries",
         "scripts/abandoned-release-tags.json",
+        "scripts/select-admissible-release-tag.py",
         '[ "$head" != "$GITHUB_SHA" ]',
         "reconciled by abandonment",
     ):


### PR DESCRIPTION
The v0.4.5 release tag can never finish. The public install proof frozen at the
tag pipes kin init through tee into kin-init.txt inside the worktree it asks kin
to admit, so an untracked non-ignored path exists before admission runs and
admission is refused on every platform. The proof is called as a local reusable
workflow, so it resolves from the tag rather than from main and no change to
main can reach the failing step. All three attempts of Release run 30678146368
failed on all five platforms, and the only Release object for the tag is the
unpromoted prerelease the workflow publishes before proof.

Left unrecorded, the tag stays the highest one the release rail serializes on.
Both the mint gate and drift resolution require the highest vX.Y.Z tag to
already be the finalized GitHub Latest release, and v0.4.5 can never become it,
so both rails stay closed against the successor that carries the repaired
harness. A reviewed record is the only waiver.

Rehearsed with the shipped selector against the repository's real tag listing.
Before this change the highest admissible tag is v0.4.5 against a finalized
Latest of v0.3.6, so both rails refuse. After it the mint gate and the train
both select v0.3.6, which is the finalized Latest, while v0.4.5 itself is
refused as a mint target so the burned version cannot be re-minted onto another
commit. A record naming a commit the tag does not carry still refuses loudly.

The second commit makes release recovery read that record, because recording an
abandonment is not enough on its own. Recovery selects the newest failed Release
run with no matching success, which stays v0.4.5, and once its retries are
exhausted it otherwise files an alert and ends in exit 1 on every scheduled
tick. Under the blanket check-run policy that existed when this failure was
diagnosed, that alert also published a `Reconcile failed release` failure
against the default-branch head that could permanently veto the successor mint.
The intended final policy is narrower: only the reviewed required contexts may
veto a release, while non-required red or unfinished checks are disclosed as
warnings. That narrowing is owned by a follow-up change; it does not make retrying
or alerting on an irreparable, reviewed-abandoned tag useful. The exact
abandonment record remains the only waiver, and recovery still stands down to
avoid guaranteed-noise retries and alerts without weakening any unrecorded
failure.

Recovery now concludes success for a tag the record retires, dispatching no
retry and filing no alert, and says so with a reconciled-by-abandonment notice.
An unrecorded failed tag is untouched: it still exhausts its retries, still
files the alert, and still exits 1, so the alarm is narrowed rather than
blinded. Nothing weaker than the reviewed record quiets it. A tag is reconciled
only when the record abandons that exact tag at the exact commit the failed
release ran, which is the same tag-and-commit pair
scripts/select-admissible-release-tag.py requires before it will skip a tag. A
record naming another commit, a record that is unreadable or missing, and a
checkout that is not this run's own commit all read as not abandoned and leave
the alert armed.

The record is read from the repository checkout at GITHUB_SHA, which the
checkout step resolves by taking no `ref:` input at all. For both of this
workflow's triggers, schedule and workflow_run, GitHub resolves GITHUB_SHA to
the last commit on the default branch and GITHUB_REF to the default branch, not
to the head of the run that triggered it, so the record is read from one
immutable main snapshot rather than from whatever main becomes while the job
runs. That is the only ref where the record can exist, since a tag's tree is
frozen before the failure that abandons it, and it is also the right trust
boundary, since a workflow_run job must not take release policy from the
triggering run's head. The step does not assume this: it compares
`git rev-parse HEAD` against GITHUB_SHA and honours no abandonment from a tree
that is not the run's own.

Every command in the new step captures its status rather than leaving it to the
implicit errexit of an Actions `run:` block, and every unhappy path degrades to
not abandoned. The record-reader step must never end non-zero on its own: the
alert step remains the only place recovery fails, and it fails for the real
unreconciled release. Under the final required-context policy, a non-required
recovery failure is disclosed rather than allowed to veto a mint; this
fail-armed reader is still required so an unreadable or mismatched record cannot
quiet the operational alarm.

The checkout carries `continue-on-error` for the same reason, on the ground
`base-image-pins.yml` already states for its own alarm: the alarm must not
become the thing that reds a main sha. Adding a checkout to this workflow added
a way for the job to fail that it did not have before, and with a failed release
still awaiting a bounded retry a network hiccup fetching the record would have
published a false recovery failure on an otherwise healthy default-branch
commit. A failed fetch now leaves no HEAD matching the run's commit, so the read
degrades to not abandoned and recovery behaves as it did before the record
existed.

Falsified against the workflow's own step bodies and `if:` conditions read out
of the YAML, never a retyped copy. A recorded tag at its recorded commit runs
the record step, emits the notice, skips both the retry and the alert, and the
check-run concludes success. An unrecorded tag runs the alert verbatim, attempts
the issue create, exits 1, and the check-run concludes failure. A recorded tag
resolved at a different commit, and a checkout whose HEAD is not GITHUB_SHA,
both fall through to that same failure, as do a failed checkout that leaves no
repository and a record file that is absent from the checkout. With the retry
still available the recorded tag skips the rerun dispatch while the unrecorded
tag still requests it. The same harness run against the pre-change workflow
reproduces the hazard:
the recorded v0.4.5 alerts and concludes failure, which is the check-run that
would refuse the recut.

scripts/test-release-workflow-authority.py passes on an isolated archive of this
head extracted outside any git repository, and fails as it should when the new
entry drops its run id, when the ledger is emptied, when the alert step drops
its abandonment gate, and when the workflow is reverted to its pre-change
baseline. The suite pins both consumers of the record decision, the bounded
retry and the exhausted-retry alert, so a later edit cannot quietly restore the
hourly failure. actionlint is clean on the workflow.

firelock-ai/kin#558 stays open, and neither the record nor the reconcile retires
it. The alert step re-files by exact title only when no open issue matches, so
the blocked-release issue has to remain open until v0.4.6 is promoted to Latest.

The install-proof write-before-admission defect is repaired on protected main.
This change does not repair frozen v0.4.5 bytes; it records why that immutable
tag is abandoned and lets the release rail advance to a separately proven
successor.

Refs FIR-1819

