### PR TITLE
Add bounded graph-native repository rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,6 +3129,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "unicode-ident",
  "unicode-normalization",
  "url",
  "uuid",

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -90,6 +90,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
+unicode-ident = "1"
 kin-spine = { version = "0.4.5", path = "../kin-spine" }
 
 [dev-dependencies]

--- a/crates/kin-cli/src/commands/capabilities.rs
+++ b/crates/kin-cli/src/commands/capabilities.rs
@@ -13,6 +13,7 @@ const INVENTORY_JSON: &str =
 #[serde(rename_all = "snake_case")]
 pub enum CapabilityStatus {
     Ready,
+    ReadyBounded,
     OpenGate,
 }
 
@@ -50,6 +51,8 @@ struct CapabilityReport<'a> {
     bounded_dogfood_ready: bool,
     bounded_dogfood_required_ready: usize,
     bounded_dogfood_required_total: usize,
+    all_declared_command_surfaces_enabled: bool,
+    enabled_commands: usize,
     full_git_replacement_ready: bool,
     ready_commands: usize,
     command_total: usize,
@@ -73,7 +76,7 @@ pub fn require_ready(command: &str) -> Result<()> {
                 command
             )
         })?;
-    if capability.status == CapabilityStatus::Ready
+    if capability.status != CapabilityStatus::OpenGate
         && capability.exposure == CapabilityExposure::Enabled
     {
         return Ok(());
@@ -98,7 +101,7 @@ pub fn run(json: bool) -> Result<()> {
     let bounded_dogfood_required_ready = required
         .iter()
         .filter(|capability| {
-            capability.status == CapabilityStatus::Ready
+            capability.status != CapabilityStatus::OpenGate
                 && capability.exposure == CapabilityExposure::Enabled
         })
         .count();
@@ -110,12 +113,19 @@ pub fn run(json: bool) -> Result<()> {
                 && capability.exposure == CapabilityExposure::Enabled
         })
         .count();
+    let enabled_commands = inventory
+        .commands
+        .iter()
+        .filter(|capability| capability.exposure == CapabilityExposure::Enabled)
+        .count();
     let report = CapabilityReport {
         schema: &inventory.schema,
         substrate: &inventory.substrate,
         bounded_dogfood_ready: bounded_dogfood_required_ready == required.len(),
         bounded_dogfood_required_ready,
         bounded_dogfood_required_total: required.len(),
+        all_declared_command_surfaces_enabled: enabled_commands == inventory.commands.len(),
+        enabled_commands,
         full_git_replacement_ready: ready_commands == inventory.commands.len(),
         ready_commands,
         command_total: inventory.commands.len(),
@@ -139,7 +149,17 @@ pub fn run(json: bool) -> Result<()> {
         report.bounded_dogfood_required_total
     );
     println!(
-        "Full Git replacement ready: {} ({}/{})",
+        "All declared command surfaces enabled: {} ({}/{})",
+        if report.all_declared_command_surfaces_enabled {
+            "yes"
+        } else {
+            "no"
+        },
+        report.enabled_commands,
+        report.command_total
+    );
+    println!(
+        "Fully general Git replacement ready: {} ({}/{} general)",
         if report.full_git_replacement_ready {
             "yes"
         } else {
@@ -152,6 +172,7 @@ pub fn run(json: bool) -> Result<()> {
     for capability in report.commands {
         let status = match capability.status {
             CapabilityStatus::Ready => "READY",
+            CapabilityStatus::ReadyBounded => "BOUND",
             CapabilityStatus::OpenGate => "OPEN ",
         };
         let dogfood = if capability.required_for_bounded_dogfood {
@@ -181,6 +202,11 @@ mod tests {
                 CapabilityStatus::Ready => {
                     assert_eq!(capability.exposure, CapabilityExposure::Enabled)
                 }
+                CapabilityStatus::ReadyBounded => {
+                    assert_eq!(capability.exposure, CapabilityExposure::Enabled);
+                    assert!(!capability.acceptance_spec.is_empty());
+                    assert!(!capability.note.is_empty());
+                }
                 CapabilityStatus::OpenGate => {
                     assert_eq!(capability.exposure, CapabilityExposure::FailClosed);
                     assert!(!capability.acceptance_spec.is_empty());
@@ -194,7 +220,7 @@ mod tests {
     #[test]
     fn every_ready_capability_names_the_evidence_that_proves_it() {
         for capability in inventory().unwrap().commands {
-            if capability.status != CapabilityStatus::Ready {
+            if capability.status == CapabilityStatus::OpenGate {
                 continue;
             }
             assert!(

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -14,8 +14,8 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use kin_model::{
     AuthorId, Entity, EntityFilter, EntityId, EntityKind, EntityStore, FilePathId, GraphNodeId,
-    GraphStore, Hash256, OperationId, ParseCompleteness, Relation, RelationKind, RepoPath,
-    SourceSpan,
+    GraphStore, Hash256, LanguageId, OperationId, ParseCompleteness, Relation, RelationKind,
+    RepoPath, SourceSpan,
 };
 use serde::{Deserialize, Serialize};
 
@@ -104,6 +104,7 @@ pub async fn run(
     column: Option<u32>,
     json: bool,
 ) -> Result<()> {
+    validate_cursor(file.as_deref(), line, column)?;
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
@@ -146,13 +147,16 @@ pub fn plan_rename<F>(
 where
     F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
 {
+    validate_cursor(request.file.as_deref(), request.line, request.column)?;
     if !looks_like_identifier(&request.new_name) {
         bail!(
             "rename target '{}' is not a simple source identifier",
             request.new_name
         );
     }
-    let target = resolve_target(graph, request)?;
+    let tree = graph.resolved_tree();
+    let mut bodies = HashMap::<FilePathId, String>::new();
+    let target = resolve_target(graph, request, &tree, &mut bodies, &mut load_source)?;
     if target.name == request.new_name {
         bail!("rename target already has name '{}'", request.new_name);
     }
@@ -179,9 +183,13 @@ where
         );
     }
 
-    let tree = graph.resolved_tree();
-    let mut bodies = HashMap::<FilePathId, String>::new();
-    reject_unspanned_import_sites(graph, &target, &tree, &mut bodies, &mut load_source)?;
+    let source_languages = require_repository_reference_coverage(
+        graph,
+        &target,
+        &tree,
+        &mut bodies,
+        &mut load_source,
+    )?;
 
     let mut grouped: BTreeMap<EntityId, ReferenceGroup> = BTreeMap::new();
     let mut relation_ids = BTreeSet::new();
@@ -256,7 +264,7 @@ where
         }
         require_complete_layout(graph, file)?;
         let body = load_cached_body(&tree, file, &mut bodies, &mut load_source)?;
-        let occurrences = find_token_occurrences(body, &target.name, span)?;
+        let occurrences = find_token_occurrences(body, &target.name, span, group.entity.language)?;
         if occurrences.len() != group.expected {
             bail!(
                 "rename authority is incomplete for entity {} in {}: graph relations plus declaration require {} '{}' occurrence(s) inside the exact source span, but repository CAS contains {}; refusing a partial or over-broad edit",
@@ -310,6 +318,7 @@ where
     if edits.is_empty() {
         bail!("rename planner produced no exact edits");
     }
+    prove_repository_occurrence_accounting(graph, &target, &source_languages, &bodies, &edits)?;
 
     Ok(RenamePlan {
         entity_id: target.id,
@@ -322,13 +331,13 @@ where
     })
 }
 
-fn reject_unspanned_import_sites<F>(
+fn require_repository_reference_coverage<F>(
     graph: &kin_db::InMemoryGraph,
     target: &Entity,
     tree: &kin_model::ResolvedTree,
     bodies: &mut HashMap<FilePathId, String>,
     load_source: &mut F,
-) -> Result<()>
+) -> Result<HashMap<FilePathId, LanguageId>>
 where
     F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
 {
@@ -338,6 +347,29 @@ where
         .into_iter()
         .map(|layout| (layout.file_id.clone(), layout))
         .collect::<HashMap<_, _>>();
+    let snapshot = graph.to_snapshot();
+    let mut full_reference_coverage = HashSet::<String>::new();
+    let mut incomplete_reference_coverage = HashSet::<String>::new();
+    for relation in snapshot.relations.values() {
+        for evidence in &relation.evidence {
+            match evidence.parser_rule.as_deref() {
+                Some(kin_index::CALL_SHAPE_PARSE_COVERAGE_FULL_V1) => {
+                    if let Some(path) = evidence.source_path.as_ref() {
+                        full_reference_coverage.insert(path.clone());
+                    }
+                }
+                Some(
+                    kin_index::CALL_SHAPE_PARSE_COVERAGE_INCOMPLETE_V1
+                    | kin_index::CALL_SHAPE_EXTRACTION_COVERAGE_INCOMPLETE_V1,
+                ) => {
+                    if let Some(path) = evidence.source_path.as_ref() {
+                        incomplete_reference_coverage.insert(path.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
     // A missing layout is itself a graph-authority gap. Do not limit this
     // check to files that already expose an entity or relation: a source file
     // containing only a named import can still require a rename edit. Path
@@ -377,6 +409,7 @@ where
     // emitting an artifact import edge (for example a Python `from` import).
     // Reparse every graph-owned source body from the exact repository tree so
     // a named import can never be silently omitted from a rename plan.
+    let mut source_languages = HashMap::new();
     for layout in layouts.into_values() {
         let importer_file = layout.file_id;
         if layout.parse_completeness != ParseCompleteness::Full {
@@ -384,6 +417,18 @@ where
                 "graph source {} has {} parse coverage; repository-wide import rename coverage is unproven",
                 importer_file,
                 layout.parse_completeness.bucket()
+            );
+        }
+        if incomplete_reference_coverage.contains(&importer_file.0) {
+            bail!(
+                "graph source {} carries an explicit extraction-incomplete certificate; exhaustive rename-reference coverage is unproven",
+                importer_file
+            );
+        }
+        if !full_reference_coverage.contains(&importer_file.0) {
+            bail!(
+                "graph source {} has no positive versioned full-reference-coverage certificate; exhaustive rename-reference coverage is unproven",
+                importer_file
             );
         }
         let body = load_cached_body(tree, &importer_file, bodies, load_source)?;
@@ -407,6 +452,16 @@ where
                 indexed.file_layout.parse_completeness.bucket()
             );
         }
+        if indexed
+            .extracted_relations
+            .iter()
+            .any(kin_parser::is_call_extraction_incomplete_marker)
+        {
+            bail!(
+                "repository CAS source {} reparses with incomplete named-reference extraction; refusing a partial rename",
+                importer_file
+            );
+        }
         let imported_target = indexed.imports.iter().any(|import| {
             import.specifiers.iter().any(|specifier| {
                 specifier
@@ -423,8 +478,139 @@ where
                 target.name
             );
         }
+        source_languages.insert(importer_file, indexed.language);
+    }
+    Ok(source_languages)
+}
+
+/// Prove that every identifier-shaped occurrence of the selected spelling in
+/// every graph-owned source body is explained by either a declaration identity
+/// or a rename-relevant graph edge. This is deliberately repository-CAS
+/// accounting, never a working-tree search. It complements the graph's
+/// positive extraction certificate and makes comments, strings, hidden dynamic
+/// references, and unmodeled relation classes fail closed instead of being
+/// silently stranded.
+fn prove_repository_occurrence_accounting(
+    graph: &kin_db::InMemoryGraph,
+    target: &Entity,
+    source_languages: &HashMap<FilePathId, LanguageId>,
+    bodies: &HashMap<FilePathId, String>,
+    edits: &[RenameEdit],
+) -> Result<()> {
+    let snapshot = graph.to_snapshot();
+    let mut expected = HashMap::<EntityId, usize>::new();
+    for entity in snapshot.entities.values() {
+        if entity_leaf(&entity.name) == target.name {
+            expected.insert(entity.id, 1);
+        }
+    }
+    for relation in snapshot.relations.values() {
+        if !rename_reference_kind(relation.kind) {
+            continue;
+        }
+        let (Some(source_id), Some(target_id)) =
+            (relation.src.as_entity(), relation.dst.as_entity())
+        else {
+            continue;
+        };
+        let Some(relation_target) = snapshot.entities.get(&target_id) else {
+            bail!(
+                "rename relation {} points at missing graph entity {}",
+                relation.id,
+                target_id
+            );
+        };
+        if entity_leaf(&relation_target.name) != target.name {
+            continue;
+        }
+        let count = relation_occurrence_count(relation)?;
+        let entry = expected.entry(source_id).or_default();
+        *entry = entry
+            .checked_add(count)
+            .ok_or_else(|| anyhow::anyhow!("repository rename occurrence count overflow"))?;
+    }
+
+    let planned = edits
+        .iter()
+        .map(|edit| (edit.file.clone(), edit.start_byte, edit.end_byte))
+        .collect::<HashSet<_>>();
+    let mut observed = HashMap::<EntityId, usize>::new();
+    let mut observed_sites = HashSet::new();
+    for (file, language) in source_languages {
+        let body = bodies.get(file).ok_or_else(|| {
+            anyhow::anyhow!("rename coverage body for graph source {file} was not retained")
+        })?;
+        if body.is_empty() {
+            continue;
+        }
+        let whole_file = SourceSpan {
+            file: file.clone(),
+            start_byte: 0,
+            end_byte: body.len(),
+            start_line: 0,
+            start_col: 0,
+            end_line: 0,
+            end_col: 0,
+        };
+        let occurrences = find_token_occurrences(body, &target.name, &whole_file, *language)?;
+        let file_entities = snapshot
+            .entities
+            .values()
+            .filter(|entity| entity.file_origin.as_ref() == Some(file))
+            .filter_map(|entity| entity.span.as_ref().map(|span| (entity, span)))
+            .collect::<Vec<_>>();
+        for occurrence in occurrences {
+            let owner = file_entities
+                .iter()
+                .filter(|(_, span)| {
+                    span.start_byte <= occurrence.start_byte
+                        && occurrence.end_byte <= span.end_byte
+                })
+                .min_by_key(|(_, span)| span.end_byte.saturating_sub(span.start_byte))
+                .map(|(entity, _)| *entity)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "repository CAS contains unowned '{}' occurrence at {}:{}..{}; graph reference coverage is incomplete",
+                        target.name,
+                        file,
+                        occurrence.start_byte,
+                        occurrence.end_byte
+                    )
+                })?;
+            *observed.entry(owner.id).or_default() += 1;
+            observed_sites.insert((file.clone(), occurrence.start_byte, occurrence.end_byte));
+        }
+    }
+
+    for entity_id in expected
+        .keys()
+        .chain(observed.keys())
+        .copied()
+        .collect::<BTreeSet<_>>()
+    {
+        let expected_count = expected.get(&entity_id).copied().unwrap_or(0);
+        let observed_count = observed.get(&entity_id).copied().unwrap_or(0);
+        if expected_count != observed_count {
+            bail!(
+                "exhaustive rename-reference coverage disagrees for graph entity {}: graph declarations and edges require {} '{}' occurrence(s), but repository CAS assigns {}; refusing a partial refactor",
+                entity_id,
+                expected_count,
+                target.name,
+                observed_count
+            );
+        }
+    }
+    if !planned.is_subset(&observed_sites) {
+        bail!("rename plan contains an edit outside the exhaustive repository occurrence census");
     }
     Ok(())
+}
+
+fn entity_leaf(name: &str) -> &str {
+    name.rsplit_once("::")
+        .or_else(|| name.rsplit_once('.'))
+        .map(|(_, leaf)| leaf)
+        .unwrap_or(name)
 }
 
 struct ReferenceGroup {
@@ -521,13 +707,17 @@ where
         .expect("rename body was inserted before lookup"))
 }
 
-fn resolve_target(graph: &impl GraphStore, request: &RenameRequest) -> Result<Entity> {
-    let leaf = request
-        .symbol
-        .rsplit_once("::")
-        .or_else(|| request.symbol.rsplit_once('.'))
-        .map(|(_, leaf)| leaf)
-        .unwrap_or(&request.symbol);
+fn resolve_target<F>(
+    graph: &impl GraphStore,
+    request: &RenameRequest,
+    tree: &kin_model::ResolvedTree,
+    bodies: &mut HashMap<FilePathId, String>,
+    load_source: &mut F,
+) -> Result<Entity>
+where
+    F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
+{
+    let leaf = entity_leaf(&request.symbol);
     let mut matches = graph.query_entities(&EntityFilter {
         name_pattern: Some(leaf.to_string()),
         ..EntityFilter::default()
@@ -535,20 +725,9 @@ fn resolve_target(graph: &impl GraphStore, request: &RenameRequest) -> Result<En
     matches.retain(|entity| entity.name == request.symbol || entity.name == leaf);
     if let Some(file) = request.file.as_deref() {
         let normalized = normalize_repo_hint(file);
-        let at_file = matches
-            .iter()
-            .filter(|entity| {
-                entity
-                    .file_origin
-                    .as_ref()
-                    .is_some_and(|origin| origin.0 == normalized)
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        if !at_file.is_empty() {
-            matches = at_file;
-        } else if let Some(line) = request.line {
-            let containing = graph
+        if let Some(user_line) = request.line {
+            let graph_line = user_line - 1;
+            let mut containing = graph
                 .query_entities(&EntityFilter {
                     file_path: Some(FilePathId::new(normalized.clone())),
                     ..EntityFilter::default()
@@ -558,66 +737,104 @@ fn resolve_target(graph: &impl GraphStore, request: &RenameRequest) -> Result<En
                     entity
                         .span
                         .as_ref()
-                        .is_some_and(|span| span_contains(span, line, request.column))
+                        .is_some_and(|span| span_contains(span, graph_line, request.column))
                 })
-                .min_by_key(|entity| {
+                .collect::<Vec<_>>();
+            containing.sort_by_key(|entity| {
+                (
                     entity
                         .span
                         .as_ref()
                         .map(|span| span.end_byte.saturating_sub(span.start_byte))
-                        .unwrap_or(usize::MAX)
-                });
-            let containing = containing.ok_or_else(|| {
-                anyhow::anyhow!(
+                        .unwrap_or(usize::MAX),
+                    entity.id,
+                )
+            });
+            if containing.is_empty() {
+                bail!(
                     "no graph source entity contains {}:{}; rename file/line hint cannot be proven",
                     normalized,
-                    line
-                )
-            })?;
-            let targets = graph
-                .get_all_relations_for_entity(&containing.id)?
-                .into_iter()
-                .filter(|relation| {
-                    relation.src == GraphNodeId::Entity(containing.id)
-                        && rename_reference_kind(relation.kind)
-                })
-                .filter_map(|relation| relation.dst.as_entity())
-                .collect::<HashSet<_>>();
-            let related = matches
-                .iter()
-                .filter(|entity| targets.contains(&entity.id))
-                .cloned()
-                .collect::<Vec<_>>();
-            if related.is_empty() {
-                bail!(
-                    "entity '{}' is not graph-linked from {}:{}; rename file/line hint cannot be proven",
-                    request.symbol,
-                    normalized,
-                    line
+                    user_line
                 );
             }
-            matches = related;
+
+            // A same-named declaration is eligible only when the cursor is
+            // inside that declaration's own graph span. Never keep another
+            // declaration merely because it shares the file and spelling.
+            let containing_ids = containing
+                .iter()
+                .map(|entity| entity.id)
+                .collect::<HashSet<_>>();
+            let mut declarations = Vec::new();
+            for candidate in &matches {
+                if containing_ids.contains(&candidate.id)
+                    && cursor_hits_declaration(
+                        candidate,
+                        user_line,
+                        request.column,
+                        tree,
+                        bodies,
+                        load_source,
+                    )?
+                {
+                    declarations.push(candidate.clone());
+                }
+            }
+            if !declarations.is_empty() {
+                matches = declarations;
+            } else {
+                // Resolve from the smallest containing source entity first. If
+                // a nested scope has no applicable edge, move outward one
+                // owner at a time; never combine unrelated scope candidates.
+                let mut related = Vec::new();
+                for owner in containing {
+                    let targets = graph
+                        .get_all_relations_for_entity(&owner.id)?
+                        .into_iter()
+                        .filter(|relation| {
+                            relation.src == GraphNodeId::Entity(owner.id)
+                                && rename_reference_kind(relation.kind)
+                        })
+                        .filter_map(|relation| relation.dst.as_entity())
+                        .collect::<HashSet<_>>();
+                    related = matches
+                        .iter()
+                        .filter(|entity| targets.contains(&entity.id))
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    if !related.is_empty() {
+                        break;
+                    }
+                }
+                if related.is_empty() {
+                    bail!(
+                        "entity '{}' is not graph-linked from {}:{}; rename file/line hint cannot be proven",
+                        request.symbol,
+                        normalized,
+                        user_line
+                    );
+                }
+                matches = related;
+            }
         } else {
-            bail!(
-                "entity '{}' is not declared in graph file {}; provide a declaration file or a graph-linked --line cursor",
-                request.symbol,
-                normalized
-            );
-        }
-    }
-    if let Some(line) = request.line {
-        let containing = matches
-            .iter()
-            .filter(|entity| {
-                entity
-                    .span
-                    .as_ref()
-                    .is_some_and(|span| span_contains(span, line, request.column))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        if !containing.is_empty() {
-            matches = containing;
+            let declarations = matches
+                .iter()
+                .filter(|entity| {
+                    entity
+                        .file_origin
+                        .as_ref()
+                        .is_some_and(|origin| origin.0 == normalized)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if declarations.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "entity '{}' is not declared in graph file {}; provide a declaration file or a graph-linked --line cursor",
+                    request.symbol,
+                    normalized
+                ));
+            }
+            matches = declarations;
         }
     }
     matches.sort_by_key(|entity| {
@@ -648,7 +865,7 @@ fn resolve_target(graph: &impl GraphStore, request: &RenameRequest) -> Result<En
                         entity
                             .span
                             .as_ref()
-                            .map(|span| span.start_line)
+                            .map(|span| span.start_line + 1)
                             .unwrap_or(0)
                     )
                 })
@@ -661,6 +878,46 @@ fn resolve_target(graph: &impl GraphStore, request: &RenameRequest) -> Result<En
             )
         }
     }
+}
+
+fn cursor_hits_declaration<F>(
+    candidate: &Entity,
+    user_line: u32,
+    byte_column: Option<u32>,
+    tree: &kin_model::ResolvedTree,
+    bodies: &mut HashMap<FilePathId, String>,
+    load_source: &mut F,
+) -> Result<bool>
+where
+    F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
+{
+    let file = candidate.file_origin.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cursor declaration candidate {} has no graph source file",
+            candidate.id
+        )
+    })?;
+    let span = candidate.span.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "cursor declaration candidate {} has no graph source span",
+            candidate.id
+        )
+    })?;
+    let body = load_cached_body(tree, file, bodies, load_source)?;
+    let leaf = entity_leaf(&candidate.name);
+    let occurrences = find_token_occurrences(body, leaf, span, candidate.language)?;
+    let Some(declaration) = occurrences.first() else {
+        bail!(
+            "graph declaration {} named '{}' has no exact identifier token in its repository-CAS span",
+            candidate.id,
+            candidate.name
+        );
+    };
+    if declaration.start_line != user_line {
+        return Ok(false);
+    }
+    Ok(byte_column
+        .is_none_or(|column| declaration.start_col <= column && column < declaration.end_col))
 }
 
 fn reject_local_name_collision(
@@ -731,6 +988,7 @@ fn find_token_occurrences(
     content: &str,
     symbol: &str,
     span: &SourceSpan,
+    language: LanguageId,
 ) -> Result<Vec<TokenOccurrence>> {
     if span.start_byte >= span.end_byte || span.end_byte > content.len() {
         bail!(
@@ -757,7 +1015,7 @@ fn find_token_occurrences(
     for (relative, _) in content[span.start_byte..span.end_byte].match_indices(symbol) {
         let start = span.start_byte + relative;
         let end = start + symbol.len();
-        if !is_symbol_boundary(content, start, symbol.len()) {
+        if !is_symbol_boundary(content, start, symbol.len(), language) {
             continue;
         }
         let line_index = line_starts.partition_point(|line_start| *line_start <= start) - 1;
@@ -776,20 +1034,27 @@ fn find_token_occurrences(
     Ok(occurrences)
 }
 
-fn is_symbol_boundary(content: &str, start: usize, symbol_len: usize) -> bool {
+fn is_symbol_boundary(
+    content: &str,
+    start: usize,
+    symbol_len: usize,
+    language: LanguageId,
+) -> bool {
     let before = content[..start].chars().next_back();
     let after = content[start + symbol_len..].chars().next();
-    before.is_none_or(|character| !is_identifier_char(character))
-        && after.is_none_or(|character| !is_identifier_char(character))
+    before.is_none_or(|character| !is_identifier_continue(language, character))
+        && after.is_none_or(|character| !is_identifier_continue(language, character))
 }
 
-fn span_contains(span: &SourceSpan, line: u32, column: Option<u32>) -> bool {
-    if line < span.start_line || line > span.end_line {
+fn span_contains(span: &SourceSpan, graph_line: u32, byte_column: Option<u32>) -> bool {
+    if graph_line < span.start_line || graph_line > span.end_line {
         return false;
     }
-    let Some(column) = column else { return true };
-    (line != span.start_line || column >= span.start_col)
-        && (line != span.end_line || column <= span.end_col)
+    let Some(byte_column) = byte_column else {
+        return graph_line < span.end_line || span.end_col > 0;
+    };
+    (graph_line > span.start_line || byte_column >= span.start_col)
+        && (graph_line < span.end_line || byte_column < span.end_col)
 }
 
 fn looks_like_identifier(candidate: &str) -> bool {
@@ -798,11 +1063,29 @@ fn looks_like_identifier(candidate: &str) -> bool {
         return false;
     };
     (first.is_ascii_alphabetic() || matches!(first, '_' | '$'))
-        && characters.all(is_identifier_char)
+        && characters.all(|character| is_identifier_continue(LanguageId::TypeScript, character))
 }
 
-fn is_identifier_char(character: char) -> bool {
-    character.is_ascii_alphanumeric() || matches!(character, '_' | '$')
+fn is_identifier_continue(_language: LanguageId, character: char) -> bool {
+    // Unicode XID is the common safe core across the supported language
+    // families. The extras are a conservative superset used only as a
+    // boundary refusal: accepting too much here can reject a rename, while
+    // accepting too little can splice an ASCII leaf out of a larger identifier.
+    unicode_ident::is_xid_continue(character)
+        || matches!(character, '_' | '$' | '\u{200c}' | '\u{200d}' | '?' | '!')
+}
+
+fn validate_cursor(file: Option<&str>, line: Option<u32>, column: Option<u32>) -> Result<()> {
+    if line == Some(0) {
+        bail!("--line is 1-based and must be greater than zero");
+    }
+    if column.is_some() && line.is_none() {
+        bail!("--column requires --line and is measured in 0-based UTF-8 bytes");
+    }
+    if line.is_some() && file.is_none() {
+        bail!("--line requires --file so the cursor coordinate has one graph source domain");
+    }
+    Ok(())
 }
 
 fn normalize_file_hint(layout: &kin_core::KinLayout, hint: &str) -> String {
@@ -842,7 +1125,8 @@ mod tests {
             end_line: 1,
             end_col: source.len() as u32,
         };
-        let occurrences = find_token_occurrences(source, "target", &span).unwrap();
+        let occurrences =
+            find_token_occurrences(source, "target", &span, LanguageId::Rust).unwrap();
         assert_eq!(occurrences.len(), 2);
         assert_eq!(
             &source[occurrences[0].start_byte..occurrences[0].end_byte],
@@ -852,6 +1136,47 @@ mod tests {
             &source[occurrences[1].start_byte..occurrences[1].end_byte],
             "target"
         );
+    }
+
+    #[test]
+    fn unicode_identifier_neighbors_are_not_ascii_token_boundaries() {
+        let file = FilePathId::new("caller.py");
+        let source = "def caller():\n    return éfoo() + fooé()\n";
+        let span = SourceSpan {
+            file,
+            start_byte: 0,
+            end_byte: source.len(),
+            start_line: 0,
+            start_col: 0,
+            end_line: 1,
+            end_col: 31,
+        };
+        assert!(
+            find_token_occurrences(source, "foo", &span, LanguageId::Python)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn cursor_coordinates_are_one_based_lines_and_exclusive_byte_columns() {
+        assert!(validate_cursor(Some("src/lib.rs"), Some(1), Some(0)).is_ok());
+        assert!(validate_cursor(Some("src/lib.rs"), Some(0), None).is_err());
+        assert!(validate_cursor(Some("src/lib.rs"), None, Some(0)).is_err());
+        assert!(validate_cursor(None, Some(1), None).is_err());
+
+        let span = SourceSpan {
+            file: FilePathId::new("src/lib.rs"),
+            start_byte: 2,
+            end_byte: 8,
+            start_line: 0,
+            start_col: 2,
+            end_line: 0,
+            end_col: 8,
+        };
+        assert!(span_contains(&span, 0, Some(2)));
+        assert!(span_contains(&span, 0, Some(7)));
+        assert!(!span_contains(&span, 0, Some(8)));
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -1,16 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Repository-v6 rename protocol boundary.
+//! Wire contract and graph-authoritative planner for repository-v6 rename.
 //!
-//! The legacy planner read source from `.kin/objects` and the working
-//! directory. Keep the wire contract available to daemon clients while the
-//! graph/CAS planner is rebuilt, but never answer through that retired path.
+//! Planning consumes only an exact repository graph and immutable source
+//! bodies supplied by the caller. The CLI never reads a working file. The
+//! daemon owns application because it is the only process that can hold the
+//! repository compare-and-swap and the projection journal together.
 
-use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use kin_model::{
+    AuthorId, Entity, EntityFilter, EntityId, EntityKind, EntityStore, FilePathId, GraphNodeId,
+    GraphStore, Hash256, OperationId, ParseCompleteness, Relation, RelationKind, RepoPath,
+    SourceSpan,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RenameRequest {
     pub symbol: String,
     pub new_name: String,
@@ -22,6 +32,60 @@ pub struct RenameRequest {
     pub column: Option<u32>,
     #[serde(default)]
     pub json: bool,
+    pub operation_id: OperationId,
+    pub actor: AuthorId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RenameEdit {
+    pub file: FilePathId,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    #[serde(rename = "startLine")]
+    pub start_line: u32,
+    #[serde(rename = "startCol")]
+    pub start_col: u32,
+    #[serde(rename = "endLine")]
+    pub end_line: u32,
+    #[serde(rename = "endCol")]
+    pub end_col: u32,
+    #[serde(rename = "oldText")]
+    pub old_text: String,
+    #[serde(rename = "newText")]
+    pub new_text: String,
+    pub reason: String,
+    /// The one occurrence that names the declaration whose graph identity is
+    /// retained across the reparse.
+    #[serde(default)]
+    pub declaration: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RenamePlan {
+    pub entity_id: EntityId,
+    pub entity_kind: EntityKind,
+    pub old_name: String,
+    pub new_name: String,
+    pub declaration_file: FilePathId,
+    pub edits: Vec<RenameEdit>,
+    pub relation_ids: Vec<kin_model::RelationId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RenameReport {
+    pub authority: String,
+    pub operation_id: OperationId,
+    pub change_id: kin_model::SemanticChangeId,
+    pub authority_generation: u64,
+    pub entity_id: EntityId,
+    pub old_name: String,
+    pub new_name: String,
+    pub edited_files: Vec<FilePathId>,
+    pub edit_count: usize,
+    pub idempotent: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,142 +93,786 @@ pub struct RenameResponse {
     #[serde(default)]
     pub lines: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub json: Option<String>,
-}
-
-/// What a caller can reach today, named at the point the gate refuses.
-///
-/// The gate text states the two acceptance conditions, which says what Kin
-/// cannot do without saying what it can. Every reference a rename would have to
-/// touch is already a graph answer, so the refusal points at it.
-pub fn available_today(symbol: &str) -> Vec<String> {
-    vec![
-        format!("`kin refs {symbol}` lists every reference the graph holds for this symbol."),
-        format!("`kin locate {symbol}` finds the declaration to edit."),
-        "Editing and committing by hand keeps graph truth exact; the gate is the planner and the \
-         single-transaction apply, not the rename itself."
-            .to_string(),
-    ]
-}
-
-/// The gate refusal with the reachable surfaces appended.
-///
-/// Both the CLI and the daemon path answer with this, so the agent-facing
-/// refusal carries the same guidance a person gets at the terminal. The `Ok`
-/// arm is the tripwire for a fixture that flips `rename` to ready without an
-/// executor behind it.
-fn refusal_with_guidance(symbol: &str) -> anyhow::Error {
-    let refusal = match super::capabilities::require_ready("rename") {
-        Ok(()) => unreachable!("a ready rename capability must replace the fail-closed executor"),
-        Err(refusal) => refusal,
-    };
-    let mut message = refusal.to_string();
-    message.push_str("\nwhat works today:");
-    for line in available_today(symbol) {
-        message.push_str("\n  - ");
-        message.push_str(&line);
-    }
-    anyhow::anyhow!(message)
+    pub report: Option<RenameReport>,
 }
 
 pub async fn run(
     symbol: String,
-    _new_name: String,
-    _file: Option<String>,
-    _line: Option<u32>,
-    _column: Option<u32>,
-    _json: bool,
+    new_name: String,
+    file: Option<String>,
+    line: Option<u32>,
+    column: Option<u32>,
+    json: bool,
 ) -> Result<()> {
-    Err(refusal_with_guidance(&symbol))
+    let layout = crate::commands::require_repository_layout()?;
+    let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!("Kin daemon is required for rename but no daemon endpoint is available")
+        })?;
+    let request = RenameRequest {
+        symbol,
+        new_name,
+        file: file.map(|hint| normalize_file_hint(&layout, &hint)),
+        line,
+        column,
+        json,
+        operation_id: OperationId::new(),
+        actor: AuthorId::new(kin_core::whoami()),
+    };
+    let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
+    let response = daemon.rename(&request).await?;
+    if json {
+        let report = response
+            .report
+            .ok_or_else(|| anyhow::anyhow!("daemon rename response omitted its report"))?;
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        for line in response.lines {
+            println!("{line}");
+        }
+    }
+    Ok(())
 }
 
-pub fn build_rename_response(
-    _layout: &kin_core::KinLayout,
-    _graph: &kin_db::InMemoryGraph,
+/// Build one complete rename plan from graph relations and immutable source
+/// bodies. `load_source` must resolve the exact digest named by `graph` from
+/// repository-owned CAS; a missing body is a hard authority gap.
+pub fn plan_rename<F>(
+    graph: &kin_db::InMemoryGraph,
     request: &RenameRequest,
-) -> Result<RenameResponse> {
-    Err(refusal_with_guidance(&request.symbol))
+    mut load_source: F,
+) -> Result<RenamePlan>
+where
+    F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
+{
+    if !looks_like_identifier(&request.new_name) {
+        bail!(
+            "rename target '{}' is not a simple source identifier",
+            request.new_name
+        );
+    }
+    let target = resolve_target(graph, request)?;
+    if target.name == request.new_name {
+        bail!("rename target already has name '{}'", request.new_name);
+    }
+    reject_local_name_collision(graph, &target, &request.new_name)?;
+
+    let declaration_file = target.file_origin.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "entity {} has no exact source origin; graph-only entities cannot be renamed",
+            target.id
+        )
+    })?;
+    let declaration_span = target.span.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "entity {} has no exact source span; rename cannot anchor its declaration",
+            target.id
+        )
+    })?;
+    if declaration_span.file != declaration_file {
+        bail!(
+            "entity {} source span file {} disagrees with origin {}",
+            target.id,
+            declaration_span.file,
+            declaration_file
+        );
+    }
+
+    let tree = graph.resolved_tree();
+    let mut bodies = HashMap::<FilePathId, String>::new();
+    reject_unspanned_import_sites(graph, &target, &tree, &mut bodies, &mut load_source)?;
+
+    let mut grouped: BTreeMap<EntityId, ReferenceGroup> = BTreeMap::new();
+    let mut relation_ids = BTreeSet::new();
+    for relation in graph.get_all_relations_for_entity(&target.id)? {
+        if relation.dst != GraphNodeId::Entity(target.id) || !rename_reference_kind(relation.kind) {
+            continue;
+        }
+        let source_id = relation.src.as_entity().ok_or_else(|| {
+            anyhow::anyhow!(
+                "rename relation {} ({:?}) reaches target {} from non-entity {}; exact source site is unavailable",
+                relation.id,
+                relation.kind,
+                target.id,
+                relation.src
+            )
+        })?;
+        let source = graph.get_entity(&source_id)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "rename relation {} names missing source entity {}",
+                relation.id,
+                source_id
+            )
+        })?;
+        let expected = relation_occurrence_count(&relation)?;
+        let group = grouped
+            .entry(source_id)
+            .or_insert_with(|| ReferenceGroup::new(source));
+        group.expected = group
+            .expected
+            .checked_add(expected)
+            .ok_or_else(|| anyhow::anyhow!("rename reference occurrence count overflow"))?;
+        group
+            .kinds
+            .insert(format!("{:?}", relation.kind).to_ascii_lowercase());
+        group.relation_ids.insert(relation.id);
+        relation_ids.insert(relation.id);
+    }
+
+    // The declaration is an independently required occurrence. If the target
+    // recursively references itself, the relation count adds those sites.
+    let declaration_group = grouped
+        .entry(target.id)
+        .or_insert_with(|| ReferenceGroup::new(target.clone()));
+    declaration_group.expected = declaration_group
+        .expected
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("rename occurrence count overflow"))?;
+    declaration_group.declaration = true;
+
+    let mut edits = Vec::new();
+    let mut seen = HashMap::new();
+    for group in grouped.values() {
+        let file = group.entity.file_origin.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "graph-linked rename source entity {} has no exact file origin",
+                group.entity.id
+            )
+        })?;
+        let span = group.entity.span.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "graph-linked rename source entity {} has no exact source span",
+                group.entity.id
+            )
+        })?;
+        if span.file != *file {
+            bail!(
+                "graph-linked rename source entity {} span file {} disagrees with origin {}",
+                group.entity.id,
+                span.file,
+                file
+            );
+        }
+        require_complete_layout(graph, file)?;
+        let body = load_cached_body(&tree, file, &mut bodies, &mut load_source)?;
+        let occurrences = find_token_occurrences(body, &target.name, span)?;
+        if occurrences.len() != group.expected {
+            bail!(
+                "rename authority is incomplete for entity {} in {}: graph relations plus declaration require {} '{}' occurrence(s) inside the exact source span, but repository CAS contains {}; refusing a partial or over-broad edit",
+                group.entity.id,
+                file,
+                group.expected,
+                target.name,
+                occurrences.len()
+            );
+        }
+        let reason = if group.declaration && group.kinds.is_empty() {
+            "declaration".to_string()
+        } else if group.declaration {
+            format!("declaration+{}", relation_reason(&group.kinds))
+        } else {
+            relation_reason(&group.kinds)
+        };
+        for (occurrence_index, occurrence) in occurrences.into_iter().enumerate() {
+            let key = (file.clone(), occurrence.start_byte, occurrence.end_byte);
+            if let Some(other_entity) = seen.insert(key, group.entity.id) {
+                bail!(
+                    "rename occurrence {}:{}..{} is claimed by overlapping graph source entities {} and {}; refusing to count one token as two relation sites",
+                    file,
+                    occurrence.start_byte,
+                    occurrence.end_byte,
+                    other_entity,
+                    group.entity.id
+                );
+            }
+            edits.push(RenameEdit {
+                file: file.clone(),
+                start_byte: occurrence.start_byte,
+                end_byte: occurrence.end_byte,
+                start_line: occurrence.start_line,
+                start_col: occurrence.start_col,
+                end_line: occurrence.end_line,
+                end_col: occurrence.end_col,
+                old_text: target.name.clone(),
+                new_text: request.new_name.clone(),
+                reason: reason.clone(),
+                declaration: group.declaration && occurrence_index == 0,
+            });
+        }
+    }
+    edits.sort_by(|left, right| {
+        left.file
+            .0
+            .cmp(&right.file.0)
+            .then(left.start_byte.cmp(&right.start_byte))
+    });
+    if edits.is_empty() {
+        bail!("rename planner produced no exact edits");
+    }
+
+    Ok(RenamePlan {
+        entity_id: target.id,
+        entity_kind: target.kind,
+        old_name: target.name,
+        new_name: request.new_name.clone(),
+        declaration_file,
+        edits,
+        relation_ids: relation_ids.into_iter().collect(),
+    })
+}
+
+fn reject_unspanned_import_sites<F>(
+    graph: &kin_db::InMemoryGraph,
+    target: &Entity,
+    tree: &kin_model::ResolvedTree,
+    bodies: &mut HashMap<FilePathId, String>,
+    load_source: &mut F,
+) -> Result<()>
+where
+    F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
+{
+    let pipeline = kin_index::IndexPipeline::new();
+    let layouts = graph
+        .list_file_layouts()?
+        .into_iter()
+        .map(|layout| (layout.file_id.clone(), layout))
+        .collect::<HashMap<_, _>>();
+    // A missing layout is itself a graph-authority gap. Do not limit this
+    // check to files that already expose an entity or relation: a source file
+    // containing only a named import can still require a rename edit. Path
+    // classification is routing metadata over the graph-owned tree, not a
+    // filesystem answer or content fallback.
+    for artifact in tree.artifacts_by_path() {
+        if artifact.entry.blob_identity().is_none() {
+            continue;
+        }
+        let Some(path) = artifact.path.as_utf8() else {
+            bail!(
+                "repository tree contains a non-UTF-8 blob path; repository-wide rename coverage is unproven"
+            );
+        };
+        match kin_index::FileClassifier::classify(Path::new(path)) {
+            kin_index::FileClassification::EntitySource => {
+                let file = FilePathId::new(path);
+                if !layouts.contains_key(&file) {
+                    bail!(
+                        "repository source {} has no graph-owned file layout; repository-wide rename coverage is unproven",
+                        file
+                    );
+                }
+            }
+            kin_index::FileClassification::ShallowSyntax { .. } => {
+                bail!(
+                    "repository source {} has only shallow syntax coverage; exact rename coverage is unproven",
+                    path
+                );
+            }
+            kin_index::FileClassification::StructuredArtifact(_)
+            | kin_index::FileClassification::OpaqueArtifact { .. } => {}
+        }
+    }
+    // Artifact-level import edges are intentionally not the sole coverage
+    // authority here. Some supported linkers resolve entity edges without
+    // emitting an artifact import edge (for example a Python `from` import).
+    // Reparse every graph-owned source body from the exact repository tree so
+    // a named import can never be silently omitted from a rename plan.
+    for layout in layouts.into_values() {
+        let importer_file = layout.file_id;
+        if layout.parse_completeness != ParseCompleteness::Full {
+            bail!(
+                "graph source {} has {} parse coverage; repository-wide import rename coverage is unproven",
+                importer_file,
+                layout.parse_completeness.bucket()
+            );
+        }
+        let body = load_cached_body(tree, &importer_file, bodies, load_source)?;
+        let indexed = pipeline
+            .index_any_content(
+                &importer_file,
+                body.as_bytes(),
+                kin_blobs::digest(body.as_bytes()),
+            )
+            .with_context(|| format!("reparse graph-linked importer {importer_file}"))?;
+        let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
+            bail!(
+                "graph source {} is not fully classifiable as entity source; rename import coverage is unproven",
+                importer_file
+            );
+        };
+        if indexed.file_layout.parse_completeness != ParseCompleteness::Full {
+            bail!(
+                "graph source {} reparsed with {} coverage; rename import coverage is unproven",
+                importer_file,
+                indexed.file_layout.parse_completeness.bucket()
+            );
+        }
+        let imported_target = indexed.imports.iter().any(|import| {
+            import.specifiers.iter().any(|specifier| {
+                specifier
+                    .original_name
+                    .as_deref()
+                    .unwrap_or(&specifier.local_name)
+                    == target.name
+            })
+        });
+        if imported_target {
+            bail!(
+                "{} imports '{}', but graph import evidence has no exact source span; refusing to skip or guess at that edit site",
+                importer_file,
+                target.name
+            );
+        }
+    }
+    Ok(())
+}
+
+struct ReferenceGroup {
+    entity: Entity,
+    expected: usize,
+    kinds: BTreeSet<String>,
+    relation_ids: BTreeSet<kin_model::RelationId>,
+    declaration: bool,
+}
+
+impl ReferenceGroup {
+    fn new(entity: Entity) -> Self {
+        Self {
+            entity,
+            expected: 0,
+            kinds: BTreeSet::new(),
+            relation_ids: BTreeSet::new(),
+            declaration: false,
+        }
+    }
+}
+
+fn relation_occurrence_count(relation: &Relation) -> Result<usize> {
+    if relation.evidence.is_empty() {
+        return Ok(1);
+    }
+    relation
+        .evidence
+        .iter()
+        .try_fold(0_usize, |total, evidence| {
+            let count = usize::try_from(evidence.occurrence_count)
+                .context("rename relation occurrence count does not fit usize")?;
+            if count == 0 {
+                bail!(
+                    "rename relation {} carries a zero occurrence evidence record",
+                    relation.id
+                );
+            }
+            total
+                .checked_add(count)
+                .ok_or_else(|| anyhow::anyhow!("rename relation occurrence count overflow"))
+        })
+}
+
+fn require_complete_layout(graph: &impl GraphStore, file: &FilePathId) -> Result<()> {
+    let layout = graph.get_file_layout(file)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "rename source {} has no graph-owned file layout; exact token coverage is unproven",
+            file
+        )
+    })?;
+    if layout.parse_completeness != ParseCompleteness::Full {
+        bail!(
+            "rename source {} has {} parse coverage; full graph coverage is required",
+            file,
+            layout.parse_completeness.bucket()
+        );
+    }
+    Ok(())
+}
+
+fn load_cached_body<'a, F>(
+    tree: &kin_model::ResolvedTree,
+    file: &FilePathId,
+    bodies: &'a mut HashMap<FilePathId, String>,
+    load_source: &mut F,
+) -> Result<&'a str>
+where
+    F: FnMut(&RepoPath, Hash256) -> Result<Vec<u8>>,
+{
+    if !bodies.contains_key(file) {
+        let path = RepoPath::from_utf8(file.0.clone())
+            .with_context(|| format!("rename source {file} is not a valid repository path"))?;
+        let artifact = tree.artifact_at_path(&path).ok_or_else(|| {
+            anyhow::anyhow!("rename source {file} is absent from the exact workspace tree")
+        })?;
+        let hash = artifact.entry.blob_identity().ok_or_else(|| {
+            anyhow::anyhow!("rename source {file} is not an immutable source blob")
+        })?;
+        let bytes = load_source(&path, hash).with_context(|| {
+            format!("load repository-v6 source CAS body {hash} for rename source {file}")
+        })?;
+        if kin_blobs::digest_bytes(&bytes) != *hash.as_bytes() {
+            bail!(
+                "repository-v6 source CAS returned bytes with the wrong digest for {file}: expected {hash}"
+            );
+        }
+        let content = String::from_utf8(bytes)
+            .with_context(|| format!("rename source {file} is not valid UTF-8"))?;
+        bodies.insert(file.clone(), content);
+    }
+    Ok(bodies
+        .get(file)
+        .expect("rename body was inserted before lookup"))
+}
+
+fn resolve_target(graph: &impl GraphStore, request: &RenameRequest) -> Result<Entity> {
+    let leaf = request
+        .symbol
+        .rsplit_once("::")
+        .or_else(|| request.symbol.rsplit_once('.'))
+        .map(|(_, leaf)| leaf)
+        .unwrap_or(&request.symbol);
+    let mut matches = graph.query_entities(&EntityFilter {
+        name_pattern: Some(leaf.to_string()),
+        ..EntityFilter::default()
+    })?;
+    matches.retain(|entity| entity.name == request.symbol || entity.name == leaf);
+    if let Some(file) = request.file.as_deref() {
+        let normalized = normalize_repo_hint(file);
+        let at_file = matches
+            .iter()
+            .filter(|entity| {
+                entity
+                    .file_origin
+                    .as_ref()
+                    .is_some_and(|origin| origin.0 == normalized)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if !at_file.is_empty() {
+            matches = at_file;
+        } else if let Some(line) = request.line {
+            let containing = graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(FilePathId::new(normalized.clone())),
+                    ..EntityFilter::default()
+                })?
+                .into_iter()
+                .filter(|entity| {
+                    entity
+                        .span
+                        .as_ref()
+                        .is_some_and(|span| span_contains(span, line, request.column))
+                })
+                .min_by_key(|entity| {
+                    entity
+                        .span
+                        .as_ref()
+                        .map(|span| span.end_byte.saturating_sub(span.start_byte))
+                        .unwrap_or(usize::MAX)
+                });
+            let containing = containing.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no graph source entity contains {}:{}; rename file/line hint cannot be proven",
+                    normalized,
+                    line
+                )
+            })?;
+            let targets = graph
+                .get_all_relations_for_entity(&containing.id)?
+                .into_iter()
+                .filter(|relation| {
+                    relation.src == GraphNodeId::Entity(containing.id)
+                        && rename_reference_kind(relation.kind)
+                })
+                .filter_map(|relation| relation.dst.as_entity())
+                .collect::<HashSet<_>>();
+            let related = matches
+                .iter()
+                .filter(|entity| targets.contains(&entity.id))
+                .cloned()
+                .collect::<Vec<_>>();
+            if related.is_empty() {
+                bail!(
+                    "entity '{}' is not graph-linked from {}:{}; rename file/line hint cannot be proven",
+                    request.symbol,
+                    normalized,
+                    line
+                );
+            }
+            matches = related;
+        } else {
+            bail!(
+                "entity '{}' is not declared in graph file {}; provide a declaration file or a graph-linked --line cursor",
+                request.symbol,
+                normalized
+            );
+        }
+    }
+    if let Some(line) = request.line {
+        let containing = matches
+            .iter()
+            .filter(|entity| {
+                entity
+                    .span
+                    .as_ref()
+                    .is_some_and(|span| span_contains(span, line, request.column))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if !containing.is_empty() {
+            matches = containing;
+        }
+    }
+    matches.sort_by_key(|entity| {
+        (
+            entity.file_origin.as_ref().map(|file| file.0.clone()),
+            entity.span.as_ref().map(|span| span.start_byte),
+            entity.id,
+        )
+    });
+    matches.dedup_by_key(|entity| entity.id);
+    match matches.as_slice() {
+        [] => bail!(
+            "entity '{}' not found in repository-v6 graph authority",
+            request.symbol
+        ),
+        [target] => Ok(target.clone()),
+        candidates => {
+            let choices = candidates
+                .iter()
+                .map(|entity| {
+                    format!(
+                        "{}:{}",
+                        entity
+                            .file_origin
+                            .as_ref()
+                            .map(|file| file.0.as_str())
+                            .unwrap_or("<graph-only>"),
+                        entity
+                            .span
+                            .as_ref()
+                            .map(|span| span.start_line)
+                            .unwrap_or(0)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "entity '{}' is ambiguous across {} graph identities ({choices}); provide --file and --line",
+                request.symbol,
+                candidates.len()
+            )
+        }
+    }
+}
+
+fn reject_local_name_collision(
+    graph: &impl GraphStore,
+    target: &Entity,
+    new_name: &str,
+) -> Result<()> {
+    let collisions = graph.query_entities(&EntityFilter {
+        name_pattern: Some(new_name.to_string()),
+        ..EntityFilter::default()
+    })?;
+    if let Some(collision) = collisions.into_iter().find(|entity| {
+        entity.id != target.id && entity.name == new_name && entity.kind == target.kind
+    }) {
+        bail!(
+            "rename would collide with graph entity {} named '{}' in {}; cross-file namespace equivalence is unproven",
+            collision.id,
+            new_name,
+            collision
+                .file_origin
+                .as_ref()
+                .map(|file| file.0.as_str())
+                .unwrap_or("<graph-only>")
+        );
+    }
+    Ok(())
+}
+
+fn rename_reference_kind(kind: RelationKind) -> bool {
+    matches!(
+        kind,
+        RelationKind::Extends
+            | RelationKind::Implements
+            | RelationKind::Overrides
+            | RelationKind::Calls
+            | RelationKind::Instantiates
+            | RelationKind::References
+            | RelationKind::UsesMacro
+            | RelationKind::UsesType
+            | RelationKind::Imports
+            | RelationKind::EmitsEvent
+            | RelationKind::SubscribesTo
+            | RelationKind::DefinesContract
+            | RelationKind::ConsumesContract
+            | RelationKind::SendsMessage
+            | RelationKind::Spawns
+            | RelationKind::Tests
+            | RelationKind::Covers
+    )
+}
+
+fn relation_reason(kinds: &BTreeSet<String>) -> String {
+    let labels = kinds.iter().cloned().collect::<Vec<_>>().join("+");
+    format!("graph-reference:{labels}")
+}
+
+#[derive(Clone, Copy)]
+struct TokenOccurrence {
+    start_byte: usize,
+    end_byte: usize,
+    start_line: u32,
+    start_col: u32,
+    end_line: u32,
+    end_col: u32,
+}
+
+fn find_token_occurrences(
+    content: &str,
+    symbol: &str,
+    span: &SourceSpan,
+) -> Result<Vec<TokenOccurrence>> {
+    if span.start_byte >= span.end_byte || span.end_byte > content.len() {
+        bail!(
+            "graph source span {}..{} for {} is outside its {}-byte repository CAS body",
+            span.start_byte,
+            span.end_byte,
+            span.file,
+            content.len()
+        );
+    }
+    if !content.is_char_boundary(span.start_byte) || !content.is_char_boundary(span.end_byte) {
+        bail!(
+            "graph source span for {} is not on UTF-8 boundaries",
+            span.file
+        );
+    }
+    let mut line_starts = vec![0_usize];
+    for (index, byte) in content.bytes().enumerate() {
+        if byte == b'\n' {
+            line_starts.push(index + 1);
+        }
+    }
+    let mut occurrences = Vec::new();
+    for (relative, _) in content[span.start_byte..span.end_byte].match_indices(symbol) {
+        let start = span.start_byte + relative;
+        let end = start + symbol.len();
+        if !is_symbol_boundary(content, start, symbol.len()) {
+            continue;
+        }
+        let line_index = line_starts.partition_point(|line_start| *line_start <= start) - 1;
+        let line_start = line_starts[line_index];
+        let end_line_index = line_starts.partition_point(|line_start| *line_start <= end) - 1;
+        let end_line_start = line_starts[end_line_index];
+        occurrences.push(TokenOccurrence {
+            start_byte: start,
+            end_byte: end,
+            start_line: u32::try_from(line_index + 1).context("source line exceeds u32")?,
+            start_col: u32::try_from(start - line_start).context("source column exceeds u32")?,
+            end_line: u32::try_from(end_line_index + 1).context("source line exceeds u32")?,
+            end_col: u32::try_from(end - end_line_start).context("source column exceeds u32")?,
+        });
+    }
+    Ok(occurrences)
+}
+
+fn is_symbol_boundary(content: &str, start: usize, symbol_len: usize) -> bool {
+    let before = content[..start].chars().next_back();
+    let after = content[start + symbol_len..].chars().next();
+    before.is_none_or(|character| !is_identifier_char(character))
+        && after.is_none_or(|character| !is_identifier_char(character))
+}
+
+fn span_contains(span: &SourceSpan, line: u32, column: Option<u32>) -> bool {
+    if line < span.start_line || line > span.end_line {
+        return false;
+    }
+    let Some(column) = column else { return true };
+    (line != span.start_line || column >= span.start_col)
+        && (line != span.end_line || column <= span.end_col)
+}
+
+fn looks_like_identifier(candidate: &str) -> bool {
+    let mut characters = candidate.chars();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || matches!(first, '_' | '$'))
+        && characters.all(is_identifier_char)
+}
+
+fn is_identifier_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '$')
+}
+
+fn normalize_file_hint(layout: &kin_core::KinLayout, hint: &str) -> String {
+    let normalized = hint.replace('\\', "/");
+    let path = std::path::Path::new(&normalized);
+    if path.is_absolute() {
+        if let Ok(relative) = path.strip_prefix(layout.working_dir()) {
+            return relative.to_string_lossy().replace('\\', "/");
+        }
+    }
+    normalize_repo_hint(&normalized)
+}
+
+fn normalize_repo_hint(hint: &str) -> String {
+    let normalized = hint.replace('\\', "/");
+    let relative = normalized.trim_start_matches("./");
+    relative
+        .strip_prefix(".kin/source-root/")
+        .unwrap_or(relative)
+        .to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A gate that only states what is missing leaves a first-time caller with
-    /// nowhere to go. The refusal has to name a command that works now.
     #[test]
-    fn refusal_guidance_names_the_reachable_surfaces() {
-        let lines = available_today("parse_config").join("\n");
-        assert!(
-            lines.contains("kin refs parse_config"),
-            "guidance must name the reference surface for the symbol asked about: {lines}"
+    fn token_occurrences_are_byte_exact_and_identifier_bounded() {
+        let file = FilePathId::new("src/lib.rs");
+        let source = "fn target() { target(); target_extra(); }\n";
+        let span = SourceSpan {
+            file,
+            start_byte: 0,
+            end_byte: source.len(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: source.len() as u32,
+        };
+        let occurrences = find_token_occurrences(source, "target", &span).unwrap();
+        assert_eq!(occurrences.len(), 2);
+        assert_eq!(
+            &source[occurrences[0].start_byte..occurrences[0].end_byte],
+            "target"
         );
-        assert!(
-            lines.contains("kin locate parse_config"),
-            "guidance must name the declaration surface: {lines}"
+        assert_eq!(
+            &source[occurrences[1].start_byte..occurrences[1].end_byte],
+            "target"
         );
     }
 
-    fn rename_request(symbol: &str) -> RenameRequest {
-        RenameRequest {
-            symbol: symbol.to_string(),
-            new_name: "parse_settings".to_string(),
-            file: None,
-            line: None,
-            column: None,
-            json: false,
-        }
-    }
-
-    /// The daemon answers `/rename` through this function, so asserting on the
-    /// capability fixture instead would leave an executor that fabricated a
-    /// response passing a test named for the executor.
     #[test]
-    fn build_rename_response_stays_fail_closed() {
-        let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/nonexistent/.kin"));
-        let graph = kin_db::InMemoryGraph::new();
-        let error = build_rename_response(&layout, &graph, &rename_request("parse_config"))
-            .expect_err("the rename executor must refuse while the gate is closed");
-        let message = error.to_string();
-        for expected in [
-            "`kin rename`",
-            "open acceptance gates:",
-            "kin refs parse_config",
-        ] {
-            assert!(
-                message.contains(expected),
-                "the wire refusal must carry {expected}: {message}"
-            );
-        }
-    }
-
-    /// The composed CLI refusal states the gate and then the reachable
-    /// surfaces. Nothing else asserts on the composition, so a change that
-    /// dropped either half would otherwise only show up in a manual run.
-    #[tokio::test]
-    async fn run_refuses_with_the_gate_and_the_reachable_surfaces() {
-        let error = run(
-            "parse_config".to_string(),
-            "parse_settings".to_string(),
-            None,
-            None,
-            None,
-            false,
-        )
-        .await
-        .expect_err("`kin rename` must refuse while the gate is closed");
-        let message = error.to_string();
-        for expected in [
-            "`kin rename`",
-            "open acceptance gates:",
-            "what works today:",
-            "kin refs parse_config",
-            "kin locate parse_config",
-        ] {
-            assert!(
-                message.contains(expected),
-                "the refusal must carry {expected}: {message}"
-            );
-        }
+    fn zero_occurrence_evidence_is_rejected() {
+        let relation = Relation {
+            id: kin_model::RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(EntityId::new()),
+            dst: GraphNodeId::Entity(EntityId::new()),
+            confidence: 1.0,
+            origin: kin_model::RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![kin_model::RelationEvidence {
+                occurrence_count: 0,
+                ..kin_model::RelationEvidence::default()
+            }],
+        };
+        assert!(relation_occurrence_count(&relation)
+            .unwrap_err()
+            .to_string()
+            .contains("zero occurrence"));
     }
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1553,20 +1553,12 @@ impl DaemonClient {
         &self,
         request: &crate::commands::rename::RenameRequest,
     ) -> Result<crate::commands::rename::RenameResponse> {
-        let resp = self
-            .send(
-                self.client
-                    .post(format!("{}/commands/rename", self.base_url))
-                    .json(request),
-                "send daemon rename request",
-            )
-            .await?;
-        if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon rename error (HTTP {}): {}", status, body);
-        }
-        resp.json().await.context("parse daemon rename response")
+        self.post_idempotent_json(
+            "/commands/rename",
+            request,
+            "send daemon-owned exact rename request",
+        )
+        .await
     }
 
     pub async fn session_workspace(

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -352,7 +352,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// [OPEN GATE] Build a semantic rename plan from graph and source-CAS truth
+    /// Rename an entity through graph relations and repository source-CAS truth
     Rename {
         /// Entity name or symbol under the cursor
         symbol: String,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -352,7 +352,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// Rename an entity through graph relations and repository source-CAS truth
+    /// Bounded graph-native rename; unsupported cases fail closed
     Rename {
         /// Entity name or symbol under the cursor
         symbol: String,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -361,10 +361,10 @@ enum Command {
         /// File hint to disambiguate the target entity
         #[arg(long)]
         file: Option<String>,
-        /// 1-based line hint to disambiguate the target entity
+        /// 1-based line hint in --file; required when --column is provided
         #[arg(long)]
         line: Option<u32>,
-        /// 0-based column hint to disambiguate the target entity
+        /// 0-based UTF-8 byte column (tree-sitter coordinate), requires --line
         #[arg(long)]
         column: Option<u32>,
         /// Output machine-readable JSON for editor integrations

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -39,12 +39,12 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_ready"], true);
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
-    assert_eq!(report["full_git_replacement_ready"], false);
+    assert_eq!(report["full_git_replacement_ready"], true);
     // Exact counts, so a silent re-seal cannot pass. They are also the reason
     // two lanes must never flip a gate in the same wave: both bumps merge
     // without conflict and main goes red with every pull request green.
     // Recount from the merged fixture rather than from either branch.
-    assert_eq!(report["ready_commands"], 32);
+    assert_eq!(report["ready_commands"], 33);
     assert_eq!(report["command_total"], 33);
 
     let commands = report["commands"]
@@ -103,7 +103,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
 }
 
 #[test]
-fn remaining_open_gate_commands_fail_before_repository_discovery() {
+fn exposed_mutation_commands_reach_repository_discovery() {
     let root = tempdir().expect("temp root");
     let home = root.path().join("home");
     std::fs::create_dir_all(&home).expect("create home");
@@ -121,6 +121,19 @@ fn remaining_open_gate_commands_fail_before_repository_discovery() {
     assert!(
         !stderr.contains("is fail-closed on repository-v6"),
         "checkout must no longer answer from the capability gate: {stderr}"
+    );
+    assert!(stderr.contains("not a Kin repository"), "{stderr}");
+
+    let output = kin_command(&home)
+        .args(["rename", "before", "after"])
+        .current_dir(root.path())
+        .output()
+        .expect("run exposed rename outside a repository");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("is fail-closed on repository-v6"),
+        "rename must no longer answer from the capability gate: {stderr}"
     );
     assert!(stderr.contains("not a Kin repository"), "{stderr}");
 }

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -39,12 +39,14 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_ready"], true);
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
-    assert_eq!(report["full_git_replacement_ready"], true);
+    assert_eq!(report["all_declared_command_surfaces_enabled"], true);
+    assert_eq!(report["enabled_commands"], 33);
+    assert_eq!(report["full_git_replacement_ready"], false);
     // Exact counts, so a silent re-seal cannot pass. They are also the reason
     // two lanes must never flip a gate in the same wave: both bumps merge
     // without conflict and main goes red with every pull request green.
     // Recount from the merged fixture rather than from either branch.
-    assert_eq!(report["ready_commands"], 33);
+    assert_eq!(report["ready_commands"], 32);
     assert_eq!(report["command_total"], 33);
 
     let commands = report["commands"]
@@ -85,7 +87,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
             .as_str()
             .expect("exposure should be a string");
         match status {
-            "ready" => assert_eq!(exposure, "enabled"),
+            "ready" | "ready_bounded" => assert_eq!(exposure, "enabled"),
             "open_gate" => {
                 assert_eq!(exposure, "fail_closed");
                 assert!(

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -280,4 +280,5 @@ fn top_level_help_marks_open_git_replacement_surfaces() {
     assert!(stdout.contains("Show coherent repository-v6 workspace status"));
     assert!(stdout.contains("Create an exact semantic and artifact commit"));
     assert!(stdout.contains("Show exact repository-v6 artifact and semantic changes"));
+    assert!(stdout.contains("Bounded graph-native rename; unsupported cases fail closed"));
 }

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -419,16 +419,24 @@
     },
     {
       "command": "rename",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "graph entity identity plus repository-v6 source CAS",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
         "plan edits from graph relations and immutable repository source bodies only",
+        "require exact graph occurrence counts for every selected declaration and reference site, refusing overlap or incomplete coverage",
+        "refuse named-import and qualified-name cases whose graph evidence cannot prove every source token",
         "apply exact workspace tree and semantic deltas through one repository transaction"
       ],
-      "evidence_tests": [],
-      "note": "kin rename has no planner: the retired one read .kin/objects and working-tree files, and nothing reads bodies from repository-v6 source CAS in its place. There is also no apply path that moves the workspace tree and semantic deltas through one repository transaction."
+      "evidence_tests": [
+        "crates/kin-cli/tests/repository_rename_planner.rs",
+        "kin_cli::commands::rename::tests::token_occurrences_are_byte_exact_and_identifier_bounded",
+        "kin_reconcile::reconciler::tests::graph_authoritative_reconcile_retains_explicit_identity_across_rename",
+        "kin_daemon::repository_rename::tests::repository_rename_commits_tree_and_semantics_and_replays_by_operation",
+        "kin_daemon::repository_rename::tests::repository_rename_refuses_unadmitted_working_tree_drift_without_moving_authority"
+      ],
+      "note": "Rename is ready for the bounded exact cases its graph can prove, not as an optimistic all-language text rewrite. The daemon resolves the target and reference-bearing source entities from the exact repository graph, requires every tree-classified source to have full graph-owned parse coverage, and loads every considered body by digest from repository-v6 source CAS. Exact identifier-bound occurrences must equal the graph relation evidence plus the declaration, so mismatched counts, overlapping entity spans, same-source shadowing, missing layouts, shallow or partial coverage, qualified declarations, cross-file new-name collisions, and named imports without exact graph source spans fail closed. The adversarial matrix exercises same-spelling different identities, repeated spanless relation evidence, overlap, coverage gaps, and real Rust, TypeScript, JavaScript, Python, Go, Java, C, and C++ linkers; unsupported shapes are refused rather than skipped. Changed bodies are reparsed in memory; the renamed declaration retains its graph identity; the entire relation identity topology must remain unchanged; and the exact tree, semantic delta, native change, workspace, and branch publish through one compare-and-swap transaction guarded by the projection recovery journal. A caller-stable operation ID provides idempotent receipt recovery, while unadmitted working-tree drift leaves authority untouched."
     },
     {
       "command": "remote plan-push",

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -419,13 +419,13 @@
     },
     {
       "command": "rename",
-      "status": "ready",
+      "status": "ready_bounded",
       "exposure": "enabled",
       "authority": "graph entity identity plus repository-v6 source CAS",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
         "plan edits from graph relations and immutable repository source bodies only",
-        "require exact graph occurrence counts for every selected declaration and reference site, refusing overlap or incomplete coverage",
+        "require positive versioned graph extraction coverage plus repository-wide source-CAS occurrence accounting for every declaration and reference site",
         "refuse named-import and qualified-name cases whose graph evidence cannot prove every source token",
         "apply exact workspace tree and semantic deltas through one repository transaction"
       ],
@@ -436,7 +436,7 @@
         "kin_daemon::repository_rename::tests::repository_rename_commits_tree_and_semantics_and_replays_by_operation",
         "kin_daemon::repository_rename::tests::repository_rename_refuses_unadmitted_working_tree_drift_without_moving_authority"
       ],
-      "note": "Rename is ready for the bounded exact cases its graph can prove, not as an optimistic all-language text rewrite. The daemon resolves the target and reference-bearing source entities from the exact repository graph, requires every tree-classified source to have full graph-owned parse coverage, and loads every considered body by digest from repository-v6 source CAS. Exact identifier-bound occurrences must equal the graph relation evidence plus the declaration, so mismatched counts, overlapping entity spans, same-source shadowing, missing layouts, shallow or partial coverage, qualified declarations, cross-file new-name collisions, and named imports without exact graph source spans fail closed. The adversarial matrix exercises same-spelling different identities, repeated spanless relation evidence, overlap, coverage gaps, and real Rust, TypeScript, JavaScript, Python, Go, Java, C, and C++ linkers; unsupported shapes are refused rather than skipped. Changed bodies are reparsed in memory; the renamed declaration retains its graph identity; the entire relation identity topology must remain unchanged; and the exact tree, semantic delta, native change, workspace, and branch publish through one compare-and-swap transaction guarded by the projection recovery journal. A caller-stable operation ID provides idempotent receipt recovery, while unadmitted working-tree drift leaves authority untouched."
+      "note": "Rename is enabled only for bounded exact cases whose graph and repository source CAS can prove exhaustive. It is not a claim of fully general all-language refactoring: named imports and qualified declarations without exact occurrence evidence still refuse. Every source must carry a positive versioned full-extraction certificate with no incomplete certificate, then a repository-wide Unicode-safe occurrence census must match declarations and rename-relevant graph edges exactly; comments, strings, hidden dynamic references, count mismatches, overlap, missing layouts, shallow or partial coverage, unsupported lexical forms, cross-file new-name collisions, and unowned occurrences fail closed. Cursor lines are converted once from the CLI's 1-based domain to graph 0-based rows, columns are explicit UTF-8 byte offsets with exclusive span ends, and reference cursors cannot select an unrelated same-named declaration. Changed bodies are reparsed in memory; the renamed declaration retains its graph identity; relation identity topology remains unchanged; and the exact tree, semantic delta, native change, workspace, and branch publish through one compare-and-swap transaction guarded by the projection recovery journal. Durable metadata binds the caller request to the canonical identity, original report, and edit set so immediate, restart, qualified-selector, response-loss, and post-later-generation replays return the same committed outcome without reinstalling old authority."
     },
     {
       "command": "remote plan-push",

--- a/crates/kin-cli/tests/repository_rename_planner.rs
+++ b/crates/kin-cli/tests/repository_rename_planner.rs
@@ -35,7 +35,7 @@ impl PlannerHarness {
         }
     }
 
-    fn add_tree_blob(&mut self, path: &str, body: &str) {
+    fn add_tree_blob(&mut self, path: &str, body: &str) -> ArtifactId {
         let artifact_id = ArtifactId::new();
         let digest = kin_blobs::digest(body.as_bytes());
         self.graph
@@ -52,10 +52,34 @@ impl PlannerHarness {
             .unwrap();
         self.bodies
             .insert(path.to_string(), body.as_bytes().to_vec());
+        artifact_id
     }
 
     fn add_file(&mut self, path: &str, body: &str, completeness: ParseCompleteness) {
-        self.add_tree_blob(path, body);
+        let artifact_id = self.add_tree_blob(path, body);
+        let parser_rule = if completeness == ParseCompleteness::Full {
+            kin_index::CALL_SHAPE_PARSE_COVERAGE_FULL_V1
+        } else {
+            kin_index::CALL_SHAPE_PARSE_COVERAGE_INCOMPLETE_V1
+        };
+        self.graph
+            .upsert_relation(&Relation {
+                id: RelationId::new(),
+                kind: RelationKind::DependsOn,
+                src: GraphNodeId::Artifact(artifact_id),
+                dst: GraphNodeId::Artifact(artifact_id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: vec![RelationEvidence {
+                    parser_rule: Some(parser_rule.to_string()),
+                    source_path: Some(path.to_string()),
+                    occurrence_count: 1,
+                    ..RelationEvidence::default()
+                }],
+            })
+            .unwrap();
         self.graph
             .upsert_file_layout(&FileLayout {
                 file_id: FilePathId::new(path),
@@ -71,6 +95,31 @@ impl PlannerHarness {
 
     fn add_entity(&self, name: &str, path: &str, start_byte: usize, end_byte: usize) -> Entity {
         let entity = test_entity(name, path, start_byte, end_byte);
+        self.graph.upsert_entity(&entity).unwrap();
+        entity
+    }
+
+    fn add_entity_at(
+        &self,
+        name: &str,
+        path: &str,
+        start_byte: usize,
+        end_byte: usize,
+        start_line: u32,
+        end_line: u32,
+        language: LanguageId,
+    ) -> Entity {
+        let mut entity = test_entity(name, path, start_byte, end_byte);
+        entity.language = language;
+        entity.span = Some(SourceSpan {
+            file: FilePathId::new(path),
+            start_byte,
+            end_byte,
+            start_line,
+            start_col: 0,
+            end_line,
+            end_col: u32::try_from(end_byte.saturating_sub(start_byte)).unwrap(),
+        });
         self.graph.upsert_entity(&entity).unwrap();
         entity
     }
@@ -116,7 +165,7 @@ fn request(symbol: &str, new_name: &str, file: Option<&str>) -> RenameRequest {
         symbol: symbol.to_string(),
         new_name: new_name.to_string(),
         file: file.map(ToString::to_string),
-        line: Some(1),
+        line: None,
         column: None,
         json: true,
         operation_id: OperationId::new(),
@@ -143,9 +192,9 @@ fn test_entity(name: &str, path: &str, start_byte: usize, end_byte: usize) -> En
             file: FilePathId::new(path),
             start_byte,
             end_byte,
-            start_line: 1,
+            start_line: 0,
             start_col: u32::try_from(start_byte).unwrap(),
-            end_line: 1,
+            end_line: 0,
             end_col: u32::try_from(end_byte).unwrap(),
         }),
         signature: format!("fn {name}()"),
@@ -349,6 +398,172 @@ fn graph_tree_source_without_a_layout_refuses_repository_wide_coverage() {
     );
 }
 
+#[test]
+fn one_based_line_cursor_selects_graph_row_zero_not_the_adjacent_identity() {
+    let mut harness = PlannerHarness::new();
+    let body = "fn target() {}\nfn target() {}\n";
+    harness.add_file("src/two.rs", body, ParseCompleteness::Full);
+    let split = body.find('\n').unwrap() + 1;
+    let first = harness.add_entity_at("target", "src/two.rs", 0, split - 1, 0, 0, LanguageId::Rust);
+    harness.add_entity_at(
+        "target",
+        "src/two.rs",
+        split,
+        body.len() - 1,
+        1,
+        1,
+        LanguageId::Rust,
+    );
+
+    let mut cursor = request("target", "renamed", Some("src/two.rs"));
+    cursor.line = Some(1);
+    let plan = plan_rename(&harness.graph, &cursor, |path, _| {
+        Ok(harness.bodies[path.as_utf8().unwrap()].clone())
+    })
+    .unwrap();
+    assert_eq!(plan.entity_id, first.id);
+    assert_eq!(plan.edits.len(), 1);
+    assert_eq!(plan.edits[0].start_line, 1);
+}
+
+#[test]
+fn reference_cursor_beats_an_unrelated_same_named_declaration_in_the_file() {
+    let mut harness = PlannerHarness::new();
+    let remote_body = "fn target() {}\n";
+    let caller_body = "fn target() {}\nfn caller() { target(); }\n";
+    harness.add_file("src/remote.rs", remote_body, ParseCompleteness::Full);
+    harness.add_file("src/caller.rs", caller_body, ParseCompleteness::Full);
+    let remote = harness.add_entity_at(
+        "target",
+        "src/remote.rs",
+        0,
+        remote_body.len(),
+        0,
+        0,
+        LanguageId::Rust,
+    );
+    let split = caller_body.find('\n').unwrap() + 1;
+    harness.add_entity_at(
+        "target",
+        "src/caller.rs",
+        0,
+        split - 1,
+        0,
+        0,
+        LanguageId::Rust,
+    );
+    let caller = harness.add_entity_at(
+        "caller",
+        "src/caller.rs",
+        split,
+        caller_body.len(),
+        1,
+        1,
+        LanguageId::Rust,
+    );
+    harness.add_reference(&caller, &remote, 1);
+    let mut cursor = request("target", "renamed", Some("src/caller.rs"));
+    cursor.line = Some(2);
+
+    let plan = plan_rename(&harness.graph, &cursor, |path, _| {
+        Ok(harness.bodies[path.as_utf8().unwrap()].clone())
+    })
+    .unwrap();
+    assert_eq!(plan.entity_id, remote.id);
+    assert_eq!(
+        plan.edits
+            .iter()
+            .map(|edit| edit.file.0.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["src/caller.rs", "src/remote.rs"])
+    );
+}
+
+#[test]
+fn extraction_incomplete_certificate_refuses_a_syntax_full_partial_refactor() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "def target():\n    return 1\n";
+    let caller_body =
+        "def other():\n    return 2\n\ndef caller(flag):\n    return (target if flag else other)()\n";
+    harness.add_file("target.py", target_body, ParseCompleteness::Full);
+    harness.add_file("caller.py", caller_body, ParseCompleteness::Full);
+    harness.add_entity_at(
+        "target",
+        "target.py",
+        0,
+        target_body.len(),
+        0,
+        1,
+        LanguageId::Python,
+    );
+    harness
+        .graph
+        .upsert_relation(&Relation {
+            id: RelationId::new(),
+            kind: RelationKind::DependsOn,
+            src: GraphNodeId::Artifact(ArtifactId::new()),
+            dst: GraphNodeId::Artifact(ArtifactId::new()),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![RelationEvidence {
+                parser_rule: Some(
+                    kin_index::CALL_SHAPE_EXTRACTION_COVERAGE_INCOMPLETE_V1.to_string(),
+                ),
+                source_path: Some("caller.py".to_string()),
+                occurrence_count: 1,
+                ..RelationEvidence::default()
+            }],
+        })
+        .unwrap();
+
+    let error = harness.plan("target", "renamed", "target.py").unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("extraction-incomplete certificate")
+            || error
+                .to_string()
+                .contains("incomplete named-reference extraction"),
+        "syntax-full extraction gaps must fail closed: {error:#}"
+    );
+}
+
+#[test]
+fn unicode_prefix_cannot_turn_a_spanless_edge_into_an_ascii_substring_edit() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "def foo():\n    return 1\n";
+    let caller_body = "def caller():\n    return éfoo()\n";
+    harness.add_file("target.py", target_body, ParseCompleteness::Full);
+    harness.add_file("caller.py", caller_body, ParseCompleteness::Full);
+    let target = harness.add_entity_at(
+        "foo",
+        "target.py",
+        0,
+        target_body.len(),
+        0,
+        1,
+        LanguageId::Python,
+    );
+    let caller = harness.add_entity_at(
+        "caller",
+        "caller.py",
+        0,
+        caller_body.len(),
+        0,
+        1,
+        LanguageId::Python,
+    );
+    harness.add_reference(&caller, &target, 1);
+
+    let error = harness.plan("foo", "renamed", "target.py").unwrap_err();
+    assert!(
+        error.to_string().contains("require 1 'foo' occurrence"),
+        "Unicode identifier neighbors must not be spliced: {error:#}"
+    );
+}
+
 struct LanguageFixture {
     name: &'static str,
     target_path: &'static str,
@@ -478,9 +693,18 @@ fn real_linker_spanless_relations_are_exact_or_refused_across_eight_languages() 
             indexed_files.push(indexed);
         }
 
-        let linked = pipeline
-            .resolve_cross_file(&parse_data, &artifact_ids)
-            .unwrap_or_else(|error| panic!("{} link: {error}", fixture.name));
+        let completeness = indexed_files
+            .iter()
+            .map(|indexed| {
+                (
+                    indexed.file_id.0.clone(),
+                    indexed.file_layout.parse_completeness.clone(),
+                )
+            })
+            .collect::<kin_index::FileParseCompletenessMap>();
+        let linked =
+            kin_index::link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)
+                .unwrap_or_else(|error| panic!("{} link: {error}", fixture.name));
         for relation in &linked {
             graph.upsert_relation(relation).unwrap();
         }
@@ -552,7 +776,8 @@ fn real_linker_spanless_relations_are_exact_or_refused_across_eight_languages() 
                 error.to_string().contains("cannot be proven")
                     || error
                         .to_string()
-                        .contains("not found in repository-v6 graph authority"),
+                        .contains("not found in repository-v6 graph authority")
+                    || error.to_string().contains("is not declared in graph file"),
                 "{} must fail closed for its qualified declaration name: {error:#}",
                 fixture.name
             );

--- a/crates/kin-cli/tests/repository_rename_planner.rs
+++ b/crates/kin-cli/tests/repository_rename_planner.rs
@@ -1,0 +1,569 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Adversarial evidence for repository-v6 rename planning.
+//!
+//! Production relation evidence currently carries occurrence counts but no
+//! source spans. These tests prove the bounded replacement contract: Kin uses
+//! the graph-owned source entity span plus the relation occurrence count to
+//! account for exact identifier sites in repository CAS, and refuses any case
+//! where one-to-one accounting cannot be established.
+
+use std::collections::{BTreeSet, HashMap};
+
+use kin_cli::commands::rename::{plan_rename, RenamePlan, RenameRequest};
+use kin_db::InMemoryGraph;
+use kin_index::linker::ArtifactIdentityMap;
+use kin_model::{
+    ArtifactId, AuthorId, Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore,
+    FileLayout, FilePathId, FingerprintAlgorithm, GraphNodeId, Hash256, ImportSection, LanguageId,
+    LocatedEntry, OperationId, ParseCompleteness, Relation, RelationEvidence, RelationId,
+    RelationKind, RelationOrigin, RepoPath, SemanticFingerprint, SourceSpan, TransactionDelta,
+    TreeDelta, TreeEntry, Visibility,
+};
+
+struct PlannerHarness {
+    graph: InMemoryGraph,
+    bodies: HashMap<String, Vec<u8>>,
+}
+
+impl PlannerHarness {
+    fn new() -> Self {
+        Self {
+            graph: InMemoryGraph::new(),
+            bodies: HashMap::new(),
+        }
+    }
+
+    fn add_tree_blob(&mut self, path: &str, body: &str) {
+        let artifact_id = ArtifactId::new();
+        let digest = kin_blobs::digest(body.as_bytes());
+        self.graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: LocatedEntry::new(
+                        RepoPath::from_utf8(path).unwrap(),
+                        TreeEntry::blob(Hash256::from_bytes(digest.0), false),
+                    ),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        self.bodies
+            .insert(path.to_string(), body.as_bytes().to_vec());
+    }
+
+    fn add_file(&mut self, path: &str, body: &str, completeness: ParseCompleteness) {
+        self.add_tree_blob(path, body);
+        self.graph
+            .upsert_file_layout(&FileLayout {
+                file_id: FilePathId::new(path),
+                parse_completeness: completeness,
+                imports: ImportSection {
+                    byte_range: 0..0,
+                    items: Vec::new(),
+                },
+                regions: Vec::new(),
+            })
+            .unwrap();
+    }
+
+    fn add_entity(&self, name: &str, path: &str, start_byte: usize, end_byte: usize) -> Entity {
+        let entity = test_entity(name, path, start_byte, end_byte);
+        self.graph.upsert_entity(&entity).unwrap();
+        entity
+    }
+
+    fn add_reference(&self, source: &Entity, target: &Entity, occurrence_count: u32) -> RelationId {
+        let relation = Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(source.id),
+            dst: GraphNodeId::Entity(target.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![RelationEvidence {
+                occurrence_count,
+                source_span: None,
+                ..RelationEvidence::default()
+            }],
+        };
+        let id = relation.id;
+        self.graph.upsert_relation(&relation).unwrap();
+        id
+    }
+
+    fn plan(&self, symbol: &str, new_name: &str, file: &str) -> anyhow::Result<RenamePlan> {
+        plan_rename(
+            &self.graph,
+            &request(symbol, new_name, Some(file)),
+            |path, _hash| {
+                let path = path.as_utf8().expect("fixture paths are UTF-8");
+                self.bodies
+                    .get(path)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing fixture body {path}"))
+            },
+        )
+    }
+}
+
+fn request(symbol: &str, new_name: &str, file: Option<&str>) -> RenameRequest {
+    RenameRequest {
+        symbol: symbol.to_string(),
+        new_name: new_name.to_string(),
+        file: file.map(ToString::to_string),
+        line: Some(1),
+        column: None,
+        json: true,
+        operation_id: OperationId::new(),
+        actor: AuthorId::new("rename-planner-test"),
+    }
+}
+
+fn test_entity(name: &str, path: &str, start_byte: usize, end_byte: usize) -> Entity {
+    Entity {
+        id: EntityId::new(),
+        kind: EntityKind::Function,
+        name: name.to_string(),
+        language: LanguageId::Rust,
+        fingerprint: SemanticFingerprint {
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: Hash256::from_bytes([0x11; 32]),
+            signature_hash: Hash256::from_bytes([0x22; 32]),
+            behavior_hash: Hash256::from_bytes([0x33; 32]),
+            equivalence_hash: Hash256::from_bytes([0x44; 32]),
+            stability_score: 1.0,
+        },
+        file_origin: Some(FilePathId::new(path)),
+        span: Some(SourceSpan {
+            file: FilePathId::new(path),
+            start_byte,
+            end_byte,
+            start_line: 1,
+            start_col: u32::try_from(start_byte).unwrap(),
+            end_line: 1,
+            end_col: u32::try_from(end_byte).unwrap(),
+        }),
+        signature: format!("fn {name}()"),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+#[test]
+fn occurrence_count_without_relation_spans_accounts_for_every_site() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "pub fn target() {}\n";
+    let caller_body = "pub fn caller() { target(); target(); }\n";
+    harness.add_file("src/target.rs", target_body, ParseCompleteness::Full);
+    harness.add_file("src/caller.rs", caller_body, ParseCompleteness::Full);
+    let target = harness.add_entity("target", "src/target.rs", 0, target_body.len());
+    let caller = harness.add_entity("caller", "src/caller.rs", 0, caller_body.len());
+    let relation_id = harness.add_reference(&caller, &target, 2);
+
+    let plan = harness.plan("target", "renamed", "src/target.rs").unwrap();
+    assert_eq!(plan.edits.len(), 3);
+    assert_eq!(plan.relation_ids, vec![relation_id]);
+    assert_eq!(
+        plan.edits
+            .iter()
+            .map(|edit| edit.file.0.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["src/caller.rs", "src/target.rs"])
+    );
+}
+
+#[test]
+fn occurrence_count_mismatch_refuses_instead_of_skipping_or_guessing() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "pub fn target() {}\n";
+    let caller_body = "pub fn caller() { target(); target(); }\n";
+    harness.add_file("src/target.rs", target_body, ParseCompleteness::Full);
+    harness.add_file("src/caller.rs", caller_body, ParseCompleteness::Full);
+    let target = harness.add_entity("target", "src/target.rs", 0, target_body.len());
+    let caller = harness.add_entity("caller", "src/caller.rs", 0, caller_body.len());
+    harness.add_reference(&caller, &target, 3);
+
+    let error = harness
+        .plan("target", "renamed", "src/target.rs")
+        .unwrap_err();
+    assert!(error.to_string().contains("require 3 'target' occurrence"));
+}
+
+#[test]
+fn overlapping_entity_spans_cannot_double_claim_one_occurrence() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "pub fn target() {}\n";
+    let caller_body = "pub fn outer() { target(); }\n";
+    harness.add_file("src/target.rs", target_body, ParseCompleteness::Full);
+    harness.add_file("src/caller.rs", caller_body, ParseCompleteness::Full);
+    let target = harness.add_entity("target", "src/target.rs", 0, target_body.len());
+    let outer = harness.add_entity("outer", "src/caller.rs", 0, caller_body.len());
+    let token_start = caller_body.find("target").unwrap();
+    let nested = harness.add_entity(
+        "nested",
+        "src/caller.rs",
+        token_start,
+        token_start + "target".len(),
+    );
+    harness.add_reference(&outer, &target, 1);
+    harness.add_reference(&nested, &target, 1);
+
+    let error = harness
+        .plan("target", "renamed", "src/target.rs")
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("overlapping graph source entities"));
+}
+
+#[test]
+fn same_spelling_different_target_only_follows_the_selected_identity() {
+    let mut harness = PlannerHarness::new();
+    let declaration = "pub fn target() {}\n";
+    let caller_a_body = "pub fn caller_a() { target(); }\n";
+    let caller_b_body = "pub fn caller_b() { target(); }\n";
+    for (path, body) in [
+        ("src/a.rs", declaration),
+        ("src/b.rs", declaration),
+        ("src/caller_a.rs", caller_a_body),
+        ("src/caller_b.rs", caller_b_body),
+    ] {
+        harness.add_file(path, body, ParseCompleteness::Full);
+    }
+    let target_a = harness.add_entity("target", "src/a.rs", 0, declaration.len());
+    let target_b = harness.add_entity("target", "src/b.rs", 0, declaration.len());
+    let caller_a = harness.add_entity("caller_a", "src/caller_a.rs", 0, caller_a_body.len());
+    let caller_b = harness.add_entity("caller_b", "src/caller_b.rs", 0, caller_b_body.len());
+    harness.add_reference(&caller_a, &target_a, 1);
+    harness.add_reference(&caller_b, &target_b, 1);
+
+    let plan = harness.plan("target", "renamed", "src/a.rs").unwrap();
+    let edited = plan
+        .edits
+        .iter()
+        .map(|edit| edit.file.0.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(edited, BTreeSet::from(["src/a.rs", "src/caller_a.rs"]));
+    assert!(!edited.contains("src/b.rs"));
+    assert!(!edited.contains("src/caller_b.rs"));
+}
+
+#[test]
+fn same_spelling_shadowing_inside_one_source_entity_refuses_ambiguous_sites() {
+    let mut harness = PlannerHarness::new();
+    let declaration = "pub fn target() {}\n";
+    let caller_body = "pub fn caller() { target(); target(); }\n";
+    harness.add_file("src/a.rs", declaration, ParseCompleteness::Full);
+    harness.add_file("src/b.rs", declaration, ParseCompleteness::Full);
+    harness.add_file("src/caller.rs", caller_body, ParseCompleteness::Full);
+    let target_a = harness.add_entity("target", "src/a.rs", 0, declaration.len());
+    let target_b = harness.add_entity("target", "src/b.rs", 0, declaration.len());
+    let caller = harness.add_entity("caller", "src/caller.rs", 0, caller_body.len());
+    harness.add_reference(&caller, &target_a, 1);
+    harness.add_reference(&caller, &target_b, 1);
+
+    let error = harness.plan("target", "renamed", "src/a.rs").unwrap_err();
+    assert!(
+        error.to_string().contains("require 1 'target' occurrence"),
+        "same-spelling shadow sites must not be guessed: {error:#}"
+    );
+}
+
+#[test]
+fn cross_file_new_name_collision_refuses_unproven_namespaces() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "pub fn target() {}\n";
+    let collision_body = "pub fn renamed() {}\n";
+    harness.add_file("src/target.rs", target_body, ParseCompleteness::Full);
+    harness.add_file("src/collision.rs", collision_body, ParseCompleteness::Full);
+    harness.add_entity("target", "src/target.rs", 0, target_body.len());
+    harness.add_entity("renamed", "src/collision.rs", 0, collision_body.len());
+
+    let error = harness
+        .plan("target", "renamed", "src/target.rs")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("cross-file namespace equivalence is unproven"),
+        "collision must fail closed: {error:#}"
+    );
+}
+
+#[test]
+fn one_unsupported_reference_file_refuses_the_whole_plan() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "pub fn target() {}\n";
+    let supported = "pub fn supported() { target(); }\n";
+    let unsupported = "pub fn unsupported() { target(); }\n";
+    harness.add_file("src/target.rs", target_body, ParseCompleteness::Full);
+    harness.add_file("src/supported.rs", supported, ParseCompleteness::Full);
+    harness.add_file(
+        "src/unsupported.rs",
+        unsupported,
+        ParseCompleteness::Partial("fixture parser gap".to_string()),
+    );
+    let target = harness.add_entity("target", "src/target.rs", 0, target_body.len());
+    let supported_entity = harness.add_entity("supported", "src/supported.rs", 0, supported.len());
+    let unsupported_entity =
+        harness.add_entity("unsupported", "src/unsupported.rs", 0, unsupported.len());
+    harness.add_reference(&supported_entity, &target, 1);
+    harness.add_reference(&unsupported_entity, &target, 1);
+
+    let error = harness
+        .plan("target", "renamed", "src/target.rs")
+        .unwrap_err();
+    assert!(error.to_string().contains("partial parse coverage"));
+}
+
+#[test]
+fn graph_tree_source_without_a_layout_refuses_repository_wide_coverage() {
+    let mut harness = PlannerHarness::new();
+    let target_body = "pub fn target() {}\n";
+    let caller_body = "pub fn caller() { target(); }\n";
+    harness.add_file("src/target.rs", target_body, ParseCompleteness::Full);
+    harness.add_file("src/caller.rs", caller_body, ParseCompleteness::Full);
+    harness.add_tree_blob("src/uncovered.rs", "use crate::target;\n");
+    let target = harness.add_entity("target", "src/target.rs", 0, target_body.len());
+    let caller = harness.add_entity("caller", "src/caller.rs", 0, caller_body.len());
+    harness.add_reference(&caller, &target, 1);
+
+    let error = harness
+        .plan("target", "renamed", "src/target.rs")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("src/uncovered.rs has no graph-owned file layout"),
+        "uncovered source must fail closed: {error:#}"
+    );
+}
+
+struct LanguageFixture {
+    name: &'static str,
+    target_path: &'static str,
+    target_source: &'static str,
+    caller_path: &'static str,
+    caller_source: &'static str,
+    has_named_import_without_span: bool,
+}
+
+fn entity_leaf(name: &str) -> &str {
+    name.rsplit(|character| character == '.' || character == ':')
+        .find(|part| !part.is_empty())
+        .unwrap_or(name)
+}
+
+const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
+    LanguageFixture {
+        name: "Rust",
+        target_path: "defs.rs",
+        target_source: "pub fn target() -> u32 { 1 }\n",
+        caller_path: "caller.rs",
+        caller_source: "pub fn caller() -> u32 { target() + target() }\n",
+        has_named_import_without_span: false,
+    },
+    LanguageFixture {
+        name: "TypeScript",
+        target_path: "defs.ts",
+        target_source: "export function target(): number { return 1; }\n",
+        caller_path: "caller.ts",
+        caller_source: "import { target } from './defs';\nexport function caller(): number { return target() + target(); }\n",
+        has_named_import_without_span: true,
+    },
+    LanguageFixture {
+        name: "JavaScript",
+        target_path: "defs.js",
+        target_source: "export function target() { return 1; }\n",
+        caller_path: "caller.js",
+        caller_source: "import { target } from './defs';\nexport function caller() { return target() + target(); }\n",
+        has_named_import_without_span: true,
+    },
+    LanguageFixture {
+        name: "Python",
+        target_path: "defs.py",
+        target_source: "def target():\n    return 1\n",
+        caller_path: "caller.py",
+        caller_source: "from defs import target\n\ndef caller():\n    return target() + target()\n",
+        has_named_import_without_span: true,
+    },
+    LanguageFixture {
+        name: "Go",
+        target_path: "defs.go",
+        target_source: "package main\n\nfunc target() int { return 1 }\n",
+        caller_path: "caller.go",
+        caller_source: "package main\n\nfunc caller() int { return target() + target() }\n",
+        has_named_import_without_span: false,
+    },
+    LanguageFixture {
+        name: "Java",
+        target_path: "Defs.java",
+        target_source: "class Defs { static int target() { return 1; } }\n",
+        caller_path: "Caller.java",
+        caller_source: "class Caller { int caller() { return target() + target(); } }\n",
+        has_named_import_without_span: false,
+    },
+    LanguageFixture {
+        name: "C",
+        target_path: "defs.c",
+        target_source: "int target(void) { return 1; }\n",
+        caller_path: "caller.c",
+        caller_source: "int caller(void) { return target() + target(); }\n",
+        has_named_import_without_span: false,
+    },
+    LanguageFixture {
+        name: "Cpp",
+        target_path: "defs.cpp",
+        target_source: "int target() { return 1; }\n",
+        caller_path: "caller.cpp",
+        caller_source: "int caller() { return target() + target(); }\n",
+        has_named_import_without_span: false,
+    },
+];
+
+#[test]
+fn real_linker_spanless_relations_are_exact_or_refused_across_eight_languages() {
+    for fixture in LANGUAGE_FIXTURES {
+        let pipeline = kin_index::IndexPipeline::new();
+        let graph = InMemoryGraph::new();
+        let mut bodies = HashMap::new();
+        let mut parse_data = Vec::new();
+        let mut artifact_ids = ArtifactIdentityMap::new();
+        let mut indexed_files = Vec::new();
+
+        for (path, source) in [
+            (fixture.target_path, fixture.target_source),
+            (fixture.caller_path, fixture.caller_source),
+        ] {
+            let digest = kin_blobs::digest(source.as_bytes());
+            let indexed = pipeline
+                .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), digest)
+                .unwrap_or_else(|error| panic!("{} index {path}: {error}", fixture.name))
+                .indexed_file;
+            let artifact_id = ArtifactId::new();
+            graph
+                .apply_transaction_delta(&TransactionDelta {
+                    tree_deltas: vec![TreeDelta::Added {
+                        artifact_id,
+                        new: LocatedEntry::new(
+                            RepoPath::from_utf8(path).unwrap(),
+                            TreeEntry::blob(Hash256::from_bytes(digest.0), false),
+                        ),
+                    }],
+                    ..TransactionDelta::default()
+                })
+                .unwrap();
+            graph.upsert_file_layout(&indexed.file_layout).unwrap();
+            for entity in &indexed.entities {
+                graph.upsert_entity(entity).unwrap();
+            }
+            artifact_ids.insert(path.to_string(), artifact_id);
+            bodies.insert(path.to_string(), source.as_bytes().to_vec());
+            parse_data.push(kin_index::FileParseData {
+                file_path: path.to_string(),
+                entities: indexed.entities.clone(),
+                relations: indexed.extracted_relations.clone(),
+                imports: indexed.imports.clone(),
+            });
+            indexed_files.push(indexed);
+        }
+
+        let linked = pipeline
+            .resolve_cross_file(&parse_data, &artifact_ids)
+            .unwrap_or_else(|error| panic!("{} link: {error}", fixture.name));
+        for relation in &linked {
+            graph.upsert_relation(relation).unwrap();
+        }
+        let target = indexed_files[0]
+            .entities
+            .iter()
+            .find(|entity| entity_leaf(&entity.name) == "target")
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} target entity; found {:?}",
+                    fixture.name,
+                    indexed_files[0]
+                        .entities
+                        .iter()
+                        .map(|entity| (&entity.name, entity.kind))
+                        .collect::<Vec<_>>()
+                )
+            });
+        let caller = indexed_files[1]
+            .entities
+            .iter()
+            .find(|entity| entity_leaf(&entity.name) == "caller")
+            .unwrap_or_else(|| panic!("{} caller entity", fixture.name));
+        let call = linked
+            .iter()
+            .find(|relation| {
+                relation.kind == RelationKind::Calls
+                    && relation.src == GraphNodeId::Entity(caller.id)
+                    && relation.dst == GraphNodeId::Entity(target.id)
+            })
+            .unwrap_or_else(|| panic!("{} repeated call edge", fixture.name));
+        assert!(
+            call.evidence
+                .iter()
+                .all(|evidence| evidence.source_span.is_none()),
+            "{} unexpectedly gained a relation span; update the bounded planner proof",
+            fixture.name
+        );
+        assert_eq!(
+            call.evidence
+                .iter()
+                .map(|evidence| evidence.occurrence_count)
+                .sum::<u32>(),
+            2,
+            "{} must retain both sites through occurrence_count",
+            fixture.name
+        );
+
+        let result = plan_rename(
+            &graph,
+            &request("target", "renamed", Some(fixture.target_path)),
+            |path, _hash| {
+                let path = path.as_utf8().unwrap();
+                Ok(bodies.get(path).unwrap().clone())
+            },
+        );
+        if fixture.has_named_import_without_span {
+            let error = result.unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("graph import evidence has no exact source span"),
+                "{} must refuse its unspanned named import: {error:#}",
+                fixture.name
+            );
+        } else if target.name != "target" {
+            let error = result.unwrap_err();
+            assert!(
+                error.to_string().contains("cannot be proven")
+                    || error
+                        .to_string()
+                        .contains("not found in repository-v6 graph authority"),
+                "{} must fail closed for its qualified declaration name: {error:#}",
+                fixture.name
+            );
+        } else {
+            let plan = result.unwrap_or_else(|error| {
+                panic!(
+                    "{} exact spanless plan should succeed: {error:#}",
+                    fixture.name
+                )
+            });
+            assert_eq!(plan.edits.len(), 3, "{} exact edit count", fixture.name);
+        }
+    }
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3400,6 +3400,7 @@ async fn command_checkout(
 
 /// POST /commands/rename — build rename plans from daemon-owned graph state.
 async fn command_rename(
+    headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<kin_cli::commands::rename::RenameRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
@@ -3413,12 +3414,23 @@ async fn command_rename(
         ));
     }
 
-    let response = kin_cli::commands::rename::build_rename_response(
-        &state.layout,
-        state.graph.as_ref(),
-        &request,
-    )
-    .map_err(internal_error)?;
+    if state.storage_backend.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "exact local rename is unavailable for hosted snapshot authority".to_string(),
+        ));
+    }
+    let session_id = extract_session_id_from_headers(&headers)?;
+    if session_id.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "rename does not accept X-Kin-Session because it mutates the primary repository \
+             workspace; rename inside a session projection and reconcile it instead"
+                .to_string(),
+        ));
+    }
+    let _coordination = state.coordination_gate.lock().await;
+    let response = crate::repository_rename::execute(&state, &request)?;
     Ok(Json(response))
 }
 

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -129,6 +129,7 @@ pub mod repository_commit;
 mod repository_drift;
 mod repository_merge;
 mod repository_merge_state;
+mod repository_rename;
 mod repository_rollback;
 mod repository_stash;
 mod repository_tag;

--- a/crates/kin-daemon/src/repository_rename.rs
+++ b/crates/kin-daemon/src/repository_rename.rs
@@ -1,0 +1,1079 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Graph-native repository-v6 rename execution.
+//!
+//! The planner reads one exact workspace graph and source bodies only from
+//! repository CAS. Changed bodies are reparsed in memory, the renamed entity's
+//! graph identity is retained explicitly, and the exact tree plus semantic
+//! delta publish through the native repository transaction/projection journal.
+
+use anyhow::{bail, Context, Result};
+use axum::http::StatusCode;
+use kin_cli::commands::rename::{
+    plan_rename, RenameEdit, RenamePlan, RenameReport, RenameRequest, RenameResponse,
+};
+use kin_model::{
+    ChangeStore, EntityDelta, EntityStore, FileLayout, FilePathId, GraphNodeId, Hash256,
+    LocatedEntry, ParseCompleteness, RepoPath, SourceRegion, TransactionDelta, TreeDelta,
+    TreeEntry,
+};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use crate::local_repository_authority::{
+    require_fresh_daemon_workspace, LocalRepositoryAuthorityContext,
+};
+use crate::repository_commit::{
+    commit_native_plan_with_projection, load_native_commit_base, load_native_source_blob,
+    plan_native_commit_from_base, recover_native_commit, NativeCommitResult,
+};
+use crate::state::{DaemonEvent, DaemonState};
+
+struct RenameExecution {
+    response: RenameResponse,
+    committed: NativeCommitResult,
+    authority_freeze: kin_db::LocalRepositoryAuthorityFreeze,
+    previous_tree: kin_model::ResolvedTree,
+    desired_tree: kin_model::ResolvedTree,
+    planned_delta: TransactionDelta,
+    layouts: Vec<FileLayout>,
+}
+
+pub(crate) fn execute(
+    state: &DaemonState,
+    request: &RenameRequest,
+) -> std::result::Result<RenameResponse, (StatusCode, String)> {
+    let graph_mutation = state.begin_graph_authority_mutation();
+    let persistence = state.persist_lock.lock().map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "daemon persistence lock poisoned".to_string(),
+        )
+    })?;
+    let previous_graph_root = hex::encode(state.graph.compute_root_hash());
+    let execution = plan_commit_and_retain_authority(state, request).map_err(rename_error)?;
+
+    if state
+        .graph
+        .get_change(&execution.committed.change.id)
+        .map_err(internal_error)?
+        .is_none()
+    {
+        state
+            .graph
+            .create_changes(vec![execution.committed.change.clone()])
+            .map_err(internal_error)?;
+    }
+    let finalization = state
+        .finalize_local_repository_commit(
+            &execution.committed.receipt,
+            &execution.authority_freeze,
+            &execution.planned_delta,
+            &execution.previous_tree,
+            &execution.desired_tree,
+        )
+        .map_err(internal_error)?;
+    for layout in execution.layouts {
+        state
+            .graph
+            .upsert_file_layout(&layout)
+            .map_err(internal_error)?;
+    }
+    if finalization.graph_changed {
+        let current_graph_root = hex::encode(state.graph.compute_root_hash());
+        state.bump_version();
+        state.emit_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: Some(previous_graph_root),
+            new_root_hash: current_graph_root,
+        });
+    } else if finalization.generation_advanced {
+        state.mark_dirty();
+    }
+    if finalization.generation_advanced {
+        state.emit_event(DaemonEvent::RepositoryAuthorityChanged {
+            repository_id: execution.committed.receipt.repository_id.to_string(),
+            operation_id: execution.committed.receipt.operation_id,
+            previous_generation: execution.committed.receipt.roots_before.generation,
+            new_generation: execution.committed.receipt.generation,
+        });
+    }
+    drop(persistence);
+    drop(graph_mutation);
+    Ok(execution.response)
+}
+
+fn plan_commit_and_retain_authority(
+    state: &DaemonState,
+    request: &RenameRequest,
+) -> Result<RenameExecution> {
+    let authority_context = LocalRepositoryAuthorityContext::from_state(state)
+        .context("bind startup-pinned repository authority for rename")?;
+    authority_context
+        .revalidate_pinned_namespace()
+        .map_err(|refusal| refusal.into_error())
+        .context("revalidate startup-pinned repository namespace for rename")?;
+
+    if let Some(recovered) = recover_native_commit(&authority_context, request.operation_id)? {
+        return recover_committed_rename(state, request, &authority_context, recovered);
+    }
+
+    let base = load_native_commit_base(&authority_context)
+        .context("load clean exact repository workspace for rename")?;
+    require_fresh_daemon_workspace(
+        state,
+        &base.roots,
+        &base.graph.to_snapshot(),
+        "renaming an entity",
+    )
+    .context("bind rename plan to the daemon's exact repository generation")?;
+    // File layouts are derived graph coverage, not repository history
+    // semantics. Repository-v6 materializes the exact entity/relation/tree
+    // authority while the daemon retains parse-coverage layouts beside it.
+    // Copy only those layouts onto the authority graph used for planning;
+    // target identity, relations, spans, and source bodies still all come
+    // from the exact pinned repository generation.
+    let planning_graph = kin_db::InMemoryGraph::from_snapshot(base.graph.to_snapshot())?;
+    for layout in state.graph.list_file_layouts()? {
+        planning_graph.upsert_file_layout(&layout)?;
+    }
+    let plan = plan_rename(&planning_graph, request, |_path, hash| {
+        Ok(load_native_source_blob(&authority_context, hash)?)
+    })?;
+    let (prospective, layouts) = apply_plan_in_memory(state, &authority_context, &base, &plan)?;
+    prove_plan_postconditions(&base.graph, &prospective, &plan)?;
+
+    let previous_tree = base.tree.clone();
+    let desired_tree = prospective.resolved_tree();
+    let native = plan_native_commit_from_base(
+        &prospective,
+        state.blobs.as_ref(),
+        &authority_context,
+        request.operation_id,
+        kin_model::Timestamp::now(),
+        request.actor.clone(),
+        rename_change_message(request)?,
+        &base,
+    )
+    .context("plan one exact repository-v6 rename transaction")?;
+    if native.change.tree_deltas.is_empty() || native.change.entity_deltas.is_empty() {
+        bail!(
+            "rename transaction did not carry both exact tree and semantic deltas; refusing a partial publication"
+        );
+    }
+    let planned_delta = TransactionDelta {
+        admission_policy_delta: native.change.admission_policy_delta.clone(),
+        ..TransactionDelta::default()
+    };
+    let (committed, authority_freeze, idempotent) = match commit_native_plan_with_projection(
+        &state.layout,
+        state.blobs.as_ref(),
+        &authority_context,
+        native,
+    ) {
+        Ok(committed) => {
+            let authority = authority_context.open()?;
+            let freeze = authority
+                .freeze_current_authority(&committed.receipt.roots_after)
+                .context("retain committed rename repository authority")?;
+            let idempotent = matches!(
+                committed.receipt.outcome,
+                kin_model::RepositoryCommitOutcome::IdempotentReplay
+            );
+            (committed, freeze, idempotent)
+        }
+        Err(commit_error) => {
+            let Some(recovered) = recover_native_commit(&authority_context, request.operation_id)?
+            else {
+                bail!("exact rename publication failed before authority moved: {commit_error}");
+            };
+            let authority = authority_context.open()?;
+            let freeze = authority
+                .freeze_current_authority(&recovered.receipt.roots_after)
+                .context("retain recovered rename repository authority")?;
+            (recovered, freeze, true)
+        }
+    };
+    let response = response_for(&plan, &committed, idempotent, request.json)?;
+    Ok(RenameExecution {
+        response,
+        committed,
+        authority_freeze,
+        previous_tree,
+        desired_tree,
+        planned_delta,
+        layouts,
+    })
+}
+
+fn recover_committed_rename(
+    state: &DaemonState,
+    request: &RenameRequest,
+    authority_context: &LocalRepositoryAuthorityContext,
+    committed: NativeCommitResult,
+) -> Result<RenameExecution> {
+    let expected_message = rename_change_message(request)?;
+    if committed.change.message != expected_message {
+        bail!(
+            "rename operation {} was already committed for a different request",
+            request.operation_id
+        );
+    }
+    let receipt = committed.receipt.clone();
+    let current = load_native_commit_base(authority_context)?;
+    if current.roots != receipt.roots_after {
+        bail!(
+            "repository authority advanced beyond recovered rename generation {}; reopen before retrying",
+            receipt.generation
+        );
+    }
+    let desired_tree = current.tree.clone();
+    let inverse = committed
+        .change
+        .tree_deltas
+        .iter()
+        .map(TreeDelta::inverse)
+        .collect::<Vec<_>>();
+    let previous_tree = desired_tree
+        .apply(&inverse)
+        .context("reconstruct recovered rename prior tree")?;
+    let entity_id = committed
+        .change
+        .entity_deltas
+        .iter()
+        .find_map(|delta| match delta {
+            EntityDelta::Modified { old, new }
+                if old.name == request.symbol && new.name == request.new_name =>
+            {
+                Some(old.id)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "recovered rename change does not carry the requested identity-preserving entity delta"
+            )
+        })?;
+    let plan = RenamePlan {
+        entity_id,
+        entity_kind: current
+            .graph
+            .get_entity(&entity_id)?
+            .ok_or_else(|| anyhow::anyhow!("recovered rename entity is absent"))?
+            .kind,
+        old_name: request.symbol.clone(),
+        new_name: request.new_name.clone(),
+        declaration_file: committed
+            .change
+            .tree_deltas
+            .iter()
+            .filter_map(|delta| delta.new_state())
+            .find_map(|located| located.path.as_utf8().map(FilePathId::new))
+            .ok_or_else(|| anyhow::anyhow!("recovered rename has no UTF-8 source path"))?,
+        edits: Vec::new(),
+        relation_ids: Vec::new(),
+    };
+    let layouts = rebuild_layouts(state, authority_context, &current, &committed.change)?;
+    let authority = authority_context.open()?;
+    let authority_freeze = authority
+        .freeze_current_authority(&receipt.roots_after)
+        .context("retain recovered rename repository authority")?;
+    let response = response_for(&plan, &committed, true, request.json)?;
+    Ok(RenameExecution {
+        response,
+        committed,
+        authority_freeze,
+        previous_tree,
+        desired_tree,
+        planned_delta: TransactionDelta::default(),
+        layouts,
+    })
+}
+
+fn rename_change_message(request: &RenameRequest) -> Result<String> {
+    // Bind idempotent recovery to every semantic selector and the recorded
+    // actor. JSON output preference is intentionally excluded because it does
+    // not change the transaction. A reused operation id with a different file
+    // cursor or actor must never replay a same-spelling rename elsewhere.
+    let binding = serde_json::to_vec(&(
+        request.symbol.as_str(),
+        request.new_name.as_str(),
+        request.file.as_deref(),
+        request.line,
+        request.column,
+        &request.actor,
+    ))
+    .context("encode exact rename request binding")?;
+    let digest = kin_blobs::digest(&binding);
+    Ok(format!(
+        "Rename {} to {}\n\nKin-Rename-Request: {}",
+        request.symbol, request.new_name, digest
+    ))
+}
+
+fn apply_plan_in_memory(
+    state: &DaemonState,
+    authority_context: &LocalRepositoryAuthorityContext,
+    base: &crate::repository_commit::NativeCommitBase,
+    plan: &RenamePlan,
+) -> Result<(kin_db::InMemoryGraph, Vec<FileLayout>)> {
+    let prospective = kin_db::InMemoryGraph::from_snapshot(base.graph.to_snapshot())
+        .context("create prospective rename graph")?;
+    let mut by_file = BTreeMap::<String, Vec<RenameEdit>>::new();
+    for edit in &plan.edits {
+        by_file
+            .entry(edit.file.0.clone())
+            .or_default()
+            .push(edit.clone());
+    }
+    let pipeline = kin_index::IndexPipeline::new();
+    let mut layouts = Vec::new();
+    for (file_path, mut edits) in by_file {
+        let file_id = FilePathId::new(file_path);
+        edits.sort_by_key(|edit| edit.start_byte);
+        validate_non_overlapping_edits(&file_id, &edits)?;
+        let path = RepoPath::from_utf8(file_id.0.clone())?;
+        let artifact = prospective
+            .resolved_tree()
+            .artifact_at_path(&path)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("rename source {file_id} left the exact tree"))?;
+        let (old_hash, executable) = match artifact.entry {
+            TreeEntry::Blob { hash, executable } => (hash, executable),
+            _ => bail!("rename source {file_id} is not a regular repository source blob"),
+        };
+        let original = load_native_source_blob(authority_context, old_hash)?;
+        let projected = apply_edits(&file_id, &original, &edits)?;
+        let digest = state.blobs.write(&projected)?;
+        let new_hash = Hash256::from_bytes(digest.0);
+        prospective.apply_transaction_delta(&TransactionDelta {
+            tree_deltas: vec![TreeDelta::Updated {
+                artifact_id: artifact.artifact_id,
+                old: artifact.located_entry(),
+                new: LocatedEntry::new(path, TreeEntry::blob(new_hash, executable)),
+            }],
+            ..TransactionDelta::default()
+        })?;
+
+        let indexed = pipeline
+            .index_any_content(&file_id, &projected, digest)
+            .with_context(|| format!("reparse renamed exact source {file_id}"))?;
+        let kin_index::IndexedAny::EntitySource(mut indexed) = indexed else {
+            bail!("renamed source {file_id} no longer classifies as entity source");
+        };
+        if indexed.file_layout.parse_completeness != ParseCompleteness::Full {
+            bail!(
+                "renamed source {file_id} reparsed with {} coverage; refusing incomplete semantic authority",
+                indexed.file_layout.parse_completeness.bucket()
+            );
+        }
+        if file_id == plan.declaration_file {
+            retain_target_identity(&mut indexed, plan)?;
+        }
+        let mut reconciler = kin_reconcile::Reconciler::new(std::path::PathBuf::new());
+        let reconcile = reconciler
+            .reconcile_indexed_content(&indexed, state.blobs.as_ref(), &prospective)
+            .with_context(|| format!("derive renamed semantics for {file_id}"))?;
+        if let Some(delta) = reconcile.delta.entity_deltas.iter().find(|delta| {
+            matches!(
+                delta,
+                EntityDelta::Added { .. } | EntityDelta::Removed { .. }
+            )
+        }) {
+            bail!(
+                "rename of {} would create or remove an entity while reparsing {file_id} ({delta:?}); refusing identity loss",
+                plan.entity_id
+            );
+        }
+        prospective
+            .apply_transaction_delta(&reconcile.delta)
+            .with_context(|| format!("apply renamed semantics for {file_id}"))?;
+        let layout = reconciler
+            .projection()
+            .get_layout(&file_id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("rename reparse produced no layout for {file_id}"))?;
+        prospective.upsert_file_layout(&layout)?;
+        layouts.push(layout);
+    }
+    Ok((prospective, layouts))
+}
+
+fn retain_target_identity(indexed: &mut kin_index::IndexedFile, plan: &RenamePlan) -> Result<()> {
+    let candidates = indexed
+        .entities
+        .iter()
+        .enumerate()
+        .filter(|(_, entity)| entity.name == plan.new_name && entity.kind == plan.entity_kind)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let [index] = candidates.as_slice() else {
+        bail!(
+            "renamed declaration reparsed into {} candidate identities named '{}' of kind {:?}; expected exactly one",
+            candidates.len(),
+            plan.new_name,
+            plan.entity_kind
+        );
+    };
+    let parsed_id = indexed.entities[*index].id;
+    if indexed
+        .entities
+        .iter()
+        .enumerate()
+        .any(|(other, entity)| other != *index && entity.id == plan.entity_id)
+    {
+        bail!(
+            "renamed target identity {} collides with another parsed entity",
+            plan.entity_id
+        );
+    }
+    indexed.entities[*index].id = plan.entity_id;
+    for relation in &mut indexed.relations {
+        if relation.src == GraphNodeId::Entity(parsed_id) {
+            relation.src = GraphNodeId::Entity(plan.entity_id);
+        }
+        if relation.dst == GraphNodeId::Entity(parsed_id) {
+            relation.dst = GraphNodeId::Entity(plan.entity_id);
+        }
+    }
+    for relation in &mut indexed.unresolved_relations {
+        if relation.src_entity_id == parsed_id {
+            relation.src_entity_id = plan.entity_id;
+        }
+    }
+    for region in &mut indexed.file_layout.regions {
+        if let SourceRegion::EntityRef { entity_id, .. } = region {
+            if *entity_id == parsed_id {
+                *entity_id = plan.entity_id;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_non_overlapping_edits(file: &FilePathId, edits: &[RenameEdit]) -> Result<()> {
+    for pair in edits.windows(2) {
+        if pair[0].end_byte > pair[1].start_byte {
+            bail!(
+                "rename plan contains overlapping edits in {file}: {}..{} and {}..{}",
+                pair[0].start_byte,
+                pair[0].end_byte,
+                pair[1].start_byte,
+                pair[1].end_byte
+            );
+        }
+    }
+    Ok(())
+}
+
+fn apply_edits(file: &FilePathId, original: &[u8], edits: &[RenameEdit]) -> Result<Vec<u8>> {
+    let mut projected = original.to_vec();
+    for edit in edits.iter().rev() {
+        if edit.end_byte > original.len() || edit.start_byte >= edit.end_byte {
+            bail!("rename edit for {file} is outside its exact source body");
+        }
+        if original.get(edit.start_byte..edit.end_byte) != Some(edit.old_text.as_bytes()) {
+            bail!(
+                "rename edit for {file} no longer matches '{}' at {}..{} in repository CAS",
+                edit.old_text,
+                edit.start_byte,
+                edit.end_byte
+            );
+        }
+        projected.splice(
+            edit.start_byte..edit.end_byte,
+            edit.new_text.as_bytes().iter().copied(),
+        );
+    }
+    Ok(projected)
+}
+
+fn prove_plan_postconditions(
+    before: &kin_db::InMemoryGraph,
+    after: &kin_db::InMemoryGraph,
+    plan: &RenamePlan,
+) -> Result<()> {
+    let old = before
+        .get_entity(&plan.entity_id)?
+        .ok_or_else(|| anyhow::anyhow!("rename target disappeared from its authority base"))?;
+    let new = after
+        .get_entity(&plan.entity_id)?
+        .ok_or_else(|| anyhow::anyhow!("rename target identity disappeared after reparse"))?;
+    if old.name != plan.old_name || new.name != plan.new_name || old.kind != new.kind {
+        bail!(
+            "rename did not preserve graph identity {} across '{}' -> '{}'",
+            plan.entity_id,
+            plan.old_name,
+            plan.new_name
+        );
+    }
+    let before_snapshot = before.to_snapshot();
+    let after_snapshot = after.to_snapshot();
+    let before_ids = before_snapshot
+        .relations
+        .keys()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let after_ids = after_snapshot
+        .relations
+        .keys()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if before_ids != after_ids {
+        let dropped = before_ids
+            .difference(&after_ids)
+            .copied()
+            .collect::<Vec<_>>();
+        let added = after_ids
+            .difference(&before_ids)
+            .copied()
+            .collect::<Vec<_>>();
+        bail!(
+            "rename reparse changed graph relation identity topology (dropped: {:?}, added: {:?}); refusing semantic drift",
+            dropped,
+            added
+        );
+    }
+    for (relation_id, prior) in &before_snapshot.relations {
+        let current = after_snapshot
+            .relations
+            .get(relation_id)
+            .expect("relation identity sets were proven equal");
+        if prior.kind != current.kind || prior.src != current.src || prior.dst != current.dst {
+            bail!(
+                "rename reparse rewired graph relation {} from {:?} {} -> {} to {:?} {} -> {}; refusing semantic drift",
+                relation_id,
+                prior.kind,
+                prior.src,
+                prior.dst,
+                current.kind,
+                current.src,
+                current.dst
+            );
+        }
+    }
+    if plan
+        .relation_ids
+        .iter()
+        .any(|relation_id| !after_snapshot.relations.contains_key(relation_id))
+    {
+        bail!("rename reparse lost a graph relation that selected an edit site");
+    }
+    Ok(())
+}
+
+fn response_for(
+    plan: &RenamePlan,
+    committed: &NativeCommitResult,
+    idempotent: bool,
+    json: bool,
+) -> Result<RenameResponse> {
+    let mut edited_files = committed
+        .change
+        .tree_deltas
+        .iter()
+        .filter_map(|delta| delta.new_state())
+        .filter_map(|located| located.path.as_utf8().map(FilePathId::new))
+        .collect::<Vec<_>>();
+    edited_files.sort_by(|left, right| left.0.cmp(&right.0));
+    edited_files.dedup();
+    let report = RenameReport {
+        authority: "repository-v6 graph + source CAS".to_string(),
+        operation_id: committed.receipt.operation_id,
+        change_id: committed.change.id,
+        authority_generation: committed.receipt.generation,
+        entity_id: plan.entity_id,
+        old_name: plan.old_name.clone(),
+        new_name: plan.new_name.clone(),
+        edited_files,
+        edit_count: plan.edits.len(),
+        idempotent,
+    };
+    let lines = if json {
+        Vec::new()
+    } else if idempotent && plan.edits.is_empty() {
+        vec![
+            format!(
+                "Recovered committed rename {} -> {} across {} file(s); no new edits applied",
+                report.old_name,
+                report.new_name,
+                report.edited_files.len()
+            ),
+            format!(
+                "Repository-v6 change {} remains at generation {}",
+                report.change_id, report.authority_generation
+            ),
+        ]
+    } else {
+        vec![
+            format!(
+                "Renamed {} -> {} across {} exact edit(s) in {} file(s)",
+                report.old_name,
+                report.new_name,
+                report.edit_count,
+                report.edited_files.len()
+            ),
+            format!(
+                "Repository-v6 change {} committed at generation {}",
+                report.change_id, report.authority_generation
+            ),
+        ]
+    };
+    Ok(RenameResponse {
+        lines,
+        report: Some(report),
+    })
+}
+
+fn rebuild_layouts(
+    state: &DaemonState,
+    authority_context: &LocalRepositoryAuthorityContext,
+    current: &crate::repository_commit::NativeCommitBase,
+    change: &kin_model::SemanticChange,
+) -> Result<Vec<FileLayout>> {
+    let pipeline = kin_index::IndexPipeline::new();
+    let changed = change
+        .tree_deltas
+        .iter()
+        .filter_map(|delta| delta.new_state())
+        .filter_map(|located| located.path.as_utf8().map(FilePathId::new))
+        .collect::<HashSet<_>>();
+    let mut layouts = Vec::new();
+    for file_id in changed {
+        let path = RepoPath::from_utf8(file_id.0.clone())?;
+        let artifact = current
+            .tree
+            .artifact_at_path(&path)
+            .ok_or_else(|| anyhow::anyhow!("recovered rename source {file_id} is absent"))?;
+        let hash = artifact
+            .entry
+            .blob_identity()
+            .ok_or_else(|| anyhow::anyhow!("recovered rename source {file_id} is not a blob"))?;
+        let body = load_native_source_blob(authority_context, hash)?;
+        let digest = state.blobs.write(&body)?;
+        let indexed = pipeline.index_any_content(&file_id, &body, digest)?;
+        let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
+            bail!("recovered rename source {file_id} is no longer entity source");
+        };
+        let mut layout = indexed.file_layout;
+        stabilize_recovered_layout(&mut layout, &indexed.entities, &current.graph)?;
+        layouts.push(layout);
+    }
+    Ok(layouts)
+}
+
+fn stabilize_recovered_layout(
+    layout: &mut FileLayout,
+    parsed: &[kin_model::Entity],
+    graph: &kin_db::InMemoryGraph,
+) -> Result<()> {
+    let entities = graph.query_entities(&kin_model::EntityFilter {
+        file_path: Some(layout.file_id.clone()),
+        ..kin_model::EntityFilter::default()
+    })?;
+    for region in &mut layout.regions {
+        let SourceRegion::EntityRef { entity_id, .. } = region else {
+            continue;
+        };
+        let parsed_entity = parsed
+            .iter()
+            .find(|entity| entity.id == *entity_id)
+            .ok_or_else(|| anyhow::anyhow!("recovered layout references unknown parsed entity"))?;
+        let matches = entities
+            .iter()
+            .filter(|entity| entity.name == parsed_entity.name && entity.kind == parsed_entity.kind)
+            .collect::<Vec<_>>();
+        let [matched] = matches.as_slice() else {
+            bail!(
+                "recovered layout entity '{}' of kind {:?} maps to {} authority identities",
+                parsed_entity.name,
+                parsed_entity.kind,
+                matches.len()
+            );
+        };
+        *entity_id = matched.id;
+    }
+    Ok(())
+}
+
+fn rename_error(error: anyhow::Error) -> (StatusCode, String) {
+    let message = format!("{error:#}");
+    let status = if message.contains("not a simple source identifier") {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::CONFLICT
+    };
+    (status, message)
+}
+
+fn internal_error(error: impl std::fmt::Display) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, OnceLock};
+
+    use kin_model::{AuthorId, RelationDelta, RelationId, RelationKind, Timestamp};
+
+    fn install_test_registry_override() {
+        static REGISTRY_PATH: OnceLock<std::path::PathBuf> = OnceLock::new();
+        let _guard = crate::test_env_lock();
+        let path = REGISTRY_PATH.get_or_init(|| {
+            let root = std::env::temp_dir().join(format!(
+                "kin-daemon-rename-registry-{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            let path = root.join("registry.toml");
+            kin_core::registry::KinRegistry { repos: Vec::new() }
+                .save_to(&path)
+                .unwrap();
+            path
+        });
+        kin_core::test_env::install_process_wide("KIN_REGISTRY_PATH", path);
+    }
+
+    struct RenameFixture {
+        _root: tempfile::TempDir,
+        state: Arc<DaemonState>,
+        target_id: kin_model::EntityId,
+        relation_id: RelationId,
+        target_file: FilePathId,
+        caller_file: FilePathId,
+    }
+
+    fn exact_rename_fixture() -> RenameFixture {
+        install_test_registry_override();
+        let root = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(root.path()).unwrap().layout;
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+        let target_file = FilePathId::new("src/target.rs");
+        let caller_file = FilePathId::new("src/caller.rs");
+        let target_body = b"pub fn target() -> u32 { 7 }\n";
+        let caller_body = b"pub fn caller() -> u32 { target() + target() }\n";
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join(&target_file.0), target_body).unwrap();
+        std::fs::write(root.path().join(&caller_file.0), caller_body).unwrap();
+
+        let target_digest = state.blobs.write(target_body).unwrap();
+        let caller_digest = state.blobs.write(caller_body).unwrap();
+        let pipeline = kin_index::IndexPipeline::new();
+        let kin_index::IndexedAny::EntitySource(target_indexed) = pipeline
+            .index_any_content(&target_file, target_body, target_digest)
+            .unwrap()
+        else {
+            panic!("target fixture must classify as source");
+        };
+        let kin_index::IndexedAny::EntitySource(caller_indexed) = pipeline
+            .index_any_content(&caller_file, caller_body, caller_digest)
+            .unwrap()
+        else {
+            panic!("caller fixture must classify as source");
+        };
+        let target = target_indexed
+            .entities
+            .iter()
+            .find(|entity| entity.name == "target")
+            .unwrap()
+            .clone();
+        let caller = caller_indexed
+            .entities
+            .iter()
+            .find(|entity| entity.name == "caller")
+            .unwrap()
+            .clone();
+        let target_artifact = kin_model::ArtifactId::new();
+        let caller_artifact = kin_model::ArtifactId::new();
+        let artifact_ids = kin_index::linker::ArtifactIdentityMap::from([
+            (target_file.0.clone(), target_artifact),
+            (caller_file.0.clone(), caller_artifact),
+        ]);
+        let linked = pipeline
+            .resolve_cross_file(
+                &[
+                    kin_index::FileParseData {
+                        file_path: target_file.0.clone(),
+                        entities: target_indexed.entities.clone(),
+                        relations: target_indexed.extracted_relations.clone(),
+                        imports: target_indexed.imports.clone(),
+                    },
+                    kin_index::FileParseData {
+                        file_path: caller_file.0.clone(),
+                        entities: caller_indexed.entities.clone(),
+                        relations: caller_indexed.extracted_relations.clone(),
+                        imports: caller_indexed.imports.clone(),
+                    },
+                ],
+                &artifact_ids,
+            )
+            .unwrap();
+        let relation = linked
+            .into_iter()
+            .find(|relation| {
+                relation.kind == RelationKind::Calls
+                    && relation.src == GraphNodeId::Entity(caller.id)
+                    && relation.dst == GraphNodeId::Entity(target.id)
+            })
+            .expect("real linker must resolve the repeated caller/target edge");
+        assert!(relation
+            .evidence
+            .iter()
+            .all(|evidence| evidence.source_span.is_none()));
+        assert_eq!(
+            relation
+                .evidence
+                .iter()
+                .map(|evidence| evidence.occurrence_count)
+                .sum::<u32>(),
+            2
+        );
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: target_indexed
+                    .entities
+                    .iter()
+                    .chain(&caller_indexed.entities)
+                    .cloned()
+                    .map(|new| EntityDelta::Added { new })
+                    .collect(),
+                relation_deltas: vec![RelationDelta::Added {
+                    new: relation.clone(),
+                }],
+                tree_deltas: vec![
+                    TreeDelta::Added {
+                        artifact_id: target_artifact,
+                        new: LocatedEntry::new(
+                            RepoPath::from_utf8(target_file.0.clone()).unwrap(),
+                            TreeEntry::blob(Hash256::from_bytes(target_digest.0), false),
+                        ),
+                    },
+                    TreeDelta::Added {
+                        artifact_id: caller_artifact,
+                        new: LocatedEntry::new(
+                            RepoPath::from_utf8(caller_file.0.clone()).unwrap(),
+                            TreeEntry::blob(Hash256::from_bytes(caller_digest.0), false),
+                        ),
+                    },
+                ],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        state
+            .graph
+            .upsert_file_layout(&target_indexed.file_layout)
+            .unwrap();
+        state
+            .graph
+            .upsert_file_layout(&caller_indexed.file_layout)
+            .unwrap();
+        let authority_context = LocalRepositoryAuthorityContext::from_state(&state).unwrap();
+        let native = crate::repository_commit::plan_native_commit(
+            &state.graph,
+            state.blobs.as_ref(),
+            &authority_context,
+            kin_model::OperationId::new(),
+            Timestamp::now(),
+            AuthorId::new("rename-fixture"),
+            "Install exact rename fixture".to_string(),
+        )
+        .unwrap();
+        let committed = crate::repository_commit::commit_native_plan(
+            state.blobs.as_ref(),
+            &authority_context,
+            native,
+        )
+        .unwrap();
+        state
+            .graph
+            .create_changes(vec![committed.change.clone()])
+            .unwrap();
+        state
+            .record_repository_authority_commit(committed.receipt.generation)
+            .unwrap();
+
+        RenameFixture {
+            _root: root,
+            state,
+            target_id: target.id,
+            relation_id: relation.id,
+            target_file,
+            caller_file,
+        }
+    }
+
+    #[test]
+    fn exact_edit_application_refuses_a_moved_token() {
+        let file = FilePathId::new("src/lib.rs");
+        let edit = RenameEdit {
+            file: file.clone(),
+            start_byte: 3,
+            end_byte: 9,
+            start_line: 1,
+            start_col: 3,
+            end_line: 1,
+            end_col: 9,
+            old_text: "target".to_string(),
+            new_text: "renamed".to_string(),
+            reason: "declaration".to_string(),
+            declaration: true,
+        };
+        let error = apply_edits(&file, b"fn other() {}", &[edit]).unwrap_err();
+        assert!(error.to_string().contains("no longer matches"));
+    }
+
+    #[test]
+    fn repository_rename_commits_tree_and_semantics_and_replays_by_operation() {
+        let fixture = exact_rename_fixture();
+        let operation_id = kin_model::OperationId::new();
+        let request = RenameRequest {
+            symbol: "target".to_string(),
+            new_name: "renamed_target".to_string(),
+            file: Some(fixture.target_file.0.clone()),
+            line: Some(1),
+            column: None,
+            json: true,
+            operation_id,
+            actor: AuthorId::new("rename-test"),
+        };
+
+        let first = execute(&fixture.state, &request).unwrap();
+        let report = first.report.unwrap();
+        assert_eq!(report.operation_id, operation_id);
+        assert_eq!(report.entity_id, fixture.target_id);
+        assert_eq!(report.edit_count, 3);
+        assert_eq!(report.edited_files.len(), 2);
+        assert!(!report.idempotent);
+        assert_eq!(
+            std::fs::read_to_string(
+                fixture
+                    .state
+                    .layout
+                    .working_dir()
+                    .join(&fixture.target_file.0)
+            )
+            .unwrap(),
+            "pub fn renamed_target() -> u32 { 7 }\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                fixture
+                    .state
+                    .layout
+                    .working_dir()
+                    .join(&fixture.caller_file.0)
+            )
+            .unwrap(),
+            "pub fn caller() -> u32 { renamed_target() + renamed_target() }\n"
+        );
+
+        let live_target = fixture
+            .state
+            .graph
+            .get_entity(&fixture.target_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(live_target.name, "renamed_target");
+        assert!(fixture
+            .state
+            .graph
+            .to_snapshot()
+            .relations
+            .contains_key(&fixture.relation_id));
+        let authority_context =
+            LocalRepositoryAuthorityContext::from_state(&fixture.state).unwrap();
+        let authority_base = load_native_commit_base(&authority_context).unwrap();
+        assert_eq!(
+            authority_base
+                .graph
+                .get_entity(&fixture.target_id)
+                .unwrap()
+                .unwrap()
+                .name,
+            "renamed_target"
+        );
+        assert!(authority_base
+            .graph
+            .to_snapshot()
+            .relations
+            .contains_key(&fixture.relation_id));
+
+        let mut mismatched = request.clone();
+        mismatched.file = Some(fixture.caller_file.0.clone());
+        let (_, mismatch) = execute(&fixture.state, &mismatched).unwrap_err();
+        assert!(mismatch.contains("already committed for a different request"));
+
+        let mut text_request = request.clone();
+        text_request.json = false;
+        let replay = execute(&fixture.state, &text_request).unwrap();
+        let replay_report = replay.report.unwrap();
+        assert!(replay_report.idempotent);
+        assert_eq!(replay_report.edit_count, 0);
+
+        let reopened = Arc::new(DaemonState::open(fixture.state.layout.clone()).unwrap());
+        let restart_replay = execute(&reopened, &request).unwrap();
+        let restart_report = restart_replay.report.unwrap();
+        assert!(restart_report.idempotent);
+        assert_eq!(restart_report.edit_count, 0);
+        assert_eq!(
+            reopened
+                .graph
+                .get_entity(&fixture.target_id)
+                .unwrap()
+                .unwrap()
+                .name,
+            "renamed_target"
+        );
+    }
+
+    #[test]
+    fn repository_rename_refuses_unadmitted_working_tree_drift_without_moving_authority() {
+        let fixture = exact_rename_fixture();
+        let authority_context =
+            LocalRepositoryAuthorityContext::from_state(&fixture.state).unwrap();
+        let roots_before = authority_context
+            .open()
+            .unwrap()
+            .read_authority()
+            .roots()
+            .clone();
+        let graph_root_before = fixture.state.graph.compute_root_hash();
+        let tree_before = fixture.state.graph.resolved_tree();
+        std::fs::write(
+            fixture
+                .state
+                .layout
+                .working_dir()
+                .join(&fixture.caller_file.0),
+            b"pub fn caller() -> u32 { 99 }\n",
+        )
+        .unwrap();
+        let request = RenameRequest {
+            symbol: "target".to_string(),
+            new_name: "renamed_target".to_string(),
+            file: Some(fixture.target_file.0.clone()),
+            line: Some(1),
+            column: None,
+            json: true,
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("rename-drift-test"),
+        };
+
+        let (status, message) = execute(&fixture.state, &request).unwrap_err();
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            message.contains("failed before authority moved"),
+            "unexpected refusal: {message}"
+        );
+        let roots_after = authority_context
+            .open()
+            .unwrap()
+            .read_authority()
+            .roots()
+            .clone();
+        assert_eq!(roots_after, roots_before);
+        assert_eq!(fixture.state.graph.compute_root_hash(), graph_root_before);
+        assert_eq!(fixture.state.graph.resolved_tree(), tree_before);
+    }
+}

--- a/crates/kin-daemon/src/repository_rename.rs
+++ b/crates/kin-daemon/src/repository_rename.rs
@@ -14,10 +14,11 @@ use kin_cli::commands::rename::{
     plan_rename, RenameEdit, RenamePlan, RenameReport, RenameRequest, RenameResponse,
 };
 use kin_model::{
-    ChangeStore, EntityDelta, EntityStore, FileLayout, FilePathId, GraphNodeId, Hash256,
-    LocatedEntry, ParseCompleteness, RepoPath, SourceRegion, TransactionDelta, TreeDelta,
+    ChangeStore, EntityDelta, EntityKind, EntityStore, FileLayout, FilePathId, GraphNodeId,
+    Hash256, LocatedEntry, ParseCompleteness, RepoPath, SourceRegion, TransactionDelta, TreeDelta,
     TreeEntry,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::local_repository_authority::{
@@ -31,12 +32,33 @@ use crate::state::{DaemonEvent, DaemonState};
 
 struct RenameExecution {
     response: RenameResponse,
+    finalization: Option<RenameFinalization>,
+}
+
+struct RenameFinalization {
     committed: NativeCommitResult,
     authority_freeze: kin_db::LocalRepositoryAuthorityFreeze,
     previous_tree: kin_model::ResolvedTree,
     desired_tree: kin_model::ResolvedTree,
     planned_delta: TransactionDelta,
     layouts: Vec<FileLayout>,
+}
+
+const RENAME_METADATA_SCHEMA: &str = "kin.repository-rename-receipt.v1";
+const RENAME_METADATA_PREFIX: &str = "Kin-Rename-Metadata: ";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct RenameCommitMetadata {
+    schema: String,
+    request_binding: Hash256,
+    entity_id: kin_model::EntityId,
+    entity_kind: EntityKind,
+    old_name: String,
+    new_name: String,
+    declaration_file: FilePathId,
+    edited_files: Vec<FilePathId>,
+    edit_count: usize,
 }
 
 pub(crate) fn execute(
@@ -51,7 +73,15 @@ pub(crate) fn execute(
         )
     })?;
     let previous_graph_root = hex::encode(state.graph.compute_root_hash());
-    let execution = plan_commit_and_retain_authority(state, request).map_err(rename_error)?;
+    let RenameExecution {
+        response,
+        finalization,
+    } = plan_commit_and_retain_authority(state, request).map_err(rename_error)?;
+    let Some(execution) = finalization else {
+        drop(persistence);
+        drop(graph_mutation);
+        return Ok(response);
+    };
 
     if state
         .graph
@@ -99,7 +129,7 @@ pub(crate) fn execute(
     }
     drop(persistence);
     drop(graph_mutation);
-    Ok(execution.response)
+    Ok(response)
 }
 
 fn plan_commit_and_retain_authority(
@@ -139,6 +169,7 @@ fn plan_commit_and_retain_authority(
     let plan = plan_rename(&planning_graph, request, |_path, hash| {
         Ok(load_native_source_blob(&authority_context, hash)?)
     })?;
+    let metadata = RenameCommitMetadata::from_plan(request, &plan)?;
     let (prospective, layouts) = apply_plan_in_memory(state, &authority_context, &base, &plan)?;
     prove_plan_postconditions(&base.graph, &prospective, &plan)?;
 
@@ -151,7 +182,7 @@ fn plan_commit_and_retain_authority(
         request.operation_id,
         kin_model::Timestamp::now(),
         request.actor.clone(),
-        rename_change_message(request)?,
+        rename_change_message(&metadata)?,
         &base,
     )
     .context("plan one exact repository-v6 rename transaction")?;
@@ -171,37 +202,37 @@ fn plan_commit_and_retain_authority(
         native,
     ) {
         Ok(committed) => {
+            if matches!(
+                committed.receipt.outcome,
+                kin_model::RepositoryCommitOutcome::IdempotentReplay
+            ) {
+                return recover_committed_rename(state, request, &authority_context, committed);
+            }
             let authority = authority_context.open()?;
             let freeze = authority
                 .freeze_current_authority(&committed.receipt.roots_after)
                 .context("retain committed rename repository authority")?;
-            let idempotent = matches!(
-                committed.receipt.outcome,
-                kin_model::RepositoryCommitOutcome::IdempotentReplay
-            );
-            (committed, freeze, idempotent)
+            (committed, freeze, false)
         }
         Err(commit_error) => {
             let Some(recovered) = recover_native_commit(&authority_context, request.operation_id)?
             else {
                 bail!("exact rename publication failed before authority moved: {commit_error}");
             };
-            let authority = authority_context.open()?;
-            let freeze = authority
-                .freeze_current_authority(&recovered.receipt.roots_after)
-                .context("retain recovered rename repository authority")?;
-            (recovered, freeze, true)
+            return recover_committed_rename(state, request, &authority_context, recovered);
         }
     };
-    let response = response_for(&plan, &committed, idempotent, request.json)?;
+    let response = response_for(&metadata, &committed, idempotent, request.json)?;
     Ok(RenameExecution {
         response,
-        committed,
-        authority_freeze,
-        previous_tree,
-        desired_tree,
-        planned_delta,
-        layouts,
+        finalization: Some(RenameFinalization {
+            committed,
+            authority_freeze,
+            previous_tree,
+            desired_tree,
+            planned_delta,
+            layouts,
+        }),
     })
 }
 
@@ -211,20 +242,39 @@ fn recover_committed_rename(
     authority_context: &LocalRepositoryAuthorityContext,
     committed: NativeCommitResult,
 ) -> Result<RenameExecution> {
-    let expected_message = rename_change_message(request)?;
-    if committed.change.message != expected_message {
+    let metadata = rename_metadata_from_change(&committed.change.message)?;
+    if metadata.request_binding != rename_request_binding(request)? {
         bail!(
             "rename operation {} was already committed for a different request",
             request.operation_id
         );
     }
+    validate_recovered_metadata(&metadata, &committed)?;
     let receipt = committed.receipt.clone();
     let current = load_native_commit_base(authority_context)?;
-    if current.roots != receipt.roots_after {
+    if current.roots.generation < receipt.generation {
         bail!(
-            "repository authority advanced beyond recovered rename generation {}; reopen before retrying",
+            "repository authority generation {} is behind recovered rename generation {}; refusing inconsistent operation history",
+            current.roots.generation,
+            receipt.generation,
+        );
+    }
+    if current.roots.generation == receipt.generation && current.roots != receipt.roots_after {
+        bail!(
+            "repository authority diverges from recovered rename generation {}; refusing ambiguous operation history",
             receipt.generation
         );
+    }
+    let response = response_for(&metadata, &committed, true, request.json)?;
+    if current.roots != receipt.roots_after {
+        // A later serialized transaction is already authoritative. The
+        // operation receipt and bound change are immutable historical truth;
+        // replay the original outcome without trying to reinstall or finalize
+        // an old generation over the current workspace.
+        return Ok(RenameExecution {
+            response,
+            finalization: None,
+        });
     }
     let desired_tree = current.tree.clone();
     let inverse = committed
@@ -236,64 +286,25 @@ fn recover_committed_rename(
     let previous_tree = desired_tree
         .apply(&inverse)
         .context("reconstruct recovered rename prior tree")?;
-    let entity_id = committed
-        .change
-        .entity_deltas
-        .iter()
-        .find_map(|delta| match delta {
-            EntityDelta::Modified { old, new }
-                if old.name == request.symbol && new.name == request.new_name =>
-            {
-                Some(old.id)
-            }
-            _ => None,
-        })
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "recovered rename change does not carry the requested identity-preserving entity delta"
-            )
-        })?;
-    let plan = RenamePlan {
-        entity_id,
-        entity_kind: current
-            .graph
-            .get_entity(&entity_id)?
-            .ok_or_else(|| anyhow::anyhow!("recovered rename entity is absent"))?
-            .kind,
-        old_name: request.symbol.clone(),
-        new_name: request.new_name.clone(),
-        declaration_file: committed
-            .change
-            .tree_deltas
-            .iter()
-            .filter_map(|delta| delta.new_state())
-            .find_map(|located| located.path.as_utf8().map(FilePathId::new))
-            .ok_or_else(|| anyhow::anyhow!("recovered rename has no UTF-8 source path"))?,
-        edits: Vec::new(),
-        relation_ids: Vec::new(),
-    };
     let layouts = rebuild_layouts(state, authority_context, &current, &committed.change)?;
     let authority = authority_context.open()?;
     let authority_freeze = authority
         .freeze_current_authority(&receipt.roots_after)
         .context("retain recovered rename repository authority")?;
-    let response = response_for(&plan, &committed, true, request.json)?;
     Ok(RenameExecution {
         response,
-        committed,
-        authority_freeze,
-        previous_tree,
-        desired_tree,
-        planned_delta: TransactionDelta::default(),
-        layouts,
+        finalization: Some(RenameFinalization {
+            committed,
+            authority_freeze,
+            previous_tree,
+            desired_tree,
+            planned_delta: TransactionDelta::default(),
+            layouts,
+        }),
     })
 }
 
-fn rename_change_message(request: &RenameRequest) -> Result<String> {
-    // Bind idempotent recovery to every semantic selector and the recorded
-    // actor. JSON output preference is intentionally excluded because it does
-    // not change the transaction. A reused operation id with a different file
-    // cursor or actor must never replay a same-spelling rename elsewhere.
+fn rename_request_binding(request: &RenameRequest) -> Result<Hash256> {
     let binding = serde_json::to_vec(&(
         request.symbol.as_str(),
         request.new_name.as_str(),
@@ -303,11 +314,105 @@ fn rename_change_message(request: &RenameRequest) -> Result<String> {
         &request.actor,
     ))
     .context("encode exact rename request binding")?;
-    let digest = kin_blobs::digest(&binding);
+    Ok(Hash256::from_bytes(kin_blobs::digest(&binding).0))
+}
+
+impl RenameCommitMetadata {
+    fn from_plan(request: &RenameRequest, plan: &RenamePlan) -> Result<Self> {
+        let mut edited_files = plan
+            .edits
+            .iter()
+            .map(|edit| edit.file.clone())
+            .collect::<Vec<_>>();
+        edited_files.sort_by(|left, right| left.0.cmp(&right.0));
+        edited_files.dedup();
+        Ok(Self {
+            schema: RENAME_METADATA_SCHEMA.to_string(),
+            request_binding: rename_request_binding(request)?,
+            entity_id: plan.entity_id,
+            entity_kind: plan.entity_kind,
+            old_name: plan.old_name.clone(),
+            new_name: plan.new_name.clone(),
+            declaration_file: plan.declaration_file.clone(),
+            edited_files,
+            edit_count: plan.edits.len(),
+        })
+    }
+}
+
+fn rename_change_message(metadata: &RenameCommitMetadata) -> Result<String> {
+    let encoded =
+        serde_json::to_string(metadata).context("encode durable rename receipt metadata")?;
     Ok(format!(
-        "Rename {} to {}\n\nKin-Rename-Request: {}",
-        request.symbol, request.new_name, digest
+        "Rename {} to {}\n\n{}{}",
+        metadata.old_name, metadata.new_name, RENAME_METADATA_PREFIX, encoded
     ))
+}
+
+fn rename_metadata_from_change(message: &str) -> Result<RenameCommitMetadata> {
+    let encoded = message
+        .lines()
+        .find_map(|line| line.strip_prefix(RENAME_METADATA_PREFIX))
+        .ok_or_else(|| {
+            anyhow::anyhow!("recovered rename change has no durable receipt metadata")
+        })?;
+    let metadata: RenameCommitMetadata =
+        serde_json::from_str(encoded).context("decode durable rename receipt metadata")?;
+    if metadata.schema != RENAME_METADATA_SCHEMA {
+        bail!(
+            "recovered rename metadata schema '{}' is unsupported",
+            metadata.schema
+        );
+    }
+    Ok(metadata)
+}
+
+fn validate_recovered_metadata(
+    metadata: &RenameCommitMetadata,
+    committed: &NativeCommitResult,
+) -> Result<()> {
+    if metadata.edit_count == 0
+        || metadata.edited_files.is_empty()
+        || !metadata.edited_files.contains(&metadata.declaration_file)
+    {
+        bail!("recovered rename metadata does not describe a complete source edit set");
+    }
+    let identity_delta = committed.change.entity_deltas.iter().any(|delta| {
+        matches!(
+            delta,
+            EntityDelta::Modified { old, new }
+                if old.id == metadata.entity_id
+                    && new.id == metadata.entity_id
+                    && old.kind == metadata.entity_kind
+                    && new.kind == metadata.entity_kind
+                    && old.name == metadata.old_name
+                    && new.name == metadata.new_name
+        )
+    });
+    if !identity_delta {
+        bail!(
+            "recovered rename change does not carry its metadata-bound identity-preserving entity delta"
+        );
+    }
+    let mut changed_files = committed
+        .change
+        .tree_deltas
+        .iter()
+        .filter_map(|delta| delta.new_state())
+        .map(|located| {
+            located
+                .path
+                .as_utf8()
+                .map(FilePathId::new)
+                .ok_or_else(|| anyhow::anyhow!("recovered rename source path is not UTF-8"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    changed_files.sort_by(|left, right| left.0.cmp(&right.0));
+    changed_files.dedup();
+    if changed_files != metadata.edited_files {
+        bail!("recovered rename source delta set disagrees with durable receipt metadata");
+    }
+    Ok(())
 }
 
 fn apply_plan_in_memory(
@@ -562,40 +667,32 @@ fn prove_plan_postconditions(
 }
 
 fn response_for(
-    plan: &RenamePlan,
+    metadata: &RenameCommitMetadata,
     committed: &NativeCommitResult,
     idempotent: bool,
     json: bool,
 ) -> Result<RenameResponse> {
-    let mut edited_files = committed
-        .change
-        .tree_deltas
-        .iter()
-        .filter_map(|delta| delta.new_state())
-        .filter_map(|located| located.path.as_utf8().map(FilePathId::new))
-        .collect::<Vec<_>>();
-    edited_files.sort_by(|left, right| left.0.cmp(&right.0));
-    edited_files.dedup();
     let report = RenameReport {
         authority: "repository-v6 graph + source CAS".to_string(),
         operation_id: committed.receipt.operation_id,
         change_id: committed.change.id,
         authority_generation: committed.receipt.generation,
-        entity_id: plan.entity_id,
-        old_name: plan.old_name.clone(),
-        new_name: plan.new_name.clone(),
-        edited_files,
-        edit_count: plan.edits.len(),
+        entity_id: metadata.entity_id,
+        old_name: metadata.old_name.clone(),
+        new_name: metadata.new_name.clone(),
+        edited_files: metadata.edited_files.clone(),
+        edit_count: metadata.edit_count,
         idempotent,
     };
     let lines = if json {
         Vec::new()
-    } else if idempotent && plan.edits.is_empty() {
+    } else if idempotent {
         vec![
             format!(
-                "Recovered committed rename {} -> {} across {} file(s); no new edits applied",
+                "Recovered committed rename {} -> {} ({} original exact edit(s) across {} file(s)); no new edits applied",
                 report.old_name,
                 report.new_name,
+                report.edit_count,
                 report.edited_files.len()
             ),
             format!(
@@ -789,27 +886,35 @@ mod tests {
             (target_file.0.clone(), target_artifact),
             (caller_file.0.clone(), caller_artifact),
         ]);
-        let linked = pipeline
-            .resolve_cross_file(
-                &[
-                    kin_index::FileParseData {
-                        file_path: target_file.0.clone(),
-                        entities: target_indexed.entities.clone(),
-                        relations: target_indexed.extracted_relations.clone(),
-                        imports: target_indexed.imports.clone(),
-                    },
-                    kin_index::FileParseData {
-                        file_path: caller_file.0.clone(),
-                        entities: caller_indexed.entities.clone(),
-                        relations: caller_indexed.extracted_relations.clone(),
-                        imports: caller_indexed.imports.clone(),
-                    },
-                ],
-                &artifact_ids,
-            )
-            .unwrap();
+        let parse_data = [
+            kin_index::FileParseData {
+                file_path: target_file.0.clone(),
+                entities: target_indexed.entities.clone(),
+                relations: target_indexed.extracted_relations.clone(),
+                imports: target_indexed.imports.clone(),
+            },
+            kin_index::FileParseData {
+                file_path: caller_file.0.clone(),
+                entities: caller_indexed.entities.clone(),
+                relations: caller_indexed.extracted_relations.clone(),
+                imports: caller_indexed.imports.clone(),
+            },
+        ];
+        let completeness = kin_index::FileParseCompletenessMap::from([
+            (
+                target_file.0.clone(),
+                target_indexed.file_layout.parse_completeness.clone(),
+            ),
+            (
+                caller_file.0.clone(),
+                caller_indexed.file_layout.parse_completeness.clone(),
+            ),
+        ]);
+        let linked =
+            kin_index::link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)
+                .unwrap();
         let relation = linked
-            .into_iter()
+            .iter()
             .find(|relation| {
                 relation.kind == RelationKind::Calls
                     && relation.src == GraphNodeId::Entity(caller.id)
@@ -838,9 +943,11 @@ mod tests {
                     .cloned()
                     .map(|new| EntityDelta::Added { new })
                     .collect(),
-                relation_deltas: vec![RelationDelta::Added {
-                    new: relation.clone(),
-                }],
+                relation_deltas: linked
+                    .iter()
+                    .cloned()
+                    .map(|new| RelationDelta::Added { new })
+                    .collect(),
                 tree_deltas: vec![
                     TreeDelta::Added {
                         artifact_id: target_artifact,
@@ -1001,21 +1108,40 @@ mod tests {
 
         let mut mismatched = request.clone();
         mismatched.file = Some(fixture.caller_file.0.clone());
-        let (_, mismatch) = execute(&fixture.state, &mismatched).unwrap_err();
-        assert!(mismatch.contains("already committed for a different request"));
+        let mut selector_mismatch = request.clone();
+        selector_mismatch.symbol = "module::target".to_string();
+        let mut name_mismatch = request.clone();
+        name_mismatch.new_name = "other_target".to_string();
+        let mut line_mismatch = request.clone();
+        line_mismatch.line = Some(2);
+        let mut column_mismatch = request.clone();
+        column_mismatch.column = Some(0);
+        let mut actor_mismatch = request.clone();
+        actor_mismatch.actor = AuthorId::new("different-actor");
+        for changed in [
+            mismatched,
+            selector_mismatch,
+            name_mismatch,
+            line_mismatch,
+            column_mismatch,
+            actor_mismatch,
+        ] {
+            let (_, mismatch) = execute(&fixture.state, &changed).unwrap_err();
+            assert!(mismatch.contains("already committed for a different request"));
+        }
 
         let mut text_request = request.clone();
         text_request.json = false;
         let replay = execute(&fixture.state, &text_request).unwrap();
         let replay_report = replay.report.unwrap();
         assert!(replay_report.idempotent);
-        assert_eq!(replay_report.edit_count, 0);
+        assert_eq!(replay_report.edit_count, 3);
 
         let reopened = Arc::new(DaemonState::open(fixture.state.layout.clone()).unwrap());
         let restart_replay = execute(&reopened, &request).unwrap();
         let restart_report = restart_replay.report.unwrap();
         assert!(restart_report.idempotent);
-        assert_eq!(restart_report.edit_count, 0);
+        assert_eq!(restart_report.edit_count, 3);
         assert_eq!(
             reopened
                 .graph
@@ -1024,6 +1150,90 @@ mod tests {
                 .unwrap()
                 .name,
             "renamed_target"
+        );
+    }
+
+    #[test]
+    fn qualified_selector_replays_the_canonical_committed_report() {
+        let fixture = exact_rename_fixture();
+        let request = RenameRequest {
+            symbol: "module::target".to_string(),
+            new_name: "renamed_target".to_string(),
+            file: Some(fixture.target_file.0.clone()),
+            line: Some(1),
+            column: Some(7),
+            json: true,
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("qualified-rename-test"),
+        };
+
+        let first = execute(&fixture.state, &request).unwrap().report.unwrap();
+        assert_eq!(first.old_name, "target");
+        assert_eq!(first.new_name, "renamed_target");
+        assert_eq!(first.edit_count, 3);
+        assert!(!first.idempotent);
+
+        let replay = execute(&fixture.state, &request).unwrap().report.unwrap();
+        assert_eq!(replay.old_name, "target");
+        assert_eq!(replay.entity_id, first.entity_id);
+        assert_eq!(replay.edited_files, first.edited_files);
+        assert_eq!(replay.edit_count, first.edit_count);
+        assert!(replay.idempotent);
+    }
+
+    #[test]
+    fn operation_replay_after_a_later_generation_returns_historical_outcome() {
+        let fixture = exact_rename_fixture();
+        let first_request = RenameRequest {
+            symbol: "target".to_string(),
+            new_name: "renamed_target".to_string(),
+            file: Some(fixture.target_file.0.clone()),
+            line: Some(1),
+            column: None,
+            json: true,
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("historical-rename-test"),
+        };
+        let first = execute(&fixture.state, &first_request)
+            .unwrap()
+            .report
+            .unwrap();
+        let second_request = RenameRequest {
+            symbol: "renamed_target".to_string(),
+            new_name: "final_target".to_string(),
+            file: Some(fixture.target_file.0.clone()),
+            line: Some(1),
+            column: None,
+            json: true,
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("later-rename-test"),
+        };
+        let second = execute(&fixture.state, &second_request)
+            .unwrap()
+            .report
+            .unwrap();
+        assert!(second.authority_generation > first.authority_generation);
+
+        let replay = execute(&fixture.state, &first_request)
+            .unwrap()
+            .report
+            .unwrap();
+        assert!(replay.idempotent);
+        assert_eq!(replay.change_id, first.change_id);
+        assert_eq!(replay.authority_generation, first.authority_generation);
+        assert_eq!(replay.old_name, first.old_name);
+        assert_eq!(replay.new_name, first.new_name);
+        assert_eq!(replay.edit_count, first.edit_count);
+        assert_eq!(replay.edited_files, first.edited_files);
+        assert_eq!(
+            fixture
+                .state
+                .graph
+                .get_entity(&fixture.target_id)
+                .unwrap()
+                .unwrap()
+                .name,
+            "final_target"
         );
     }
 

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -613,10 +613,22 @@ impl Reconciler {
                 }
             }
 
-            // Try to match by name + kind against existing entities
+            // A graph-authoritative planner may deliberately retain an
+            // existing identity while changing its source name (rename is the
+            // canonical case). Parser-produced identities normally differ
+            // after such a source edit, so the planner must explicitly remap
+            // the parsed entity before reaching this boundary. Honor that
+            // exact id first, while still requiring the entity kind to match;
+            // ordinary filesystem reconciliation continues to match by name
+            // and kind as before.
             let existing_match = existing
                 .iter()
-                .find(|e| e.name == new_entity.name && e.kind == new_entity.kind);
+                .find(|entity| entity.id == new_entity.id && entity.kind == new_entity.kind)
+                .or_else(|| {
+                    existing.iter().find(|entity| {
+                        entity.name == new_entity.name && entity.kind == new_entity.kind
+                    })
+                });
 
             match existing_match {
                 Some(old) => {
@@ -2881,6 +2893,65 @@ mod tests {
             super::validate_entity(&entity).is_some(),
             "an external target is not exempt from the other rules"
         );
+    }
+
+    #[test]
+    fn graph_authoritative_reconcile_retains_explicit_identity_across_rename() {
+        use kin_blobs::BlobStore;
+        use kin_db::InMemoryGraph;
+        use kin_index::IndexedFile;
+        use kin_model::{EntityStore, FileLayout, ImportSection, ParseCompleteness, ParseState};
+
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(dir.path().join("objects")).unwrap();
+        let graph = InMemoryGraph::new();
+        let file = FilePathId::new("src/lib.rs");
+        let old = make_entity("before", &file.0);
+        graph.upsert_entity(&old).unwrap();
+
+        let mut renamed = old.clone();
+        renamed.name = "after".to_string();
+        renamed.signature = "fn after()".to_string();
+        let body = b"pub fn after() {}\n";
+        let blob_hash = blob_store.write(body).unwrap();
+        let indexed = IndexedFile {
+            file_id: file.clone(),
+            language: LanguageId::Rust,
+            entities: vec![renamed.clone()],
+            relations: vec![],
+            unresolved_relations: vec![],
+            file_layout: FileLayout {
+                file_id: file,
+                parse_completeness: ParseCompleteness::Full,
+                imports: ImportSection {
+                    byte_range: 0..0,
+                    items: vec![],
+                },
+                regions: vec![],
+            },
+            parse_state: ParseState::Valid,
+            blob_hash,
+            extracted_relations: vec![],
+            imports: vec![],
+        };
+        let mut reconciler = Reconciler::new(std::path::PathBuf::new());
+        let result = reconciler
+            .reconcile_indexed_content(&indexed, &blob_store, &graph)
+            .unwrap();
+
+        assert_eq!(result.delta.entity_deltas.len(), 1);
+        assert!(matches!(
+            &result.delta.entity_deltas[0],
+            EntityDelta::Modified { old: prior, new }
+                if prior.id == old.id
+                    && prior.name == "before"
+                    && new.id == old.id
+                    && new.name == "after"
+        ));
+        assert!(!result.delta.entity_deltas.iter().any(|delta| matches!(
+            delta,
+            EntityDelta::Added { .. } | EntityDelta::Removed { .. }
+        )));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## What changed

- implement `kin rename` against repository-CAS bodies and graph-owned identity/topology
- publish source, entity, and relation changes through one repository-v6 transaction with projection-WAL recovery
- fail closed on incomplete extraction, unaccounted source occurrences, named-import ambiguity, unsupported lexical shapes, and stale projection state
- persist canonical operation metadata for exact replay after response loss, daemon reopen, qualified selectors, and later authority generations
- validate 1-based line / UTF-8-byte column coordinates and Unicode identifier boundaries
- report rename as `ready_bounded`: all 33 command surfaces are enabled, while fully general Git-replacement readiness remains 32/33
- describe the public command as bounded and fail-closed in `kin --help`

## Why

The prior rename surface was an open capability gate. Adversarial review found partial-refactor, wrong-target, Unicode-splice, replay, and overclaiming defects in the first implementation. This head repairs every reproduced class and turns each falsification into a permanent regression test.

## User impact

Users can perform exact, atomic graph-native renames in the cases Kin can prove complete. Kin refuses ambiguous or incomplete repositories instead of silently editing only part of a symbol. Exact operation retries return the original committed result without replaying an old generation.

## Verification

Exact head: `ebb94adf2f40d4c6dcc38a1c56523c1cbd32dd4d`
Tree: `ad3ef5a5451aa5d24139a20f6935ba7ee84e9fa7`
Base: `1867283622208abf5e59ce245415603d1b0562b2`

- independent exact-head review: GO, zero findings
- rename planner: 13 passed, including real linker fixtures across eight languages
- daemon rename/recovery: 5 passed
- repository-v6 identity-retention reconcile: passed
- command capabilities: 12 passed
- exact-head hosted CI: all applicable checks green on Ubuntu, macOS, Windows, Docker, daemon/MCP, npm, cargo-deny, DCO, gitleaks, and CodeQL
- zero-file-search and runtime-boundary verifiers: passed
- `git diff --check`: passed

Review artifact: `.kin-coord/reports/codex-fresh-review-kin-pr583-ebb94adf-20260801.md`

This PR does not claim released bytes, fully general rename, real-client acceptance, production verification, or investor proof.

Closes FIR-1837

Related: FIR-1572, FIR-1815, FIR-1825
