### PR TITLE
Refuse a release archive root file whose name is not a release component

### DIFF
--- a/scripts/release-archive-shape.cjs
+++ b/scripts/release-archive-shape.cjs
@@ -30,6 +30,29 @@ const MAX_ARCHIVE_MEMBERS = 256;
 const MAX_BUNDLE_ENTRIES = 64;
 const MAX_BUNDLE_DEPTH = 6;
 
+// Component file names a release archive root may carry, by target family.
+//
+// This is the release-build side of a two-sided contract. `kin update` stages a
+// downloaded archive by matching every member's file name against the component
+// list for the running platform and aborts the whole staging on the first name
+// it does not manage. A stray file at the archive root therefore does not
+// degrade an update, it stops every update on that platform until a new release
+// replaces the archive. Naming the sanctioned set here is what keeps that
+// failure inside the release build, where the archive can still be rebuilt.
+//
+// The set is an upper bound rather than a checklist. Which components are
+// mandatory is decided by the packaging step's own presence assertions and by
+// the publish job's per-artifact required list; what this decides is only which
+// names may appear at all, which is why the Windows projection components sit
+// here even though that leg ships them opportunistically. Adding a component to
+// a release archive means adding it to the updater's platform component list
+// and to this set together.
+const ROOT_FILES_BY_FAMILY = {
+  darwin: Object.freeze(["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"]),
+  linux: Object.freeze(["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"]),
+  windows: Object.freeze(["kin.exe", "kin-daemon.exe", "kin-vfs.exe", "kin_vfs_shim.dll"]),
+};
+
 // Whether a target triple is one whose archive may carry the notification
 // bundle. Only macOS has a bundle concept, so every other leg must stay flat.
 function targetCarriesNotifierBundle(target) {
@@ -37,6 +60,26 @@ function targetCarriesNotifierBundle(target) {
     throw new Error("release archive shape requires a target triple");
   }
   return target.endsWith("-apple-darwin");
+}
+
+// The component file names an archive for `target` may carry at its root.
+//
+// An unrecognized triple is refused rather than defaulted onto a family. The
+// release matrix is a closed list that the publish job pins by target, so a
+// triple that reaches here without a family is a matrix change that did not
+// update this file, and judging its archive by another platform's names would
+// admit exactly the entries this set exists to refuse.
+function releaseArchiveRootFiles(target) {
+  if (targetCarriesNotifierBundle(target)) {
+    return ROOT_FILES_BY_FAMILY.darwin;
+  }
+  if (target.includes("-windows-")) {
+    return ROOT_FILES_BY_FAMILY.windows;
+  }
+  if (target.includes("-linux-")) {
+    return ROOT_FILES_BY_FAMILY.linux;
+  }
+  throw new Error(`release archive shape has no component list for target ${target}`);
 }
 
 // Split an archive member path into its segments, rejecting the encodings that
@@ -82,6 +125,7 @@ function assertReleaseArchiveMemberPaths(memberPaths, options) {
     throw new Error("release archive shape requires an artifact name");
   }
   const bundleAllowed = targetCarriesNotifierBundle(target);
+  const rootFiles = releaseArchiveRootFiles(target);
   const label = `${artifact} archive listing`;
   if (!Array.isArray(memberPaths) || memberPaths.length === 0) {
     throw new Error(`${label} is empty`);
@@ -128,6 +172,9 @@ function assertReleaseArchiveMemberPaths(memberPaths, options) {
     }
     if (isDirectory) {
       throw new Error(`${label} declares unexpected directory '${member}'`);
+    }
+    if (!rootFiles.includes(relative[0])) {
+      throw new Error(`${label} declares unexpected file '${member}'`);
     }
   }
 
@@ -204,6 +251,7 @@ function assertNotifierBundle(bundleRoot, bundleName) {
 function classifyReleaseArchiveRoot(contentRoot, options) {
   const { target } = options ?? {};
   const bundleAllowed = targetCarriesNotifierBundle(target);
+  const rootFiles = releaseArchiveRootFiles(target);
   const files = [];
   const bundles = [];
   for (const entry of fs.readdirSync(contentRoot, { withFileTypes: true })) {
@@ -211,6 +259,11 @@ function classifyReleaseArchiveRoot(contentRoot, options) {
       throw new Error(`release archive root entry '${entry.name}' is a symbolic link`);
     }
     if (entry.isFile()) {
+      if (!rootFiles.includes(entry.name)) {
+        throw new Error(
+          `release archive root for ${target} holds unexpected file '${entry.name}'`
+        );
+      }
       files.push(entry.name);
       continue;
     }
@@ -244,5 +297,6 @@ module.exports = {
   NOTIFIER_BUNDLE_DIR,
   assertReleaseArchiveMemberPaths,
   classifyReleaseArchiveRoot,
+  releaseArchiveRootFiles,
   targetCarriesNotifierBundle,
 };

--- a/scripts/release-archive-shape.test.cjs
+++ b/scripts/release-archive-shape.test.cjs
@@ -13,6 +13,7 @@ const {
   NOTIFIER_BUNDLE_DIR,
   assertReleaseArchiveMemberPaths,
   classifyReleaseArchiveRoot,
+  releaseArchiveRootFiles,
   targetCarriesNotifierBundle,
 } = require("./release-archive-shape.cjs");
 
@@ -59,6 +60,10 @@ const LINUX_LISTING = [
 const WINDOWS_LISTING = ["kin.exe", "kin-daemon.exe", "kin-vfs.exe"];
 
 const MACOS_FILES = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"];
+const LINUX_FILES = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"];
+// Sorted the way the classifier returns names, which puts the bare CLI between
+// the hyphenated binaries and the underscored shim.
+const WINDOWS_FILES = ["kin-daemon.exe", "kin-vfs.exe", "kin.exe", "kin_vfs_shim.dll"];
 
 function tempRoot() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "release-archive-shape-"));
@@ -91,7 +96,15 @@ function macosRoot(options = {}) {
 
 function linuxRoot() {
   const root = tempRoot();
-  for (const name of ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"]) {
+  for (const name of LINUX_FILES) {
+    writeFile(root, [name], 0o755);
+  }
+  return root;
+}
+
+function windowsRoot() {
+  const root = tempRoot();
+  for (const name of WINDOWS_FILES) {
     writeFile(root, [name], 0o755);
   }
   return root;
@@ -204,8 +217,86 @@ test("the extracted macOS root yields exactly the four provenance-bearing files"
 
 test("the extracted Linux root yields its files and no bundle", () => {
   const { files, bundles } = classifyReleaseArchiveRoot(linuxRoot(), { target: LINUX_TARGET });
-  assert.deepEqual(files, ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"]);
+  assert.deepEqual(files, LINUX_FILES);
   assert.deepEqual(bundles, []);
+});
+
+test("the extracted Windows root yields its files and no bundle", () => {
+  const { files, bundles } = classifyReleaseArchiveRoot(windowsRoot(), { target: WINDOWS_TARGET });
+  assert.deepEqual(files, WINDOWS_FILES);
+  assert.deepEqual(bundles, []);
+});
+
+test("the sanctioned root files are read per target family", () => {
+  assert.deepEqual(releaseArchiveRootFiles(MACOS_TARGET).slice().sort(), MACOS_FILES);
+  assert.deepEqual(releaseArchiveRootFiles("aarch64-apple-darwin").slice().sort(), MACOS_FILES);
+  assert.deepEqual(releaseArchiveRootFiles(LINUX_TARGET).slice().sort(), LINUX_FILES);
+  assert.deepEqual(
+    releaseArchiveRootFiles("aarch64-unknown-linux-musl").slice().sort(),
+    LINUX_FILES
+  );
+  assert.deepEqual(releaseArchiveRootFiles(WINDOWS_TARGET).slice().sort(), WINDOWS_FILES);
+  assert.throws(() => releaseArchiveRootFiles(""), /requires a target triple/);
+  assert.throws(
+    () => releaseArchiveRootFiles("wasm32-unknown-unknown"),
+    /no component list for target wasm32-unknown-unknown/
+  );
+});
+
+test("an extracted root holding a stray file is rejected and names it", () => {
+  for (const [root, target] of [
+    [macosRoot(), MACOS_TARGET],
+    [linuxRoot(), LINUX_TARGET],
+    [windowsRoot(), WINDOWS_TARGET],
+  ]) {
+    writeFile(root, ["README"]);
+    assert.throws(
+      () => classifyReleaseArchiveRoot(root, { target }),
+      /holds unexpected file 'README'/,
+      `a stray root file survived the ${target} archive shape check`
+    );
+  }
+});
+
+test("a component belonging to another target family is not a sanctioned name", () => {
+  // Copying the Unix CLI into a Windows archive, or a dylib shim into a Linux
+  // one, is a plausible packaging slip and is only caught if the sanctioned set
+  // is read per family rather than pooled across every release leg.
+  const windows = windowsRoot();
+  writeFile(windows, ["kin"], 0o755);
+  assert.throws(
+    () => classifyReleaseArchiveRoot(windows, { target: WINDOWS_TARGET }),
+    /holds unexpected file 'kin'/
+  );
+
+  const linux = linuxRoot();
+  writeFile(linux, ["libkin_vfs_shim.dylib"], 0o755);
+  assert.throws(
+    () => classifyReleaseArchiveRoot(linux, { target: LINUX_TARGET }),
+    /holds unexpected file 'libkin_vfs_shim\.dylib'/
+  );
+});
+
+test("a listing declaring a stray root file is rejected before extraction", () => {
+  const cases = [
+    [LINUX_ARTIFACT, LINUX_TARGET, [...LINUX_LISTING, `${LINUX_ARTIFACT}/README`], /'.*\/README'/],
+    [
+      MACOS_ARTIFACT,
+      MACOS_TARGET,
+      [...MACOS_LISTING, `${MACOS_ARTIFACT}/install.sh`],
+      /'.*\/install\.sh'/,
+    ],
+    // The Windows zip is flat, so a stray member carries no prefix to hide in.
+    [WINDOWS_ARTIFACT, WINDOWS_TARGET, [...WINDOWS_LISTING, "kin.pdb"], /'kin\.pdb'/],
+  ];
+  for (const [artifact, target, listing, named] of cases) {
+    assert.throws(
+      () => assertReleaseArchiveMemberPaths(listing, { artifact, target }),
+      /declares unexpected file/,
+      `a stray ${artifact} listing member survived the pre-extraction check`
+    );
+    assert.throws(() => assertReleaseArchiveMemberPaths(listing, { artifact, target }), named);
+  }
 });
 
 test("an extracted root holding an unsanctioned directory is rejected", () => {

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -4446,6 +4446,80 @@ def main() -> None:
         "./scripts/release-archive-shape.test.cjs",
         "release archive shape regression",
     )
+
+    # The release build decides which files may sit at an archive root; the
+    # updater decides which names it is willing to stage. `kin update` aborts a
+    # whole staging on the first name it does not manage, so a name sanctioned
+    # here that the updater has never heard of publishes cleanly and then stops
+    # every update on that platform until a later release replaces the archive.
+    # Pin the two sets against each other instead of trusting them to be edited
+    # together. Only one direction is required: the updater deliberately manages
+    # names the release no longer ships, so that it can delete a stale copy.
+    archive_shape = (ROOT / "scripts" / "release-archive-shape.cjs").read_text(
+        encoding="utf-8"
+    )
+    for policy in (
+        "holds unexpected file",
+        "declares unexpected file",
+        "has no component list for target",
+    ):
+        require(archive_shape, policy, "sanctioned release archive root file names")
+    updater = (ROOT / "crates" / "kin-cli" / "src" / "commands" / "update.rs").read_text(
+        encoding="utf-8"
+    )
+
+    def between(content: str, start: str, end: str, label: str) -> str:
+        try:
+            begin = content.index(start) + len(start)
+            return content[begin : content.index(end, begin)]
+        except ValueError as error:
+            raise AssertionError(
+                f"cannot read {label}: anchor moved, so this check would compare "
+                "two empty sets and pass without judging anything"
+            ) from error
+
+    for family, spec, cli in (
+        ("darwin", "MACOS_COMPONENTS", "kin"),
+        ("linux", "LINUX_COMPONENTS", "kin"),
+        ("windows", "WINDOWS_COMPONENTS", "kin.exe"),
+    ):
+        sanctioned = set(
+            re.findall(
+                r'"([^"]+)"',
+                between(
+                    archive_shape,
+                    f"  {family}: Object.freeze([",
+                    "]),",
+                    f"the {family} release archive root file names",
+                ),
+            )
+        )
+        managed = set(
+            re.findall(
+                r'name: "([^"]+)"',
+                between(
+                    updater,
+                    f"const {spec}: &[ComponentSpec] = &[",
+                    "\n];",
+                    f"the updater's {spec} list",
+                ),
+            )
+        )
+        # Both extractions have to have found the CLI, or an anchor drifted and
+        # the subset below is comparing nothing against nothing.
+        for names, source in ((sanctioned, family), (managed, spec)):
+            if cli not in names:
+                raise AssertionError(
+                    f"{source} component names do not include {cli}, so the release "
+                    "archive and updater component sets were not actually read"
+                )
+        unmanaged = sorted(sanctioned - managed)
+        if unmanaged:
+            raise AssertionError(
+                f"release archive root files {unmanaged} are sanctioned for {family} "
+                f"but are not in the updater's {spec}, so an archive carrying them "
+                "would publish and then abort every update on that platform"
+            )
     archive_attestation_start = publish_job.index(
         "      - name: Attest final release archives and provenance"
     )


### PR DESCRIPTION
## Mechanism

`classifyReleaseArchiveRoot` allowlisted archive-root **directories** by name and
validated the notifier bundle's interior, but its file branch accepted any regular
file with no name check at all. `assertReleaseArchiveMemberPaths`, the sibling guard
that judges the declared listing before extraction, had the same asymmetry: it
refused an unexpected root directory and accepted any root file member.

That is not a cosmetic gap. The returned file list is the release's content
inventory, so a stray root file was hashed into the per-artifact provenance manifest
by the build job and then confirmed against that same manifest by the publish job.
Both sides agreed, because both derived the inventory from the same blind classifier.
Nothing downstream would have caught it either: the archive digest, the signature,
and the attestation all cover the stray file happily, since it really is in the
archive they describe.

The first thing that notices is a user. `kin update` stages an archive by matching
every member's file name against the `ComponentSpec` list for the running platform
and bails on the first name it does not manage:

```rust
let Some(component) = spec.iter().copied().find(|item| item.name == name) else {
    anyhow::bail!("release archive contains unexpected file '{}'", path.display());
};
```

That is a whole-archive abort, not a skipped entry, and it lives in both the tar and
zip staging paths. One stray file at the archive root therefore does not degrade an
update, it stops **every** update on that platform until a later release replaces the
archive.

This adds the file-branch allowlist symmetric with the directory branch, on both the
extracted root and the declared listing, with the refusal naming the offending entry.
The sanctioned names are derived per target family from what the packaging steps
actually assemble, cross-checked against the installer and the updater's component
lists rather than guessed.

The set is an upper bound, not a checklist. Which components are mandatory is already
decided by the packaging step's presence assertions and the publish job's per-artifact
`required` list, which is why the Windows projection components are sanctioned here
even though that leg copies them with `-ErrorAction SilentlyContinue`. An unrecognized
target triple is refused rather than defaulted onto a family, since judging an archive
by another platform's component names would admit exactly what the set exists to
reject.

## Authority pin

The release build and the updater hold two halves of one contract and nothing compared
them, so `test-release-workflow-authority.py` now reads both and requires the sanctioned
set to be a subset of the updater's per-platform `ComponentSpec` names. Only that
direction holds: the updater deliberately manages names the release no longer ships
(`kin-mcp`) so it can delete a stale copy.

Both extractions assert they found the platform CLI before comparing, because an anchor
that drifts would otherwise leave the subset check comparing two empty sets and passing
without judging anything.

## Falsification

Red then green, against the same planted stray. Logs in
`scratchpad/fir1789-falsify-{red,green,gates,gates-postrebase}.log`.

**Red**, pre-fix module, a `README` planted at a Linux archive root:

```
classifyReleaseArchiveRoot      ACCEPTED stray root file
  inventory it returned: ["README","kin","kin-daemon","kin-vfs","libkin_vfs_shim.so"]
assertReleaseArchiveMemberPaths ACCEPTED stray root member 'kin-linux-x86_64/README'
```

The stray reaching the returned inventory is the defect's full shape: it would have
been hashed into the manifest as a legitimate component.

**Green**, same fixture, fixed module:

```
classifyReleaseArchiveRoot      refused: release archive root for x86_64-unknown-linux-musl holds unexpected file 'README'
assertReleaseArchiveMemberPaths refused: kin-linux-x86_64 archive listing declares unexpected file 'kin-linux-x86_64/README'
```

The authority needle was falsified three ways, each failing as intended before being
reverted:

| Mutation | Result |
| --- | --- |
| `kin-stray` added to the darwin sanctioned set | `release archive root files ['kin-stray'] are sanctioned for darwin but are not in the updater's MACOS_COMPONENTS` |
| extraction anchor drifted (`Object.freeze( [`) | `anchor moved, so this check would compare two empty sets and pass without judging anything` |
| root-file refusal string removed | `sanctioned release archive root file names is missing required policy: holds unexpected file` |

Five new node tests cover the extracted root and the pre-extraction listing across all
three families, including the non-obvious case that a component belonging to another
family is not a sanctioned name (a Unix `kin` in a Windows archive), which only fails
if the set is read per family rather than pooled. The legitimate shapes still pass:
the real macOS listing is accepted whole, and all three roots classify to their
expected inventories.

The tests were themselves falsified against the pre-fix module, because a suite that
passes on broken code proves nothing. Running the new suite against the parent commit's
`release-archive-shape.cjs` gives 14 passed, 4 failed, and the four that fail are
exactly the four asserting the new refusals:

```
* the sanctioned root files are read per target family
* an extracted root holding a stray file is rejected and names it
* a component belonging to another target family is not a sanctioned name
* a listing declaring a stray root file is rejected before extraction
```

The fifth new test (the Windows root classifying to its expected inventory) passes
against both, which is correct: it is an accept-side test, and the pre-fix classifier
accepted the legitimate Windows files too.

## Gates

- `node --test` over the six release-policy suites: 45 passed, 0 failed
- `python3 scripts/test-release-workflow-authority.py`: pass, including on an isolated
  `/tmp` `git archive` extraction with no git repo and no worktree state
- the four sibling python release suites (`test_install_optional_vfs`,
  `test_installer_parity`, `test-npm-automatic-release`, `test-verify-npm-release`): pass
- re-run after rebasing onto `94f957bb`
- no cargo: the diff is cjs and python only. No workflow yaml moved, so no actionlint.

Refs FIR-1789 (the ticket's F3 bundle-depth-cap divergence and F4 node --check remain open in it; F1 is fixed in both guards and F2 incidentally)

