### PR TITLE
Record the Windows repository-creation loss in the 0.4.4 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ it.
   rather than something this release introduces: v0.3.6 accepted only the one
   format it wrote, and so does this one. The accepted range widens when the
   format is declared stable, not before.
+- Windows loses repository creation. `kin init` is refused at both admission
+  boundaries under this release, the exact-Git one and the native bootstrap in
+  an empty directory, so a Windows host cannot create a repository at all, and
+  the daemon, graph queries, and MCP tool calls that v0.3.6 served there have
+  nothing to run against. Both refusals stop in the graph authority store,
+  which makes metadata durable by reopening the containing directory and
+  syncing it, and Windows denies that open unless it carries backup semantics.
+  Neither refusal leaves a partial repository behind. This is where admission
+  stops now, one transaction further than the config writer it stopped at
+  before, and Windows returns as each remaining gate is closed. macOS and
+  Linux are unaffected.
 
 ### Changed
 


### PR DESCRIPTION
One Breaking bullet recording that Windows cannot create a repository under
0.4.x, when v0.3.6 could.

## Why the 0.4.4 section

0.4.4 is the roll-up staging area for abandoned tags. `prepare-release.mjs`
`upsertChangelogSection` replaces the section of the version it is preparing
wholesale, and `main` removes the working version's section first, so a bullet
written into the version being published is regenerated away. An abandoned
section is never the prepare target, so `extract-release-notes.mjs` carries it
forward intact under its "Carried forward from" notice.

## What the bullet says, and how it differs from the brief

The brief scoped this to Git-repository admission and attributed it to an
unported exact-Git transaction layer. `scripts/assert-windows-init-contract.sh`,
which is required per pull request and green, asserts something wider and with a
different cause:

- Exact-Git admission is refused, and the script explicitly refutes both the
  mutable-source proof stage and the config writer, so neither is the cause any
  more.
- Native bootstrap in an empty directory is refused as well, at the same place.
  The loss is therefore all repository creation, not Git admission alone.
- Both stop at `for durable metadata flush`, which is kin-db
  `storage/mmap.rs:282`. The graph store makes metadata durable by reopening the
  containing directory and syncing it, and Windows refuses that open without
  `FILE_FLAG_BACKUP_SEMANTICS`.

The script's third assertion, a populated non-Git directory, refuses because Kin
never derives authority from existing filesystem contents. That holds on every
platform and is not part of this loss, so the bullet does not claim it.

The capability baseline is install-proof run 29749887140 (2026-07-20), which installed the then-latest published release, predating the v0.3.6 tag by six days: windows-latest passed first-run, graph query and MCP, and capability validation there. v0.3.6 itself was never Windows-proven end to end (its weekly run failed earlier in the installer for an unrelated reason), so the loss is anchored to the 0.3.x line rather than the v0.3.6 tag specifically. v0.3.6's own capability is evidenced directly by its ci.yml step that reopens a fresh Windows graph through the daemon, which ran green at that tag. The bullet
does not claim the flush gap is the last remaining gate, because the two gates
before it were each revealed by closing the one ahead of it.

## Validation

- `node --test scripts/extract-release-notes.test.mjs`, 22/22 pass. No fixture
  needed updating: the suite builds its own synthetic changelog constant, and
  the only test reading a real repository file reads
  `abandoned-release-tags.json`, which is untouched.
- `node --test` over `check-release-version`, `prepare-release`, `release-order`
  and `resolve-release-intent`, 30/30 pass.
- Ran the extractor against the real `CHANGELOG.md` for 0.4.5. The bullet
  appears in the composed notes under `## Carried forward from v0.4.4`, which is
  the end-to-end proof the suite alone does not give.

One note for whoever sequences later tags: carry-forward is not automatic past
0.4.5. `abandonedAncestors` walks `superseded_by` backwards, so v0.4.6 reaches
this section only if v0.4.5 is itself recorded abandoned and superseded by it.


