### PR TITLE
Qualify an empty neighborhood by the direction the traversal walked

### DIFF
--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4085,6 +4085,71 @@ mod tests {
         );
     }
 
+    /// The focal is added to the entity list only when the store actually holds
+    /// it, so an id that was never upserted yields an empty neighborhood that
+    /// says nothing about isolation. `entity_count` is the name that fact
+    /// travels under from this handler to the guard that reads it, and only an
+    /// end-to-end call pins the two together.
+    #[test]
+    fn graph_neighborhood_missing_focal_is_not_an_absence() {
+        let (store, _, _, _) = neighborhood_fixture();
+        let never_upserted = EntityId::new();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(never_upserted.to_string()),
+        );
+        let annotated = crate::finalize_with_envelope(
+            handle_graph_neighborhood(&args, &store).unwrap(),
+            structurally_ready_envelope(),
+            "graph_neighborhood",
+        );
+        let response = parsed_response(&annotated);
+        assert_eq!(response["entity_count"], 0);
+        assert_eq!(response["negative"]["kind"], "focal_not_in_graph");
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "an entity the walk never found must not be certified isolated: {}",
+            response["negative"]
+        );
+    }
+
+    /// `limit: 0` empties the emitted edge array of a neighborhood that really
+    /// has neighbors. The pre-truncation total is the only thing that can tell
+    /// a capped answer from an absence, and `relation_count` is the name it
+    /// travels under from this handler to the guard that reads it.
+    #[test]
+    fn graph_neighborhood_truncated_to_zero_is_not_an_absence() {
+        let (store, _, focal_id, _) = neighborhood_fixture();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        );
+        args.insert("limit".to_string(), serde_json::json!(0));
+        let annotated = crate::finalize_with_envelope(
+            handle_graph_neighborhood(&args, &store).unwrap(),
+            structurally_ready_envelope(),
+            "graph_neighborhood",
+        );
+        let response = parsed_response(&annotated);
+        assert!(
+            response["relations"]
+                .as_array()
+                .expect("relations must be an array")
+                .is_empty(),
+            "the caller capped the array to nothing"
+        );
+        assert_eq!(
+            response["relation_count"], 2,
+            "the pre-truncation total still reports the two real edges"
+        );
+        assert!(
+            response.get("negative").is_none(),
+            "a truncated edge array is not an absence and must not be qualified as one: {response}"
+        );
+    }
+
     /// The declared tool schema must offer the parameter the handler honors,
     /// and the description must claim the direction the traversal delivers.
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4171,10 +4171,11 @@ mod tests {
         );
     }
 
-    /// Nothing in this crate may quietly go back to the outgoing-only
-    /// traversal: `get_dependency_neighborhood` is fed only the outgoing index
-    /// in kin-db, which is what made this tool answer dependencies when it was
-    /// asked for dependents.
+    /// This file may not quietly go back to the outgoing-only traversal:
+    /// `get_dependency_neighborhood` is fed only the outgoing index in kin-db,
+    /// which is what made this tool answer dependencies when it was asked for
+    /// dependents. The scan reads this one file, so it guards the handler that
+    /// regressed rather than every call site in the crate.
     #[test]
     fn graph_neighborhood_does_not_use_the_outgoing_only_traversal() {
         // Split so this guard's own source line is not a match for itself.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2456,7 +2456,10 @@ neighborhood stays within token budgets even at depth; when you then want to rea
 specific neighbor's implementation, follow up with get_entity_source, and when you want \
 a directional ordered chain with bodies inlined, use trace_data_flow. \
 When no neighbors come back, the additive `negative` object's `safe_to_conclude_absent` \
-flag says whether \"isolated, no dependencies\" is authoritative or merely \"not indexed yet\".";
+flag says whether that absence is authoritative or merely \"not indexed yet\", and its \
+`subject` scopes the absence to the side that was walked, so an empty 'in' result is never \
+read as \"no dependencies\". A focal that is not in the graph is reported as that gap \
+rather than as an isolated entity.";
 
 /// Traverse the neighborhood around a focal entity in the requested direction.
 ///
@@ -4016,6 +4019,43 @@ mod tests {
         assert_eq!(neighborhood_names(&response), vec!["lonely"]);
         assert_eq!(response["relation_count"], 0);
         assert_eq!(response["truncated"], false);
+    }
+
+    /// The description promises that when no neighbors come back, the additive
+    /// `negative` object says whether "isolated, no dependencies" is
+    /// authoritative or merely "not indexed yet". The neighborhood always
+    /// returns the focal itself, so that promise was keyed on a list that is
+    /// never empty for an indexed entity and never arrived. Asserted end to end
+    /// through the annotation chokepoint, and on a directional walk, because an
+    /// empty `in` walk is evidence about dependents alone.
+    #[test]
+    fn graph_neighborhood_isolated_focal_carries_the_promised_negative() {
+        let store = InMemoryGraph::new();
+        let lonely = make_entity("lonely", "src/lonely.rs");
+        let lonely_id = lonely.id;
+        store.upsert_entity(&lonely).unwrap();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(lonely_id.to_string()),
+        );
+        args.insert("direction".to_string(), serde_json::json!("in"));
+        let annotated = crate::finalize_with_envelope(
+            handle_graph_neighborhood(&args, &store).unwrap(),
+            structurally_ready_envelope(),
+            "graph_neighborhood",
+        );
+        let response = parsed_response(&annotated);
+        assert_eq!(response["negative"]["kind"], "no_neighbors");
+        assert_eq!(response["negative"]["safe_to_conclude_absent"], true);
+        assert!(
+            response["negative"]["subject"]
+                .as_str()
+                .expect("the negative must carry a subject")
+                .contains("dependents"),
+            "an incoming-only walk must qualify dependents alone: {}",
+            response["negative"]
+        );
     }
 
     /// The declared tool schema must offer the parameter the handler honors,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4058,6 +4058,33 @@ mod tests {
         );
     }
 
+    /// At depth 0 the frontier is dropped before a single edge is read, so the
+    /// empty neighborhood describes the request and not the entity. The focal
+    /// here has a dependent and a dependency, and neither is looked at.
+    #[test]
+    fn graph_neighborhood_at_depth_zero_does_not_certify_isolation() {
+        let (store, _, focal_id, _) = neighborhood_fixture();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        );
+        args.insert("depth".to_string(), serde_json::json!(0));
+        let annotated = crate::finalize_with_envelope(
+            handle_graph_neighborhood(&args, &store).unwrap(),
+            structurally_ready_envelope(),
+            "graph_neighborhood",
+        );
+        let response = parsed_response(&annotated);
+        assert_eq!(response["relation_count"], 0);
+        assert_eq!(response["negative"]["kind"], "no_traversal");
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "an entity with both a caller and a callee must never be certified isolated: {}",
+            response["negative"]
+        );
+    }
+
     /// The declared tool schema must offer the parameter the handler honors,
     /// and the description must claim the direction the traversal delivers.
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -453,13 +453,13 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         {
             return None;
         }
-        if payload.get("entity_count").and_then(Value::as_u64) == Some(0) {
+        let neighborhood_gap = if payload.get("entity_count").and_then(Value::as_u64) == Some(0) {
             kind = "focal_not_in_graph";
             subject = "the focal entity is not in the graph, so no neighborhood was walked";
-            trustworthy = false;
-            trust_reason = "focal_not_in_graph: the focal entity was not found, so an empty \
-                 neighborhood is not evidence that it is isolated"
-                .to_string();
+            Some(
+                "focal_not_in_graph: the focal entity was not found, so an empty \
+                 neighborhood is not evidence that it is isolated",
+            )
         } else if payload.get("depth").and_then(Value::as_u64) == Some(0) {
             // A depth of zero expands no edges at all, so the empty result is a
             // fact about the request and not about the entity. Certifying that
@@ -468,12 +468,29 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
             kind = "no_traversal";
             subject = "no traversal was performed at depth 0, so nothing was examined \
                  about the entity's neighbors";
+            Some(
+                "depth_zero: the walk expanded no edges, so an empty neighborhood \
+                 is not evidence of isolation",
+            )
+        } else {
+            if let Some(directional) = neighborhood_absence_subject(payload) {
+                subject = directional;
+            }
+            None
+        };
+
+        // A neighborhood gap describes this request or this focal; the
+        // envelope's gap describes the substrate underneath both. When the
+        // substrate was already untrustworthy it is the reason everything looks
+        // absent, so it leads and the specific gap follows rather than being
+        // overwritten by it.
+        if let Some(gap) = neighborhood_gap {
+            trust_reason = if trustworthy {
+                gap.to_string()
+            } else {
+                format!("{trust_reason}; {gap}")
+            };
             trustworthy = false;
-            trust_reason = "depth_zero: the walk expanded no edges, so an empty neighborhood \
-                 is not evidence of isolation"
-                .to_string();
-        } else if let Some(directional) = neighborhood_absence_subject(payload) {
-            subject = directional;
         }
     }
 
@@ -1015,6 +1032,33 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("depth_zero"));
+    }
+
+    /// A degraded substrate is the reason every entity looks absent, so it is
+    /// the reason that explains the neighborhood's own. Reporting only the
+    /// specific gap would name a fact about the graph's contents where the
+    /// truth is that the graph could not be trusted to answer at all.
+    #[test]
+    fn neighborhood_gap_keeps_the_substrate_reason_beside_it() {
+        let mut env = structural_ready_envelope();
+        env.degraded = Degraded {
+            embed_worker_failed: Some(true),
+            ..Degraded::default()
+        };
+        let mut payload = neighborhood_payload("both", 0);
+        payload["entity_count"] = json!(0);
+        let negative = negative_for("graph_neighborhood", &payload, &env)
+            .expect("a focal the walk never found must still be qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("degraded"),
+            "the substrate gap that explains the absence must survive: {reason}"
+        );
+        assert!(
+            reason.contains("focal_not_in_graph"),
+            "the neighborhood's own gap must still be reported: {reason}"
+        );
     }
 
     /// `limit: 0` empties the edge array of a neighborhood that really has

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -460,6 +460,18 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
             trust_reason = "focal_not_in_graph: the focal entity was not found, so an empty \
                  neighborhood is not evidence that it is isolated"
                 .to_string();
+        } else if payload.get("depth").and_then(Value::as_u64) == Some(0) {
+            // A depth of zero expands no edges at all, so the empty result is a
+            // fact about the request and not about the entity. Certifying that
+            // as isolation would answer, from a walk that examined nothing, the
+            // question a caller asks before deleting code.
+            kind = "no_traversal";
+            subject = "no traversal was performed at depth 0, so nothing was examined \
+                 about the entity's neighbors";
+            trustworthy = false;
+            trust_reason = "depth_zero: the walk expanded no edges, so an empty neighborhood \
+                 is not evidence of isolation"
+                .to_string();
         } else if let Some(directional) = neighborhood_absence_subject(payload) {
             subject = directional;
         }
@@ -905,6 +917,7 @@ mod tests {
         json!({
             "focal_id": focal,
             "direction": direction,
+            "depth": 2,
             "entity_count": entities.len(),
             "relation_count": relations.len(),
             "entities": entities,
@@ -980,6 +993,28 @@ mod tests {
                 .contains("either direction"),
             "only a merged walk may claim both sides are empty"
         );
+    }
+
+    /// `depth: 0` expands no edges at all, so the empty result describes the
+    /// request rather than the entity. Reading it as authoritative isolation
+    /// would answer, off a walk that examined nothing, the question a caller
+    /// asks before deleting code.
+    #[test]
+    fn neighborhood_at_depth_zero_never_certifies_absence() {
+        let mut payload = neighborhood_payload("both", 0);
+        payload["depth"] = json!(0);
+        let negative = negative_for("graph_neighborhood", &payload, &structural_ready_envelope())
+            .expect("depth zero must still be qualified rather than left bare");
+        assert_eq!(negative["kind"], json!("no_traversal"));
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a walk that expanded no edges cannot certify isolation"
+        );
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("depth_zero"));
     }
 
     /// `limit: 0` empties the edge array of a neighborhood that really has

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -86,8 +86,15 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
             always: false,
             class: NegativeClass::Structural,
         },
+        // The neighborhood always returns the focal itself, so an empty
+        // `entities` says the focal is not in the graph rather than that it has
+        // no neighbors, and for an indexed entity the list is never empty at
+        // all. Every neighbor is discovered by traversing an edge, so the
+        // emitted edge set is what "no neighbors" actually reads. `subject` and
+        // `kind` here are the merged-walk defaults; [`negative_for`] narrows
+        // both to the direction the traversal was asked for.
         "graph_neighborhood" => RetrievalSpec {
-            field: "entities",
+            field: "relations",
             kind: "no_neighbors",
             subject: "the entity has no graph neighbors at the requested depth",
             always: false,
@@ -170,10 +177,37 @@ fn coverage_value(envelope: &Envelope) -> Value {
     }
 }
 
+/// What an empty neighborhood means for the side that was actually walked.
+/// Direction became a parameter when the traversal stopped being outgoing-only,
+/// and an absence inherits it: an incoming-only walk that comes back empty is
+/// evidence about dependents and says nothing about the focal's dependencies.
+/// A payload without a direction gets the unnarrowed wording rather than a
+/// guess.
+fn neighborhood_absence_subject(payload: &Value) -> Option<&'static str> {
+    match payload.get("direction").and_then(Value::as_str)? {
+        "in" => Some(
+            "the entity has no dependents at the requested depth; its dependencies were not walked",
+        ),
+        "out" => Some(
+            "the entity has no dependencies at the requested depth; its dependents were not walked",
+        ),
+        "both" => {
+            Some("the entity has no graph neighbors in either direction at the requested depth")
+        }
+        _ => None,
+    }
+}
+
 /// A human sentence spelling out "absent as-of X, coverage Y%, degraded Z" and
 /// the actionable consequence, so the negative is legible without cross-reading
-/// the envelope.
-fn build_advice(spec: &RetrievalSpec, envelope: &Envelope, trustworthy: bool) -> String {
+/// the envelope. `subject` is passed rather than read off `spec` because a tool
+/// may narrow its own framing before the advice is built.
+fn build_advice(
+    spec: &RetrievalSpec,
+    subject: &str,
+    envelope: &Envelope,
+    trustworthy: bool,
+) -> String {
     let as_of = match &envelope.graph_as_of {
         Some(value) => format!("graph as-of {value}"),
         None => "an unversioned graph snapshot".to_string(),
@@ -205,10 +239,7 @@ fn build_advice(spec: &RetrievalSpec, envelope: &Envelope, trustworthy: bool) ->
         "Absence is NOT authoritative: do not conclude the target is unused or deletable — an empty result may mean 'not indexed'. Re-check after embedding is complete and the daemon is healthy."
     };
 
-    format!(
-        "{}, against {as_of} with {coverage} and {degraded}. {consequence}",
-        spec.subject
-    )
+    format!("{subject}, against {as_of} with {coverage} and {degraded}. {consequence}")
 }
 
 /// True when `payload.focal_entity.kind` is a method — the entity kind whose
@@ -403,6 +434,37 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         }
     }
 
+    // An empty edge set has two readings with opposite consequences: a focal
+    // that is in the graph and genuinely has nothing on the side that was
+    // walked, and a focal the walk never found. Only the first is evidence
+    // about the entity — certifying the second as isolation answers a question
+    // the traversal never reached.
+    let mut kind = spec.kind;
+    let mut subject = spec.subject;
+    if tool == "graph_neighborhood" {
+        // The emitted edge array is capped by the caller's `limit`, and a
+        // `limit` of zero empties it while the walk still found neighbors. The
+        // pre-truncation total is what decides whether anything was there, so a
+        // truncated answer is never dressed up as an absence.
+        if payload
+            .get("relation_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|total| total > 0)
+        {
+            return None;
+        }
+        if payload.get("entity_count").and_then(Value::as_u64) == Some(0) {
+            kind = "focal_not_in_graph";
+            subject = "the focal entity is not in the graph, so no neighborhood was walked";
+            trustworthy = false;
+            trust_reason = "focal_not_in_graph: the focal entity was not found, so an empty \
+                 neighborhood is not evidence that it is isolated"
+                .to_string();
+        } else if let Some(directional) = neighborhood_absence_subject(payload) {
+            subject = directional;
+        }
+    }
+
     let interpretation = if spec.always {
         "qualified_verdicts"
     } else {
@@ -410,8 +472,8 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     };
 
     let mut negative = Map::new();
-    negative.insert("kind".to_string(), json!(spec.kind));
-    negative.insert("subject".to_string(), json!(spec.subject));
+    negative.insert("kind".to_string(), json!(kind));
+    negative.insert("subject".to_string(), json!(subject));
     negative.insert("result_count".to_string(), json!(count));
     negative.insert("interpretation".to_string(), json!(interpretation));
     negative.insert("safe_to_conclude_absent".to_string(), json!(trustworthy));
@@ -435,7 +497,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     );
     negative.insert(
         "advice".to_string(),
-        json!(build_advice(&spec, envelope, trustworthy)),
+        json!(build_advice(&spec, subject, envelope, trustworthy)),
     );
     Some(Value::Object(negative))
 }
@@ -828,6 +890,137 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("has_references: false"));
+    }
+
+    /// A neighborhood payload for a focal that was found, carrying `count`
+    /// neighbors reached over `count` edges in `direction`.
+    fn neighborhood_payload(direction: &str, count: usize) -> Value {
+        let focal = "00000000-0000-0000-0000-000000000001";
+        let mut entities = vec![json!({ "id": focal, "name": "focal" })];
+        let mut relations = Vec::new();
+        for index in 0..count {
+            entities.push(json!({ "id": focal, "name": format!("neighbor{index}") }));
+            relations.push(json!({ "src": focal, "dst": focal, "direction": "outgoing" }));
+        }
+        json!({
+            "focal_id": focal,
+            "direction": direction,
+            "entity_count": entities.len(),
+            "relation_count": relations.len(),
+            "entities": entities,
+            "relations": relations,
+        })
+    }
+
+    /// The neighborhood always returns the focal itself, so keying its absence
+    /// on the entity list meant the qualifier the tool's own description
+    /// promises never fired for an entity that is in the graph — the only case
+    /// an agent asks "is this really isolated?" about.
+    #[test]
+    fn neighborhood_with_no_neighbors_is_qualified() {
+        let payload = neighborhood_payload("both", 0);
+        let negative = negative_for("graph_neighborhood", &payload, &structural_ready_envelope())
+            .expect("an indexed focal with no neighbors must carry a negative");
+        assert_eq!(negative["kind"], json!("no_neighbors"));
+        assert_eq!(negative["result_count"], json!(0));
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+    }
+
+    /// One neighbor is not an absence, whichever side it sits on.
+    #[test]
+    fn neighborhood_with_a_neighbor_gets_no_negative() {
+        let payload = neighborhood_payload("both", 1);
+        assert!(
+            negative_for("graph_neighborhood", &payload, &structural_ready_envelope()).is_none()
+        );
+    }
+
+    /// Since the traversal became directional, an empty walk is empty only on
+    /// the side that was walked: an entity with forty dependencies and no
+    /// dependents must not be handed back as having no neighbors at all.
+    #[test]
+    fn neighborhood_absence_names_the_direction_that_was_walked() {
+        let dependents = neighborhood_payload("in", 0);
+        let negative = negative_for(
+            "graph_neighborhood",
+            &dependents,
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        let subject = negative["subject"].as_str().unwrap().to_string();
+        assert!(
+            subject.contains("dependents") && !subject.contains("no graph neighbors"),
+            "an incoming-only walk must claim only dependents: {subject}"
+        );
+        assert!(
+            negative["advice"].as_str().unwrap().contains("dependents"),
+            "the advice sentence carries the same framing"
+        );
+
+        let dependencies = neighborhood_payload("out", 0);
+        let negative = negative_for(
+            "graph_neighborhood",
+            &dependencies,
+            &structural_ready_envelope(),
+        )
+        .unwrap();
+        let subject = negative["subject"].as_str().unwrap().to_string();
+        assert!(
+            subject.contains("dependencies") && !subject.contains("no graph neighbors"),
+            "an outgoing-only walk must claim only dependencies: {subject}"
+        );
+
+        let both = neighborhood_payload("both", 0);
+        let negative =
+            negative_for("graph_neighborhood", &both, &structural_ready_envelope()).unwrap();
+        assert!(
+            negative["subject"]
+                .as_str()
+                .unwrap()
+                .contains("either direction"),
+            "only a merged walk may claim both sides are empty"
+        );
+    }
+
+    /// `limit: 0` empties the edge array of a neighborhood that really has
+    /// neighbors. A truncated answer is not an absence, and the pre-truncation
+    /// total is the only thing that can tell them apart.
+    #[test]
+    fn neighborhood_truncated_to_nothing_is_not_an_absence() {
+        let mut payload = neighborhood_payload("both", 3);
+        payload["entities"] = json!([]);
+        payload["relations"] = json!([]);
+        assert!(
+            negative_for("graph_neighborhood", &payload, &structural_ready_envelope()).is_none(),
+            "a walk that found three edges must not report an absence when the caller capped the output"
+        );
+    }
+
+    /// A focal that is not in the graph produces the same empty edge set as an
+    /// isolated one. Certifying that as authoritative isolation answers a
+    /// question the walk never reached, so report the gap instead.
+    #[test]
+    fn neighborhood_absent_focal_is_a_gap_not_certified_isolation() {
+        let payload = json!({
+            "focal_id": "00000000-0000-0000-0000-000000000001",
+            "direction": "both",
+            "entity_count": 0,
+            "relation_count": 0,
+            "entities": [],
+            "relations": [],
+        });
+        let negative = negative_for("graph_neighborhood", &payload, &structural_ready_envelope())
+            .expect("a missing focal must still be qualified");
+        assert_eq!(negative["kind"], json!("focal_not_in_graph"));
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a graph that never held the focal cannot certify that it is isolated"
+        );
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("focal_not_in_graph"));
     }
 
     #[test]


### PR DESCRIPTION
## What was already true

The direction defect this ticket names was fixed in #487: `handle_graph_neighborhood`
now walks `get_all_relations_for_entity`, which reads kin-db's outgoing *and* incoming
adjacency indexes, honors `direction` of `out` / `in` / `both`, and tags every returned
edge with the direction it was traversed in. A source-level guard test refuses any
reintroduction of the outgoing-only `get_dependency_neighborhood` call in that crate.

I re-proved that rather than taking it on trust. Forcing the traversal back to
outgoing-only (`want_incoming = false`) turns four tests red, including the dependent
that a change to the focal can break going missing from the default neighborhood.

## What was still wrong

Fixing the traversal gave the tool a direction axis that its absence contract never
learned about, and left one promise the code never kept.

The tool description states that when no neighbors come back, the additive `negative`
object says whether "isolated, no dependencies" is authoritative or merely "not indexed
yet". That promise was keyed on the `entities` array. The neighborhood always returns
the focal itself, so for an entity that is in the graph the array is never empty and the
qualifier never fired. An agent asking "is this really isolated?" got a bare empty
neighbor list with nothing attached.

The single case where the array *was* empty is a focal the walk never found, and there
the negative asserted "the entity has no graph neighbors at the requested depth". That
certifies isolation for an entity the traversal never reached.

And with direction now a parameter, an absence is only an absence on the side that was
walked. An entity with forty dependencies and no dependents came back described as
having no graph neighbors at all.

## Mechanism

Key the absence on the traversed edge set. A neighbor is only ever discovered by
traversing an edge, and that edge is emitted, so an empty edge set is exactly "no
neighbors" while an empty entity list is a different fact.

- The pre-truncation `relation_count` decides emptiness, so a caller passing `limit: 0`
  empties the array without the response being read as an absence.
- A focal that is not in the graph reports `kind: "focal_not_in_graph"` and is forced
  inconclusive, so a graph that never held the entity cannot certify that it is isolated.
- The subject names the side walked. An `in` walk that comes back empty claims dependents
  alone and says so, an `out` walk claims dependencies alone, and only a merged walk
  claims both sides are empty. The advice sentence inherits the same framing.
- The tool description is updated to match what the negative now says.

`build_advice` takes the subject explicitly rather than reading it off the spec, since a
tool may narrow its own framing before the advice is built.

## Evidence

Falsification log: the new absence tests were run red against this same head before the
fix, and the direction tests were run red against a deliberately reverted traversal.

- Probe A, traversal forced back to outgoing-only: 4 failed, 7 passed. The default
  neighborhood returned `["callee", "focal"]` where the dependent `caller` belongs.
- Probe B, landed traversal plus the new tests, fix not yet applied: direction tests
  green, 4 absence tests red. End to end the `negative` key was `Null` for an isolated
  indexed focal, and a missing focal reported `no_neighbors` instead of the graph gap.
- After the fix: 15 passed, 0 failed. The fix round below added three tests to this
  filtered set, so the same probe reads 18 passed, 0 failed at the current head.

Gates at head bb43dac7, all under `RUSTFLAGS=-D warnings`:

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --all-targets --all-features` with the ci.yml allowlist rc=0
- `cargo build --all-targets --locked` rc=0
- `cargo nextest run --workspace` rc=0, 4671 passed, 10 skipped
- `cargo test --doc --workspace` rc=0

The test phase ran under the `daemon` lane lock, released immediately after. The figures
in this section were re-taken at the current head and supersede the earlier ones from
`0720f291`.

## Fix round after review

Review of `0720f291` returned CONDITIONAL-GO with one P1. That P1 and both P2s are fixed
here, plus one P3.

**P1. `depth: 0` certified an absence from a walk that traversed nothing.** The change
above guards a caller-supplied `limit: 0`, which empties the emitted array while the walk
really found neighbors. It did not guard `depth: 0`, which is the stronger case, because
there the frontier is dropped before a single relation is read. `depth` is declared as a
bare integer with no minimum and `get_optional_u64` passes zero straight through, so an
agent could ask for a zero-depth neighborhood of an entity with forty dependents and be
handed `safe_to_conclude_absent: true` with advice ending "safe to treat the target as
genuinely absent/unused". Depth zero is now its own kind, `no_traversal`, forced
inconclusive, so the advice sentence flips to "Absence is NOT authoritative". This was
newly reachable through the absence re-keying above, so it never existed on main.

**P2. The substrate gap is no longer overwritten by the neighborhood's own reason.** When
the daemon reports a degraded signal or answers from the offline fallback, every entity
looks absent, and that is why an empty neighborhood came back at all. Assigning the
neighborhood's reason unconditionally discarded it, so a probe run mid-ingest was told the
focal entity was not found when the truth was that the graph had not finished loading. The
envelope's reason now leads and the specific one follows.

**P2. The absence counts are pinned to the handler that emits them.** `relation_count` and
`entity_count` are read out of a payload built by string key, with nothing in the type
system coupling the two, and every unit test built those keys itself. Renaming either one
in the handler left the suite green while the guard silently stopped firing. Two end-to-end
calls through `finalize_with_envelope` now cover them, one for a focal that was never
upserted and one for a neighborhood capped to nothing. Both renames were run as mutations
and both now go red.

**P3. The traversal guard states the reach it has.** Its comment claimed the whole crate
while the body is `include_str!("entities.rs")` and scans one file.

## Scope note

This closes the defect in the ticket title and the fix it prescribes. The secondary
0-indexed line-number finding recorded in the same ticket body is carried by FIR-1662
and is not touched here. Strike the closing keyword if that half should keep this ticket
open.

Closes FIR-1595

