### PR TITLE
Let only reviewed required checks veto a release, and make a blocked one visible

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -289,24 +289,26 @@ jobs:
           set -euo pipefail
           # Advice given before classification is wrong in the direction that
           # costs most. Rerunning is right for the transient failures this
-          # controller exists for and useless for a deterministic one: a
-          # lockfile pinning a dependency that cannot compile for a release
-          # target fails identically on every attempt, and the recovery is a
-          # recut against fixed dependencies rather than another run. Telling
-          # an operator to rerun that is telling them to wait for nothing.
+          # controller exists for and useless for a confirmed source-bound one:
+          # a lockfile pinning a dependency that cannot compile for a release
+          # target needs a recut against fixed dependencies. The controller can
+          # identify a repeated failure surface, but only logs and source
+          # diagnosis can establish that root cause.
           #
           # The signature is the whole set of failing job and step pairs per
-          # attempt. It is deliberately not the error text: step identity is
-          # cheap, needs no log download, and is what actually separated the
-          # two cases.
+          # attempt. It is deliberately not called root-cause proof: step
+          # identity is cheap and needs no log download, but a persistent
+          # registry or notarization outage can repeat at the same step too.
+          # A repeated signature changes the immediate recommendation and tells
+          # the operator where to start; the logs still decide rerun versus recut.
           #
           # The set is sorted and joined rather than reduced to its first
           # element. The jobs API returns jobs in job-id order, ids are minted
           # at queue time, and parallel matrix legs queue in a different order
           # on each attempt, so the first failing job of a matrix failure is a
           # coin flip. Taking it would report three identical failures of the
-          # same step as three different ones and advise a rerun that cannot
-          # work, which is the exact advice this classifier exists to stop.
+          # same step as three different ones and recommend another immediate
+          # rerun without surfacing the repeated shape.
           #
           # Pages are slurped and filtered in one pass. `--paginate` with an
           # inline query applies the query per page, which would emit one line
@@ -345,22 +347,30 @@ jobs:
           distinct="$(sort -u "$signatures" | wc -l | tr -d ' ')"
           failing_steps="$(head -1 "$signatures")"
           if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] && [ "$distinct" -eq 1 ]; then
-            verdict="deterministic"
-            advice="Every attempt failed at the same step, so a rerun cannot reach a different outcome. Recovery is a version recut against fixed dependencies, not another run of this release."
+            verdict="repeated failure signature"
+            advice="Every observed attempt failed in the same job and step set, so another immediate rerun is unlikely to help. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
+          elif [ "$unknown" -ne 0 ]; then
+            verdict="indeterminate"
+            advice="At least one attempt could not be read or carried no concrete failed step, so neither a deterministic nor a transient cause is established. Inspect the unrecorded attempts before choosing a same-release rerun or a source-fixed recut."
           else
-            verdict="not proven deterministic"
-            advice="The attempts did not fail identically, which is the transient shape this controller exists for. Diagnose and rerun the same release rather than cutting a newer version."
+            verdict="varying failure signatures"
+            advice="The observed failing job and step sets differed, which is consistent with the transient shape this controller exists for. Diagnose and rerun the same release rather than cutting a newer version unless the logs identify a source-bound defect."
           fi
 
           # A mint that reported failure on a release it had already created
           # would otherwise send this controller to repair a healthy release,
           # so say what actually exists before advising anything.
-          if release="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>/dev/null)"; then
+          release_error="$(mktemp)"
+          if release="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>"$release_error")"; then
             assets="$(jq '.assets | length' <<< "$release")"
             draft="$(jq -r '.draft' <<< "$release")"
-            release_state="A GitHub Release for \`${TAG}\` already exists with ${assets} asset(s), draft=${draft}. Confirm it is genuinely incomplete before repairing it."
-          else
+            prerelease="$(jq -r '.prerelease' <<< "$release")"
+            release_state="A GitHub Release for \`${TAG}\` already exists with ${assets} asset(s), draft=${draft}, prerelease=${prerelease}. Confirm it is genuinely incomplete before repairing it."
+          elif grep -Eq '\(HTTP 404\)' "$release_error"; then
             release_state="No GitHub Release object exists for \`${TAG}\`."
+          else
+            release_reason="$(tr -d '\r' < "$release_error" | tail -n 1)"
+            release_state="GitHub Release state for \`${TAG}\` could not be read (${release_reason:-unknown API error}). Do not infer that the Release is absent; inspect it before repairing anything."
           fi
 
           title="Release blocked after automatic retries: ${TAG}"

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -295,22 +295,39 @@ jobs:
           # recut against fixed dependencies rather than another run. Telling
           # an operator to rerun that is telling them to wait for nothing.
           #
-          # The signature is the failing job and step per attempt. It is
-          # deliberately not the error text: step identity is cheap, needs no
-          # log download, and is what actually separated the two cases.
+          # The signature is the whole set of failing job and step pairs per
+          # attempt. It is deliberately not the error text: step identity is
+          # cheap, needs no log download, and is what actually separated the
+          # two cases.
+          #
+          # The set is sorted and joined rather than reduced to its first
+          # element. The jobs API returns jobs in job-id order, ids are minted
+          # at queue time, and parallel matrix legs queue in a different order
+          # on each attempt, so the first failing job of a matrix failure is a
+          # coin flip. Taking it would report three identical failures of the
+          # same step as three different ones and advise a rerun that cannot
+          # work, which is the exact advice this classifier exists to stop.
+          #
+          # Pages are slurped and filtered in one pass. `--paginate` with an
+          # inline query applies the query per page, which would emit one line
+          # per page and break the one-line-per-attempt mapping below.
           signatures="$(mktemp)"
           unknown=0
           for attempt in $(seq 1 "$ATTEMPTS"); do
-            if ! signature="$(gh api \
-              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs" \
-              -q '[ .jobs[]
-                    | select(.conclusion == "failure")
-                    | { job: .name,
-                        step: ( .steps[]?
-                                | select(.conclusion == "failure")
-                                | .name ) }
-                    | "\(.job) / \(.step)"
-                  ] | first // ""' 2>/dev/null)"; then
+            if attempt_jobs="$(gh api --paginate --slurp \
+              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs?per_page=100" \
+              2>/dev/null)"; then
+              signature="$(jq -r '
+                [ .[].jobs[]
+                  | select(.conclusion == "failure")
+                  | { job: .name,
+                      step: ( .steps[]?
+                              | select(.conclusion == "failure")
+                              | .name ) }
+                  | "\(.job) / \(.step)"
+                ] | unique | join("; ")' <<< "$attempt_jobs" 2>/dev/null)" \
+                || signature=""
+            else
               signature=""
             fi
             if [ -z "$signature" ]; then
@@ -326,7 +343,7 @@ jobs:
             printf '%s\n' "$signature" >> "$signatures"
           done
           distinct="$(sort -u "$signatures" | wc -l | tr -d ' ')"
-          first_signature="$(head -1 "$signatures")"
+          failing_steps="$(head -1 "$signatures")"
           if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] && [ "$distinct" -eq 1 ]; then
             verdict="deterministic"
             advice="Every attempt failed at the same step, so a rerun cannot reach a different outcome. Recovery is a version recut against fixed dependencies, not another run of this release."
@@ -376,5 +393,5 @@ jobs:
               --body-file "$body" \
               >/dev/null
           fi
-          echo "::error::${TAG} exhausted its automatic retries after ${ATTEMPTS} attempt(s), ${verdict}, first failing step: ${first_signature}: ${RUN_URL}"
+          echo "::error::${TAG} exhausted its automatic retries after ${ATTEMPTS} attempt(s), ${verdict}, failing steps: ${failing_steps}: ${RUN_URL}"
           exit 1

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -284,8 +284,68 @@ jobs:
           SHA: ${{ steps.resolve.outputs.sha }}
           RUN_ID: ${{ steps.resolve.outputs.run_id }}
           RUN_URL: ${{ steps.resolve.outputs.url }}
+          ATTEMPTS: ${{ steps.resolve.outputs.attempt }}
         run: |
           set -euo pipefail
+          # Advice given before classification is wrong in the direction that
+          # costs most. Rerunning is right for the transient failures this
+          # controller exists for and useless for a deterministic one: a
+          # lockfile pinning a dependency that cannot compile for a release
+          # target fails identically on every attempt, and the recovery is a
+          # recut against fixed dependencies rather than another run. Telling
+          # an operator to rerun that is telling them to wait for nothing.
+          #
+          # The signature is the failing job and step per attempt. It is
+          # deliberately not the error text: step identity is cheap, needs no
+          # log download, and is what actually separated the two cases.
+          signatures="$(mktemp)"
+          unknown=0
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            if ! signature="$(gh api \
+              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs" \
+              -q '[ .jobs[]
+                    | select(.conclusion == "failure")
+                    | { job: .name,
+                        step: ( .steps[]?
+                                | select(.conclusion == "failure")
+                                | .name ) }
+                    | "\(.job) / \(.step)"
+                  ] | first // ""' 2>/dev/null)"; then
+              signature=""
+            fi
+            if [ -z "$signature" ]; then
+              unknown=$((unknown + 1))
+              # Deliberately constant rather than attempt-numbered. A numbered
+              # placeholder would make unreadable attempts differ from each
+              # other, so the distinct-signature count alone would reject them
+              # and the unknown count below would never be what decided it. The
+              # guard against classifying an unreadable run has to be the one
+              # doing the work, not a spare wheel behind an accident of text.
+              signature="unrecorded"
+            fi
+            printf '%s\n' "$signature" >> "$signatures"
+          done
+          distinct="$(sort -u "$signatures" | wc -l | tr -d ' ')"
+          first_signature="$(head -1 "$signatures")"
+          if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] && [ "$distinct" -eq 1 ]; then
+            verdict="deterministic"
+            advice="Every attempt failed at the same step, so a rerun cannot reach a different outcome. Recovery is a version recut against fixed dependencies, not another run of this release."
+          else
+            verdict="not proven deterministic"
+            advice="The attempts did not fail identically, which is the transient shape this controller exists for. Diagnose and rerun the same release rather than cutting a newer version."
+          fi
+
+          # A mint that reported failure on a release it had already created
+          # would otherwise send this controller to repair a healthy release,
+          # so say what actually exists before advising anything.
+          if release="$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>/dev/null)"; then
+            assets="$(jq '.assets | length' <<< "$release")"
+            draft="$(jq -r '.draft' <<< "$release")"
+            release_state="A GitHub Release for \`${TAG}\` already exists with ${assets} asset(s), draft=${draft}. Confirm it is genuinely incomplete before repairing it."
+          else
+            release_state="No GitHub Release object exists for \`${TAG}\`."
+          fi
+
           title="Release blocked after automatic retries: ${TAG}"
           existing="$(gh issue list \
             --repo "$REPO" \
@@ -295,11 +355,26 @@ jobs:
             --jq ".[] | select(.title == \"${title}\") | .number" \
             | head -1)"
           if [ -z "$existing" ]; then
+            body="$(mktemp)"
+            {
+              printf "The automatic release controller exhausted its retries for \`%s\` at \`%s\` after %s attempt(s).\n\n" \
+                "$TAG" "$SHA" "$ATTEMPTS"
+              printf 'Release run: %s (id %s)\n\n' "$RUN_URL" "$RUN_ID"
+              printf 'Classification: **%s**. %s\n\n' "$verdict" "$advice"
+              printf 'Failing step per attempt:\n\n'
+              index=0
+              while IFS= read -r line; do
+                index=$((index + 1))
+                printf -- '- attempt %s: %s\n' "$index" "$line"
+              done < "$signatures"
+              printf '\n%s\n\n' "$release_state"
+              printf 'The tag and any immutable public artifacts remain in place.\n'
+            } > "$body"
             gh issue create \
               --repo "$REPO" \
               --title "$title" \
-              --body "The automatic release controller exhausted two retries for \`${TAG}\` at \`${SHA}\`. Release run: ${RUN_URL} (id ${RUN_ID}). The tag and any immutable public artifacts remain in place; diagnose and rerun the same release rather than cutting a newer version." \
+              --body-file "$body" \
               >/dev/null
           fi
-          echo "::error::${TAG} exhausted its two automatic retries: ${RUN_URL}"
+          echo "::error::${TAG} exhausted its automatic retries after ${ATTEMPTS} attempt(s), ${verdict}, first failing step: ${first_signature}: ${RUN_URL}"
           exit 1

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -161,13 +161,12 @@ jobs:
       # one immutable main snapshot instead of from whatever main becomes while
       # the job runs. Nothing from the failed tag's own head is trusted.
       #
-      # Reading the record is tolerated rather than propagated, on the same
-      # ground base-image-pins.yml states: the alarm must not become the thing
-      # that reds a main sha. Without this a network hiccup fetching the record
-      # would fail the job and publish exactly the check-run that refuses a
-      # release, which is the hazard this step exists to remove. A failed
-      # checkout instead leaves no HEAD for the next step to verify, so it reads
-      # as "not abandoned" and recovery behaves as it did before the record
+      # Reading the record is tolerated rather than propagated. A network hiccup
+      # must not replace the real retry-or-alert decision with a controller
+      # checkout failure. Recovery is not in the mint's reviewed veto set, but a
+      # failed checkout would still hide the actionable release state behind an
+      # advisory red. Leaving no verified HEAD instead reads as "not abandoned",
+      # so recovery remains responsible exactly as it was before the record
       # existed.
       - name: Checkout the abandonment record from the default-branch commit
         if: steps.resolve.outputs.needed == 'true'
@@ -196,11 +195,12 @@ jobs:
           SHA: ${{ steps.resolve.outputs.sha }}
         run: |
           set -euo pipefail
-          # Nothing in this step may end in a non-zero status of its own. The
-          # check-run it would publish is the one the mint gate refuses a
-          # release commit for, so every status is captured rather than left to
-          # the step's implicit errexit, and every unhappy path degrades to "not
-          # abandoned", which leaves the alert armed to fail for the real reason.
+          # Nothing in this step may end in a non-zero status of its own. This
+          # controller is outside the mint's reviewed veto set, but failing here
+          # would still replace the actionable retry-or-alert verdict with an
+          # ingestion error. Every status is therefore captured, and every
+          # unhappy path degrades to "not abandoned", leaving recovery armed to
+          # report the real release failure.
           head=""
           status=0
           head="$(git rev-parse HEAD)" || status=$?

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -664,12 +664,17 @@ jobs:
           DECLINE_LIMIT: "4"
         run: |
           set -euo pipefail
+          # Diagnostics go to their own file rather than into the captured
+          # value. Folding stderr into the success path would let any warning
+          # gh writes be parsed as a run id, and the counter would then be
+          # quietly wrong rather than loudly wrong.
+          read_error="$(mktemp)"
           if ! runs="$(gh api \
             "repos/${REPO}/actions/workflows/release-tag.yml/runs?per_page=20&status=completed" \
             -q '.workflow_runs[]
                 | select(.id != (env.CURRENT_RUN_ID | tonumber))
-                | .id' 2>&1)"; then
-            echo "::notice::could not read prior mint runs, so this decline is not escalated: ${runs}"
+                | .id' 2>"$read_error")"; then
+            echo "::notice::could not read prior mint runs, so this decline is not escalated: $(cat "$read_error")"
             exit 0
           fi
           consecutive=1
@@ -683,8 +688,8 @@ jobs:
                    | select(.name == "Mint release tag")
                    | .steps[]
                    | select(.name == "Escalate a persistent mint decline")
-                   | .conclusion] | first // ""' 2>&1)"; then
-              echo "::notice::stopped counting at run ${run_id}: ${marker}"
+                   | .conclusion] | first // ""' 2>"$read_error")"; then
+              echo "::notice::stopped counting at run ${run_id}: $(cat "$read_error")"
               break
             fi
             case "$marker" in
@@ -1205,11 +1210,12 @@ jobs:
                   )
           for line in announcements:
               print(f"::warning::{line}")
+          not_waited = []
           for item in unwaited:
-              print(
-                  "::notice::not waiting for a check no required context "
-                  f"covers: {item}"
+              not_waited.append(
+                  f"not waiting for a check no required context covers: {item}"
               )
+              print(f"::notice::{not_waited[-1]}")
 
           verdict = (
               f"verified {len(required)} required checks against their workflow "
@@ -1224,7 +1230,10 @@ jobs:
               with open(summary_path, "a") as handle:
                   handle.write("### Release check verification\n\n")
                   handle.write(f"{verdict}\n")
-                  for line in announcements:
+                  # Every class the gate declined to act on reaches the summary,
+                  # including the unfinished ones. A downgrade that only shows
+                  # up as an annotation is half a disclosure.
+                  for line in announcements + not_waited:
                       handle.write(f"\n- {line}\n")
           PY
             status=$?

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -662,6 +662,7 @@ jobs:
           CURRENT_RUN_ID: ${{ github.run_id }}
           DECLINE_REASON: ${{ steps.prior.outputs.decline_reason }}
           DECLINE_LIMIT: "4"
+          DECLINE_SCAN_LIMIT: "100"
         run: |
           set -euo pipefail
           # Diagnostics go to their own file rather than into the captured
@@ -670,7 +671,7 @@ jobs:
           # quietly wrong rather than loudly wrong.
           read_error="$(mktemp)"
           if ! runs="$(gh api \
-            "repos/${REPO}/actions/workflows/release-tag.yml/runs?per_page=20&status=completed" \
+            "repos/${REPO}/actions/workflows/release-tag.yml/runs?per_page=${DECLINE_SCAN_LIMIT}&status=completed" \
             -q '.workflow_runs[]
                 | select(.id != (env.CURRENT_RUN_ID | tonumber))
                 | .id' 2>"$read_error")"; then
@@ -678,22 +679,42 @@ jobs:
             exit 0
           fi
           consecutive=1
-          examined=0
+          scanned=0
           while IFS= read -r run_id; do
             [ -n "$run_id" ] || continue
-            [ "$examined" -lt "$DECLINE_LIMIT" ] || break
-            examined=$((examined + 1))
-            if ! marker="$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" \
+            [ "$scanned" -lt "$DECLINE_SCAN_LIMIT" ] || break
+            scanned=$((scanned + 1))
+            if ! state="$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" \
               -q '[.jobs[]
                    | select(.name == "Mint release tag")
-                   | .steps[]
-                   | select(.name == "Escalate a persistent mint decline")
-                   | .conclusion] | first // ""' 2>"$read_error")"; then
+                   | {
+                       job: .conclusion,
+                       marker: ([.steps[]?
+                         | select(.name == "Escalate a persistent mint decline")
+                         | .conclusion] | first // "")
+                     }] | first // {job: "", marker: ""}' \
+              2>"$read_error")"; then
               echo "::notice::stopped counting at run ${run_id}: $(cat "$read_error")"
               break
             fi
+            if ! job_conclusion="$(jq -er '.job | strings' <<< "$state")" ||
+               ! marker="$(jq -er '.marker | strings' <<< "$state")"; then
+              echo "::notice::stopped counting at run ${run_id}: unreadable mint job state"
+              break
+            fi
+            # `workflow_run` starts this workflow for every completed CI run.
+            # Its job-level guard skips the whole mint job for unrelated CI
+            # events, and those controller invocations are not mint outcomes at
+            # all. Ignore them. A mint job that did run but skipped this step is
+            # different: it reached a non-decline outcome and resets the streak.
+            if [ "$job_conclusion" = skipped ]; then
+              continue
+            fi
             case "$marker" in
-              success|failure) consecutive=$((consecutive + 1)) ;;
+              success|failure)
+                consecutive=$((consecutive + 1))
+                [ "$consecutive" -lt "$DECLINE_LIMIT" ] || break
+                ;;
               *) break ;;
             esac
           done <<< "$runs"
@@ -722,9 +743,10 @@ jobs:
         # pull-request-only job is inapplicable on a merged main HEAD. This
         # reviewed set is the complete veto authority. Red or unfinished checks
         # outside it are announced, but they neither refuse nor delay the mint;
-        # add any context that must block a release to this reviewed list. It is
-        # the main branch-protection required contexts plus the Windows installer
-        # leg, which is release-critical and never optional.
+        # add any context that must block a release to this reviewed list. The
+        # active main ruleset should carry the same contexts, but this reviewed
+        # source declaration remains the mint's authority rather than mutable
+        # live configuration.
         #
         # Evidence is resolved through workflow provenance, not through the
         # context name. A merge-queue landing publishes the same context names
@@ -1058,9 +1080,17 @@ jobs:
                       f"(conclusion={run['conclusion']})"
                   )
               if workflow.get("status") != "completed":
-                  pending.append(
-                      f"required check workflow not completed: {name} "
-                      f"(status={workflow.get('status')})"
+                  # A required job can already be immutable green while an
+                  # advisory sibling keeps their shared workflow in progress.
+                  # Waiting on that aggregate would restore an advisory veto
+                  # through status instead of conclusion. Record it loudly and
+                  # judge the required context itself above.
+                  degraded_producers.append(
+                      (
+                          workflow.get("path"),
+                          workflow.get("id"),
+                          f"is still {workflow.get('status')}",
+                      )
                   )
               elif workflow.get("conclusion") != "success":
                   # The producing run carries jobs beyond the release-critical
@@ -1075,7 +1105,7 @@ jobs:
                       (
                           workflow.get("path"),
                           workflow.get("id"),
-                          workflow.get("conclusion"),
+                          f"concluded {workflow.get('conclusion')}",
                       )
                   )
 
@@ -1183,10 +1213,10 @@ jobs:
           # nobody was told about. Announcing on the retry passes instead would
           # repeat every line up to sixty times and train the reader to skip it.
           announcements = []
-          for path, run_id, conclusion in sorted(set(degraded_producers)):
+          for path, run_id, state in sorted(set(degraded_producers)):
               announcements.append(
-                  "admitting over a producing run that concluded "
-                  f"{conclusion}: {path} run {run_id}; every required context "
+                  f"admitting over a producing run that {state}: "
+                  f"{path} run {run_id}; every required context "
                   "it produces is green"
               )
           for item in downgraded:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -719,11 +719,12 @@ jobs:
         # presence-required release-critical set — a sha missing any of these is
         # refused even if nothing failed. Every required check must conclude
         # success except DCO, which is allowed to report skipped because that
-        # pull-request-only job is inapplicable on a merged main HEAD. Separately,
-        # no check anywhere may be failing or still in progress; the second loop
-        # owns that present-check strictness, so this list need not mirror every
-        # CI context. It is the main branch-protection required contexts plus the
-        # Windows installer leg, which is release-critical and never optional.
+        # pull-request-only job is inapplicable on a merged main HEAD. This
+        # reviewed set is the complete veto authority. Red or unfinished checks
+        # outside it are announced, but they neither refuse nor delay the mint;
+        # add any context that must block a release to this reviewed list. It is
+        # the main branch-protection required contexts plus the Windows installer
+        # leg, which is release-critical and never optional.
         #
         # Evidence is resolved through workflow provenance, not through the
         # context name. A merge-queue landing publishes the same context names

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -332,6 +332,25 @@ jobs:
           AUTOMATIC: ${{ steps.resolve.outputs.automatic }}
         run: |
           set -euo pipefail
+          # Declining to mint is a real outcome that exits the job green on
+          # purpose, which is what made a blocked release indistinguishable
+          # from a minted one on the board. A decline therefore has to be
+          # legible without reading logs: a warning annotation, a step summary
+          # section, and a named reason the escalation step can quote.
+          decline() { # <reason> <sentence>
+            printf '::warning::release mint declined (%s): %s\n' "$1" "$2"
+            {
+              echo "### Release mint declined"
+              echo
+              echo "Reason: \`$1\`"
+              echo
+              echo "$2"
+            } >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "ready=false"
+              echo "decline_reason=$1"
+            } >> "$GITHUB_OUTPUT"
+          }
           runs="$(gh api "repos/${REPO}/actions/workflows/release.yml/runs?per_page=100")"
           active="$(jq '[.workflow_runs[] | select(
             .status == "requested" or .status == "queued" or .status == "in_progress" or
@@ -339,8 +358,7 @@ jobs:
           )] | length' <<< "$runs")"
           if [ "$active" -ne 0 ]; then
             if [ "$AUTOMATIC" = true ]; then
-              echo "::notice::${active} Release run(s) are active; a scheduled reconcile will retry."
-              echo "ready=false" >> "$GITHUB_OUTPUT"
+              decline release-in-flight "${active} Release run(s) are active; a scheduled reconcile will retry."
               exit 0
             fi
             echo "::error::${active} Release run(s) are active"
@@ -389,8 +407,7 @@ jobs:
           highest_tag="$(cat "$admissible")"
           if [ -z "$highest_tag" ] || [ "$highest_tag" != "$latest_tag" ]; then
             if [ "$AUTOMATIC" = true ]; then
-              echo "::notice::highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}; release recovery will reconcile it."
-              echo "ready=false" >> "$GITHUB_OUTPUT"
+              decline unfinalized-latest "highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}; release recovery will reconcile it."
               exit 0
             fi
             echo "::error::highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}"
@@ -431,8 +448,7 @@ jobs:
               <<< "$runs")"
             if [ "$matching_count" -ne 0 ]; then
               if [ "$AUTOMATIC" = true ]; then
-                echo "::notice::latest stable ${latest_tag}@${latest_sha} has preserved Release attempts but none succeeded; recovery owns this state."
-                echo "ready=false" >> "$GITHUB_OUTPUT"
+                decline unrecovered-latest "latest stable ${latest_tag}@${latest_sha} has preserved Release attempts but none succeeded; recovery owns this state."
                 exit 0
               fi
               echo "::error::latest stable ${latest_tag}@${latest_sha} has preserved Release attempts but none succeeded"
@@ -624,6 +640,71 @@ jobs:
             echo "prior stable authority: ${latest_tag}@${latest_sha} run=${successful}"
           fi
           echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Escalate a persistent mint decline
+        if: >-
+          steps.resolve.outputs.needed == 'true' &&
+          steps.prior.outputs.ready == 'false'
+        # One decline is ordinary: a release still in flight blocks its
+        # successor by design, and the next reconcile clears it. A decline that
+        # keeps repeating is a stuck release lane, and because a decline exits
+        # green it looked exactly like a healthy mint on the board while a
+        # release sat blocked.
+        #
+        # This step runs only on the decline path, so its own conclusion on a
+        # prior run is the decline marker. Reading that is what makes the
+        # outcome machine-visible without parsing logs, and it counts an
+        # already-escalated decline too, so a lane that stays blocked stays red
+        # instead of alarming once every few runs.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          DECLINE_REASON: ${{ steps.prior.outputs.decline_reason }}
+          DECLINE_LIMIT: "4"
+        run: |
+          set -euo pipefail
+          if ! runs="$(gh api \
+            "repos/${REPO}/actions/workflows/release-tag.yml/runs?per_page=20&status=completed" \
+            -q '.workflow_runs[]
+                | select(.id != (env.CURRENT_RUN_ID | tonumber))
+                | .id' 2>&1)"; then
+            echo "::notice::could not read prior mint runs, so this decline is not escalated: ${runs}"
+            exit 0
+          fi
+          consecutive=1
+          examined=0
+          while IFS= read -r run_id; do
+            [ -n "$run_id" ] || continue
+            [ "$examined" -lt "$DECLINE_LIMIT" ] || break
+            examined=$((examined + 1))
+            if ! marker="$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" \
+              -q '[.jobs[]
+                   | select(.name == "Mint release tag")
+                   | .steps[]
+                   | select(.name == "Escalate a persistent mint decline")
+                   | .conclusion] | first // ""' 2>&1)"; then
+              echo "::notice::stopped counting at run ${run_id}: ${marker}"
+              break
+            fi
+            case "$marker" in
+              success|failure) consecutive=$((consecutive + 1)) ;;
+              *) break ;;
+            esac
+          done <<< "$runs"
+          if [ "$consecutive" -ge "$DECLINE_LIMIT" ]; then
+            {
+              echo "### Release mint blocked"
+              echo
+              echo "Declined ${consecutive} times in a row, most recently for \`${DECLINE_REASON}\`."
+              echo
+              echo "The mint is not failing on its own account and would keep reporting"
+              echo "success. Something is holding the release lane closed."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::release lane declined ${consecutive} times in a row (${DECLINE_REASON}); it is blocked, not idle"
+            exit 1
+          fi
+          echo "::notice::release mint declined (${DECLINE_REASON}); ${consecutive} in a row, escalating at ${DECLINE_LIMIT}"
 
       - name: Verify required checks are green
         if: >-

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -809,6 +809,13 @@ jobs:
           non_failing_optional = {"success", "skipped", "neutral"}
           errors = []
           pending = []
+          # Everything the gate declines to treat as a veto. Reported once, on
+          # the pass that admits the release, so a mint is never quiet about
+          # what it chose to look past.
+          degraded_producers = []
+          downgraded = []
+          discounted = []
+          unwaited = []
 
           if required != list(expected_provenance):
               errors.append("required check order does not match its provenance contract")
@@ -969,29 +976,107 @@ jobs:
                       f"(status={workflow.get('status')})"
                   )
               elif workflow.get("conclusion") != "success":
-                  errors.append(
-                      f"required check workflow not green: {name} "
-                      f"(conclusion={workflow.get('conclusion')})"
+                  # The producing run carries jobs beyond the release-critical
+                  # ones, so its aggregate conclusion is not a release verdict.
+                  # A red coverage or npm-launcher job turns the whole ci.yml
+                  # run red and would otherwise veto through every required
+                  # context that run produces, which is the same defect the
+                  # sweep below stopped committing per check-run. This
+                  # context's own conclusion is judged directly above; record
+                  # the producer so admitting over it is never silent.
+                  degraded_producers.append(
+                      (
+                          workflow.get("path"),
+                          workflow.get("id"),
+                          workflow.get("conclusion"),
+                      )
                   )
+
+          # A check-run is this release's evidence only when its producing
+          # workflow run is the landing push on the release branch. The merge
+          # queue builds the same workflows at this exact sha on its own ref,
+          # and for a solo queue entry the speculative sha IS the landing sha,
+          # so a queue job the queue never waited for concludes after the merge
+          # on the commit being released, having gated nothing. Gate 1 already
+          # discounts those for required contexts. The sweep discounts them the
+          # same way instead of letting one poison the mint.
+          evidence_workflows = set()
+          for workflow in workflow_runs:
+              if (
+                  workflow.get("event") == "push"
+                  and workflow.get("head_branch") == release_branch
+              ):
+                  evidence_workflows.add(
+                      (workflow.get("workflow_id"), workflow.get("path"))
+                  )
+          required_names = set(required)
 
           for run in check_runs:
               name = run["name"]
               # Exclude only this exact workflow identity's tag-mint attempts,
-              # including a prior refusal on the same SHA. A same-name check
-              # from another workflow remains visible and must be green.
+              # including a prior refusal on the same SHA.
               if (
                   name == "Mint release tag"
                   and run.get("check_suite_id") in release_tag_suite_ids
               ):
                   continue
-              if run["status"] != "completed":
-                  pending.append(
-                      f"check still in progress: {name} (status={run['status']})"
-                  )
-              elif run["conclusion"] not in non_failing_optional:
+              producers = workflows_by_suite.get(run.get("check_suite_id"), [])
+              producer = producers[0] if len(producers) == 1 else None
+              if name == "Mint release tag":
+                  # The mint's own job name from a producer that is not the
+                  # reviewed release-tag workflow. Never release evidence and
+                  # never merely advisory: a second writer of this name is an
+                  # authority conflict whatever it concluded.
                   errors.append(
-                      f"check not green: {name} "
-                      f"(conclusion={run['conclusion']})"
+                      f"release-tag job name claimed by another producer: {name} "
+                      f"(suite={run.get('check_suite_id')}, "
+                      f"conclusion={run.get('conclusion')})"
+                  )
+                  continue
+              if producer is None:
+                  origin = (
+                      "no unique workflow run for suite "
+                      f"{run.get('check_suite_id')}"
+                  )
+              else:
+                  origin = (
+                      f"{producer.get('path')} run {producer.get('id')} "
+                      f"({producer.get('event')} on {producer.get('head_branch')})"
+                  )
+              is_evidence = (
+                  producer is not None
+                  and producer.get("event") == "push"
+                  and producer.get("head_branch") == release_branch
+              )
+              if not is_evidence:
+                  discounted.append(
+                      {
+                          "name": name,
+                          "origin": origin,
+                          "twin": producer is not None
+                          and (
+                              producer.get("workflow_id"),
+                              producer.get("path"),
+                          )
+                          in evidence_workflows,
+                          "status": run.get("status"),
+                          "conclusion": run.get("conclusion"),
+                      }
+                  )
+                  continue
+              if name in required_names:
+                  # Already judged in full above against its exact provenance.
+                  # Judging it again by name here is what let a queue-side
+                  # namesake decide a release.
+                  continue
+              if run["status"] != "completed":
+                  # Its verdict cannot veto this release, so waiting for one
+                  # would only give a hung advisory job a second way to burn
+                  # the mint once the retry budget runs out.
+                  unwaited.append(f"{name} (status={run['status']})")
+              elif run["conclusion"] not in non_failing_optional:
+                  downgraded.append(
+                      f"{name} (conclusion={run['conclusion']}, from {origin})"
                   )
 
           if errors:
@@ -1005,11 +1090,61 @@ jobs:
                   print(f"  - {item}")
               sys.exit(2)
 
-          print(
+          # The release is admissible. Everything the gate declined to treat as
+          # a veto is announced here, on the one pass that admits it, so a
+          # release is never quietly minted from a commit carrying a red that
+          # nobody was told about. Announcing on the retry passes instead would
+          # repeat every line up to sixty times and train the reader to skip it.
+          announcements = []
+          for path, run_id, conclusion in sorted(set(degraded_producers)):
+              announcements.append(
+                  "admitting over a producing run that concluded "
+                  f"{conclusion}: {path} run {run_id}; every required context "
+                  "it produces is green"
+              )
+          for item in downgraded:
+              announcements.append(
+                  f"admitting over a red check no required context covers: {item}"
+              )
+          for entry in discounted:
+              if (
+                  entry["status"] == "completed"
+                  and entry["conclusion"] not in non_failing_optional
+              ):
+                  announcements.append(
+                      "discounting a red check that is not this release's "
+                      f"evidence: {entry['name']} "
+                      f"(conclusion={entry['conclusion']}, from {entry['origin']}); "
+                      + (
+                          "the landing push build on the release branch is the "
+                          "evidence"
+                          if entry["twin"]
+                          else "it has no build on the release branch at this sha"
+                      )
+                  )
+          for line in announcements:
+              print(f"::warning::{line}")
+          for item in unwaited:
+              print(
+                  "::notice::not waiting for a check no required context "
+                  f"covers: {item}"
+              )
+
+          verdict = (
               f"verified {len(required)} required checks against their workflow "
-              f"provenance; {len(check_runs)} total checks, none failing or in "
-              "progress"
+              f"provenance; {len(check_runs)} check-runs on the sha, "
+              f"{len(discounted)} not this release's evidence, "
+              f"{len(downgraded)} red and covered by no required context, "
+              f"{len(unwaited)} unfinished and not waited for"
           )
+          print(verdict)
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a") as handle:
+                  handle.write("### Release check verification\n\n")
+                  handle.write(f"{verdict}\n")
+                  for line in announcements:
+                      handle.write(f"\n- {line}\n")
           PY
             status=$?
             set -e

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -118,12 +118,11 @@ The single job refuses — before any tag is created — unless **all** hold:
    so another check-writing App cannot satisfy one by copying its name. Every
    required non-DCO context must conclude `success`; `DCO Sign-off` alone may
    be `skipped` on merged `main` because PR-time DCO already gated the merge.
-   Second, **no** check on the SHA may be failing or still in progress. The
-   workflow's own GitHub Actions `Mint release tag` check-run is self-excluded
-   from this second guard — a refused dispatch is recorded as a failed
-   `Mint release tag` check-run on the target SHA, and a gate must not read its
-   own refusals as evidence. `skipped`/`neutral` remain non-failing only for
-   checks outside the presence-required set.
+   This reviewed set is the complete release veto authority. A red or unfinished
+   check outside it is announced in the workflow annotation and step summary,
+   but it neither refuses nor delays the mint. If an advisory check becomes
+   release-critical, add it to this reviewed set so that change is explicit and
+   reviewable rather than granting every check writer an implicit veto.
    The presence-required set is:
    - `Check & Test (ubuntu-latest)`
    - `Check & Test (macos-latest)`
@@ -133,10 +132,9 @@ The single job refuses — before any tag is created — unless **all** hold:
    - `Windows installer + vector-free release build`
 
    This is the `main` branch-protection required contexts **plus** the Windows
-   installer leg, which is release-critical and never optional. Because the
-   second guard already refuses any present check that is failing, this list need
-   not mirror every CI context — extend it only to force *presence* of a
-   release-critical check (add branch-protection additions here too).
+   installer leg, which is release-critical and never optional. It need not
+   mirror every CI context; it must name every context whose presence and green
+   verdict are required to release (add branch-protection additions here too).
 6. **The prior release lane is settled.** No Release run may be queued or
    active, and the prior stable must have either a successful exact tag/SHA
    Release run or its attested terminal completion marker. This prevents GitHub

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -110,8 +110,9 @@ The single job refuses — before any tag is created — unless **all** hold:
    root `Cargo.toml` **at that SHA** must equal the tag minus its `v`. This is
    the same version `release.yml` later asserts against the built packages.
 5. **Required checks are green on that SHA.** Read from
-   `repos/<owner>/<repo>/commits/<sha>/check-runs`. Two independent guards run.
-   First, every context in the **presence-required release-critical set**
+   `repos/<owner>/<repo>/commits/<sha>/check-runs`. A required-context guard and
+   an advisory-evidence audit run. Every context in the
+   **presence-required release-critical set**
    (`REQUIRED_CHECKS`) must be present and green — a SHA missing any of these is
    refused even if nothing failed (a SHA that never ran CI is refused, not passed
    vacuously). Required contexts are bound to the GitHub Actions App identity,
@@ -131,10 +132,11 @@ The single job refuses — before any tag is created — unless **all** hold:
    - `gitleaks (full history)`
    - `Windows installer + vector-free release build`
 
-   This is the `main` branch-protection required contexts **plus** the Windows
-   installer leg, which is release-critical and never optional. It need not
-   mirror every CI context; it must name every context whose presence and green
-   verdict are required to release (add branch-protection additions here too).
+   This reviewed list is the authority for release admission. The active `main`
+   ruleset should carry the same contexts, but the mint does not read mutable
+   ruleset configuration at runtime; keep the two declarations aligned through
+   reviewed changes. The list need not mirror every CI context. It must name
+   every context whose presence and green verdict are required to release.
 6. **The prior release lane is settled.** No Release run may be queued or
    active, and the prior stable must have either a successful exact tag/SHA
    Release run or its attested terminal completion marker. This prevents GitHub
@@ -149,6 +151,14 @@ Only then does it mint the App token, create `refs/tags/<tag>` at the SHA, and
 **post-verify** that the new ref points at the SHA. A run summary records the
 tag, SHA, and actor.
 
+An automatic mint may correctly decline while a prior release is still active
+or unresolved. Such a decline writes a warning annotation, a titled summary,
+and a named reason. The first three consecutive real declines remain green; the
+fourth and every later consecutive decline fail visibly as a blocked lane.
+`workflow_run` invocations whose entire mint job is skipped are controller noise,
+not mint outcomes, and do not reset or increment that count. A completed mint
+job that did not take the decline path resets it.
+
 ## Automatic recovery
 
 The release controller immediately and periodically reconciles failed,
@@ -160,6 +170,15 @@ active release before requesting `rerun-failed-jobs`. The initial attempt plus
 two retries is the hard cap. Cancellation is treated as an operator stop and is
 never retried. If all three attempts fail, the controller opens one
 `Release blocked after automatic retries` issue and stops.
+
+The issue compares the complete failing job/step set across attempts. A repeated
+set is reported as a **repeated failure signature**, not as proof of a
+deterministic root cause: external registries, notarization services, and runner
+infrastructure can repeatedly fail at the same step. Logs and source diagnosis
+decide whether to preserve the tag for a same-release rerun or land a source fix
+and recut. Unreadable attempts are reported as indeterminate. A Release API 404
+is reported as absence; any other API failure is reported as unknown state and
+never rewritten as proof that no Release exists.
 
 There is one exception, and only one: a tag the reviewed record has already
 retired is reconciled instead of alerted. Before retrying or alerting, the
@@ -251,9 +270,10 @@ gh run list --workflow=release-tag.yml -L 1
 gh run watch <run-id>
 ```
 
-On success the tag exists and `release.yml` has started. On any refusal the job
-fails at the offending step with a `::error::` line naming exactly what was
-unmet; nothing is created.
+On mint success the tag exists and `release.yml` has started. A break-glass
+refusal or hard policy failure fails at the offending step with an `::error::`
+line and creates nothing. Correct automatic declines follow the warning and
+four-decline escalation behavior above; they are not successful mints.
 
 ## One-time founder setup
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3283,6 +3283,25 @@ def assert_recovery_record_authority(release_recovery: str) -> None:
         )
 
 
+def assert_recovery_abandonment_stand_down(release_recovery: str) -> None:
+    """Pin both retry and alert to the active reviewed-abandonment condition."""
+
+    condition = "steps.record.outputs.abandoned != 'true'"
+    for marker, duty in (
+        ("name: Re-run failed jobs", "bounded retry"),
+        (
+            "name: Alert after automatic retries are exhausted",
+            "exhausted-retry alert",
+        ),
+    ):
+        active = "\n".join(job_step_active_lines(release_recovery, "reconcile", marker))
+        if condition not in active:
+            raise AssertionError(
+                f"release recovery's {duty} must actively stand down for a tag "
+                "the tracked abandonment record already retired"
+            )
+
+
 def assert_abandoned_tag_admission(
     release_tag: str,
     release_train: str,
@@ -4322,27 +4341,21 @@ def main() -> None:
     ):
         require(release_recovery, policy, "bounded automatic release recovery")
 
-    # Recovery's failing check-run lands on the default branch head, and the
-    # mint gate refuses a release commit carrying any check-run outside
-    # success/skipped/neutral. An hourly tick that alerts on a tag the reviewed
-    # record has already retired therefore kills the very release that
-    # supersedes it. Both consumers of the record decision are pinned here
-    # rather than trusting one substring: the retry must not spend runners on an
-    # abandoned tag, and the alert must not stamp failure on one.
-    for step, duty in (
-        ("      - name: Re-run failed jobs\n", "bounded retry"),
-        (
-            "      - name: Alert after automatic retries are exhausted\n",
-            "exhausted-retry alert",
-        ),
-    ):
-        start = release_recovery.index(step)
-        end = release_recovery.index("\n        env:", start)
-        if "steps.record.outputs.abandoned != 'true'" not in release_recovery[start:end]:
-            raise AssertionError(
-                f"release recovery's {duty} must stand down for a tag the "
-                "tracked abandonment record already retired"
+    # Recovery is outside the mint's reviewed veto set, but it still must not
+    # spend runners or raise an advisory alarm for a release the reviewed record
+    # retired. Parse active step fields so a comment repeating the condition
+    # cannot satisfy the guard while the YAML `if` omits it.
+    assert_recovery_abandonment_stand_down(release_recovery)
+    expect_assertion(
+        "recovery repeats its stand-down condition only in comments",
+        "must actively stand down",
+        lambda: assert_recovery_abandonment_stand_down(
+            release_recovery.replace(
+                "          steps.record.outputs.abandoned != 'true'",
+                "          # steps.record.outputs.abandoned != 'true'",
             )
+        ),
+    )
     for forbidden in (
         "workflow_dispatch:",
         "contents: write",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2834,14 +2834,21 @@ def execute_recovery_escalation(
         for index, signature in enumerate(attempt_signatures, start=1):
             if signature is None:
                 continue
-            job, step_name = signature
-            payload = {
-                "jobs": [
-                    {
-                        "name": "Preflight",
-                        "conclusion": "success",
-                        "steps": [{"name": "Checkout", "conclusion": "success"}],
-                    },
+            # A single failing job makes the jobs API's ordering irrelevant,
+            # which is the shape production never produces for a matrix
+            # failure. Every attempt therefore carries its failures in the
+            # order given, so a caller can vary it the way real queue-time job
+            # ids do.
+            failures = [signature] if isinstance(signature, tuple) else list(signature)
+            jobs: list[dict[str, object]] = [
+                {
+                    "name": "Preflight",
+                    "conclusion": "success",
+                    "steps": [{"name": "Checkout", "conclusion": "success"}],
+                }
+            ]
+            for job, step_name in failures:
+                jobs.append(
                     {
                         "name": job,
                         "conclusion": "failure",
@@ -2849,9 +2856,9 @@ def execute_recovery_escalation(
                             {"name": "Checkout", "conclusion": "success"},
                             {"name": step_name, "conclusion": "failure"},
                         ],
-                    },
-                ]
-            }
+                    }
+                )
+            payload = {"jobs": jobs}
             target = (
                 f"repos_firelock-ai_kin_actions_runs_{run_id}"
                 f"_attempts_{index}_jobs"
@@ -2872,24 +2879,33 @@ def execute_recovery_escalation(
                 case "$1" in
                   api)
                     shift
-                    path=""; query=""
+                    path=""; query=""; slurp=0
                     while [ $# -gt 0 ]; do
                       case "$1" in
                         -q|--jq) shift; query="$1" ;;
+                        --slurp) slurp=1 ;;
                         -*) ;;
                         *) [ -n "$path" ] || path="$1" ;;
                       esac
                       shift
                     done
+                    path="${path%%\\?*}"
                     file="$FIXTURE/responses/$(printf '%s' "$path" | tr '/' '_')"
                     if [ ! -f "$file" ]; then
                       echo "gh: Not Found (HTTP 404)" >&2
                       exit 1
                     fi
-                    if [ -n "$query" ]; then
-                      jq -r "$query" < "$file"
+                    # `--slurp` returns an array of page responses, which is
+                    # the shape the caller's query has to handle.
+                    if [ "$slurp" = 1 ]; then
+                      body="$(jq -c '[.]' < "$file")"
                     else
-                      cat "$file"
+                      body="$(cat "$file")"
+                    fi
+                    if [ -n "$query" ]; then
+                      jq -r "$query" <<< "$body"
+                    else
+                      printf '%s\n' "$body"
                     fi
                     ;;
                   issue)
@@ -3014,6 +3030,31 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
                 f"{needle!r}: {unreadable_body}"
             )
 
+    # The shape production actually produces. Release builds are a matrix, so
+    # more than one leg fails, and the jobs API orders by job id, which is
+    # minted at queue time. Real attempts of run 30627672394 returned the two
+    # failing legs in the order below: aarch64 first, then x86_64 first, then
+    # aarch64 again. Reducing the failing set to its first element reads that
+    # as three different failures and advises a rerun that cannot work, which
+    # is verbatim the advice FIR-1782 exists to eliminate.
+    aarch64 = (
+        "Build (kin-linux-aarch64)",
+        "Build kin-cli + kin-daemon (native)",
+    )
+    x86_64 = (
+        "Build (kin-linux-x86_64)",
+        "Build kin-cli + kin-daemon (native)",
+    )
+    _, matrix_body = execute_recovery_escalation(
+        source,
+        [[aarch64, x86_64], [x86_64, aarch64], [aarch64, x86_64]],
+    )
+    if "Classification: **deterministic**" not in matrix_body:
+        raise AssertionError(
+            "a matrix failure that repeated identically was classified by the "
+            f"order its legs happened to queue in: {matrix_body}"
+        )
+
     # Every attempt unreadable is the case that isolates the unknown count.
     # The signatures all match each other, so nothing but that count stands
     # between a total read failure and a verdict of "deterministic, recut it".
@@ -3039,6 +3080,58 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         raise AssertionError(
             "recovery advised repair without saying the release already exists: "
             f"{existing_release_body}"
+        )
+
+
+def assert_required_check_set_is_single_sourced(release_tag: str) -> None:
+    """The env list and the provenance table must name the same contexts.
+
+    Dropping a context from the env alone leaves the table intact, so every
+    literal needle still matches and the suite stays green while the mint has
+    quietly stopped requiring a release-critical check. The workflow's own
+    order check fails that closed at runtime, but only after the drift has
+    landed and started burning mint attempts, which is a log to read rather
+    than a red PR.
+    """
+
+    workflow = ".github/workflows/release-tag.yml"
+    step = workflow_step_source(
+        workflow,
+        release_tag,
+        "      - name: Verify required checks are green",
+    )
+    block = re.search(
+        r"\n          REQUIRED_CHECKS: \|\n((?:            \S.*\n)+)",
+        step,
+    )
+    if block is None:
+        raise AssertionError(
+            f"{workflow} no longer declares REQUIRED_CHECKS as a block scalar"
+        )
+    env_names = tuple(
+        line.strip() for line in block.group(1).splitlines() if line.strip()
+    )
+    table = re.search(
+        r"\nexpected_provenance = \{\n(.*?)\n\}\n",
+        release_check_gate_source(release_tag),
+        re.DOTALL,
+    )
+    if table is None:
+        raise AssertionError(
+            f"{workflow} no longer declares an expected_provenance table"
+        )
+    table_names = tuple(
+        re.findall(r'^    "(.+?)": \(', table.group(1), re.MULTILINE)
+    )
+    if env_names != REQUIRED_RELEASE_CHECKS:
+        raise AssertionError(
+            "the release gate's REQUIRED_CHECKS env no longer matches the "
+            f"reviewed required set: {env_names}"
+        )
+    if table_names != REQUIRED_RELEASE_CHECKS:
+        raise AssertionError(
+            "the release gate's expected_provenance table no longer matches "
+            f"the reviewed required set: {table_names}"
         )
 
 
@@ -6757,6 +6850,7 @@ def main() -> None:
     assert_rust_cache_steps(workflow_sources)
     assert_required_context_action_pins(workflow_sources)
     assert_tag_readback_retries(release_tag)
+    assert_required_check_set_is_single_sourced(release_tag)
     assert_soft_decline_is_legible(release_tag)
     assert_recovery_escalation_classifies(
         RELEASE_RECOVERY.read_text(encoding="utf-8")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2791,6 +2791,257 @@ def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
                 )
 
 
+def recovery_escalation_source(release_recovery: str) -> str:
+    """Extract the escalation step exactly as the recovery controller runs it."""
+
+    anchor = "      - name: Alert after automatic retries are exhausted\n"
+    if anchor not in release_recovery:
+        raise AssertionError(
+            "release-recovery no longer carries the escalation step"
+        )
+    start = release_recovery.index(anchor)
+    remainder = release_recovery[start + 1 :]
+    end = (
+        release_recovery.index("\n      - name:", start + 1)
+        if "\n      - name:" in remainder
+        else len(release_recovery)
+    )
+    step = release_recovery[start:end]
+    marker = "        run: |\n"
+    return textwrap.dedent(step[step.index(marker) + len(marker) :])
+
+
+def execute_recovery_escalation(
+    source: str,
+    attempt_signatures: list[tuple[str, str] | None],
+    *,
+    release: dict[str, object] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the escalation against scripted attempt jobs and release state.
+
+    The `gh` stub answers `-q` by running the real `jq`, so the workflow's own
+    query decides the signature. A stub that returned canned answers would
+    exercise the shell and leave the jq that does the classifying unproven.
+    """
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        script = root / "escalate.sh"
+        script.write_text(source, encoding="utf-8")
+        responses = root / "responses"
+        responses.mkdir()
+        run_id = "4242"
+        for index, signature in enumerate(attempt_signatures, start=1):
+            if signature is None:
+                continue
+            job, step_name = signature
+            payload = {
+                "jobs": [
+                    {
+                        "name": "Preflight",
+                        "conclusion": "success",
+                        "steps": [{"name": "Checkout", "conclusion": "success"}],
+                    },
+                    {
+                        "name": job,
+                        "conclusion": "failure",
+                        "steps": [
+                            {"name": "Checkout", "conclusion": "success"},
+                            {"name": step_name, "conclusion": "failure"},
+                        ],
+                    },
+                ]
+            }
+            target = (
+                f"repos_firelock-ai_kin_actions_runs_{run_id}"
+                f"_attempts_{index}_jobs"
+            )
+            (responses / target).write_text(json.dumps(payload), encoding="utf-8")
+        if release is not None:
+            (responses / "repos_firelock-ai_kin_releases_tags_v9.9.9").write_text(
+                json.dumps(release),
+                encoding="utf-8",
+            )
+        binaries = root / "bin"
+        binaries.mkdir()
+        (binaries / "gh").write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -uo pipefail
+                case "$1" in
+                  api)
+                    shift
+                    path=""; query=""
+                    while [ $# -gt 0 ]; do
+                      case "$1" in
+                        -q|--jq) shift; query="$1" ;;
+                        -*) ;;
+                        *) [ -n "$path" ] || path="$1" ;;
+                      esac
+                      shift
+                    done
+                    file="$FIXTURE/responses/$(printf '%s' "$path" | tr '/' '_')"
+                    if [ ! -f "$file" ]; then
+                      echo "gh: Not Found (HTTP 404)" >&2
+                      exit 1
+                    fi
+                    if [ -n "$query" ]; then
+                      jq -r "$query" < "$file"
+                    else
+                      cat "$file"
+                    fi
+                    ;;
+                  issue)
+                    shift
+                    case "$1" in
+                      list) exit 0 ;;
+                      create)
+                        shift
+                        while [ $# -gt 0 ]; do
+                          case "$1" in
+                            --title) shift; printf '%s' "$1" > "$FIXTURE/issue-title" ;;
+                            --body-file) shift; cp "$1" "$FIXTURE/issue-body" ;;
+                          esac
+                          shift
+                        done
+                        ;;
+                    esac
+                    ;;
+                esac
+                """
+            ),
+            encoding="utf-8",
+        )
+        (binaries / "gh").chmod(0o755)
+        environment = dict(os.environ)
+        environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
+        environment.update(
+            {
+                "FIXTURE": str(root),
+                "GH_TOKEN": "fixture",
+                "REPO": "firelock-ai/kin",
+                "TAG": "v9.9.9",
+                "SHA": RELEASE_GATE_FIXTURE_SHA,
+                "RUN_ID": run_id,
+                "RUN_URL": f"https://example.invalid/runs/{run_id}",
+                "ATTEMPTS": str(len(attempt_signatures)),
+            }
+        )
+        completed = subprocess.run(
+            ["bash", str(script)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=60,
+            check=False,
+        )
+        body_path = root / "issue-body"
+        body = body_path.read_text(encoding="utf-8") if body_path.exists() else ""
+        return completed, body
+
+
+def assert_recovery_escalation_classifies(release_recovery: str) -> None:
+    """Recovery must classify before advising, and never advise a dead rerun.
+
+    Advising a rerun for a deterministic failure is the wrong answer in the
+    expensive direction: a lockfile pinning a dependency that cannot build for
+    a release target fails identically every time, and the operator waits for a
+    retry that can never succeed.
+    """
+
+    source = recovery_escalation_source(release_recovery)
+    compile_failure = ("build-artifacts (x86_64-unknown-linux-musl)", "Build release binaries")
+
+    deterministic, body = execute_recovery_escalation(
+        source,
+        [compile_failure, compile_failure, compile_failure],
+    )
+    if deterministic.returncode == 0:
+        raise AssertionError(
+            "recovery escalation stopped failing the run: "
+            f"{deterministic.stdout}{deterministic.stderr}"
+        )
+    for needle in (
+        "Classification: **deterministic**",
+        "a rerun cannot reach a different outcome",
+        "version recut against fixed dependencies",
+        "- attempt 1: build-artifacts (x86_64-unknown-linux-musl) / Build release binaries",
+        "after 3 attempt(s)",
+        "No GitHub Release object exists for `v9.9.9`.",
+    ):
+        if needle not in body:
+            raise AssertionError(
+                f"identical repeated failures were not classified: {needle!r}: {body}"
+            )
+    if "Diagnose and rerun the same release" in body:
+        raise AssertionError(
+            f"a deterministic failure was still advised to rerun: {body}"
+        )
+
+    _, transient_body = execute_recovery_escalation(
+        source,
+        [
+            ("build-artifacts (x86_64-apple-darwin)", "Notarize"),
+            ("publish", "Push image"),
+            compile_failure,
+        ],
+    )
+    for needle in (
+        "Classification: **not proven deterministic**",
+        "Diagnose and rerun the same release",
+    ):
+        if needle not in transient_body:
+            raise AssertionError(
+                f"differing failures lost the rerun advice: {needle!r}: "
+                f"{transient_body}"
+            )
+
+    # An attempt whose jobs cannot be read is not evidence that the failure
+    # repeated. Claiming deterministic from an unreadable attempt would retire
+    # a recoverable release on a transient API error.
+    _, unreadable_body = execute_recovery_escalation(
+        source,
+        [compile_failure, None, compile_failure],
+    )
+    for needle in (
+        "Classification: **not proven deterministic**",
+        "- attempt 2: unrecorded",
+    ):
+        if needle not in unreadable_body:
+            raise AssertionError(
+                "an unreadable attempt was folded into a deterministic verdict: "
+                f"{needle!r}: {unreadable_body}"
+            )
+
+    # Every attempt unreadable is the case that isolates the unknown count.
+    # The signatures all match each other, so nothing but that count stands
+    # between a total read failure and a verdict of "deterministic, recut it".
+    _, blind_body = execute_recovery_escalation(source, [None, None, None])
+    if "Classification: **not proven deterministic**" not in blind_body:
+        raise AssertionError(
+            "a run whose attempts could not be read at all was classified "
+            f"deterministic: {blind_body}"
+        )
+
+    # A mint that reported failure on a release it had already created would
+    # otherwise send this controller to repair a healthy release.
+    _, existing_release_body = execute_recovery_escalation(
+        source,
+        [compile_failure, compile_failure, compile_failure],
+        release={"draft": False, "assets": [{"name": "kin-x86_64.tar.gz"}]},
+    )
+    if (
+        "already exists with 1 asset(s)" not in existing_release_body
+        or "Confirm it is genuinely incomplete before repairing it."
+        not in existing_release_body
+    ):
+        raise AssertionError(
+            "recovery advised repair without saying the release already exists: "
+            f"{existing_release_body}"
+        )
+
+
 def assert_soft_decline_is_legible(release_tag: str) -> None:
     """A decline exits the job green, so it has to be loud, named, and counted.
 
@@ -6507,6 +6758,9 @@ def main() -> None:
     assert_required_context_action_pins(workflow_sources)
     assert_tag_readback_retries(release_tag)
     assert_soft_decline_is_legible(release_tag)
+    assert_recovery_escalation_classifies(
+        RELEASE_RECOVERY.read_text(encoding="utf-8")
+    )
 
     with tempfile.TemporaryDirectory() as directory:
         fixture_directory = Path(directory)

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2816,6 +2816,7 @@ def execute_recovery_escalation(
     attempt_signatures: list[tuple[str, str] | None],
     *,
     release: dict[str, object] | None = None,
+    release_error: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str]:
     """Run the escalation against scripted attempt jobs and release state.
 
@@ -2864,9 +2865,17 @@ def execute_recovery_escalation(
                 f"_attempts_{index}_jobs"
             )
             (responses / target).write_text(json.dumps(payload), encoding="utf-8")
+        release_response = responses / "repos_firelock-ai_kin_releases_tags_v9.9.9"
+        if release is not None and release_error is not None:
+            raise AssertionError("release fixture cannot be both readable and failed")
         if release is not None:
-            (responses / "repos_firelock-ai_kin_releases_tags_v9.9.9").write_text(
+            release_response.write_text(
                 json.dumps(release),
+                encoding="utf-8",
+            )
+        if release_error is not None:
+            Path(f"{release_response}.error").write_text(
+                release_error,
                 encoding="utf-8",
             )
         binaries = root / "bin"
@@ -2891,6 +2900,10 @@ def execute_recovery_escalation(
                     done
                     path="${path%%\\?*}"
                     file="$FIXTURE/responses/$(printf '%s' "$path" | tr '/' '_')"
+                    if [ -f "$file.error" ]; then
+                      cat "$file.error" >&2
+                      exit 1
+                    fi
                     if [ ! -f "$file" ]; then
                       echo "gh: Not Found (HTTP 404)" >&2
                       exit 1
@@ -2958,41 +2971,42 @@ def execute_recovery_escalation(
 
 
 def assert_recovery_escalation_classifies(release_recovery: str) -> None:
-    """Recovery must classify before advising, and never advise a dead rerun.
+    """Recovery must classify before advising without inventing root-cause proof.
 
-    Advising a rerun for a deterministic failure is the wrong answer in the
-    expensive direction: a lockfile pinning a dependency that cannot build for
-    a release target fails identically every time, and the operator waits for a
-    retry that can never succeed.
+    A repeated job/step surface is useful evidence that another immediate rerun
+    is unlikely to help, but it cannot distinguish a source-bound failure from
+    an external outage that repeatedly reaches the same step. The issue must
+    preserve that distinction before it tells an operator to burn a version.
     """
 
     source = recovery_escalation_source(release_recovery)
     compile_failure = ("build-artifacts (x86_64-unknown-linux-musl)", "Build release binaries")
 
-    deterministic, body = execute_recovery_escalation(
+    repeated, body = execute_recovery_escalation(
         source,
         [compile_failure, compile_failure, compile_failure],
     )
-    if deterministic.returncode == 0:
+    if repeated.returncode == 0:
         raise AssertionError(
             "recovery escalation stopped failing the run: "
-            f"{deterministic.stdout}{deterministic.stderr}"
+            f"{repeated.stdout}{repeated.stderr}"
         )
     for needle in (
-        "Classification: **deterministic**",
-        "a rerun cannot reach a different outcome",
-        "version recut against fixed dependencies",
+        "Classification: **repeated failure signature**",
+        "another immediate rerun is unlikely to help",
+        "recut only after confirming a source-bound defect",
+        "preserve this tag for a same-release rerun if the cause is external",
         "- attempt 1: build-artifacts (x86_64-unknown-linux-musl) / Build release binaries",
         "after 3 attempt(s)",
         "No GitHub Release object exists for `v9.9.9`.",
     ):
         if needle not in body:
             raise AssertionError(
-                f"identical repeated failures were not classified: {needle!r}: {body}"
+                f"identical repeated signatures were not reported: {needle!r}: {body}"
             )
-    if "Diagnose and rerun the same release" in body:
+    if "a rerun cannot reach a different outcome" in body:
         raise AssertionError(
-            f"a deterministic failure was still advised to rerun: {body}"
+            f"step identity was overstated as root-cause proof: {body}"
         )
 
     _, transient_body = execute_recovery_escalation(
@@ -3004,7 +3018,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         ],
     )
     for needle in (
-        "Classification: **not proven deterministic**",
+        "Classification: **varying failure signatures**",
         "Diagnose and rerun the same release",
     ):
         if needle not in transient_body:
@@ -3021,14 +3035,21 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         [compile_failure, None, compile_failure],
     )
     for needle in (
-        "Classification: **not proven deterministic**",
+        "Classification: **indeterminate**",
         "- attempt 2: unrecorded",
+        "neither a deterministic nor a transient cause is established",
+        "Inspect the unrecorded attempts",
     ):
         if needle not in unreadable_body:
             raise AssertionError(
                 "an unreadable attempt was folded into a deterministic verdict: "
                 f"{needle!r}: {unreadable_body}"
             )
+    if "The attempts did not fail identically" in unreadable_body:
+        raise AssertionError(
+            "an unreadable attempt was reported as an observed difference: "
+            f"{unreadable_body}"
+        )
 
     # The shape production actually produces. Release builds are a matrix, so
     # more than one leg fails, and the jobs API orders by job id, which is
@@ -3049,7 +3070,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         source,
         [[aarch64, x86_64], [x86_64, aarch64], [aarch64, x86_64]],
     )
-    if "Classification: **deterministic**" not in matrix_body:
+    if "Classification: **repeated failure signature**" not in matrix_body:
         raise AssertionError(
             "a matrix failure that repeated identically was classified by the "
             f"order its legs happened to queue in: {matrix_body}"
@@ -3059,7 +3080,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     # The signatures all match each other, so nothing but that count stands
     # between a total read failure and a verdict of "deterministic, recut it".
     _, blind_body = execute_recovery_escalation(source, [None, None, None])
-    if "Classification: **not proven deterministic**" not in blind_body:
+    if "Classification: **indeterminate**" not in blind_body:
         raise AssertionError(
             "a run whose attempts could not be read at all was classified "
             f"deterministic: {blind_body}"
@@ -3070,16 +3091,44 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     _, existing_release_body = execute_recovery_escalation(
         source,
         [compile_failure, compile_failure, compile_failure],
-        release={"draft": False, "assets": [{"name": "kin-x86_64.tar.gz"}]},
+        release={
+            "draft": False,
+            "prerelease": True,
+            "assets": [{"name": "kin-x86_64.tar.gz"}],
+        },
     )
     if (
         "already exists with 1 asset(s)" not in existing_release_body
+        or "prerelease=true" not in existing_release_body
         or "Confirm it is genuinely incomplete before repairing it."
         not in existing_release_body
     ):
         raise AssertionError(
             "recovery advised repair without saying the release already exists: "
             f"{existing_release_body}"
+        )
+
+    # Only a real 404 proves absence. A permissions, rate-limit, server, or
+    # network failure is unknown state and must never be rewritten as "no
+    # Release", which would send repair after an object that may exist.
+    _, unreadable_release_body = execute_recovery_escalation(
+        source,
+        [compile_failure, compile_failure, compile_failure],
+        release_error="gh: API rate limit exceeded (HTTP 403)\n",
+    )
+    for needle in (
+        "GitHub Release state for `v9.9.9` could not be read",
+        "Do not infer that the Release is absent",
+    ):
+        if needle not in unreadable_release_body:
+            raise AssertionError(
+                "recovery converted an unreadable Release API state into absence: "
+                f"{needle!r}: {unreadable_release_body}"
+            )
+    if "No GitHub Release object exists" in unreadable_release_body:
+        raise AssertionError(
+            "recovery claimed Release absence after a non-404 API failure: "
+            f"{unreadable_release_body}"
         )
 
 
@@ -3132,6 +3181,126 @@ def assert_required_check_set_is_single_sourced(release_tag: str) -> None:
         raise AssertionError(
             "the release gate's expected_provenance table no longer matches "
             f"the reviewed required set: {table_names}"
+        )
+
+
+def decline_escalation_source(release_tag: str) -> str:
+    """Extract the persistent-decline shell exactly as the mint runs it."""
+
+    step = workflow_step_source(
+        ".github/workflows/release-tag.yml",
+        release_tag,
+        "      - name: Escalate a persistent mint decline",
+    )
+    marker = "        run: |\n"
+    if marker not in step:
+        raise AssertionError("persistent-decline step no longer has a shell body")
+    return textwrap.dedent(step[step.index(marker) + len(marker) :])
+
+
+def execute_decline_escalation(
+    source: str,
+    prior_runs: list[tuple[int, str, str | None]],
+) -> subprocess.CompletedProcess[str]:
+    """Run the decline counter against production-shaped workflow/job payloads.
+
+    Each tuple is `(run id, Mint release tag job conclusion, escalation-step
+    conclusion)`. A `None` marker models a whole job skipped by the workflow's
+    job-level `workflow_run` guard; that is the high-volume production shape
+    that must be ignored rather than mistaken for a successful mint.
+    """
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        script = root / "decline.sh"
+        script.write_text(source, encoding="utf-8")
+        responses = root / "responses"
+        responses.mkdir()
+        list_path = responses / (
+            "repos_firelock-ai_kin_actions_workflows_release-tag.yml_runs"
+        )
+        list_path.write_text(
+            json.dumps({"workflow_runs": [{"id": run_id} for run_id, _, _ in prior_runs]}),
+            encoding="utf-8",
+        )
+        for run_id, job_conclusion, marker in prior_runs:
+            steps = []
+            if marker is not None:
+                steps.append(
+                    {
+                        "name": "Escalate a persistent mint decline",
+                        "conclusion": marker,
+                    }
+                )
+            payload = {
+                "jobs": [
+                    {
+                        "name": "Mint release tag",
+                        "conclusion": job_conclusion,
+                        "steps": steps,
+                    }
+                ]
+            }
+            (responses / f"repos_firelock-ai_kin_actions_runs_{run_id}_jobs").write_text(
+                json.dumps(payload),
+                encoding="utf-8",
+            )
+
+        binaries = root / "bin"
+        binaries.mkdir()
+        (binaries / "gh").write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -uo pipefail
+                [ "$1" = api ] || exit 2
+                shift
+                path=""; query=""
+                while [ $# -gt 0 ]; do
+                  case "$1" in
+                    -q|--jq) shift; query="$1" ;;
+                    -*) ;;
+                    *) [ -n "$path" ] || path="$1" ;;
+                  esac
+                  shift
+                done
+                path="${path%%\\?*}"
+                file="$FIXTURE/responses/$(printf '%s' "$path" | tr '/' '_')"
+                if [ ! -f "$file" ]; then
+                  echo "gh: Not Found (HTTP 404)" >&2
+                  exit 1
+                fi
+                if [ -n "$query" ]; then
+                  jq -r "$query" < "$file"
+                else
+                  cat "$file"
+                fi
+                """
+            ),
+            encoding="utf-8",
+        )
+        (binaries / "gh").chmod(0o755)
+        environment = dict(os.environ)
+        environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
+        environment.update(
+            {
+                "FIXTURE": str(root),
+                "GH_TOKEN": "fixture",
+                "REPO": "firelock-ai/kin",
+                "CURRENT_RUN_ID": "99999",
+                "DECLINE_REASON": "unrecovered-latest",
+                "DECLINE_LIMIT": "4",
+                "DECLINE_SCAN_LIMIT": "100",
+                "GITHUB_STEP_SUMMARY": str(root / "summary.md"),
+            }
+        )
+        return subprocess.run(
+            ["bash", str(script)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=30,
+            check=False,
         )
 
 
@@ -3200,6 +3369,49 @@ def assert_soft_decline_is_legible(release_tag: str) -> None:
         raise AssertionError(
             f"{workflow} needs a decline budget above one, because a single "
             "decline while a release is in flight is correct behaviour"
+        )
+
+    source = decline_escalation_source(release_tag)
+    # `workflow_run` creates skipped controller jobs for unrelated CI
+    # completions. They interleave with real scheduled declines in production
+    # and must not reset the streak. The previous implementation stopped at the
+    # first such run, so this fixture makes the fourth real decline fail only
+    # when the skipped jobs are actively ignored.
+    interleaved = execute_decline_escalation(
+        source,
+        [
+            (910, "skipped", None),
+            (909, "success", "success"),
+            (908, "skipped", None),
+            (907, "success", "success"),
+            (906, "skipped", None),
+            (905, "failure", "failure"),
+        ],
+    )
+    if interleaved.returncode == 0 or "declined 4 times in a row" not in (
+        interleaved.stdout + interleaved.stderr
+    ):
+        raise AssertionError(
+            "whole-job workflow_run skips reset the persistent-decline counter: "
+            f"{interleaved.stdout}{interleaved.stderr}"
+        )
+
+    # A mint job that really ran and skipped the escalation step is a genuine
+    # non-decline (mint/no-op/refusal elsewhere), so it must reset the streak
+    # even when older declines exist behind it.
+    reset = execute_decline_escalation(
+        source,
+        [
+            (920, "success", "skipped"),
+            (919, "success", "success"),
+            (918, "failure", "failure"),
+            (917, "success", "success"),
+        ],
+    )
+    if reset.returncode != 0 or "1 in a row" not in reset.stdout:
+        raise AssertionError(
+            "a completed non-decline mint no longer resets decline escalation: "
+            f"{reset.stdout}{reset.stderr}"
         )
 
 
@@ -6697,6 +6909,13 @@ def main() -> None:
             check_runs,
             "Check & Test (ubuntu-latest)",
         )["check_suite_id"]
+        # This coupling is mandatory in the real Actions API: while any sibling
+        # job is in progress, its producer workflow cannot be completed/success.
+        # Leaving the fixture completed creates an impossible state and lets the
+        # gate keep waiting on the aggregate without the test noticing.
+        workflow_fixture(workflow_runs, ci_suite).update(
+            {"status": "in_progress", "conclusion": None}
+        )
         check_runs.append(
             non_required_check(
                 "npm launcher tests",
@@ -6711,6 +6930,8 @@ def main() -> None:
         release_gate,
         "an unfinished advisory check no required context covers",
         (
+            "admitting over a producing run that is still in_progress: "
+            ".github/workflows/ci.yml run 1001",
             "not waiting for a check no required context covers: "
             "npm launcher tests (status=in_progress)",
         ),

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3035,8 +3035,8 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     # minted at queue time. Real attempts of run 30627672394 returned the two
     # failing legs in the order below: aarch64 first, then x86_64 first, then
     # aarch64 again. Reducing the failing set to its first element reads that
-    # as three different failures and advises a rerun that cannot work, which
-    # is verbatim the advice FIR-1782 exists to eliminate.
+    # as two different failures and advises a rerun that cannot work, which
+    # is verbatim the advice this suite exists to eliminate.
     aarch64 = (
         "Build (kin-linux-aarch64)",
         "Build kin-cli + kin-daemon (native)",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2389,6 +2389,39 @@ def assert_release_check_accepted(
             f"{check_name}={conclusion}: {result.stdout}{result.stderr}"
         )
 
+def assert_release_gate_admits(
+    source: str,
+    label: str,
+    expected: tuple[str, ...],
+    mutate_fixture: Callable[
+        [
+            list[dict[str, object]],
+            list[dict[str, object]],
+            dict[str, object],
+        ],
+        None,
+    ],
+) -> None:
+    """Require a fixture to be admitted, and to announce what it admitted over.
+
+    A downgrade that is not announced is worse than the refusal it replaces, so
+    admission and announcement are asserted together and never separately.
+    """
+
+    result = execute_release_check_gate(source, {}, mutate_fixture=mutate_fixture)
+    output = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise AssertionError(
+            f"release gate refused an admissible fixture: {label}: {output}"
+        )
+    for needle in expected:
+        if needle not in output:
+            raise AssertionError(
+                f"release gate admitted {label} silently, expected {needle!r}: "
+                f"{output}"
+            )
+
+
 def run_tag_selector(
     manifest: str,
     candidates: str,
@@ -5899,8 +5932,27 @@ def main() -> None:
     assert_release_gate_fixture_rejected(
         release_gate,
         "same-name tag check from another workflow is not self-excluded",
-        "check not green: Mint release tag (conclusion=failure)",
+        "release-tag job name claimed by another producer: Mint release tag",
         add_external_mint_failure,
+    )
+
+    def add_external_mint_success(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        current_run: dict[str, object],
+    ) -> None:
+        """A green namesake is the same authority conflict as a red one."""
+
+        add_external_mint_failure(check_runs, workflow_runs, current_run)
+        for run in check_runs:
+            if run["name"] == "Mint release tag" and run["id"] == 8_101:
+                run["conclusion"] = "success"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "green same-name tag check from another workflow is admitted",
+        "release-tag job name claimed by another producer: Mint release tag",
+        add_external_mint_success,
     )
 
     def add_higher_id_success_collision(
@@ -6068,6 +6120,199 @@ def main() -> None:
                 f"producer: {name}: {queue_only_fixture.stdout}"
                 f"{queue_only_fixture.stderr}"
             )
+
+    def non_required_check(
+        name: str,
+        suite_id: int,
+        check_id: int,
+        *,
+        status: str = "completed",
+        conclusion: str | None = "failure",
+    ) -> dict[str, object]:
+        return {
+            "name": name,
+            "status": status,
+            "conclusion": conclusion,
+            "id": check_id,
+            "app_id": GITHUB_ACTIONS_APP_ID,
+            "app_slug": "github-actions",
+            "check_suite_id": suite_id,
+            "head_sha": RELEASE_GATE_FIXTURE_SHA,
+        }
+
+    def add_red_queue_job_after_landing(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        current_run: dict[str, object],
+    ) -> None:
+        """The queue's own build reds on the landing sha, after the merge.
+
+        A solo queue entry's speculative sha IS the landing sha, so a
+        merge_group job no ruleset required keeps running past the merge and
+        concludes on the exact commit being released.
+        """
+
+        add_merge_queue_producer(check_runs, workflow_runs, current_run)
+        check_runs.append(
+            non_required_check("Windows authority tests", 201, 30_001)
+        )
+
+    assert_release_gate_admits(
+        release_gate,
+        "a merge_group job the queue never waited for concluded red",
+        (
+            "discounting a red check that is not this release's evidence: "
+            "Windows authority tests",
+            "the landing push build on the release branch is the evidence",
+        ),
+        add_red_queue_job_after_landing,
+    )
+
+    def add_red_queue_only_job(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """A red job from a workflow that never builds the release branch."""
+
+        workflow_runs.append(
+            {
+                "id": 30_100,
+                "workflow_id": 400_200,
+                "path": ".github/workflows/queue-only.yml",
+                "event": "merge_group",
+                "head_branch": "gh-readonly-queue/main/pr-2-" + "0" * 40,
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+                "status": "completed",
+                "conclusion": "failure",
+                "check_suite_id": 302,
+            }
+        )
+        check_runs.append(non_required_check("Queue-only smoke", 302, 30_101))
+
+    assert_release_gate_admits(
+        release_gate,
+        "a red job that only ever runs inside the queue",
+        (
+            "discounting a red check that is not this release's evidence: "
+            "Queue-only smoke",
+            "it has no build on the release branch at this sha",
+        ),
+        add_red_queue_only_job,
+    )
+
+    def add_red_non_required_push_job(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """A registry blip reds a landing-push job no ruleset requires."""
+
+        workflow_runs.append(
+            {
+                "id": 31_000,
+                "workflow_id": 400_300,
+                "path": ".github/workflows/docker.yml",
+                "event": "push",
+                "head_branch": "main",
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+                "status": "completed",
+                "conclusion": "failure",
+                "check_suite_id": 303,
+            }
+        )
+        check_runs.append(
+            non_required_check("Docker Image Build (no push)", 303, 31_001)
+        )
+
+    assert_release_gate_admits(
+        release_gate,
+        "a red landing-push check that no required context covers",
+        (
+            "admitting over a red check no required context covers: "
+            "Docker Image Build (no push) (conclusion=failure",
+        ),
+        add_red_non_required_push_job,
+    )
+
+    def red_non_required_job_inside_required_producer(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """A red advisory job turns its whole required producer's run red."""
+
+        ci_suite = required_check_fixture(
+            check_runs,
+            "Check & Test (ubuntu-latest)",
+        )["check_suite_id"]
+        workflow_fixture(workflow_runs, ci_suite)["conclusion"] = "failure"
+        check_runs.append(non_required_check("Code Coverage", ci_suite, 32_001))
+
+    assert_release_gate_admits(
+        release_gate,
+        "a red advisory job inside the workflow that produces required contexts",
+        (
+            "admitting over a producing run that concluded failure: "
+            ".github/workflows/ci.yml run 1001",
+            "admitting over a red check no required context covers: "
+            "Code Coverage (conclusion=failure",
+        ),
+        red_non_required_job_inside_required_producer,
+    )
+
+    def unfinished_non_required_check(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """An advisory job still running when every required context is green."""
+
+        ci_suite = required_check_fixture(
+            check_runs,
+            "Check & Test (ubuntu-latest)",
+        )["check_suite_id"]
+        check_runs.append(
+            non_required_check(
+                "npm launcher tests",
+                ci_suite,
+                33_001,
+                status="in_progress",
+                conclusion=None,
+            )
+        )
+
+    assert_release_gate_admits(
+        release_gate,
+        "an unfinished advisory check no required context covers",
+        (
+            "not waiting for a check no required context covers: "
+            "npm launcher tests (status=in_progress)",
+        ),
+        unfinished_non_required_check,
+    )
+
+    def unfinished_required_check(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        required_check_fixture(check_runs, "cargo-deny").update(
+            {"status": "in_progress", "conclusion": None}
+        )
+
+    unfinished_required_fixture = execute_release_check_gate(
+        release_gate,
+        {},
+        mutate_fixture=unfinished_required_check,
+    )
+    if unfinished_required_fixture.returncode != 2:
+        raise AssertionError(
+            "an unfinished required context no longer holds the mint for retry: "
+            f"rc={unfinished_required_fixture.returncode} "
+            f"{unfinished_required_fixture.stdout}"
+            f"{unfinished_required_fixture.stderr}"
+        )
 
     def change_required_workflow_path(
         check_runs: list[dict[str, object]],

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2791,6 +2791,74 @@ def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
                 )
 
 
+def assert_soft_decline_is_legible(release_tag: str) -> None:
+    """A decline exits the job green, so it has to be loud, named, and counted.
+
+    The failure this pins is not a wrong answer but an invisible one: the mint
+    declining to mint concluded success and read on the board exactly like a
+    mint that happened, so a blocked release stayed hidden until somebody read
+    the step conclusions by hand.
+    """
+
+    workflow = ".github/workflows/release-tag.yml"
+    admission = workflow_step_source(
+        workflow,
+        release_tag,
+        "      - name: Admit the serialized release lane",
+    )
+    for needle in (
+        "decline() { # <reason> <sentence>",
+        "printf '::warning::release mint declined (%s): %s\\n' \"$1\" \"$2\"",
+        '} >> "$GITHUB_STEP_SUMMARY"',
+        'echo "decline_reason=$1"',
+    ):
+        require(admission, needle, f"{workflow} soft-decline legibility")
+
+    # Every automatic decline goes through the helper. A bare `ready=false`
+    # beside a `::notice::` is the exact shape that made a blocked release
+    # indistinguishable from a healthy one, so exactly one write may exist and
+    # it is the helper's.
+    ready_false_writes = admission.count('echo "ready=false"')
+    if ready_false_writes != 1:
+        raise AssertionError(
+            f"{workflow} must write ready=false only through the decline helper, "
+            f"so every decline is announced and named: found {ready_false_writes}"
+        )
+    declines = re.findall(r"^\s+decline [a-z][a-z-]* ", admission, re.MULTILINE)
+    if len(declines) != 3:
+        raise AssertionError(
+            f"{workflow} has three automatic soft-decline branches, each of "
+            f"which must announce itself: found {len(declines)}"
+        )
+
+    escalation_name = "Escalate a persistent mint decline"
+    escalation = workflow_step_source(
+        workflow,
+        release_tag,
+        f"      - name: {escalation_name}",
+    )
+    if "steps.prior.outputs.ready == 'false'" not in escalation:
+        raise AssertionError(
+            f"{workflow} must escalate only on the decline path, so an ordinary "
+            "mint is never held against a decline budget"
+        )
+    # The counter's only decline marker is this step's own conclusion on prior
+    # runs, so the name it selects on and the name it runs under have to be the
+    # same string. Renaming the step without renaming the query would silently
+    # reset the count to one on every run and never escalate again.
+    if f'select(.name == "{escalation_name}")' not in escalation:
+        raise AssertionError(
+            f"{workflow} escalation must count prior runs by its own step name, "
+            f"which is the only durable record of a decline: {escalation_name}"
+        )
+    limit = re.search(r'DECLINE_LIMIT: "(\d+)"', escalation)
+    if limit is None or int(limit.group(1)) < 2:
+        raise AssertionError(
+            f"{workflow} needs a decline budget above one, because a single "
+            "decline while a release is in flight is correct behaviour"
+        )
+
+
 def assert_selector_arguments(
     release_tag: str,
     release_train: str,
@@ -6438,6 +6506,7 @@ def main() -> None:
     assert_rust_cache_steps(workflow_sources)
     assert_required_context_action_pins(workflow_sources)
     assert_tag_readback_retries(release_tag)
+    assert_soft_decline_is_legible(release_tag)
 
     with tempfile.TemporaryDirectory() as directory:
         fixture_directory = Path(directory)


### PR DESCRIPTION
This repairs the release rail so only the reviewed required contexts veto a release, while every advisory downgrade remains visible. It also makes automatic mint declines machine-visible and makes exhausted-release recovery report only what its evidence proves.

## Release-veto authority

The required set is unchanged and must be present, GitHub-Actions-App-authored, bound to its exact workflow id/path/push-on-main provenance, unique, complete, and green:

- `Check & Test (ubuntu-latest)`
- `Check & Test (macos-latest)`
- `DCO Sign-off`
- `cargo-deny`
- `gitleaks (full history)`
- `Windows installer + vector-free release build`

The active `main` ruleset currently carries the same six contexts. The mint does not read mutable ruleset configuration at runtime; its reviewed source table remains release authority, and the authority suite pins both declarations inside the workflow.

Check-runs from merge-queue producers are not landing-push evidence. Red or unfinished landing-push checks outside the required set are advisory: the mint admits over them, emits warning/notice annotations, and records the downgrade in the step summary. A required job is judged directly even while an advisory sibling leaves their shared workflow in progress; the producer aggregate is announced rather than regaining a veto through status. A foreign producer claiming the `Mint release tag` job name is refused regardless of conclusion.

## Visible mint declines

All three correct automatic-decline paths use one helper that writes a warning, titled summary, `ready=false`, and a named reason. A fourth consecutive real decline fails the run visibly.

The counter distinguishes two states the earlier head conflated:

- a whole `Mint release tag` job skipped by an unrelated `workflow_run` invocation is controller noise and is ignored;
- a mint job that actually ran but skipped the escalation step is a real non-decline and resets the streak.

The scan is bounded to the newest 100 completed controller runs. The production-shaped fixture interleaves whole-job skips between three prior declines and requires the current fourth decline to fail; a second fixture requires a completed non-decline to reset the count.

## Truthful exhausted-release recovery

Recovery still preserves immutable tags and public artifacts, retries only failed jobs on the same Release run, and caps the initial attempt plus two automatic retries. PR #563's tracked-abandonment selector remains the only stand-down authority; both retry and alert actively require `steps.record.outputs.abandoned != 'true'`.

The final issue now compares each attempt's complete sorted failing job/step set:

- identical readable sets are a **repeated failure signature** and make another immediate rerun unlikely;
- differing sets are **varying failure signatures**, consistent with transient failure;
- any unreadable/no-concrete-failure attempt is **indeterminate**.

Step identity is not called deterministic root-cause proof. The issue tells the operator to inspect logs, recut only after confirming a source-bound defect, and preserve the tag for a same-release rerun when the cause is external.

Release-object state is also fail-truthful: HTTP 404 proves absence; an existing object reports asset count plus draft/prerelease state; every other API failure is reported as unknown and never rewritten as “no Release exists.”

Live API inspection confirms the full failing sets repeat while raw job order varies across all three attempts of runs `30627672394` and `30678146368`, so sorting the whole set remains load-bearing.

## PR #563 integration

The branch remains based on PR #563's squash `e2893b84f13707f902a0e3de981df88a0f90e94a`. The conflict resolution preserves its four-argument selector invocation (`MANIFEST CANDIDATES MINTING_TAG OUTPUT`), exact-default-branch checkout verification, `assert_recovery_record_authority`, and active retry/alert stand-down assertions.

## Exact-head verification

Exact head: `22efe43f0e6c19090b8c393ded7aa5846cbd34f9`

Passed locally at this exact head:

- `python3 scripts/test-release-workflow-authority.py`
- `actionlint .github/workflows/release-tag.yml .github/workflows/release-recovery.yml`
- `python3 -m py_compile scripts/test-release-workflow-authority.py`
- `git diff --check`
- `python3 scripts/verify-zero-file-search.py` (147 source files)
- `bash scripts/zero_file_search_guard.sh`

The diff remains exactly four files: the two release workflows, the authority suite, and `docs/release-bot.md`. No Rust source, lockfile, or `ci.yml` bytes changed. No local `cargo test --workspace` claim is made. Exact-head hosted CI and a different independent rereviewer are required before queue admission; this repair does not self-issue GO.

Closes FIR-1769.
Closes FIR-1781.
Closes FIR-1782.

Delivers fix 2 of FIR-1762; the Docker Hub dependency-removal fix remains outside this PR.
