### PR TITLE
Keep a test's managed config paths inside the test that resolved them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,6 +866,12 @@ jobs:
       - name: Check Private Repo Coupling
         run: bash scripts/check_private_repo_coupling.sh
 
+      # The guard above is invoked from the repository root here and nowhere
+      # else, which is the one working directory that hid a broken exclusion.
+      # These tests run it from a foreign directory in both directions.
+      - name: Test Private Repo Coupling Guard
+        run: python3 scripts/test-private-repo-coupling.py
+
       # The committed Cargo.lock plus .cargo/config.toml pins kin-* dependencies
       # to public source until every crate is registry-published.
       - name: Build

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1545,6 +1545,14 @@ mod tests {
     }
 
     fn graph_source_fixture(source: Option<&[u8]>) -> GraphSourceFixture {
+        // Publication proves the Git source three times and requires all three
+        // proofs to agree, and the proof deliberately includes the contents of
+        // the user's resolved global excludes file, which is addressed through
+        // `HOME`. A neighbouring test that moves `HOME` between two of those
+        // proofs therefore fails publication as uncertain. Holding the
+        // environment mutation domain, without changing anything in it, is what
+        // keeps `HOME` still for the width of the window.
+        let _domain = kin_core::test_env::EnvVarGuard::new();
         let temp = tempfile::tempdir().unwrap();
         let repo = temp.path().join("repo");
         fs::create_dir(&repo).unwrap();

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1538,6 +1538,16 @@ mod tests {
 
     #[tokio::test]
     async fn report_is_non_empty_and_serializes_with_ids() {
+        // Health inspects the managed MCP client configs, which are addressed
+        // from the home directory, so an unscoped run reads the developer's
+        // live configuration and reports on whatever it happens to contain.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let kin_home = tmp.path().join("kin-home");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&kin_home).unwrap();
+        let _env = EnvVarGuard::set("HOME", &home).with("KIN_HOME", &kin_home);
+
         let report = run_health_checks().await;
         assert!(!report.checks.is_empty());
         let json = serde_json::to_string(&report).expect("report serializes");

--- a/crates/kin-cli/src/commands/managed_config_scope.rs
+++ b/crates/kin-cli/src/commands/managed_config_scope.rs
@@ -9,9 +9,10 @@
 //! `.agents/mcp_config.json`, and writes back into it.
 //!
 //! This module supplies the ceiling. `KIN_MCP_SCAN_ROOT` pins discovery to one
-//! directory and rejects any repository root found above it, and
-//! `KIN_MCP_FIXTURE_ROOT` turns an escape into an immediate panic instead of a
-//! silent write into the enclosing checkout.
+//! directory and rejects any repository root found above it, and a test build
+//! additionally refuses a managed path that leaves the fixture the test
+//! declared or that lands under the real user's home directory, so an escape is
+//! an immediate panic rather than a silent write into a live config.
 
 use std::path::{Path, PathBuf};
 
@@ -19,12 +20,6 @@ use std::path::{Path, PathBuf};
 ///
 /// Discovery starts here and never binds a repository above it.
 pub(crate) const SCAN_ROOT_ENV: &str = "KIN_MCP_SCAN_ROOT";
-
-/// Directory that bounds every managed-config path a test may touch.
-///
-/// Set only by tests. A managed path outside it aborts the test at the moment
-/// the path is resolved, rather than after it has written into a real checkout.
-pub(crate) const FIXTURE_ROOT_ENV: &str = "KIN_MCP_FIXTURE_ROOT";
 
 /// Resolve a directory to its canonical form, tolerating a path that does not
 /// exist yet by canonicalizing the nearest existing ancestor and re-appending
@@ -96,21 +91,149 @@ pub(crate) fn discover_repo_root() -> Option<PathBuf> {
     Some(root)
 }
 
-/// Abort immediately when a managed-config path escapes the declared fixture.
+/// Abort immediately when a managed-config path escapes its test scope.
 ///
 /// A test that would read or write outside its fixture has already lost its
 /// isolation; failing at path resolution names the offending path while the
-/// stack still shows which flow produced it.
+/// stack still shows which flow produced it. Compiled away entirely outside a
+/// test build, so the shipped CLI carries no lever that can panic it.
 pub(crate) fn guard_managed_path(path: &Path) {
-    let Some(fixture) = env_dir(FIXTURE_ROOT_ENV) else {
-        return;
-    };
-    assert!(
-        is_within(&fixture, path),
-        "managed config path escaped its fixture: {} is outside {}",
-        canonical_dir(path).display(),
-        fixture.display()
-    );
+    #[cfg(test)]
+    test_scope::assert_managed_path_is_test_scoped(path);
+    #[cfg(not(test))]
+    let _ = path;
+}
+
+/// The ceiling a test build puts under managed-config path resolution.
+///
+/// Two rules, both enforced where the path is resolved rather than where it is
+/// written:
+///
+/// - a test may declare a fixture directory, and a managed path outside it
+///   aborts
+/// - no test may resolve a managed path under the real user's home directory,
+///   declared fixture or not
+///
+/// The second rule needs no per-test opt-in, which is the point: the defect it
+/// catches is a test *forgetting* to scope its home, and a guard a test has to
+/// remember is not a guard against forgetting. It reads the home from the
+/// password database rather than from `$HOME` precisely because `$HOME` is what
+/// a correctly scoped test overrides.
+///
+/// The declaration is thread-local and not an environment variable. The
+/// environment table is process-global and readers of it take no lock, so a
+/// variable one test sets is observed by every test running beside it;
+/// `#[serial]` does not close that, because it orders a test only against other
+/// serial tests. A thread-local declaration cannot be observed by another test
+/// at all. The cost is that a flow which resolves managed paths on a spawned
+/// thread is outside its parent's declaration, so a test that needs the ceiling
+/// there declares it in the worker too.
+#[cfg(test)]
+pub(crate) mod test_scope {
+    use super::{canonical_dir, is_within};
+    use std::cell::RefCell;
+    use std::path::{Path, PathBuf};
+
+    thread_local! {
+        /// Fixture ceiling declared by the test running on this thread.
+        static DECLARED_FIXTURE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+    }
+
+    /// A declared fixture ceiling, in force until it is dropped.
+    pub(crate) struct FixtureScope {
+        previous: Option<PathBuf>,
+        /// Binds the scope to the thread that declared it, since that is the
+        /// only thread whose thread-local it can restore.
+        _not_send: std::marker::PhantomData<*const ()>,
+    }
+
+    impl FixtureScope {
+        /// Bound every managed path this thread resolves to `root`.
+        pub(crate) fn declare(root: &Path) -> Self {
+            let previous = DECLARED_FIXTURE.with(|slot| slot.replace(Some(canonical_dir(root))));
+            Self {
+                previous,
+                _not_send: std::marker::PhantomData,
+            }
+        }
+    }
+
+    impl Drop for FixtureScope {
+        fn drop(&mut self) {
+            let previous = self.previous.take();
+            // `try_with` because a scope dropped during thread teardown may
+            // find the thread-local already destroyed, and a panic there would
+            // abort the process rather than fail the test.
+            let _ = DECLARED_FIXTURE.try_with(|slot| *slot.borrow_mut() = previous);
+        }
+    }
+
+    /// The invoking user's home directory as the system records it.
+    ///
+    /// Read from the password database so that overriding `$HOME`, which is how
+    /// a test scopes itself, cannot also move the boundary it is checked
+    /// against. Windows has no equivalent lookup wired here, so the home rule
+    /// is unenforced there and the declared-fixture rule carries alone.
+    #[cfg(unix)]
+    pub(crate) fn real_user_home() -> Option<&'static Path> {
+        use std::ffi::{CStr, OsStr};
+        use std::os::unix::ffi::OsStrExt;
+
+        static HOME: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+        HOME.get_or_init(|| {
+            let mut buffer = vec![0 as libc::c_char; 4096];
+            let mut record: libc::passwd = unsafe { std::mem::zeroed() };
+            let mut found: *mut libc::passwd = std::ptr::null_mut();
+            // SAFETY: `record` and `buffer` outlive the call and are not
+            // aliased, the reentrant form is required because managed paths are
+            // resolved from several test threads at once, and `record` is read
+            // only after the call reports a match.
+            let code = unsafe {
+                libc::getpwuid_r(
+                    libc::getuid(),
+                    &mut record,
+                    buffer.as_mut_ptr(),
+                    buffer.len(),
+                    &mut found,
+                )
+            };
+            if code != 0 || found.is_null() || record.pw_dir.is_null() {
+                return None;
+            }
+            // SAFETY: a matched record's `pw_dir` points into `buffer`, which is
+            // still alive, and the string it points at is NUL terminated.
+            let dir = unsafe { CStr::from_ptr(record.pw_dir) };
+            Some(PathBuf::from(OsStr::from_bytes(dir.to_bytes())))
+        })
+        .as_deref()
+    }
+
+    #[cfg(not(unix))]
+    fn real_user_home() -> Option<&'static Path> {
+        None
+    }
+
+    /// Panic unless `path` belongs to the test that resolved it.
+    pub(crate) fn assert_managed_path_is_test_scoped(path: &Path) {
+        if let Some(fixture) = DECLARED_FIXTURE.with(|slot| slot.borrow().clone()) {
+            assert!(
+                is_within(&fixture, path),
+                "managed config path escaped its fixture: {} is outside {}",
+                canonical_dir(path).display(),
+                fixture.display()
+            );
+        }
+        if let Some(home) = real_user_home() {
+            assert!(
+                !is_within(home, path),
+                "a test resolved the managed config path {} under the real home {}. Point HOME \
+                 and KIN_HOME at a fixture directory for the duration of the test, or this test \
+                 reads and can write the developer's live configuration",
+                canonical_dir(path).display(),
+                home.display()
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -134,5 +257,55 @@ mod tests {
             canonical_dir(&missing),
             dir.path().canonicalize().unwrap().join("absent/leaf.json")
         );
+    }
+
+    /// A fixture one test declares must not bound any other test.
+    ///
+    /// This is the shape that made the suite intermittently fail: the
+    /// declaration used to be an environment variable, which is one table
+    /// shared by every thread in the process, so a test that merely resolved a
+    /// managed path in its own temporary directory aborted whenever it happened
+    /// to run beside the declaring test. Serializing the declaring test did not
+    /// close it, because that orders it only against other serial tests.
+    #[test]
+    fn a_declared_fixture_does_not_reach_another_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let fixture = dir.path().join("fixture");
+        let outside = dir.path().join("outside/mcp.json");
+        std::fs::create_dir_all(&fixture).unwrap();
+
+        let _declared = test_scope::FixtureScope::declare(&fixture);
+        test_scope::assert_managed_path_is_test_scoped(&fixture.join("mcp.json"));
+
+        let escaping = outside.clone();
+        let bounded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            test_scope::assert_managed_path_is_test_scoped(&escaping);
+        }));
+        assert!(
+            bounded.is_err(),
+            "the thread that declared the fixture must still be bounded by it"
+        );
+
+        std::thread::spawn(move || test_scope::assert_managed_path_is_test_scoped(&outside))
+            .join()
+            .expect("a fixture declared on one thread must not bound another");
+    }
+
+    /// No test may resolve a managed config path under the real home, whether
+    /// or not it declared a fixture. The developer's live client configuration
+    /// is there, and a test that reaches it reports on state it does not
+    /// control and can write state it does not own.
+    #[cfg(unix)]
+    #[test]
+    #[should_panic(expected = "under the real home")]
+    fn a_managed_path_under_the_real_home_aborts_with_no_declaration() {
+        let home = test_scope::real_user_home().expect("the password database records a home");
+        test_scope::assert_managed_path_is_test_scoped(&home.join(".kin/probe.json"));
+    }
+
+    #[test]
+    fn a_managed_path_in_a_temporary_fixture_needs_no_declaration() {
+        let dir = tempfile::tempdir().unwrap();
+        test_scope::assert_managed_path_is_test_scoped(&dir.path().join("mcp.json"));
     }
 }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -15704,9 +15704,11 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
 
     /// The fixture guard must fail at the moment an escaping path is resolved,
     /// so a leak is reported against the flow that produced it.
+    ///
+    /// Not serialized, and it does not need to be: the declaration is
+    /// thread-local, so no other test can observe it however they interleave.
     #[cfg(unix)]
     #[test]
-    #[serial]
     #[should_panic(expected = "managed config path escaped its fixture")]
     fn managed_config_outside_the_declared_fixture_aborts_immediately() {
         let dir = tempfile::tempdir().unwrap();
@@ -15714,10 +15716,8 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let outside = dir.path().join("outside");
         fs::create_dir_all(&fixture).unwrap();
         fs::create_dir_all(&outside).unwrap();
-        let _fixture_root = EnvVarGuard::set(
-            crate::commands::managed_config_scope::FIXTURE_ROOT_ENV,
-            &fixture,
-        );
+        let _fixture_root =
+            crate::commands::managed_config_scope::test_scope::FixtureScope::declare(&fixture);
         let _ = ConfigLock::acquire(&outside.join("mcp.json"));
     }
 

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -10516,6 +10516,19 @@ mod tests {
         (archive, provenance, identities)
     }
 
+    /// Point ambient home resolution at the fixture for a test's lifetime.
+    ///
+    /// An update records the MCP repair obligation it will owe after the swap,
+    /// and the client configs that obligation covers are addressed from the
+    /// home directory rather than from the install root the test passes in. A
+    /// test that leaves `HOME` alone therefore resolves, and can write, the
+    /// developer's live configuration.
+    fn fixture_home(tmp: &tempfile::TempDir, kin_home: &Path) -> EnvVarGuard {
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        EnvVarGuard::set("HOME", &home).with("KIN_HOME", kin_home)
+    }
+
     fn write_bundle(root: &Path, spec: &[ComponentSpec], prefix: &[u8]) {
         fs::create_dir_all(root.join("bin")).unwrap();
         fs::create_dir_all(root.join("lib")).unwrap();
@@ -11348,6 +11361,7 @@ cwd = {:?}
         let kin_home = tmp.path().join("kin-home");
         let stage = tmp.path().join("stage");
         write_bundle(&kin_home, LINUX_COMPONENTS, b"old-");
+        let _env = fixture_home(&tmp, &kin_home);
         let expected: Vec<_> = LINUX_COMPONENTS
             .iter()
             .map(|component| {
@@ -12094,6 +12108,7 @@ cwd = {:?}
         let stage = tmp.path().join("stage");
         let outside = tmp.path().join("outside-bin");
         write_bundle(&kin_home, LINUX_COMPONENTS, b"old-");
+        let _env = fixture_home(&tmp, &kin_home);
         fs::create_dir(&outside).unwrap();
         fs::write(outside.join("kin-daemon"), b"outside-victim").unwrap();
         stage_archive(
@@ -12148,6 +12163,7 @@ cwd = {:?}
         let stage = tmp.path().join("stage");
         let outside = tmp.path().join("outside-lib");
         write_bundle(&kin_home, LINUX_COMPONENTS, b"old-");
+        let _env = fixture_home(&tmp, &kin_home);
         fs::create_dir(&outside).unwrap();
         fs::write(outside.join("libkin_vfs_shim.so"), b"outside-victim").unwrap();
         stage_archive(
@@ -12690,6 +12706,7 @@ cwd = {:?}
         let detached = tmp.path().join("kin-home-detached");
         let stage = tmp.path().join("stage");
         write_bundle(&kin_home, LINUX_COMPONENTS, b"old-");
+        let _env = fixture_home(&tmp, &kin_home);
         let expected = bundle_snapshot(&kin_home, LINUX_COMPONENTS);
         stage_archive(
             &full_linux_archive("kin-linux-x86_64"),
@@ -12745,6 +12762,7 @@ cwd = {:?}
         let kin_home = tmp.path().join("kin-home");
         let stage = tmp.path().join("stage");
         write_bundle(&kin_home, LINUX_COMPONENTS, b"old-");
+        let _env = fixture_home(&tmp, &kin_home);
         let expected = bundle_snapshot(&kin_home, LINUX_COMPONENTS);
         stage_archive(
             &full_linux_archive("kin-linux-x86_64"),

--- a/scripts/check_private_repo_coupling.sh
+++ b/scripts/check_private_repo_coupling.sh
@@ -8,6 +8,13 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 1
 fi
 
+# ripgrep anchors a glob containing a slash to the working directory rather than
+# to the path it is told to search, so searching an absolute repo root from any
+# other directory silently stops matching every exclusion below, and the guard
+# then reports its own pattern list as coupling. Searching '.' from the repo
+# root is what makes the exclusions mean what they read as.
+cd "$repo_root"
+
 patterns=(
   '\.\./kinlab'
   'kinlab\.git'
@@ -23,9 +30,9 @@ hits=()
 for pattern in "${patterns[@]}"; do
   while IFS=: read -r file line _; do
     [[ -z "$file" ]] && continue
-    file="${file#"$repo_root/"}"
+    file="${file#./}"
     hits+=("$file:$line:$pattern")
-  done < <(rg -n "$pattern" "$repo_root" \
+  done < <(rg -n "$pattern" . \
     -g '!target/**' \
     -g '!.git/**' \
     -g '!scripts/check_private_repo_coupling.sh' \

--- a/scripts/test-private-repo-coupling.py
+++ b/scripts/test-private-repo-coupling.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Deterministic tests for the private repo coupling guard.
+
+The guard excludes its own pattern list with ripgrep globs, and ripgrep anchors
+a glob containing a slash to the working directory rather than to the path it is
+told to search. A guard that searched an absolute repo root therefore matched
+its exclusions only when it happened to be invoked from that root, and reported
+its own patterns as coupling from anywhere else. That shape cannot turn CI red,
+because CI always invokes it from the root, so it is pinned here instead: every
+case below runs the guard from a working directory that is not the tree it
+scans.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+GUARD = SCRIPTS_DIR / "check_private_repo_coupling.sh"
+GUARD_RELATIVE = f"scripts/{GUARD.name}"
+
+# The private project name, assembled so this file's own source never carries a
+# reference the guard rejects. A test that plants coupling has to spell it out,
+# and spelling it out in source would make the test itself a hit.
+PRIVATE = "kin" + "lab"
+
+# One reference of each shape the guard rejects, so a fixture proves the guard
+# still fires rather than only that it stays quiet.
+COUPLING_REFERENCES = (
+    f"../{PRIVATE}",
+    f"{PRIVATE}.git",
+    f"pnpm --filter @{PRIVATE}/web",
+    f"@{PRIVATE}/control-plane",
+    f"@{PRIVATE}/web",
+    f"{PRIVATE}-control-plane",
+    f"{PRIVATE}-web",
+    f"cargo install --git https://example.invalid/{PRIVATE}",
+)
+
+
+def run_guard(guard: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run `guard` from `cwd`, which is never the tree the guard scans."""
+    return subprocess.run(
+        ["bash", str(guard)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def make_fixture_tree(tmp: Path) -> Path:
+    """A minimal repository carrying a copy of the guard and clean sources."""
+    repo = tmp / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    shutil.copy2(GUARD, repo / GUARD_RELATIVE)
+    (repo / "src").mkdir()
+    (repo / "src/lib.rs").write_text("pub fn kin() -> &'static str { \"kin\" }\n")
+    (repo / "README.md").write_text("# fixture\n\nNo private references here.\n")
+    return repo
+
+
+def test_clean_fixture_passes_from_a_foreign_working_directory() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        repo = make_fixture_tree(tmp)
+        elsewhere = tmp / "elsewhere"
+        elsewhere.mkdir()
+
+        result = run_guard(repo / GUARD_RELATIVE, elsewhere)
+
+        assert result.returncode == 0, (
+            "the guard must exclude its own pattern list wherever it is invoked "
+            f"from; stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "passed" in result.stdout
+
+
+def test_the_verdict_does_not_depend_on_the_working_directory() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        repo = make_fixture_tree(tmp)
+        elsewhere = tmp / "elsewhere"
+        elsewhere.mkdir()
+        guard = repo / GUARD_RELATIVE
+
+        from_root = run_guard(guard, repo)
+        from_elsewhere = run_guard(guard, elsewhere)
+        from_filesystem_root = run_guard(guard, Path("/"))
+
+        codes = {
+            from_root.returncode,
+            from_elsewhere.returncode,
+            from_filesystem_root.returncode,
+        }
+        assert codes == {0}, f"the guard's verdict moved with the caller's cwd: {codes}"
+
+
+def test_a_planted_coupling_still_fails_from_a_foreign_working_directory() -> None:
+    for reference in COUPLING_REFERENCES:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            repo = make_fixture_tree(tmp)
+            elsewhere = tmp / "elsewhere"
+            elsewhere.mkdir()
+            planted = repo / "docs/dev-setup.md"
+            planted.parent.mkdir()
+            planted.write_text(f"Build the console with `{reference}` first.\n")
+
+            result = run_guard(repo / GUARD_RELATIVE, elsewhere)
+
+            assert result.returncode == 1, (
+                f"a planted {reference!r} must fail the guard; "
+                f"stdout={result.stdout!r} stderr={result.stderr!r}"
+            )
+            assert "docs/dev-setup.md" in result.stderr, (
+                f"the guard must name the coupled file for {reference!r}: "
+                f"{result.stderr!r}"
+            )
+            assert GUARD_RELATIVE not in result.stderr, (
+                "the guard must not report its own pattern list beside a real "
+                f"hit: {result.stderr!r}"
+            )
+
+
+def test_the_real_repository_passes_from_a_foreign_working_directory() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        result = run_guard(GUARD, Path(raw))
+
+        assert result.returncode == 0, (
+            "the checked-in tree must pass its own coupling guard from any "
+            f"working directory; stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+
+def main() -> None:
+    if shutil.which("rg") is None:
+        raise SystemExit("private repo coupling guard tests require ripgrep (rg)")
+    tests = (
+        test_clean_fixture_passes_from_a_foreign_working_directory,
+        test_the_verdict_does_not_depend_on_the_working_directory,
+        test_a_planted_coupling_still_fails_from_a_foreign_working_directory,
+        test_the_real_repository_passes_from_a_foreign_working_directory,
+    )
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"{len(tests)} private repo coupling guard tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three test and tooling defects, all of the same family: a check that reads state it does not own. Two are process-global environment channels between tests, one is a working-directory dependency in a shell guard. A fourth of the same family surfaced while verifying the first two and is fixed here as well.

## The fixture ceiling was a channel between tests

`managed_config_outside_the_declared_fixture_aborts_immediately` declared its ceiling by setting `KIN_MCP_FIXTURE_ROOT`. The environment table is one table per process and a reader of it takes no lock, so every `setup_ledger` test that resolved a managed config path through `ConfigLock::acquire` read another test's ceiling and aborted against a fixture it had never heard of. `#[serial]` on the declaring test does not close that, because `serial_test` orders a test against other serial tests only, and none of the readers are serial. `crates/kin-core/src/test_env.rs` already documents that exact ceiling in its module header.

The declaration is now a thread-local scope, which another test cannot observe however the two interleave, and it compiles away outside a test build rather than shipping a lever that can panic the CLI. The declaring test no longer needs `#[serial]`.

Falsification, 20 rounds per arm over the whole `commands::setup_ledger::tests::` module plus the declaring test at `--test-threads=16`, same binary target and host:

| arm | failed rounds |
| --- | --- |
| `managed_config_scope.rs` and `setup.rs` at `origin/main` | 15/20 |
| this branch | 0/20 |

Each arm's binary was checked for the module it was supposed to carry before the rounds ran, since a stale binary would give a green arm that proves nothing.

## Six tests resolved the developer's live configuration

An update records the MCP repair obligation it will owe after the swap, and the client configs that obligation covers are addressed from the ambient home rather than from the install root the test passes in. With `HOME` unscoped that is the developer's real home. Pointing the fixture ceiling at a scratch directory and running the reported test alone names the escape directly:

```
managed config path escaped its fixture:
  /Users/troyfortinjr/.kin/mcp-topology.guard is outside <scratch>
```

Running the whole kin-cli lib binary with the ceiling set to a directory that contains every legitimate fixture but not the real home found six tests, not one: five update flows and the health report. All six now point `HOME` and `KIN_HOME` at fixture directories. `KIN_HOME` alone is not enough, which I checked rather than assumed: the topology guard is `KIN_HOME`-derived but the client-config enumeration immediately after it is `HOME`-derived, so scoping only the first moves the escape one line down.

For the durable half, a kin-cli lib test build now refuses any managed config path under the invoking user's home, at the point of resolution; the integration-test surface sits outside this guard and is recorded as the remaining exposure. The home comes from the password database rather than from `$HOME`, precisely because `$HOME` is what a correctly scoped test overrides, so the boundary cannot be moved by the thing being checked. It needs no per-test opt-in, which is the point: the defect is a test forgetting to scope its home, and a guard you have to remember is not a guard against forgetting. Its blast radius was measured before it was adopted and is exactly those six tests.

Two limits worth stating. The home rule is unenforced on Windows, where no equivalent lookup is wired, and the declared-fixture rule carries alone there. The rule covers managed-config lock and plan resolution, which is where writes happen, so a test that read a real-home file without locking it would not be caught.

## The coupling guard could not pass, and the ripgrep version was not why

The ticket attributes this to the host's ripgrep version. It is not a version difference. ripgrep anchors a `-g` glob containing a slash to the process working directory, not to the path it is told to search. The guard searched an absolute repo root, so `!scripts/check_private_repo_coupling.sh`, `!target/**`, and `!.git/**` matched only when the guard happened to be invoked from that root, and matched nothing from anywhere else, at which point the guard reported its own pattern list as coupling. Same host, same ripgrep 15.1.0, same clean tree, exit 0 from the repository root and exit 1 from one directory down.

The guard now searches from the repository root, which repairs `target/**` and `.git/**` at the same time. `scripts/test-private-repo-coupling.py`, wired into the `check` job beside it, runs the guard from a foreign working directory in both directions: a clean fixture passes, each of the eight rejected reference shapes planted into a fixture still fails and names the planted file, the verdict is identical from three different working directories, and the real tree passes from a temp directory. The test assembles the private project name from fragments so its own source is not a hit, which the environment-mutation scanner in `test_env.rs` already does for the same reason. The first version of the test tripped the guard on itself.

## Repository publication was not stable against a neighbour moving HOME

Found while verifying the above, when `commands::graph::tests::graph_source_*` failed twice in three full-suite runs, differently each time. `init_from_git` proves the Git source three times across publication and requires the proofs to agree, and that proof deliberately includes the contents of the user's resolved global excludes file, which is addressed through `$HOME`. Any test that moves `HOME` between two of those proofs makes them differ, and publication fails as uncertain.

Attribution was settled by experiment rather than by assertion, because the alternative was that this branch had caused it. Pairing the graph tests with `commands::setup::tests::`, a module whose `HOME`-moving tests are entirely pre-existing:

| arm | failed rounds |
| --- | --- |
| graph tests alone | 0/10 |
| graph tests beside the setup module, before | 5/6 |
| graph tests beside the setup module, after | 0/6 |

The 5/6 and 0/6 reproduction arms were observed live and their logs were not retained; the mechanism is corroborated by the retained lib-after3.log line 1062.

So the defect is main's. This branch does add five more `HOME` windows, which widens it, and that is the reason to fix it here rather than file it. The fixture now holds the environment mutation domain, without changing anything in it, for the width of the publication, which is what `test_env.rs` provides `EnvVarGuard::new()` for. Other `init_from_git` callers live in `kin-daemon`'s unit tests and one kin-cli integration test; neither binary contains a test that mutates `HOME` today, so the structural dependency is there but the live exposure is not, and I left those alone rather than fix what I could not reproduce.

## Verification

Green at the final head: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features` under the ci.yml allowlist with `RUSTFLAGS=-Dwarnings`, `cargo build --all-targets`, `scripts/check_private_repo_coupling.sh`, `scripts/test-private-repo-coupling.py`, `scripts/check_runtime_boundaries.sh`. Three full `cargo test -p kin-cli --lib` runs, the authority runner: 1014/1015, 1015/1015, and 1014/1015; the two failures were the publication defect above, now fixed and re-verified, and a daemon-connection failure in an integration test structurally unreachable from this diff, since arbitrated green by CI at this head.

Not claimed: the workspace `nextest` plus `cargo test --doc` gate had not finished locally when this was opened, since the daemon lock is held by an m8 lane with priority; it is queued and CI runs the same gate here. The home-directory rule was measured on macOS, where temp fixtures live outside the home; on the Linux runner the checkout lives under the runner's home, and the local sweep found no test resolving a managed path inside the checkout, but that is inference from one host rather than a CI observation.

Closes FIR-1817
Closes FIR-1799
Closes FIR-1790

