### PR TITLE
Publish a staged repository on native Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,19 +297,6 @@ jobs:
             "config::windows::capability_exclusion_tests" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-core --lib
-          # Admission itself, in process. `kin init` is the transaction the
-          # contract script drives end to end, but that script runs two steps
-          # later and reports one line naming a path that two different
-          # components can report. These cases stage, publish, seal, and
-          # promote a repository through the same code the binary does, so a
-          # refusal names a test and a line instead of a path. Until this
-          # existed, `init.rs` had no native Windows coverage at all, which is
-          # why a refusal in it could only be seen by a thirty-minute job that
-          # then could not say which call refused.
-          run_required_filter "kin-core repository initialization" \
-            "init::tests" \
-            --locked --target x86_64-pc-windows-msvc \
-            -p kin-core --lib
           run_nonempty_target "kin-git library" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-git --lib
@@ -329,6 +316,19 @@ jobs:
             "commands::setup::tests::full_uninstall" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-cli --no-default-features --lib
+          # Admission itself, in process. `kin init` is the transaction the
+          # contract script drives end to end, but that script runs two steps
+          # later and reports one line naming a path that two different
+          # components can report. These cases stage, publish, seal, and
+          # promote a repository through the same code the binary does, so a
+          # refusal names a test and a line instead of a path. Until this
+          # existed, `init.rs` had no native Windows coverage at all, which is
+          # why a refusal in it could only be seen by a thirty-minute job that
+          # then could not say which call refused.
+          run_required_filter "kin-core repository initialization" \
+            "init::tests" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-core --lib
           run_required_exact "native full managed uninstall lifecycle" \
             "commands::setup::tests::native_full_uninstall_runtime_executes_retirement_and_user_path_cleanup" \
             --locked --target x86_64-pc-windows-msvc \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,19 @@ jobs:
             "config::windows::capability_exclusion_tests" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-core --lib
+          # Admission itself, in process. `kin init` is the transaction the
+          # contract script drives end to end, but that script runs two steps
+          # later and reports one line naming a path that two different
+          # components can report. These cases stage, publish, seal, and
+          # promote a repository through the same code the binary does, so a
+          # refusal names a test and a line instead of a path. Until this
+          # existed, `init.rs` had no native Windows coverage at all, which is
+          # why a refusal in it could only be seen by a thirty-minute job that
+          # then could not say which call refused.
+          run_required_filter "kin-core repository initialization" \
+            "init::tests" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-core --lib
           run_nonempty_target "kin-git library" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-git --lib

--- a/crates/kin-core/src/config.rs
+++ b/crates/kin-core/src/config.rs
@@ -2289,6 +2289,53 @@ mod capability_owned_config_replacement_tests {
         assert!(residual_writer_entries(&config).is_empty());
     }
 
+    /// The path shape admission actually hands the writer.
+    ///
+    /// `kin init` canonicalizes the stage root before it saves anything, and a
+    /// canonical path on Windows carries the `\\?\` verbatim prefix. Every
+    /// other case in this module passes a temporary path that was never
+    /// canonicalized, so none of them exercises the shape the binary uses, and
+    /// all of them pass on a platform where `kin init` fails at this exact
+    /// file. That gap is why this case exists.
+    ///
+    /// Publication and the read-back are asserted as separate steps because
+    /// they are separate calls that fail for different reasons. Admission
+    /// reads this file again immediately afterwards to seal repository
+    /// metadata, and that read reports the same path as the writer would, so a
+    /// test that collapsed them could not say which one refused.
+    #[test]
+    fn a_canonical_stage_path_publishes_the_way_admission_calls_it() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let stage = directory
+            .path()
+            .join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&stage).expect("create stage");
+        let config = std::fs::canonicalize(&stage)
+            .expect("canonicalize stage")
+            .join("config.toml");
+
+        if let Err(error) = save_config_atomically_scoped(
+            &config,
+            b"mode = \"native\"\n",
+            ConfigAuthorityKind::InitializationStage,
+        ) {
+            panic!("publishing through a canonical stage path refused: {error}");
+        }
+
+        match std::fs::read(&config) {
+            Ok(published) => assert_eq!(published, b"mode = \"native\"\n"),
+            Err(error) => panic!(
+                "the published config could not be read back, which is the call that seals \
+                 repository metadata: {error}"
+            ),
+        }
+        assert!(
+            residual_writer_entries(&config).is_empty(),
+            "publication left writer-owned intermediates behind: {:?}",
+            residual_writer_entries(&config)
+        );
+    }
+
     #[test]
     fn a_stage_directory_that_is_not_a_canonical_uuid_v4_is_refused() {
         let directory = tempfile::tempdir().expect("tempdir");

--- a/crates/kin-core/src/config/windows.rs
+++ b/crates/kin-core/src/config/windows.rs
@@ -88,10 +88,9 @@ use std::path::{Path, PathBuf};
 
 use windows_sys::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS};
 use windows_sys::Win32::Storage::FileSystem::{
-    MoveFileExW, ReplaceFileW, FILE_ADD_FILE, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS,
-    FILE_FLAG_OPEN_REPARSE_POINT, FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, FILE_READ_DATA,
-    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, MOVEFILE_REPLACE_EXISTING,
-    MOVEFILE_WRITE_THROUGH, REPLACEFILE_WRITE_THROUGH,
+    MoveFileExW, ReplaceFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+    FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, FILE_READ_DATA, FILE_SHARE_DELETE, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, REPLACEFILE_WRITE_THROUGH,
 };
 
 use super::{validated_config_authority_path, ConfigAuthorityKind, ConfigSaveHookPoint};
@@ -115,7 +114,7 @@ struct ConfigAuthority {
     /// transaction runs, in the same way the crate's `_process_guard` locals
     /// are held rather than read. The identity it was opened with is captured
     /// once below, because a handle's identity cannot change while it is open.
-    _retained_directory: Option<File>,
+    _retained_directory: File,
     directory_identity: ConfigFileIdentity,
     display_directory: PathBuf,
     display_config: PathBuf,
@@ -150,7 +149,7 @@ pub(super) fn save_config_atomically_scoped_with_hook(
     kind: ConfigAuthorityKind,
     mut hook: impl FnMut(ConfigSaveHookPoint) -> Result<()>,
 ) -> Result<()> {
-    let mut authority = ConfigAuthority::open(path, kind)?;
+    let authority = ConfigAuthority::open(path, kind)?;
     let (handle, temp) = authority.create_temp()?;
     let mut handle = Some(handle);
     let hook: &mut dyn FnMut(ConfigSaveHookPoint) -> Result<()> = &mut hook;
@@ -187,8 +186,6 @@ pub(super) fn save_config_atomically_scoped_with_hook(
             "config temp file",
         )?;
         hook(ConfigSaveHookPoint::BeforePublication)?;
-        authority.release_retained_directory();
-        std::thread::sleep(std::time::Duration::from_millis(50));
 
         match authority.expected_config {
             Some(expected) => {
@@ -219,7 +216,7 @@ impl ConfigAuthority {
         let expected_config =
             inspect_config_file(directory_path, config_name, path, "repository config")?;
         let authority = Self {
-            _retained_directory: Some(directory),
+            _retained_directory: directory,
             directory_identity,
             display_directory: directory_path.to_path_buf(),
             display_config: path.to_path_buf(),
@@ -229,10 +226,6 @@ impl ConfigAuthority {
         authority.revalidate_visible_directory()?;
         authority.revalidate_expected_config()?;
         Ok(authority)
-    }
-
-    fn release_retained_directory(&mut self) {
-        self._retained_directory.take();
     }
 
     fn create_temp(&self) -> Result<(File, ConfigTemp)> {
@@ -245,8 +238,8 @@ impl ConfigAuthority {
             let file = match OpenOptions::new()
                 .write(true)
                 .create_new(true)
-                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
-                .custom_flags(FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT)
+                .share_mode(0)
+                .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
                 .open(&display_path)
             {
                 Ok(file) => file,
@@ -567,7 +560,7 @@ impl ConfigAuthority {
 fn open_retained_config_directory(path: &Path) -> Result<File> {
     open_config_directory(
         path,
-        FILE_LIST_DIRECTORY | FILE_ADD_FILE,
+        FILE_LIST_DIRECTORY,
         FILE_SHARE_READ | FILE_SHARE_WRITE,
     )
 }
@@ -583,7 +576,7 @@ fn open_config_directory_nofollow(path: &Path) -> Result<File> {
     open_config_directory(
         path,
         FILE_READ_ATTRIBUTES,
-        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
     )
 }
 
@@ -643,12 +636,9 @@ fn inspect_config_file(
     label: &str,
 ) -> Result<Option<ConfigFileIdentity>> {
     let target = directory.join(name);
-    if !target.exists() {
-        return Ok(None);
-    }
     let file = match OpenOptions::new()
         .access_mode(FILE_READ_ATTRIBUTES)
-        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
         .open(&target)
     {
@@ -669,14 +659,7 @@ fn inspect_config_file(
 }
 
 fn wide(path: &Path) -> Vec<u16> {
-    let path_str = path.to_string_lossy();
-    let clean = if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
-        Path::new(stripped)
-    } else {
-        path
-    };
-    clean
-        .as_os_str()
+    path.as_os_str()
         .encode_wide()
         .chain(std::iter::once(0))
         .collect()
@@ -697,22 +680,13 @@ fn move_file_replace(source: &Path, destination: &Path) -> std::io::Result<()> {
 }
 
 fn move_file(source: &Path, destination: &Path, flags: u32) -> std::io::Result<()> {
-    let source_wide = wide(source);
-    let destination_wide = wide(destination);
-    let mut attempts = 0;
-    loop {
-        let moved = unsafe { MoveFileExW(source_wide.as_ptr(), destination_wide.as_ptr(), flags) };
-        if moved != 0 {
-            return Ok(());
-        }
-        let error = std::io::Error::last_os_error();
-        if error.raw_os_error() == Some(5) && attempts < 50 {
-            attempts += 1;
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            continue;
-        }
-        return Err(error);
+    let source = wide(source);
+    let destination = wide(destination);
+    let moved = unsafe { MoveFileExW(source.as_ptr(), destination.as_ptr(), flags) };
+    if moved == 0 {
+        return Err(std::io::Error::last_os_error());
     }
+    Ok(())
 }
 
 /// `RENAME_EXCHANGE`'s purpose, by the call Windows provides for it.

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -739,6 +739,22 @@ fn stage_owner_name(stage_id: uuid::Uuid) -> String {
 const OWN_STAGE_OWNER_LOCK_ATTEMPTS: u32 = 100;
 const OWN_STAGE_OWNER_LOCK_RETRY: std::time::Duration = std::time::Duration::from_millis(5);
 
+/// Whether a lock attempt was refused because someone else holds the lock.
+///
+/// The two platforms do not report contention as the same `ErrorKind`. Unix
+/// `flock` fails with `EWOULDBLOCK`, which std maps to `WouldBlock`, while
+/// Windows `LockFileEx` fails with `ERROR_LOCK_VIOLATION`, which std leaves
+/// uncategorized because only the socket-level `WSAEWOULDBLOCK` maps to
+/// `WouldBlock` there. Testing the kind alone therefore recognizes contention
+/// on Unix and nothing on Windows, which silently turns the bounded retry in
+/// `lock_own_stage_owner` into a single attempt. Comparing against the lock
+/// crate's own contention error is what keeps this true on both.
+fn is_lock_contention(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::WouldBlock
+        || (error.raw_os_error().is_some()
+            && error.raw_os_error() == fs2::lock_contended_error().raw_os_error())
+}
+
 /// Take the exclusive lock on an owner file this call just created with
 /// `create_new`, tolerating a concurrent recovery scan.
 ///
@@ -749,22 +765,6 @@ const OWN_STAGE_OWNER_LOCK_RETRY: std::time::Duration = std::time::Duration::fro
 /// outright on that. Contention on a file nobody else can name is transient by
 /// construction, so it is retried; anything else, and contention that outlasts
 /// the bound, still fails closed.
-/// Whether a lock attempt was refused because someone else holds the lock.
-///
-/// The two platforms do not report contention as the same `ErrorKind`. Unix
-/// `flock` fails with `EWOULDBLOCK`, which std maps to `WouldBlock`, while
-/// Windows `LockFileEx` fails with `ERROR_LOCK_VIOLATION`, which std leaves
-/// uncategorized because only the socket-level `WSAEWOULDBLOCK` maps to
-/// `WouldBlock` there. Testing the kind alone therefore recognizes contention
-/// on Unix and nothing on Windows, which silently turns the bounded retry below
-/// into a single attempt. Comparing against the lock crate's own contention
-/// error is what keeps this true on both.
-fn is_lock_contention(error: &std::io::Error) -> bool {
-    error.kind() == std::io::ErrorKind::WouldBlock
-        || (error.raw_os_error().is_some()
-            && error.raw_os_error() == fs2::lock_contended_error().raw_os_error())
-}
-
 fn lock_own_stage_owner(owner_file: &File) -> std::io::Result<()> {
     let mut last = match owner_file.try_lock_exclusive() {
         Ok(()) => return Ok(()),

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -341,6 +341,13 @@ impl SealedContentSource for PreparedRepositoryInit {
 impl Drop for PreparedRepositoryInit {
     fn drop(&mut self) {
         if self.cleanup_armed {
+            // Released before the stage is removed, not alongside it. Fields
+            // drop only after this body returns, so leaving the authority in
+            // place here would mean removing a directory its backend still
+            // holds open. Unix allows that and Windows does not, which would
+            // leave the stage behind on the platform where a failed init most
+            // needs to clean up after itself.
+            drop(self.authority.take());
             if let Some(lease) = self.stage_lease.take() {
                 cleanup_staging_layout(lease, &self.layout, &self.manifest);
             }
@@ -742,13 +749,29 @@ const OWN_STAGE_OWNER_LOCK_RETRY: std::time::Duration = std::time::Duration::fro
 /// outright on that. Contention on a file nobody else can name is transient by
 /// construction, so it is retried; anything else, and contention that outlasts
 /// the bound, still fails closed.
+/// Whether a lock attempt was refused because someone else holds the lock.
+///
+/// The two platforms do not report contention as the same `ErrorKind`. Unix
+/// `flock` fails with `EWOULDBLOCK`, which std maps to `WouldBlock`, while
+/// Windows `LockFileEx` fails with `ERROR_LOCK_VIOLATION`, which std leaves
+/// uncategorized because only the socket-level `WSAEWOULDBLOCK` maps to
+/// `WouldBlock` there. Testing the kind alone therefore recognizes contention
+/// on Unix and nothing on Windows, which silently turns the bounded retry below
+/// into a single attempt. Comparing against the lock crate's own contention
+/// error is what keeps this true on both.
+fn is_lock_contention(error: &std::io::Error) -> bool {
+    error.kind() == std::io::ErrorKind::WouldBlock
+        || (error.raw_os_error().is_some()
+            && error.raw_os_error() == fs2::lock_contended_error().raw_os_error())
+}
+
 fn lock_own_stage_owner(owner_file: &File) -> std::io::Result<()> {
     let mut last = match owner_file.try_lock_exclusive() {
         Ok(()) => return Ok(()),
         Err(error) => error,
     };
     for _ in 1..OWN_STAGE_OWNER_LOCK_ATTEMPTS {
-        if last.kind() != std::io::ErrorKind::WouldBlock {
+        if !is_lock_contention(&last) {
             return Err(last);
         }
         std::thread::sleep(OWN_STAGE_OWNER_LOCK_RETRY);
@@ -1043,8 +1066,12 @@ fn publish_repository_layout_impl(
         ));
     }
 
-    sync_layout_recursively(prepared.layout.root())?;
+    // Closed before the flush rather than after it. The staged authority
+    // retains directory handles inside the stage, and flushing a file needs a
+    // writable handle on Windows, so the backend is released first and the
+    // flush below runs against a stage this call is the only holder of.
     drop(prepared.authority.take());
+    sync_layout_recursively(prepared.layout.root())?;
     verify_repository_layout(
         &prepared.layout,
         &prepared.metadata_seal,
@@ -1674,6 +1701,31 @@ fn validate_publish_destination(layout: &KinLayout, final_kin_dir: &Path) -> Res
     Ok(())
 }
 
+/// Open one staged file for the flush below.
+///
+/// Unix `fsync` accepts a read-only descriptor, so opening read-only is both
+/// sufficient and the weaker request. Windows has no equivalent: `sync_all` is
+/// `FlushFileBuffers`, which Microsoft documents as requiring `GENERIC_WRITE`
+/// on the handle, and which refuses a read-only one with
+/// `ERROR_ACCESS_DENIED`. Publication has to ask for write access there.
+///
+/// The difference is named here because of how it presents when it is missed.
+/// `sync_layout_recursively` walks each directory's children in sorted order,
+/// and a staged layout's first three entries are the empty directories
+/// `adapters`, `backups`, and `bench`, so `config.toml` is the first regular
+/// file the walk reaches. A read-only flush therefore reports an access denial
+/// against the staged repository config, which reads as the config writer
+/// refusing to publish rather than as publication failing to flush.
+#[cfg(not(windows))]
+fn open_to_flush(path: &Path) -> std::io::Result<File> {
+    File::open(path)
+}
+
+#[cfg(windows)]
+fn open_to_flush(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new().read(true).write(true).open(path)
+}
+
 fn sync_layout_recursively(path: &Path) -> Result<()> {
     let metadata = std::fs::symlink_metadata(path).map_err(|error| KinError::io(path, error))?;
     let file_type = metadata.file_type();
@@ -1684,7 +1736,7 @@ fn sync_layout_recursively(path: &Path) -> Result<()> {
         )));
     }
     if file_type.is_file() {
-        let file = std::fs::File::open(path).map_err(|error| KinError::io(path, error))?;
+        let file = open_to_flush(path).map_err(|error| KinError::io(path, error))?;
         return file.sync_all().map_err(|error| KinError::io(path, error));
     }
     if !file_type.is_dir() {
@@ -2252,9 +2304,8 @@ mod tests {
             .open(&owner_path)
             .unwrap();
         scanner.try_lock_exclusive().unwrap();
-        assert_eq!(
-            owner_file.try_lock_exclusive().unwrap_err().kind(),
-            std::io::ErrorKind::WouldBlock,
+        assert!(
+            is_lock_contention(&owner_file.try_lock_exclusive().unwrap_err()),
             "the scan must really be holding the lock"
         );
 
@@ -2285,10 +2336,9 @@ mod tests {
             .unwrap();
         holder.try_lock_exclusive().unwrap();
 
-        assert_eq!(
-            lock_own_stage_owner(&owner_file).unwrap_err().kind(),
-            std::io::ErrorKind::WouldBlock
-        );
+        assert!(is_lock_contention(
+            &lock_own_stage_owner(&owner_file).unwrap_err()
+        ));
     }
 
     fn prepare_unborn(
@@ -2376,6 +2426,103 @@ mod tests {
         crate::tree::initialize_projection_control_directory(&stage)
             .expect("initialize projection control directory");
         publish_staged_config(&stage);
+    }
+
+    /// The platform fact `open_to_flush` exists for.
+    ///
+    /// Windows refuses `FlushFileBuffers` on a handle without write access,
+    /// while the identical Unix `fsync` on a read-only descriptor is legal.
+    /// That asymmetry is the whole reason publication opens staged files for
+    /// write, so it is asserted rather than left as a claim in a comment: if
+    /// Windows ever stops refusing, this fails and the extra access being
+    /// requested can be given back. Pairing the refusal with the same flush
+    /// succeeding through `open_to_flush` is what keeps a refusal arriving for
+    /// some unrelated reason from passing as this one.
+    #[cfg(windows)]
+    #[test]
+    fn a_read_only_handle_cannot_flush_on_windows() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("staged.toml");
+        std::fs::write(&path, b"mode = \"native\"\n").unwrap();
+
+        let refused = File::open(&path)
+            .expect("a read-only handle opens")
+            .sync_all()
+            .expect_err("a read-only handle must not be able to flush on Windows");
+        let access_denied = i32::try_from(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED)
+            .expect("a documented WIN32_ERROR fits an i32");
+        assert_eq!(
+            refused.raw_os_error(),
+            Some(access_denied),
+            "the refusal must be the documented access denial, not something else: {refused}"
+        );
+
+        open_to_flush(&path)
+            .expect("a writable handle opens")
+            .sync_all()
+            .expect("the same file must flush through a writable handle");
+    }
+
+    /// Publication flushes a staged layout, so every file in one must flush.
+    ///
+    /// This is the call `kin init` refused at on native Windows. The walk sorts
+    /// each directory's children, and a staged layout opens with the empty
+    /// directories `adapters`, `backups`, and `bench`, so `config.toml` is the
+    /// first regular file it reaches and was the name every access denial
+    /// carried. Building the layout the way preparation builds it is what makes
+    /// this case reach the same file in the same order.
+    #[test]
+    fn a_staged_layout_flushes_every_file_it_holds() {
+        let parent = tempfile::tempdir().unwrap();
+        let stage = canonical_stage(&parent);
+        let layout = KinLayout::new(stage.clone());
+        for directory in layout.all_dirs() {
+            std::fs::create_dir_all(&directory).expect("create a staged layout directory");
+        }
+        std::fs::write(layout.version_path(), KIN_LAYOUT_VERSION.to_string())
+            .expect("write the staged layout version");
+        KinConfig::default()
+            .save_initialization_stage(&stage)
+            .expect("publish the staged repository config");
+
+        sync_layout_recursively(&stage).expect("a staged layout must flush before publication");
+    }
+
+    /// Orphan recovery stays disabled where it cannot prove what it reaps.
+    ///
+    /// The reaping cases are gated to Unix because this returns zero without
+    /// scanning anywhere else. Asserting that here is what keeps the gate a
+    /// stated platform boundary rather than a silent hole: if recovery is ever
+    /// implemented off Unix, this fails and sends the reader to the cases that
+    /// should then be ungated.
+    #[cfg(not(unix))]
+    #[test]
+    fn orphan_recovery_is_disabled_off_unix() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = directory.path().canonicalize().unwrap();
+        let repository = parent.join("repository");
+        std::fs::create_dir(&repository).unwrap();
+        let final_kin = repository.canonicalize().unwrap().join(".kin");
+        let staging_root = parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
+        let mut prepared = prepare_repository_layout_at(
+            &staging_root,
+            &final_kin,
+            KinConfig::default(),
+            KinManifest::new(),
+        )
+        .unwrap();
+        prepared.cleanup_armed = false;
+        drop(prepared);
+
+        assert_eq!(
+            recover_orphaned_repository_stages(&parent, &final_kin).unwrap(),
+            0,
+            "recovery must reap nothing where it cannot prove ownership"
+        );
+        assert!(
+            staging_root.is_dir(),
+            "an unreaped stage must be left exactly where it was"
+        );
     }
 
     #[test]
@@ -2713,6 +2860,15 @@ mod tests {
         assert!(!owner_path.exists());
     }
 
+    /// Reaping is Unix-only, so the case that asserts a reap is too.
+    ///
+    /// `recover_orphaned_repository_stages` returns zero without scanning
+    /// anything off Unix, by the design stated on it: recovery stays disabled
+    /// where the platform cannot expose a stable file identity and
+    /// current-user ownership. `orphan_recovery_is_disabled_off_unix` below is
+    /// what holds that boundary honest, so this stays where the behaviour it
+    /// names actually exists rather than being weakened to pass everywhere.
+    #[cfg(unix)]
     #[test]
     fn orphan_recovery_reaps_only_an_unlocked_exactly_owned_stage() {
         let directory = tempfile::tempdir().unwrap();
@@ -2804,6 +2960,8 @@ mod tests {
         assert!(hard_link.is_file());
     }
 
+    /// Also asserts a reap, so it is bound to the platform that reaps.
+    #[cfg(unix)]
     #[test]
     fn orphan_recovery_is_bound_to_the_exact_destination() {
         let directory = tempfile::tempdir().unwrap();
@@ -3268,7 +3426,16 @@ mod tests {
         );
     }
 
-    #[cfg(any(unix, windows))]
+    /// The replacement this detects cannot be staged on Windows at all.
+    ///
+    /// The case works by renaming the authority root out from under a live
+    /// backend. On Windows that rename is refused with a sharing violation,
+    /// because the backend retains directory handles that withhold DELETE
+    /// sharing, so the scenario cannot be constructed and the test fails in
+    /// its own setup rather than in the behaviour it checks. Windows excludes
+    /// the replacement where Unix detects it, which is the stronger of the two
+    /// and is why this is gated rather than weakened.
+    #[cfg(unix)]
     #[test]
     fn staged_authority_backend_rejects_a_replaced_root() {
         let directory = tempfile::tempdir().unwrap();

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -1514,6 +1514,22 @@ fn read_to_seal(path: &Path, label: &str) -> Result<Vec<u8>> {
     })
 }
 
+/// Read one staged metadata file again, to check it against its seal.
+///
+/// Sealing and verifying read the same name at different points in the
+/// transaction, so they need to be told apart for the same reason the seal
+/// needs to be told apart from the writer. A verification that cannot be read
+/// means something took the file away after preparation, which is a different
+/// failure from never having been able to read it.
+fn read_to_verify_seal(path: &Path, label: &str) -> Result<Vec<u8>> {
+    std::fs::read(path).map_err(|error| {
+        KinError::Other(format!(
+            "reread {label} at {} to check it against its seal: {error}",
+            path.display()
+        ))
+    })
+}
+
 fn capture_metadata_seal(layout: &KinLayout) -> Result<RepositoryMetadataSeal> {
     let config_bytes = read_to_seal(&layout.config_path(), "repository config")?;
     let manifest_bytes = read_to_seal(&layout.manifest_path(), "repository manifest")?;
@@ -1546,7 +1562,7 @@ fn verify_sealed_metadata_file(
     expected_bytes: &[u8],
     expected_hash: Hash256,
 ) -> Result<()> {
-    let observed = std::fs::read(path).map_err(|error| KinError::io(path, error))?;
+    let observed = read_to_verify_seal(path, label)?;
     let observed_hash = Hash256::from_bytes(Sha256::digest(&observed).into());
     if observed_hash != expected_hash || observed != expected_bytes {
         return Err(KinError::Other(format!(

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -1498,11 +1498,25 @@ fn validate_bootstrap_transaction(
     Ok(())
 }
 
+/// Read one staged metadata file, saying which read this was.
+///
+/// The config writer reports its own refusals against the same path this reads,
+/// so an unlabelled failure here is indistinguishable from a failure to publish
+/// and sends the reader to the wrong component. Sealing happens after
+/// publication, so naming the step is the difference between "the writer could
+/// not publish" and "the writer published something this cannot read".
+fn read_to_seal(path: &Path, label: &str) -> Result<Vec<u8>> {
+    std::fs::read(path).map_err(|error| {
+        KinError::Other(format!(
+            "read published {label} at {} to seal staged repository metadata: {error}",
+            path.display()
+        ))
+    })
+}
+
 fn capture_metadata_seal(layout: &KinLayout) -> Result<RepositoryMetadataSeal> {
-    let config_bytes = std::fs::read(layout.config_path())
-        .map_err(|error| KinError::io(layout.config_path(), error))?;
-    let manifest_bytes = std::fs::read(layout.manifest_path())
-        .map_err(|error| KinError::io(layout.manifest_path(), error))?;
+    let config_bytes = read_to_seal(&layout.config_path(), "repository config")?;
+    let manifest_bytes = read_to_seal(&layout.manifest_path(), "repository manifest")?;
     Ok(RepositoryMetadataSeal {
         config_hash: Hash256::from_bytes(Sha256::digest(&config_bytes).into()),
         manifest_hash: Hash256::from_bytes(Sha256::digest(&manifest_bytes).into()),

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -2318,6 +2318,66 @@ mod tests {
         (prepared, transaction)
     }
 
+    /// A canonical stage, built the way admission builds one.
+    ///
+    /// Admission canonicalizes before it stages, and the config writer only
+    /// owns a `.kin.init-<uuid-v4>` directory, so both are required here for
+    /// the save below to be the same call admission makes.
+    fn canonical_stage(parent: &tempfile::TempDir) -> PathBuf {
+        let root = parent.path().canonicalize().expect("canonicalize parent");
+        let stage = root.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
+        create_private_staging_root(&stage).expect("create stage");
+        stage
+    }
+
+    fn publish_staged_config(stage: &Path) {
+        KinConfig::default()
+            .save_initialization_stage(stage)
+            .expect("publish staged repository config");
+        let published =
+            std::fs::read(stage.join("config.toml")).expect("read back the published config");
+        assert!(
+            !published.is_empty(),
+            "a published config must hold the bytes it was given"
+        );
+    }
+
+    /// Building the stage must not break publishing into it.
+    ///
+    /// `kin init` assembles a stage in steps and then saves the repository
+    /// config into it. The config writer's own cases already prove it publishes
+    /// into a bare stage, so when admission refuses at that save, the cause has
+    /// to be something the stage gained on the way rather than the writer. Each
+    /// case below adds one construction step and then publishes through the
+    /// same entry admission uses, so the first one to refuse names the step
+    /// that caused it instead of leaving a whole transaction under suspicion.
+    #[test]
+    fn a_bare_stage_publishes_its_config() {
+        let parent = tempfile::tempdir().unwrap();
+        let stage = canonical_stage(&parent);
+        publish_staged_config(&stage);
+    }
+
+    #[test]
+    fn a_stage_holding_its_authority_backend_publishes_its_config() {
+        let parent = tempfile::tempdir().unwrap();
+        let stage = canonical_stage(&parent);
+        let layout = KinLayout::new(stage.clone());
+        // Held across the save, exactly as admission holds it.
+        let _backend = create_staged_repository_authority_backend(&layout.kindb_dir())
+            .expect("create staged authority backend");
+        publish_staged_config(&stage);
+    }
+
+    #[test]
+    fn a_stage_with_its_projection_control_directory_publishes_its_config() {
+        let parent = tempfile::tempdir().unwrap();
+        let stage = canonical_stage(&parent);
+        crate::tree::initialize_projection_control_directory(&stage)
+            .expect("initialize projection control directory");
+        publish_staged_config(&stage);
+    }
+
     #[test]
     fn init_creates_unborn_repository_authority() {
         let directory = tempfile::tempdir().unwrap();

--- a/crates/kin-projection/src/tree.rs
+++ b/crates/kin-projection/src/tree.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -879,11 +879,21 @@ fn sync_directory_tree(root: &Path) -> Result<()> {
         }
         index += 1;
     }
+    #[cfg(unix)]
     for directory in directories.into_iter().rev() {
-        File::open(&directory)
+        std::fs::File::open(&directory)
             .and_then(|file| file.sync_all())
             .map_err(|error| io(&directory, error))?;
     }
+    // Windows refuses `File::open` on a directory outright, so reaching the
+    // flush above there turns a healthy staged tree into an access denial
+    // rather than making it more durable. The file payloads are still flushed
+    // individually before the staged tree is moved into place; only the
+    // stronger parent-directory power-loss guarantee is Unix-specific. This is
+    // the same boundary `kin-daemon`'s `sync_directory_metadata` and
+    // `kin-core`'s `sync_parent_directory` already draw.
+    #[cfg(not(unix))]
+    let _ = directories;
     Ok(())
 }
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -7328,6 +7328,19 @@ def main() -> None:
         "config::windows::capability_exclusion_tests",
         "native retained-capability exclusion proof",
     )
+    # `kin init` is what the admission script drives, and it lives two steps
+    # later behind a build. When it refuses, the script reports one line naming
+    # a path that both the config writer and the metadata seal report against,
+    # so the end-to-end leg cannot say which component refused. Running
+    # admission in process here names a test instead. This is required rather
+    # than merely present because `init.rs` carried no native Windows coverage
+    # at all until it was added, which is how a refusal in it stayed unlocated
+    # across repeated attempts.
+    require(
+        ci_jobs["windows-authority-tests"],
+        "init::tests",
+        "native repository initialization proof",
+    )
     require(
         ci_jobs["windows-authority-tests"],
         "target/x86_64-pc-windows-msvc/debug/kin.exe",


### PR DESCRIPTION
## Result

`init::tests` on windows-latest, job `91868155707`, head `a1e76c1d`:

```
test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 366 filtered out; finished in 16.89s
```

**47 passed, 0 failed**, against `13 passed; 34 failed` on the two previous rounds over the
same 47 cases. Occurrences of `Access is denied` across the whole job log: **0**, down
from 20.

The job itself is still red, on a different and already-ticketed defect:
`commands::setup::tests::native_full_uninstall_runtime_executes_retirement_and_user_path_cleanup`
fails after 427.53s. That is FIR-1867. It is not a required context, so it does not block
this merge, but it does keep steps 11 to 13 skipped, which is why the end-to-end
`assert-windows-init-contract.sh` still has not run on a pull request.

`Windows installer + vector-free release build`, the required check this exists to turn
green, is deliberately off the pull-request path and reports `skipped` there. It executes
for real only on the push to `main`, so it cannot be proven before landing.

## Summary

Native `kin init` could not publish a repository on Windows. It refused with
`IO error: \\?\...\.kin.init-<uuid>\config.toml: Access is denied. (os error 5)`, which
kept `Windows installer + vector-free release build` red, and `release-tag.yml` names that
check in `REQUIRED_CHECKS`, so no release tag could mint while it stayed red.

**The cause was never the config writer.** It was publication flushing staged files
through a read-only handle. Six earlier attempts aimed at the writer and none moved the
outcome, which is consistent with the writer having been innocent throughout.

This PR locates the refusal, fixes it, and gives `init.rs` the native Windows coverage it
had none of.

## Root cause

`sync_layout_recursively`, which publication calls to flush the staged layout:

```rust
let file = std::fs::File::open(path)?;   // read access only
return file.sync_all();                  // FlushFileBuffers on Windows
```

`File::sync_all` is `FlushFileBuffers` on Windows (`library/std/src/sys/fs/windows.rs`),
and Microsoft documents `FlushFileBuffers` as requiring `GENERIC_WRITE` on the handle. A
read-only handle is refused with `ERROR_ACCESS_DENIED`. The identical Unix `fsync` on a
read-only descriptor is legal, which is why this never surfaced off Windows.

**Why it always named `config.toml`.** The walk sorts each directory's children. A staged
layout opens with the empty directories `adapters`, `backups`, and `bench`; an empty
directory recurses into nothing, and Windows' `sync_parent_directory` is a documented
no-op. So `config.toml` is the first regular file the walk reaches, and the access denial
landed on it every time. That is what made the failure read as the config writer refusing
to publish rather than as publication failing to flush.

The name is also the discriminating evidence: a delete-pending or ACL cause would name
whichever file it happened to reach, while only a sorted walk names the same file in 19
failures out of 19.

## What the evidence ruled out on the way

- **Parent sharing.** Round 4 inferred that failures were exactly the stages sharing
  `%TEMP%`. The log refutes it: 8 of the 20 access denials stage inside a private
  `.tmpXXXXXX` parent, for example
  `...\Temp\.tmpNt6Cf9\.kin.init-52635dd0-...\config.toml`. This also retires the
  dedicated-parent counter-observation, which was never a second cause.
- **The orphan-recovery scan.** `recover_orphaned_repository_stages` is
  `#[cfg(not(unix))] { return Ok(0) }`. It does nothing at all on Windows, so it could
  not have reaped a sibling or marked anything delete-pending there.
- **The config writer and the verbatim `\\?\` path**, by
  `a_canonical_stage_path_publishes_the_way_admission_calls_it` passing on windows-latest.
- **The metadata seal and its reread**, which are `KinError::Other` while the live failure
  is `KinError::Io`.

The two cases that can distinguish preparation from publication settle it:
`publish_atomically_reopens_exact_authority_and_source_bodies` and
`publish_atomically_moves_an_external_same_filesystem_stage` panic at their
`publish_repository_layout(...)` line, not at their preparation line. The config save had
already returned `Ok`.

## Behaviour change

Staged files are opened for **write** before being flushed, on Windows only. Unix keeps
the read-only open, which is the weaker request and can flush a file the process has no
write permission on.

Three further Unix assumptions on the same path are fixed with it:

1. **The staged authority is closed before the stage is flushed**, rather than after. Its
   backend retains directory handles inside the stage which, by kin-db's own stated
   design, withhold `DELETE` sharing on Windows. A flush that now needs a writable handle
   must not race them.
2. **`PreparedRepositoryInit::drop` closes the authority before removing the stage.**
   Fields drop only after the `Drop` body returns, so the old order asked Windows to
   remove a directory its own backend still held open. This is why four cases asserted
   `!staging_root.exists()` and failed: a failed init left its stage behind on Windows.
3. **`lock_own_stage_owner` recognizes contention on both platforms.** `fs2` reports it
   with the platform's own error and the two share no `ErrorKind`: Unix `EWOULDBLOCK` maps
   to `WouldBlock`, while Windows `ERROR_LOCK_VIOLATION` is left uncategorized because only
   the socket-level `WSAEWOULDBLOCK` maps there. Testing the kind alone silently reduced a
   100-attempt bounded retry to a single attempt on Windows. Latent rather than active,
   since the owner file is created under a fresh UUID and the only other lock holder would
   be the recovery scan, which does not run there.

Cases asserting orphan reaping and authority-root replacement are bound to `#[cfg(unix)]`,
where the behaviour they name exists. Recovery is disabled off Unix by design, and Windows
refuses the replacement rename outright with a sharing violation, so that test failed in
its own setup rather than in what it checks. A new `orphan_recovery_is_disabled_off_unix`
asserts the boundary instead of leaving it implicit.

## Falsification

The fix is falsifiable three ways, wired in rather than argued:

- `a_read_only_handle_cannot_flush_on_windows` asserts the platform fact the fix rests on:
  `File::open` then `sync_all` must fail with exactly `ERROR_ACCESS_DENIED`, and the same
  file must flush through `open_to_flush`. If Windows does not refuse a read-only flush,
  this fails and the fix is wrong.
- `a_staged_layout_flushes_every_file_it_holds` drives the exact call that refused,
  against a layout built the way preparation builds one.
- The 19 access denials are themselves the revert demonstration, already run twice at
  `6b1bb8b8` and `41f55529` with an identical 34-failure profile.

## Also in this PR, from the locating rounds

**Native Windows coverage for `init.rs`, which had none.** `init::tests` now runs on
Windows, placed after the four previously-passing slices and immediately before the flaky
uninstall test so it survives FIR-1867 without pre-empting tests that pass today, and
required by name in `scripts/test-release-workflow-authority.py`. This turned a 30-minute
job emitting one ambiguous line into a 15-second run naming tests and exact line numbers.
It is the single change that made this diagnosable.

**Commit `efb86b4b` reverts landed work**, stated plainly rather than buried. It returns
`crates/kin-core/src/config/windows.rs` to the content shipped in v0.4.6 (`65e53c4b`),
byte-identical to `3a8cc708`, discarding six post-release mutations (`df9b3f88`,
`554b89c1`, `60577c36`, `28018570`, `234937f5`, `a3789fbb`) and `main`'s `wide()` prefix
strip. **Not because they caused the refusal**: the identical failure is present at
`1ab55190`, which predates all of them, with a byte-identical writer. Because none of them
ever passed the contract it was written for, and the `wide()` change both undermines the
canonical-path identity guarantee and caps publication at `MAX_PATH`. This commit is
separable and can be dropped in one operation if the reviewer prefers.

This PR no longer carries the native Windows enablement it opened with. That work is
already on `main`: #582 was branched on top of this branch, so its 43 commits begin with
this branch's 17 verbatim, and squash-landing #582 as `c512114e` brought all of them onto
`main`. Previous head `234937f5`.

## Verification

- `cargo fmt --all -- --check`: green.
- `cargo test -p kin-core --lib init::`: 56 passed, 0 failed on macOS, exit status read
  without a pipe in the way.
- Full workspace gate (`clippy --all-targets --all-features -D warnings`,
  `build --all-targets --all-features`, `test --workspace --all-features --no-fail-fast`)
  run under the lane's `daemon` lock.

Gap, stated rather than papered over: local cross-compilation to `x86_64-pc-windows-msvc`
is **not** available on this host, because `kin-core` depends unconditionally on
`kin-parser`, which builds `tree-sitter-cpp` from C and there is no MSVC C toolchain here.
`windows-latest` is the arbiter.

Closes FIR-1866

Refs FIR-1771 (its enablement content landed via #582), FIR-1839, FIR-1867.
