### PR TITLE
Make refs counts entity-accurate and fail closed

### DIFF
--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -271,7 +271,6 @@ pub fn build_bulk_refs_response(
     }
 
     let relation_kinds = parse_bulk_relation_kind(&request.kind)?;
-    let allowed: std::collections::HashSet<RelationKind> = relation_kinds.iter().copied().collect();
     let mut results = Vec::with_capacity(request.entity_ids.len());
     let mut with_references = 0usize;
 
@@ -308,26 +307,21 @@ pub fn build_bulk_refs_response(
             continue;
         };
 
-        let mut reference_count = 0usize;
-        let mut matched_kinds: Vec<RelationKind> = Vec::new();
-        for rel in graph.get_all_relations_for_entity(&entity_id)? {
-            let Some(src_entity_id) = rel.src.as_entity() else {
-                continue;
-            };
-            if rel.dst != GraphNodeId::Entity(entity_id) {
-                continue;
-            }
-            if !allowed.contains(&rel.kind) {
-                continue;
-            }
-            if src_entity_id == entity_id {
-                continue;
-            }
-            reference_count += 1;
-            if !matched_kinds.contains(&rel.kind) {
-                matched_kinds.push(rel.kind);
-            }
-        }
+        // Bulk mode reports the same unit as the ordinary `kin refs` surface:
+        // distinct referencing entities, not raw relation edges. One caller
+        // may carry Calls, Imports, and References edges to the same target,
+        // and ingestion may retain duplicate observations of an edge. Counting
+        // those edges here made the compact answer disagree with the rows the
+        // human-readable command could actually enumerate. Keep one grouping
+        // authority for both paths so the count cannot drift again.
+        let references = collect_graph_references(graph, &entity_id, &relation_kinds)?;
+        let reference_count = references.len();
+        let mut matched_kinds: Vec<RelationKind> = references
+            .iter()
+            .flat_map(|entry| entry.relation_kinds.iter().copied())
+            .collect();
+        matched_kinds.sort_by_key(relation_kind_rank);
+        matched_kinds.dedup();
 
         let has_references = reference_count > 0;
         if has_references {
@@ -526,7 +520,10 @@ fn display_read_path(_layout: &kin_core::KinLayout, rel_path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_refs_response, parse_relation_kinds, refs_not_found_guidance, RefsRequest};
+    use super::{
+        build_bulk_refs_response, build_refs_response, parse_relation_kinds,
+        refs_not_found_guidance, BulkRefsRequest, RefsRequest,
+    };
     use kin_model::RelationKind;
 
     /// `kin refs` must answer only from graph-owned relation edges. A reference
@@ -688,7 +685,7 @@ mod tests {
     /// replaces collapsed them into a single row wearing the first caller's
     /// name, under a count line that then miscounted the referencing entities.
     #[test]
-    fn refs_lists_every_referencing_entity_not_one_per_file() {
+    fn refs_and_bulk_count_referencing_entities_not_relation_edges() {
         use kin_db::InMemoryGraph;
         use kin_model::relation::{Relation, RelationOrigin};
         use kin_model::{
@@ -750,6 +747,23 @@ mod tests {
                 })
                 .unwrap();
         }
+        // The same caller can carry multiple graph-owned observations of the
+        // target. They enrich its row; they do not create more callers.
+        for kind in [RelationKind::References, RelationKind::Calls] {
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind,
+                    src: GraphNodeId::Entity(caller_a.id),
+                    dst: GraphNodeId::Entity(target.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
 
         let response = build_refs_response(
             &layout,
@@ -769,6 +783,32 @@ mod tests {
         assert!(
             joined.contains("caller_a") && joined.contains("caller_b"),
             "both same-file callers must be listed: {joined}"
+        );
+
+        let compact = build_bulk_refs_response(
+            &graph,
+            &BulkRefsRequest {
+                entity_ids: vec![target.id.to_string()],
+                kind: "Any".to_string(),
+                compact: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(compact.results[0]["reference_count"], 2);
+
+        let verbose = build_bulk_refs_response(
+            &graph,
+            &BulkRefsRequest {
+                entity_ids: vec![target.id.to_string()],
+                kind: "Any".to_string(),
+                compact: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(verbose.results[0]["reference_count"], 2);
+        assert_eq!(
+            verbose.results[0]["matched_kinds"],
+            serde_json::json!(["Calls", "References"])
         );
     }
 }

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -79,6 +79,9 @@ fn default_bulk_compact() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BulkRefsResponse {
     pub total_checked: usize,
+    pub classified_count: usize,
+    pub error_count: usize,
+    pub incomplete_verdict_count: usize,
     pub with_references: usize,
     pub without_references: usize,
     #[serde(default)]
@@ -273,37 +276,30 @@ pub fn build_bulk_refs_response(
     let relation_kinds = parse_bulk_relation_kind(&request.kind)?;
     let mut results = Vec::with_capacity(request.entity_ids.len());
     let mut with_references = 0usize;
+    let mut without_references = 0usize;
+    let mut error_count = 0usize;
+    let mut incomplete_verdict_count = 0usize;
 
     for raw_id in &request.entity_ids {
         let parsed = uuid::Uuid::parse_str(raw_id.trim());
         let Ok(uuid) = parsed else {
-            let mut row = serde_json::json!({
-                "entity_id": raw_id,
-                "error": "invalid entity_id (not a UUID)",
-            });
-            if !request.compact {
-                row["has_references"] = serde_json::json!(false);
-                row["reference_count"] = serde_json::json!(0);
-            }
-            results.push(row);
+            error_count += 1;
+            results.push(bulk_refs_error_row(
+                raw_id,
+                "invalid entity_id (not a UUID)",
+                request.compact,
+            ));
             continue;
         };
         let entity_id = EntityId(uuid);
         let entity = graph.get_entity(&entity_id)?;
         let Some(entity) = entity else {
-            let mut row = serde_json::json!({
-                "entity_id": raw_id,
-                "error": "entity not found",
-                "has_references": false,
-                "reference_count": 0,
-            });
-            if !request.compact {
-                row["name"] = serde_json::Value::Null;
-                row["kind"] = serde_json::Value::Null;
-                row["file_path"] = serde_json::Value::Null;
-                row["matched_kinds"] = serde_json::json!([]);
-            }
-            results.push(row);
+            error_count += 1;
+            results.push(bulk_refs_error_row(
+                raw_id,
+                "entity not found",
+                request.compact,
+            ));
             continue;
         };
 
@@ -314,18 +310,45 @@ pub fn build_bulk_refs_response(
         // those edges here made the compact answer disagree with the rows the
         // human-readable command could actually enumerate. Keep one grouping
         // authority for both paths so the count cannot drift again.
-        let references = collect_graph_references(graph, &entity_id, &relation_kinds)?;
-        let reference_count = references.len();
-        let mut matched_kinds: Vec<RelationKind> = references
-            .iter()
-            .flat_map(|entry| entry.relation_kinds.iter().copied())
-            .collect();
-        matched_kinds.sort_by_key(relation_kind_rank);
-        matched_kinds.dedup();
+        let collected = collect_graph_references(graph, &entity_id, &relation_kinds)?;
+        let reference_count = collected.references.len();
+        let matched_kinds = collected.matched_kinds;
+
+        if !collected.missing_source_ids.is_empty() {
+            incomplete_verdict_count += 1;
+            let missing_source_count = collected.missing_source_ids.len();
+            let known_reference_count = reference_count + missing_source_count;
+            let mut row = serde_json::json!({
+                "entity_id": entity_id.to_string(),
+                "has_references": null,
+                "reference_count": null,
+                "known_reference_count": known_reference_count,
+                "reference_count_complete": false,
+                "verdict_complete": false,
+                "verdict_reason": format!(
+                    "graph reference authority incomplete: {missing_source_count} incoming source entity record(s) missing"
+                ),
+                "missing_source_entity_count": missing_source_count,
+            });
+            if !request.compact {
+                row["name"] = serde_json::json!(entity.name);
+                row["kind"] = serde_json::json!(format!("{:?}", entity.kind));
+                row["file_path"] =
+                    serde_json::json!(entity.file_origin.as_ref().map(|p| p.0.clone()));
+                row["matched_kinds"] = serde_json::json!(matched_kinds
+                    .into_iter()
+                    .map(relation_kind_label)
+                    .collect::<Vec<_>>());
+            }
+            results.push(row);
+            continue;
+        }
 
         let has_references = reference_count > 0;
         if has_references {
             with_references += 1;
+        } else {
+            without_references += 1;
         }
 
         if request.compact {
@@ -335,7 +358,6 @@ pub fn build_bulk_refs_response(
                 "reference_count": reference_count,
             }));
         } else {
-            matched_kinds.sort_by_key(relation_kind_rank);
             results.push(serde_json::json!({
                 "entity_id": entity_id.to_string(),
                 "name": entity.name,
@@ -352,10 +374,18 @@ pub fn build_bulk_refs_response(
     }
 
     let total_checked = request.entity_ids.len();
+    let classified_count = with_references + without_references;
+    debug_assert_eq!(
+        total_checked,
+        classified_count + error_count + incomplete_verdict_count
+    );
     Ok(BulkRefsResponse {
         total_checked,
+        classified_count,
+        error_count,
+        incomplete_verdict_count,
         with_references,
-        without_references: total_checked - with_references,
+        without_references,
         relation_kinds: relation_kinds
             .iter()
             .copied()
@@ -364,6 +394,25 @@ pub fn build_bulk_refs_response(
         compact: request.compact,
         results,
     })
+}
+
+fn bulk_refs_error_row(entity_id: &str, error: &str, compact: bool) -> serde_json::Value {
+    let mut row = serde_json::json!({
+        "entity_id": entity_id,
+        "error": error,
+        "has_references": null,
+        "reference_count": null,
+        "known_reference_count": null,
+        "reference_count_complete": false,
+        "verdict_complete": false,
+    });
+    if !compact {
+        row["name"] = serde_json::Value::Null;
+        row["kind"] = serde_json::Value::Null;
+        row["file_path"] = serde_json::Value::Null;
+        row["matched_kinds"] = serde_json::json!([]);
+    }
+    row
 }
 
 fn parse_bulk_relation_kind(value: &str) -> Result<Vec<RelationKind>> {
@@ -402,6 +451,13 @@ struct ReferenceEntry {
     relation_kinds: Vec<RelationKind>,
 }
 
+#[derive(Debug, Clone)]
+struct ReferenceCollection {
+    references: Vec<ReferenceEntry>,
+    missing_source_ids: Vec<EntityId>,
+    matched_kinds: Vec<RelationKind>,
+}
+
 /// Collect incoming references to `target` from graph-owned relation edges.
 ///
 /// The graph is the sole authority for what references an entity. There is no
@@ -413,7 +469,24 @@ fn collect_references(
     target: &Entity,
     relation_kinds: &[RelationKind],
 ) -> Result<Vec<ReferenceEntry>> {
-    let mut entries = collect_graph_references(graph, &target.id, relation_kinds)?;
+    let collected = collect_graph_references(graph, &target.id, relation_kinds)?;
+    if !collected.missing_source_ids.is_empty() {
+        let sample = collected
+            .missing_source_ids
+            .iter()
+            .take(3)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "graph reference authority incomplete for entity {}: {} incoming source entity \
+             record(s) missing (sample: {})",
+            target.id,
+            collected.missing_source_ids.len(),
+            sample
+        );
+    }
+    let mut entries = collected.references;
     entries.sort_by(|left, right| {
         left.file_path
             .cmp(&right.file_path)
@@ -427,9 +500,10 @@ fn collect_graph_references(
     graph: &impl GraphStore,
     entity_id: &EntityId,
     relation_kinds: &[RelationKind],
-) -> Result<Vec<ReferenceEntry>> {
+) -> Result<ReferenceCollection> {
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
-    let mut grouped: HashMap<EntityId, ReferenceEntry> = HashMap::new();
+    let mut grouped: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
+    let mut matched_kinds = Vec::new();
 
     for rel in graph.get_all_relations_for_entity(entity_id)? {
         if rel.dst != GraphNodeId::Entity(*entity_id) || !allowed.contains(&rel.kind) {
@@ -446,37 +520,33 @@ fn collect_graph_references(
         if src_entity_id == *entity_id {
             continue;
         }
-        let Some(entity) = graph.get_entity(&src_entity_id)? else {
+        push_relation_kind(grouped.entry(src_entity_id).or_default(), rel.kind);
+        push_relation_kind(&mut matched_kinds, rel.kind);
+    }
+
+    let mut references = Vec::with_capacity(grouped.len());
+    let mut missing_source_ids = Vec::new();
+    for (source_id, mut source_kinds) in grouped {
+        source_kinds.sort_by_key(relation_kind_rank);
+        let Some(entity) = graph.get_entity(&source_id)? else {
+            missing_source_ids.push(source_id);
             continue;
         };
-
-        let file_path = entity.file_origin.as_ref().map(|f| f.0.clone());
-        // The graph entity id is the grouping authority. File/name are display
-        // metadata and are not unique: overloads and nested declarations may
-        // legitimately share both while remaining distinct callers.
-        let entry = grouped
-            .entry(src_entity_id)
-            .or_insert_with(|| ReferenceEntry {
-                entity_id: src_entity_id,
-                name: entity.name.clone(),
-                file_path: file_path.clone(),
-                start_line: entity.span.as_ref().map(|s| s.start_line),
-                relation_kinds: Vec::new(),
-            });
-        if entry.file_path.is_none() {
-            entry.file_path = file_path;
-        }
-        if entry.start_line.is_none() {
-            entry.start_line = entity.span.as_ref().map(|s| s.start_line);
-        }
-        push_relation_kind(&mut entry.relation_kinds, rel.kind);
+        references.push(ReferenceEntry {
+            entity_id: source_id,
+            name: entity.name.clone(),
+            file_path: entity.file_origin.as_ref().map(|f| f.0.clone()),
+            start_line: entity.span.as_ref().map(|s| s.start_line),
+            relation_kinds: source_kinds,
+        });
     }
-
-    let mut entries = grouped.into_values().collect::<Vec<_>>();
-    for entry in &mut entries {
-        entry.relation_kinds.sort_by_key(relation_kind_rank);
-    }
-    Ok(entries)
+    missing_source_ids.sort();
+    matched_kinds.sort_by_key(relation_kind_rank);
+    Ok(ReferenceCollection {
+        references,
+        missing_source_ids,
+        matched_kinds,
+    })
 }
 
 fn push_relation_kind(kinds: &mut Vec<RelationKind>, kind: RelationKind) {
@@ -527,7 +597,7 @@ fn display_read_path(_layout: &kin_core::KinLayout, rel_path: &str) -> String {
 mod tests {
     use super::{
         build_bulk_refs_response, build_refs_response, parse_relation_kinds,
-        refs_not_found_guidance, BulkRefsRequest, RefsRequest,
+        refs_not_found_guidance, BulkRefsRequest, BulkRefsResponse, RefsRequest,
     };
     use kin_model::RelationKind;
 
@@ -822,6 +892,11 @@ mod tests {
             },
         )
         .unwrap();
+        assert_eq!(compact.classified_count, 1);
+        assert_eq!(compact.error_count, 0);
+        assert_eq!(compact.incomplete_verdict_count, 0);
+        assert_eq!(compact.with_references, 1);
+        assert_eq!(compact.without_references, 0);
         assert_eq!(compact.results[0]["reference_count"], 2);
         assert_eq!(compact.results[0]["has_references"], true);
         assert_eq!(compact.results[0]["entity_id"], target.id.to_string());
@@ -859,7 +934,234 @@ mod tests {
         .unwrap();
         assert_eq!(self_only_kind.results[0]["has_references"], false);
         assert_eq!(self_only_kind.results[0]["reference_count"], 0);
+        assert_eq!(self_only_kind.classified_count, 1);
+        assert_eq!(self_only_kind.error_count, 0);
+        assert_eq!(self_only_kind.incomplete_verdict_count, 0);
         assert_eq!(self_only_kind.with_references, 0);
         assert_eq!(self_only_kind.without_references, 1);
+    }
+
+    #[test]
+    fn bulk_invalid_and_missing_targets_are_errors_never_negative_verdicts() {
+        let graph = kin_db::InMemoryGraph::new();
+        let missing_id = kin_model::EntityId::new().to_string();
+
+        for compact in [true, false] {
+            let response = build_bulk_refs_response(
+                &graph,
+                &BulkRefsRequest {
+                    entity_ids: vec!["not-a-uuid".to_string(), missing_id.clone()],
+                    kind: "Any".to_string(),
+                    compact,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(response.total_checked, 2);
+            assert_eq!(response.classified_count, 0);
+            assert_eq!(response.error_count, 2);
+            assert_eq!(response.incomplete_verdict_count, 0);
+            assert_eq!(response.with_references, 0);
+            assert_eq!(response.without_references, 0);
+            assert_bulk_error_row(
+                &response.results[0],
+                compact,
+                "invalid entity_id (not a UUID)",
+            );
+            assert_bulk_error_row(&response.results[1], compact, "entity not found");
+        }
+    }
+
+    #[test]
+    fn dangling_reference_source_is_explicitly_incomplete_in_both_modes() {
+        use kin_db::InMemoryGraph;
+        use kin_model::relation::{Relation, RelationOrigin};
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, SemanticFingerprint,
+            Visibility,
+        };
+
+        fn entity(name: &str, rel_path: &str) -> Entity {
+            Entity {
+                id: EntityId::new(),
+                kind: EntityKind::Function,
+                name: name.to_string(),
+                language: LanguageId::Rust,
+                fingerprint: SemanticFingerprint {
+                    algorithm: FingerprintAlgorithm::V1TreeSitter,
+                    ast_hash: Hash256::from_bytes([0; 32]),
+                    signature_hash: Hash256::from_bytes([0; 32]),
+                    behavior_hash: Hash256::from_bytes([0; 32]),
+                    equivalence_hash: Hash256::from_bytes([0; 32]),
+                    stability_score: 1.0,
+                },
+                file_origin: Some(FilePathId::new(rel_path)),
+                span: None,
+                signature: name.to_string(),
+                visibility: Visibility::Public,
+                role: EntityRole::Source,
+                doc_summary: None,
+                metadata: EntityMetadata::default(),
+                lineage_parent: None,
+                created_in: None,
+                superseded_by: None,
+            }
+        }
+
+        let target = entity("target", "target.rs");
+        let materialized_caller = entity("caller", "caller.rs");
+        let missing_source_id = EntityId::new();
+        let graph = InMemoryGraph::new();
+        graph.upsert_entity(&target).unwrap();
+        graph.upsert_entity(&materialized_caller).unwrap();
+
+        for (source_id, kind) in [
+            (materialized_caller.id, RelationKind::References),
+            (missing_source_id, RelationKind::References),
+            // Repeated/multi-kind observations from the missing source remain
+            // one known caller identity while preserving the known kind union.
+            (missing_source_id, RelationKind::References),
+            (missing_source_id, RelationKind::Calls),
+        ] {
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind,
+                    src: GraphNodeId::Entity(source_id),
+                    dst: GraphNodeId::Entity(target.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        for compact in [true, false] {
+            let response = build_bulk_refs_response(
+                &graph,
+                &BulkRefsRequest {
+                    entity_ids: vec![target.id.to_string()],
+                    kind: "Any".to_string(),
+                    compact,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(response.total_checked, 1);
+            assert_eq!(response.classified_count, 0);
+            assert_eq!(response.error_count, 0);
+            assert_eq!(response.incomplete_verdict_count, 1);
+            assert_eq!(response.with_references, 0);
+            assert_eq!(response.without_references, 0);
+
+            let row = &response.results[0];
+            assert!(row["has_references"].is_null());
+            assert!(row["reference_count"].is_null());
+            assert_eq!(row["known_reference_count"], 2);
+            assert_eq!(row["reference_count_complete"], false);
+            assert_eq!(row["verdict_complete"], false);
+            assert_eq!(row["missing_source_entity_count"], 1);
+            assert!(row["verdict_reason"]
+                .as_str()
+                .unwrap()
+                .contains("graph reference authority incomplete"));
+            if compact {
+                assert!(row.get("name").is_none());
+                assert!(row.get("matched_kinds").is_none());
+            } else {
+                assert_eq!(row["name"], "target");
+                assert_eq!(row["kind"], "Function");
+                assert_eq!(row["file_path"], "target.rs");
+                assert_eq!(
+                    row["matched_kinds"],
+                    serde_json::json!(["Calls", "References"])
+                );
+            }
+        }
+
+        let layout = kin_core::KinLayout::new(tempfile::tempdir().unwrap().path().join(".kin"));
+        let error = build_refs_response(
+            &layout,
+            &graph,
+            &RefsRequest {
+                entity: target.id.to_string(),
+                kind: "all".to_string(),
+            },
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("graph reference authority incomplete"),
+            "ordinary refs must fail loud on the same gap: {error:#}"
+        );
+    }
+
+    #[test]
+    fn request_level_bulk_failures_return_no_classification_response() {
+        let graph = kin_db::InMemoryGraph::new();
+        assert!(build_bulk_refs_response(
+            &graph,
+            &BulkRefsRequest {
+                entity_ids: Vec::new(),
+                kind: "Any".to_string(),
+                compact: true,
+            },
+        )
+        .is_err());
+        assert!(build_bulk_refs_response(
+            &graph,
+            &BulkRefsRequest {
+                entity_ids: vec![kin_model::EntityId::new().to_string()],
+                kind: "unsupported".to_string(),
+                compact: false,
+            },
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn legacy_bulk_response_without_completeness_counts_fails_closed() {
+        let legacy = serde_json::json!({
+            "total_checked": 1,
+            "with_references": 0,
+            "without_references": 1,
+            "relation_kinds": ["Calls", "Imports", "References"],
+            "compact": true,
+            "results": [{
+                "entity_id": kin_model::EntityId::new().to_string(),
+                "has_references": false,
+                "reference_count": 0
+            }]
+        });
+
+        let error = serde_json::from_value::<BulkRefsResponse>(legacy).unwrap_err();
+        assert!(
+            error.to_string().contains("classified_count"),
+            "a version-skewed response must fail instead of recovering unsafe negatives: {error}"
+        );
+    }
+
+    fn assert_bulk_error_row(row: &serde_json::Value, compact: bool, expected_error: &str) {
+        assert_eq!(row["error"], expected_error);
+        assert!(row["has_references"].is_null());
+        assert!(row["reference_count"].is_null());
+        assert!(row["known_reference_count"].is_null());
+        assert_eq!(row["reference_count_complete"], false);
+        assert_eq!(row["verdict_complete"], false);
+        if compact {
+            assert!(row.get("name").is_none());
+            assert!(row.get("kind").is_none());
+            assert!(row.get("file_path").is_none());
+            assert!(row.get("matched_kinds").is_none());
+        } else {
+            assert!(row["name"].is_null());
+            assert!(row["kind"].is_null());
+            assert!(row["file_path"].is_null());
+            assert_eq!(row["matched_kinds"], serde_json::json!([]));
+        }
     }
 }

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -395,6 +395,7 @@ fn relation_kind_label(kind: RelationKind) -> String {
 
 #[derive(Debug, Clone)]
 struct ReferenceEntry {
+    entity_id: EntityId,
     name: String,
     file_path: Option<String>,
     start_line: Option<u32>,
@@ -417,6 +418,7 @@ fn collect_references(
         left.file_path
             .cmp(&right.file_path)
             .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.entity_id.cmp(&right.entity_id))
     });
     Ok(entries)
 }
@@ -427,7 +429,7 @@ fn collect_graph_references(
     relation_kinds: &[RelationKind],
 ) -> Result<Vec<ReferenceEntry>> {
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
-    let mut grouped: HashMap<String, ReferenceEntry> = HashMap::new();
+    let mut grouped: HashMap<EntityId, ReferenceEntry> = HashMap::new();
 
     for rel in graph.get_all_relations_for_entity(entity_id)? {
         if rel.dst != GraphNodeId::Entity(*entity_id) || !allowed.contains(&rel.kind) {
@@ -436,18 +438,31 @@ fn collect_graph_references(
         let Some(src_entity_id) = rel.src.as_entity() else {
             continue;
         };
+        // A recursive/self relation does not establish reachability from
+        // another entity. Bulk refs has always excluded it for dead-code and
+        // caller classification; keeping that rule in the shared collector
+        // makes the ordinary and bulk surfaces agree without turning a
+        // self-recursive orphan into a referenced entity.
+        if src_entity_id == *entity_id {
+            continue;
+        }
         let Some(entity) = graph.get_entity(&src_entity_id)? else {
             continue;
         };
 
         let file_path = entity.file_origin.as_ref().map(|f| f.0.clone());
-        let key = reference_key(file_path.as_deref(), &entity.name);
-        let entry = grouped.entry(key).or_insert_with(|| ReferenceEntry {
-            name: entity.name.clone(),
-            file_path: file_path.clone(),
-            start_line: entity.span.as_ref().map(|s| s.start_line),
-            relation_kinds: Vec::new(),
-        });
+        // The graph entity id is the grouping authority. File/name are display
+        // metadata and are not unique: overloads and nested declarations may
+        // legitimately share both while remaining distinct callers.
+        let entry = grouped
+            .entry(src_entity_id)
+            .or_insert_with(|| ReferenceEntry {
+                entity_id: src_entity_id,
+                name: entity.name.clone(),
+                file_path: file_path.clone(),
+                start_line: entity.span.as_ref().map(|s| s.start_line),
+                relation_kinds: Vec::new(),
+            });
         if entry.file_path.is_none() {
             entry.file_path = file_path;
         }
@@ -468,16 +483,6 @@ fn push_relation_kind(kinds: &mut Vec<RelationKind>, kind: RelationKind) {
     if !kinds.contains(&kind) {
         kinds.push(kind);
     }
-}
-
-fn reference_key(file_path: Option<&str>, name: &str) -> String {
-    // Keyed by (file, name), not by file alone: two entities in the same file
-    // that both reference the target are two rows, not one row wearing the
-    // first entity's name. The listing enumerates referencing entities, and
-    // the count line above it says so.
-    file_path
-        .map(|path| format!("{path}\u{1f}{name}"))
-        .unwrap_or_else(|| format!("name:{name}"))
 }
 
 fn parse_relation_kinds(kind: &str) -> Result<Vec<RelationKind>> {
@@ -681,11 +686,11 @@ mod tests {
         assert_eq!(kinds, vec![RelationKind::Imports]);
     }
 
-    /// Two callers in one file are two rows. The per-file grouping this
-    /// replaces collapsed them into a single row wearing the first caller's
-    /// name, under a count line that then miscounted the referencing entities.
+    /// Distinct entity ids are distinct callers even when their display
+    /// metadata is identical. Duplicate/multi-kind edges from one caller enrich
+    /// that caller's row, and self-edges do not establish external reachability.
     #[test]
-    fn refs_and_bulk_count_referencing_entities_not_relation_edges() {
+    fn refs_and_bulk_count_distinct_external_entities_not_relation_edges_or_self_edges() {
         use kin_db::InMemoryGraph;
         use kin_model::relation::{Relation, RelationOrigin};
         use kin_model::{
@@ -725,8 +730,10 @@ mod tests {
         let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
 
         let target = entity("probe_symbol", "target_mod.rs");
-        let caller_a = entity("caller_a", "callers.rs");
-        let caller_b = entity("caller_b", "callers.rs");
+        // Same file and same name are deliberate: display metadata cannot be
+        // the grouping key. These remain two semantic entities by id.
+        let caller_a = entity("shared_caller", "callers.rs");
+        let caller_b = entity("shared_caller", "callers.rs");
 
         let graph = InMemoryGraph::new();
         for e in [&target, &caller_a, &caller_b] {
@@ -764,6 +771,27 @@ mod tests {
                 })
                 .unwrap();
         }
+        // A recursive-only edge does not make the target reachable from some
+        // other entity and must not affect either count or matched_kinds.
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+        ] {
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind,
+                    src: GraphNodeId::Entity(target.id),
+                    dst: GraphNodeId::Entity(target.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
 
         let response = build_refs_response(
             &layout,
@@ -781,8 +809,8 @@ mod tests {
             "count line must count entities: {joined}"
         );
         assert!(
-            joined.contains("caller_a") && joined.contains("caller_b"),
-            "both same-file callers must be listed: {joined}"
+            joined.matches("shared_caller @ callers.rs:0").count() == 2,
+            "both same-metadata entity ids must be listed separately: {joined}"
         );
 
         let compact = build_bulk_refs_response(
@@ -795,6 +823,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(compact.results[0]["reference_count"], 2);
+        assert_eq!(compact.results[0]["has_references"], true);
+        assert_eq!(compact.results[0]["entity_id"], target.id.to_string());
+        assert!(compact.results[0].get("matched_kinds").is_none());
+        assert!(compact.results[0].get("name").is_none());
 
         let verbose = build_bulk_refs_response(
             &graph,
@@ -806,9 +838,28 @@ mod tests {
         )
         .unwrap();
         assert_eq!(verbose.results[0]["reference_count"], 2);
+        assert_eq!(verbose.results[0]["has_references"], true);
+        assert_eq!(verbose.results[0]["entity_id"], target.id.to_string());
+        assert_eq!(verbose.results[0]["name"], "probe_symbol");
+        assert_eq!(verbose.results[0]["kind"], "Function");
+        assert_eq!(verbose.results[0]["file_path"], "target_mod.rs");
         assert_eq!(
             verbose.results[0]["matched_kinds"],
             serde_json::json!(["Calls", "References"])
         );
+
+        let self_only_kind = build_bulk_refs_response(
+            &graph,
+            &BulkRefsRequest {
+                entity_ids: vec![target.id.to_string()],
+                kind: "Imports".to_string(),
+                compact: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(self_only_kind.results[0]["has_references"], false);
+        assert_eq!(self_only_kind.results[0]["reference_count"], 0);
+        assert_eq!(self_only_kind.with_references, 0);
+        assert_eq!(self_only_kind.without_references, 1);
     }
 }


### PR DESCRIPTION
## What changed

`kin refs --bulk-json` now reports reference truth per external caller entity instead of counting raw relation edges.

- groups callers by stable `EntityId`, so duplicate and multi-kind edges do not inflate counts;
- keeps distinct entities distinct even when file/name metadata matches;
- excludes self edges from external-reference verdicts and counts;
- reports invalid or missing requested targets as errors rather than false negatives;
- reports dangling source entities and graph gaps as incomplete/null verdicts;
- fails ordinary refs requests loudly when a complete answer cannot be produced;
- fails closed against older daemon response shapes that lack the required completeness counters; and
- prevents errors or incomplete evaluations from entering `without_references`.

The runtime answer remains graph-authoritative; no raw filesystem fallback was introduced.

## Verification

At exact head `c5f69ec37a858271f823fbadd6ba021c8124fb12`:

- refs unit suite: 10 passed, 0 failed;
- dead-code focused suite: 4 passed, 0 failed;
- exact CI allowlisted clippy with `RUSTFLAGS=-Dwarnings`: passed in the repair lane;
- `cargo fmt --all -- --check`: passed;
- `git diff --check`: passed;
- both zero-file-search authority guards: passed.

Independent final review of the complete resulting `refs.rs` and exact repair delta returned SOURCE GO with P0/P1/P2/P3 = 0/0/0/0.

## Scope

This fixes the refs-count/data-hygiene item recorded on FIR-1584. It does not close FIR-1584 because that issue also tracks graph-viz dangling links, offline D3 delivery, and noisy `kin deps` output.

This is source and local-test evidence only. Hosted CI, merge-queue landing, release, and released-byte acceptance remain separate gates.

Refs FIR-1584.