### PR TITLE
Carry the sections of superseded release tags into the notes that replace them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           python3 ./scripts/test-verify-npm-release.py
           node --test \
             ./scripts/check-release-version.test.mjs \
+            ./scripts/extract-release-notes.test.mjs \
             ./scripts/prepare-release.test.mjs \
             ./scripts/read-update-build-identity.test.cjs \
             ./scripts/release-archive-shape.test.cjs \
@@ -634,6 +635,7 @@ jobs:
           python3 scripts/test-release-workflow-authority.py
           node --test \
             scripts/check-release-version.test.mjs \
+            scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \
             scripts/release-archive-shape.test.cjs
           node --check scripts/check-release-version.mjs

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -193,10 +193,21 @@ export function composeNotes(changelog, version, abandonments) {
   };
 }
 
+/// Say only what the abandonment record proves.
+///
+/// The record proves a tag was superseded; it does not prove nothing was ever
+/// published for it. v0.4.5 is the counterexample: it carries a live public
+/// prerelease with assets, so claiming it was never published, or that its
+/// notes ship here for the first time, is false to anyone who opens the
+/// releases page.
 function carriedForwardNotice(tags) {
   const named = tags.join(', ');
-  const plural = tags.length > 1 ? 'releases were tagged but never published' : 'release was tagged but never published';
-  return `## Carried forward from ${named}\n\nThe following ${plural}, so the notes below ship here for the first time.\n`;
+  // Each branch is a whole sentence so number agreement cannot drift apart
+  // across a shared tail.
+  const sentence = tags.length > 1
+    ? 'The following tags were superseded before their releases completed, so the notes recorded for them are collected here.'
+    : 'The following tag was superseded before its release completed, so the notes recorded for it are collected here.';
+  return `## Carried forward from ${named}\n\n${sentence}\n`;
 }
 
 async function readChangelog(input) {

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,4 +1,13 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const RELEASE_TAG = /^v\d+\.\d+\.\d+$/;
+
+const DEFAULT_ABANDONED = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'abandoned-release-tags.json',
+);
 
 function parseArgs(argv) {
   const args = new Map();
@@ -19,10 +28,11 @@ function parseArgs(argv) {
     input: args.get('input'),
     output: args.get('output'),
     version: args.get('version'),
+    abandoned: args.get('abandoned'),
   };
 }
 
-function extractSection(changelog, version) {
+export function extractSection(changelog, version) {
   const normalized = changelog.replace(/\r\n/g, '\n');
   const heading = `## [${version}]`;
   const start = normalized.indexOf(heading);
@@ -38,6 +48,133 @@ function extractSection(changelog, version) {
   return `${section.trim()}\n`;
 }
 
+/// Read the abandoned release-tag record into a tag-to-successor map.
+///
+/// Validation is strict for the same reason the tag selector's is: a record
+/// that cannot be trusted must stop the run rather than resolve to an empty
+/// chain, because an empty chain is indistinguishable from "nothing was
+/// abandoned" and would publish notes that silently omit the superseded work.
+export function loadAbandonments(raw) {
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`abandoned release-tag record is not valid JSON: ${error.message}`);
+  }
+
+  if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error('abandoned release-tag record must be a JSON object');
+  }
+  if (manifest.schema_version !== 1) {
+    throw new Error(
+      `abandoned release-tag record must declare schema_version 1, found ${JSON.stringify(manifest.schema_version)}`,
+    );
+  }
+  if (!Array.isArray(manifest.abandoned)) {
+    throw new Error("abandoned release-tag record must carry an 'abandoned' array");
+  }
+
+  const abandonments = new Map();
+  for (const record of manifest.abandoned) {
+    if (record === null || typeof record !== 'object' || Array.isArray(record)) {
+      throw new Error('every abandoned release-tag entry must be a JSON object');
+    }
+    const { tag, superseded_by: supersededBy } = record;
+    if (typeof tag !== 'string' || !RELEASE_TAG.test(tag)) {
+      throw new Error(`abandoned tag ${JSON.stringify(tag)} is not a vX.Y.Z release tag`);
+    }
+    if (typeof supersededBy !== 'string' || !RELEASE_TAG.test(supersededBy)) {
+      throw new Error(`abandoned tag ${tag} names a successor that is not a vX.Y.Z release tag`);
+    }
+    if (supersededBy === tag) {
+      throw new Error(`abandoned tag ${tag} cannot supersede itself`);
+    }
+    if (abandonments.has(tag)) {
+      throw new Error(`release tag ${tag} is recorded as abandoned more than once`);
+    }
+    abandonments.set(tag, supersededBy);
+  }
+
+  return abandonments;
+}
+
+function parseSemver(tag) {
+  return tag.replace(/^v/, '').split('.').map(Number);
+}
+
+function descendingByVersion(left, right) {
+  const a = parseSemver(left);
+  const b = parseSemver(right);
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) {
+      return b[i] - a[i];
+    }
+  }
+  return 0;
+}
+
+/// Every abandoned tag this version stands in for, newest first.
+///
+/// Walks the `superseded_by` edges backwards from the version being published,
+/// transitively: v0.4.5 collects v0.4.4, and v0.4.4's own predecessor v0.4.3
+/// with it. Traversal is breadth-first over a visited set, so a record that
+/// points in a circle terminates instead of hanging, and a successor named by
+/// more than one abandoned tag contributes all of them rather than whichever
+/// sorted first.
+export function abandonedAncestors(abandonments, version) {
+  const target = `v${version.replace(/^v/, '')}`;
+  const ancestors = [];
+  // Seeded with the version being published so it can never be collected as
+  // its own predecessor: a record that names it abandoned is contradictory,
+  // and following that edge would emit its section twice.
+  const seen = new Set([target]);
+  const queue = [target];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const [tag, supersededBy] of abandonments) {
+      if (supersededBy !== current || seen.has(tag)) {
+        continue;
+      }
+      seen.add(tag);
+      ancestors.push(tag);
+      queue.push(tag);
+    }
+  }
+
+  return ancestors.sort(descendingByVersion);
+}
+
+/// The release notes for a version, carrying forward the sections of every tag
+/// it supersedes.
+///
+/// With no abandoned predecessors this is byte-identical to the single section
+/// the extractor has always emitted. A predecessor that has no changelog
+/// section of its own contributes nothing and is reported, because the record
+/// tracks abandoned tags and the changelog tracks released content: the two do
+/// not have to line up, and v0.4.3 is a real example of one that does not.
+export function composeNotes(changelog, version, abandonments) {
+  const rolledUp = abandonedAncestors(abandonments, version);
+  const wanted = [version, ...rolledUp.map((tag) => tag.replace(/^v/, ''))];
+
+  const sections = [];
+  const missing = [];
+  for (const candidate of wanted) {
+    const section = extractSection(changelog, candidate);
+    if (section === null) {
+      missing.push(candidate);
+    } else {
+      sections.push(section);
+    }
+  }
+
+  return {
+    notes: sections.length > 0 ? sections.join('\n') : null,
+    rolledUp,
+    missing,
+  };
+}
+
 async function readChangelog(input) {
   try {
     return await fs.readFile(input, 'utf8');
@@ -49,11 +186,29 @@ async function readChangelog(input) {
   }
 }
 
+async function readAbandonments(abandonedPath, explicit) {
+  let raw;
+  try {
+    raw = await fs.readFile(abandonedPath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT' && !explicit) {
+      // The default record is absent. Say so rather than rolling up nothing in
+      // silence: a missing record and an empty one produce the same notes, and
+      // only one of them is correct.
+      console.warn(`no abandoned release-tag record at ${abandonedPath}; no superseded sections will be rolled up`);
+      return new Map();
+    }
+    throw error;
+  }
+
+  return loadAbandonments(raw);
+}
+
 async function main() {
-  const { input, output, version } = parseArgs(process.argv.slice(2));
+  const { input, output, version, abandoned } = parseArgs(process.argv.slice(2));
 
   if (!input || !output || !version) {
-    throw new Error('usage: node scripts/extract-release-notes.mjs --version <version> --input <path> --output <path>');
+    throw new Error('usage: node scripts/extract-release-notes.mjs --version <version> --input <path> --output <path> [--abandoned <path>]');
   }
 
   const changelog = await readChangelog(input);
@@ -63,17 +218,32 @@ async function main() {
     console.warn(`changelog not found at ${input}; falling back to auto-generated release notes`);
     notes = '';
   } else {
-    notes = extractSection(changelog, version);
-    if (notes === null) {
-      console.warn(`no changelog section for version ${version}; falling back to auto-generated release notes`);
-      notes = '';
+    const abandonments = await readAbandonments(abandoned ?? DEFAULT_ABANDONED, abandoned !== undefined);
+    const composed = composeNotes(changelog, version, abandonments);
+
+    for (const absent of composed.missing) {
+      if (absent !== version) {
+        console.warn(`superseded version ${absent} has no changelog section to roll up`);
+      }
     }
+    if (composed.notes === null) {
+      console.warn(`no changelog section for version ${version}; falling back to auto-generated release notes`);
+    } else if (composed.missing.includes(version)) {
+      console.warn(`no changelog section for version ${version}; publishing only the superseded sections it carries forward`);
+    }
+    if (composed.rolledUp.length > 0) {
+      console.warn(`rolling up sections for abandoned ${composed.rolledUp.join(', ')} into ${version}`);
+    }
+
+    notes = composed.notes ?? '';
   }
 
   await fs.writeFile(output, notes);
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -155,24 +156,47 @@ export function abandonedAncestors(abandonments, version) {
 /// not have to line up, and v0.4.3 is a real example of one that does not.
 export function composeNotes(changelog, version, abandonments) {
   const rolledUp = abandonedAncestors(abandonments, version);
-  const wanted = [version, ...rolledUp.map((tag) => tag.replace(/^v/, ''))];
 
-  const sections = [];
-  const missing = [];
-  for (const candidate of wanted) {
+  const own = extractSection(changelog, version);
+  const missing = own === null ? [version] : [];
+
+  const carried = [];
+  for (const tag of rolledUp) {
+    const candidate = tag.replace(/^v/, '');
     const section = extractSection(changelog, candidate);
     if (section === null) {
       missing.push(candidate);
     } else {
-      sections.push(section);
+      carried.push({ tag, section });
     }
   }
 
+  const parts = [];
+  if (own !== null) {
+    parts.push(own);
+  }
+  if (carried.length > 0) {
+    // Say why a superseded version's heading is in these notes. Without this a
+    // reader sees a bare `## [0.4.4]` under the 0.4.5 release and reasonably
+    // concludes 0.4.4 shipped, when the whole reason its content is here is
+    // that it never did. The workflow-log warning is not a substitute: nobody
+    // reading a release ever sees it.
+    parts.push(carriedForwardNotice(carried.map((entry) => entry.tag)));
+    parts.push(...carried.map((entry) => entry.section));
+  }
+
   return {
-    notes: sections.length > 0 ? sections.join('\n') : null,
+    notes: parts.length > 0 ? parts.join('\n') : null,
     rolledUp,
+    carried: carried.map((entry) => entry.tag),
     missing,
   };
+}
+
+function carriedForwardNotice(tags) {
+  const named = tags.join(', ');
+  const plural = tags.length > 1 ? 'releases were tagged but never published' : 'release was tagged but never published';
+  return `## Carried forward from ${named}\n\nThe following ${plural}, so the notes below ship here for the first time.\n`;
 }
 
 async function readChangelog(input) {
@@ -241,7 +265,10 @@ async function main() {
   await fs.writeFile(output, notes);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// `import.meta.url` is already a realpath, so the entry point must be resolved
+// the same way or invocation through a symlink compares false, main() never
+// runs, and the process exits 0 having written no notes at all.
+if (process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href) {
   main().catch((error) => {
     console.error(error.message);
     process.exitCode = 1;

--- a/scripts/extract-release-notes.test.mjs
+++ b/scripts/extract-release-notes.test.mjs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import {
+  abandonedAncestors,
+  composeNotes,
+  extractSection,
+  loadAbandonments,
+} from './extract-release-notes.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./extract-release-notes.mjs', import.meta.url));
+
+const CHANGELOG = [
+  '# Changelog',
+  '',
+  '## [Unreleased]',
+  '',
+  '- nothing yet',
+  '',
+  '## [0.4.5] - 2026-08-01',
+  '',
+  '- the published one',
+  '',
+  '## [0.4.4] - 2026-07-31',
+  '',
+  '- the abandoned one',
+  '',
+  '## [0.3.6] - 2026-07-26',
+  '',
+  '- an older release',
+  '',
+].join('\n');
+
+function record(entries) {
+  return JSON.stringify({ schema_version: 1, abandoned: entries });
+}
+
+const CHAIN = record([
+  { tag: 'v0.4.3', superseded_by: 'v0.4.4' },
+  { tag: 'v0.4.4', superseded_by: 'v0.4.5' },
+]);
+
+function runScript(args, { cwd } = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd, encoding: 'utf8' });
+}
+
+function withTempDir(body) {
+  const dir = mkdtempSync(join(tmpdir(), 'extract-release-notes-'));
+  try {
+    return body(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('a version with no abandoned predecessors emits exactly its own section', () => {
+  const composed = composeNotes(CHANGELOG, '0.3.6', new Map());
+
+  assert.equal(composed.notes, extractSection(CHANGELOG, '0.3.6'));
+  assert.deepEqual(composed.rolledUp, []);
+  assert.deepEqual(composed.missing, []);
+});
+
+test('a version carries forward the section of the tag it supersedes', () => {
+  const composed = composeNotes(CHANGELOG, '0.4.5', loadAbandonments(CHAIN));
+
+  assert.deepEqual(composed.rolledUp, ['v0.4.4', 'v0.4.3']);
+  assert.match(composed.notes, /## \[0\.4\.5\]/);
+  assert.match(composed.notes, /the published one/);
+  assert.match(composed.notes, /## \[0\.4\.4\]/);
+  assert.match(composed.notes, /the abandoned one/);
+  // The roll-up stops at the abandoned chain and does not sweep in the last
+  // tag that actually published.
+  assert.doesNotMatch(composed.notes, /## \[0\.3\.6\]/);
+  assert.doesNotMatch(composed.notes, /an older release/);
+});
+
+test('sections are ordered newest first and separated by a blank line', () => {
+  const composed = composeNotes(CHANGELOG, '0.4.5', loadAbandonments(CHAIN));
+
+  assert.ok(
+    composed.notes.indexOf('## [0.4.5]') < composed.notes.indexOf('## [0.4.4]'),
+    'the version being published must lead its superseded sections',
+  );
+  assert.match(composed.notes, /- the published one\n\n## \[0\.4\.4\]/);
+});
+
+test('an abandoned predecessor with no changelog section is reported, not invented', () => {
+  const composed = composeNotes(CHANGELOG, '0.4.5', loadAbandonments(CHAIN));
+
+  // v0.4.3 is abandoned and has no section of its own. This is the real shape
+  // of the record in this repository.
+  assert.deepEqual(composed.missing, ['0.4.3']);
+});
+
+test('a missing section for the version itself still carries its superseded sections', () => {
+  const changelog = ['# Changelog', '', '## [0.4.4] - 2026-07-31', '', '- the abandoned one', ''].join('\n');
+  const composed = composeNotes(changelog, '0.4.5', loadAbandonments(CHAIN));
+
+  assert.match(composed.notes, /the abandoned one/);
+  assert.ok(composed.missing.includes('0.4.5'));
+});
+
+test('nothing found at all reports no notes rather than an empty string', () => {
+  const composed = composeNotes('# Changelog\n', '0.4.5', loadAbandonments(CHAIN));
+
+  assert.equal(composed.notes, null);
+});
+
+test('the chain is walked transitively rather than one hop', () => {
+  const deep = loadAbandonments(
+    record([
+      { tag: 'v1.0.0', superseded_by: 'v1.0.1' },
+      { tag: 'v1.0.1', superseded_by: 'v1.0.2' },
+      { tag: 'v1.0.2', superseded_by: 'v1.0.3' },
+    ]),
+  );
+
+  assert.deepEqual(abandonedAncestors(deep, '1.0.3'), ['v1.0.2', 'v1.0.1', 'v1.0.0']);
+});
+
+test('an unrelated abandoned tag is not rolled into a version it never preceded', () => {
+  const ancestors = abandonedAncestors(loadAbandonments(CHAIN), '0.9.0');
+
+  assert.deepEqual(ancestors, []);
+});
+
+test('several abandoned tags naming one successor all contribute', () => {
+  const forked = loadAbandonments(
+    record([
+      { tag: 'v2.0.0', superseded_by: 'v2.0.2' },
+      { tag: 'v2.0.1', superseded_by: 'v2.0.2' },
+    ]),
+  );
+
+  assert.deepEqual(abandonedAncestors(forked, '2.0.2'), ['v2.0.1', 'v2.0.0']);
+});
+
+test('a record pointing in a circle terminates instead of hanging', () => {
+  const circular = new Map([
+    ['v3.0.0', 'v3.0.1'],
+    ['v3.0.1', 'v3.0.0'],
+  ]);
+
+  const ancestors = abandonedAncestors(circular, '3.0.1');
+
+  assert.deepEqual(ancestors, ['v3.0.0']);
+});
+
+test('a malformed record is refused rather than resolving to an empty chain', () => {
+  assert.throws(() => loadAbandonments('{'), /not valid JSON/);
+  assert.throws(() => loadAbandonments('[]'), /must be a JSON object/);
+  assert.throws(() => loadAbandonments(JSON.stringify({ abandoned: [] })), /schema_version 1/);
+  assert.throws(() => loadAbandonments(JSON.stringify({ schema_version: 1 })), /'abandoned' array/);
+  assert.throws(() => loadAbandonments(record([{ tag: '0.4.4', superseded_by: 'v0.4.5' }])), /not a vX\.Y\.Z release tag/);
+  assert.throws(() => loadAbandonments(record([{ tag: 'v0.4.4', superseded_by: 'latest' }])), /successor that is not/);
+  assert.throws(() => loadAbandonments(record([{ tag: 'v0.4.4', superseded_by: 'v0.4.4' }])), /cannot supersede itself/);
+  assert.throws(
+    () => loadAbandonments(record([{ tag: 'v0.4.4', superseded_by: 'v0.4.5' }, { tag: 'v0.4.4', superseded_by: 'v0.4.6' }])),
+    /abandoned more than once/,
+  );
+});
+
+test('the repository record parses and chains v0.4.3 through v0.4.4', () => {
+  const raw = readFileSync(new URL('./abandoned-release-tags.json', import.meta.url), 'utf8');
+  const abandonments = loadAbandonments(raw);
+
+  assert.deepEqual(abandonedAncestors(abandonments, '0.4.5'), ['v0.4.4', 'v0.4.3']);
+});
+
+test('end to end, the script rolls the superseded section into the output file', () => {
+  withTempDir((dir) => {
+    const input = join(dir, 'CHANGELOG.md');
+    const output = join(dir, 'release-notes.md');
+    const abandoned = join(dir, 'abandoned.json');
+    writeFileSync(input, CHANGELOG);
+    writeFileSync(abandoned, CHAIN);
+
+    const result = runScript([
+      '--version', '0.4.5',
+      '--input', input,
+      '--output', output,
+      '--abandoned', abandoned,
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const notes = readFileSync(output, 'utf8');
+    assert.match(notes, /## \[0\.4\.5\]/);
+    assert.match(notes, /## \[0\.4\.4\]/);
+    assert.match(result.stderr, /rolling up sections for abandoned v0\.4\.4, v0\.4\.3/);
+  });
+});
+
+test('end to end, an empty record reproduces the single-section output byte for byte', () => {
+  withTempDir((dir) => {
+    const input = join(dir, 'CHANGELOG.md');
+    const withRecord = join(dir, 'with.md');
+    const withoutRecord = join(dir, 'without.md');
+    const empty = join(dir, 'empty.json');
+    writeFileSync(input, CHANGELOG);
+    writeFileSync(empty, record([]));
+
+    const rolled = runScript(['--version', '0.4.5', '--input', input, '--output', withRecord, '--abandoned', empty]);
+    assert.equal(rolled.status, 0, rolled.stderr);
+
+    writeFileSync(withoutRecord, extractSection(CHANGELOG, '0.4.5'));
+
+    assert.equal(readFileSync(withRecord, 'utf8'), readFileSync(withoutRecord, 'utf8'));
+  });
+});
+
+test('end to end, an explicitly named record that is absent fails loud', () => {
+  withTempDir((dir) => {
+    const input = join(dir, 'CHANGELOG.md');
+    writeFileSync(input, CHANGELOG);
+
+    const result = runScript([
+      '--version', '0.4.5',
+      '--input', input,
+      '--output', join(dir, 'out.md'),
+      '--abandoned', join(dir, 'nope.json'),
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /ENOENT/);
+  });
+});
+
+test('end to end, a malformed record fails the run instead of publishing thin notes', () => {
+  withTempDir((dir) => {
+    const input = join(dir, 'CHANGELOG.md');
+    const abandoned = join(dir, 'abandoned.json');
+    writeFileSync(input, CHANGELOG);
+    writeFileSync(abandoned, '{ "schema_version": 1, "abandoned": [ { "tag": "nope" } ] }');
+
+    const result = runScript([
+      '--version', '0.4.5',
+      '--input', input,
+      '--output', join(dir, 'out.md'),
+      '--abandoned', abandoned,
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /not a vX\.Y\.Z release tag/);
+  });
+});
+
+test('end to end, a missing changelog still falls back to auto-generated notes', () => {
+  withTempDir((dir) => {
+    const output = join(dir, 'release-notes.md');
+
+    const result = runScript([
+      '--version', '0.4.5',
+      '--input', join(dir, 'absent.md'),
+      '--output', output,
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(output, 'utf8'), '');
+    assert.match(result.stderr, /changelog not found/);
+  });
+});

--- a/scripts/extract-release-notes.test.mjs
+++ b/scripts/extract-release-notes.test.mjs
@@ -3,7 +3,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -90,7 +90,65 @@ test('sections are ordered newest first and separated by a blank line', () => {
     composed.notes.indexOf('## [0.4.5]') < composed.notes.indexOf('## [0.4.4]'),
     'the version being published must lead its superseded sections',
   );
-  assert.match(composed.notes, /- the published one\n\n## \[0\.4\.4\]/);
+  assert.match(composed.notes, /- the published one\n\n## Carried forward/);
+  assert.match(composed.notes, /first time\.\n\n## \[0\.4\.4\]/);
+});
+
+test('carried-forward sections say why a superseded heading is in these notes', () => {
+  const composed = composeNotes(CHANGELOG, '0.4.5', loadAbandonments(CHAIN));
+
+  // A bare `## [0.4.4]` under the 0.4.5 release reads as though 0.4.4 shipped.
+  // The whole reason its content is here is that it did not.
+  assert.match(composed.notes, /## Carried forward from v0\.4\.4/);
+  assert.match(composed.notes, /never published/);
+  assert.deepEqual(composed.carried, ['v0.4.4']);
+});
+
+test('the notice names every tag actually carried, not every tag walked', () => {
+  // v0.4.3 is in the chain but has no section, so it contributes nothing and
+  // must not be announced as carried forward.
+  const composed = composeNotes(CHANGELOG, '0.4.5', loadAbandonments(CHAIN));
+
+  assert.deepEqual(composed.rolledUp, ['v0.4.4', 'v0.4.3']);
+  assert.deepEqual(composed.carried, ['v0.4.4']);
+  assert.doesNotMatch(composed.notes, /Carried forward from v0\.4\.4, v0\.4\.3/);
+});
+
+test('no carried-forward notice appears when nothing was carried', () => {
+  const composed = composeNotes(CHANGELOG, '0.3.6', new Map());
+
+  assert.doesNotMatch(composed.notes, /Carried forward/);
+});
+
+test('the notice reads as plural only when several tags are carried', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '## [2.0.2] - 2026-08-01',
+    '',
+    '- the published one',
+    '',
+    '## [2.0.1] - 2026-07-31',
+    '',
+    '- one abandoned',
+    '',
+    '## [2.0.0] - 2026-07-30',
+    '',
+    '- another abandoned',
+    '',
+  ].join('\n');
+  const forked = loadAbandonments(
+    record([
+      { tag: 'v2.0.0', superseded_by: 'v2.0.2' },
+      { tag: 'v2.0.1', superseded_by: 'v2.0.2' },
+    ]),
+  );
+
+  const composed = composeNotes(changelog, '2.0.2', forked);
+
+  assert.deepEqual(composed.carried, ['v2.0.1', 'v2.0.0']);
+  assert.match(composed.notes, /## Carried forward from v2\.0\.1, v2\.0\.0/);
+  assert.match(composed.notes, /releases were tagged but never published/);
 });
 
 test('an abandoned predecessor with no changelog section is reported, not invented', () => {
@@ -250,6 +308,34 @@ test('end to end, a malformed record fails the run instead of publishing thin no
 
     assert.equal(result.status, 1);
     assert.match(result.stderr, /not a vX\.Y\.Z release tag/);
+  });
+});
+
+test('end to end, the script still writes its notes when invoked through a symlink', () => {
+  withTempDir((dir) => {
+    // `import.meta.url` is a realpath. An entry-point guard that does not
+    // resolve the same way compares false through a symlink, main() never
+    // runs, and the process exits 0 having written nothing. The release rail
+    // would publish empty notes and report success.
+    const linked = join(dir, 'extract-release-notes.mjs');
+    symlinkSync(SCRIPT, linked);
+
+    const input = join(dir, 'CHANGELOG.md');
+    const output = join(dir, 'release-notes.md');
+    const abandoned = join(dir, 'abandoned.json');
+    writeFileSync(input, CHANGELOG);
+    writeFileSync(abandoned, CHAIN);
+
+    const result = spawnSync(
+      process.execPath,
+      [linked, '--version', '0.4.5', '--input', input, '--output', output, '--abandoned', abandoned],
+      { encoding: 'utf8' },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const notes = readFileSync(output, 'utf8');
+    assert.match(notes, /## \[0\.4\.5\]/);
+    assert.match(notes, /## \[0\.4\.4\]/);
   });
 });
 

--- a/scripts/extract-release-notes.test.mjs
+++ b/scripts/extract-release-notes.test.mjs
@@ -91,7 +91,7 @@ test('sections are ordered newest first and separated by a blank line', () => {
     'the version being published must lead its superseded sections',
   );
   assert.match(composed.notes, /- the published one\n\n## Carried forward/);
-  assert.match(composed.notes, /first time\.\n\n## \[0\.4\.4\]/);
+  assert.match(composed.notes, /collected here\.\n\n## \[0\.4\.4\]/);
 });
 
 test('carried-forward sections say why a superseded heading is in these notes', () => {
@@ -100,7 +100,13 @@ test('carried-forward sections say why a superseded heading is in these notes', 
   // A bare `## [0.4.4]` under the 0.4.5 release reads as though 0.4.4 shipped.
   // The whole reason its content is here is that it did not.
   assert.match(composed.notes, /## Carried forward from v0\.4\.4/);
-  assert.match(composed.notes, /never published/);
+  assert.match(composed.notes, /superseded before its release completed/);
+  // Number must agree across the whole sentence, not just its opening clause.
+  assert.match(composed.notes, /the notes recorded for it are collected here/);
+  assert.doesNotMatch(composed.notes, /for them are collected/);
+  // v0.4.5 carries a live public prerelease with assets, so the notice must not
+  // claim anything was never published or is shipping for the first time.
+  assert.doesNotMatch(composed.notes, /never published|for the first time/);
   assert.deepEqual(composed.carried, ['v0.4.4']);
 });
 
@@ -148,7 +154,8 @@ test('the notice reads as plural only when several tags are carried', () => {
 
   assert.deepEqual(composed.carried, ['v2.0.1', 'v2.0.0']);
   assert.match(composed.notes, /## Carried forward from v2\.0\.1, v2\.0\.0/);
-  assert.match(composed.notes, /releases were tagged but never published/);
+  assert.match(composed.notes, /tags were superseded before their releases completed/);
+  assert.doesNotMatch(composed.notes, /never published|for the first time/);
 });
 
 test('an abandoned predecessor with no changelog section is reported, not invented', () => {


### PR DESCRIPTION
A release tag that is abandoned is superseded before its release completes, so the changelog section written for it never reaches the notes of a completed release, whether the abandoned tag left a public prerelease behind or nothing at all. The next tag then published only its own section, and everything recorded against the tags it stood in for was dropped from the notes without a word.

## What changed

`scripts/extract-release-notes.mjs` now walks `scripts/abandoned-release-tags.json` backwards from the version being published, following `superseded_by`, and concatenates the section of every tag in that chain after its own.

On this repository's real record that is not hypothetical. Publishing `0.4.5` today emits only its own section; with this change it also carries `0.4.4`, the tag whose macOS legs were refused by its own frozen workflow. Verified against the committed `CHANGELOG.md` and record:

```
$ node ./scripts/extract-release-notes.mjs --version 0.4.5 --input ./CHANGELOG.md --output /tmp/rn.md
superseded version 0.4.3 has no changelog section to roll up
rolling up sections for abandoned v0.4.4, v0.4.3 into 0.4.5
$ grep '^## \[' /tmp/rn.md
## [0.4.5] - 2026-08-01
## [0.4.4] - 2026-07-31
```

Decisions worth reviewing:

- **The walk is transitive, not one hop.** A version replacing a tag that had itself already replaced another carries both forward. `v0.4.5` collects `v0.4.4` and `v0.4.3` behind it.
- **Traversal is breadth-first over a visited set seeded with the version being published.** A record that points in a circle terminates instead of hanging, and a contradictory record naming the published version as abandoned cannot make it its own predecessor and emit its section twice.
- **A successor named by more than one abandoned tag collects all of them**, rather than whichever happened to sort first.
- **Sections are ordered newest first**, matching how the changelog reads, separated by a blank line.
- **Carried sections are labeled, and the label says only what the record proves.** They follow a `## Carried forward from ...` notice stating the tags were superseded before their releases completed. Without a label a reader sees a bare `## [0.4.4]` under the 0.4.5 release and concludes 0.4.4 shipped. The label deliberately does not claim the tags were never published: v0.4.5 carries a live public prerelease with 18 assets, so that claim would contradict the releases page beside it. The notice names the tags actually carried, not every tag walked, and is absent when nothing was carried.
- **Byte-identical output when there is nothing to roll up.** This is what the release path relies on, and it is asserted by a test that runs the script both ways and compares the files.
- **A predecessor with no changelog section contributes nothing and says so.** The record tracks abandoned tags and the changelog tracks released content; the two do not have to line up. `v0.4.3` is a real example of one that does not, which is why this is a warning rather than an error.
- **A malformed record stops the run** instead of resolving to an empty chain. An empty chain and an unreadable one produce the same notes and only one of them is correct. Validation follows the tag selector's shape: `schema_version` 1, `vX.Y.Z` tags, no self-supersession, no duplicates.
- **The record path resolves relative to the script**, not the working directory, and takes an optional `--abandoned` override so the tests never touch the committed record.

The `release.yml` call site is unchanged: the new flag is optional and the existing three arguments keep their meaning.

## Evidence

22 tests in `scripts/extract-release-notes.test.mjs`, covering the roll-up, transitive chaining, ordering and separator, the byte-identical no-predecessor case, the missing-section and missing-version cases, cycle termination, forked ancestry, every validation refusal, the committed record parsing and chaining `v0.4.3` through `v0.4.4`, the labeling and its singular and plural wording, an entry point invoked through a symlink, and six end-to-end runs of the actual script.

**The test file is wired into both `ci.yml` `node --test` lists**, alongside the other release-policy tests. A test that is not enumerated there never runs, which would have made this suite decorative.

Local gates at the final head:

| Gate | Result |
|------|--------|
| `node --test` over the full list-1 set | rc=0, 62 passed |
| `node --check ./scripts/extract-release-notes.mjs` | rc=0 |
| `python3 ./scripts/test-release-workflow-authority.py` | rc=0 |
| `python3 ./scripts/test-npm-automatic-release.py` | rc=0 |
| `actionlint .github/workflows/ci.yml` | rc=0 |

**Falsification.** A suite that has never been shown to fail proves nothing, so the new tests were run against nine poisoned copies of the extractor, one per behavior this change promises. Every mutation was caught:

| Mutation | Result |
|----------|--------|
| roll-up removed entirely | caught, 13 failing tests |
| chain walked one hop only | caught, 6 failing tests |
| malformed record swallowed into an empty chain | caught, 2 failing tests |
| self-exclusion removed from the visited set | caught, 1 failing test |
| section separator dropped | caught, 1 failing test |
| ancestry ignored, every abandoned tag rolled in | caught, 1 failing test |
| realpath dropped from the entry-point guard | caught, 1 failing test |
| carried-forward notice removed | caught, 3 failing tests |
| notice reverts to claiming never published | caught, 2 failing tests |

The harness and its log are at `scratchpad/fix-1812-falsify.sh` and `scratchpad/fix-1812-falsify.log`. It refuses to report anything if the baseline suite is not green first, and reports a mutation site that no longer exists as a stale harness rather than as evidence.

No Rust source changed, so the Rust gates cannot be affected by this diff; `git diff --stat` over `crates/`, `Cargo.toml`, and `Cargo.lock` is empty. The full workspace suite still runs on this pull request in CI.

## Review fixes applied

1. **Carried sections shipped unlabeled** (missed requirement). Fixed as described above.
2. **The entry-point guard could silently no-op** (regression this change introduced). The first commit added `import.meta.url === pathToFileURL(process.argv[1]).href` so the test file could import the module without running `main()`. Node resolves `import.meta.url` to the realpath, so invocation through a symlink compared false, `main()` never ran, and the process **exited 0 having written no notes**. On the release rail that publishes an empty notes file and reports success. Now resolved through `realpathSync`, matching `scripts/release-order.mjs`, and held by a test that drives the script through a symlink. The falsification table below confirms that test is what catches it.

The third finding, that publishing only carried sections when the version has no section of its own is worse than auto-generated notes, is a judgment call and is left as implemented: with the notice now attached, carrying the content forward under an explicit label beats dropping it, and dropping it is what this ticket exists to stop. Flagged here so a reviewer can overrule it.

## Interaction with pull request 563

563 records `v0.4.5` as abandoned with `superseded_by: v0.4.6`. That makes this change land at exactly the right time and the two do not conflict, which was checked rather than assumed: 563's diff was applied locally and the suite stayed green at 22 of 22, because the one test that reads the committed record asserts what precedes `0.4.5`, and adding `v0.4.5` as a tag does not change that.

With both landed, publishing `v0.4.6` carries three tags forward instead of dropping them:

```
ancestors of 0.4.6: [ 'v0.4.5', 'v0.4.4', 'v0.4.3' ]
```

Without this change, `v0.4.6` would publish its own section alone and silently omit everything recorded for the three tags it stands in for. Order of landing does not matter; both orders are safe.

## Claims not being made

- Not claiming the published `0.4.5` release notes are retroactively corrected. This changes what the extractor produces from here on; a release already published is not touched.
- Not claiming anything about which tags belong in the record. This reads the record as recorded and does not decide abandonment.

Closes FIR-1812

