### PR TITLE
Assert the Windows admission contract the installed release actually ships

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -362,12 +362,13 @@ jobs:
       #
       # So the two steps below assert the contract the product ships, in the
       # contract's own words, and the three repository-dependent steps after
-      # them became Unix-only. Windows still proves the installer, the
-      # binaries, their version and provenance, every admission refusal, and
-      # the whole repo-free setup surface. It no longer proves a repository, a
-      # running daemon, a graph query, or an MCP tool call. That is a real loss
-      # of release coverage on one platform, taken deliberately and meant to be
-      # temporary.
+      # them became Unix-only. Windows still proves the installer, both
+      # binaries' version, the CLI's own build provenance, every admission
+      # refusal, and the whole repo-free setup surface. It no longer proves a
+      # repository, a running daemon, a graph query, an MCP tool call, or the
+      # daemon's build provenance, which reaches `kin status` from a running
+      # daemon and so needs a repository. That is a real loss of release
+      # coverage on one platform, taken deliberately and meant to be temporary.
       #
       # This step is also the tripwire that ends the reduction. When the Windows
       # transaction-layer port lands and admission succeeds again,
@@ -459,15 +460,22 @@ jobs:
             #
             # Counted where they actually appear, the two boundaries that reach
             # the graph store DO leave their unpublished stage and its `.owner`
-            # marker behind, which is two entries each. Nothing reaps them:
-            # recover_orphaned_repository_stages is `#[cfg(not(unix))] => Ok(0)`
-            # and the cleanup that does run is best-effort against the same open
-            # handles that refuse the admission. That is a real defect and it
-            # was invisible for as long as the count looked in the wrong place.
-            # It is asserted by exact count in both directions, so the
-            # transaction-layer port that finally drives it to zero trips this
-            # and has to come here and say so, exactly as a restored admission
-            # trips `require_refused` above.
+            # marker behind, which is two entries each. This is post-refusal
+            # residue measured before any reaper could run: each boundary owns a
+            # freshly created parent and sees one `kin init`, and
+            # recover_orphaned_repository_stages runs against that parent before
+            # the stage exists, so it finds nothing to reap on any platform.
+            # What moves the count is refusal-time cleanup, or the
+            # transaction-layer port fixing cleanup_owned_staging_root on the
+            # failing path, where removal is best-effort against the same open
+            # handles that refuse the admission. Proving the off-unix reaper arm
+            # instead needs a second init against a parent already holding
+            # residue, which is a different fixture from this one. That is a
+            # real defect and it was invisible for as long as the count looked
+            # in the wrong place. It is asserted by exact count in both
+            # directions, so whatever finally drives it to zero trips this and
+            # has to come here and say so, exactly as a restored admission trips
+            # `require_refused` above.
             local parent
             parent="$(dirname "$2")"
             local staged
@@ -521,13 +529,14 @@ jobs:
           echo "Installed Windows release refused every admission boundary at the cause it names, published no authority, and left exactly the unreaped stage residue this platform is known to leave."
 
       # What Windows still proves without a repository. This is the whole
-      # remaining first-run surface on the platform: the binaries' own build
+      # remaining first-run surface on the platform: the CLI's own build
       # provenance bound to the release tag's public source, the platform
       # capability posture, and the setup writers for the shell hook, the
       # install ledger, and every agent-client MCP config a repo-free install
-      # can write, which is four of the five. Codex is excluded by the product
-      # rather than by this proof, because its entry binds an exact
-      # repository, and that exclusion is asserted below.
+      # can write, which is four of the five. `kin bench-meta` reports the CLI
+      # build alone, so the daemon's build provenance is not bound here. Codex
+      # is excluded by the product rather than by this proof, because its entry
+      # binds an exact repository, and that exclusion is asserted below.
       - name: Windows repo-free provenance and setup proof
         if: runner.os == 'Windows'
         shell: bash

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -446,23 +446,34 @@ jobs:
             if [ -e "$2/.kin" ]; then
               fail "$1 left a half-created repository at $2/.kin" "$3"
             fi
+            # WINDOWS CLEANUP GAP, asserted rather than assumed.
+            #
             # The stage is a sibling of the admitted directory, not a child of
             # it: crates/kin-core/src/git_init.rs derives it from the source's
             # parent and crates/kin-core/src/init.rs from the working
             # directory's, so a count taken inside the admitted directory can
-            # never see one and would pass on every input. Each boundary
+            # never see one and would report zero on every input. Each boundary
             # therefore owns a private parent holding nothing but the directory
             # under test, which keeps a survivor attributable to the boundary
-            # that left it. Windows needs this most: orphaned stages are reaped
-            # on the next init only on Unix, and the cleanup that does run there
-            # is best-effort against the same open-handle behavior that refuses
-            # the admission in the first place.
+            # that left it.
+            #
+            # Counted where they actually appear, the two boundaries that reach
+            # the graph store DO leave their unpublished stage and its `.owner`
+            # marker behind, which is two entries each. Nothing reaps them:
+            # recover_orphaned_repository_stages is `#[cfg(not(unix))] => Ok(0)`
+            # and the cleanup that does run is best-effort against the same open
+            # handles that refuse the admission. That is a real defect and it
+            # was invisible for as long as the count looked in the wrong place.
+            # It is asserted by exact count in both directions, so the
+            # transaction-layer port that finally drives it to zero trips this
+            # and has to come here and say so, exactly as a restored admission
+            # trips `require_refused` above.
             local parent
             parent="$(dirname "$2")"
             local staged
             staged="$(count_matching "$parent" '.kin.init-*')"
-            if [ "$staged" != "0" ]; then
-              fail "$1 left $staged unpublished stage directory(s) in $parent" "$3"
+            if [ "$staged" != "$4" ]; then
+              fail "$1 left $staged stage entries in $parent, expected $4" "$3"
             fi
           }
 
@@ -482,7 +493,7 @@ jobs:
             # before it reaches the boundary under test.
             git -c core.hooksPath= -c commit.gpgsign=false commit -qm probe
           )
-          require_refused "Windows exact-Git admission" "$git_boundary" "$git_log"
+          require_refused "Windows exact-Git admission" "$git_boundary" "$git_log" 2
           refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE" "$git_log"
           refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL" "$git_log"
           require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP" "$git_log"
@@ -490,7 +501,7 @@ jobs:
           native_boundary="$scratch/native-unborn/repo"
           native_log="$scratch/kin-init-native-unborn.txt"
           mkdir -p "$native_boundary"
-          require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log"
+          require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log" 2
           refute_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL" "$native_log"
           require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP" "$native_log"
 
@@ -500,14 +511,14 @@ jobs:
           populated_log="$scratch/kin-init-native-populated.txt"
           mkdir -p "$populated_boundary"
           printf 'untracked\n' > "$populated_boundary/stray.txt"
-          require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log"
+          require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log" 0
           require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL" "$populated_log"
 
           if [ "$failures" -ne 0 ]; then
             echo "::error::the installed Windows release did not refuse admission as the shipped contract asserts ($failures check(s) failed)"
             exit 1
           fi
-          echo "Installed Windows release refused every admission boundary at the cause it names, and published nothing."
+          echo "Installed Windows release refused every admission boundary at the cause it names, published no authority, and left exactly the unreaped stage residue this platform is known to leave."
 
       # What Windows still proves without a repository. This is the whole
       # remaining first-run surface on the platform: the binaries' own build

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -439,21 +439,34 @@ jobs:
             if (cd "$2" && kin init) > "$3" 2>&1; then
               fail "$1 unexpectedly succeeded" "$3"
             fi
-            # A refusal publishes nothing. Both boundaries stage into a sibling
+            # A refusal publishes nothing. Both boundaries stage into a
             # `.kin.init-<uuid>` and only move it into place at the end, so a
             # `.kin` of any shape means a refusal published authority anyway,
             # and a surviving stage means it did not clean up after itself.
             if [ -e "$2/.kin" ]; then
               fail "$1 left a half-created repository at $2/.kin" "$3"
             fi
+            # The stage is a sibling of the admitted directory, not a child of
+            # it: crates/kin-core/src/git_init.rs derives it from the source's
+            # parent and crates/kin-core/src/init.rs from the working
+            # directory's, so a count taken inside the admitted directory can
+            # never see one and would pass on every input. Each boundary
+            # therefore owns a private parent holding nothing but the directory
+            # under test, which keeps a survivor attributable to the boundary
+            # that left it. Windows needs this most: orphaned stages are reaped
+            # on the next init only on Unix, and the cleanup that does run there
+            # is best-effort against the same open-handle behavior that refuses
+            # the admission in the first place.
+            local parent
+            parent="$(dirname "$2")"
             local staged
-            staged="$(count_matching "$2" '.kin.init-*')"
+            staged="$(count_matching "$parent" '.kin.init-*')"
             if [ "$staged" != "0" ]; then
-              fail "$1 left $staged unpublished stage directory(s) in $2" "$3"
+              fail "$1 left $staged unpublished stage directory(s) in $parent" "$3"
             fi
           }
 
-          git_boundary="$scratch/exact-git"
+          git_boundary="$scratch/exact-git/repo"
           git_log="$scratch/kin-init-exact-git.txt"
           mkdir -p "$git_boundary"
           (
@@ -474,7 +487,7 @@ jobs:
           refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL" "$git_log"
           require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP" "$git_log"
 
-          native_boundary="$scratch/native-unborn"
+          native_boundary="$scratch/native-unborn/repo"
           native_log="$scratch/kin-init-native-unborn.txt"
           mkdir -p "$native_boundary"
           require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log"
@@ -483,7 +496,7 @@ jobs:
 
           # A capability Windows now has must not become permission to derive
           # authority from whatever happens to be lying in the directory.
-          populated_boundary="$scratch/native-populated"
+          populated_boundary="$scratch/native-populated/repo"
           populated_log="$scratch/kin-init-native-populated.txt"
           mkdir -p "$populated_boundary"
           printf 'untracked\n' > "$populated_boundary/stray.txt"

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -342,7 +342,306 @@ jobs:
           }, null, 2)}\n`);
           NODE
 
+      # WINDOWS COVERAGE REDUCTION, stated here so that no later reader mistakes
+      # this leg for the one it replaces.
+      #
+      # Until 2026-07-20 the Windows leg proved the same first-run surface the
+      # Unix legs still prove: a repository admitted by `kin init`, a daemon
+      # serving it, a graph query, an MCP tool call, and a validated capability
+      # report. Run 29749887140, against the promoted v0.3.6 release, is the
+      # last run in which all of that passed on windows-latest.
+      #
+      # It cannot pass now. `kin init` refuses every admission boundary on
+      # Windows, because the graph store flushes a directory the way Unix does,
+      # by reopening it and syncing, and Windows refuses that open. The refusal
+      # is not an accident: scripts/assert-windows-init-contract.sh asserts it
+      # by name on every pull request as the contract this product ships. A
+      # release gate demanding success while a required check demands refusal
+      # cannot go green on either answer, which is why this leg had no passing
+      # outcome available to it at all.
+      #
+      # So the two steps below assert the contract the product ships, in the
+      # contract's own words, and the three repository-dependent steps after
+      # them became Unix-only. Windows still proves the installer, the
+      # binaries, their version and provenance, every admission refusal, and
+      # the whole repo-free setup surface. It no longer proves a repository, a
+      # running daemon, a graph query, or an MCP tool call. That is a real loss
+      # of release coverage on one platform, taken deliberately and meant to be
+      # temporary.
+      #
+      # This step is also the tripwire that ends the reduction. When the Windows
+      # transaction-layer port lands and admission succeeds again,
+      # `require_refused` fails with "unexpectedly succeeded", and whoever reads
+      # that failure should delete these two steps, drop the three
+      # `runner.os != 'Windows'` guards below, and flip the contract script back
+      # to asserting a successful admission.
+      - name: Windows admission contract proof
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The shipped Windows admission contract, in the exact words
+          # scripts/assert-windows-init-contract.sh pins on every pull request.
+          # This runner is anonymous and has no checkout, so the strings are
+          # retyped; scripts/test-release-workflow-authority.py requires them to
+          # equal that script's own variables, so wording drifting in either
+          # file fails a required check instead of quietly passing here.
+          CONFIG_REFUSAL="cannot publish repository config"
+          SOURCE_PROOF_STAGE="prove mutable Git workspace"
+          DURABLE_FLUSH_GAP="for durable metadata flush"
+          NON_EMPTY_REFUSAL="requires an empty directory"
+
+          scratch="kin-windows-admission"
+          mkdir -p "$scratch"
+
+          # Every assertion reports and the step exits once at the end. One
+          # Windows round is expensive, so stopping at the first failure would
+          # cost a second round to learn what the second boundary did.
+          failures=0
+          fail() {
+            failures=$((failures + 1))
+            echo "::error::$1"
+            echo "--- captured kin init output: $2 ---"
+            cat "$2" || true
+            echo "--- end $2 ---"
+          }
+          # `grep -c` exits 1 on zero matches, which `set -e` would otherwise
+          # treat as a fatal error rather than as the answer.
+          occurrences() {
+            grep -Fc -- "$1" "$2" || true
+          }
+          require_text() {
+            if [ "$(occurrences "$2" "$3")" -eq 0 ]; then
+              fail "$1 did not report: $2" "$3"
+            fi
+          }
+          refute_text() {
+            if [ "$(occurrences "$2" "$3")" -ne 0 ]; then
+              fail "$1 stopped at a gate this platform no longer has: $2" "$3"
+            fi
+          }
+          # Deliberately not `find`: on a Windows runner that name also belongs
+          # to System32\find.exe, whose arguments mean something else entirely,
+          # and a PATH order resolving to it would report zero for every input
+          # rather than fail. An unmatched glob stays literal here because
+          # nullglob is off, and the `-e` test rejects it.
+          count_matching() {
+            local matches=0
+            local entry
+            for entry in "$1"/$2; do
+              if [ -e "$entry" ]; then
+                matches=$((matches + 1))
+              fi
+            done
+            echo "$matches"
+          }
+          require_refused() {
+            if (cd "$2" && kin init) > "$3" 2>&1; then
+              fail "$1 unexpectedly succeeded" "$3"
+            fi
+            # A refusal publishes nothing. Both boundaries stage into a sibling
+            # `.kin.init-<uuid>` and only move it into place at the end, so a
+            # `.kin` of any shape means a refusal published authority anyway,
+            # and a surviving stage means it did not clean up after itself.
+            if [ -e "$2/.kin" ]; then
+              fail "$1 left a half-created repository at $2/.kin" "$3"
+            fi
+            local staged
+            staged="$(count_matching "$2" '.kin.init-*')"
+            if [ "$staged" != "0" ]; then
+              fail "$1 left $staged unpublished stage directory(s) in $2" "$3"
+            fi
+          }
+
+          git_boundary="$scratch/exact-git"
+          git_log="$scratch/kin-init-exact-git.txt"
+          mkdir -p "$git_boundary"
+          (
+            cd "$git_boundary"
+            git init -q
+            git config user.email ci@firelock.ai
+            git config user.name ci
+            printf 'fn probe() {}\n' > probe.rs
+            git add probe.rs
+            # Hooks and signing are neutralized for this one invocation and NOT
+            # written into the fixture's config. A recorded `core.hooksPath` is
+            # itself a local compatibility blocker that admission refuses on
+            # before it reaches the boundary under test.
+            git -c core.hooksPath= -c commit.gpgsign=false commit -qm probe
+          )
+          require_refused "Windows exact-Git admission" "$git_boundary" "$git_log"
+          refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE" "$git_log"
+          refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL" "$git_log"
+          require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP" "$git_log"
+
+          native_boundary="$scratch/native-unborn"
+          native_log="$scratch/kin-init-native-unborn.txt"
+          mkdir -p "$native_boundary"
+          require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log"
+          refute_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL" "$native_log"
+          require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP" "$native_log"
+
+          # A capability Windows now has must not become permission to derive
+          # authority from whatever happens to be lying in the directory.
+          populated_boundary="$scratch/native-populated"
+          populated_log="$scratch/kin-init-native-populated.txt"
+          mkdir -p "$populated_boundary"
+          printf 'untracked\n' > "$populated_boundary/stray.txt"
+          require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log"
+          require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL" "$populated_log"
+
+          if [ "$failures" -ne 0 ]; then
+            echo "::error::the installed Windows release did not refuse admission as the shipped contract asserts ($failures check(s) failed)"
+            exit 1
+          fi
+          echo "Installed Windows release refused every admission boundary at the cause it names, and published nothing."
+
+      # What Windows still proves without a repository. This is the whole
+      # remaining first-run surface on the platform: the binaries' own build
+      # provenance bound to the release tag's public source, the platform
+      # capability posture, and the setup writers for the shell hook, the
+      # install ledger, and all five agent-client MCP configs.
+      - name: Windows repo-free provenance and setup proof
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          PROOF_SHELL: ${{ matrix.setup-shell }}
+        run: |
+          set -euo pipefail
+          kin bench-meta --json > kin-windows-bench-meta.json
+          cat kin-windows-bench-meta.json
+          kin registry authority --json > kin-windows-registry-authority.json
+          cat kin-windows-registry-authority.json
+          # Negative control. An unsupported capability must refuse to be
+          # repaired rather than report a success it cannot deliver, so this
+          # command failing is the assertion.
+          if kin registry authority --fix > kin-windows-registry-fix.txt 2>&1; then
+            cat kin-windows-registry-fix.txt >&2
+            echo "installed Windows kin reported registry authority --fix succeeded on a platform that does not support it" >&2
+            exit 1
+          fi
+          cat kin-windows-registry-fix.txt
+
+          # Prove every supported agent-client config writer without requiring
+          # the proprietary clients on a public runner. Detection is PATH-based;
+          # which-rs follows PATHEXT on Windows, so these inert shims are real
+          # .exe copies rather than shell scripts.
+          fake_agent_bin="$RUNNER_TEMP/kin-proof-agent-bin"
+          mkdir -p "$fake_agent_bin"
+          for agent in claude cursor codex gemini windsurf; do
+            cp "$(command -v kin)" "$fake_agent_bin/$agent.exe"
+          done
+          export PATH="$fake_agent_bin:$PATH"
+
+          kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
+            2>&1 | tee kin-windows-setup.txt
+          kin setup status --json | tee kin-windows-health.json
+          kin doctor --json | tee kin-windows-doctor.json
+
+          node <<'NODE'
+          const fs = require("fs");
+          const os = require("os");
+          const path = require("path");
+
+          const expectedCommit = fs.readFileSync("expected-commit.txt", "utf8").trim();
+          const expectedLock = fs.readFileSync("expected-lock-sha.txt", "utf8").trim();
+          const meta = JSON.parse(fs.readFileSync("kin-windows-bench-meta.json", "utf8"));
+          if (meta.kin_commit !== expectedCommit) {
+            throw new Error(`installed Windows build SHA ${meta.kin_commit ?? "missing"} does not match release tag ${expectedCommit}`);
+          }
+          if (meta.kin_dirty !== false) {
+            throw new Error("installed Windows release binary is dirty or did not report a clean build");
+          }
+          if (meta.kin_source_known !== true) {
+            throw new Error("installed Windows release binary did not prove source_known=true");
+          }
+          if (meta.dependency_provenance !== expectedLock) {
+            throw new Error(`installed Windows Cargo.lock provenance ${meta.dependency_provenance ?? "missing"} does not match release source ${expectedLock}`);
+          }
+
+          const authority = JSON.parse(fs.readFileSync("kin-windows-registry-authority.json", "utf8"));
+          if (authority.checks?.length !== 1 || authority.checks[0]?.state !== "unsupported") {
+            throw new Error(`Windows registry authority must report exactly one unsupported capability check: ${JSON.stringify(authority.checks ?? null)}`);
+          }
+
+          const nonHealthyChecks = (report) => (report.checks ?? [])
+            .filter((check) => check.status !== "healthy")
+            .map((check) => `${check.id}=${check.status}`)
+            .join(", ") || "none";
+          // The repo-free Windows posture, pinned by name. `repo_init` is
+          // missing because there is no repository here, and `daemon_running`
+          // is unsupported because the daemon is repo-scoped. Both are the
+          // product's own documented no-repository answers, so both are
+          // required rather than tolerated: a change that turns either into
+          // something else has to come here and say so.
+          const required = new Map([
+            ["kin_binary", "healthy"],
+            ["kin_daemon_binary", "healthy"],
+            ["shell_path", "healthy"],
+            ["setup_ledger", "healthy"],
+            ["registry_authority", "unsupported"],
+            ["vfs_projection", "unsupported"],
+            ["semantic_query_readiness", "unsupported"],
+            ["daemon_running", "unsupported"],
+            ["repo_init", "missing"],
+            ["mcp_client_claude", "healthy"],
+            ["mcp_client_cursor", "healthy"],
+            ["mcp_client_codex", "healthy"],
+            ["mcp_client_gemini", "healthy"],
+            ["mcp_client_windsurf", "healthy"],
+          ]);
+
+          for (const reportPath of ["kin-windows-health.json", "kin-windows-doctor.json"]) {
+            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+            const checks = new Map(report.checks.map((check) => [check.id, check]));
+            // Missing `repo_init` is the one degradation this repo-free posture
+            // expects, and it flips the aggregate report.healthy to false on its
+            // own. Accept that single named reason and keep every other
+            // degradation fatal, so a real regression in any other check still
+            // fails this leg.
+            const onlyMissingRepositoryBlocks = report.checks.every(
+              (check) =>
+                check.id === "repo_init" ||
+                check.status === "healthy" ||
+                check.status === "unsupported"
+            );
+            if (!onlyMissingRepositoryBlocks) {
+              throw new Error(
+                `${reportPath}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
+              );
+            }
+            for (const [id, expected] of required) {
+              const actual = checks.get(id)?.status;
+              if (actual !== expected) {
+                throw new Error(`${reportPath}: ${id} is ${actual ?? "missing"}, expected ${expected}`);
+              }
+            }
+            const hardFailures = report.checks.filter((check) =>
+              check.id !== "repo_init" &&
+              (check.status === "missing" || check.status === "misconfigured")
+            );
+            if (hardFailures.length > 0) {
+              throw new Error(`${reportPath}: hard failures: ${hardFailures.map((c) => c.id).join(", ")}`);
+            }
+          }
+
+          const home = os.homedir();
+          const jsonConfigs = [
+            path.join(home, ".claude.json"),
+            path.join(home, ".cursor", "mcp.json"),
+            path.join(home, ".gemini", "settings.json"),
+            path.join(home, ".codeium", "windsurf", "mcp_config.json"),
+          ];
+          for (const configPath of jsonConfigs) {
+            const entry = JSON.parse(fs.readFileSync(configPath, "utf8"))?.mcpServers?.kin;
+            if (!entry || JSON.stringify(entry.args) !== JSON.stringify(["mcp", "start"]) || entry.env?.KIN_MCP_TOOL_PROFILE !== "agent-default") {
+              throw new Error(`${configPath}: Kin MCP entry is missing or malformed`);
+            }
+          }
+          NODE
+
       - name: First-run repository, daemon, and setup proof
+        if: runner.os != 'Windows'
         shell: bash
         env:
           PROOF_SHELL: ${{ matrix.setup-shell }}
@@ -414,6 +713,7 @@ jobs:
           kin doctor --json | tee kin-doctor.json
 
       - name: Graph query and MCP tool-call proof
+        if: runner.os != 'Windows'
         shell: bash
         working-directory: kin-install-proof
         run: |
@@ -710,6 +1010,7 @@ jobs:
           kin locate hello --json --explain --max-files 5 | tee kin-semantic-locate.json
 
       - name: Validate installed capability proof
+        if: runner.os != 'Windows'
         shell: bash
         working-directory: kin-install-proof
         run: |
@@ -759,14 +1060,7 @@ jobs:
           if (!semanticCoverage) {
             throw new Error("kin-status.json: semantic_coverage is missing");
           }
-          if (runnerOs === "Windows") {
-            if (semanticCoverage.supported !== false || semanticCoverage.complete !== false) {
-              throw new Error("Windows vector-free status must report semantic coverage as unsupported and incomplete");
-            }
-            if ((semanticCoverage.note ?? "").includes("kin embed")) {
-              throw new Error("Windows vector-free status offers impossible kin embed remediation");
-            }
-          } else if (semanticCoverage.supported !== true) {
+          if (semanticCoverage.supported !== true) {
             throw new Error(`${runnerOs} release unexpectedly lacks semantic vector support`);
           }
           const reports = ["kin-health.json", "kin-doctor.json"].map((path) => [
@@ -784,8 +1078,8 @@ jobs:
             ["repo_init", "healthy"],
             ["shell_path", "healthy"],
             ["setup_ledger", "healthy"],
-            ["registry_authority", runnerOs === "Windows" ? "unsupported" : "healthy"],
-            ["vfs_projection", runnerOs === "Windows" ? "unsupported" : "healthy"],
+            ["registry_authority", "healthy"],
+            ["vfs_projection", "healthy"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],
             ["mcp_client_codex", "healthy"],
@@ -805,7 +1099,6 @@ jobs:
             // unhealthy reason fatal: any missing/misconfigured check, or any
             // other check that is neither healthy nor unsupported, still fails.
             const onlyPendingEmbeddingsBlocks =
-              runnerOs !== "Windows" &&
               checks.get("semantic_query_readiness")?.status === "stale" &&
               report.checks.every(
                 (check) =>
@@ -825,11 +1118,7 @@ jobs:
               }
             }
             const semanticReadiness = checks.get("semantic_query_readiness")?.status;
-            if (runnerOs === "Windows") {
-              if (semanticReadiness !== "unsupported") {
-                throw new Error(`${path}: semantic_query_readiness is ${semanticReadiness ?? "missing"}, expected unsupported`);
-              }
-            } else if (!["healthy", "stale"].includes(semanticReadiness)) {
+            if (!["healthy", "stale"].includes(semanticReadiness)) {
               throw new Error(`${path}: semantic_query_readiness is ${semanticReadiness ?? "missing"}, expected healthy or stale`);
             }
             const hardFailures = report.checks.filter((check) =>
@@ -862,42 +1151,32 @@ jobs:
               throw new Error(`${configPath}: Kin MCP entry is missing or malformed`);
             }
           }
-          if (runnerOs === "Windows") {
-            const vectorDegradations = (locate.degradations ?? []).filter((entry) => entry.component === "vector_index");
-            if (vectorDegradations.length !== 1 || vectorDegradations[0].reason !== "feature_disabled") {
-              throw new Error(`Windows locate must report one feature_disabled vector degradation: ${JSON.stringify(vectorDegradations)}`);
+          const embed = JSON.parse(fs.readFileSync("kin-embed.json", "utf8"));
+          if (embed.pending_entities !== 0 || embed.pending_artifacts !== 0 || embed.time_limited === true) {
+            throw new Error(`bounded clean-install embedding did not reach full coverage: ${JSON.stringify(embed)}`);
+          }
+          const embeddedStatus = JSON.parse(fs.readFileSync("kin-embedded-status.json", "utf8"));
+          if (embeddedStatus.semantic_coverage?.supported !== true || embeddedStatus.semantic_coverage?.complete !== true) {
+            throw new Error("Unix status did not prove complete semantic coverage after embedding");
+          }
+          for (const reportPath of ["kin-embedded-health.json", "kin-embedded-doctor.json"]) {
+            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+            const readiness = report.checks?.find((check) => check.id === "semantic_query_readiness")?.status;
+            if (report.healthy !== true || readiness !== "healthy") {
+              throw new Error(
+                `${reportPath}: overall healthy=${report.healthy}; ` +
+                `semantic_query_readiness=${readiness ?? "missing"}; ` +
+                `non-healthy checks: ${nonHealthyChecks(report)}`
+              );
             }
-            if ((vectorDegradations[0].remediation ?? "").includes("kin embed")) {
-              throw new Error("Windows vector-free locate offers impossible kin embed remediation");
-            }
-          } else {
-            const embed = JSON.parse(fs.readFileSync("kin-embed.json", "utf8"));
-            if (embed.pending_entities !== 0 || embed.pending_artifacts !== 0 || embed.time_limited === true) {
-              throw new Error(`bounded clean-install embedding did not reach full coverage: ${JSON.stringify(embed)}`);
-            }
-            const embeddedStatus = JSON.parse(fs.readFileSync("kin-embedded-status.json", "utf8"));
-            if (embeddedStatus.semantic_coverage?.supported !== true || embeddedStatus.semantic_coverage?.complete !== true) {
-              throw new Error("Unix status did not prove complete semantic coverage after embedding");
-            }
-            for (const reportPath of ["kin-embedded-health.json", "kin-embedded-doctor.json"]) {
-              const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-              const readiness = report.checks?.find((check) => check.id === "semantic_query_readiness")?.status;
-              if (report.healthy !== true || readiness !== "healthy") {
-                throw new Error(
-                  `${reportPath}: overall healthy=${report.healthy}; ` +
-                  `semantic_query_readiness=${readiness ?? "missing"}; ` +
-                  `non-healthy checks: ${nonHealthyChecks(report)}`
-                );
-              }
-            }
-            const semanticSearch = JSON.parse(fs.readFileSync("kin-semantic-search.json", "utf8"));
-            if (!Array.isArray(semanticSearch) || !semanticSearch.some((record) => record.name === "hello" && record.file === "probe.py")) {
-              throw new Error("semantic kin search did not return the seeded hello entity");
-            }
-            const semanticLocate = JSON.parse(fs.readFileSync("kin-semantic-locate.json", "utf8"));
-            if (semanticLocate.semantic_coverage?.supported !== true || semanticLocate.semantic_coverage?.complete !== true || !semanticLocate.files?.some((entry) => entry.path === "probe.py")) {
-              throw new Error("semantic kin locate did not prove complete coverage and return probe.py");
-            }
+          }
+          const semanticSearch = JSON.parse(fs.readFileSync("kin-semantic-search.json", "utf8"));
+          if (!Array.isArray(semanticSearch) || !semanticSearch.some((record) => record.name === "hello" && record.file === "probe.py")) {
+            throw new Error("semantic kin search did not return the seeded hello entity");
+          }
+          const semanticLocate = JSON.parse(fs.readFileSync("kin-semantic-locate.json", "utf8"));
+          if (semanticLocate.semantic_coverage?.supported !== true || semanticLocate.semantic_coverage?.complete !== true || !semanticLocate.files?.some((entry) => entry.path === "probe.py")) {
+            throw new Error("semantic kin locate did not prove complete coverage and return probe.py");
           }
           NODE
 
@@ -920,6 +1199,13 @@ jobs:
             release-provenance-attestation.json
             installed-vfs-provenance.json
             latest-release-url.txt
+            kin-windows-bench-meta.json
+            kin-windows-registry-authority.json
+            kin-windows-registry-fix.txt
+            kin-windows-setup.txt
+            kin-windows-health.json
+            kin-windows-doctor.json
+            kin-windows-admission/*.txt
             kin-install-proof/*.txt
             kin-install-proof/*.json
             kin-install-proof/*.log

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -524,7 +524,10 @@ jobs:
       # remaining first-run surface on the platform: the binaries' own build
       # provenance bound to the release tag's public source, the platform
       # capability posture, and the setup writers for the shell hook, the
-      # install ledger, and all five agent-client MCP configs.
+      # install ledger, and every agent-client MCP config a repo-free install
+      # can write, which is four of the five. Codex is excluded by the product
+      # rather than by this proof, because its entry binds an exact
+      # repository, and that exclusion is asserted below.
       - name: Windows repo-free provenance and setup proof
         if: runner.os == 'Windows'
         shell: bash
@@ -610,7 +613,6 @@ jobs:
             ["repo_init", "missing"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],
-            ["mcp_client_codex", "healthy"],
             ["mcp_client_gemini", "healthy"],
             ["mcp_client_windsurf", "healthy"],
           ]);
@@ -646,6 +648,18 @@ jobs:
             );
             if (hardFailures.length > 0) {
               throw new Error(`${reportPath}: hard failures: ${hardFailures.map((c) => c.id).join(", ")}`);
+            }
+            // Codex is the one agent client Kin cannot configure without a
+            // repository. Its entry binds `mcp start --repo <exact
+            // repository>`, so setup refuses it by design here and never
+            // writes the config, which drops the check from the report
+            // entirely. Asserted as an absence rather than left unmentioned,
+            // so a Codex writer that ever becomes repo-free trips this and
+            // has to come here and say so.
+            if (checks.has("mcp_client_codex")) {
+              throw new Error(
+                `${reportPath}: mcp_client_codex is present without a repository, so the repo-free Codex writer changed`
+              );
             }
           }
 

--- a/scripts/assert-windows-init-contract.sh
+++ b/scripts/assert-windows-init-contract.sh
@@ -128,6 +128,7 @@ require_refused() {
   local label="$1"
   local dir="$2"
   local log="$3"
+  local expected_residue="$4"
   if (cd "$dir" && "$kin_bin" init) > "$log" 2>&1; then
     fail "$label unexpectedly succeeded" "$log"
   fi
@@ -138,22 +139,32 @@ require_refused() {
   if [ -e "$dir/.kin" ]; then
     fail "$label left a half-created repository at $dir/.kin" "$log"
   fi
+  # WINDOWS CLEANUP GAP, asserted rather than assumed.
+  #
   # The stage is a sibling of the admitted directory, not a child of it:
   # crates/kin-core/src/git_init.rs derives it from the source's parent and
   # crates/kin-core/src/init.rs from the working directory's, so a count taken
-  # inside the admitted directory can never see one and would pass on every
-  # input. Each boundary therefore owns a private parent holding nothing but
-  # the directory under test, which keeps a survivor attributable to the
-  # boundary that left it. Windows needs this most: orphaned stages are reaped
-  # on the next init only on Unix, and the cleanup that does run there is
-  # best-effort against the same open-handle behavior that refuses the
-  # admission in the first place.
+  # inside the admitted directory can never see one and would report zero on
+  # every input. Each boundary therefore owns a private parent holding nothing
+  # but the directory under test, which keeps a survivor attributable to the
+  # boundary that left it.
+  #
+  # Counted where they actually appear, the two boundaries that reach the graph
+  # store DO leave their unpublished stage and its `.owner` marker behind,
+  # which is two entries each. Nothing reaps them: recover_orphaned_repository_stages
+  # is `#[cfg(not(unix))] => Ok(0)` and the cleanup that does run is best-effort
+  # against the same open handles that refuse the admission. That is a real
+  # defect and it was invisible for as long as the count looked in the wrong
+  # place. It is asserted by exact count in both directions, so the
+  # transaction-layer port that finally drives it to zero trips this and has to
+  # come here and say so, exactly as a restored admission trips the refusal
+  # assertion above.
   local parent
   parent="$(dirname "$dir")"
   local staged
   staged="$(count_matching "$parent" '.kin.init-*')"
-  if [ "$staged" != "0" ]; then
-    fail "$label left $staged unpublished stage directory(s) in $parent" "$log"
+  if [ "$staged" != "$expected_residue" ]; then
+    fail "$label left $staged stage entries in $parent, expected $expected_residue" "$log"
   fi
 }
 
@@ -184,7 +195,7 @@ mkdir -p "$git_boundary"
   # one under test.
   git -c core.hooksPath= -c commit.gpgsign=false commit -qm probe
 )
-require_refused "Windows exact-Git admission" "$git_boundary" "$git_log"
+require_refused "Windows exact-Git admission" "$git_boundary" "$git_log" 2
 refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE" "$git_log"
 refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL" "$git_log"
 require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP" "$git_log"
@@ -192,7 +203,7 @@ require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP" "$git_log"
 native_boundary="$scratch/native-unborn/repo"
 native_log="$scratch/kin-init-native-unborn.txt"
 mkdir -p "$native_boundary"
-require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log"
+require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log" 2
 refute_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL" "$native_log"
 require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP" "$native_log"
 
@@ -202,11 +213,11 @@ populated_boundary="$scratch/native-populated/repo"
 populated_log="$scratch/kin-init-native-populated.txt"
 mkdir -p "$populated_boundary"
 printf 'untracked\n' > "$populated_boundary/stray.txt"
-require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log"
+require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log" 0
 require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL" "$populated_log"
 
 if [ "$failures" -ne 0 ]; then
   echo "::error::Windows admission did not behave as asserted ($failures check(s) failed)"
   exit 1
 fi
-echo "Windows admission refused every boundary at the cause it names, and published nothing."
+echo "Windows admission refused every boundary at the cause it names, published no authority, and left exactly the unreaped stage residue this platform is known to leave."

--- a/scripts/assert-windows-init-contract.sh
+++ b/scripts/assert-windows-init-contract.sh
@@ -151,14 +151,19 @@ require_refused() {
   #
   # Counted where they actually appear, the two boundaries that reach the graph
   # store DO leave their unpublished stage and its `.owner` marker behind,
-  # which is two entries each. Nothing reaps them: recover_orphaned_repository_stages
-  # is `#[cfg(not(unix))] => Ok(0)` and the cleanup that does run is best-effort
-  # against the same open handles that refuse the admission. That is a real
-  # defect and it was invisible for as long as the count looked in the wrong
-  # place. It is asserted by exact count in both directions, so the
-  # transaction-layer port that finally drives it to zero trips this and has to
-  # come here and say so, exactly as a restored admission trips the refusal
-  # assertion above.
+  # which is two entries each. This is post-refusal residue measured before any
+  # reaper could run: each boundary owns a freshly created parent and sees one
+  # `kin init`, and recover_orphaned_repository_stages runs against that parent
+  # before the stage exists, so it finds nothing to reap on any platform. What
+  # moves the count is refusal-time cleanup, or the transaction-layer port
+  # fixing cleanup_owned_staging_root on the failing path, where removal is
+  # best-effort against the same open handles that refuse the admission.
+  # Proving the off-unix reaper arm instead needs a second init against a parent
+  # already holding residue, which is a different fixture from this one. That is
+  # a real defect and it was invisible for as long as the count looked in the
+  # wrong place. It is asserted by exact count in both directions, so whatever
+  # finally drives it to zero trips this and has to come here and say so,
+  # exactly as a restored admission trips the refusal assertion above.
   local parent
   parent="$(dirname "$dir")"
   local staged

--- a/scripts/assert-windows-init-contract.sh
+++ b/scripts/assert-windows-init-contract.sh
@@ -131,17 +131,29 @@ require_refused() {
   if (cd "$dir" && "$kin_bin" init) > "$log" 2>&1; then
     fail "$label unexpectedly succeeded" "$log"
   fi
-  # A refusal publishes nothing. Both boundaries stage into a sibling
+  # A refusal publishes nothing. Both boundaries stage into a
   # `.kin.init-<uuid>` and only move it into place at the end, so a `.kin` of
   # any shape means a refusal published authority anyway, and a surviving stage
   # means it did not clean up after itself.
   if [ -e "$dir/.kin" ]; then
     fail "$label left a half-created repository at $dir/.kin" "$log"
   fi
+  # The stage is a sibling of the admitted directory, not a child of it:
+  # crates/kin-core/src/git_init.rs derives it from the source's parent and
+  # crates/kin-core/src/init.rs from the working directory's, so a count taken
+  # inside the admitted directory can never see one and would pass on every
+  # input. Each boundary therefore owns a private parent holding nothing but
+  # the directory under test, which keeps a survivor attributable to the
+  # boundary that left it. Windows needs this most: orphaned stages are reaped
+  # on the next init only on Unix, and the cleanup that does run there is
+  # best-effort against the same open-handle behavior that refuses the
+  # admission in the first place.
+  local parent
+  parent="$(dirname "$dir")"
   local staged
-  staged="$(count_matching "$dir" '.kin.init-*')"
+  staged="$(count_matching "$parent" '.kin.init-*')"
   if [ "$staged" != "0" ]; then
-    fail "$label left $staged unpublished stage directory(s) in $dir" "$log"
+    fail "$label left $staged unpublished stage directory(s) in $parent" "$log"
   fi
 }
 
@@ -155,7 +167,7 @@ if ! "$kin_bin" --version > "$startup_log" 2>&1; then
   fail "kin --version did not run, so nothing below reports on admission" "$startup_log"
 fi
 
-git_boundary="$scratch/exact-git"
+git_boundary="$scratch/exact-git/repo"
 git_log="$scratch/kin-init-exact-git.txt"
 mkdir -p "$git_boundary"
 (
@@ -177,7 +189,7 @@ refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE" "$git_log"
 refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL" "$git_log"
 require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP" "$git_log"
 
-native_boundary="$scratch/native-unborn"
+native_boundary="$scratch/native-unborn/repo"
 native_log="$scratch/kin-init-native-unborn.txt"
 mkdir -p "$native_boundary"
 require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log"
@@ -186,7 +198,7 @@ require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP" "$native_log
 
 # A capability Windows now has must not become permission to derive authority
 # from whatever happens to be lying in the directory.
-populated_boundary="$scratch/native-populated"
+populated_boundary="$scratch/native-populated/repo"
 populated_log="$scratch/kin-init-native-populated.txt"
 mkdir -p "$populated_boundary"
 printf 'untracked\n' > "$populated_boundary/stray.txt"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -27,6 +27,8 @@ RELEASE_TAG = WORKFLOWS / "release-tag.yml"
 RELEASE_TRAIN = WORKFLOWS / "release-train.yml"
 RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
+WINDOWS_INIT_CONTRACT = ROOT / "scripts" / "assert-windows-init-contract.sh"
+WINDOWS_INIT_CONTRACT_POLICY = "scripts/assert-windows-init-contract.sh"
 INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
 PREPARE_RELEASE = ROOT / "scripts" / "prepare-release.mjs"
@@ -700,6 +702,55 @@ def workflow_active_header_source(workflow: str) -> str:
     return classifier_active_job_source(workflow.split(marker, 1)[0])
 
 
+def active_lines(source: str) -> list[str]:
+    """Return a block's non-blank, non-comment lines, stripped of indentation."""
+
+    return [
+        line.strip()
+        for line in source.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def install_proof_step(install_proof: str, name: str) -> str:
+    """Return one install-proof step, from its name to the next step's name."""
+
+    anchor = f"      - name: {name}\n"
+    if install_proof.count(anchor) != 1:
+        raise AssertionError(f"install proof must declare one step named {name}")
+    start = install_proof.index(anchor)
+    return install_proof[
+        start : install_proof.index("\n      - name: ", start + len(anchor))
+    ]
+
+
+def windows_init_contract_strings() -> dict[str, str]:
+    """Return the shipped Windows admission contract's own refusal strings.
+
+    The install proof installs a public release anonymously and has no
+    checkout, so it cannot run the contract script and retypes these instead.
+    Reading the script here is the only thing that keeps the two statements of
+    one contract from drifting apart.
+    """
+
+    source = WINDOWS_INIT_CONTRACT.read_text(encoding="utf-8")
+    strings: dict[str, str] = {}
+    for name in (
+        "CONFIG_REFUSAL",
+        "SOURCE_PROOF_STAGE",
+        "DURABLE_FLUSH_GAP",
+        "NON_EMPTY_REFUSAL",
+    ):
+        bindings = re.findall(rf'(?m)^{name}="([^"]+)"$', source)
+        if len(bindings) != 1:
+            raise AssertionError(
+                f"{WINDOWS_INIT_CONTRACT_POLICY} must bind {name} exactly once: "
+                f"{bindings}"
+            )
+        strings[name] = bindings[0]
+    return strings
+
+
 def assert_install_proof_init_log_authority(first_run: str) -> None:
     """Keep the install proof's own report files out of the worktree kin init admits.
 
@@ -708,32 +759,182 @@ def assert_install_proof_init_log_authority(first_run: str) -> None:
     differ. A report file written into that worktree therefore breaks admission
     twice over: it is an untracked non-ignored path, and an ignored one would
     still change size between the repeats.
+
+    Pinning the capture lines is not enough on its own, because the property is
+    about the whole span between entering that worktree and admitting it. Three
+    mutations leave every pinned line in place and still break admission or the
+    evidence it produces: an unrelated write into the worktree before init, a
+    copy-back reordered above init, and a second init that an exact-prefix count
+    cannot see. So the span is closed-form, the capture order is asserted, and
+    an `init` this function does not recognize is refused by name.
     """
 
-    active = [
-        line.strip()
-        for line in first_run.splitlines()
-        if line.strip() and not line.strip().startswith("#")
+    active = active_lines(first_run)
+    admission = 'kin init > "$init_log" 2>&1 || init_status=$?'
+    bootstrap = (
+        "git init -q && git config user.email ci@firelock.ai && git config user.name ci"
+    )
+    entry = "mkdir -p kin-install-proof && cd kin-install-proof"
+    copy_back = 'cp "$init_log" kin-init.txt'
+    propagate = 'if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi'
+    # An `init` token anywhere in an active line, not a prefix of one:
+    # `(cd sub && kin init)`, `eval kin init`, and `"$KIN" init` all admit a
+    # worktree and none of them starts with `kin init`.
+    init_token = re.compile(r"(?<![\w./-])init(?![\w-])")
+    admissions = [
+        line for line in active if init_token.search(line) and line != bootstrap
     ]
-    init_lines = [line for line in active if line.startswith("kin init")]
-    if len(init_lines) != 1:
+    if len(admissions) != 1:
         raise AssertionError(
-            "install proof must invoke kin init exactly once in the first-run step"
+            "install proof must invoke kin init exactly once in the first-run "
+            f"step: {admissions}"
         )
-    if init_lines[0] != 'kin init > "$init_log" 2>&1 || init_status=$?':
+    if admissions[0] != admission:
         raise AssertionError(
             "kin init must write its log outside the worktree it admits rather "
-            f"than through a relative redirect or pipe: {init_lines[0]}"
+            f"than through a relative redirect or pipe: {admissions[0]}"
         )
     for policy in (
+        entry,
         'init_log="$RUNNER_TEMP/kin-init.txt"',
-        'cp "$init_log" kin-init.txt',
-        'if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi',
+        copy_back,
+        propagate,
     ):
         if policy not in active:
             raise AssertionError(
                 f"install-proof init log capture lost an active line: {policy}"
             )
+    # The log is copied back after admission and kin's own exit status is
+    # propagated after that. Reordering the copy above init leaves every pinned
+    # line present, and only `set -e` on a not-yet-created file catches it.
+    order = [active.index(step) for step in (admission, copy_back, propagate)]
+    if order != sorted(order):
+        raise AssertionError(
+            "install-proof init log capture must admit, then copy the log back, "
+            f"then propagate kin's own exit status; found line order {order}"
+        )
+    # Nothing may write into the worktree between entering it and admitting it.
+    # A line-presence check cannot see an inserted write, and an inserted write
+    # is byte-for-byte the class that broke the v0.4.5 release proof.
+    prelude = active[active.index(entry) + 1 : order[0]]
+    committed_prelude = [
+        bootstrap,
+        "printf 'def hello():\\n    return 42\\n' > probe.py",
+        'git add -A && git commit -qm "probe"',
+        'init_log="$RUNNER_TEMP/kin-init.txt"',
+        "init_status=0",
+    ]
+    if prelude != committed_prelude:
+        raise AssertionError(
+            "only the committed Git bootstrap may run between entering the "
+            f"worktree kin init admits and admitting it; found {prelude}"
+        )
+
+
+def assert_install_proof_repo_steps_are_unix_only(install_proof: str) -> None:
+    """Keep every repository-dependent install-proof step off Windows.
+
+    `kin init` refuses every admission boundary on Windows and the contract
+    script asserts that refusal by name on every pull request, so a step
+    needing an admitted repository has no passing outcome available to it
+    there. Without these guards the release gate demands the admission the
+    shipped product refuses, and the Windows leg cannot go green on either
+    answer.
+    """
+
+    for step in (
+        "First-run repository, daemon, and setup proof",
+        "Graph query and MCP tool-call proof",
+        "Validate installed capability proof",
+    ):
+        if "if: runner.os != 'Windows'" not in "\n".join(
+            active_lines(install_proof_step(install_proof, step))
+        ):
+            raise AssertionError(
+                f"install proof requires a Kin repository on Windows: {step} lost "
+                "its runner.os != 'Windows' guard"
+            )
+
+
+def assert_install_proof_windows_admission_contract(
+    windows_admission: str, contract: dict[str, str]
+) -> None:
+    """Require the install proof to assert the refusal Windows actually ships.
+
+    A release proof that asserted an admission the product refuses can never go
+    green, and one that asserted a refusal the product no longer produces would
+    go green on the wrong behavior. Both failure modes are closed by requiring
+    each boundary to name its own cause in the contract's own words, and by
+    requiring every refusal to have published nothing.
+    """
+
+    active = "\n".join(active_lines(windows_admission))
+    for name, refusal in contract.items():
+        binding = f'{name}="{refusal}"'
+        if binding not in active:
+            raise AssertionError(
+                "install proof must assert the shipped Windows admission contract "
+                f"verbatim; {name} drifted from {WINDOWS_INIT_CONTRACT_POLICY}: "
+                f"expected {binding}"
+            )
+    for policy in (
+        'require_refused "Windows exact-Git admission"',
+        'refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE"',
+        'refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL"',
+        'require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP"',
+        'require_refused "Windows native-unborn bootstrap"',
+        'refute_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL"',
+        'require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP"',
+        'require_refused "Windows non-empty native boundary"',
+        'require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL"',
+        'fail "$1 unexpectedly succeeded" "$3"',
+        'if [ -e "$2/.kin" ]; then',
+        "staged=\"$(count_matching \"$2\" '.kin.init-*')\"",
+    ):
+        require(active, policy, "shipped Windows admission contract proof")
+
+
+def assert_install_proof_repo_free_windows_proof(repo_free: str) -> None:
+    """Keep proving every Windows surface that survives without a repository.
+
+    Windows-gating the repository steps is a reduction in release coverage, so
+    what remains has to stay genuinely falsifiable rather than becoming a leg
+    that installs a binary and declares victory. The installed binaries still
+    prove their build provenance against the release tag's own public source,
+    the platform capability posture is still pinned by name including the
+    repair negative control, and setup still writes and validates the shell
+    hook, the install ledger, and all five agent-client MCP configs.
+    """
+
+    active = "\n".join(active_lines(repo_free))
+    for policy in (
+        "kin bench-meta --json > kin-windows-bench-meta.json",
+        "kin registry authority --json > kin-windows-registry-authority.json",
+        "if kin registry authority --fix > kin-windows-registry-fix.txt 2>&1; then",
+        'kin setup --no-interactive --intent agent --shell "$PROOF_SHELL"',
+        "kin setup status --json | tee kin-windows-health.json",
+        "kin doctor --json | tee kin-windows-doctor.json",
+        'fs.readFileSync("expected-commit.txt", "utf8").trim()',
+        'fs.readFileSync("expected-lock-sha.txt", "utf8").trim()',
+        "meta.kin_commit !== expectedCommit",
+        "meta.kin_dirty !== false",
+        "meta.kin_source_known !== true",
+        "meta.dependency_provenance !== expectedLock",
+        'authority.checks[0]?.state !== "unsupported"',
+        '["repo_init", "missing"]',
+        '["daemon_running", "unsupported"]',
+        '["registry_authority", "unsupported"]',
+        '["vfs_projection", "unsupported"]',
+        '["semantic_query_readiness", "unsupported"]',
+        '["shell_path", "healthy"]',
+        '["setup_ledger", "healthy"]',
+        '["mcp_client_claude", "healthy"]',
+        '["mcp_client_cursor", "healthy"]',
+        '["mcp_client_codex", "healthy"]',
+        '["mcp_client_gemini", "healthy"]',
+        '["mcp_client_windsurf", "healthy"]',
+    ):
+        require(active, policy, "repo-free Windows install proof")
 
 
 def assert_docs_only_classifier_guard(workflow: str) -> None:
@@ -3585,15 +3786,22 @@ def main() -> None:
     first_run_start = install_proof.index(
         "      - name: First-run repository, daemon, and setup proof"
     )
+    # The guarded span ends at the next step rather than three steps later, so
+    # the failure message naming the first-run step describes the region it
+    # actually covers and a legitimate later `kin init` is not misdiagnosed.
+    graph_query_start = install_proof.index(
+        "      - name: Graph query and MCP tool-call proof",
+        first_run_start,
+    )
     embedding_start = install_proof.index(
         "      - name: Unix embedding and semantic retrieval proof",
-        first_run_start,
+        graph_query_start,
     )
     validation_start = install_proof.index(
         "      - name: Validate installed capability proof",
         embedding_start,
     )
-    first_run = install_proof[first_run_start:embedding_start]
+    first_run = install_proof[first_run_start:graph_query_start]
     embedding = install_proof[embedding_start:validation_start]
     for policy in (
         'case "$PROOF_SHELL" in',
@@ -3637,6 +3845,159 @@ def main() -> None:
             lambda mutated=first_run.replace(
                 active_line, f"# {active_line}", 1
             ): assert_install_proof_init_log_authority(mutated),
+        )
+    for label, wrapped_init in (
+        ("a wrapped second kin init", "(cd sub && kin init)"),
+        ("an indirect second admission", '"$KIN" init'),
+        ("an evaluated second admission", "eval kin init"),
+    ):
+        expect_assertion(
+            f"{wrapped_init} escapes the exactly-once count",
+            "exactly once",
+            lambda mutated=f"{first_run}\n          {wrapped_init}\n": (
+                assert_install_proof_init_log_authority(mutated)
+            ),
+        )
+    expect_assertion(
+        "an unrelated write into the admitted worktree escapes the guard",
+        "only the committed Git bootstrap may run",
+        lambda: assert_install_proof_init_log_authority(
+            first_run.replace(
+                '          init_log="$RUNNER_TEMP/kin-init.txt"\n',
+                "          echo scratch > proof-note.txt\n"
+                '          init_log="$RUNNER_TEMP/kin-init.txt"\n',
+                1,
+            )
+        ),
+    )
+    expect_assertion(
+        "the init log is copied back before the worktree is admitted",
+        "must admit, then copy the log back",
+        lambda: assert_install_proof_init_log_authority(
+            first_run.replace(
+                '          kin init > "$init_log" 2>&1 || init_status=$?\n'
+                '          cat "$init_log"\n'
+                '          cp "$init_log" kin-init.txt\n',
+                '          cp "$init_log" kin-init.txt\n'
+                '          kin init > "$init_log" 2>&1 || init_status=$?\n'
+                '          cat "$init_log"\n',
+                1,
+            )
+        ),
+    )
+
+    # The Windows leg asserts the admission the shipped product refuses, and
+    # everything the platform still proves without a repository.
+    windows_contract = windows_init_contract_strings()
+    windows_admission = install_proof_step(
+        install_proof, "Windows admission contract proof"
+    )
+    assert_install_proof_windows_admission_contract(windows_admission, windows_contract)
+    expect_assertion(
+        "the install proof's Windows refusal wording drifts from the contract script",
+        "drifted from",
+        lambda: assert_install_proof_windows_admission_contract(
+            windows_admission.replace(
+                windows_contract["DURABLE_FLUSH_GAP"],
+                "for durable metadata sync",
+                1,
+            ),
+            windows_contract,
+        ),
+    )
+    expect_assertion(
+        "the contract script's refusal wording drifts from the install proof",
+        "drifted from",
+        lambda: assert_install_proof_windows_admission_contract(
+            windows_admission,
+            {**windows_contract, "NON_EMPTY_REFUSAL": "requires an empty folder"},
+        ),
+    )
+    for label, active_line in (
+        (
+            "a Windows refusal may publish a repository anyway",
+            'if [ -e "$2/.kin" ]; then',
+        ),
+        (
+            "a Windows refusal may leave its unpublished stage behind",
+            "staged=\"$(count_matching \"$2\" '.kin.init-*')\"",
+        ),
+        (
+            "a successful Windows admission stops failing the leg",
+            'fail "$1 unexpectedly succeeded" "$3"',
+        ),
+        (
+            "the exact-Git refusal stops having to name its own cause",
+            'require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP"',
+        ),
+        (
+            "the non-empty native boundary stops being asserted",
+            'require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL"',
+        ),
+    ):
+        expect_assertion(
+            label,
+            "shipped Windows admission contract proof",
+            lambda mutated=windows_admission.replace(
+                active_line, f"# {active_line}", 1
+            ): assert_install_proof_windows_admission_contract(
+                mutated, windows_contract
+            ),
+        )
+
+    assert_install_proof_repo_steps_are_unix_only(install_proof)
+    for repo_step in (
+        "First-run repository, daemon, and setup proof",
+        "Graph query and MCP tool-call proof",
+        "Validate installed capability proof",
+    ):
+        expect_assertion(
+            f"the install proof demands a Kin repository on Windows in {repo_step}",
+            "runner.os != 'Windows' guard",
+            lambda mutated=install_proof.replace(
+                f"      - name: {repo_step}\n        if: runner.os != 'Windows'\n",
+                f"      - name: {repo_step}\n",
+                1,
+            ): assert_install_proof_repo_steps_are_unix_only(mutated),
+        )
+
+    repo_free = install_proof_step(
+        install_proof, "Windows repo-free provenance and setup proof"
+    )
+    assert_install_proof_repo_free_windows_proof(repo_free)
+    for label, original, mutation in (
+        (
+            "the Windows leg stops binding installed provenance to the release tag",
+            "meta.kin_commit !== expectedCommit",
+            'meta.kin_commit !== "0000000000000000000000000000000000000000"',
+        ),
+        (
+            "the Windows leg stops proving the release Cargo.lock provenance",
+            "meta.dependency_provenance !== expectedLock",
+            'meta.dependency_provenance !== ""',
+        ),
+        (
+            "the Windows registry-authority repair negative control disappears",
+            "if kin registry authority --fix > kin-windows-registry-fix.txt 2>&1; then",
+            "if false; then",
+        ),
+        (
+            "the repo-free posture stops requiring a missing repository",
+            '["repo_init", "missing"]',
+            '["repo_init", "healthy"]',
+        ),
+        (
+            "the repo-free posture stops proving the agent-client MCP writers",
+            '["mcp_client_codex", "healthy"]',
+            "",
+        ),
+    ):
+        expect_assertion(
+            label,
+            "repo-free Windows install proof",
+            lambda mutated=repo_free.replace(
+                original, mutation, 1
+            ): assert_install_proof_repo_free_windows_proof(mutated),
         )
     for policy in (
         "PROOF_SHELL: ${{ matrix.setup-shell }}",
@@ -3724,6 +4085,16 @@ def main() -> None:
         "release-provenance.json.sha256",
         "release-provenance-attestation.json",
         "installed-vfs-provenance.json",
+        # The Windows leg's whole evidence trail. Its admission logs are the
+        # only record of what each refusal actually said, and the v0.4.5
+        # incident was diagnosed from exactly this kind of uploaded log.
+        "kin-windows-bench-meta.json",
+        "kin-windows-registry-authority.json",
+        "kin-windows-registry-fix.txt",
+        "kin-windows-setup.txt",
+        "kin-windows-health.json",
+        "kin-windows-doctor.json",
+        "kin-windows-admission/*.txt",
     ):
         require(proof_upload, report, "preserved installed-artifact proof report")
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -926,7 +926,10 @@ def assert_install_proof_repo_free_windows_proof(repo_free: str) -> None:
     prove their build provenance against the release tag's own public source,
     the platform capability posture is still pinned by name including the
     repair negative control, and setup still writes and validates the shell
-    hook, the install ledger, and all five agent-client MCP configs.
+    hook, the install ledger, and every agent-client MCP config a repo-free
+    install can write. Codex is the exception, excluded by the product because
+    its entry binds an exact repository, and its absence is asserted rather
+    than left unmentioned.
     """
 
     active = "\n".join(active_lines(repo_free))
@@ -953,7 +956,7 @@ def assert_install_proof_repo_free_windows_proof(repo_free: str) -> None:
         '["setup_ledger", "healthy"]',
         '["mcp_client_claude", "healthy"]',
         '["mcp_client_cursor", "healthy"]',
-        '["mcp_client_codex", "healthy"]',
+        'if (checks.has("mcp_client_codex")) {',
         '["mcp_client_gemini", "healthy"]',
         '["mcp_client_windsurf", "healthy"]',
     ):
@@ -4043,7 +4046,7 @@ def main() -> None:
         ),
         (
             "the repo-free posture stops proving the agent-client MCP writers",
-            '["mcp_client_codex", "healthy"]',
+            '["mcp_client_windsurf", "healthy"]',
             "",
         ),
     ):

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -751,6 +751,26 @@ def windows_init_contract_strings() -> dict[str, str]:
     return strings
 
 
+def assert_windows_contract_stage_check_is_reachable(contract_source: str) -> None:
+    """Keep the shipped contract's published-nothing check able to fail at all.
+
+    Both admission paths stage into the PARENT of the directory they admit:
+    `crates/kin-core/src/git_init.rs` derives the stage from the source's
+    parent and `crates/kin-core/src/init.rs` from the working directory's. A
+    stage count taken inside the admitted directory therefore reports zero for
+    every input and passes whether or not the refusal cleaned up after itself.
+    This script is a required Windows check on every pull request, so a form
+    that cannot fail is worse here than no check at all: it reads as proof.
+    """
+
+    active = "\n".join(active_lines(contract_source))
+    for policy in (
+        'parent="$(dirname "$dir")"',
+        "staged=\"$(count_matching \"$parent\" '.kin.init-*')\"",
+    ):
+        require(active, policy, "reachable Windows stage-leak check")
+
+
 def assert_install_proof_init_log_authority(first_run: str) -> None:
     """Keep the install proof's own report files out of the worktree kin init admits.
 
@@ -889,7 +909,8 @@ def assert_install_proof_windows_admission_contract(
         'require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL"',
         'fail "$1 unexpectedly succeeded" "$3"',
         'if [ -e "$2/.kin" ]; then',
-        "staged=\"$(count_matching \"$2\" '.kin.init-*')\"",
+        'parent="$(dirname "$2")"',
+        "staged=\"$(count_matching \"$parent\" '.kin.init-*')\"",
     ):
         require(active, policy, "shipped Windows admission contract proof")
 
@@ -3893,6 +3914,34 @@ def main() -> None:
         install_proof, "Windows admission contract proof"
     )
     assert_install_proof_windows_admission_contract(windows_admission, windows_contract)
+    # The published-nothing half of the contract, in both files that state it.
+    # It counted stages inside the directory it admits, which is never where a
+    # stage is created, so it passed on every input in both.
+    windows_contract_source = WINDOWS_INIT_CONTRACT.read_text(encoding="utf-8")
+    assert_windows_contract_stage_check_is_reachable(windows_contract_source)
+    expect_assertion(
+        "the contract script counts stages where one can never appear",
+        "reachable Windows stage-leak check",
+        lambda: assert_windows_contract_stage_check_is_reachable(
+            windows_contract_source.replace(
+                'staged="$(count_matching "$parent"',
+                'staged="$(count_matching "$dir"',
+                1,
+            )
+        ),
+    )
+    expect_assertion(
+        "the install proof counts stages where one can never appear",
+        "shipped Windows admission contract proof",
+        lambda: assert_install_proof_windows_admission_contract(
+            windows_admission.replace(
+                'staged="$(count_matching "$parent"',
+                'staged="$(count_matching "$2"',
+                1,
+            ),
+            windows_contract,
+        ),
+    )
     expect_assertion(
         "the install proof's Windows refusal wording drifts from the contract script",
         "drifted from",
@@ -3920,7 +3969,7 @@ def main() -> None:
         ),
         (
             "a Windows refusal may leave its unpublished stage behind",
-            "staged=\"$(count_matching \"$2\" '.kin.init-*')\"",
+            "staged=\"$(count_matching \"$parent\" '.kin.init-*')\"",
         ),
         (
             "a successful Windows admission stops failing the leg",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -767,6 +767,7 @@ def assert_windows_contract_stage_check_is_reachable(contract_source: str) -> No
     for policy in (
         'parent="$(dirname "$dir")"',
         "staged=\"$(count_matching \"$parent\" '.kin.init-*')\"",
+        'if [ "$staged" != "$expected_residue" ]; then',
     ):
         require(active, policy, "reachable Windows stage-leak check")
 
@@ -898,19 +899,20 @@ def assert_install_proof_windows_admission_contract(
                 f"expected {binding}"
             )
     for policy in (
-        'require_refused "Windows exact-Git admission"',
+        'require_refused "Windows exact-Git admission" "$git_boundary" "$git_log" 2',
         'refute_text "Windows exact-Git admission" "$SOURCE_PROOF_STAGE"',
         'refute_text "Windows exact-Git admission" "$CONFIG_REFUSAL"',
         'require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP"',
-        'require_refused "Windows native-unborn bootstrap"',
+        'require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log" 2',
         'refute_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL"',
         'require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP"',
-        'require_refused "Windows non-empty native boundary"',
+        'require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log" 0',
         'require_text "Windows non-empty native boundary" "$NON_EMPTY_REFUSAL"',
         'fail "$1 unexpectedly succeeded" "$3"',
         'if [ -e "$2/.kin" ]; then',
         'parent="$(dirname "$2")"',
         "staged=\"$(count_matching \"$parent\" '.kin.init-*')\"",
+        'if [ "$staged" != "$4" ]; then',
     ):
         require(active, policy, "shipped Windows admission contract proof")
 
@@ -3972,6 +3974,10 @@ def main() -> None:
             "staged=\"$(count_matching \"$parent\" '.kin.init-*')\"",
         ),
         (
+            "the non-empty boundary stops having to leave nothing behind",
+            'require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log" 0',
+        ),
+        (
             "a successful Windows admission stops failing the leg",
             'fail "$1 unexpectedly succeeded" "$3"',
         ),
@@ -4218,9 +4224,9 @@ def main() -> None:
         'refute_text "Windows native-unborn bootstrap" "$CONFIG_REFUSAL"',
         'require_text "Windows exact-Git admission" "$DURABLE_FLUSH_GAP"',
         'require_text "Windows native-unborn bootstrap" "$DURABLE_FLUSH_GAP"',
-        'require_refused "Windows exact-Git admission"',
-        'require_refused "Windows native-unborn bootstrap"',
-        'require_refused "Windows non-empty native boundary"',
+        'require_refused "Windows exact-Git admission" "$git_boundary" "$git_log" 2',
+        'require_refused "Windows native-unborn bootstrap" "$native_boundary" "$native_log" 2',
+        'require_refused "Windows non-empty native boundary" "$populated_boundary" "$populated_log" 0',
         'fail "$label unexpectedly succeeded" "$log"',
         'if [ -e "$dir/.kin" ]; then',
         "'.kin.init-*'",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -703,12 +703,20 @@ def workflow_active_header_source(workflow: str) -> str:
 
 
 def active_lines(source: str) -> list[str]:
-    """Return a block's non-blank, non-comment lines, stripped of indentation."""
+    """Return a block's non-blank, non-comment lines, stripped of indentation.
+
+    Both comment markers count. These blocks are shell steps that embed
+    JavaScript in `node <<'NODE'` heredocs, so a policy pinned inside a heredoc
+    is commented out with `//`, and dropping only `#` would let that comment-out
+    keep satisfying the substring match instead of breaking it.
+    """
 
     return [
         line.strip()
         for line in source.splitlines()
-        if line.strip() and not line.strip().startswith("#")
+        if line.strip()
+        and not line.strip().startswith("#")
+        and not line.strip().startswith("//")
     ]
 
 
@@ -922,14 +930,15 @@ def assert_install_proof_repo_free_windows_proof(repo_free: str) -> None:
 
     Windows-gating the repository steps is a reduction in release coverage, so
     what remains has to stay genuinely falsifiable rather than becoming a leg
-    that installs a binary and declares victory. The installed binaries still
-    prove their build provenance against the release tag's own public source,
-    the platform capability posture is still pinned by name including the
-    repair negative control, and setup still writes and validates the shell
-    hook, the install ledger, and every agent-client MCP config a repo-free
-    install can write. Codex is the exception, excluded by the product because
-    its entry binds an exact repository, and its absence is asserted rather
-    than left unmentioned.
+    that installs a binary and declares victory. The installed CLI still proves
+    its own build provenance against the release tag's own public source, the
+    platform capability posture is still pinned by name including the repair
+    negative control, and setup still writes and validates the shell hook, the
+    install ledger, and every agent-client MCP config a repo-free install can
+    write. `kin bench-meta` reports the CLI build alone, so the daemon's build
+    provenance is among what this leg no longer binds. Codex is the exception,
+    excluded by the product because its entry binds an exact repository, and
+    its absence is asserted rather than left unmentioned.
     """
 
     active = "\n".join(active_lines(repo_free))
@@ -4048,6 +4057,11 @@ def main() -> None:
             "the repo-free posture stops proving the agent-client MCP writers",
             '["mcp_client_windsurf", "healthy"]',
             "",
+        ),
+        (
+            "a repo-free posture pin is commented out in the heredoc it lives in",
+            '["repo_init", "missing"]',
+            '// ["repo_init", "missing"]',
         ),
     ):
         expect_assertion(


### PR DESCRIPTION
## This reduces what the release gate proves on Windows

Read this part before the rest. Until 2026-07-20 the Windows leg of the install proof
proved the same first-run surface the Unix legs still prove, meaning a repository admitted
by `kin init`, a daemon serving it, a graph query, an MCP tool call, and a validated
capability report. Run **29749887140**, against the promoted v0.3.6 release, is the last run
in which all of that passed on `windows-latest`. This PR ratifies that coverage away.

After this change Windows no longer proves a repository, a running daemon, a graph query, an
MCP tool call, or the daemon binary's build provenance, which reaches the proof only through a
running daemon. That is a real loss of release coverage on one platform, taken deliberately.
**FIR-1742** is the restoration ticket. It scopes Windows exact-Git admission as a
transaction-layer port rather than a flag flip, and it is what eventually flips the contract
back to asserting a successful admission and returns these steps to the Windows leg.

The reduction is temporary by construction rather than by intention. The new admission step is
its own tripwire: when the port lands and admission succeeds again, `require_refused` fails with
"unexpectedly succeeded", and whoever reads that failure deletes the two new steps, drops the
three `runner.os != 'Windows'` guards, and flips the contract script back.

## Why the leg had no passing outcome at all

`install-proof.yml` required `kin init` on `windows-latest` to succeed. `scripts/assert-windows-init-contract.sh`
requires the same command to be refused, names the cause, and runs as a required check on every
pull request. Both are required, so no answer made the Windows leg green and no v0.4.6 recut could
pass there.

The refusal is not an accident. The graph store flushes a directory the way Unix does, by reopening
it and syncing, and Windows refuses that open. The contract asserts that by name as the behavior the
product ships.

## What Windows proves now

A new step drives all three admission boundaries, the exact-Git repository, the native unborn
directory, and the populated directory, and requires each refusal to name its own cause in the
contract script's own words and to have published nothing. The authority suite parses that script's
bindings and requires the proof to carry them verbatim, so wording drifting in either file fails a
required check instead of quietly passing.

A second step proves what the platform still ships without a repository, which is the installer, the
binaries, the CLI's build provenance bound to the release tag's public source, the registry authority
posture with its repair negative control, and the setup writers for the shell hook, the install
ledger, and every agent-client MCP config a repo-free install can write.

That last part is four of the five, not all five, and dispatching the proof against the real release
is what established it. Codex binds `mcp start --repo <exact repository>` in its config, so setup
refuses to write one without a repository, the file never appears, and the check drops out of the
report rather than reporting unhealthy. Codex is asserted absent here instead of required healthy, so
the exclusion is stated rather than quietly dropped and a Codex writer that ever stops needing a
repository trips the assertion. The Unix leg has a repository and still requires that entry healthy.

## A second thing this reduces, found by making a guard falsifiable

The published-nothing half of the contract **could not fail**. Both admission paths stage into the
parent of the directory they admit, one deriving it from the source's parent and the other from the
working directory's, but the check counted `.kin.init-*` **inside** the admitted directory. It
reported zero for every input and passed whether or not a refusal had cleaned up after itself. That
was true in the required per-PR check too, not only in the new install-proof copy, and it had been
true since that check landed.

Counting where a stage can actually appear turned the check red immediately, and what it reports is
real. In run 30690138555 on `windows-latest`, both boundaries that reach the graph store left their
unpublished stage **and** its `.owner` marker behind after refusing, two entries each. The count is
post-refusal residue before any reaper could act: each proof boundary is a freshly created parent
that sees exactly one init, and the orphan reaper runs before that init's staging root exists, so
implementing its off-unix arm alone would leave these counts unchanged. The cleanup that does run
at refusal is best-effort against the same open handles that refuse the admission. The boundary
that refuses before a stage exists leaves nothing.

The half that matters holds. No `.kin` appeared at any boundary, so authority is never published,
and that stays a hard failure. The residue is now asserted by exact count per boundary, in both
files that state the contract, so it is recorded rather than hidden and a change in either direction
has to come here and say so. The transaction-layer port, or cleanup at refusal time once handles close, drives the count to
zero and trips this the same way a restored admission trips the refusal itself.

This is a second Windows defect being ratified rather than fixed, and it belongs with the first under
FIR-1742. It was not introduced here. It was made visible here.

## Guard holes closed

Mutation testing against PR 560's guard found three coverage holes where every pinned line stayed in
place and admission still broke. An unrelated write into the worktree before init, a copy-back
reordered above init, and a second init reached through a subshell, an eval, or a variable. The span
between entering the worktree and admitting it is now closed-form, capture order is asserted, an
unrecognized init is refused by name, and the guarded span ends at the next step rather than three
steps later so its failure message describes the region it covers.

## Verification

`scripts/test-release-workflow-authority.py` exits 0 on an isolated `/tmp` git-archive of this head.
Twenty-one mutations applied to the real `install-proof.yml` and `assert-windows-init-contract.sh` each
turned the suite red and each restored to green, covering the three Windows step guards, wording
drift in both directions, the commented-out posture pin, the stage count returning to the unreachable
form in either file, each per-boundary residue expectation, the provenance binding, the repair
negative control, the repo-free posture, and all three init-span holes. `actionlint`, `shellcheck`, and `bash -n` are clean.

Install Proof was dispatched from this branch against the real v0.4.5 assets three times, and every
correction above came from a real runner rather than from reading. Run **30690138555** proved the
three Windows guards work, the repository-dependent steps skipping as intended, and surfaced the
stage residue. Run **30690366674** turned the admission step green with the residue asserted and
surfaced the Codex expectation. Run **30690667443** is the leg at this head, and `windows-latest` is **green end to end**: installer,
binaries, admission contract, and repo-free provenance and setup all pass, with the three
repository-dependent steps skipping. The objective of this change is proven on the real release
rather than argued.

The Unix legs still fail at "Graph-backed VFS projection proof" in every one of those runs. That is a
separate release blocker, unchanged by this PR and not addressed here.

Refs FIR-1820. Alignment resolves the contradiction between two required gates. It does not fix the
Windows admission regression, which stays open under FIR-1742.

## Claims not being made

- Not claiming this fixes Windows. It does not.
- Not claiming which commit regressed Windows admission. It was not bisected.
- Not claiming the stage residue is correct behavior. It is a defect. Asserting it records it and
  makes the fix trip a required check, which is the opposite of blessing it.
- Not claiming the Unix legs pass. They still fail at the VFS projection step, which is a separate
  release blocker and not touched here.

