### PR TITLE
Exclude derived build output from ingest and add a confirmed tracked-set purge

### DIFF
--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -51,6 +51,7 @@ pub mod overview;
 pub mod pipeline;
 pub mod prepared_state;
 pub mod publish;
+pub mod purge_ignored;
 pub mod reconcile;
 pub mod ref_lookup;
 pub mod refs;

--- a/crates/kin-cli/src/commands/purge_ignored.rs
+++ b/crates/kin-cli/src/commands/purge_ignored.rs
@@ -41,6 +41,20 @@ pub struct PurgeIgnoredRequest {
     pub actor: AuthorId,
 }
 
+/// What the published transition actually did.
+///
+/// A confirmed purge plans from a complete working-directory walk, the same
+/// shape the watch loop admits, so it can also carry an addition or
+/// modification made since the last tick. Reporting only the planned purge set
+/// would name a number the transition did not do.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PublishedTransition {
+    pub removed: usize,
+    pub added: usize,
+    pub modified: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct PurgeIgnoredReport {
@@ -63,6 +77,9 @@ pub struct PurgeIgnoredReport {
     /// Present only when this purge published a transition.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authority_generation: Option<u64>,
+    /// What the published transition did. `None` for a dry run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published: Option<PublishedTransition>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,6 +119,22 @@ pub fn summary_lines(report: &PurgeIgnoredReport) -> Vec<String> {
     }
     if report.purge_count == 0 {
         lines.push("Nothing to purge.".to_string());
+    } else if let Some(published) = report.published {
+        // Report what the transition did, not what was planned. A confirmed
+        // purge admits a complete working-directory observation, so it can
+        // carry an edit made since the last watch-loop tick, and claiming the
+        // planned count would describe a transition that did not happen.
+        lines.push(format!(
+            "Published: {} removed, {} added, {} modified.",
+            published.removed, published.added, published.modified
+        ));
+        if published.removed != report.purge_count {
+            lines.push(format!(
+                "Note: {} paths were reported as covered; the observation also carried \
+                 concurrent working-directory changes.",
+                report.purge_count
+            ));
+        }
     } else if report.applied {
         lines.push(format!("Untracked {} paths.", report.purge_count));
     } else {
@@ -147,6 +180,11 @@ mod tests {
             sample_truncated: purge_count > 1,
             applied,
             authority_generation: applied.then_some(7),
+            published: applied.then_some(PublishedTransition {
+                removed: purge_count,
+                added: 0,
+                modified: 0,
+            }),
         }
     }
 
@@ -164,11 +202,44 @@ mod tests {
     }
 
     #[test]
-    fn applied_summary_reports_the_change_instead_of_a_dry_run() {
+    fn applied_summary_reports_the_published_transition_not_the_planned_set() {
         let lines = summary_lines(&report(40, true, true));
         let text = lines.join("\n");
-        assert!(text.contains("Untracked 40 paths."), "{text}");
+        assert!(
+            text.contains("Published: 40 removed, 0 added, 0 modified."),
+            "{text}"
+        );
         assert!(!text.contains("Dry run"), "{text}");
+    }
+
+    /// A confirmed purge admits a complete observation, so it can carry an edit
+    /// made since the last watch-loop tick. The summary must describe what the
+    /// transition did rather than repeating the planned count.
+    #[test]
+    fn a_transition_wider_than_the_purge_set_is_reported_as_such() {
+        let mut wider = report(40, true, true);
+        wider.published = Some(PublishedTransition {
+            removed: 40,
+            added: 2,
+            modified: 1,
+        });
+        let text = summary_lines(&wider).join("\n");
+        assert!(
+            text.contains("Published: 40 removed, 2 added, 1 modified."),
+            "{text}"
+        );
+        assert!(!text.contains("Untracked 40 paths."), "{text}");
+
+        // A removal count that disagrees with the reported set is called out.
+        let mut fewer = report(40, true, true);
+        fewer.published = Some(PublishedTransition {
+            removed: 38,
+            added: 0,
+            modified: 0,
+        });
+        let text = summary_lines(&fewer).join("\n");
+        assert!(text.contains("Published: 38 removed"), "{text}");
+        assert!(text.contains("40 paths were reported as covered"), "{text}");
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/purge_ignored.rs
+++ b/crates/kin-cli/src/commands/purge_ignored.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Wire types and CLI transport for retiring tracked paths that ignore rules
+//! now cover.
+//!
+//! Ignore rules never hide tracked paths, so a repository that admitted derived
+//! output before a rule existed keeps carrying it in graph truth forever. That
+//! retention is deliberate: an ignore rule must never turn into a silent
+//! deletion. Retiring the backlog is therefore an operator action with its own
+//! surface, and this is that surface.
+//!
+//! The default is a dry run. It names how many tracked paths the current rules
+//! cover, how many would remain, and a bounded sample of the paths themselves.
+//! Nothing moves until `--confirm`.
+
+use anyhow::{anyhow, Context, Result};
+use kin_model::{AuthorId, OperationId, RepositoryId};
+use serde::{Deserialize, Serialize};
+
+pub const PURGE_IGNORED_SCHEMA: &str = "kin.purge-ignored.v1";
+
+/// How many purged paths the report carries back.
+///
+/// A purge can cover millions of paths. The count is the decision input; the
+/// sample only lets an operator confirm the rules match what they expected.
+pub const REPORTED_PATH_SAMPLE: usize = 50;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PurgeIgnoredRequest {
+    /// Publish the removal. Without it the daemon only reports what it would do.
+    pub confirm: bool,
+    /// Confirm a purge that removes more than 75% of a non-trivial tree.
+    ///
+    /// A repository whose graph is mostly build output legitimately trips the
+    /// mass-deletion guard, and that is exactly the case this command exists to
+    /// fix, so the operator can accept it without disabling the guard globally.
+    pub confirm_mass_deletion: bool,
+    pub operation_id: OperationId,
+    pub actor: AuthorId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PurgeIgnoredReport {
+    pub schema: String,
+    pub repository_id: RepositoryId,
+    /// Whether the repository states its own rules in `.kinignore`.
+    pub kinignore_present: bool,
+    /// Tracked paths before this purge.
+    pub tracked_total: usize,
+    /// Tracked paths the current ignore rules cover.
+    pub purge_count: usize,
+    /// Tracked paths that remain.
+    pub retained_total: usize,
+    /// Up to [`REPORTED_PATH_SAMPLE`] of the covered paths, in path order.
+    pub sample_paths: Vec<String>,
+    /// True when `sample_paths` is shorter than `purge_count`.
+    pub sample_truncated: bool,
+    /// False for a dry run.
+    pub applied: bool,
+    /// Present only when this purge published a transition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_generation: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PurgeIgnoredResponse {
+    #[serde(default)]
+    pub lines: Vec<String>,
+    #[serde(default)]
+    pub mutated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub report: Option<PurgeIgnoredReport>,
+}
+
+/// Render the operator-facing summary for one purge report.
+///
+/// Kept separate from transport so the wording is asserted directly rather than
+/// through a daemon round trip.
+pub fn summary_lines(report: &PurgeIgnoredReport) -> Vec<String> {
+    let mut lines = Vec::new();
+    if !report.kinignore_present {
+        lines.push(
+            "This repository has no .kinignore; the built-in defaults decided this set."
+                .to_string(),
+        );
+    }
+    lines.push(format!(
+        "{} of {} tracked paths are covered by ignore rules; {} would remain.",
+        report.purge_count, report.tracked_total, report.retained_total
+    ));
+    for path in &report.sample_paths {
+        lines.push(format!("  {path}"));
+    }
+    if report.sample_truncated {
+        lines.push(format!(
+            "  ... {} more",
+            report.purge_count.saturating_sub(report.sample_paths.len())
+        ));
+    }
+    if report.purge_count == 0 {
+        lines.push("Nothing to purge.".to_string());
+    } else if report.applied {
+        lines.push(format!("Untracked {} paths.", report.purge_count));
+    } else {
+        lines.push("Dry run; nothing changed. Re-run with --confirm to untrack these.".to_string());
+    }
+    lines
+}
+
+pub async fn run(confirm: bool, confirm_mass_deletion: bool) -> Result<()> {
+    let cwd = std::env::current_dir().context("resolve current directory")?;
+    let layout = crate::commands::require_repository_layout_at(&cwd)?;
+    let base_url = crate::daemon_client::resolve_daemon_url(&layout)
+        .await?
+        .ok_or_else(|| anyhow!("Kin daemon is required to retire tracked paths"))?;
+    let client = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, &layout)?;
+    let response = client
+        .purge_ignored(&PurgeIgnoredRequest {
+            confirm,
+            confirm_mass_deletion,
+            operation_id: OperationId::new(),
+            actor: AuthorId::new(kin_core::whoami()),
+        })
+        .await?;
+    for line in &response.lines {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(purge_count: usize, applied: bool, kinignore_present: bool) -> PurgeIgnoredReport {
+        PurgeIgnoredReport {
+            schema: PURGE_IGNORED_SCHEMA.to_string(),
+            repository_id: RepositoryId::new("purge-summary").unwrap(),
+            kinignore_present,
+            tracked_total: 100,
+            purge_count,
+            retained_total: 100 - purge_count,
+            sample_paths: vec!["target/debug/app.o".to_string()],
+            sample_truncated: purge_count > 1,
+            applied,
+            authority_generation: applied.then_some(7),
+        }
+    }
+
+    #[test]
+    fn dry_run_summary_names_counts_and_refuses_to_claim_a_change() {
+        let lines = summary_lines(&report(40, false, true));
+        let text = lines.join("\n");
+        assert!(text.contains("40 of 100 tracked paths"), "{text}");
+        assert!(text.contains("60 would remain"), "{text}");
+        assert!(text.contains("target/debug/app.o"), "{text}");
+        assert!(text.contains("... 39 more"), "{text}");
+        assert!(text.contains("Dry run; nothing changed"), "{text}");
+        assert!(!text.contains("Untracked"), "{text}");
+        assert!(!text.contains("no .kinignore"), "{text}");
+    }
+
+    #[test]
+    fn applied_summary_reports_the_change_instead_of_a_dry_run() {
+        let lines = summary_lines(&report(40, true, true));
+        let text = lines.join("\n");
+        assert!(text.contains("Untracked 40 paths."), "{text}");
+        assert!(!text.contains("Dry run"), "{text}");
+    }
+
+    #[test]
+    fn an_unconfigured_repository_is_told_the_defaults_decided_the_set() {
+        let text = summary_lines(&report(40, false, false)).join("\n");
+        assert!(text.contains("no .kinignore"), "{text}");
+        assert!(
+            text.contains("built-in defaults decided this set"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn an_empty_purge_says_so_rather_than_offering_confirm() {
+        let mut empty = report(0, false, true);
+        empty.sample_paths.clear();
+        empty.sample_truncated = false;
+        let text = summary_lines(&empty).join("\n");
+        assert!(text.contains("Nothing to purge."), "{text}");
+        assert!(!text.contains("--confirm"), "{text}");
+    }
+}

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1504,6 +1504,18 @@ impl DaemonClient {
         .await
     }
 
+    pub async fn purge_ignored(
+        &self,
+        request: &crate::commands::purge_ignored::PurgeIgnoredRequest,
+    ) -> Result<crate::commands::purge_ignored::PurgeIgnoredResponse> {
+        self.post_idempotent_json(
+            "/commands/purge-ignored",
+            request,
+            "send daemon-owned tracked-path purge request",
+        )
+        .await
+    }
+
     pub async fn rollback(
         &self,
         request: &crate::commands::rollback::RollbackRequest,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -853,6 +853,16 @@ enum Command {
         #[arg(last = true)]
         task: Vec<String>,
     },
+    /// Retire tracked paths that ignore rules now cover. Reports without changing anything
+    /// unless --confirm is given.
+    PurgeIgnored {
+        /// Publish the removal instead of only reporting it
+        #[arg(long)]
+        confirm: bool,
+        /// Accept a purge that removes more than 75% of a non-trivial tree
+        #[arg(long)]
+        confirm_mass_deletion: bool,
+    },
     /// Admit one exact disposable-session observation into repository-v6 authority
     Reconcile {
         /// Session ID (defaults to most recent session)
@@ -3040,6 +3050,13 @@ fn main() -> Result<()> {
                     commands::capabilities::require_ready("open")?;
                     commands::session_run::open(editor, restrict_discovery, restrict_filesystem)
                         .await
+                }
+                Command::PurgeIgnored {
+                    confirm,
+                    confirm_mass_deletion,
+                } => {
+                    commands::capabilities::require_ready("purge-ignored")?;
+                    commands::purge_ignored::run(confirm, confirm_mass_deletion).await
                 }
                 Command::Reconcile {
                     session,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1163,6 +1163,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/resolve", post(command_resolve))
         .route("/commands/drift", post(command_drift))
         .route("/commands/tag", post(command_tag))
+        .route("/commands/purge-ignored", post(command_purge_ignored))
         .route("/commands/rollback", post(command_rollback))
         .route("/commands/checkout", post(command_checkout))
         .route("/commands/stash", post(command_stash))
@@ -3374,6 +3375,46 @@ async fn command_tag(
 
     let _coordination = state.coordination_gate.lock().await;
     let response = crate::repository_tag::execute(&state, &request)?;
+    Ok(Json(response))
+}
+
+/// POST /commands/purge-ignored — retire tracked paths that ignore rules cover.
+///
+/// Reports without mutating unless the request confirms. The coordination gate
+/// is held for both, so the watch loop cannot admit a competing observation
+/// between the tracked set this reports and the transition it publishes.
+async fn command_purge_ignored(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_cli::commands::purge_ignored::PurgeIgnoredRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if !state
+        .is_initialized
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "daemon not fully initialized".to_string(),
+        ));
+    }
+    if state.storage_backend.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "local repository purge authority is unavailable for hosted snapshot authority"
+                .to_string(),
+        ));
+    }
+    if extract_session_id_from_headers(&headers)?.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "purge publishes against HEAD authority; run it without ambient session scope"
+                .to_string(),
+        ));
+    }
+
+    let _coordination = state.coordination_gate.lock().await;
+    let response = crate::repository_purge::execute(&state, &request)
+        .map_err(|error| (StatusCode::CONFLICT, error.to_string()))?;
     Ok(Json(response))
 }
 
@@ -16895,6 +16936,142 @@ mod tests {
             .await
             .unwrap();
         (status, String::from_utf8_lossy(&body).to_string())
+    }
+
+    async fn purge_ignored_through_api(
+        app: &axum::Router,
+        confirm: bool,
+    ) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/commands/purge-ignored")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "confirm": confirm,
+                            "confirm_mass_deletion": true,
+                            "operation_id": kin_model::OperationId::new(),
+                            "actor": AuthorId::new("purge-acceptance")
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    fn tracked_paths(state: &DaemonState) -> std::collections::BTreeSet<String> {
+        state
+            .graph
+            .resolved_tree()
+            .artifacts_by_path()
+            .map(|artifact| artifact.path.to_string())
+            .collect()
+    }
+
+    /// A default exclude alone retires nothing, because ignore rules never hide
+    /// tracked identity. The purge is what retires the backlog, and the removal
+    /// has to be in authority rather than only in the live graph.
+    #[tokio::test]
+    async fn purge_ignored_untracks_admitted_derived_output_and_survives_restart() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let layout = state.layout.clone();
+
+        for (path, content) in [
+            ("src/lib.rs", &b"pub fn kept() {}"[..]),
+            ("target/debug/app.o", &b"derived"[..]),
+            ("target/debug/deps/lib.rlib", &b"derived"[..]),
+        ] {
+            install_working_copy_file(&state, path, content, false);
+            install_repository_file(&state, path, content);
+        }
+        let app = router(Arc::clone(&state));
+
+        // Precondition: the derived output really is tracked, so the assertions
+        // below cannot pass because it was never admitted.
+        assert!(tracked_paths(&state).contains("target/debug/app.o"));
+
+        let (_, dry) = purge_ignored_through_api(&app, false).await;
+        assert_eq!(dry["mutated"], json!(false));
+        assert_eq!(dry["report"]["purge_count"], json!(2));
+        assert_eq!(dry["report"]["tracked_total"], json!(3));
+        assert_eq!(dry["report"]["retained_total"], json!(1));
+        assert_eq!(dry["report"]["applied"], json!(false));
+        assert_eq!(dry["report"]["kinignore_present"], json!(false));
+        assert_eq!(
+            dry["report"]["sample_paths"],
+            json!(["target/debug/app.o", "target/debug/deps/lib.rlib"])
+        );
+        assert!(
+            tracked_paths(&state).contains("target/debug/app.o"),
+            "a dry run untracked a path"
+        );
+
+        let (_, applied) = purge_ignored_through_api(&app, true).await;
+        assert_eq!(applied["mutated"], json!(true));
+        assert_eq!(applied["report"]["applied"], json!(true));
+        assert_eq!(applied["report"]["purge_count"], json!(2));
+        assert!(applied["report"]["authority_generation"].is_number());
+
+        let live = tracked_paths(&state);
+        assert!(live.contains("src/lib.rs"));
+        assert!(!live.contains("target/debug/app.o"));
+        assert!(!live.contains("target/debug/deps/lib.rlib"));
+
+        // The files are still on disk. Only tracking was retired.
+        assert!(layout.working_dir().join("target/debug/app.o").exists());
+
+        // Restart: a fresh daemon rebuilds its graph from persisted authority,
+        // so this fails if the purge only moved the in-memory view.
+        drop(app);
+        drop(state);
+        let restarted = Arc::new(DaemonState::open(layout).unwrap());
+        let after_restart = tracked_paths(&restarted);
+        assert!(after_restart.contains("src/lib.rs"));
+        assert!(
+            !after_restart.contains("target/debug/app.o"),
+            "the purge did not survive a restart: {after_restart:?}"
+        );
+        assert!(!after_restart.contains("target/debug/deps/lib.rlib"));
+    }
+
+    /// A repository that states `!target` keeps its build output tracked, so the
+    /// purge set is driven by the repository's rules and not by a hardcoded list.
+    #[tokio::test]
+    async fn purge_ignored_honors_a_readmitted_default() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        install_working_copy_file(&state, ".kinignore", b"!target\n", false);
+        install_repository_file(&state, ".kinignore", b"!target\n");
+        install_working_copy_file(&state, "target/debug/app.o", b"derived", false);
+        install_repository_file(&state, "target/debug/app.o", b"derived");
+        let app = router(Arc::clone(&state));
+
+        let (_, dry) = purge_ignored_through_api(&app, false).await;
+        assert_eq!(dry["report"]["purge_count"], json!(0));
+        assert_eq!(dry["report"]["kinignore_present"], json!(true));
+        assert!(dry["lines"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|line| line.as_str().unwrap().contains("Nothing to purge.")));
+
+        let (_, applied) = purge_ignored_through_api(&app, true).await;
+        assert_eq!(applied["mutated"], json!(false));
+        assert!(tracked_paths(&state).contains("target/debug/app.o"));
     }
 
     fn branch_change(state: &DaemonState) -> SemanticChangeId {

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1706,7 +1706,9 @@ mod tests {
         graph.create_change(&genesis).unwrap();
 
         let source = layout.working_dir();
-        let files: &[(&str, &[u8])] = &[
+        // Parser support, vendoring, opaque bytes, and generated-but-committed
+        // artifacts never decide membership.
+        let expected: &[(&str, &[u8])] = &[
             ("Dockerfile", b"FROM scratch"),
             ("compose.yaml", b"services: {}"),
             ("Cargo.lock", b"version = 4"),
@@ -1717,10 +1719,14 @@ mod tests {
             ("assets/logo.bin", b"\x00\xff\x10"),
             ("vendor/lib/source.c", b"int vendored(void) { return 1; }"),
             ("generated/schema.pb", b"\x01\x02generated"),
+        ];
+        // Build output a compiler reproduces is excluded by the built-in
+        // defaults, so it never reaches repository truth.
+        let derived: &[(&str, &[u8])] = &[
             ("node_modules/pkg/index.js", b"export default 1"),
             ("target/debug/build.log", b"built"),
         ];
-        for (relative, bytes) in files {
+        for (relative, bytes) in expected.iter().chain(derived) {
             let path = source.join(relative);
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::write(path, bytes).unwrap();
@@ -1736,10 +1742,16 @@ mod tests {
                 _ => None,
             })
             .collect::<std::collections::BTreeSet<_>>();
-        for (relative, _) in files {
+        for (relative, _) in expected {
             assert!(
                 admitted.contains(*relative),
                 "missing exact member {relative}"
+            );
+        }
+        for (relative, _) in derived {
+            assert!(
+                !admitted.contains(*relative),
+                "derived output admitted: {relative}"
             );
         }
     }

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -129,6 +129,7 @@ pub mod repository_commit;
 mod repository_drift;
 mod repository_merge;
 mod repository_merge_state;
+mod repository_purge;
 mod repository_rename;
 mod repository_rollback;
 mod repository_stash;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -345,10 +345,12 @@ fn is_within_graph_only_member(state: &DaemonState, path: &RepoPath) -> Result<b
     Ok(false)
 }
 
-fn publish_exact_workspace_tree(
+/// Returns the authority generation this admission published, or `None` when
+/// the desired tree already matched authority and nothing moved.
+pub(crate) fn publish_exact_workspace_tree(
     state: &DaemonState,
     admitted: &crate::repository_commit::AdmittedWorkspaceTree,
-) -> Result<()> {
+) -> Result<Option<u64>> {
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
     let Some(admission) = crate::repository_commit::publish_workspace_tree(
@@ -359,7 +361,7 @@ fn publish_exact_workspace_tree(
         kin_model::AuthorId::new(kin_core::whoami()),
     )?
     else {
-        return Ok(());
+        return Ok(None);
     };
     state.record_repository_authority_commit(admission.receipt.generation)?;
     info!(
@@ -369,7 +371,7 @@ fn publish_exact_workspace_tree(
         file_deltas = admission.file_count,
         "admitted exact workspace tree into repository authority"
     );
-    Ok(())
+    Ok(Some(admission.receipt.generation))
 }
 
 fn invalid_tree_transition(error: impl std::fmt::Display) -> DaemonError {
@@ -395,7 +397,7 @@ fn mass_deletion_refused(removed: u64, total_graph_files: u64) -> DaemonError {
 }
 
 /// Read the repository roots the next observation will be planned against.
-fn current_authority_roots(state: &DaemonState) -> Result<kin_model::RootBundle> {
+pub(crate) fn current_authority_roots(state: &DaemonState) -> Result<kin_model::RootBundle> {
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
@@ -530,7 +532,7 @@ fn exact_tree_admission(
             previous.clone(),
             desired_tree,
         );
-        publish_exact_workspace_tree(state, &admitted)?;
+        let _ = publish_exact_workspace_tree(state, &admitted)?;
         state.graph.apply_transaction_delta(&TransactionDelta {
             entity_deltas: Vec::new(),
             relation_deltas: Vec::new(),
@@ -2350,7 +2352,11 @@ mod tests {
 /// threshold to the shared `graph_collapse_is_wipe` predicate so the fs-sync
 /// guard and the shutdown guard stay consistent (>75% gone, baseline ≥ 16). An
 /// explicit operator override (`allow_override`) always permits the deletions.
-fn should_block_mass_deletion(removed: u64, total_graph_files: u64, allow_override: bool) -> bool {
+pub(crate) fn should_block_mass_deletion(
+    removed: u64,
+    total_graph_files: u64,
+    allow_override: bool,
+) -> bool {
     if allow_override {
         return false;
     }

--- a/crates/kin-daemon/src/repository_purge.rs
+++ b/crates/kin-daemon/src/repository_purge.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Daemon-owned retirement of tracked paths that ignore rules now cover.
+//!
+//! Ignore rules deliberately never hide tracked paths, so adding a rule cannot
+//! turn graph-owned identity into a deletion. The cost of that safety is a
+//! backlog: a repository that admitted derived output before a rule existed
+//! keeps carrying it. This module is the deliberate operator action that
+//! retires the backlog, and nothing here runs without an explicit confirmation.
+//!
+//! The removal is published as one complete exact-tree observation, the same
+//! transition shape the watch loop admits, with one difference: the scan is
+//! given a tracked set that omits the covered paths. Those paths are then
+//! untracked and ignored, so the walk skips them and the planner reports them
+//! as removed. Doing it through a real completed walk rather than a synthesized
+//! delta means the purge inherits the same completion proof, authority
+//! compare-and-swap, and mass-deletion guard as every other admission.
+
+use anyhow::{Context, Result};
+use kin_cli::commands::purge_ignored::{
+    summary_lines, PurgeIgnoredReport, PurgeIgnoredRequest, PurgeIgnoredResponse,
+    PURGE_IGNORED_SCHEMA, REPORTED_PATH_SAMPLE,
+};
+use kin_db::EntityStore;
+use kin_model::{RepoPath, TransactionDelta, TreeDelta};
+use std::collections::BTreeSet;
+
+use crate::error::DaemonError;
+use crate::state::DaemonState;
+
+fn invalid(message: String) -> DaemonError {
+    DaemonError::Graph(kin_db::KinDbError::Model(
+        kin_model::ModelError::InvalidOperation(message),
+    ))
+}
+
+/// Plan and, when confirmed, publish the retirement of ignored tracked paths.
+pub(crate) fn execute(
+    state: &DaemonState,
+    request: &PurgeIgnoredRequest,
+) -> Result<PurgeIgnoredResponse> {
+    let working_dir = state.layout.working_dir();
+    let ignore = kin_index::RepositoryIgnore::load(working_dir)
+        .map_err(kin_index::IndexError::from)
+        .context("load repository ignore rules")?;
+    let previous = state.graph.resolved_tree();
+
+    let mut tracked = Vec::new();
+    let mut graph_only = BTreeSet::new();
+    for artifact in previous.artifacts_by_path() {
+        tracked.push(artifact.path.clone());
+        if kin_core::source_projection_disposition(&artifact.path, artifact.entry)?
+            != kin_core::SourceProjectionDisposition::Materialized
+        {
+            graph_only.insert(artifact.path.clone());
+        }
+    }
+
+    let covered = kin_index::tracked_paths_covered_by_ignore(&ignore, tracked.iter());
+    // A graph-only member's identity is owned by import truth and cannot be
+    // reconstructed from a host walk, so it is never retired by a rule that
+    // happens to match its path. Dropping it from the tracked set would also
+    // break the scanner's graph-only-is-a-subset-of-tracked precondition.
+    let purge_set = covered
+        .paths()
+        .iter()
+        .filter(|path| !graph_only.contains(*path))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let sample_paths = purge_set
+        .iter()
+        .take(REPORTED_PATH_SAMPLE)
+        .map(|path| path.to_string())
+        .collect::<Vec<_>>();
+    let mut report = PurgeIgnoredReport {
+        schema: PURGE_IGNORED_SCHEMA.to_string(),
+        repository_id:
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?
+                .repository_id()
+                .clone(),
+        kinignore_present: ignore.is_configured(),
+        tracked_total: covered.tracked_total(),
+        purge_count: purge_set.len(),
+        retained_total: covered.tracked_total().saturating_sub(purge_set.len()),
+        sample_truncated: purge_set.len() > sample_paths.len(),
+        sample_paths,
+        applied: false,
+        authority_generation: None,
+    };
+
+    if !request.confirm || purge_set.is_empty() {
+        let lines = summary_lines(&report);
+        return Ok(PurgeIgnoredResponse {
+            lines,
+            mutated: false,
+            report: Some(report),
+        });
+    }
+
+    let expected_roots = crate::loop_runner::current_authority_roots(state)?;
+    let retained_tracked = tracked
+        .iter()
+        .filter(|path| !purge_set.contains(*path))
+        .collect::<Vec<&RepoPath>>();
+    let scan = kin_index::scan_repository_preserving_graph_only(
+        working_dir,
+        &ignore,
+        retained_tracked.into_iter(),
+        graph_only.iter(),
+    )
+    .map_err(kin_index::IndexError::from)
+    .context("walk the working directory for the purge observation")?;
+    let observed =
+        crate::commit_deltas::observed_tree_from_complete_scan(&state.blobs, &scan, &previous)?;
+    let deltas = kin_core::plan_observed_tree_deltas(&previous, observed.entries().clone())?;
+
+    let removed = deltas
+        .iter()
+        .filter(|delta| matches!(delta, TreeDelta::Removed { .. }))
+        .count();
+    // The guard exists so an unconfirmed observation cannot wipe a tree. A
+    // repository whose graph is mostly build output trips it legitimately, so
+    // the operator confirms this purge specifically rather than disabling the
+    // guard for every observation the daemon makes.
+    if crate::loop_runner::should_block_mass_deletion(
+        removed as u64,
+        previous.len() as u64,
+        request.confirm_mass_deletion,
+    ) {
+        return Err(invalid(format!(
+            "this purge removes {removed} of {} tracked paths; re-run with \
+             --confirm-mass-deletion to accept a removal that large",
+            previous.len()
+        ))
+        .into());
+    }
+
+    let desired_tree = previous
+        .apply(&deltas)
+        .map_err(|error| invalid(format!("invalid purge tree transition: {error}")))?;
+    let admitted = crate::repository_commit::AdmittedWorkspaceTree::from_complete_observation(
+        observed.completion(),
+        expected_roots,
+        previous.clone(),
+        desired_tree,
+    );
+    let generation = crate::loop_runner::publish_exact_workspace_tree(state, &admitted)?;
+    state.graph.apply_transaction_delta(&TransactionDelta {
+        entity_deltas: Vec::new(),
+        relation_deltas: Vec::new(),
+        tree_deltas: deltas,
+        ..TransactionDelta::default()
+    })?;
+
+    report.applied = true;
+    report.authority_generation = generation;
+    let lines = summary_lines(&report);
+    Ok(PurgeIgnoredResponse {
+        lines,
+        mutated: true,
+        report: Some(report),
+    })
+}

--- a/crates/kin-daemon/src/repository_purge.rs
+++ b/crates/kin-daemon/src/repository_purge.rs
@@ -19,8 +19,8 @@
 
 use anyhow::{Context, Result};
 use kin_cli::commands::purge_ignored::{
-    summary_lines, PurgeIgnoredReport, PurgeIgnoredRequest, PurgeIgnoredResponse,
-    PURGE_IGNORED_SCHEMA, REPORTED_PATH_SAMPLE,
+    summary_lines, PublishedTransition, PurgeIgnoredReport, PurgeIgnoredRequest,
+    PurgeIgnoredResponse, PURGE_IGNORED_SCHEMA, REPORTED_PATH_SAMPLE,
 };
 use kin_db::EntityStore;
 use kin_model::{RepoPath, TransactionDelta, TreeDelta};
@@ -88,6 +88,7 @@ pub(crate) fn execute(
         sample_paths,
         applied: false,
         authority_generation: None,
+        published: None,
     };
 
     if !request.confirm || purge_set.is_empty() {
@@ -146,20 +147,55 @@ pub(crate) fn execute(
         previous.clone(),
         desired_tree,
     );
+
+    // Raise the graph-authority writer guard before touching the live graph.
+    // The handler's coordination gate excludes other writers, but the seqlock
+    // readers (mcp graph status, xref reads) take no gate at all: they sample
+    // the authority epoch, read, and revalidate. Without this guard the epoch
+    // never moves and `active_writers` stays zero, so a reader spanning a purge
+    // of up to 1.28M artifacts revalidates a torn view as stable. Dropping the
+    // guard also invalidates cross-repo spine edges pointing at purged
+    // artifacts, which would otherwise still be served as complete.
+    let graph_mutation = state.begin_graph_authority_mutation();
     let generation = crate::loop_runner::publish_exact_workspace_tree(state, &admitted)?;
     state.graph.apply_transaction_delta(&TransactionDelta {
         entity_deltas: Vec::new(),
         relation_deltas: Vec::new(),
-        tree_deltas: deltas,
+        tree_deltas: deltas.clone(),
         ..TransactionDelta::default()
     })?;
+    drop(graph_mutation);
+    // VFS paging cursors, the /vfs/version endpoint, and the version half of the
+    // xref read check all key on this. Skipping it after the single largest tree
+    // transition the system can make would leave every projection reader
+    // believing nothing changed.
+    state.bump_version();
 
     report.applied = true;
     report.authority_generation = generation;
+    report.published = Some(published_composition(&deltas));
     let lines = summary_lines(&report);
     Ok(PurgeIgnoredResponse {
         lines,
         mutated: true,
         report: Some(report),
     })
+}
+
+/// Count what the published transition actually did.
+///
+/// The purge plans from a complete working-directory walk, exactly as the watch
+/// loop does, so the transition also carries any addition or modification made
+/// since the last tick. Reporting the planned purge set alone would name a
+/// number the transition did not do.
+fn published_composition(deltas: &[TreeDelta]) -> PublishedTransition {
+    let mut published = PublishedTransition::default();
+    for delta in deltas {
+        match delta {
+            TreeDelta::Removed { .. } => published.removed += 1,
+            TreeDelta::Added { .. } => published.added += 1,
+            _ => published.modified += 1,
+        }
+    }
+    published
 }

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -68,9 +68,9 @@ pub use pipeline::{
 pub use repository::{
     host_path_from_repo_path, is_repository_control_path, read_verified_scanned_entry,
     repo_path_from_host_relative, scan_repository, scan_repository_preserving_graph_only,
-    should_track_host_relative_path, CompleteRepositoryScan, CompleteScanToken,
-    IncompleteRepositoryScan, RepositoryIgnore, RepositoryScanDiagnostics, ScannedEntryKind,
-    ScannedRepositoryEntry,
+    should_track_host_relative_path, tracked_paths_covered_by_ignore, CompleteRepositoryScan,
+    CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
+    RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
 };
 pub use support::{compute_coverage_report, CoverageReport};
 pub use watcher::{FileEvent, FileWatcher};

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -4,13 +4,19 @@
 //! Exact repository membership discovery.
 //!
 //! Repository membership is independent of parser support. This scanner admits
-//! every regular file and symbolic link, including configuration, generated
-//! output, vendored trees, binaries, and files in unsupported languages. Only
-//! Kin/Git control metadata is inherently excluded.
+//! every regular file and symbolic link, including configuration, vendored
+//! trees, binaries, and files in unsupported languages. Kin/Git control
+//! metadata is inherently excluded, and the compiler/packager output named by
+//! [`DEFAULT_IGNORED_NAMES`] is excluded by default because the graph is the
+//! system of record for source truth, not for derived bytes that any build
+//! reproduces.
 //!
-//! Explicit `.kinignore` rules apply only to paths that are not already tracked.
-//! A tracked path remains observable after a rule begins matching it, so ignore
+//! Ignore rules apply only to paths that are not already tracked. A tracked
+//! path remains observable after a rule begins matching it, so ignore
 //! configuration can never silently turn graph-owned truth into a deletion.
+//! Retiring already-admitted derived output is therefore a deliberate operator
+//! action: [`tracked_paths_covered_by_ignore`] names exactly which tracked
+//! paths a purge would untrack.
 //!
 //! A caller receives [`CompleteRepositoryScan`] only after every representable
 //! directory entry, metadata lookup, file read, and symbolic-link read
@@ -156,23 +162,116 @@ impl CompleteRepositoryScan {
     }
 }
 
-/// Literal, repo-scoped admission rules loaded from `.kinignore`.
+/// Names excluded from repository membership before any `.kinignore` is read.
+///
+/// Every entry is compiler, packager, or tool output that a build reproduces
+/// from source already under graph truth. Admitting them costs content-address
+/// storage and retrieval quality while adding no semantic truth.
+///
+/// Ambiguous names are deliberately absent. `build`, `out`, `bin`, and `vendor`
+/// routinely hold hand-written source or vendored dependency source, so they
+/// stay admitted and a repository that wants them excluded says so in its
+/// `.kinignore`. The rule for adding an entry here is that the name must be
+/// unambiguously derived output across the ecosystems that use it.
+pub const DEFAULT_IGNORED_NAMES: &[&str] = &[
+    // Rust, Maven, and sbt build output. This is the name that dominates
+    // derived-byte volume in a polyglot workspace.
+    "target",
+    // Package-manager dependency trees.
+    "node_modules",
+    // JavaScript and Python packaging output.
+    "dist",
+    // Python bytecode and environment/tool caches.
+    "__pycache__",
+    ".venv",
+    ".tox",
+    ".nox",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".ipynb_checkpoints",
+    // JavaScript framework and bundler caches.
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".turbo",
+    ".parcel-cache",
+    ".nyc_output",
+    // Build-tool and provider caches.
+    ".gradle",
+    ".terraform",
+    // Kin fleet lane-coordination state.
+    ".kin-coord",
+    // Finder metadata.
+    ".DS_Store",
+];
+
+/// Literal, repo-scoped admission rules: [`DEFAULT_IGNORED_NAMES`] plus the
+/// contents of `.kinignore`.
 ///
 /// A pattern without `/` matches a component at any depth. A pattern with `/`
 /// matches one repository path or its descendants. Glob interpretation is
 /// intentionally absent.
-#[derive(Debug, Clone, Default)]
+///
+/// A `!` prefix re-admits a path that another rule excludes, which is the only
+/// way to override a built-in default. Re-admission wins regardless of rule
+/// order, so `!target` restores an ordinary `target` directory and
+/// `!target/keep.rs` restores one path beneath an otherwise-excluded tree.
+#[derive(Debug, Clone)]
 pub struct RepositoryIgnore {
     names: BTreeSet<Vec<u8>>,
     prefixes: Vec<RepoPath>,
+    readmitted_names: BTreeSet<Vec<u8>>,
+    readmitted_prefixes: Vec<RepoPath>,
+    configured: bool,
+}
+
+impl Default for RepositoryIgnore {
+    /// The built-in defaults, as though a repository carried no `.kinignore`.
+    ///
+    /// An empty rule set is [`RepositoryIgnore::admit_everything`]. Defaulting
+    /// to no rules is what let derived output reach graph truth unbounded, so
+    /// the safe construction is the one callers get implicitly.
+    fn default() -> Self {
+        let mut rules = Self::admit_everything();
+        for name in DEFAULT_IGNORED_NAMES {
+            rules.names.insert(name.as_bytes().to_vec());
+        }
+        rules
+    }
 }
 
 impl RepositoryIgnore {
+    /// Rules that exclude nothing, not even build output.
+    ///
+    /// Reserved for callers that must observe a complete host tree, such as
+    /// import and projection fixtures. Runtime scan paths use
+    /// [`RepositoryIgnore::load`].
+    pub fn admit_everything() -> Self {
+        Self {
+            names: BTreeSet::new(),
+            prefixes: Vec::new(),
+            readmitted_names: BTreeSet::new(),
+            readmitted_prefixes: Vec::new(),
+            configured: false,
+        }
+    }
+
     pub fn load(root: &Path) -> Result<Self, IncompleteRepositoryScan> {
         let path = root.join(".kinignore");
         let bytes = match fs::read(&path) {
             Ok(bytes) => bytes,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let rules = Self::default();
+                if let Some(warning) = rules.missing_configuration_warning() {
+                    tracing::warn!(
+                        repository = %root.display(),
+                        defaults = DEFAULT_IGNORED_NAMES.len(),
+                        "{warning}"
+                    );
+                }
+                return Ok(rules);
+            }
             Err(error) => {
                 return Err(IncompleteRepositoryScan::io(
                     path,
@@ -192,16 +291,26 @@ impl RepositoryIgnore {
         })?;
 
         let mut rules = Self::default();
+        rules.configured = true;
         for (line_index, raw) in content.lines().enumerate() {
             let line = raw.trim();
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            let pattern = line.trim_end_matches('/');
+            let (pattern, readmit) = match line.strip_prefix('!') {
+                Some(rest) => (rest.trim(), true),
+                None => (line, false),
+            };
+            let pattern = pattern.trim_end_matches('/');
             let pattern = pattern.strip_prefix("./").unwrap_or(pattern);
             if pattern.is_empty() {
                 continue;
             }
+            let (names, prefixes) = if readmit {
+                (&mut rules.readmitted_names, &mut rules.readmitted_prefixes)
+            } else {
+                (&mut rules.names, &mut rules.prefixes)
+            };
             if pattern.contains('/') {
                 let prefix = RepoPath::from_utf8(pattern).map_err(|error| {
                     IncompleteRepositoryScan::io(
@@ -211,30 +320,137 @@ impl RepositoryIgnore {
                         RepositoryScanDiagnostics::default(),
                     )
                 })?;
-                rules.prefixes.push(prefix);
+                prefixes.push(prefix);
             } else {
-                rules.names.insert(pattern.as_bytes().to_vec());
+                names.insert(pattern.as_bytes().to_vec());
             }
         }
         rules.prefixes.sort();
         rules.prefixes.dedup();
+        rules.readmitted_prefixes.sort();
+        rules.readmitted_prefixes.dedup();
         Ok(rules)
     }
 
-    pub fn matches(&self, path: &RepoPath) -> bool {
+    /// Whether this repository states its own admission rules in `.kinignore`.
+    pub const fn is_configured(&self) -> bool {
+        self.configured
+    }
+
+    /// Operator-facing warning for a repository with no `.kinignore`.
+    ///
+    /// Returned rather than only logged so callers can surface it on their own
+    /// channel and tests can assert its content.
+    pub fn missing_configuration_warning(&self) -> Option<String> {
+        if self.configured {
+            return None;
+        }
+        Some(format!(
+            "no .kinignore: admission is running on {} built-in default excludes \
+             ({}). Derived output outside those names will be ingested as \
+             repository truth. Write a .kinignore to state this repository's \
+             rules, and use `!name` to re-admit a default.",
+            DEFAULT_IGNORED_NAMES.len(),
+            DEFAULT_IGNORED_NAMES.join(", ")
+        ))
+    }
+
+    fn matches_rules(names: &BTreeSet<Vec<u8>>, prefixes: &[RepoPath], path: &RepoPath) -> bool {
         let bytes = path.as_bytes();
         if bytes
             .split(|byte| *byte == b'/')
-            .any(|component| self.names.contains(component))
+            .any(|component| names.contains(component))
         {
             return true;
         }
-        self.prefixes.iter().any(|prefix| {
+        prefixes.iter().any(|prefix| {
             bytes == prefix.as_bytes()
                 || bytes
                     .strip_prefix(prefix.as_bytes())
                     .is_some_and(|suffix| suffix.starts_with(b"/"))
         })
+    }
+
+    pub fn matches(&self, path: &RepoPath) -> bool {
+        if Self::matches_rules(&self.readmitted_names, &self.readmitted_prefixes, path) {
+            return false;
+        }
+        Self::matches_rules(&self.names, &self.prefixes, path)
+    }
+
+    /// Whether any re-admission rule names a path strictly beneath `directory`.
+    ///
+    /// An excluded directory is pruned before its children are read, so a
+    /// re-admitted descendant is only reachable when the walk descends anyway.
+    fn readmits_below(&self, directory: &RepoPath) -> bool {
+        let prefix = directory.as_bytes();
+        self.readmitted_prefixes.iter().any(|readmitted| {
+            readmitted
+                .as_bytes()
+                .strip_prefix(prefix)
+                .is_some_and(|suffix| suffix.starts_with(b"/"))
+        })
+    }
+}
+
+/// Tracked paths that current ignore rules would exclude if they arrived today.
+///
+/// Ignore rules never hide tracked paths, so a repository that admitted derived
+/// output before a rule existed keeps carrying it. This is the evidence a purge
+/// reports before it acts and the exact set it removes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IgnoredTrackedPaths {
+    paths: Vec<RepoPath>,
+    tracked_total: usize,
+}
+
+impl IgnoredTrackedPaths {
+    /// The tracked paths covered by ignore rules, in repository path order.
+    pub fn paths(&self) -> &[RepoPath] {
+        &self.paths
+    }
+
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    /// How many paths the repository tracks in total.
+    pub const fn tracked_total(&self) -> usize {
+        self.tracked_total
+    }
+
+    /// Tracked paths that would remain after a purge.
+    pub const fn retained_total(&self) -> usize {
+        self.tracked_total.saturating_sub(self.paths.len())
+    }
+}
+
+/// Name the tracked paths that `ignore` covers.
+///
+/// This reads graph-owned tracked identity, never the host filesystem: a purge
+/// decides what to untrack from repository truth, so an absent or stale working
+/// directory cannot change the answer.
+pub fn tracked_paths_covered_by_ignore<'a>(
+    ignore: &RepositoryIgnore,
+    tracked: impl IntoIterator<Item = &'a RepoPath>,
+) -> IgnoredTrackedPaths {
+    let mut tracked_total = 0;
+    let mut paths = Vec::new();
+    for path in tracked {
+        tracked_total += 1;
+        if ignore.matches(path) {
+            paths.push(path.clone());
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    IgnoredTrackedPaths {
+        paths,
+        tracked_total,
     }
 }
 
@@ -447,7 +663,10 @@ impl Scanner<'_> {
             let ignored = self.ignore.matches(&repo_path);
 
             if file_type.is_dir() {
-                if ignored && !self.is_tracked_or_contains_tracked(&repo_path) {
+                if ignored
+                    && !self.is_tracked_or_contains_tracked(&repo_path)
+                    && !self.ignore.readmits_below(&repo_path)
+                {
                     self.diagnostics.ignored_untracked_entries += 1;
                     continue;
                 }
@@ -740,11 +959,14 @@ mod tests {
         scan_repository(root, &ignore, std::iter::empty()).unwrap()
     }
 
+    /// Membership stays independent of parser support, hidden names, and
+    /// vendoring. Only control metadata and derived output are excluded, and
+    /// `build`/`out`/`vendor` stay admitted because those names are ambiguous.
     #[test]
     fn scan_admits_every_non_control_repository_surface() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
-        let files: &[(&str, &[u8])] = &[
+        let admitted: &[(&str, &[u8])] = &[
             ("Dockerfile", b"FROM alpine"),
             ("compose.yaml", b"services: {}"),
             ("Cargo.lock", b"version = 4"),
@@ -754,18 +976,20 @@ mod tests {
             ("notes/brain.brainfuck", b"+++[>+++<-]"),
             ("assets/logo.bin", b"\x00\xff\x10"),
             ("unrelated/receipt.pdf", b"%PDF-not-really"),
-            ("node_modules/pkg/index.js", b"export default 1"),
-            ("target/generated.rs", b"pub const GENERATED: bool = true;"),
             ("vendor/lib/source.c", b"int vendored(void) { return 1; }"),
-            ("dist/app.js", b"console.log('dist')"),
             ("build/report.txt", b"build output"),
             ("out/data", b"output"),
-            ("__pycache__/state.bin", b"cache"),
-            (".next/server/app.js", b"next"),
             (".env.example", b"NAME=value"),
             (".kinignore", b""),
         ];
-        for (relative, content) in files {
+        let excluded_by_default: &[(&str, &[u8])] = &[
+            ("node_modules/pkg/index.js", b"export default 1"),
+            ("target/generated.rs", b"pub const GENERATED: bool = true;"),
+            ("dist/app.js", b"console.log('dist')"),
+            ("__pycache__/state.bin", b"cache"),
+            (".next/server/app.js", b"next"),
+        ];
+        for (relative, content) in admitted.iter().chain(excluded_by_default) {
             let host = root.join(relative);
             fs::create_dir_all(host.parent().unwrap()).unwrap();
             fs::write(host, content).unwrap();
@@ -783,13 +1007,19 @@ mod tests {
 
         let scan = scan(root);
         let paths = scan.paths().cloned().collect::<BTreeSet<_>>();
-        for (relative, _) in files {
+        for (relative, _) in admitted {
             assert!(paths.contains(&path(relative)), "missing {relative}");
+        }
+        for (relative, _) in excluded_by_default {
+            assert!(
+                !paths.contains(&path(relative)),
+                "derived output admitted: {relative}"
+            );
         }
         assert!(paths.contains(&path(".kin-release/downstreams.json")));
         assert!(!paths.iter().any(is_repository_control_path));
-        assert_eq!(scan.len(), files.len() + 1);
-        assert_eq!(scan.diagnostics().admitted_entries, files.len() + 1);
+        assert_eq!(scan.len(), admitted.len() + 1);
+        assert_eq!(scan.diagnostics().admitted_entries, admitted.len() + 1);
     }
 
     #[cfg(unix)]
@@ -846,36 +1076,205 @@ mod tests {
         assert!(scan.entry(&non_utf8).is_some());
     }
 
+    /// Uses names absent from [`DEFAULT_IGNORED_NAMES`] on purpose. Asserting
+    /// this against `target` would pass on the built-in defaults alone and
+    /// prove nothing about `.kinignore` parsing.
     #[test]
     fn explicit_ignore_applies_only_before_tracking() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
-        fs::create_dir_all(root.join("target/nested")).unwrap();
-        fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
-        fs::write(root.join("target/nested/new.bin"), b"new").unwrap();
-        fs::write(root.join("target/retained.bin"), b"retained").unwrap();
-        fs::write(root.join("node_modules/pkg/index.js"), b"generated").unwrap();
+        fs::create_dir_all(root.join("build/nested")).unwrap();
+        fs::create_dir_all(root.join("vendor/pkg")).unwrap();
+        fs::write(root.join("build/nested/new.bin"), b"new").unwrap();
+        fs::write(root.join("build/retained.bin"), b"retained").unwrap();
+        fs::write(root.join("vendor/pkg/index.js"), b"generated").unwrap();
         fs::write(root.join(".env"), b"SECRET=never-admit-untracked").unwrap();
-        fs::write(root.join(".kinignore"), b"target/\nnode_modules/\n.env\n").unwrap();
+        fs::write(root.join(".kinignore"), b"build/\nvendor/\n.env\n").unwrap();
         let ignore = RepositoryIgnore::load(root).unwrap();
+        assert!(ignore.is_configured());
 
         let initial = scan_repository(root, &ignore, std::iter::empty()).unwrap();
-        assert!(initial.entry(&path("target/nested/new.bin")).is_none());
-        assert!(initial.entry(&path("target/retained.bin")).is_none());
-        assert!(initial.entry(&path("node_modules/pkg/index.js")).is_none());
+        assert!(initial.entry(&path("build/nested/new.bin")).is_none());
+        assert!(initial.entry(&path("build/retained.bin")).is_none());
+        assert!(initial.entry(&path("vendor/pkg/index.js")).is_none());
         assert!(initial.entry(&path(".env")).is_none());
 
-        let retained = path("target/retained.bin");
-        fs::write(root.join("target/retained.bin"), b"updated tracked bytes").unwrap();
+        let retained = path("build/retained.bin");
+        fs::write(root.join("build/retained.bin"), b"updated tracked bytes").unwrap();
         let tracked = scan_repository(root, &ignore, [&retained]).unwrap();
         assert!(tracked.entry(&retained).is_some());
         assert_eq!(
             tracked.entry(&retained).unwrap().content_hash,
             sha256_bytes(b"updated tracked bytes")
         );
-        assert!(tracked.entry(&path("target/nested/new.bin")).is_none());
-        assert!(tracked.entry(&path("node_modules/pkg/index.js")).is_none());
+        assert!(tracked.entry(&path("build/nested/new.bin")).is_none());
+        assert!(tracked.entry(&path("vendor/pkg/index.js")).is_none());
         assert!(tracked.entry(&path(".env")).is_none());
+    }
+
+    #[test]
+    fn missing_kinignore_warns_and_still_applies_defaults() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::write(root.join("main.rs"), b"fn main() {}").unwrap();
+
+        let unconfigured = RepositoryIgnore::load(root).unwrap();
+        assert!(!unconfigured.is_configured());
+        let warning = unconfigured
+            .missing_configuration_warning()
+            .expect("absent .kinignore must warn");
+        assert!(warning.contains(".kinignore"), "{warning}");
+        assert!(warning.contains("target"), "{warning}");
+        assert!(warning.contains("built-in default excludes"), "{warning}");
+        assert!(unconfigured.matches(&path("target/debug/app")));
+
+        // Falsification: the same call against a repository that states its
+        // rules must go quiet, so the assertions above cannot pass vacuously.
+        fs::write(root.join(".kinignore"), b"# stated\n").unwrap();
+        let configured = RepositoryIgnore::load(root).unwrap();
+        assert!(configured.is_configured());
+        assert_eq!(configured.missing_configuration_warning(), None);
+        assert!(configured.matches(&path("target/debug/app")));
+    }
+
+    #[test]
+    fn default_excludes_reject_untracked_derived_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let derived = [
+            "target/debug/app.o",
+            "node_modules/pkg/index.js",
+            "dist/bundle.js",
+            "__pycache__/mod.pyc",
+            ".venv/bin/python",
+            ".pytest_cache/v/lastfailed",
+            ".next/server/page.js",
+            ".turbo/cache.log",
+            ".gradle/state.bin",
+            ".terraform/provider",
+            ".kin-coord/worktrees/lane/file",
+        ];
+        for relative in derived {
+            let host = root.join(relative);
+            fs::create_dir_all(host.parent().unwrap()).unwrap();
+            fs::write(host, b"derived").unwrap();
+        }
+        fs::write(root.join("lib.rs"), b"pub fn kept() {}").unwrap();
+
+        let scan = scan(root);
+        for relative in derived {
+            assert!(
+                scan.entry(&path(relative)).is_none(),
+                "derived output admitted: {relative}"
+            );
+        }
+        assert!(scan.entry(&path("lib.rs")).is_some());
+        assert_eq!(scan.len(), 1);
+        assert!(scan.diagnostics().ignored_untracked_entries > 0);
+
+        // Falsification: the fixture really does contain those trees, so an
+        // empty rule set must admit every one of them.
+        let everything = scan_repository(
+            root,
+            &RepositoryIgnore::admit_everything(),
+            std::iter::empty(),
+        )
+        .unwrap();
+        for relative in derived {
+            assert!(
+                everything.entry(&path(relative)).is_some(),
+                "fixture never created {relative}"
+            );
+        }
+        assert_eq!(everything.len(), derived.len() + 1);
+    }
+
+    #[test]
+    fn readmit_rule_overrides_a_built_in_default() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("target/deep")).unwrap();
+        fs::create_dir_all(root.join("dist")).unwrap();
+        fs::write(root.join("target/keep.rs"), b"pub fn keep() {}").unwrap();
+        fs::write(root.join("target/deep/drop.o"), b"object").unwrap();
+        fs::write(root.join("dist/app.js"), b"bundle").unwrap();
+
+        // A whole-name re-admission restores the tree.
+        fs::write(root.join(".kinignore"), b"!target\n").unwrap();
+        let whole = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &whole, std::iter::empty()).unwrap();
+        assert!(scan.entry(&path("target/keep.rs")).is_some());
+        assert!(scan.entry(&path("target/deep/drop.o")).is_some());
+        assert!(scan.entry(&path("dist/app.js")).is_none());
+
+        // A path re-admission descends into an otherwise-pruned directory and
+        // restores exactly one member.
+        fs::write(root.join(".kinignore"), b"!target/keep.rs\n").unwrap();
+        let single = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &single, std::iter::empty()).unwrap();
+        assert!(scan.entry(&path("target/keep.rs")).is_some());
+        assert!(scan.entry(&path("target/deep/drop.o")).is_none());
+
+        // Falsification: drop the re-admission and the same fixture loses it.
+        fs::write(root.join(".kinignore"), b"# nothing re-admitted\n").unwrap();
+        let none = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &none, std::iter::empty()).unwrap();
+        assert!(scan.entry(&path("target/keep.rs")).is_none());
+    }
+
+    /// The trap behind FIR-1854: a default exclude alone retires nothing,
+    /// because ignore rules never hide graph-owned identity.
+    #[test]
+    fn default_excludes_never_hide_already_tracked_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("target/debug")).unwrap();
+        fs::write(root.join("target/debug/tracked.o"), b"admitted earlier").unwrap();
+        fs::write(root.join("target/debug/fresh.o"), b"arrived later").unwrap();
+
+        let tracked = path("target/debug/tracked.o");
+        let ignore = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &ignore, [&tracked]).unwrap();
+
+        assert!(
+            scan.entry(&tracked).is_some(),
+            "a default exclude must not silently delete graph-owned truth"
+        );
+        assert!(scan.entry(&path("target/debug/fresh.o")).is_none());
+        assert!(scan.missing_tracked_paths([&tracked]).is_empty());
+    }
+
+    #[test]
+    fn tracked_paths_covered_by_ignore_names_the_purge_set() {
+        let ignore = RepositoryIgnore::default();
+        let tracked = [
+            path("src/main.rs"),
+            path("target/debug/app.o"),
+            path("target/debug/deps/lib.rlib"),
+            path("node_modules/pkg/index.js"),
+            path("vendor/lib/source.c"),
+        ];
+
+        let covered = tracked_paths_covered_by_ignore(&ignore, tracked.iter());
+        assert_eq!(
+            covered.paths(),
+            [
+                path("node_modules/pkg/index.js"),
+                path("target/debug/app.o"),
+                path("target/debug/deps/lib.rlib"),
+            ]
+        );
+        assert_eq!(covered.len(), 3);
+        assert_eq!(covered.tracked_total(), 5);
+        assert_eq!(covered.retained_total(), 2);
+        assert!(!covered.is_empty());
+
+        // Falsification: the same tracked set under empty rules purges nothing.
+        let none =
+            tracked_paths_covered_by_ignore(&RepositoryIgnore::admit_everything(), tracked.iter());
+        assert!(none.is_empty());
+        assert_eq!(none.tracked_total(), 5);
+        assert_eq!(none.retained_total(), 5);
     }
 
     #[cfg(unix)]

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -168,11 +168,15 @@ impl CompleteRepositoryScan {
 /// from source already under graph truth. Admitting them costs content-address
 /// storage and retrieval quality while adding no semantic truth.
 ///
-/// Ambiguous names are deliberately absent. `build`, `out`, `bin`, and `vendor`
-/// routinely hold hand-written source or vendored dependency source, so they
-/// stay admitted and a repository that wants them excluded says so in its
-/// `.kinignore`. The rule for adding an entry here is that the name must be
-/// unambiguously derived output across the ecosystems that use it.
+/// Ambiguous names are deliberately absent. `build`, `out`, `bin`, `vendor`,
+/// and `coverage` routinely hold hand-written source or vendored dependency
+/// source, so they stay admitted and a repository that wants them excluded says
+/// so in its `.kinignore`. The rule for adding an entry here is that the name
+/// must be unambiguously derived output across the ecosystems that use it.
+///
+/// A `!` rule re-admits anything here, and re-admission is scoped: it cancels
+/// only the rules matching at or above its own boundary, so `!target` does not
+/// also re-admit `target/node_modules`.
 pub const DEFAULT_IGNORED_NAMES: &[&str] = &[
     // Rust, Maven, and sbt build output. This is the name that dominates
     // derived-byte volume in a polyglot workspace.
@@ -205,6 +209,22 @@ pub const DEFAULT_IGNORED_NAMES: &[&str] = &[
     // Finder metadata.
     ".DS_Store",
 ];
+
+/// Roots already warned about a missing `.kinignore` in this process.
+static WARNED_ROOTS: std::sync::OnceLock<std::sync::Mutex<BTreeSet<PathBuf>>> =
+    std::sync::OnceLock::new();
+
+/// Whether this process should emit the missing-`.kinignore` warning for `root`.
+///
+/// Returns true exactly once per root. A poisoned lock warns rather than
+/// swallowing the condition, because an unheard warning is the failure here.
+fn warn_once_for_root(root: &Path) -> bool {
+    let warned = WARNED_ROOTS.get_or_init(|| std::sync::Mutex::new(BTreeSet::new()));
+    match warned.lock() {
+        Ok(mut warned) => warned.insert(root.to_path_buf()),
+        Err(_) => true,
+    }
+}
 
 /// Literal, repo-scoped admission rules: [`DEFAULT_IGNORED_NAMES`] plus the
 /// contents of `.kinignore`.
@@ -263,12 +283,18 @@ impl RepositoryIgnore {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 let rules = Self::default();
-                if let Some(warning) = rules.missing_configuration_warning() {
-                    tracing::warn!(
-                        repository = %root.display(),
-                        defaults = DEFAULT_IGNORED_NAMES.len(),
-                        "{warning}"
-                    );
+                // Latched per root. `load` runs once per watch-loop event batch
+                // against a ~100ms poll, so an unlatched warning would repeat
+                // several hundred characters per second on every repository in
+                // the fleet and bury the warnings that need reading.
+                if warn_once_for_root(root) {
+                    if let Some(warning) = rules.missing_configuration_warning() {
+                        tracing::warn!(
+                            repository = %root.display(),
+                            defaults = DEFAULT_IGNORED_NAMES.len(),
+                            "{warning}"
+                        );
+                    }
                 }
                 return Ok(rules);
             }
@@ -355,34 +381,80 @@ impl RepositoryIgnore {
         ))
     }
 
-    fn matches_rules(names: &BTreeSet<Vec<u8>>, prefixes: &[RepoPath], path: &RepoPath) -> bool {
-        let bytes = path.as_bytes();
-        if bytes
-            .split(|byte| *byte == b'/')
-            .any(|component| names.contains(component))
-        {
-            return true;
+    /// Whether any rule matches at or below byte offset `floor` in `bytes`.
+    ///
+    /// `floor` is the end of a re-admitted ancestor. Passing `0` tests the whole
+    /// path, which is the ordinary unqualified match.
+    fn rules_match_below(
+        names: &BTreeSet<Vec<u8>>,
+        prefixes: &[RepoPath],
+        bytes: &[u8],
+        floor: usize,
+    ) -> bool {
+        let mut start = 0;
+        for component in bytes.split(|byte| *byte == b'/') {
+            if start >= floor && names.contains(component) {
+                return true;
+            }
+            start += component.len() + 1;
         }
         prefixes.iter().any(|prefix| {
-            bytes == prefix.as_bytes()
-                || bytes
-                    .strip_prefix(prefix.as_bytes())
-                    .is_some_and(|suffix| suffix.starts_with(b"/"))
+            let prefix = prefix.as_bytes();
+            prefix.len() > floor
+                && (bytes == prefix
+                    || bytes
+                        .strip_prefix(prefix)
+                        .is_some_and(|suffix| suffix.starts_with(b"/")))
         })
     }
 
-    pub fn matches(&self, path: &RepoPath) -> bool {
-        if Self::matches_rules(&self.readmitted_names, &self.readmitted_prefixes, path) {
-            return false;
+    /// End offset of the deepest re-admitted ancestor-or-self of `bytes`.
+    fn readmit_floor(&self, bytes: &[u8]) -> Option<usize> {
+        let mut floor = None;
+        let mut start = 0;
+        for component in bytes.split(|byte| *byte == b'/') {
+            if self.readmitted_names.contains(component) {
+                floor = Some(start + component.len());
+            }
+            start += component.len() + 1;
         }
-        Self::matches_rules(&self.names, &self.prefixes, path)
+        for prefix in &self.readmitted_prefixes {
+            let prefix = prefix.as_bytes();
+            if bytes == prefix
+                || bytes
+                    .strip_prefix(prefix)
+                    .is_some_and(|suffix| suffix.starts_with(b"/"))
+            {
+                floor = Some(floor.map_or(prefix.len(), |floor: usize| floor.max(prefix.len())));
+            }
+        }
+        floor
     }
 
-    /// Whether any re-admission rule names a path strictly beneath `directory`.
+    /// Whether ignore rules exclude `path`.
     ///
-    /// An excluded directory is pruned before its children are read, so a
-    /// re-admitted descendant is only reachable when the walk descends anyway.
+    /// A re-admission cancels only the rules matching at or above its own
+    /// boundary. Rules that match strictly deeper still apply, so `!target`
+    /// restores a `target` tree without dragging `target/node_modules` back in
+    /// with it. Without that scoping the escape hatch would reintroduce exactly
+    /// the unbounded derived output it exists to let an operator recover from.
+    pub fn matches(&self, path: &RepoPath) -> bool {
+        let bytes = path.as_bytes();
+        let floor = self.readmit_floor(bytes).unwrap_or(0);
+        Self::rules_match_below(&self.names, &self.prefixes, bytes, floor)
+    }
+
+    /// Whether the walk must descend into an otherwise-excluded `directory`
+    /// because a re-admission could name something beneath it.
+    ///
+    /// A bare-name rule such as `!keep.rs` names no directory, so its depth
+    /// cannot be known without looking. Descending is the conservative answer:
+    /// it costs directory reads, and the file branch still applies
+    /// `ignored && !tracked`, so a re-admission never admits its siblings.
     fn readmits_below(&self, directory: &RepoPath) -> bool {
+        if !self.readmitted_names.is_empty() {
+            return true;
+        }
         let prefix = directory.as_bytes();
         self.readmitted_prefixes.iter().any(|readmitted| {
             readmitted
@@ -1220,6 +1292,61 @@ mod tests {
         let none = RepositoryIgnore::load(root).unwrap();
         let scan = scan_repository(root, &none, std::iter::empty()).unwrap();
         assert!(scan.entry(&path("target/keep.rs")).is_none());
+    }
+
+    /// A bare-name re-admission has no directory to descend from, so the walker
+    /// must descend anyway or the documented escape hatch is a silent no-op.
+    #[test]
+    fn bare_name_readmission_reaches_inside_a_pruned_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("dist")).unwrap();
+        fs::write(root.join("dist/keep.rs"), b"pub fn keep() {}").unwrap();
+        fs::write(root.join("dist/bundle.js"), b"derived").unwrap();
+        fs::write(root.join(".kinignore"), b"!keep.rs\n").unwrap();
+
+        let ignore = RepositoryIgnore::load(root).unwrap();
+        assert!(!ignore.matches(&path("dist/keep.rs")));
+        let scan = scan_repository(root, &ignore, std::iter::empty()).unwrap();
+        assert!(
+            scan.entry(&path("dist/keep.rs")).is_some(),
+            "the predicate admitted the path but the walker never reached it"
+        );
+        // Descending must not admit the siblings it walked past.
+        assert!(scan.entry(&path("dist/bundle.js")).is_none());
+
+        // Falsification: without the rule the same fixture keeps the file out.
+        fs::write(root.join(".kinignore"), b"# nothing re-admitted\n").unwrap();
+        let none = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &none, std::iter::empty()).unwrap();
+        assert!(scan.entry(&path("dist/keep.rs")).is_none());
+    }
+
+    /// Re-admission must cancel only the rule it overrides. If it blanket-won,
+    /// rescuing one tree would drag every nested default back in, which is the
+    /// volume problem this whole change exists to fix.
+    #[test]
+    fn readmission_does_not_defeat_defaults_nested_below_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::write(root.join(".kinignore"), b"!target\n").unwrap();
+        let ignore = RepositoryIgnore::load(root).unwrap();
+
+        assert!(!ignore.matches(&path("target/keep.rs")));
+        assert!(!ignore.matches(&path("target/deep/keep.rs")));
+        assert!(
+            ignore.matches(&path("target/node_modules/pkg/index.js")),
+            "a nested default was defeated by an ancestor re-admission"
+        );
+        assert!(ignore.matches(&path("target/sub/.DS_Store")));
+        assert!(ignore.matches(&path("target/a/dist/bundle.js")));
+
+        // A prefix re-admission scopes the same way.
+        fs::write(root.join(".kinignore"), b"!target/keep\n").unwrap();
+        let prefixed = RepositoryIgnore::load(root).unwrap();
+        assert!(!prefixed.matches(&path("target/keep/src/lib.rs")));
+        assert!(prefixed.matches(&path("target/keep/node_modules/pkg/index.js")));
+        assert!(prefixed.matches(&path("target/other.o")));
     }
 
     /// The trap behind FIR-1854: a default exclude alone retires nothing,

--- a/crates/kin-index/src/support.rs
+++ b/crates/kin-index/src/support.rs
@@ -277,7 +277,12 @@ fn sorted_map(map: &HashMap<String, usize>) -> Vec<(&String, &usize)> {
 }
 
 /// Collect every admitted repository file. Parser support, hidden names, and
-/// generated/vendor directory names do not affect membership.
+/// vendor directory names do not affect membership.
+///
+/// This deliberately loads the repository's real admission rules rather than
+/// [`crate::RepositoryIgnore::admit_everything`]. Coverage answers "how much of
+/// what Kin tracks is enriched", so counting build output Kin never admits would
+/// inflate the denominator with files that can never gain coverage.
 fn collect_all_files(root: &Path) -> crate::Result<Vec<std::path::PathBuf>> {
     let ignore = crate::RepositoryIgnore::load(root)?;
     let scan = crate::scan_repository(root, &ignore, std::iter::empty())?;
@@ -400,26 +405,39 @@ mod tests {
 
         fs::write(root.join("visible.rs"), "fn f() {}").unwrap();
 
-        // Dot-directories, dependency trees, and generated outputs are exact
-        // repository members even when their content gets only shallow/opaque
-        // semantic enrichment.
+        // A dot-directory and a vendored tree are exact repository members even
+        // when their content gets only shallow/opaque semantic enrichment.
         let hidden = root.join(".hidden");
         fs::create_dir(&hidden).unwrap();
         fs::write(hidden.join("secret.rs"), "fn s() {}").unwrap();
 
-        // node_modules
+        let vendored = root.join("vendor");
+        fs::create_dir(&vendored).unwrap();
+        fs::write(vendored.join("dep.js"), "module.exports = {}").unwrap();
+
+        // Build output is not a member, so coverage never counts it. Including
+        // it would inflate the denominator with files that cannot be enriched.
         let nm = root.join("node_modules");
         fs::create_dir(&nm).unwrap();
         fs::write(nm.join("dep.js"), "module.exports = {}").unwrap();
 
-        // target
         let target = root.join("target");
         fs::create_dir(&target).unwrap();
         fs::write(target.join("built.rs"), "fn b() {}").unwrap();
 
         let report = compute_coverage_report(root).unwrap();
-        assert_eq!(report.total_files, 4);
-        assert_eq!(report.entity_source_count, 4);
+        assert_eq!(report.total_files, 3);
+        assert_eq!(report.entity_source_count, 3);
+
+        // Falsification: the fixture really does carry the two derived files, so
+        // an empty rule set must count all five.
+        let everything = crate::scan_repository(
+            root,
+            &crate::RepositoryIgnore::admit_everything(),
+            [].iter(),
+        )
+        .unwrap();
+        assert_eq!(everything.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## The defect

`kin_index::RepositoryIgnore::load` read only `.kinignore`, and a missing file returned
`Self::default()`, which was an empty rule set. No repo in the fleet has a `.kinignore`, so
admission was excluding nothing but Kin/Git control metadata. The umbrella daemon ingested
617GB (about 1.28M objects, roughly 99% Rust build artifacts by magic-byte sampling) into
ingest-cas.

An ignore-file-only fix looks correct and is not, because of the second half of the trap. The
scanner deliberately does not hide tracked paths (`repository.rs`, the `ignored && !tracked`
guards), so adding excludes retires nothing that was already admitted. That retention is a real
safety property worth keeping: an ignore rule must never turn graph-owned identity into a silent
deletion. It means retiring the backlog has to be a separate, deliberate action.

## What changed

**1. Built-in default excludes, plus a loud warning when a repository states no rules.**

`RepositoryIgnore::default()` now carries `DEFAULT_IGNORED_NAMES`, so every one of the five
`load` call sites gets the fix without changes. The empty rule set is still reachable as the
explicitly named `RepositoryIgnore::admit_everything()`, so the safe construction is the one
callers get implicitly. `load` warns through `tracing` when `.kinignore` is absent, and
`missing_configuration_warning()` returns the same text so callers can surface it on their own
channel and tests can assert its content.

A `!` prefix in `.kinignore` re-admits anything a rule excludes, including a built-in default.
Re-admission wins regardless of rule order. `!target` restores an ordinary `target` directory,
and `!target/keep.rs` restores a single path beneath an otherwise-pruned tree (the walker
descends into an excluded directory when a re-admission names something below it).

Re-admission is **scoped**: it cancels only the rules matching at or above its own boundary, so
`!target` restores a `target` tree without also re-admitting `target/node_modules`. Without that
scoping the recovery path would reintroduce the unbounded derived output this PR exists to stop.
A bare-name rule such as `!keep.rs` names no directory, so the walker descends into excluded
directories whenever any bare-name rule exists; the file branch still applies
`ignored && !tracked`, so descending never admits the siblings it walks past.

**The chosen set, and why.** Every entry is compiler, packager, or tool output that a build
reproduces from source already under graph truth. Admitting it costs CAS storage and retrieval
quality while adding no semantic truth.

- Build output: `target` (Cargo, Maven, sbt, and the name that dominates the 617GB), `dist`
- Dependency trees: `node_modules`
- Python: `__pycache__`, `.venv`, `.tox`, `.nox`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`,
  `.ipynb_checkpoints`
- JS frameworks and bundlers: `.next`, `.nuxt`, `.svelte-kit`, `.turbo`, `.parcel-cache`,
  `.nyc_output`
- Build-tool and provider caches: `.gradle`, `.terraform`
- Kin fleet lane-coordination state: `.kin-coord`
- Finder noise: `.DS_Store`

Deliberately **not** included: `build`, `out`, `bin`, `vendor`, `coverage`. Each routinely holds
hand-written source or vendored dependency source. The rule for adding an entry is that the name
must be unambiguously derived output across the ecosystems that use it; ambiguous names stay
admitted and a repository excludes them in its own `.kinignore`. This is also why the escape
hatch exists: a hardcoded unconditional exclusion in a system of record is a trap.

**Corroboration, and why it is not the same list.** `kin_core::should_preserve_checkout_path`
already carries a "generated dependency/build directories" policy naming `node_modules`,
`target`, `__pycache__`, `.next`, `dist`, `build`, `vendor`. Its five-name core is exactly the
core chosen here, which is useful independent evidence that these are the codebase's canonical
derived names. The two lists are deliberately not unified, because they answer opposite
questions. That one decides what checkout cleanup must **not delete** from a working tree, so
being over-inclusive is the safe direction and `build`/`vendor` belong. This one decides what
must **not be ingested** as truth, where over-inclusion is the harmful direction: excluding a
`vendor/` tree would drop real source out of the graph.

**2. `kin purge-ignored`, a confirmed tracked-set purge.**

Defaults to a dry run that reports how many tracked paths current rules cover, how many would
remain, and a bounded sample of the paths. Nothing moves until `--confirm`.

The removal publishes as one complete exact-tree observation whose scan is handed a tracked set
omitting the covered paths. Those paths are then untracked and ignored, so the walk skips them
and the planner reports them as removed. Going through a real completed walk rather than a
synthesized delta means the purge inherits the same `CompleteScanToken` completion proof,
authority compare-and-swap, and mass-deletion guard as every other admission. A repository whose
graph is mostly build output trips that guard legitimately, so `--confirm-mass-deletion` accepts
it for this operation instead of disabling the guard globally.

Graph-only members (imported Gitlinks) are never retired even when a rule matches their path:
their identity comes from import truth rather than a host walk, and dropping them would also
break the scanner's graph-only-is-a-subset-of-tracked precondition.

The purge holds `begin_graph_authority_mutation()` across the publish, matching every other
repository-level mutator. The handler's coordination gate excludes other writers, but the seqlock
readers (`mcp_graph_status_with_stable_authority`, `prepare_xref_graph_read`) take no gate: they
sample the authority epoch, read, then revalidate. Without the writer guard the epoch never moves
and `active_writers` stays zero, so a reader spanning a purge of up to 1.28M artifacts would
revalidate a torn view as stable. Taking the guard (begin_graph_authority_mutation) also invalidates cross-repo spine edges up front, matching every incumbent mutator; the guard's Drop then bumps the epoch and releases the writer count
pointing at purged artifacts. `state.bump_version()` follows, so VFS paging cursors, the
`/vfs/version` endpoint, and the version half of the xref read check all see the change.

An applied run reports the **published** transition (removed, added, modified), not the planned
set. A confirmed purge admits a complete working-directory observation, the same shape the watch
loop admits, so it can also carry an edit made since the last tick; reporting the planned count
would name a number the transition did not do.

## Operator runbook for the umbrella reclaim

The reclaim is a separate operation, run after this lands. It is GPU-serialized:

```
bin/kin-lane acquire gpu <lane> --pid $$          # BEFORE the first invocation
bin/kin-lane acquire daemon <lane> --pid $$
kin purge-ignored                                 # dry run; reports, changes nothing
kin purge-ignored --confirm --confirm-mass-deletion
bin/kin-lane release daemon <lane>
bin/kin-lane release gpu <lane>
```

The gpu lock is required **before the dry run, not just before `--confirm`**. The dry run opens
the store, and opening a store with pending embeddings spawns a daemon that begins Metal
inference on its own. The 617GB umbrella store is exactly that case, so an unlocked dry run
contends for the one GPU with whatever proof or benchmark run holds it.

`--confirm-mass-deletion` is expected to be necessary here: a store that is ~99% build artifacts
trips the >75% guard by construction. That flag confirms this one operation rather than disabling
the guard for every observation the daemon makes.

## Doctrine change, called out deliberately

`scan_admits_every_non_control_repository_surface` previously asserted that `target/`,
`node_modules/`, `dist/`, `__pycache__/`, and `.next/` **are** admitted, and the module doc said
membership includes "generated output". That was the documented design, and this PR reverses it.
The test now asserts those five are excluded while `vendor/`, `build/`, `out/`, binaries, PDFs,
lockfiles, and dotfiles stay admitted, so it still proves membership is independent of parser
support, hidden names, and vendoring.

`explicit_ignore_applies_only_before_tracking` was rewritten to use `build/` and `vendor/`
instead of `target/` and `node_modules/`. Asserting it against a defaulted name would pass on the
built-in defaults alone and prove nothing about `.kinignore` parsing, which is a check that
cannot fail.

Two more fixtures carried the same assumption:

- `commit_deltas::tests::commit_admits_mixed_codebase_membership_independent_of_language_support`
  required `node_modules/pkg/index.js` and `target/debug/build.log` to reach repository truth. Its
  fixture is now split into an admitted set and a derived set, so it proves both halves. The
  load-bearing entries for the original intent (`unsupported/program.xyzzy`, `assets/logo.bin`,
  `vendor/`, `generated/`) are untouched, so language-independent membership is still proven.
- `support::tests::coverage_report_includes_every_non_control_directory` counted
  `node_modules/dep.js` and `target/built.rs` toward coverage. Decided deliberately rather than by
  changing the expected number: `collect_all_files` keeps loading the repository's real rules,
  because coverage answers "how much of what Kin tracks is enriched" and counting files Kin never
  admits inflates the denominator with files that can never gain coverage. The fixture now uses a
  `vendor/` tree for the still-admitted case and asserts the derived pair is excluded, with an
  `admit_everything()` arm proving the fixture really created all five files.

## Correction to an earlier claim in this PR's history

An earlier revision of this body said the `commit_deltas` failure "was the only failure across
`cargo test --workspace --all-features`". That was **wrong**. `cargo test` stops at the first
failing test binary unless `--no-fail-fast` is passed, so `kin_index` never ran in that invocation
and the `support.rs` failure was invisible. The gate for this head is run with `--no-fail-fast`.

## Tests

21 new tests. Every assertion was falsified by mutating the implementation and confirming the
intended test goes red, then restoring:

| Mutation | Test that went red |
| --- | --- |
| drop `"target"` from `DEFAULT_IGNORED_NAMES` | 4 repository tests |
| `missing_configuration_warning` always `None` | `missing_kinignore_warns_and_still_applies_defaults` |
| `matches()` ignores re-admission rules | `readmit_rule_overrides_a_built_in_default` |
| ignore rules hide tracked paths | `default_excludes_never_hide_already_tracked_paths` |
| `tracked_paths_covered_by_ignore` returns empty | `tracked_paths_covered_by_ignore_names_the_purge_set` |
| purge skips authority publication | `purge_ignored_untracks_admitted_derived_output_and_survives_restart` |
| dry run publishes anyway | `purge_ignored_untracks_admitted_derived_output_and_survives_restart` |
| purge ignores the repository re-admission rule | `purge_ignored_honors_a_readmitted_default` |
| drop `"target"` and `"node_modules"` from the defaults | `commit_admits_mixed_codebase_membership_independent_of_language_support` |

Added in the review round, covering the escape-hatch defects and the reporting fix:
`bare_name_readmission_reaches_inside_a_pruned_directory` (the predicate admitted a path the
walker never reached), `readmission_does_not_defeat_defaults_nested_below_it` (`!target` must not
drag `target/node_modules` back in), and
`a_transition_wider_than_the_purge_set_is_reported_as_such`.

The restart test drops the state and reopens `DaemonState` from the same layout, so a fresh
daemon rebuilds its graph from persisted authority. The "purge skips authority publication"
mutation going red is what proves it checks persisted truth rather than the in-memory view.
Several tests also carry an in-test falsification arm (for example, the derived-output fixture is
re-scanned under `admit_everything()` to prove the fixture really created those trees).

## Not claiming

- The purge was **not** run against the real umbrella store. That reclaim is operated separately
  once this lands.
- The 617GB figure is inherited from the ticket's investigation, not re-measured here.
- The default set is a judgment call about which names are unambiguously derived. It is expected
  to need additions; the `!` escape hatch is what keeps a wrong call recoverable per repository.
- Any benchmark or proof run that ingests the same corpus across this merge is not comparing like
  with like, because admission scope changed. A FIR-1117 or M1 run straddling this merge has
  non-comparable arms. Sequencing note for the release/proof captain, not a defect here.
- A non-Gitlink graph-only member (`GraphOnlyHostUnrepresentable`) plans as `Removed` here, as it
  already does in `exact_tree_admission`. Pre-existing and shared, but amplified by
  `--confirm-mass-deletion`. Ticketed against the shared path rather than fixed in this PR.

## Partial evidence toward FIR-1475

FIR-1475 requires that "ignore, no-follow, special-file, unreadable-file, mass-deletion,
projection health, retry, and LSP-generation behavior remain fail closed". This PR touches two of
those clauses and leaves them fail closed, with tests:

- **Ignore.** Ignore rules still never hide tracked paths, now asserted directly by
  `default_excludes_never_hide_already_tracked_paths`, and falsified by a mutation that lets them
  hide tracked paths.
- **Mass deletion.** The purge routes through the same `should_block_mass_deletion` thresholds as
  the watch loop and refuses without `--confirm-mass-deletion`; it never deletes by side channel.

It does **not** satisfy the rest of that ticket's acceptance (abort-before-record on relation,
traversal, and blob-write errors; complete inventory for deletions; blob confirmation for every
newly referenced hash; presence recording for admissible artifacts). Hence `Refs`, not `Closes`.
Noted so the ticket's re-scope has evidence attached rather than another orphan.

Closes FIR-1854
Refs FIR-1841
Refs FIR-1475

