### PR TITLE
Name artifact identities in the form the merge resolver accepts

### DIFF
--- a/crates/kin-cli/src/commands/resolve.rs
+++ b/crates/kin-cli/src/commands/resolve.rs
@@ -202,7 +202,10 @@ fn plan_action(
         });
     }
     for binding in keep_path {
-        let (path, artifact) = binding.split_once('=').ok_or_else(|| {
+        // Split on the last `=`, not the first: an artifact identity never
+        // contains one, but a contested path may, and the listing emits this
+        // binding with the path interpolated raw.
+        let (path, artifact) = binding.rsplit_once('=').ok_or_else(|| {
             anyhow::anyhow!(
                 "--keep-path expects <PATH>=<ARTIFACT>, naming which claimant keeps the contested \
                  path, found {binding}"
@@ -254,6 +257,63 @@ fn parse_record_hash(value: &str) -> Result<Hash256> {
         )
     })?;
     Ok(Hash256::from_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keep_path_directives(binding: &str) -> Vec<ResolveDirective> {
+        let action = plan_action(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![binding.to_string()],
+            false,
+            false,
+            false,
+            false,
+        )
+        .expect("a keep-path binding plans an action");
+        match action {
+            ResolveAction::Settle { directives, all } => {
+                assert_eq!(all, None, "naming a claimant takes no side");
+                directives
+            }
+            other => panic!("a keep-path binding settles a conflict, got {other:?}"),
+        }
+    }
+
+    /// The contested-path listing emits `--keep-path <PATH>=<ARTIFACT>` with the
+    /// path interpolated raw, so a path holding an `=` reaches this parser with
+    /// two of them. Splitting on the first would name the path `docs/a` and
+    /// refuse it, leaving the contested path unsettleable from the command the
+    /// product just printed. An artifact identity holds no `=`, which is what
+    /// makes the last one the unambiguous separator.
+    #[test]
+    fn a_contested_path_holding_an_equals_sign_still_names_its_claimant() {
+        let artifact = "0b9bdc92-369a-51e9-a45d-3cbbb304dd0a";
+        assert_eq!(
+            keep_path_directives(&format!("docs/a=b.md={artifact}")),
+            vec![ResolveDirective {
+                selector: "docs/a=b.md".to_string(),
+                choice: ResolveChoice::PathOwner {
+                    artifact: artifact.to_string(),
+                },
+            }]
+        );
+        // The ordinary binding keeps its existing reading.
+        assert_eq!(
+            keep_path_directives(&format!("docs/notes.md={artifact}")),
+            vec![ResolveDirective {
+                selector: "docs/notes.md".to_string(),
+                choice: ResolveChoice::PathOwner {
+                    artifact: artifact.to_string(),
+                },
+            }]
+        );
+    }
 }
 
 async fn execute(request: ResolveRequest) -> Result<ResolveResponse> {

--- a/crates/kin-cli/tests/repository_merge_resolution.rs
+++ b/crates/kin-cli/tests/repository_merge_resolution.rs
@@ -185,6 +185,51 @@ fn conflicting_repository(root: &Path) -> std::path::PathBuf {
     repo
 }
 
+/// Both branches add a different file at one path. Artifact identity is seeded
+/// on the commit that introduced the artifact, so each branch allocates its
+/// own, both survive composition, and the merge parks on a contested path whose
+/// only settlement is naming one claimant.
+fn path_colliding_repository(root: &Path) -> std::path::PathBuf {
+    let repo = root.join("repo");
+    initialize_git_repo(&repo);
+
+    run_git(&repo, &["switch", "-c", "feature"]);
+    fs::create_dir_all(repo.join("docs")).expect("create docs directory on feature");
+    fs::write(repo.join("docs/notes.md"), b"feature notes\n").expect("add notes on feature");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "feature notes"]);
+
+    run_git(&repo, &["switch", "main"]);
+    fs::create_dir_all(repo.join("docs")).expect("create docs directory on main");
+    fs::write(repo.join("docs/notes.md"), b"main notes\n").expect("add notes on main");
+    run_git(&repo, &["add", "--all"]);
+    run_git(&repo, &["commit", "-m", "main notes"]);
+    repo
+}
+
+/// Every artifact identity claiming one path in the graph a change resolves to.
+fn artifacts_at_path(
+    layout: &kin_core::KinLayout,
+    change: &SemanticChangeId,
+    path: &str,
+) -> Vec<String> {
+    let manager = open_authority(layout);
+    let lease = manager.read_authority();
+    let mut snapshot = lease.snapshot().clone();
+    snapshot.repository_authority = None;
+    drop(lease);
+    let graph =
+        kin_db::InMemoryGraph::from_snapshot(snapshot).expect("prepare graph-owned history");
+    let state = kin_db::ChangeStore::resolve_graph_at(&graph, change)
+        .expect("resolve the exact graph a change publishes");
+    state
+        .tree
+        .artifacts()
+        .filter(|artifact| artifact.path.to_string() == path)
+        .map(|artifact| artifact.artifact_id.0.to_string())
+        .collect()
+}
+
 /// A parked merge is graph truth, not process state. Stopping the daemon and
 /// reading again must return the identical record: same identity, same
 /// conflicts, still in progress.
@@ -596,5 +641,122 @@ fn settling_and_publishing_cannot_be_one_request() {
         String::from_utf8_lossy(&both.stderr).contains("settle conflicts first"),
         "the refusal says why: {}",
         String::from_utf8_lossy(&both.stderr)
+    );
+}
+
+/// A contested path is settled only by naming one claimant, so the identity the
+/// record reports has to be the identity the resolver accepts. When the two
+/// disagreed, every claimant the report emitted was refused and a merge that
+/// collided on a path could only be abandoned.
+#[test]
+fn a_contested_path_settles_from_the_identity_the_record_reports() {
+    let root = tempdir().expect("temp root");
+    let repo = path_colliding_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+
+    ok(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+
+    let report = conflicts_report(&runtime, &repo);
+    let entries = report["record"]["entries"]
+        .as_array()
+        .expect("the record lists its conflicts");
+    let collision = entries
+        .iter()
+        .find(|entry| entry["divergence"]["divergence"] == "path_collision")
+        .unwrap_or_else(|| panic!("both branches adding one path collide on it: {report}"));
+    let claimants: Vec<String> = collision["divergence"]["artifacts"]
+        .as_array()
+        .expect("a contested path names its claimants")
+        .iter()
+        .map(|claimant| {
+            claimant
+                .as_str()
+                .expect("a claimant identity serializes as a string")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(claimants.len(), 2, "one claimant per branch: {report}");
+
+    // The identity the report emitted is the identity the resolver takes back.
+    let owner = claimants[0].clone();
+    ok(
+        &run_kin(
+            &runtime,
+            &repo,
+            &["resolve", "--keep-path", &format!("docs/notes.md={owner}")],
+        ),
+        "kin resolve --keep-path",
+    );
+    let settled = persisted_record(&layout).expect("the merge record is persisted");
+    assert_eq!(
+        settled.unresolved().count(),
+        0,
+        "naming an owner settles the contested path"
+    );
+
+    ok(
+        &run_kin(&runtime, &repo, &["resolve", "--continue"]),
+        "kin resolve --continue",
+    );
+
+    let published = persisted_record(&layout).expect("the terminated record is retained");
+    let merge_change = match published.state {
+        kin_model::MergeTransactionState::Committed { merge_change, .. } => merge_change,
+        other => panic!("a fully settled merge publishes, found {other:?}"),
+    };
+
+    // The artifact that kept the path is exactly the one that was named, and it
+    // is the only one left claiming it.
+    assert_eq!(
+        artifacts_at_path(&layout, &merge_change, "docs/notes.md"),
+        vec![owner],
+        "the named claimant is the artifact the merge published at that path"
+    );
+}
+
+/// The listing has to name the claimants it will accept back. Stating only how
+/// many artifacts collide leaves a caller reading the human surface with no
+/// selector to pass to `--keep-path`.
+#[test]
+fn a_contested_path_listing_names_its_claimants() {
+    let root = tempdir().expect("temp root");
+    let repo = path_colliding_repository(root.path());
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+
+    ok(
+        &run_kin(&runtime, &repo, &["merge", "feature"]),
+        "kin merge",
+    );
+
+    let listing = ok(&run_kin(&runtime, &repo, &["conflicts"]), "kin conflicts");
+    let record = persisted_record(&layout).expect("the merge is parked");
+    let claimants: Vec<String> = record
+        .entries
+        .iter()
+        .flat_map(|entry| match &entry.divergence {
+            kin_model::MergeDivergence::PathCollision { artifacts } => artifacts.clone(),
+            _ => Vec::new(),
+        })
+        .map(|artifact| artifact.0.to_string())
+        .collect();
+    assert_eq!(claimants.len(), 2, "one claimant per branch: {listing}");
+    for claimant in claimants {
+        assert!(
+            listing.contains(&claimant),
+            "the listing names claimant {claimant}: {listing}"
+        );
+    }
+    // A wrapper rendering contains the bare identity as a substring, so the
+    // assertions above alone would pass on a listing nothing can select from.
+    // The listing has to carry the identity in the form the resolver accepts
+    // and no other.
+    assert!(
+        !listing.contains("ArtifactId("),
+        "the listing carries identities in the form the resolver accepts: {listing}"
     );
 }

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1854,18 +1854,33 @@ pub(crate) fn render_artifact(artifact: &kin_model::ArtifactId) -> String {
     artifact.0.to_string()
 }
 
-pub(crate) fn render_subject(entry: &MergeConflictEntry) -> String {
-    match &entry.subject {
-        MergeConflictSubject::Entity { entity } => match &entry.label {
-            Some(name) => format!("entity {name} ({entity})"),
-            None => format!("entity {entity}"),
-        },
+/// Name a subject held without the entry that labels it.
+///
+/// `MergeConflictSubject` has no `Display`, so the alternative at these sites is
+/// a `{:?}` rendering that reaches the caller as `ArtifactId(<uuid>)`. That is
+/// the wrapper form the resolver refuses, quoted by a message the caller is
+/// meant to act on. Routing these sites here keeps one identity form across
+/// every surface, including the refusals.
+pub(crate) fn render_subject_identity(subject: &MergeConflictSubject) -> String {
+    match subject {
+        MergeConflictSubject::Entity { entity } => format!("entity {entity}"),
         MergeConflictSubject::Relation { relation } => format!("relation {relation}"),
-        MergeConflictSubject::Artifact { artifact } => match &entry.label {
-            Some(path) => format!("artifact {path} ({})", render_artifact(artifact)),
-            None => format!("artifact {}", render_artifact(artifact)),
-        },
+        MergeConflictSubject::Artifact { artifact } => {
+            format!("artifact {}", render_artifact(artifact))
+        }
         MergeConflictSubject::Path { path } => format!("path {path}"),
+    }
+}
+
+pub(crate) fn render_subject(entry: &MergeConflictEntry) -> String {
+    match (&entry.subject, &entry.label) {
+        (MergeConflictSubject::Entity { entity }, Some(name)) => {
+            format!("entity {name} ({entity})")
+        }
+        (MergeConflictSubject::Artifact { artifact }, Some(path)) => {
+            format!("artifact {path} ({})", render_artifact(artifact))
+        }
+        (subject, _) => render_subject_identity(subject),
     }
 }
 
@@ -2084,6 +2099,43 @@ mod tests {
         assert!(
             !rendered.contains("ArtifactId("),
             "listing carries identities in the form the resolver accepts: {rendered}"
+        );
+    }
+
+    /// Taking a side for everything names a subject without the entry that
+    /// labels it, and it names it inside a refusal the caller is meant to act
+    /// on. A claimant quoted there has to carry the same form as the listing,
+    /// or the message hands back an identity the resolver rejects.
+    #[test]
+    fn a_subject_named_without_its_entry_carries_the_form_the_resolver_accepts() {
+        let artifact = ArtifactId::new();
+        let rendered = render_subject_identity(&MergeConflictSubject::Artifact { artifact });
+        assert!(
+            rendered.contains(&render_artifact(&artifact)),
+            "a subject names its artifact: {rendered}"
+        );
+        // The wrapper form carries the bare identity as a substring, so the
+        // assertion above alone is satisfied by a rendering nothing can select
+        // from. The form itself is what has to hold.
+        assert!(
+            !rendered.contains("ArtifactId("),
+            "a subject names its artifact in the form the resolver accepts: {rendered}"
+        );
+        // One rendering serves both halves. A second one is precisely how the
+        // wrapper form survived on this surface while every other emitter moved.
+        let entry = MergeConflictEntry {
+            subject: MergeConflictSubject::Artifact { artifact },
+            divergence: MergeDivergence::ChangedBothSides,
+            base: MergeSideValue::Absent,
+            ours: MergeSideValue::Absent,
+            theirs: MergeSideValue::Absent,
+            label: None,
+            resolution: MergeEntryResolution::Unresolved,
+        };
+        assert_eq!(
+            render_subject(&entry),
+            rendered,
+            "the entry path and the bare-subject path render one identity form"
         );
     }
 

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1417,7 +1417,7 @@ fn collect_dangling_endpoints(
                             .get(&artifact)
                             .or_else(|| theirs.tree.get(&artifact))
                             .map(|resolved| resolved.path.to_string())
-                            .unwrap_or_else(|| format!("{artifact:?}"));
+                            .unwrap_or_else(|| render_artifact(&artifact));
                         (
                             *endpoint,
                             format!(
@@ -1819,9 +1819,22 @@ pub(crate) fn render_entry(entry: &MergeConflictEntry) -> String {
         MergeDivergence::RemovedOursChangedTheirs => {
             "removed on the active branch and changed on the source branch".to_string()
         }
+        // The claimants are the whole conflict, and naming an owner is the only
+        // way to settle it, so the listing names them. A caller who cannot read
+        // the claimants from the listing has no selector to pass back.
         MergeDivergence::PathCollision { artifacts } => format!(
-            "{} distinct artifacts occupy this path after composing both sides",
-            artifacts.len()
+            "{} distinct artifacts occupy this path after composing both sides ({}); keep one \
+             with `kin resolve --keep-path {}=<ARTIFACT>`",
+            artifacts.len(),
+            artifacts
+                .iter()
+                .map(render_artifact)
+                .collect::<Vec<_>>()
+                .join(", "),
+            match &entry.subject {
+                MergeConflictSubject::Path { path } => path.to_string(),
+                _ => "<PATH>".to_string(),
+            }
         ),
         MergeDivergence::DanglingEndpoint { .. } => entry
             .label
@@ -1829,6 +1842,16 @@ pub(crate) fn render_entry(entry: &MergeConflictEntry) -> String {
             .unwrap_or_else(|| "relates to a node neither composed side kept".to_string()),
     };
     format!("{}: {detail}", render_subject(entry))
+}
+
+/// The one textual form of an artifact identity these commands emit and accept.
+///
+/// It is exactly the form the record serializes, so an identity read out of
+/// `kin conflicts --json` is the string `kin resolve` takes back. `ArtifactId`
+/// has no `Display`, so a `{:?}` rendering here would print a wrapper form that
+/// no surface emits and that therefore cannot round-trip.
+pub(crate) fn render_artifact(artifact: &kin_model::ArtifactId) -> String {
+    artifact.0.to_string()
 }
 
 pub(crate) fn render_subject(entry: &MergeConflictEntry) -> String {
@@ -1839,8 +1862,8 @@ pub(crate) fn render_subject(entry: &MergeConflictEntry) -> String {
         },
         MergeConflictSubject::Relation { relation } => format!("relation {relation}"),
         MergeConflictSubject::Artifact { artifact } => match &entry.label {
-            Some(path) => format!("artifact {path} ({artifact:?})"),
-            None => format!("artifact {artifact:?}"),
+            Some(path) => format!("artifact {path} ({})", render_artifact(artifact)),
+            None => format!("artifact {}", render_artifact(artifact)),
         },
         MergeConflictSubject::Path { path } => format!("path {path}"),
     }
@@ -1998,6 +2021,70 @@ mod tests {
             tree: ResolvedTree::from_artifacts([target, anchor]).unwrap(),
             ..ResolvedGraphState::default()
         }
+    }
+
+    /// The form these commands print is the form the record serializes, so a
+    /// selector can be copied straight out of `kin conflicts --json`. This
+    /// fails the moment a rendering drifts back to the `ArtifactId(..)` wrapper
+    /// form, which no Kin surface emits and which therefore cannot be passed
+    /// back to settle anything.
+    #[test]
+    fn an_artifact_renders_exactly_as_the_record_serializes_it() {
+        let artifact = ArtifactId::new();
+        let serialized = serde_json::to_value(artifact).expect("an artifact identity serializes");
+        assert_eq!(
+            render_artifact(&artifact),
+            serialized
+                .as_str()
+                .expect("an artifact identity serializes as a string"),
+        );
+        assert_ne!(
+            render_artifact(&artifact),
+            format!("{artifact:?}"),
+            "the wrapper debug form is not what the record serializes"
+        );
+    }
+
+    /// A contested path is settled only by naming one claimant, so a listing
+    /// that states the count without naming them leaves the caller no selector
+    /// to pass back.
+    #[test]
+    fn a_contested_path_names_the_claimants_it_accepts_back() {
+        let left = ArtifactId::new();
+        let right = ArtifactId::new();
+        let entry = MergeConflictEntry {
+            subject: MergeConflictSubject::Path {
+                path: RepoPath::from_utf8("docs/notes.md").unwrap(),
+            },
+            divergence: MergeDivergence::PathCollision {
+                artifacts: vec![left, right],
+            },
+            base: MergeSideValue::Absent,
+            ours: MergeSideValue::Absent,
+            theirs: MergeSideValue::Absent,
+            label: Some("docs/notes.md".to_string()),
+            resolution: MergeEntryResolution::Unresolved,
+        };
+        let rendered = render_entry(&entry);
+        assert!(
+            rendered.contains(&render_artifact(&left)),
+            "listing names its first claimant: {rendered}"
+        );
+        assert!(
+            rendered.contains(&render_artifact(&right)),
+            "listing names its second claimant: {rendered}"
+        );
+        assert!(
+            rendered.contains("docs/notes.md"),
+            "listing names the contested path: {rendered}"
+        );
+        // A wrapper rendering contains the bare identity as a substring, so the
+        // assertions above alone would pass on a listing nothing can select
+        // from. The claimants have to appear in the form the resolver accepts.
+        assert!(
+            !rendered.contains("ArtifactId("),
+            "listing carries identities in the form the resolver accepts: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -33,7 +33,7 @@ use crate::local_repository_authority::ActiveLocalRepositoryAuthority;
 use crate::repository_merge::{
     classify_merge_error, local_workspace, merge_bad_request, merge_bind_refusal, merge_conflict,
     publish_resolved_merge, render_artifact, render_conflict_lines, render_entry, render_subject,
-    repository_finalization_error, restore_point, MergeExecution,
+    render_subject_identity, repository_finalization_error, restore_point, MergeExecution,
 };
 use crate::state::DaemonState;
 
@@ -313,7 +313,10 @@ fn settle(
             let resolution =
                 resolution_for(&next, &subject, &ResolveChoice::Side { side }, &provenance)?;
             next = next.resolve_entry(&subject, resolution).with_context(|| {
-                format!("settle merge conflict {subject:?} by taking the {side:?} side")
+                format!(
+                    "settle merge conflict {} by taking the {side:?} side",
+                    render_subject_identity(&subject)
+                )
             })?;
             settled.push(subject);
         }

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -32,7 +32,7 @@ use kin_model::{
 use crate::local_repository_authority::ActiveLocalRepositoryAuthority;
 use crate::repository_merge::{
     classify_merge_error, local_workspace, merge_bad_request, merge_bind_refusal, merge_conflict,
-    publish_resolved_merge, render_conflict_lines, render_entry, render_subject,
+    publish_resolved_merge, render_artifact, render_conflict_lines, render_entry, render_subject,
     repository_finalization_error, restore_point, MergeExecution,
 };
 use crate::state::DaemonState;
@@ -523,7 +523,7 @@ fn entry_matches(entry: &kin_model::MergeConflictEntry, needle: &str) -> bool {
     let by_identity = match &entry.subject {
         MergeConflictSubject::Entity { entity } => entity.to_string() == needle,
         MergeConflictSubject::Relation { relation } => relation.to_string() == needle,
-        MergeConflictSubject::Artifact { artifact } => format!("{artifact:?}") == needle,
+        MergeConflictSubject::Artifact { artifact } => render_artifact(artifact) == needle,
         MergeConflictSubject::Path { path } => path.to_string() == needle,
     };
     if by_identity {
@@ -571,14 +571,14 @@ fn resolution_for(
             };
             let owner = artifacts
                 .iter()
-                .find(|claimant| format!("{claimant:?}") == artifact.trim())
+                .find(|claimant| render_artifact(claimant) == artifact.trim())
                 .copied()
                 .ok_or_else(|| {
                     merge_bad_request(format!(
                         "{artifact} does not claim this path; its claimants are {}",
                         artifacts
                             .iter()
-                            .map(|claimant| format!("{claimant:?}"))
+                            .map(render_artifact)
                             .collect::<Vec<_>>()
                             .join(", ")
                     ))


### PR DESCRIPTION
## What was wrong

`ArtifactId` is a newtype over `Uuid` with no `Display` impl. The merge command
surfaces rendered and matched artifact identities through `{:?}`, which prints
`ArtifactId(<uuid>)`, while the record's own serde form is the bare `<uuid>`.
The listing and the selector therefore spoke different languages, and the
language the selector spoke was emitted by nothing.

The sharp end is a contested path. `MergeDivergence::PathCollision` is settled
only by naming one claimant with `kin resolve --keep-path <PATH>=<ARTIFACT>`,
because `--all-ours` and `--all-theirs` deliberately skip paths. But:

- the human `kin conflicts` listing stated only how many artifacts collided and
  never named them, so there was no selector to read;
- `kin conflicts --json` did name them, as bare UUIDs, and feeding one straight
  back was refused;
- the only place the accepted form ever appeared was inside the refusal that
  rejected the identity it was quoting.

Falsified end to end against the real daemon before the fix:

```
0b9bdc92-369a-51e9-a45d-3cbbb304dd0a does not claim this path; its claimants are
ArtifactId(0b9bdc92-369a-51e9-a45d-3cbbb304dd0a), ArtifactId(621c83d8-...)
```

That is the same UUID being told it is not one of itself. A merge that collided
on a path could be abandoned or dropped whole, but not settled.

## Mechanism

One canonical textual form for an artifact identity, `render_artifact`, equal to
what the record serializes. Every emitter and the matcher route through it:

- `render_subject`, and its identity half `render_subject_identity` for the
  sites that hold a subject without the entry that labels it;
- the refusal raised when `--all-ours` or `--all-theirs` cannot settle an entry,
  which rendered the whole subject with `{:?}` and so named a claimant in the
  wrapper form the resolver rejects;
- the dangling-endpoint label;
- `entry_matches`, and the `--keep-path` claimant match with its refusal list.

Splitting `render_subject` is a pure extraction. Its output is byte-identical
across all eight combinations of the four subject kinds with a label present or
absent: the two labeled arms stay explicit and everything else delegates.

The contested-path listing now names its claimants and the flag that settles
them, so the conflict is actionable from the human surface as well as the JSON
report.

A sweep of the merge surfaces at this head for a Debug rendering of an artifact
identity or of a conflict subject returns exactly one hit, the deliberate
`assert_ne!` inside the serialize-parity guard. `MergeConflictSubject` reaches
only the two files edited here; the other workspace hits for `MergeConflict` are
an unrelated request type in `commands/merge.rs` and the reconcile crate, and
neither renders an identity. Debug renderings of an `ArtifactId` do survive
elsewhere in the workspace, in kin-core tree operations, kin-git import and
kin-context retrieval diagnostics, none of which is a selector the resolver
takes back.

`--keep-path` also now splits its binding on the last `=` rather than the first.
An artifact identity never contains one, but a contested path may, and this
change is what starts emitting that command with the path interpolated raw. On
`docs/a=b.md=<ARTIFACT>` the old reading produced the selector `docs/a`, which
matches no conflict, so the command the product printed could not settle the
path it named.

Nothing here changes what is persisted. The record already carried the claimant
identities; the commands simply now answer with them.

## Evidence

Red-then-green. Every guard added here has been driven red by a mutation of the
line it defends, and each run asserts how many tests actually ran, so a filter
that matched nothing cannot pass as a red proof.

| mutation | guards driven red | ran / failed |
| --- | --- | --- |
| `render_artifact` back to the Debug form | the three unit rendering guards, including the new subject guard | 3 / 3 |
| the same, end to end against a real daemon | the integration listing guard | 1 / 1 |
| `rsplit_once('=')` back to `split_once('=')` | the binding guard | 1 / 1 |

The listing guard printed the wrapper form verbatim under its mutation:

```
- path docs/notes.md: 2 distinct artifacts occupy this path after composing both
  sides (ArtifactId(097ac8f5-...), ArtifactId(37cca2e0-...)); keep one with
  `kin resolve --keep-path docs/notes.md=<ARTIFACT>`
```

and the binding guard resolved `docs/a=b.md=<uuid>` to the selector `docs/a`
with the claimant `b.md=<uuid>`, which is the failure exactly.

One weakness that falsification exposed and this PR fixes: `ArtifactId(<uuid>)`
contains `<uuid>` as a substring, so a plain `contains` assertion passes under
both forms. Every claimant guard now also asserts the wrapper form is absent, so
they distinguish the two cases instead of passing on either.

Coverage added, for a conflict class the existing eight tests never exercised:

- `a_contested_path_settles_from_the_identity_the_record_reports` takes a
  claimant out of `kin conflicts --json`, settles with it, publishes with
  `--continue`, and asserts the published tree keeps exactly the named artifact
  and no other at that path;
- `a_contested_path_listing_names_its_claimants` asserts the human listing
  carries the identities in the accepted form;
- `a_subject_named_without_its_entry_carries_the_form_the_resolver_accepts`
  covers the refusal surface, and pins the two halves of the subject rendering
  to one form so neither can drift;
- `a_contested_path_holding_an_equals_sign_still_names_its_claimant` covers the
  binding parser for a path holding an `=` alongside the ordinary reading;
- two further unit guards pin the rendering against future drift.

Gates at this head:

| gate | result |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo build --all-targets --locked` | 0 |
| `cargo clippy --all-targets --all-features` with the ci.yml 45-lint allowlist, `RUSTFLAGS=-D warnings` | 0 |
| `cargo test -p kin-cli --no-default-features --locked` | 0 |
| `cargo nextest run --workspace` | 4666 passed, 0 failed, 10 skipped |
| `cargo test --doc --workspace` | 0 |

The allowlist is read out of `.github/workflows/ci.yml` at this head by script
rather than retyped, and diffed against the capture taken before the rebase, so
the local clippy gate cannot drift from the hosted one. The featureless kin-cli
pass is included because this branch adds a `#[cfg(test)]` module to that crate
and the rebase brought in the step that resolves that configuration. Every test
phase ran under the fleet daemon lock, acquired and released around the tests
themselves rather than around compilation.

## Scope

Refs FIR-1621. This closes one gap in the landed `conflicts` and `resolve`
wiring and adds the missing path-collision coverage. It is not the full
post-merge audit still owed against bee8507f, and it makes no claim about the
remaining acceptance items beyond the tests listed above.

