### PR TITLE
Bind the MCP commit precondition to the authority revision it plans against

### DIFF
--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -153,8 +153,10 @@ impl ActiveLocalRepositoryAuthority {
 /// same authority generation, it holds no exact tree state authority has not
 /// admitted, and it has neither dropped nor rewritten any entity or relation
 /// that authority owns. Because a derived lead is permitted, every caller must
-/// plan its daemon-side transition from the live graph via
-/// [`plan_daemon_semantic_delta`] rather than reusing the authority-side delta.
+/// plan its daemon-side transition from the live graph rather than reusing the
+/// authority-side delta: repository commands do that through
+/// [`plan_daemon_semantic_delta`], and the exact MCP commit path does it through
+/// its own post-commit live-to-authority correction.
 pub(crate) fn require_fresh_daemon_workspace(
     state: &DaemonState,
     roots: &RootBundle,
@@ -164,8 +166,8 @@ pub(crate) fn require_fresh_daemon_workspace(
     let daemon_generation = state.snapshot_generation.load(Ordering::SeqCst);
     if daemon_generation != roots.generation {
         bail!(
-            "daemon repository cursor is at generation {daemon_generation}, but {operation} \
-             authority is at generation {}; reopen from repository authority before mutating",
+            "daemon repository cursor is at generation {daemon_generation}, but the authority for \
+             {operation} is at generation {}; reopen from repository authority before mutating",
             roots.generation
         );
     }

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -25,7 +25,9 @@ use kin_model::{
 };
 use sha2::{Digest, Sha256};
 
-use crate::local_repository_authority::LocalRepositoryAuthorityContext;
+use crate::local_repository_authority::{
+    require_fresh_daemon_workspace, LocalRepositoryAuthorityContext,
+};
 use crate::repository_commit::{
     commit_native_plan_with_projection, load_native_commit_base, load_native_source_blob,
     plan_native_commit_from_base, recover_native_commit, NativeCommitBase, NativeCommitResult,
@@ -193,7 +195,7 @@ fn commit_exact_transaction_inner(
 
     let base = load_native_commit_base(&authority_context)
         .map_err(|error| format!("load exact MCP commit base: {error}"))?;
-    require_live_graph_matches_authority(state.graph.as_ref(), &base.graph)?;
+    require_bound_authority_revision(state, &base, &transaction_id)?;
     let plan = match plan_exact_transaction(
         state,
         &authority_context,
@@ -662,17 +664,50 @@ fn persist_registry_checked(
         .map_err(|error| error.to_string())
 }
 
-fn require_live_graph_matches_authority(
-    live: &kin_db::InMemoryGraph,
-    authority: &kin_db::InMemoryGraph,
+/// Refuse an exact MCP commit unless the daemon is still bound to the authority
+/// revision this attempt is being planned against.
+///
+/// This is deliberately not a live-graph-equals-authority check. That invariant
+/// is unachievable by design: the reconcile loop publishes only the tree through
+/// the repository compare-and-swap and leaves parser semantics in the live
+/// graph, and the asynchronous LSP enrichment worker writes relations into the
+/// live graph outside the coordination gate. Both reach authority only when a
+/// change is committed, so equality held for a moment after each commit and then
+/// failed at the next enrichment tick, refusing every legitimate agent commit
+/// that followed one.
+///
+/// Equality was never what kept derived enrichment out of the published change
+/// either. [`plan_exact_transaction`] builds its prospective graph from
+/// `base.graph`, which is repository authority, and applies only the staged
+/// operations, so a derived lead in the live graph cannot reach publication no
+/// matter what this precondition says. The live graph matters after the commit
+/// instead, because [`install_authority_graph`] corrects it onto authority from
+/// the live side.
+///
+/// So what must hold is the binding, not the equality: the daemon is at the same
+/// authority generation this plan is loading, it holds no exact tree state
+/// authority has not admitted, and it has neither dropped nor rewritten anything
+/// that generation owns. That is exactly the boundary every other repository
+/// command is held to, and reusing it keeps one definition of freshness across
+/// them rather than a second, stricter one that only the MCP path can fail.
+fn require_bound_authority_revision(
+    state: &DaemonState,
+    base: &NativeCommitBase,
+    transaction_id: &str,
 ) -> Result<(), String> {
-    if semantic_workspace_matches(live, authority) {
-        return Ok(());
-    }
-    Err(
-        "daemon query graph does not match the clean repository workspace authority; refusing to absorb an unrelated dirty overlay into the MCP commit"
-            .to_string(),
+    require_fresh_daemon_workspace(
+        state,
+        &base.roots,
+        &base.graph.to_snapshot(),
+        "committing an MCP transaction",
     )
+    .map_err(|error| {
+        format!(
+            "Cannot commit transaction {transaction_id}: {error}. No repository authority moved \
+             and the staged operations are untouched, so re-send this commit unchanged once the \
+             daemon is reading current repository authority."
+        )
+    })
 }
 
 fn semantic_workspace_matches(left: &kin_db::InMemoryGraph, right: &kin_db::InMemoryGraph) -> bool {
@@ -4238,5 +4273,296 @@ mod tests {
             &authority.graph
         ));
         drop(dir);
+    }
+
+    /// Find the derived entity an enrichment tick installed into the live graph.
+    fn live_enrichment_entity(state: &Arc<DaemonState>) -> Entity {
+        state
+            .graph
+            .to_snapshot()
+            .entities
+            .values()
+            .find(|entity| entity.name == "enriched_inside_the_command_window")
+            .cloned()
+            .expect("the enrichment tick installs its anchor entity into the live graph")
+    }
+
+    /// The precondition must accept the state an ordinary agent session is
+    /// actually in.
+    ///
+    /// The enrichment worker publishes into the live query graph continuously
+    /// and those facets cross the repository compare-and-swap only when a change
+    /// is committed, so a live graph that leads authority is the normal case
+    /// between commits, not a corrupt one. A precondition demanding equality
+    /// refuses here, which is the wedge: it holds for a moment after each commit
+    /// and then fails at the next tick.
+    ///
+    /// Accepting it costs nothing, because the exact planner reads its
+    /// prospective graph from repository authority and applies only the staged
+    /// operations. This proves both halves: the commit succeeds, and the derived
+    /// lead it committed over is absent from the published authority graph.
+    #[test]
+    fn a_commit_after_an_enrichment_tick_publishes_only_its_staged_operations() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        assert!(
+            semantic_workspace_matches(state.graph.as_ref(), &before.graph),
+            "the fixture must start from a daemon that matches authority, or this test cannot \
+             prove the enrichment tick is what the old precondition refused"
+        );
+
+        state.install_derived_enrichment();
+        let derived = live_enrichment_entity(&state);
+        let derived_relations: Vec<_> = state
+            .graph
+            .to_snapshot()
+            .relations
+            .iter()
+            .filter(|(_, relation)| relation.origin == RelationOrigin::Lsp)
+            .map(|(id, _)| *id)
+            .collect();
+        assert!(
+            !derived_relations.is_empty(),
+            "the enrichment tick must install at least one derived relation"
+        );
+        assert!(
+            !semantic_workspace_matches(state.graph.as_ref(), &before.graph),
+            "the enrichment tick must actually put the live graph ahead of authority, or this \
+             test passes without reproducing the refusal it exists to falsify"
+        );
+
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a commit issued after an enrichment tick must not be refused: {}",
+            result_text(&result)
+        );
+        assert_eq!(
+            sessions.get_transaction(&transaction_id).unwrap().state,
+            "committed"
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(after.roots.generation, before.roots.generation + 1);
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n"
+        );
+        let published = after.graph.to_snapshot();
+        assert!(
+            !published.entities.contains_key(&derived.id),
+            "the published change must carry only the staged operations; the derived enrichment \
+             entity reached repository authority"
+        );
+        for relation_id in &derived_relations {
+            assert!(
+                !published.relations.contains_key(relation_id),
+                "derived relation {relation_id} reached repository authority"
+            );
+        }
+        let reparsed = after.graph.get_entity(&entity.id).unwrap().unwrap();
+        assert_ne!(
+            reparsed.fingerprint, entity.fingerprint,
+            "the staged body edit must still be what this commit published"
+        );
+    }
+
+    /// Enrich the live graph the way the LSP worker actually does: one relation
+    /// on an entity repository authority already owns, upserted under nothing
+    /// but the graph-authority epoch.
+    ///
+    /// `DaemonState::install_derived_enrichment` also adds an anchor entity, so
+    /// it diverges both domains at once. The real worker only ever adds
+    /// relations, which is the divergence an ordinary session actually carries
+    /// between commits, and it is the narrower case to prove.
+    fn install_lsp_relation_on(state: &Arc<DaemonState>, entity: &Entity) -> Relation {
+        let relation = Relation {
+            id: kin_model::RelationId::new(),
+            kind: kin_model::RelationKind::Calls,
+            src: GraphNodeId::Entity(entity.id),
+            dst: GraphNodeId::Entity(entity.id),
+            confidence: 0.95,
+            origin: RelationOrigin::Lsp,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+        let guard = state.begin_graph_authority_mutation();
+        state.graph.upsert_relation(&relation).unwrap();
+        state.bump_version();
+        drop(guard);
+        relation
+    }
+
+    /// The same acceptance as the enrichment-tick case, in the exact shape the
+    /// LSP worker writes: relations only, on entities authority already owns.
+    #[test]
+    fn a_commit_after_an_lsp_relation_tick_publishes_only_its_staged_operations() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        assert!(semantic_workspace_matches(
+            state.graph.as_ref(),
+            &before.graph
+        ));
+
+        let derived = install_lsp_relation_on(&state, &entity);
+        assert!(
+            !semantic_workspace_matches(state.graph.as_ref(), &before.graph),
+            "an LSP relation tick must put the live graph ahead of authority, or this test \
+             proves nothing about the refusal it exists to falsify"
+        );
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a commit issued after an LSP relation tick must not be refused: {}",
+            result_text(&result)
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(after.roots.generation, before.roots.generation + 1);
+        assert!(
+            !after
+                .graph
+                .to_snapshot()
+                .relations
+                .contains_key(&derived.id),
+            "the derived LSP relation must not be absorbed into the published change"
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n"
+        );
+    }
+
+    /// The binding this precondition protects is the authority revision, so a
+    /// daemon reading an older revision than the one being planned against must
+    /// still be refused, and the refusal must name that revision gap.
+    #[test]
+    fn a_commit_planned_against_a_trailing_daemon_cursor_is_refused() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let live_before = state.graph.compute_root_hash();
+        assert!(
+            before.roots.generation > 0,
+            "the fixture must have published at least one generation to trail"
+        );
+        let stale_generation = before.roots.generation - 1;
+        state
+            .snapshot_generation
+            .store(stale_generation, Ordering::SeqCst);
+
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+
+        assert_eq!(result.is_error, Some(true));
+        let message = result_text(&result);
+        assert!(
+            message.contains(&format!("cursor is at generation {stale_generation}"))
+                && message.contains(&format!("is at generation {}", before.roots.generation)),
+            "the refusal must name both sides of the stale revision binding: {message}"
+        );
+        assert!(
+            message.contains("reopen from repository authority"),
+            "the refusal must say what to do: {message}"
+        );
+        assert_eq!(
+            sessions.get_transaction(&transaction_id).unwrap().state,
+            "active",
+            "a refused precondition must leave the staged operations re-sendable"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "no repository authority may move behind a refused precondition"
+        );
+        assert_eq!(state.graph.compute_root_hash(), live_before);
+    }
+
+    /// A derived lead is permitted, a derived loss is not. A daemon that has
+    /// dropped semantics repository authority owns is answering from something
+    /// other than graph truth, and the post-commit correction would be computed
+    /// from that gap, so the commit must be refused and the refusal must name
+    /// what went missing.
+    #[test]
+    fn a_commit_from_a_daemon_missing_authority_owned_semantics_is_refused() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let authority_owned = before
+            .graph
+            .to_snapshot()
+            .entities
+            .values()
+            .find(|candidate| candidate.id == entity.id)
+            .cloned()
+            .expect("the fixture entity is owned by repository authority");
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: vec![EntityDelta::Removed {
+                    old: authority_owned.clone(),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+
+        assert_eq!(result.is_error, Some(true));
+        let message = result_text(&result);
+        assert!(
+            message.contains("no longer holds the repository workspace authority")
+                && message.contains(&format!("entity {} is missing", entity.id)),
+            "the refusal must name the authority-owned semantics that went missing: {message}"
+        );
+        assert!(
+            message.contains("reopen before committing an MCP transaction"),
+            "the refusal must say what to do: {message}"
+        );
+        assert_eq!(
+            sessions.get_transaction(&transaction_id).unwrap().state,
+            "active"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout).unwrap().roots,
+            before.roots,
+            "no repository authority may move behind a refused precondition"
+        );
     }
 }


### PR DESCRIPTION
## The precondition semantics, and the ruling behind them

The exact MCP commit path gated every transaction on the daemon's live query
graph being byte-equal to the clean workspace authority it had just loaded, over
`entities`, `relations`, and `resolved_tree`.

That invariant is unachievable by design, and this PR proceeds from that as a
settled ruling rather than reopening it. The daemon's query graph legitimately
leads durable authority: the reconcile loop publishes only the tree through the
repository compare-and-swap and leaves parser semantics in the live graph, and
the asynchronous LSP enrichment worker upserts relations into the live graph
under nothing but the graph-authority epoch (`kin-daemon/src/daemon.rs:680`,
holding neither `coordination_gate` nor the persistence lock). Both reach
authority only when a change is committed. So the precondition held for a moment
after each commit and then failed at the next enrichment tick, refusing ordinary
agent commits with a message about absorbing an unrelated dirty overlay.

**Equality was never what kept derived enrichment out of the published change.**
`plan_exact_transaction` builds its prospective graph from `base.graph`, which is
repository authority, and applies only the staged operations before
`plan_native_commit_from_base`. A derived lead in the live graph cannot reach
publication regardless of what the precondition says. The guard's stated purpose
was already served by the planner.

What the commit does depend on is the *binding*, which the old guard never
checked. The live graph matters after the commit, because `install_authority_graph`
computes `transaction_delta_between(live, authority)` and corrects the daemon
graph from the live side. For that correction to mean anything, three properties
must hold at plan time:

1. the daemon is at the same authority generation this plan is loading,
2. it holds no exact tree state authority has not admitted,
3. it has neither dropped nor rewritten anything that generation owns.

A derived *lead* is fine. A derived *loss* is not.

That is exactly `require_fresh_daemon_workspace`, the boundary checkout, branch,
merge, and rollback already answer to. The MCP path now shares it rather than
carrying a second, stricter definition of freshness that only it could fail.
`NativeCommitBase` already carried `roots: RootBundle`, so binding the revision
needed no new plumbing.

The post-commit sites are unchanged, as predicted: `semantic_workspace_matches`
survives for no-op detection (both sides authority-derived) and for the
post-correction assertion.

## Why reusing that boundary is sound here

`state.snapshot_generation` is the repository authority roots generation on this
path. It is initialized from `lease.roots().generation` (`state.rs:1833`) and
advanced only by `record_repository_authority_commit`. The two sites that store a
*backend* generation instead (`state.rs:4004`, `4045`) are both inside the
`storage_backend.is_some()` branch, and `commit_exact_transaction_inner` returns
early for storage-backend daemons. `state.rs:4084-4090` states the same
invariant in its own words.

## Refusals now name the binding and the exit

Each refusal is wrapped with the transaction id and `No repository authority
moved and the staged operations are untouched, so re-send this commit unchanged
once the daemon is reading current repository authority.` That is verified, not
asserted: the precondition sits strictly before `prepare_transaction_commit` and
does not route through `unstage_failed_attempt`, so the staged set survives, and
the tests check the transaction is still `active` after each refusal.

One shared message was reworded. `require_fresh_daemon_workspace` interpolated
its gerund operation phrase as `but {operation} authority is at generation`,
which reads as "but checking out a path authority is at generation N" for every
existing caller. It now reads `but the authority for {operation} is at
generation`. No test asserted the old wording.

## Evidence

Four tests added to `mcp_commit::tests`, run red against the old precondition and
green against the new one.

RED, old precondition, tests unchanged:

```
test result: FAILED. 33 passed; 3 failed; 0 ignored; 578 filtered out
  a_commit_after_an_enrichment_tick_publishes_only_its_staged_operations
  a_commit_from_a_daemon_missing_authority_owned_semantics_is_refused
  a_commit_planned_against_a_trailing_daemon_cursor_is_refused
```

Two things that run made visible:

- The old guard returned the **identical** message for the legitimate
  post-enrichment commit and for the genuine authority-loss case. It could not
  distinguish them, which is why it wedged sessions instead of protecting them.
- The trailing-cursor case *succeeded* under the old guard, because it never
  inspected the authority revision at all. Stated precisely: that is a
  constructed case, not a live hole, since real external authority movement would
  also diverge the graph and trip the equality check with a misleading message.
  The claim is that the old guard had no revision binding, not that a soundness
  hole was being exploited.

GREEN, reworked precondition: `test result: ok. 37 passed; 0 failed`.

The guards are non-vacuous by construction. Both acceptance tests assert the live
graph matches authority *before* the tick and diverges *after* it, so a test that
stopped reproducing the divergence fails rather than passing silently.

Gates at final head (`RUSTFLAGS=-D warnings` throughout):

| gate | rc |
| --- | --- |
| `cargo fmt -- --check` | 0 |
| clippy, ci.yml allowlist, `--all-targets --all-features` | 0 |
| `cargo build --all-targets --locked` | 0 |
| `scripts/check_runtime_boundaries.sh` | 0 |
| `cargo nextest run --workspace` | not run (daemon lock) |
| `cargo test --doc` | not run (daemon lock) |
| `cargo test --workspace` (the authority) | not run (daemon lock) |

The three workspace test gates are queued behind another lane's daemon lock and
will be reported here when they land. The focused `mcp_commit` module suite is
green at this head (37 passed, 0 failed).

## What this does not claim

No live-daemon acceptance was run. FIR-1633 asks for one on the grounds that
in-process coverage does not reproduce enrichment timing; these tests instead
place the tick deterministically at the point that matters, in the exact write
shape the worker uses. That is a deviation from the written acceptance, so this
PR references FIR-1633 without a closing keyword and leaves the call to review.

Worth recording for whoever builds that live reproducer, because it narrows the
work: the enrichment worker is the only reachable source of this divergence, so
the reproducer needs rust-analyzer and not merely a live daemon. The other
divergence source, parser semantics left behind by reconcile, cannot reach this
precondition, because divergent parser semantics imply changed bytes, changed
bytes move the exact tree, and a moved tree makes the workspace dirty, which
`load_native_commit_base` refuses one step earlier.

The LSP worker's missing `coordination_gate` is not fixed here. A relation upsert
can still interleave with commit finalization. The reworked precondition
tolerates the resulting lead by design, but it does not serialize the writer.

FIR-1611 was assessed as a possible dependency and is not one, so nothing here
closes it. It binds storage namespace identity; this binds authority revision.
Two findings from that assessment are worth recording, because the second
changes what FIR-1611 is waiting on:

- The mislabeling is still live on main. `revalidate_pinned_local_namespace`
  rides `load_snapshot_authority(...)?` wholesale and `open_bound` maps all of
  its errors to `Identity`, so a missing `.lock` or a truncated snapshot on an
  intact namespace is answered as a replaced repository.
- It is **not** blocked on a kin-db API. The pinned `kin-db = "=0.7.8"` already
  exposes `LocalFileBackend::probe_pinned_repository_namespace` returning a typed
  `LocalNamespaceProbe`, documented to take no lock and decode no snapshot, which
  covers the single-load-bind item too. The kin-side consumer already exists as
  **PR 471**, whose own body gates it on "kin-db 0.6.5 publishing". That gate
  lifted long ago: 471 bumps kin-db to 0.6.6 while main is on 0.7.8. FIR-1611 is
  waiting on a rebase of PR 471, not on a design or a kin-db mint.

PR 471 also edits `crates/kin-daemon/src/local_repository_authority.rs`, in a
different region than this PR does. PR 562 edits `crates/kin-daemon/src/mcp_commit.rs`,
in an unrelated `kin history` test. Neither looks like a textual conflict, but
they are the same files, so they should not be batched on an assumption of
independence.

