### PR TITLE
Adopt released KinVFS 0.3.0 in Kin proof and runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,7 +463,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: c782905f39500a7a107aba5a91e85119c77726fa
+          ref: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -932,7 +932,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: c782905f39500a7a107aba5a91e85119c77726fa
+          EXPECTED_VFS_COMMIT: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1203,7 +1203,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: c782905f39500a7a107aba5a91e85119c77726fa
+          ref: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1261,7 +1261,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: c782905f39500a7a107aba5a91e85119c77726fa
+          EXPECTED_VFS_COMMIT: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1555,7 +1555,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: c782905f39500a7a107aba5a91e85119c77726fa
+      expected_vfs_commit: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3745,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.1.5"
+version = "0.3.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0a6c0383abd5fdf900c67427ac5f9ab40306cd2165e8d4c86c1e2cfa3d57bbba"
+checksum = "12ff474623a86dced7abba355db891e534a15b2ca31be382fc14ab6c73790385"
 dependencies = [
  "lru",
  "parking_lot",
@@ -6612,7 +6612,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.8", registry = "kin", default-features = false }
-kin-vfs-core = { version = "0.1.5", registry = "kin" }
+kin-vfs-core = { version = "0.3.0", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -6423,7 +6423,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: c782905f39500a7a107aba5a91e85119c77726fa",
+        "expected_vfs_commit: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
Kin's release workflow was still pinned to KinVFS commit `c782905f` and
registry crate `kin-vfs-core 0.1.5`. That combination predates the VFS
fail-closed and canary repairs now landed in KinVFS #76, so a Kin recut would
have reproduced the stale projection bytes.

This deliberately adopts the released protocol boundary instead of changing
only the checkout:

- resolve `kin-vfs-core 0.3.0` from the Kin registry and retain its registry
  source and checksum in `Cargo.lock`;
- pin both release checkouts to KinVFS squash
  `921c24ec67240ec6dce66bb2c05a333e1c9a2b42`;
- bind artifact provenance and public install proof to that same immutable
  commit; and
- update the authority test's required install-proof literal.

The five references remain one exact commit, and the release compatibility
guard now sees `kin-vfs-core 0.3.0` on both sides.

## Upstream release evidence

KinVFS `v0.3.0` is not inferred from a green source PR:

- registry publish run `30694430020` passed repo verification,
  registry-only build, publish, fresh-consumer smoke, tag mint, and downstream
  notification;
- release run `30694497554` passed macOS and Linux workspace tests and
  published the GitHub release;
- annotated tag object `48fc3508cf06d4da619a8483eb24ccce802d5a2d`
  peels to exact squash
  `921c24ec67240ec6dce66bb2c05a333e1c9a2b42`; and
- the downloaded registry package resolved as `kin-vfs-core 0.3.0` with
  checksum `12ff474623a86dced7abba355db891e534a15b2ca31be382fc14ab6c73790385`.

## Local verification

At exact head `7c8a77159ac55689d72611fb9267a4028531d603`:

- `cargo check -p kin-cli --locked` — pass;
- `cargo check -p kin-cli --locked --no-default-features` — pass;
- `cargo test -p kin-cli --locked` — pass, including 1,068 library tests,
  CLI/integration suites, Windows authority order, and doctests;
- `cargo fmt --all -- --check` — pass;
- release-workflow authority suite and `actionlint` — pass;
- Python bytecode validation and `git diff --check` — pass; and
- both zero-file-search guards — pass, verifier scanned 147 source files.

## Scope boundary

FIR-1599 stays open: this resolves Kin's deliberate core adoption, but its
separate KinVFS Dependabot PR 59/60 and stale experimental-Windows CI prose
remain. This PR also does not claim a Kin release, released-byte install proof,
or real-client acceptance; it makes those gates capable of exercising the
landed VFS bytes.

Refs FIR-1599.
Refs FIR-1638.
Refs FIR-1819.