### PR TITLE
Report status embedding coverage from the graph that actually holds the vector index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,6 +978,14 @@ jobs:
       - name: Test featureless kin-cli
         run: cargo test -p kin-cli --no-default-features --locked
 
+      # kin-daemon owns feature-dependent status sampling and response tests of
+      # its own. A featureless package check compiles those routes but does not
+      # execute assertions that can accidentally encode the vector-enabled
+      # answer. Run the complete daemon package under the same release feature
+      # set; doctests need no companion step because the crate disables them.
+      - name: Test featureless kin-daemon
+        run: cargo test -p kin-daemon --no-default-features --locked
+
   # Security audit moved to sast.yml (cargo-deny: advisories + licenses + bans + sources)
 
   coverage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- The `kin status --json` contract moves from `kin.status.v2` to `kin.status.v3`
+  and gains a required top-level `embedding_coverage` object. The field carries
+  no serde default, and the report refuses unknown fields, so both parse
+  directions break across binaries: a v2 reader rejects a v3 payload on the
+  schema string, and a v2 payload no longer deserializes as a status report at
+  all. Any consumer pinning the schema string or the exact v2 field set must be
+  updated to read `embedding_coverage.state` before any count, because the
+  payload deliberately omits `indexed`, `pending`, and `total` when coverage was
+  not observed.
+
 ## [0.4.5] - 2026-08-01
 
 ### Changed

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -810,10 +810,12 @@ async fn live_status_from_running_daemon(
         .map_err(unavailable)?;
     // The client's default request budget is minutes long, which is right for a
     // mutation and wrong for a read that already has a complete local answer.
-    // Route resolution above only returns an endpoint that answered `/health`,
-    // so what is bounded here is the narrower case of a daemon that is alive but
-    // stuck inside this handler. The budget still has to cover a real authority
-    // open on a large store, which is the same work the fallback would do.
+    // Supervisor-derived route resolution above returns only an endpoint that
+    // answered `/health`; an explicit `KIN_DAEMON_URL` is trusted as supplied.
+    // The budget therefore covers both an explicit unreachable route and the
+    // narrower case of a healthy daemon stuck inside this handler. It still has
+    // to allow a real authority open on a large store, which is the same work
+    // the fallback would do.
     match tokio::time::timeout(
         LIVE_STATUS_READ_BUDGET,
         client.command_status(&CommandStatusRequest::new(false)),

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -232,8 +232,24 @@ pub enum EmbeddingCoverageUnobserved {
     /// This build ships no vector backend, so no index can be attached at all.
     VectorSupportDisabled,
     /// An embedding pass held the work lock, so no counter set could be sampled
-    /// at one instant.
+    /// at one instant. Transient: the next read observes coverage once the pass
+    /// releases.
     SamplingContended,
+    /// The embedding work lock is poisoned, so an embedding pass panicked while
+    /// holding it and no later pass can take it. This is permanent for the
+    /// daemon's lifetime and means the embedding loop is dead, which is why it
+    /// is not reported as contention: an operator told to retry a contended
+    /// sample would wait for a pass that will never run.
+    EmbeddingWorkLockPoisoned,
+    /// A graph mutation batch was in flight across every sampling attempt, so
+    /// no counter set could be paired with a stable graph authority. Transient,
+    /// and distinct from a held embedding lock because the work that has to
+    /// finish first is a different one.
+    GraphMutationInFlight,
+    /// The sampling task did not complete, so nothing was measured. Distinct
+    /// from every state above, all of which are answers about a graph that was
+    /// reachable.
+    SamplingFailed,
 }
 
 /// Embedding coverage of the live view that answers semantic queries.
@@ -625,6 +641,9 @@ impl StatusReport {
                 self.semantic_enrichment.workspace_generation, self.workspace.generation
             ));
         }
+        self.embedding_coverage
+            .validate()
+            .map_err(|error| format!("embedding_coverage is invalid: {error}"))?;
         Ok(())
     }
 }
@@ -721,7 +740,7 @@ pub fn inspect(
         .as_ref()
         .map(AuthorityPayloadReceipt::from_payload_stats);
 
-    Ok(StatusReport {
+    let report = StatusReport {
         schema: STATUS_SCHEMA.to_string(),
         authority: "repository-v6".to_string(),
         repo_root: layout.working_dir().to_path_buf(),
@@ -746,7 +765,15 @@ pub fn inspect(
         semantic_enrichment,
         embedding_coverage,
         authority_payload,
-    })
+    };
+    // Validate on the way out, not only on the way in. The reader already
+    // refuses an illegal report; running the same check here means a future
+    // coverage source that publishes an impossible triple fails in the process
+    // that built it rather than in every consumer that parses it.
+    report
+        .validate()
+        .map_err(|error| anyhow::anyhow!("repository-v6 status report is invalid: {error}"))?;
+    Ok(report)
 }
 
 /// Read status from the daemon that already holds this repository's live query
@@ -758,10 +785,14 @@ pub fn inspect(
 /// fallback will publish, so an unreachable daemon is reported as an
 /// unobserved coverage rather than inferred as an unembedded repository.
 ///
-/// A daemon that answers is not automatically believed. A build mismatch or a
-/// status schema this binary cannot parse both surface here as an unavailable
-/// daemon, so version skew degrades to a named absence instead of failing the
-/// command.
+/// A daemon that answers is not automatically believed. A status response this
+/// binary cannot parse, which includes one carrying a status schema it does not
+/// know, surfaces here as an unavailable daemon, so schema skew degrades to a
+/// named absence instead of failing the command. A build mismatch alone does
+/// not reach that gate: `check_response_build_match` refuses a mismatched
+/// daemon build only under `KIN_STRICT_BUILD_MATCH` and otherwise warns once
+/// and hands back the response. What protects this read from a skewed daemon is
+/// the schema, not the build check.
 async fn live_status_from_running_daemon(
     layout: &kin_core::KinLayout,
 ) -> std::result::Result<StatusReport, EmbeddingCoverageUnobserved> {
@@ -938,6 +969,16 @@ fn render_embedding_coverage(coverage: &EmbeddingCoverage) -> String {
                     "this build ships no vector backend"
                 }
                 EmbeddingCoverageUnobserved::SamplingContended => "an embedding pass was in flight",
+                EmbeddingCoverageUnobserved::EmbeddingWorkLockPoisoned => {
+                    "the embedding work lock is poisoned; this daemon's embedding loop is dead \
+                     and will not resume without a restart"
+                }
+                EmbeddingCoverageUnobserved::GraphMutationInFlight => {
+                    "a graph mutation was in flight across every sampling attempt"
+                }
+                EmbeddingCoverageUnobserved::SamplingFailed => {
+                    "the coverage sample did not complete"
+                }
             };
             format!("not observed ({explanation})")
         }
@@ -1354,6 +1395,55 @@ mod tests {
                 .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
             "{}",
             render_text(&observed, None)
+        );
+    }
+
+    /// A permanent condition must not read as the transient one. Once the
+    /// embedding work lock is poisoned no later pass can take it, so the text
+    /// has to stop telling the reader an embedding pass is in flight.
+    #[test]
+    fn a_poisoned_embedding_lock_renders_apart_from_a_pass_in_flight() {
+        let contended = render_embedding_coverage(&EmbeddingCoverage::unobserved(
+            EmbeddingCoverageUnobserved::SamplingContended,
+        ));
+        let poisoned = render_embedding_coverage(&EmbeddingCoverage::unobserved(
+            EmbeddingCoverageUnobserved::EmbeddingWorkLockPoisoned,
+        ));
+
+        assert_ne!(
+            contended, poisoned,
+            "a dead embedding loop and a pass in flight must not render alike"
+        );
+        assert!(poisoned.contains("poisoned"), "{poisoned}");
+        assert!(
+            !poisoned.contains("in flight"),
+            "a poisoned lock has no pass in flight to wait for: {poisoned}"
+        );
+    }
+
+    /// The reader already refuses an impossible triple. The writer has to as
+    /// well, or a future coverage source publishes one and only its consumers
+    /// find out.
+    #[test]
+    fn building_a_report_refuses_an_impossible_coverage_triple() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
+
+        let error = inspect(
+            &init.layout,
+            &binding,
+            EmbeddingCoverage::Observed {
+                source: EmbeddingCoverageSource::LiveQueryGraph,
+                indexed: 9,
+                pending: 0,
+                total: 3,
+            },
+        )
+        .expect_err("a report indexing more objects than it holds must not be built");
+        assert!(
+            error.to_string().contains("embedding_coverage is invalid"),
+            "{error}"
         );
     }
 

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -3,15 +3,26 @@
 
 //! Coherent repository-v6 status.
 //!
-//! Status reads one immutable authority lease. It never inspects checkout
-//! contents, legacy branch sidecars, Git, or a separately opened graph
-//! snapshot. Opening the authority also revalidates every referenced source
-//! body in the repository-owned CAS.
+//! Every count below the enrichment line comes from one immutable authority
+//! lease. Nothing here inspects checkout contents, legacy branch sidecars, Git,
+//! or a separately opened graph snapshot. Opening the authority also
+//! revalidates every referenced source body in the repository-owned CAS.
+//!
+//! The lease may be read in this process or, when a daemon already holds this
+//! repository, by that daemon on this command's behalf. Both read the same
+//! durable authority; only the daemon can additionally observe the live query
+//! graph, which is why the report can come from there.
 //!
 //! Semantic counts are resolved from the workspace's durable first-parent
 //! history and cumulative semantic overlay inside that lease. They deliberately
 //! do not describe the daemon's mutable live graph: runtime reconcile and LSP
 //! work may advance that derived view without changing repository authority.
+//!
+//! Embedding coverage is the one figure here that authority does not carry.
+//! A repository-v6 lease records semantic identities, not which of them a
+//! vector index holds, so coverage is reported as its own object naming the
+//! live view it was sampled from. When no such view is available the object
+//! says so; it never reports the zero that an unindexed graph would produce.
 
 use std::path::PathBuf;
 
@@ -23,10 +34,28 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use super::repository_authority::ActiveRepositoryAuthority;
 
-/// First status contract whose enrichment counts name their durable view and
-/// exact authority/workspace generations. The earlier, unreleased v1 shape
-/// carried counts with different semantics and cannot be inferred truthfully.
-pub const STATUS_SCHEMA: &str = "kin.status.v2";
+/// First status contract carrying embedding coverage alongside enrichment
+/// counts that name their durable view and exact authority/workspace
+/// generations.
+///
+/// v2 carried no embedding, index, or vector state anywhere in the payload, so
+/// a v2 reader cannot be handed a v3 one: absence of coverage was not a legal
+/// v2 encoding of "coverage unknown", it was the whole shape. The version moves
+/// rather than the field being defaulted, so a version-skewed pair fails naming
+/// the schema instead of silently agreeing on a number neither of them meant.
+/// The earlier, unreleased v1 shape carried counts with different semantics and
+/// cannot be inferred truthfully either.
+pub const STATUS_SCHEMA: &str = "kin.status.v3";
+
+/// How long `kin status` will wait on a live daemon read before falling back to
+/// its own authority read and reporting coverage as unobserved.
+///
+/// Status always has a complete local answer, so this bounds an optional
+/// enrichment rather than the command itself. It is deliberately not shorter:
+/// the daemon performs the same authority open the fallback would, and a budget
+/// tight enough to protect against a stuck handler would also abandon a
+/// legitimate read on a large store.
+const LIVE_STATUS_READ_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
 
 fn deserialize_status_schema<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
 where
@@ -61,7 +90,7 @@ where
     let completion_attested = bool::deserialize(deserializer)?;
     if completion_attested {
         return Err(serde::de::Error::custom(
-            "kin.status.v2 does not carry a semantic-enrichment completion attestation",
+            "kin.status.v3 does not carry a semantic-enrichment completion attestation",
         ));
     }
     Ok(false)
@@ -165,6 +194,205 @@ impl SemanticEnrichmentStatus {
             _ => Ok(()),
         }
     }
+}
+
+/// The live view one coverage observation was sampled from.
+///
+/// Coverage is only meaningful against the graph a query would actually search,
+/// so the reader is told which graph answered rather than being left to assume
+/// the durable authority did.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingCoverageSource {
+    /// A live query graph with a validated vector index installed. This is the
+    /// same view `kin graph status` and `kin_graph_status` report.
+    LiveQueryGraph,
+}
+
+/// Why coverage could not be observed.
+///
+/// Each variant is a distinct, actionable state. Collapsing any of them into
+/// `indexed = 0` would publish a number that a fully embedded repository is
+/// indistinguishable from.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingCoverageUnobserved {
+    /// No daemon holds this repository's live query graph. Status does not
+    /// start one: it is a read, and opening a store with pending embeddings
+    /// begins inference.
+    NoRunningDaemon,
+    /// A daemon was reachable but its status response could not be used, which
+    /// includes a daemon built against a different status schema.
+    DaemonStatusUnavailable,
+    /// The live graph carries no vector index, so nothing in it can answer how
+    /// many objects are indexed. `embedding_status` reports zero indexed for
+    /// every retrievable object in this state, which is exactly the reading a
+    /// never-embedded repository produces.
+    NoVectorIndexAttached,
+    /// This build ships no vector backend, so no index can be attached at all.
+    VectorSupportDisabled,
+    /// An embedding pass held the work lock, so no counter set could be sampled
+    /// at one instant.
+    SamplingContended,
+}
+
+/// Embedding coverage of the live view that answers semantic queries.
+///
+/// Reported as a sum type because "nothing is indexed" and "nobody could say"
+/// are different facts and every consumer that gates on progress needs to tell
+/// them apart.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum EmbeddingCoverage {
+    Observed {
+        source: EmbeddingCoverageSource,
+        indexed: usize,
+        pending: usize,
+        total: usize,
+    },
+    Unobserved {
+        reason: EmbeddingCoverageUnobserved,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum EmbeddingCoverageState {
+    Observed,
+    Unobserved,
+}
+
+/// Deserialized as a flat wire shape rather than a tagged enum so that a
+/// payload carrying the counts of one state under the tag of another is
+/// refused instead of having its extra members dropped.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EmbeddingCoverageWire {
+    state: EmbeddingCoverageState,
+    #[serde(default)]
+    source: Option<EmbeddingCoverageSource>,
+    #[serde(default)]
+    reason: Option<EmbeddingCoverageUnobserved>,
+    #[serde(default)]
+    indexed: Option<usize>,
+    #[serde(default)]
+    pending: Option<usize>,
+    #[serde(default)]
+    total: Option<usize>,
+}
+
+impl<'de> Deserialize<'de> for EmbeddingCoverage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = EmbeddingCoverageWire::deserialize(deserializer)?;
+        let coverage = match wire.state {
+            EmbeddingCoverageState::Observed => {
+                if wire.reason.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "embedding_coverage is observed but carries an unobserved reason",
+                    ));
+                }
+                let missing = |field: &str| {
+                    serde::de::Error::custom(format!(
+                        "embedding_coverage is observed but carries no {field}"
+                    ))
+                };
+                Self::Observed {
+                    source: wire.source.ok_or_else(|| missing("source"))?,
+                    indexed: wire.indexed.ok_or_else(|| missing("indexed"))?,
+                    pending: wire.pending.ok_or_else(|| missing("pending"))?,
+                    total: wire.total.ok_or_else(|| missing("total"))?,
+                }
+            }
+            EmbeddingCoverageState::Unobserved => {
+                if wire.source.is_some()
+                    || wire.indexed.is_some()
+                    || wire.pending.is_some()
+                    || wire.total.is_some()
+                {
+                    return Err(serde::de::Error::custom(
+                        "embedding_coverage is unobserved but carries coverage counts",
+                    ));
+                }
+                Self::Unobserved {
+                    reason: wire.reason.ok_or_else(|| {
+                        serde::de::Error::custom(
+                            "embedding_coverage is unobserved but carries no reason",
+                        )
+                    })?,
+                }
+            }
+        };
+        coverage.validate().map_err(serde::de::Error::custom)?;
+        Ok(coverage)
+    }
+}
+
+impl EmbeddingCoverage {
+    pub fn unobserved(reason: EmbeddingCoverageUnobserved) -> Self {
+        Self::Unobserved { reason }
+    }
+
+    /// The same triple invariants `kin.graph-status.v1` enforces.
+    ///
+    /// Two surfaces reporting one repository's coverage must not disagree about
+    /// which triples are legal, or a consumer that validates against one of
+    /// them accepts a payload the other calls impossible.
+    fn validate(&self) -> std::result::Result<(), String> {
+        let Self::Observed {
+            indexed,
+            pending,
+            total,
+            ..
+        } = self
+        else {
+            return Ok(());
+        };
+        if indexed > total {
+            return Err(format!(
+                "embedding_coverage.indexed ({indexed}) exceeds embedding_coverage.total ({total})"
+            ));
+        }
+        let uncovered = total.saturating_sub(*indexed);
+        if *pending < uncovered {
+            return Err(format!(
+                "embedding_coverage.pending ({pending}) does not account for the {uncovered} \
+                 retrievable objects that are not indexed"
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Sample coverage from a live query graph.
+///
+/// `embedding_status` derives `indexed` by testing every retrievable key
+/// against the graph's vector index and answers zero for all of them when no
+/// index is installed. A graph reconstructed from a snapshot never has one, so
+/// counting it there would report zero coverage on a fully embedded repository
+/// in a well-formed payload. Coverage is therefore published only once an index
+/// is proven attached, and the absence is named otherwise.
+#[cfg(feature = "vector")]
+pub fn observe_embedding_coverage(graph: &kin_db::InMemoryGraph) -> EmbeddingCoverage {
+    if graph.vector_index_stats().is_none() {
+        return EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::NoVectorIndexAttached);
+    }
+    let status = graph.embedding_status();
+    EmbeddingCoverage::Observed {
+        source: EmbeddingCoverageSource::LiveQueryGraph,
+        indexed: status.indexed,
+        pending: status.pending,
+        total: status.total,
+    }
+}
+
+/// Feature-disabled counterpart: with no vector backend there is no index to
+/// attach and no coverage to observe.
+#[cfg(not(feature = "vector"))]
+pub fn observe_embedding_coverage(_graph: &kin_db::InMemoryGraph) -> EmbeddingCoverage {
+    EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::VectorSupportDisabled)
 }
 
 /// Read the durable enrichment this exact authority lease carries.
@@ -323,6 +551,10 @@ pub struct StatusReport {
     pub repository: RepositoryStatus,
     pub workspace: WorkspaceStatus,
     pub semantic_enrichment: SemanticEnrichmentStatus,
+    /// Coverage of the live query graph, not of the authority lease above.
+    /// Required in v3: a report that omitted it would be one whose reader could
+    /// not tell an unobservable repository from an unembedded one.
+    pub embedding_coverage: EmbeddingCoverage,
     /// Absent only where authority was never persisted and generation zero was
     /// built in memory. A persisted repository always reports the payload its
     /// open recovered.
@@ -341,6 +573,7 @@ struct StatusReportWire {
     repository: RepositoryStatus,
     workspace: WorkspaceStatus,
     semantic_enrichment: SemanticEnrichmentStatus,
+    embedding_coverage: EmbeddingCoverage,
     #[serde(default)]
     authority_payload: Option<AuthorityPayloadReceipt>,
 }
@@ -358,6 +591,7 @@ impl<'de> Deserialize<'de> for StatusReport {
             repository: wire.repository,
             workspace: wire.workspace,
             semantic_enrichment: wire.semantic_enrichment,
+            embedding_coverage: wire.embedding_coverage,
             authority_payload: wire.authority_payload,
         };
         report.validate().map_err(serde::de::Error::custom)?;
@@ -449,9 +683,17 @@ impl CommandStatusRequest {
     }
 }
 
+/// Build one status report from an authority lease plus a stated coverage
+/// observation.
+///
+/// Coverage is a parameter rather than something this function derives, because
+/// nothing reachable from an authority lease can answer it. Making the caller
+/// supply it means every path has to name where its coverage came from, and no
+/// path can reach a default that reads as measured.
 pub fn inspect(
     layout: &kin_core::KinLayout,
     binding: &kin_core::LocalRepositoryAuthorityBinding,
+    embedding_coverage: EmbeddingCoverage,
 ) -> Result<StatusReport> {
     let authority = ActiveRepositoryAuthority::open(binding)?;
     let lease = authority.manager().read_authority();
@@ -502,14 +744,73 @@ pub fn inspect(
             artifact_count,
         },
         semantic_enrichment,
+        embedding_coverage,
         authority_payload,
     })
 }
 
-pub fn run(json: bool) -> Result<()> {
+/// Read status from the daemon that already holds this repository's live query
+/// graph, so the report carries coverage sampled from a real vector index.
+///
+/// This never starts a daemon. Status is a read, and opening a store whose
+/// embeddings are pending starts inference on its own, which is not something a
+/// status command may do as a side effect. The error is the reason the local
+/// fallback will publish, so an unreachable daemon is reported as an
+/// unobserved coverage rather than inferred as an unembedded repository.
+///
+/// A daemon that answers is not automatically believed. A build mismatch or a
+/// status schema this binary cannot parse both surface here as an unavailable
+/// daemon, so version skew degrades to a named absence instead of failing the
+/// command.
+async fn live_status_from_running_daemon(
+    layout: &kin_core::KinLayout,
+) -> std::result::Result<StatusReport, EmbeddingCoverageUnobserved> {
+    let base_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout)
+        .await
+        .ok_or(EmbeddingCoverageUnobserved::NoRunningDaemon)?;
+    let unavailable = |error: anyhow::Error| {
+        tracing::debug!(%error, "live status unavailable; reporting coverage as unobserved");
+        EmbeddingCoverageUnobserved::DaemonStatusUnavailable
+    };
+    // The token is resolved from the repository this command resolved, not from
+    // the process directory, so running status from a subdirectory does not
+    // authenticate against a different repository's daemon.
+    let client = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout)
+        .map_err(unavailable)?;
+    // The client's default request budget is minutes long, which is right for a
+    // mutation and wrong for a read that already has a complete local answer.
+    // Route resolution above only returns an endpoint that answered `/health`,
+    // so what is bounded here is the narrower case of a daemon that is alive but
+    // stuck inside this handler. The budget still has to cover a real authority
+    // open on a large store, which is the same work the fallback would do.
+    match tokio::time::timeout(
+        LIVE_STATUS_READ_BUDGET,
+        client.command_status(&CommandStatusRequest::new(false)),
+    )
+    .await
+    {
+        Ok(response) => response
+            .map(|response| response.report)
+            .map_err(unavailable),
+        Err(_elapsed) => {
+            tracing::debug!(
+                budget_secs = LIVE_STATUS_READ_BUDGET.as_secs(),
+                "live status read exceeded its budget; reporting coverage as unobserved"
+            );
+            Err(EmbeddingCoverageUnobserved::DaemonStatusUnavailable)
+        }
+    }
+}
+
+pub async fn run(json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
-    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
-    let report = inspect(&layout, &binding)?;
+    let report = match live_status_from_running_daemon(&layout).await {
+        Ok(report) => report,
+        Err(reason) => {
+            let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
+            inspect(&layout, &binding, EmbeddingCoverage::unobserved(reason))?
+        }
+    };
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
@@ -579,6 +880,10 @@ fn render_text(report: &StatusReport, build: Option<&BuildStatus>) -> String {
             report.semantic_enrichment.workspace_generation
         ),
         "Live graph enrichment: see `kin graph status`".to_string(),
+        format!(
+            "Live embedding coverage: {}",
+            render_embedding_coverage(&report.embedding_coverage)
+        ),
         "Source CAS: verified".to_string(),
         match report.authority_payload.as_ref() {
             Some(payload) => format!(
@@ -601,6 +906,42 @@ fn render_text(report: &StatusReport, build: Option<&BuildStatus>) -> String {
         ));
     }
     lines.into_iter().map(|line| format!("{line}\n")).collect()
+}
+
+/// Render coverage so the text surface states the same distinction the payload
+/// does. An unobserved coverage prints why, never a count.
+fn render_embedding_coverage(coverage: &EmbeddingCoverage) -> String {
+    match coverage {
+        EmbeddingCoverage::Observed {
+            source,
+            indexed,
+            pending,
+            total,
+        } => {
+            let view = match source {
+                EmbeddingCoverageSource::LiveQueryGraph => "live query graph",
+            };
+            format!("{indexed}/{total} indexed, {pending} pending ({view})")
+        }
+        EmbeddingCoverage::Unobserved { reason } => {
+            let explanation = match reason {
+                EmbeddingCoverageUnobserved::NoRunningDaemon => {
+                    "no daemon holds this repository's live graph"
+                }
+                EmbeddingCoverageUnobserved::DaemonStatusUnavailable => {
+                    "the daemon's status response could not be used"
+                }
+                EmbeddingCoverageUnobserved::NoVectorIndexAttached => {
+                    "the live graph carries no vector index"
+                }
+                EmbeddingCoverageUnobserved::VectorSupportDisabled => {
+                    "this build ships no vector backend"
+                }
+                EmbeddingCoverageUnobserved::SamplingContended => "an embedding pass was in flight",
+            };
+            format!("not observed ({explanation})")
+        }
+    }
 }
 
 fn render_head(head: &WorkspaceHead) -> String {
@@ -632,24 +973,31 @@ fn build_id(sha: &str, dirty: bool) -> String {
 mod tests {
     use super::*;
 
+    /// The coverage a bare authority read publishes. These cases exercise the
+    /// durable half of the report, where no live graph was consulted, so this
+    /// is the honest observation for them rather than a stand-in for one.
+    fn unobserved_fixture() -> EmbeddingCoverage {
+        EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::NoRunningDaemon)
+    }
+
     #[test]
-    fn unreleased_v1_enrichment_is_not_silently_reinterpreted_as_v2() {
+    fn unreleased_v1_enrichment_is_not_silently_reinterpreted_as_v3() {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
-        let report = inspect(&init.layout, &binding).unwrap();
+        let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
         let mut legacy = serde_json::to_value(report).unwrap();
         legacy["schema"] = serde_json::Value::String("kin.status.v1".to_string());
 
         let error = serde_json::from_value::<StatusReport>(legacy)
             .expect_err("a complete late-v1 daemon response must be rejected by schema");
 
-        assert_eq!(STATUS_SCHEMA, "kin.status.v2");
+        assert_eq!(STATUS_SCHEMA, "kin.status.v3");
         assert!(
             error
                 .to_string()
                 .contains("unsupported status schema 'kin.status.v1'"),
-            "v1 must fail explicitly even when every v2 payload field is present: {error}"
+            "v1 must fail explicitly even when every v3 payload field is present: {error}"
         );
     }
 
@@ -661,7 +1009,7 @@ mod tests {
         // than reusing the in-memory authority that init constructed.
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
 
-        let report = inspect(&init.layout, &binding).unwrap();
+        let report = inspect(&init.layout, &binding, unobserved_fixture()).unwrap();
 
         // `None` is legal only where authority was never persisted. Accepting it
         // here would let status report a read whose payload was never measured.
@@ -695,11 +1043,13 @@ mod tests {
     }
 
     #[test]
-    fn v2_accepts_a_report_without_a_payload_receipt_but_rejects_an_incoherent_one() {
+    fn v3_accepts_a_report_without_a_payload_receipt_but_rejects_an_incoherent_one() {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
-        let valid = serde_json::to_value(inspect(&init.layout, &binding).unwrap()).unwrap();
+        let valid =
+            serde_json::to_value(inspect(&init.layout, &binding, unobserved_fixture()).unwrap())
+                .unwrap();
 
         let mut without_receipt = valid.clone();
         without_receipt
@@ -708,7 +1058,7 @@ mod tests {
             .remove("authority_payload");
         assert_eq!(
             serde_json::from_value::<StatusReport>(without_receipt)
-                .expect("the receipt is additive over the released v2 shape")
+                .expect("the receipt is additive over the released report shape")
                 .authority_payload,
             None
         );
@@ -742,7 +1092,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_enrichment_round_trip_preserves_view_and_generations() {
+    fn v3_enrichment_round_trip_preserves_view_and_generations() {
         let enrichment = SemanticEnrichmentStatus {
             view: SemanticEnrichmentView::DurableRepositoryAuthority,
             authority_generation: 9,
@@ -765,11 +1115,13 @@ mod tests {
     }
 
     #[test]
-    fn v2_rejects_false_authority_completion_and_generation_claims() {
+    fn v3_rejects_false_authority_completion_and_generation_claims() {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
-        let valid = serde_json::to_value(inspect(&init.layout, &binding).unwrap()).unwrap();
+        let valid =
+            serde_json::to_value(inspect(&init.layout, &binding, unobserved_fixture()).unwrap())
+                .unwrap();
 
         let mut wrong_authority = valid.clone();
         wrong_authority["authority"] = serde_json::json!("live-daemon-graph");
@@ -828,9 +1180,181 @@ mod tests {
             ),
         ] {
             let error = serde_json::from_value::<StatusReport>(payload)
-                .expect_err("a contradictory v2 status claim must fail deserialization");
+                .expect_err("a contradictory v3 status claim must fail deserialization");
             assert!(error.to_string().contains(expected), "{error}");
         }
+    }
+
+    #[test]
+    fn a_v2_payload_is_refused_by_schema_and_a_v3_one_may_not_omit_coverage() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
+        let valid =
+            serde_json::to_value(inspect(&init.layout, &binding, unobserved_fixture()).unwrap())
+                .unwrap();
+
+        // A v2 payload is exactly a v3 one without coverage. It must fail
+        // naming the version, not the field: the field's absence is not a v2
+        // statement that coverage was unknown, it is a different contract.
+        let mut released_v2 = valid.clone();
+        let object = released_v2.as_object_mut().unwrap();
+        object.remove("embedding_coverage");
+        object.insert(
+            "schema".to_string(),
+            serde_json::Value::String("kin.status.v2".to_string()),
+        );
+        let error = serde_json::from_value::<StatusReport>(released_v2)
+            .expect_err("a released v2 payload is not a v3 report");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported status schema 'kin.status.v2'"),
+            "version skew must be reported as a schema mismatch: {error}"
+        );
+
+        // Within v3 the field is required, so a truncated payload cannot be
+        // read as a repository whose coverage happened to be absent.
+        let mut without_coverage = valid;
+        without_coverage
+            .as_object_mut()
+            .unwrap()
+            .remove("embedding_coverage");
+        let error = serde_json::from_value::<StatusReport>(without_coverage)
+            .expect_err("v3 coverage is required, not defaulted");
+        assert!(
+            error.to_string().contains("embedding_coverage"),
+            "unexpected missing-coverage error: {error}"
+        );
+    }
+
+    #[test]
+    fn coverage_states_may_not_borrow_each_other_s_members() {
+        let observed = serde_json::to_value(EmbeddingCoverage::Observed {
+            source: EmbeddingCoverageSource::LiveQueryGraph,
+            indexed: 5,
+            pending: 2,
+            total: 7,
+        })
+        .unwrap();
+        assert_eq!(observed["state"], "observed");
+        assert_eq!(observed["source"], "live_query_graph");
+        assert_eq!(
+            serde_json::from_value::<EmbeddingCoverage>(observed.clone()).unwrap(),
+            EmbeddingCoverage::Observed {
+                source: EmbeddingCoverageSource::LiveQueryGraph,
+                indexed: 5,
+                pending: 2,
+                total: 7,
+            }
+        );
+
+        let unobserved = serde_json::to_value(EmbeddingCoverage::unobserved(
+            EmbeddingCoverageUnobserved::NoVectorIndexAttached,
+        ))
+        .unwrap();
+        assert_eq!(unobserved["state"], "unobserved");
+        assert_eq!(unobserved["reason"], "no_vector_index_attached");
+        assert!(
+            unobserved.get("indexed").is_none(),
+            "an unobserved coverage must not serialize a count: {unobserved}"
+        );
+
+        // A count smuggled under the unobserved tag would let a consumer read
+        // zero coverage from a payload that declared it had none to report.
+        let mut counted_absence = unobserved.clone();
+        counted_absence["indexed"] = serde_json::json!(0);
+        let error = serde_json::from_value::<EmbeddingCoverage>(counted_absence)
+            .expect_err("an unobserved coverage carrying counts must be refused");
+        assert!(
+            error.to_string().contains("carries coverage counts"),
+            "{error}"
+        );
+
+        let mut reasoned_observation = observed;
+        reasoned_observation["reason"] = serde_json::json!("no_running_daemon");
+        let error = serde_json::from_value::<EmbeddingCoverage>(reasoned_observation)
+            .expect_err("an observed coverage carrying an absence reason must be refused");
+        assert!(error.to_string().contains("unobserved reason"), "{error}");
+
+        let mut reasonless_absence = unobserved;
+        reasonless_absence.as_object_mut().unwrap().remove("reason");
+        let error = serde_json::from_value::<EmbeddingCoverage>(reasonless_absence)
+            .expect_err("an unobserved coverage must say why");
+        assert!(error.to_string().contains("carries no reason"), "{error}");
+    }
+
+    #[test]
+    fn coverage_rejects_the_triples_graph_status_v1_rejects() {
+        let over_indexed = serde_json::json!({
+            "state": "observed",
+            "source": "live_query_graph",
+            "indexed": 8,
+            "pending": 0,
+            "total": 7,
+        });
+        let error = serde_json::from_value::<EmbeddingCoverage>(over_indexed)
+            .expect_err("more indexed than retrievable is impossible");
+        assert!(error.to_string().contains("exceeds"), "{error}");
+
+        // graph-status.v1 refuses this triple, so status must too: it asserts
+        // that nothing is indexed and nothing is outstanding at once.
+        let unaccounted = serde_json::json!({
+            "state": "observed",
+            "source": "live_query_graph",
+            "indexed": 0,
+            "pending": 0,
+            "total": 7,
+        });
+        let error = serde_json::from_value::<EmbeddingCoverage>(unaccounted)
+            .expect_err("uncovered objects with nothing pending is impossible");
+        assert!(
+            error.to_string().contains("does not account for"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn text_status_states_an_absent_coverage_rather_than_printing_zero() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
+
+        let unobserved = inspect(
+            &init.layout,
+            &binding,
+            EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::NoVectorIndexAttached),
+        )
+        .unwrap();
+        let rendered = render_text(&unobserved, None);
+        assert!(
+            rendered.contains(
+                "Live embedding coverage: not observed (the live graph carries no vector index)"
+            ),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains("0/0 indexed"),
+            "an unobservable coverage must never render as a measured zero: {rendered}"
+        );
+
+        let observed = inspect(
+            &init.layout,
+            &binding,
+            EmbeddingCoverage::Observed {
+                source: EmbeddingCoverageSource::LiveQueryGraph,
+                indexed: 41,
+                pending: 16,
+                total: 57,
+            },
+        )
+        .unwrap();
+        assert!(
+            render_text(&observed, None)
+                .contains("Live embedding coverage: 41/57 indexed, 16 pending (live query graph)"),
+            "{}",
+            render_text(&observed, None)
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2159,7 +2159,7 @@ fn main() -> Result<()> {
             match cli.command {
                 Command::Capabilities { json } => commands::capabilities::run(json),
                 Command::Init { path, json } => commands::init::run(path, json).await,
-                Command::Status { json } => commands::status::run(json),
+                Command::Status { json } => commands::status::run(json).await,
                 Command::Resources { action } => match action {
                     ResourcesAction::Inspect { json, profile } => {
                         commands::resources::run(json, profile).await

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -448,7 +448,12 @@ fn status_reports_durable_admission_enrichment_from_one_authority_generation() {
     let graph_entities = graph.list_all_entities().expect("list entities").len();
     let graph_relations = graph.graph_stats().total_relations;
 
-    let report = status::inspect(&admitted.layout, &admitted.binding).expect("inspect status");
+    let report = status::inspect(
+        &admitted.layout,
+        &admitted.binding,
+        status::EmbeddingCoverage::unobserved(status::EmbeddingCoverageUnobserved::NoRunningDaemon),
+    )
+    .expect("inspect status");
 
     assert_eq!(report.semantic_enrichment.entity_count, graph_entities);
     assert_eq!(report.semantic_enrichment.relation_count, graph_relations);
@@ -472,6 +477,142 @@ fn status_reports_durable_admission_enrichment_from_one_authority_generation() {
     assert!(report.semantic_enrichment.semantic_change_count > 0);
 }
 
+/// Install a real vector index over every retrievable key this graph owns,
+/// through kin-db's own compatibility-checked loader.
+///
+/// The vectors are fixture values; the index, the keys, and the load path are
+/// the production ones. What the caller is measuring is where coverage is read
+/// from, so the index has to be genuinely attached to the graph under test.
+#[cfg(feature = "vector")]
+fn install_full_vector_index(graph: &kin_db::InMemoryGraph, sidecar: &Path) -> usize {
+    let snapshot = graph.to_snapshot();
+    let mut keys: Vec<kin_model::RetrievalKey> = graph
+        .list_all_entities()
+        .expect("list entities")
+        .iter()
+        .map(|entity| kin_model::RetrievalKey::Entity(entity.id))
+        .collect();
+    keys.extend(
+        snapshot
+            .entity_revisions
+            .values()
+            .flat_map(|revisions| revisions.iter())
+            .map(|revision| kin_model::RetrievalKey::EntityRevision(revision.revision_id)),
+    );
+    keys.extend(
+        snapshot
+            .resolved_tree
+            .artifacts()
+            .map(|artifact| kin_model::RetrievalKey::Artifact(artifact.artifact_id)),
+    );
+
+    let vectors = kin_db::VectorIndex::new(4).expect("create vector index");
+    for (index, key) in keys.iter().enumerate() {
+        let embedding = match index % 3 {
+            0 => [1.0, 0.0, 0.0, 0.0],
+            1 => [0.0, 1.0, 0.0, 0.0],
+            _ => [0.0, 0.0, 1.0, 0.0],
+        };
+        vectors
+            .upsert_retrievable(*key, &embedding)
+            .expect("upsert retrievable vector");
+    }
+
+    let descriptor = kin_db::IndexDescriptor {
+        model_id: Some("status-coverage-fixture@v1".to_string()),
+        graph_root: Some(hex::encode(graph.compute_root_hash())),
+    };
+    vectors.set_descriptor(descriptor.clone());
+    vectors.save(sidecar).expect("save vector index");
+    assert!(
+        matches!(
+            graph.load_vector_index_compatible(sidecar, &descriptor),
+            kin_db::VectorIndexLoad::Loaded(_)
+        ),
+        "the fixture sidecar must install into the graph it was built from"
+    );
+    keys.len()
+}
+
+/// FIR-1785: coverage must come from a graph that actually holds an index.
+///
+/// The regression this pins is not a wrong number, it is a well-formed one.
+/// `embedding_status` answers `indexed = 0` for every retrievable object when
+/// no vector index is installed, and a graph rebuilt from an authority snapshot
+/// never has one. Reading coverage there reports zero on a fully embedded
+/// repository. So the same graph is measured twice, once before an index is
+/// attached and once after, and the two readings must differ in kind: an
+/// absence first, then real counts.
+#[cfg(feature = "vector")]
+#[test]
+fn status_reports_coverage_from_the_index_the_live_graph_carries() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let admitted = admit(&repo);
+    let graph = workspace_query_graph(&admitted.binding);
+
+    // Exactly the source a snapshot-derived read would have used. It carries no
+    // index, so it must report that rather than counting zero against a total.
+    assert_eq!(
+        status::observe_embedding_coverage(&graph),
+        status::EmbeddingCoverage::unobserved(
+            status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+        ),
+        "a graph with no vector index must report an absence, never a coverage of zero"
+    );
+
+    let seeded = install_full_vector_index(&graph, &root.path().join("coverage.kvec"));
+    assert!(seeded > 0, "the admitted graph must own retrievable keys");
+
+    let coverage = status::observe_embedding_coverage(&graph);
+    let status::EmbeddingCoverage::Observed {
+        source,
+        indexed,
+        pending,
+        total,
+    } = coverage
+    else {
+        panic!("an attached index must produce an observation, found {coverage:?}");
+    };
+    assert_eq!(source, status::EmbeddingCoverageSource::LiveQueryGraph);
+    assert!(
+        indexed > 0,
+        "an embedded repository must not report zero indexed objects \
+         (indexed={indexed}, pending={pending}, total={total}, seeded={seeded})"
+    );
+    assert_eq!(
+        indexed, total,
+        "every retrievable key was seeded (pending={pending}, seeded={seeded})"
+    );
+    assert_eq!(
+        pending, 0,
+        "nothing is outstanding once every key is indexed"
+    );
+
+    // The same numbers have to survive the report and its wire form, or the
+    // payload consumers read is not the observation that was taken.
+    let report = status::inspect(&admitted.layout, &admitted.binding, coverage)
+        .expect("inspect status with observed coverage");
+    let encoded = serde_json::to_value(&report).expect("serialize status report");
+    assert_eq!(encoded["schema"], "kin.status.v3");
+    assert_eq!(encoded["embedding_coverage"]["state"], "observed");
+    assert_eq!(
+        encoded["embedding_coverage"]["indexed"],
+        serde_json::json!(indexed)
+    );
+    assert!(
+        encoded["embedding_coverage"]["indexed"].as_u64().unwrap() > 0,
+        "the serialized payload must carry the nonzero coverage that was observed"
+    );
+    assert_eq!(
+        serde_json::from_value::<status::StatusReport>(encoded)
+            .expect("a report carrying observed coverage must round-trip")
+            .embedding_coverage,
+        coverage
+    );
+}
+
 #[test]
 fn status_reports_enrichment_absent_on_an_unenriched_repository() {
     let root = tempdir().expect("temp root");
@@ -481,7 +622,12 @@ fn status_reports_enrichment_absent_on_an_unenriched_repository() {
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&result.layout)
         .expect("bind published repository authority");
 
-    let report = status::inspect(&result.layout, &binding).expect("inspect status");
+    let report = status::inspect(
+        &result.layout,
+        &binding,
+        status::EmbeddingCoverage::unobserved(status::EmbeddingCoverageUnobserved::NoRunningDaemon),
+    )
+    .expect("inspect status");
 
     assert_eq!(
         report.semantic_enrichment.presence,

--- a/crates/kin-cli/tests/repository_status.rs
+++ b/crates/kin-cli/tests/repository_status.rs
@@ -93,7 +93,7 @@ fn status_is_one_exact_authority_lease_and_ignores_checkout_and_git_drift() {
     );
     let before_report: Value =
         serde_json::from_slice(&before.stdout).expect("status stdout should be JSON");
-    assert_eq!(before_report["schema"], "kin.status.v2");
+    assert_eq!(before_report["schema"], "kin.status.v3");
     assert_eq!(before_report["authority"], "repository-v6");
     assert_eq!(before_report["repository"]["generation"], 1);
     assert_eq!(before_report["repository"]["source_cas_verified"], true);
@@ -125,6 +125,24 @@ fn status_is_one_exact_authority_lease_and_ignores_checkout_and_git_drift() {
     assert_eq!(
         before_report["semantic_enrichment"]["semantic_change_count"],
         1
+    );
+    // No daemon holds this repository, so there is no live graph to sample and
+    // no vector index behind it. Status has to say that rather than publish the
+    // zero an unindexed graph would produce, which is the reading a fully
+    // embedded repository would be indistinguishable from.
+    assert_eq!(
+        before_report["embedding_coverage"]["state"], "unobserved",
+        "coverage cannot be observed with no daemon running: {}",
+        before_report["embedding_coverage"]
+    );
+    assert_eq!(
+        before_report["embedding_coverage"]["reason"],
+        "no_running_daemon"
+    );
+    assert!(
+        before_report["embedding_coverage"].get("indexed").is_none(),
+        "an unobserved coverage must carry no count: {}",
+        before_report["embedding_coverage"]
     );
 
     // Make the checkout and Git metadata maximally misleading. Status must

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2458,6 +2458,22 @@ async fn graph_mutations(
     Ok(Json(serde_json::json!({"status": "ok"})))
 }
 
+/// Sample embedding coverage from the daemon's own query graph, the one view in
+/// this process that has a validated vector index installed.
+///
+/// The sample is taken under the embedding-work lock so a pass in flight cannot
+/// span the published counters, matching how `kin_graph_status` observes the
+/// same source. A contended lock reports that state rather than waiting: status
+/// is a read and must not block on an embedding pass.
+fn live_embedding_coverage(state: &DaemonState) -> kin_cli::commands::status::EmbeddingCoverage {
+    use kin_cli::commands::status::{EmbeddingCoverage, EmbeddingCoverageUnobserved};
+
+    let Ok(_embedding_guard) = state.embedding_work.try_lock() else {
+        return EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::SamplingContended);
+    };
+    kin_cli::commands::status::observe_embedding_coverage(&state.graph)
+}
+
 /// POST /commands/status — render one coherent repository-v6 authority lease.
 async fn command_status(
     State(state): State<Arc<DaemonState>>,
@@ -2476,8 +2492,13 @@ async fn command_status(
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
-    let report = kin_cli::commands::status::inspect(&state.layout, &repository_authority)
-        .map_err(internal_error)?;
+    let embedding_coverage = live_embedding_coverage(&state);
+    let report = kin_cli::commands::status::inspect(
+        &state.layout,
+        &repository_authority,
+        embedding_coverage,
+    )
+    .map_err(internal_error)?;
     let daemon_build = kin_buildinfo::get();
     let build = kin_cli::commands::status::BuildStatus {
         cli_sha: request
@@ -17779,6 +17800,24 @@ mod tests {
         assert!(result.report.repository.source_cas_verified);
         assert!(result.text.contains("Kin repository-v6 status"));
         assert!(result.text.contains("Live graph enrichment"));
+        // This daemon's graph carries entities but no vector index. The handler
+        // has to say so: reporting the zero that `embedding_status` returns in
+        // that state would be indistinguishable from a repository whose
+        // embeddings are complete and empty.
+        assert_eq!(
+            result.report.embedding_coverage,
+            kin_cli::commands::status::EmbeddingCoverage::unobserved(
+                kin_cli::commands::status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+            ),
+            "status must report an unindexed live graph as unobservable coverage"
+        );
+        assert!(
+            result.text.contains(
+                "Live embedding coverage: not observed (the live graph carries no vector index)"
+            ),
+            "text: {}",
+            result.text
+        );
 
         let graph_response = app
             .clone()
@@ -17841,6 +17880,122 @@ mod tests {
         );
         assert!(!mcp_status.completion_attested);
         assert!(mcp_status.response_envelope.is_none());
+    }
+
+    /// FIR-1785: the endpoint must publish the coverage of the index this
+    /// daemon is actually holding.
+    ///
+    /// The sibling case above proves an unindexed graph is reported as an
+    /// absence, which a handler that always answered "unobserved" would also
+    /// satisfy. This one attaches a real index to the same daemon graph and
+    /// requires the counts to move, so the handler has to be reading the graph
+    /// rather than describing it.
+    #[cfg(feature = "vector")]
+    #[tokio::test]
+    async fn command_status_publishes_the_coverage_of_the_daemon_s_indexed_graph() {
+        install_test_registry_override();
+        let dir =
+            std::env::temp_dir().join(format!("kin-daemon-status-coverage-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let initialized = kin_core::init(&dir).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        let entity = test_entity("indexed_symbol", "src/indexed.rs");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        // Seed every retrievable key the graph could ask about, then install the
+        // index through kin-db's own compatibility-checked loader.
+        let snapshot = state.graph.to_snapshot();
+        let mut keys = vec![kin_model::RetrievalKey::Entity(entity.id)];
+        keys.extend(
+            snapshot
+                .entity_revisions
+                .values()
+                .flat_map(|revisions| revisions.iter())
+                .map(|revision| kin_model::RetrievalKey::EntityRevision(revision.revision_id)),
+        );
+        let vectors = kin_db::VectorIndex::new(4).unwrap();
+        for key in &keys {
+            vectors
+                .upsert_retrievable(*key, &[1.0, 0.0, 0.0, 0.0])
+                .unwrap();
+        }
+        let descriptor = kin_db::IndexDescriptor {
+            model_id: Some("daemon-status-coverage-fixture@v1".to_string()),
+            graph_root: Some(hex::encode(state.graph.compute_root_hash())),
+        };
+        vectors.set_descriptor(descriptor.clone());
+        let sidecar = dir.join("coverage.kvec");
+        vectors.save(&sidecar).unwrap();
+        assert!(matches!(
+            state
+                .graph
+                .load_vector_index_compatible(&sidecar, &descriptor),
+            kin_db::VectorIndexLoad::Loaded(_)
+        ));
+
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::post("/commands/status")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::json!({ "json": false }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let result: kin_cli::commands::status::CommandStatusResponse =
+            serde_json::from_slice(&body).unwrap();
+
+        let kin_cli::commands::status::EmbeddingCoverage::Observed {
+            source,
+            indexed,
+            pending,
+            total,
+        } = result.report.embedding_coverage
+        else {
+            panic!(
+                "an indexed daemon graph must publish observed coverage, found {:?}",
+                result.report.embedding_coverage
+            );
+        };
+        assert_eq!(
+            source,
+            kin_cli::commands::status::EmbeddingCoverageSource::LiveQueryGraph
+        );
+        assert!(
+            indexed > 0,
+            "the endpoint reported no indexed objects for an indexed graph \
+             (indexed={indexed}, pending={pending}, total={total})"
+        );
+        assert_eq!(indexed, total, "every retrievable key was seeded");
+        // Not `pending == 0`. `pending` is `max(queue_length, total - indexed)`,
+        // and upserting the entity above put it on the graph's embedding queue,
+        // so a fully covered graph still reports the queued work. Coverage and
+        // outstanding work are different facts; only the first is asserted here.
+        assert!(
+            pending >= total - indexed,
+            "pending ({pending}) must account for the uncovered keys"
+        );
+        assert!(
+            result.text.contains(&format!(
+                "Live embedding coverage: {indexed}/{total} indexed"
+            )),
+            "text: {}",
+            result.text
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1638,12 +1638,13 @@ const GRAPH_STATUS_STABLE_READ_ATTEMPTS: usize = 3;
 /// request.
 ///
 /// Entity/relation mutations participate in the daemon's graph-authority
-/// seqlock. Normal foreground/background embedding passes use
-/// `embedding_work`; kin-db's own queue/vector locks keep reset and startup
-/// requeue transitions structurally valid. Holding the outer lock while reading
-/// all counters, then revalidating the graph epoch and selected HEAD/session
-/// graph, prevents a normal embedding pass or graph mutation from spanning the
-/// published observation without asking kin-mcp to reread a mutable graph.
+/// seqlock. Normal foreground/background embedding passes and vector-index
+/// reset/requeue transitions use `embedding_work`; kin-db's own queue/vector
+/// locks keep startup requeue transitions structurally valid. Holding the outer
+/// lock while reading all counters, then revalidating the graph epoch and
+/// selected HEAD/session graph, prevents an embedding transition or graph
+/// mutation from spanning the published observation without asking kin-mcp to
+/// reread a mutable graph.
 async fn mcp_graph_status_with_stable_authority(
     state: &DaemonState,
     session_id: Option<&SessionId>,
@@ -2464,12 +2465,13 @@ async fn graph_mutations(
 /// This observes the same source as `kin_graph_status` through the same
 /// mechanism: a stable graph-authority epoch is taken before the sample and
 /// revalidated after it, and the counters themselves are read under the
-/// embedding-work lock. Neither a normal embedding pass nor a graph mutation
-/// batch can therefore span the published triple, which would otherwise pair a
-/// `total` counted mid-batch with an `indexed` measured against an index that
-/// has not seen those keys. The session-scope revalidation the sibling also
-/// performs has no analogue here: status always samples HEAD, whose ownership
-/// is stable for the daemon's lifetime.
+/// embedding-work lock. Neither an embedding pass, a vector-index reset/requeue
+/// transition, nor a graph mutation batch can therefore span the published
+/// triple, which would otherwise pair a `total` counted mid-batch with an
+/// `indexed` measured against an index that has not seen those keys. The
+/// session-scope revalidation the sibling also performs has no analogue here:
+/// status always samples HEAD, whose ownership is stable for the daemon's
+/// lifetime.
 ///
 /// Every way of not observing is named rather than collapsed. A held lock is
 /// transient, a poisoned one is permanent and says the embedding loop is dead,
@@ -2502,10 +2504,11 @@ async fn live_embedding_coverage(
 ///
 /// `embedding_status` allocates a set of every retrievable key and probes the
 /// vector index once per key, and the embed loop takes this same std mutex from
-/// its own `spawn_blocking`. Sampling inline on a tokio worker would hold the
-/// lock across that whole walk on a thread the runtime cannot reschedule, so
-/// each `kin status` would stall the next embedding batch for the duration of
-/// the walk.
+/// its own `spawn_blocking`. Sampling there keeps the O(N) walk off a Tokio
+/// worker, and `try_lock` keeps status from waiting behind embedding work that
+/// already owns the boundary. If status wins first, its sample can delay a
+/// later embedding pass until the walk completes; only a blocking-pool thread
+/// waits, and no std mutex guard is held across an async await.
 async fn sample_embedding_coverage(
     state: Arc<DaemonState>,
 ) -> std::result::Result<
@@ -2514,16 +2517,10 @@ async fn sample_embedding_coverage(
 > {
     use kin_cli::commands::status::EmbeddingCoverageUnobserved;
 
-    let sampled = tokio::task::spawn_blocking(move || match state.embedding_work.try_lock() {
-        Ok(_embedding_guard) => Ok(kin_cli::commands::status::observe_embedding_coverage(
-            &state.graph,
-        )),
-        Err(std::sync::TryLockError::WouldBlock) => {
-            Err(EmbeddingCoverageUnobserved::SamplingContended)
-        }
-        Err(std::sync::TryLockError::Poisoned(_)) => {
-            Err(EmbeddingCoverageUnobserved::EmbeddingWorkLockPoisoned)
-        }
+    let sampled = tokio::task::spawn_blocking(move || {
+        try_sample_embedding_coverage_with(&state, |graph| {
+            kin_cli::commands::status::observe_embedding_coverage(graph)
+        })
     })
     .await;
 
@@ -2532,6 +2529,28 @@ async fn sample_embedding_coverage(
         Err(error) => {
             tracing::warn!(%error, "embedding coverage sample did not complete");
             Err(EmbeddingCoverageUnobserved::SamplingFailed)
+        }
+    }
+}
+
+/// Synchronous sampling core used by the blocking production path and the
+/// forced reset/sampling interleaving regression.
+fn try_sample_embedding_coverage_with(
+    state: &DaemonState,
+    sample: impl FnOnce(&kin_db::InMemoryGraph) -> kin_cli::commands::status::EmbeddingCoverage,
+) -> std::result::Result<
+    kin_cli::commands::status::EmbeddingCoverage,
+    kin_cli::commands::status::EmbeddingCoverageUnobserved,
+> {
+    use kin_cli::commands::status::EmbeddingCoverageUnobserved;
+
+    match state.embedding_work.try_lock() {
+        Ok(_embedding_guard) => Ok(sample(state.graph.as_ref())),
+        Err(std::sync::TryLockError::WouldBlock) => {
+            Err(EmbeddingCoverageUnobserved::SamplingContended)
+        }
+        Err(std::sync::TryLockError::Poisoned(_)) => {
+            Err(EmbeddingCoverageUnobserved::EmbeddingWorkLockPoisoned)
         }
     }
 }
@@ -18057,6 +18076,102 @@ mod tests {
             )),
             "text: {}",
             result.text
+        );
+    }
+
+    /// An IndexError reset that starts after status proves an index is attached
+    /// must wait until status has read the matching counters.
+    ///
+    /// The contention callback is reached only after the reset's `try_lock`
+    /// loses to the production sampling boundary. That lets the sampler force
+    /// the exact attachment-check/reset-attempt/counter-read ordering without
+    /// sleeps. Before the reset was part of `embedding_work`, the detach could
+    /// land in that gap and produce the plausible but false observed zero.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn vector_reset_cannot_split_status_attachment_from_coverage_counters() {
+        let state = test_state();
+        let entity = test_entity("reset_race_symbol", "src/reset_race.rs");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        let snapshot = state.graph.to_snapshot();
+        let mut keys = vec![kin_model::RetrievalKey::Entity(entity.id)];
+        keys.extend(
+            snapshot
+                .entity_revisions
+                .values()
+                .flat_map(|revisions| revisions.iter())
+                .map(|revision| kin_model::RetrievalKey::EntityRevision(revision.revision_id)),
+        );
+        let vectors = kin_db::VectorIndex::new(4).unwrap();
+        for key in &keys {
+            vectors
+                .upsert_retrievable(*key, &[1.0, 0.0, 0.0, 0.0])
+                .unwrap();
+        }
+        let descriptor = kin_db::IndexDescriptor {
+            model_id: Some("daemon-status-reset-race-fixture@v1".to_string()),
+            graph_root: Some(hex::encode(state.graph.compute_root_hash())),
+        };
+        vectors.set_descriptor(descriptor.clone());
+        let sidecar = state.layout.root().join("status-reset-race.kvec");
+        vectors.save(&sidecar).unwrap();
+        assert!(matches!(
+            state
+                .graph
+                .load_vector_index_compatible(&sidecar, &descriptor),
+            kin_db::VectorIndexLoad::Loaded(_)
+        ));
+
+        let (attachment_checked_tx, attachment_checked_rx) = std::sync::mpsc::sync_channel(0);
+        let (reset_waiting_tx, reset_waiting_rx) = std::sync::mpsc::sync_channel(0);
+        let sample_state = Arc::clone(&state);
+        let sampler = std::thread::spawn(move || {
+            try_sample_embedding_coverage_with(&sample_state, move |graph| {
+                assert!(
+                    graph.vector_index_stats().is_some(),
+                    "the forced interleaving starts after status proves attachment"
+                );
+                attachment_checked_tx.send(()).unwrap();
+                reset_waiting_rx.recv().unwrap();
+
+                // This is the counter half of `observe_embedding_coverage`,
+                // split out only so the channel can pin the reset attempt in
+                // the otherwise invisible gap between its two kin-db calls.
+                let status = graph.embedding_status();
+                kin_cli::commands::status::EmbeddingCoverage::Observed {
+                    source: kin_cli::commands::status::EmbeddingCoverageSource::LiveQueryGraph,
+                    indexed: status.indexed,
+                    pending: status.pending,
+                    total: status.total,
+                }
+            })
+        });
+
+        attachment_checked_rx.recv().unwrap();
+        let reset_state = Arc::clone(&state);
+        let resetter = std::thread::spawn(move || {
+            crate::daemon::reset_vector_index_and_requeue_after_contention_for_test(
+                &reset_state,
+                move || reset_waiting_tx.send(()).unwrap(),
+            )
+        });
+
+        let sampled = sampler.join().unwrap().unwrap();
+        let kin_cli::commands::status::EmbeddingCoverage::Observed { indexed, total, .. } = sampled
+        else {
+            panic!("the attached index must remain observable until sampling completes")
+        };
+        assert!(indexed > 0, "the forced interleaving fabricated a zero");
+        assert_eq!(indexed, total, "every fixture key was indexed");
+
+        resetter.join().unwrap().unwrap();
+        assert_eq!(
+            kin_cli::commands::status::observe_embedding_coverage(&state.graph),
+            kin_cli::commands::status::EmbeddingCoverage::unobserved(
+                kin_cli::commands::status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+            ),
+            "the reset must run immediately after the sample releases the boundary"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2461,17 +2461,79 @@ async fn graph_mutations(
 /// Sample embedding coverage from the daemon's own query graph, the one view in
 /// this process that has a validated vector index installed.
 ///
-/// The sample is taken under the embedding-work lock so a pass in flight cannot
-/// span the published counters, matching how `kin_graph_status` observes the
-/// same source. A contended lock reports that state rather than waiting: status
-/// is a read and must not block on an embedding pass.
-fn live_embedding_coverage(state: &DaemonState) -> kin_cli::commands::status::EmbeddingCoverage {
+/// This observes the same source as `kin_graph_status` through the same
+/// mechanism: a stable graph-authority epoch is taken before the sample and
+/// revalidated after it, and the counters themselves are read under the
+/// embedding-work lock. Neither a normal embedding pass nor a graph mutation
+/// batch can therefore span the published triple, which would otherwise pair a
+/// `total` counted mid-batch with an `indexed` measured against an index that
+/// has not seen those keys. The session-scope revalidation the sibling also
+/// performs has no analogue here: status always samples HEAD, whose ownership
+/// is stable for the daemon's lifetime.
+///
+/// Every way of not observing is named rather than collapsed. A held lock is
+/// transient, a poisoned one is permanent and says the embedding loop is dead,
+/// and a mutation outlasting every attempt is a third state.
+async fn live_embedding_coverage(
+    state: &Arc<DaemonState>,
+) -> kin_cli::commands::status::EmbeddingCoverage {
     use kin_cli::commands::status::{EmbeddingCoverage, EmbeddingCoverageUnobserved};
 
-    let Ok(_embedding_guard) = state.embedding_work.try_lock() else {
-        return EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::SamplingContended);
-    };
-    kin_cli::commands::status::observe_embedding_coverage(&state.graph)
+    for _ in 0..GRAPH_STATUS_STABLE_READ_ATTEMPTS {
+        let Some(authority_epoch) = state.stable_graph_authority_epoch() else {
+            tokio::task::yield_now().await;
+            continue;
+        };
+        let coverage = match sample_embedding_coverage(Arc::clone(state)).await {
+            Ok(coverage) => coverage,
+            Err(reason) => return EmbeddingCoverage::unobserved(reason),
+        };
+        if !state.graph_authority_epoch_is_current(authority_epoch) {
+            tokio::task::yield_now().await;
+            continue;
+        }
+        return coverage;
+    }
+
+    EmbeddingCoverage::unobserved(EmbeddingCoverageUnobserved::GraphMutationInFlight)
+}
+
+/// Take one coverage reading on a blocking thread.
+///
+/// `embedding_status` allocates a set of every retrievable key and probes the
+/// vector index once per key, and the embed loop takes this same std mutex from
+/// its own `spawn_blocking`. Sampling inline on a tokio worker would hold the
+/// lock across that whole walk on a thread the runtime cannot reschedule, so
+/// each `kin status` would stall the next embedding batch for the duration of
+/// the walk.
+async fn sample_embedding_coverage(
+    state: Arc<DaemonState>,
+) -> std::result::Result<
+    kin_cli::commands::status::EmbeddingCoverage,
+    kin_cli::commands::status::EmbeddingCoverageUnobserved,
+> {
+    use kin_cli::commands::status::EmbeddingCoverageUnobserved;
+
+    let sampled = tokio::task::spawn_blocking(move || match state.embedding_work.try_lock() {
+        Ok(_embedding_guard) => Ok(kin_cli::commands::status::observe_embedding_coverage(
+            &state.graph,
+        )),
+        Err(std::sync::TryLockError::WouldBlock) => {
+            Err(EmbeddingCoverageUnobserved::SamplingContended)
+        }
+        Err(std::sync::TryLockError::Poisoned(_)) => {
+            Err(EmbeddingCoverageUnobserved::EmbeddingWorkLockPoisoned)
+        }
+    })
+    .await;
+
+    match sampled {
+        Ok(coverage) => coverage,
+        Err(error) => {
+            tracing::warn!(%error, "embedding coverage sample did not complete");
+            Err(EmbeddingCoverageUnobserved::SamplingFailed)
+        }
+    }
 }
 
 /// POST /commands/status — render one coherent repository-v6 authority lease.
@@ -2492,7 +2554,7 @@ async fn command_status(
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
-    let embedding_coverage = live_embedding_coverage(&state);
+    let embedding_coverage = live_embedding_coverage(&state).await;
     let report = kin_cli::commands::status::inspect(
         &state.layout,
         &repository_authority,
@@ -17995,6 +18057,103 @@ mod tests {
             )),
             "text: {}",
             result.text
+        );
+    }
+
+    /// A held embedding lock is transient and a poisoned one is permanent, so
+    /// the payload has to name them apart.
+    ///
+    /// The embed loop takes this same mutex, so a batch that panics poisons it
+    /// for the daemon's lifetime. Publishing that as contention would tell an
+    /// operator to retry a pass that can never run again, on every status read
+    /// from then on.
+    #[tokio::test]
+    async fn live_coverage_names_a_poisoned_embedding_lock_apart_from_a_contended_one() {
+        let state = test_state();
+
+        // Contention first, while the lock is only held. The guard lives on
+        // another thread so this test never holds a lock across an await.
+        let (held_tx, held_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let holder_state = Arc::clone(&state);
+        let holder = std::thread::spawn(move || {
+            let _embedding_guard = holder_state.embedding_work.lock().unwrap();
+            held_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        held_rx.recv().unwrap();
+        let contended = live_embedding_coverage(&state).await;
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+        assert_eq!(
+            contended,
+            kin_cli::commands::status::EmbeddingCoverage::unobserved(
+                kin_cli::commands::status::EmbeddingCoverageUnobserved::SamplingContended
+            ),
+            "a held embedding lock is the transient state and must say so"
+        );
+
+        // Then poison it exactly as a panicking embedding batch would.
+        let poisoner_state = Arc::clone(&state);
+        let panicked = std::thread::spawn(move || {
+            let _embedding_guard = poisoner_state.embedding_work.lock().unwrap();
+            panic!("embedding batch panicked while holding the embedding work lock");
+        })
+        .join();
+        assert!(panicked.is_err(), "the poisoning thread must have panicked");
+        assert!(
+            matches!(
+                state.embedding_work.try_lock(),
+                Err(std::sync::TryLockError::Poisoned(_))
+            ),
+            "the fixture must leave the embedding work lock poisoned"
+        );
+
+        let poisoned = live_embedding_coverage(&state).await;
+        assert_eq!(
+            poisoned,
+            kin_cli::commands::status::EmbeddingCoverage::unobserved(
+                kin_cli::commands::status::EmbeddingCoverageUnobserved::EmbeddingWorkLockPoisoned
+            ),
+            "a poisoned embedding lock must be published as its own permanent state"
+        );
+        assert_ne!(
+            poisoned, contended,
+            "a dead embedding loop must not be published as a pass in flight"
+        );
+    }
+
+    /// A graph mutation batch must not span the published triple.
+    ///
+    /// `total` is counted from graph truth and `indexed` is measured against the
+    /// index, so a sample taken mid-batch can pair keys the index has not seen
+    /// with an index that has not seen them. Both wire invariants still hold for
+    /// that triple, so no consumer would refuse it; the sampler has to.
+    #[tokio::test]
+    async fn live_coverage_refuses_counters_a_graph_mutation_could_span() {
+        let state = test_state();
+        let mutation_guard = state.begin_graph_authority_mutation();
+
+        let during = live_embedding_coverage(&state).await;
+        assert_eq!(
+            during,
+            kin_cli::commands::status::EmbeddingCoverage::unobserved(
+                kin_cli::commands::status::EmbeddingCoverageUnobserved::GraphMutationInFlight
+            ),
+            "coverage sampled across a graph mutation must be refused, not published"
+        );
+
+        // The refusal has to be caused by the mutation rather than by a path
+        // that can no longer observe anything, so the same state answers
+        // differently once the batch completes.
+        drop(mutation_guard);
+        let after = live_embedding_coverage(&state).await;
+        assert_eq!(
+            after,
+            kin_cli::commands::status::EmbeddingCoverage::unobserved(
+                kin_cli::commands::status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+            ),
+            "with no mutation in flight the sampler must report the graph's own state"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -11228,6 +11228,23 @@ mod tests {
         Arc::new(DaemonState::open(layout).unwrap())
     }
 
+    fn unattached_vector_coverage_reason() -> kin_cli::commands::status::EmbeddingCoverageUnobserved
+    {
+        if cfg!(feature = "vector") {
+            kin_cli::commands::status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+        } else {
+            kin_cli::commands::status::EmbeddingCoverageUnobserved::VectorSupportDisabled
+        }
+    }
+
+    fn unattached_vector_coverage_text() -> &'static str {
+        if cfg!(feature = "vector") {
+            "Live embedding coverage: not observed (the live graph carries no vector index)"
+        } else {
+            "Live embedding coverage: not observed (this build ships no vector backend)"
+        }
+    }
+
     fn committed_test_state() -> Arc<DaemonState> {
         let initial = test_state();
         let layout = initial.layout.clone();
@@ -17881,21 +17898,21 @@ mod tests {
         assert!(result.report.repository.source_cas_verified);
         assert!(result.text.contains("Kin repository-v6 status"));
         assert!(result.text.contains("Live graph enrichment"));
-        // This daemon's graph carries entities but no vector index. The handler
-        // has to say so: reporting the zero that `embedding_status` returns in
-        // that state would be indistinguishable from a repository whose
-        // embeddings are complete and empty.
+        // This daemon's graph carries entities but no vector index. A vector
+        // build has to name that missing attachment; a featureless build has to
+        // name its deliberately absent backend. Neither may report the zero
+        // that `embedding_status` returns, because that would be
+        // indistinguishable from a repository whose embeddings are complete
+        // and empty.
         assert_eq!(
             result.report.embedding_coverage,
             kin_cli::commands::status::EmbeddingCoverage::unobserved(
-                kin_cli::commands::status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+                unattached_vector_coverage_reason()
             ),
-            "status must report an unindexed live graph as unobservable coverage"
+            "status must report why live embedding coverage is unobservable"
         );
         assert!(
-            result.text.contains(
-                "Live embedding coverage: not observed (the live graph carries no vector index)"
-            ),
+            result.text.contains(unattached_vector_coverage_text()),
             "text: {}",
             result.text
         );
@@ -18266,9 +18283,9 @@ mod tests {
         assert_eq!(
             after,
             kin_cli::commands::status::EmbeddingCoverage::unobserved(
-                kin_cli::commands::status::EmbeddingCoverageUnobserved::NoVectorIndexAttached
+                unattached_vector_coverage_reason()
             ),
-            "with no mutation in flight the sampler must report the graph's own state"
+            "with no mutation in flight the sampler must report the build's graph state"
         );
     }
 

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2763,9 +2763,9 @@ mod tests {
         let initialized = kin_core::init(repo.path()).unwrap();
         let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
 
-        // Prepare the fresh index that stands in for a successful foreground
-        // `/embed --rebuild`. It is installed only after that request acquires
-        // `embedding_work` below.
+        // Prepare one compatible sidecar for both sides of the race. Attach it
+        // now as the stale index recovery must detach, then let the foreground
+        // `/embed --rebuild` install it fresh after acquiring `embedding_work`.
         let descriptor = kin_db::IndexDescriptor {
             model_id: Some("foreground-rebuild-race-fixture@v1".to_string()),
             graph_root: Some(hex::encode(state.graph.compute_root_hash())),

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -192,6 +192,62 @@ fn next_embed_error_backoff(current: Option<Duration>, base: Duration, max: Dura
     current.unwrap_or(base).saturating_mul(2).min(max)
 }
 
+/// Detach a stale vector index and rebuild both embedding queues as one
+/// embedding-work transition.
+///
+/// This function blocks on a std mutex and must therefore run on a blocking
+/// thread when called from async code. The outer mutex is the same boundary
+/// status sampling uses, so a sample cannot observe an attached index and then
+/// have this transition detach it before the counters are read.
+fn reset_vector_index_and_requeue(
+    state: &DaemonState,
+) -> std::result::Result<(), kin_db::KinDbError> {
+    reset_vector_index_and_requeue_with_contention(state, || {})
+}
+
+/// Testable core for [`reset_vector_index_and_requeue`].
+///
+/// `on_contention` runs after `try_lock` proves another embedding-work
+/// transition owns the boundary and immediately before this caller waits. The
+/// production path uses a no-op; the deterministic race regression uses the
+/// callback to force the reset attempt between the sampler's attachment check
+/// and counter read without sleeps or scheduler assumptions.
+fn reset_vector_index_and_requeue_with_contention(
+    state: &DaemonState,
+    on_contention: impl FnOnce(),
+) -> std::result::Result<(), kin_db::KinDbError> {
+    let _embedding_guard = match state.embedding_work.try_lock() {
+        Ok(guard) => guard,
+        Err(std::sync::TryLockError::WouldBlock) => {
+            on_contention();
+            state.embedding_work.lock().map_err(|_| {
+                kin_db::KinDbError::ConcurrentAccessError(
+                    "embedding work lock poisoned".to_string(),
+                )
+            })?
+        }
+        Err(std::sync::TryLockError::Poisoned(_)) => {
+            return Err(kin_db::KinDbError::ConcurrentAccessError(
+                "embedding work lock poisoned".to_string(),
+            ));
+        }
+    };
+
+    state.graph.reset_vector_index();
+    #[cfg(feature = "embeddings")]
+    state.graph.queue_missing_for_embedding();
+    state.graph.queue_missing_artifacts_for_embedding();
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
+    state: &DaemonState,
+    on_contention: impl FnOnce(),
+) -> std::result::Result<(), kin_db::KinDbError> {
+    reset_vector_index_and_requeue_with_contention(state, on_contention)
+}
+
 /// Poll `workspace/symbol` with an empty query until the LSP server responds
 /// or the deadline is reached. Language servers like rust-analyzer and pyright
 /// continue background indexing after the `initialize` handshake; this probe
@@ -1463,16 +1519,44 @@ pub async fn run_with_authority(
                                 error = %e,
                                 "embedding worker hit a vector-index error — resetting vector index and re-queueing once"
                             );
-                            embed_state.graph.reset_vector_index();
-                            #[cfg(feature = "embeddings")]
-                            embed_state.graph.queue_missing_for_embedding();
-                            embed_state.graph.queue_missing_artifacts_for_embedding();
-                            index_reset_triggered = true;
-                            error_backoff = None;
-                            error!(
-                                error = %e,
-                                "embedding worker error — reset vector index, retrying next interval"
-                            );
+                            // The failed batch has released `embedding_work`.
+                            // Reacquire it on a blocking thread for the complete
+                            // detach + requeue transition so status sampling can
+                            // never span the vector-only mutation, while no
+                            // Tokio worker blocks on the std mutex.
+                            let state_for_reset = Arc::clone(&embed_state);
+                            let reset_failure = match tokio::task::spawn_blocking(move || {
+                                reset_vector_index_and_requeue(&state_for_reset)
+                            })
+                            .await
+                            {
+                                Ok(Ok(())) => None,
+                                Ok(Err(reset_error)) => Some(reset_error.to_string()),
+                                Err(reset_error) => {
+                                    Some(format!("vector-index reset task failed: {reset_error}"))
+                                }
+                            };
+                            if let Some(reset_error) = reset_failure {
+                                let next = next_embed_error_backoff(
+                                    error_backoff,
+                                    embed_interval,
+                                    EMBED_ERROR_BACKOFF_MAX,
+                                );
+                                error_backoff = Some(next);
+                                error!(
+                                    error = %e,
+                                    reset_error,
+                                    backoff_s = next.as_secs(),
+                                    "embedding worker error — vector-index reset failed, backing off"
+                                );
+                            } else {
+                                index_reset_triggered = true;
+                                error_backoff = None;
+                                error!(
+                                    error = %e,
+                                    "embedding worker error — reset vector index, retrying next interval"
+                                );
+                            }
                         } else {
                             // The one-shot reset did not clear it (or it is a
                             // non-index error): back off exponentially so the

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -192,27 +192,60 @@ fn next_embed_error_backoff(current: Option<Duration>, base: Duration, max: Dura
     current.unwrap_or(base).saturating_mul(2).min(max)
 }
 
-/// Detach a stale vector index and rebuild both embedding queues as one
-/// embedding-work transition.
-///
-/// This function blocks on a std mutex and must therefore run on a blocking
-/// thread when called from async code. The outer mutex is the same boundary
-/// status sampling uses, so a sample cannot observe an attached index and then
-/// have this transition detach it before the counters are read.
-fn reset_vector_index_and_requeue(
-    state: &DaemonState,
-) -> std::result::Result<(), kin_db::KinDbError> {
-    reset_vector_index_and_requeue_with_contention(state, || {})
+#[derive(Debug)]
+enum BackgroundEmbeddingBatchOutcome {
+    Completed(usize),
+    ResetAfterIndexError(kin_db::KinDbError),
+    Failed(kin_db::KinDbError),
 }
 
-/// Testable core for [`reset_vector_index_and_requeue`].
+/// Run one background embedding batch and any first-error vector recovery under
+/// one `embedding_work` guard.
 ///
-/// `on_contention` runs after `try_lock` proves another embedding-work
-/// transition owns the boundary and immediately before this caller waits. The
-/// production path uses a no-op; the deterministic race regression uses the
-/// callback to force the reset attempt between the sampler's attachment check
-/// and counter read without sleeps or scheduler assumptions.
-fn reset_vector_index_and_requeue_with_contention(
+/// The recovery decision belongs inside this critical section. In particular,
+/// a foreground `/embed --rebuild` that is already waiting must not acquire the
+/// guard, publish a fresh index, and then be wiped by recovery from this stale
+/// failed batch.
+fn run_background_embedding_batch(
+    state: &DaemonState,
+    reset_on_index_error: bool,
+    process: impl FnOnce(&DaemonState) -> std::result::Result<usize, kin_db::KinDbError>,
+) -> BackgroundEmbeddingBatchOutcome {
+    let _embedding_guard = match state.embedding_work.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return BackgroundEmbeddingBatchOutcome::Failed(
+                kin_db::KinDbError::ConcurrentAccessError(
+                    "embedding work lock poisoned".to_string(),
+                ),
+            );
+        }
+    };
+
+    match process(state) {
+        Ok(count) => BackgroundEmbeddingBatchOutcome::Completed(count),
+        Err(error)
+            if reset_on_index_error && matches!(&error, kin_db::KinDbError::IndexError(_)) =>
+        {
+            reset_vector_index_and_requeue_under_guard(state);
+            BackgroundEmbeddingBatchOutcome::ResetAfterIndexError(error)
+        }
+        Err(error) => BackgroundEmbeddingBatchOutcome::Failed(error),
+    }
+}
+
+/// Detach a stale vector index and rebuild both embedding queues while the
+/// caller owns `embedding_work`.
+fn reset_vector_index_and_requeue_under_guard(state: &DaemonState) {
+    state.graph.reset_vector_index();
+    #[cfg(feature = "embeddings")]
+    state.graph.queue_missing_for_embedding();
+    state.graph.queue_missing_artifacts_for_embedding();
+}
+
+/// Deterministically expose reset contention to the status/reset race test.
+#[cfg(all(test, feature = "vector"))]
+pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
     state: &DaemonState,
     on_contention: impl FnOnce(),
 ) -> std::result::Result<(), kin_db::KinDbError> {
@@ -233,19 +266,8 @@ fn reset_vector_index_and_requeue_with_contention(
         }
     };
 
-    state.graph.reset_vector_index();
-    #[cfg(feature = "embeddings")]
-    state.graph.queue_missing_for_embedding();
-    state.graph.queue_missing_artifacts_for_embedding();
+    reset_vector_index_and_requeue_under_guard(state);
     Ok(())
-}
-
-#[cfg(test)]
-pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
-    state: &DaemonState,
-    on_contention: impl FnOnce(),
-) -> std::result::Result<(), kin_db::KinDbError> {
-    reset_vector_index_and_requeue_with_contention(state, on_contention)
 }
 
 /// Poll `workspace/symbol` with an empty query until the LSP server responds
@@ -1427,6 +1449,7 @@ pub async fn run_with_authority(
                 let batch = embed_batch_size;
                 let state_for_embed = Arc::clone(&embed_state);
                 let is_artifact = pending == 0;
+                let reset_on_index_error = !index_reset_triggered;
                 let label = if is_artifact {
                     "embedded artifacts"
                 } else {
@@ -1439,23 +1462,22 @@ pub async fn run_with_authority(
                 };
 
                 let embed_result = tokio::task::spawn_blocking(move || {
-                    let _guard = state_for_embed.embedding_work.lock().map_err(|_| {
-                        kin_db::KinDbError::ConcurrentAccessError(
-                            "embedding work lock poisoned".to_string(),
-                        )
-                    })?;
-                    if is_artifact {
-                        state_for_embed
-                            .graph
-                            .process_artifact_embedding_queue(batch)
-                    } else {
-                        state_for_embed.graph.process_embedding_queue(batch)
-                    }
+                    run_background_embedding_batch(
+                        &state_for_embed,
+                        reset_on_index_error,
+                        |state| {
+                            if is_artifact {
+                                state.graph.process_artifact_embedding_queue(batch)
+                            } else {
+                                state.graph.process_embedding_queue(batch)
+                            }
+                        },
+                    )
                 })
                 .await;
 
                 match embed_result {
-                    Ok(Ok(count)) if count > 0 => {
+                    Ok(BackgroundEmbeddingBatchOutcome::Completed(count)) if count > 0 => {
                         consecutive_panics = 0;
                         // A successful batch means the index now matches the
                         // embedder — clear any error backoff / reset latch.
@@ -1494,7 +1516,7 @@ pub async fn run_with_authority(
                             drain_pending_flush(&mut pending_flush).await;
                         }
                     }
-                    Ok(Ok(_)) => {
+                    Ok(BackgroundEmbeddingBatchOutcome::Completed(_)) => {
                         // Queue drained out from under us (e.g. an explicit
                         // `/embed` request raced ahead). Stop draining and return
                         // to the idle sleep.
@@ -1503,80 +1525,42 @@ pub async fn run_with_authority(
                         error_backoff = None;
                         break;
                     }
-                    Ok(Err(e)) => {
+                    Ok(BackgroundEmbeddingBatchOutcome::ResetAfterIndexError(e)) => {
+                        warn!(
+                            error = %e,
+                            "embedding worker hit a vector-index error — reset vector index and re-queued once"
+                        );
+                        index_reset_triggered = true;
+                        error_backoff = None;
+                        error!(
+                            error = %e,
+                            "embedding worker error — reset vector index, retrying next interval"
+                        );
+                        break;
+                    }
+                    Ok(BackgroundEmbeddingBatchOutcome::Failed(e)) => {
                         // Distinguish a persistent vector-index error (a stale
                         // loaded index dimension vs the live embedder) from a
-                        // transient one. On the FIRST index error, trigger the
-                        // kin-db reset/re-queue contract exactly once and retry at
-                        // the normal interval — the rebuilt index is sized to the
-                        // live embedder and should succeed next pass. If the error
-                        // persists (reset already attempted) or it is some other
-                        // error, back off exponentially so the worker never
-                        // busy-spins.
-                        let is_index_error = matches!(e, kin_db::KinDbError::IndexError(_));
-                        if is_index_error && !index_reset_triggered {
-                            warn!(
-                                error = %e,
-                                "embedding worker hit a vector-index error — resetting vector index and re-queueing once"
-                            );
-                            // The failed batch has released `embedding_work`.
-                            // Reacquire it on a blocking thread for the complete
-                            // detach + requeue transition so status sampling can
-                            // never span the vector-only mutation, while no
-                            // Tokio worker blocks on the std mutex.
-                            let state_for_reset = Arc::clone(&embed_state);
-                            let reset_failure = match tokio::task::spawn_blocking(move || {
-                                reset_vector_index_and_requeue(&state_for_reset)
-                            })
-                            .await
-                            {
-                                Ok(Ok(())) => None,
-                                Ok(Err(reset_error)) => Some(reset_error.to_string()),
-                                Err(reset_error) => {
-                                    Some(format!("vector-index reset task failed: {reset_error}"))
-                                }
-                            };
-                            if let Some(reset_error) = reset_failure {
-                                let next = next_embed_error_backoff(
-                                    error_backoff,
-                                    embed_interval,
-                                    EMBED_ERROR_BACKOFF_MAX,
-                                );
-                                error_backoff = Some(next);
-                                error!(
-                                    error = %e,
-                                    reset_error,
-                                    backoff_s = next.as_secs(),
-                                    "embedding worker error — vector-index reset failed, backing off"
-                                );
-                            } else {
-                                index_reset_triggered = true;
-                                error_backoff = None;
-                                error!(
-                                    error = %e,
-                                    "embedding worker error — reset vector index, retrying next interval"
-                                );
-                            }
-                        } else {
-                            // The one-shot reset did not clear it (or it is a
-                            // non-index error): back off exponentially so the
-                            // worker never busy-spins. A stale vector index is NOT
-                            // a reason to block the graph snapshot flush — it
-                            // self-heals on load — so shutdown persistence is left
-                            // untouched here; the graph anti-wipe guard is keyed on
-                            // entity-count collapse, not on embed errors.
-                            let next = next_embed_error_backoff(
-                                error_backoff,
-                                embed_interval,
-                                EMBED_ERROR_BACKOFF_MAX,
-                            );
-                            error_backoff = Some(next);
-                            error!(
-                                error = %e,
-                                backoff_s = next.as_secs(),
-                                "embedding worker error — backing off"
-                            );
-                        }
+                        // transient one. The first IndexError was recovered
+                        // inside the failed batch's critical section above. If
+                        // it persists (reset already attempted) or it is some
+                        // other error, back off exponentially so the worker
+                        // never busy-spins. A stale vector index is NOT a reason
+                        // to block the graph snapshot flush — it self-heals on
+                        // load — so shutdown persistence is left untouched
+                        // here; the graph anti-wipe guard is keyed on
+                        // entity-count collapse, not on embed errors.
+                        let next = next_embed_error_backoff(
+                            error_backoff,
+                            embed_interval,
+                            EMBED_ERROR_BACKOFF_MAX,
+                        );
+                        error_backoff = Some(next);
+                        error!(
+                            error = %e,
+                            backoff_s = next.as_secs(),
+                            "embedding worker error — backing off"
+                        );
                         break;
                     }
                     Err(e) => {
@@ -2763,6 +2747,97 @@ mod tests {
         // The backoff is always strictly greater than the idle interval, so a
         // persistent error can never tight-spin at the 5s idle cadence.
         assert!(b1 > base);
+    }
+
+    /// Recovery from a failed background batch must precede a foreground
+    /// rebuild that was already waiting on `embedding_work`.
+    ///
+    /// Both rendezvous channels are zero-capacity: the batch cannot report its
+    /// synthetic IndexError until the foreground thread has observed real lock
+    /// contention, and the foreground cannot acquire until the batch has reset
+    /// under that same guard. No sleeps or scheduler timing are involved.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn background_index_recovery_precedes_already_waiting_foreground_rebuild() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+
+        // Prepare the fresh index that stands in for a successful foreground
+        // `/embed --rebuild`. It is installed only after that request acquires
+        // `embedding_work` below.
+        let descriptor = kin_db::IndexDescriptor {
+            model_id: Some("foreground-rebuild-race-fixture@v1".to_string()),
+            graph_root: Some(hex::encode(state.graph.compute_root_hash())),
+        };
+        let vectors = kin_db::VectorIndex::new(4).unwrap();
+        vectors
+            .upsert(kin_model::EntityId::new(), &[1.0, 0.0, 0.0, 0.0])
+            .unwrap();
+        vectors.set_descriptor(descriptor.clone());
+        let sidecar = state.layout.root().join("foreground-rebuild-race.kvec");
+        vectors.save(&sidecar).unwrap();
+        assert!(matches!(
+            state
+                .graph
+                .load_vector_index_compatible(&sidecar, &descriptor),
+            kin_db::VectorIndexLoad::Loaded(1)
+        ));
+
+        let (batch_started_tx, batch_started_rx) = std::sync::mpsc::sync_channel(0);
+        let (foreground_waiting_tx, foreground_waiting_rx) = std::sync::mpsc::sync_channel(0);
+
+        let batch_state = Arc::clone(&state);
+        let background = std::thread::spawn(move || {
+            super::run_background_embedding_batch(&batch_state, true, move |_| {
+                batch_started_tx.send(()).unwrap();
+                foreground_waiting_rx.recv().unwrap();
+                Err(kin_db::KinDbError::IndexError(
+                    "synthetic stale background index".to_string(),
+                ))
+            })
+        });
+
+        batch_started_rx.recv().unwrap();
+        let foreground_state = Arc::clone(&state);
+        let foreground = std::thread::spawn(move || {
+            let _foreground_guard = match foreground_state.embedding_work.try_lock() {
+                Ok(_) => panic!("background batch must still own embedding_work"),
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    foreground_waiting_tx.send(()).unwrap();
+                    foreground_state.embedding_work.lock().unwrap()
+                }
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    panic!("embedding_work unexpectedly poisoned")
+                }
+            };
+
+            assert!(
+                foreground_state.graph.vector_index_stats().is_none(),
+                "the stale background index must be reset before the waiting rebuild acquires"
+            );
+            assert!(matches!(
+                foreground_state
+                    .graph
+                    .load_vector_index_compatible(&sidecar, &descriptor),
+                kin_db::VectorIndexLoad::Loaded(1)
+            ));
+        });
+
+        let outcome = background.join().unwrap();
+        match outcome {
+            super::BackgroundEmbeddingBatchOutcome::ResetAfterIndexError(error) => {
+                assert!(matches!(error, kin_db::KinDbError::IndexError(_)));
+            }
+            other => panic!("unexpected background batch outcome: {other:?}"),
+        }
+        foreground.join().unwrap();
+
+        assert_eq!(
+            state.graph.vector_index_stats(),
+            Some((4, 1)),
+            "no stale recovery may run after the waiting foreground rebuild publishes"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1590,7 +1590,7 @@ mod tests {
         let result = ToolCallResult::text(
             serde_json::json!({
                 "report": {
-                    "schema": "kin.status.v2",
+                    "schema": "kin.status.v3",
                     "semantic_enrichment": { "entity_count": 42 }
                 }
             })


### PR DESCRIPTION
`kin status --json` has carried no embedding, index, or vector state since status moved
onto the repository-v6 authority lease. Every consumer that gates on embedding progress
reads nothing: the kin-bench coverage probe, kin-editor's progress display, and the MCP
agent surfaces. This restores coverage to the payload and sources it from the only view
that can answer it truthfully.

## Breaking change

The `kin status --json` contract moves from `kin.status.v2` to `kin.status.v3` and gains a
required top-level `embedding_coverage` object. The field carries no serde default and top-level `StatusReportWire` refuses unknown fields,
so both parse directions break across binaries: a v2 reader
rejects a v3 payload on the schema string, and a v2 payload no longer deserializes as a
status report at all. Any consumer pinning the schema string or the exact v2 field set has
to be updated. This is recorded under `## [Unreleased]` in `CHANGELOG.md` as well, so the
release-notes roll-up has an input rather than having to infer the break from the diff.

Readers must check `embedding_coverage.state` before any count. The payload deliberately
omits `indexed`, `pending`, and `total` when coverage was not observed, so a probe that
defaults a missing key would reintroduce the exact failure this change removes.

## Where the number actually comes from

`InMemoryGraph::embedding_status` derives `indexed` by testing each retrievable key
against the graph's vector index, and returns zero for every key when no index is
installed. Every `InMemoryGraph` constructor initialises `vector_index` to `None`, so a
graph rebuilt from an authority snapshot never has one. Reading coverage there produces
`indexed: 0, pending: N, total: N` on a fully embedded repository: well formed, plausible,
and false.

A persisted sidecar is attached to a reconstructed graph only through an explicit validated
load. `SnapshotManager::open` and `open_read_only_for_locate` perform that load during construction, and the paths
in this repo that build a graph outside those constructors attach it themselves through
`load_vector_index_into_graph_if_valid` (`crates/kin-cli/src/backend.rs`,
`crates/kin-cli/src/commands/prepared_state.rs`, and `crates/kin-daemon/src/state.rs`).
The daemon's query graph is therefore the view where coverage is real at query time, and it
is the same source `kin graph status` and `kin_graph_status` already report.

So coverage is sampled there:

- `observe_embedding_coverage` (`crates/kin-cli/src/commands/status.rs`) refuses to count
  a graph with no index attached. `vector_index_stats()` returns `None` in exactly that
  state, which is the discriminator between "nothing is indexed" and "nobody can say".
- The daemon's `/commands/status` handler samples its own graph through the same mechanism
  `kin_graph_status` uses: it takes a stable graph-authority epoch, reads the counters
  under the embedding-work lock, revalidates the epoch afterwards, and retries up to three
  times. Embedding passes and the background IndexError reset/requeue transition share
  that same lock, so neither an embedding transition nor a graph mutation batch can span
  the published triple. Without that outer boundary, a reset could detach the index after
  the attachment check but before the counters were read, producing a plausible false zero.
  The background worker also classifies the failed batch and performs its one-shot reset
  before releasing that same guard. A foreground `/embed --rebuild` already waiting on the
  failed batch therefore runs after recovery; stale recovery cannot wipe the fresh index it
  publishes.
- `kin status` reads from a daemon that is **already running** for this repository. It
  never starts one: status is a read, and opening a store whose embeddings are pending
  begins inference on its own. With no daemon it falls back to the local authority read
  and publishes an unobserved coverage naming the reason.
- `inspect` takes the observation as a parameter rather than deriving it. Nothing
  reachable from an authority lease can answer coverage, so every caller has to state
  where its number came from and no path can reach a default that reads as measured.

Two details on the live read that are easy to miss. The bearer token is resolved from the
layout this command resolved rather than from the process working directory, so running
status from a subdirectory cannot authenticate against a different repository's daemon.
And `KIN_DAEMON_URL`, when set, now redirects the whole report rather than only its
coverage, since the report is taken from the daemon wholesale. The supervisor route it
falls back to does validate repository identity against the working directory, and
`bin/kin-lane` unsets that variable for every lane command, which is the same convention
the mutation paths already rely on. The read's time bound and its fallback are described
below, under the deviations.

The durable authority read is unchanged. `durable_semantic_enrichment_summary` is not
touched, no graph is materialised on `kin status` or `kin init`, and the enrichment object
keeps its `durable_repository_authority` view. Coverage is a separate object with its own
source discriminator, so the `view` label is not stretched over numbers the durable
authority does not carry.

## What the daemon now pays per status read

`embedding_status` allocates a set of every retrievable entity, revision, and artifact id
and probes the vector index once per key, so a `kin status` against a running daemon costs
an O(N) walk on that daemon. Before this change `kin status` did not touch the daemon at
all. `kin_graph_status` already pays the same cost, but it is agent-initiated rather than
the command a human or a script runs in a loop.

The walk therefore runs on a blocking thread rather than inline on a tokio worker. That
keeps the O(N) sample off a Tokio worker, while `try_lock` keeps status from waiting behind
an embedding pass that already owns the mutex. The guarantee is deliberately asymmetric:
if status acquires first, its sample can delay a later embedding pass until the walk
completes. In that ordering only a blocking-pool thread waits, and no std mutex guard is
held across an async await.

## Two deviations from the direction the ticket suggested

Both were taken deliberately, so they are recorded here rather than left to be discovered in
review.

The first is the source. FIR-1785 suggests carrying coverage on the repository authority
payload receipt. It cannot be done from this repository today. `AuthorityPayloadStats`
(`kin-db 0.7.8`, `src/storage/backend.rs`) carries `snapshot_generation`,
`head_generation`, `snapshot_bytes`, `acknowledged_delta_count`, `acknowledged_delta_bytes`,
and `total_payload_bytes`, and no embedding state at all. The persisted sidecar's `indexed`
count lives on `VectorIndexMetadata`, whose struct and readers are private to kin-db, so
there is no public accessor to read it through. Putting coverage on the receipt therefore
needs a kin-db change plus a registry publish train, which is a cross-repo release action.
The live query graph carries the same graph-owned truth today with no publish, so that is
what this plumbs. If the receipt later grows the field, the source discriminator already in
the payload is where that second source would announce itself.

That receipt route is redirected rather than dropped: the kin-db payload-stats extension the
ticket names is tracked as its own successor ticket, so the direction FIR-1785 stated keeps
an owner after this lands. Successor ticket: FIR-1834, Carry embedding coverage in the kin-db
authority payload receipt.

The second is that `kin status` now reads a process outside itself, which it never did
before. It reads only a daemon that is already running for this repository and never starts
one, because opening a store whose embeddings are pending begins inference on its own and a
status read must not do that. With no daemon it falls back to the local authority read and
publishes an unobserved coverage naming `no_running_daemon`. The read is bounded at 30
seconds because the daemon client's default request budget is five minutes and status
always has a complete local answer already; on elapse it falls back with
`daemon_status_unavailable`. That bound is a design bound rather than a tested one: the `no_running_daemon` named-absence
fallback is covered by a subprocess test; no test drives `daemon_status_unavailable` or a daemon
into the elapsed branch.

## Loud absence

`embedding_coverage` is a sum type, not a triple:

```json
{"state": "observed", "source": "live_query_graph", "indexed": 41, "pending": 16, "total": 57}
{"state": "unobserved", "reason": "no_vector_index_attached"}
```

The unobserved reasons are distinct and actionable: `no_running_daemon`,
`daemon_status_unavailable`, `no_vector_index_attached`, `vector_support_disabled`,
`sampling_contended`, `embedding_work_lock_poisoned`, `graph_mutation_in_flight`, and
`sampling_failed`. The wire form refuses a payload that mixes states, so counts cannot be
smuggled under an absence and an absence cannot be published without a reason. Observed
triples are validated against the same two invariants `kin.graph-status.v1` enforces,
including the `pending < uncovered` check, so the two surfaces agree on which triples are
legal, and that validation now runs on the emitting side as well as the reading side.

The permanent states are kept apart from the transient ones on purpose. A held embedding
lock clears on its own and says so. A poisoned one does not: the embed loop takes the same
mutex, so a batch that panics leaves it poisoned for the daemon's lifetime, and reporting
that as contention would tell an operator to retry a pass that can never run again.

## Why the schema version moves rather than the field defaulting

`kin.status.v2` carried no embedding state anywhere in the payload. A missing
`embedding_coverage` was not a v2 encoding of "coverage unknown"; it was the entire v2
shape. Adding the field with `#[serde(default)]` would make a v2 payload deserialize into
a v3 report whose coverage a reader could not distinguish from a real observation, and
top-level `StatusReportWire` carries `deny_unknown_fields`, so the reverse direction breaks
regardless.

The schema is therefore `kin.status.v3` and the field is required. A version-skewed pair
fails naming the schema (`unsupported status schema 'kin.status.v2'`) rather than agreeing
on a number neither of them meant. This is the rule already stated above the sibling
coverage contract in `crates/kin-mcp/src/handlers/entities.rs`: unknown fields require a
new schema version instead of silently changing what an existing consumer believes it
measured. The CLI treats a daemon it cannot parse as `daemon_status_unavailable` and falls
back, so a skewed daemon degrades to a loud absence instead of an error. A build mismatch
alone does not reach that gate: the client warns and accepts a mismatched build unless
`KIN_STRICT_BUILD_MATCH` is set, so it is the schema that protects this read.

## Evidence

`status_reports_coverage_from_the_index_the_live_graph_carries` admits a real Git
repository through the exact admission boundary, then measures the same graph twice. Before
an index is attached it must report `no_vector_index_attached`; after a real
`kin_db::VectorIndex` is installed over the graph's own retrievable keys through kin-db's
compatibility-checked loader, it must report nonzero `indexed`, and the counts must survive
the report and its wire form.

`command_status_publishes_the_coverage_of_the_daemon_s_indexed_graph` does the same through
the HTTP endpoint, so the daemon wiring is proven end to end rather than inferred. Its
sibling case pins the unindexed daemon graph to an absence.

Both halves were falsified against a deliberately broken source:

- Removing the attachment guard, which is what PR 551 did, turns the first assertion red
  with `Observed { source: LiveQueryGraph, indexed: 0, pending: 5, total: 5 }`: the exact
  fabricated triple, on a repository whose five retrievable keys are all present.
- Hardcoding `indexed: 0` with the guard intact turns the second assertion red at
  `indexed=0, pending=5, total=5, seeded=9`, proving the nonzero assertion is load-bearing
  rather than vacuous.

Five further cases cover the states and transitions the sampler must not confuse.
`vector_reset_cannot_split_status_attachment_from_coverage_counters` forces the exact
attachment-check/reset-attempt/counter-read ordering through channel handshakes. The reset
must report that it is waiting on the shared embedding-work boundary before the counters
are allowed to run; the sample must stay nonzero, and only after it returns may the reset
detach the index and turn the next observation into `no_vector_index_attached`.
`background_index_recovery_precedes_already_waiting_foreground_rebuild` starts with a real
attached vector index, holds the production batch boundary, proves a foreground rebuild is
already waiting through a zero-capacity channel handshake, then injects the background
IndexError. The foreground can acquire only after recovery has detached the stale index;
it installs a compatible fresh sidecar, and the final assertion proves that index remains
attached with no stale recovery left to run. The test uses no sleeps or scheduler timing.
`live_coverage_names_a_poisoned_embedding_lock_apart_from_a_contended_one` poisons the
embedding work lock the way a panicking batch does and requires a different payload from
the one a merely held lock produces.
`live_coverage_refuses_counters_a_graph_mutation_could_span` samples across a live graph
mutation, requires the refusal, then drops the mutation and requires the same state to
answer differently, so the refusal cannot come from a path that can no longer observe
anything. `building_a_report_refuses_an_impossible_coverage_triple` proves the emitting
side rejects a triple its readers would reject.

Behavioral-repair local gates at `b128438be645de553b022deed64b38cdd1816d97`, all under
`RUSTFLAGS=-D warnings` where the workflow applies it to clippy, build, and test: both
channel-synchronized race regressions; `cargo test -p kin-daemon --locked` (616 library
tests plus every daemon package integration target); the formerly-red
`cargo check -p kin-daemon --no-default-features --all-targets --locked`;
`cargo fmt --all -- --check`; package-scoped
`cargo clippy -p kin-daemon --all-targets --all-features --locked` under the ci.yml
allowlist; `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`,
`scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`; `cargo
build -p kin-daemon --all-targets --locked`; and `git diff --check`.

Head `48d8776111eeabb0b3a717e148b19eba18dbeaf6` is the signed-off,
comment-only child that corrects the fixture explanation after the stale index was made
load-bearing. At that head, `cargo fmt --all -- --check`, `git diff --check`, and the
waiting-foreground race regression passed again under `RUSTFLAGS=-D warnings`.

Prior review head `9dbb59c0be405f7446c0e03a3af863ad773f8b0f` is the signed-off,
comment-only child that corrected the explicit-route health wording found by independent
review. At that exact head, `cargo fmt --all -- --check` and `git diff --check` passed.

The immediately preceding branch head `0d854153b5035afbcb0274afbb85c526794946a7`
also passed the broader unchanged workspace gate: `cargo nextest run --workspace
--no-fail-fast --locked` (4671/4671), `cargo test --doc --locked`, and `cargo test -p
kin-cli --no-default-features --locked`, whose unit and integration binaries all passed.

Independent rereview of `9dbb59c0be405f7446c0e03a3af863ad773f8b0f` found one P2 outside
the race repair itself: two ungated daemon tests encoded the vector-enabled
`no_vector_index_attached` answer even when `kin-daemon --no-default-features` correctly
returns `vector_support_disabled`. The hosted matrix compiled that package shape but did
not execute its full status assertions.

Correction head `7211fa8295520c6fe39088f4b1b437a44d477525` makes those expectations
build-aware and adds `cargo test -p kin-daemon --no-default-features --locked` to the
required Linux CI job. At that exact local head, the complete featureless daemon package
suite passed (605 library tests, 6 binary tests, and 28 integration tests; 639 total), both
corrected assertions passed again with default features, `cargo fmt --all -- --check`,
`actionlint .github/workflows/ci.yml`, both zero-file-search guards, and `git diff --check`
passed. Fresh independent delta review and hosted CI remain required before queue admission.

## Not claiming

This does not close FIR-1785. The ticket's exit criteria include the harness reading status
again and its `kin graph status` fallback becoming dead code with a test proving the
primary path, and kin-bench is a separate repository. That follow-up has two stale readers
to fix rather than one: the enrichment probe, and the prepared-state reuse gate in
`kin-bench-eval.rs` that still pins `kin.status.v1` and has therefore been failing since v2
shipped.

This supersedes PR 551, which took the same direction of sourcing from repository authority
but read counts from a snapshot-rebuilt graph that structurally cannot carry them.

Refs FIR-1785.
