### PR TITLE
Bound daemon shutdown against a saturated runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,6 +3228,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.11.0",
+ "signal-hook-registry",
  "socket2",
  "sysinfo",
  "tar",

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1015,7 +1015,12 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
             daemon.display_name.clone()
         };
         let kin_root = Path::new(&daemon.repo_root).join(".kin");
-        let outcome = stop_worker_at(&kin_root, daemon.pid, remaining_budget(deadline), uninstall_root)?;
+        let outcome = stop_worker_at(
+            &kin_root,
+            daemon.pid,
+            remaining_budget(deadline),
+            uninstall_root,
+        )?;
         if outcome.is_success() {
             remove_stale_daemon_files(&kin_root);
         }
@@ -1037,7 +1042,8 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
                 let already = reports.iter().any(|r| r.pid == pid);
                 if !already && is_process_alive(pid) {
                     let working_dir = kin_root.parent().unwrap_or(&kin_root).to_path_buf();
-                    let outcome = stop_worker_at(&kin_root, pid, remaining_budget(deadline), uninstall_root)?;
+                    let outcome =
+                        stop_worker_at(&kin_root, pid, remaining_budget(deadline), uninstall_root)?;
                     if outcome.is_success() {
                         remove_stale_daemon_files(&kin_root);
                     }

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -88,25 +88,45 @@ fn stop_timeout() -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Worst case for one daemon that rides its force-exit escalation all the way:
+/// `DEFAULT_SHUTDOWN_ESCALATION_GRACE` (25s) plus one `SHUTDOWN_WATCH_POLL`
+/// (250ms) for the watchdog to notice. Any sweep budget has to clear this for
+/// the FIRST identity alone, or a single wedged daemon consumes the whole sweep.
+const DAEMON_FORCE_EXIT_WORST_CASE: Duration = Duration::from_millis(25_250);
+
+/// Reserved for the supervisor, which is stopped last.
+const SUPERVISOR_STOP_RESERVE: Duration = Duration::from_secs(10);
+
 /// How long the whole `--all` sweep may take, as opposed to how long any one
 /// identity may take.
 ///
 /// `--all` stops identities in sequence, so giving each the full per-identity
 /// ceiling made the command's real bound `identities × ceiling` with nothing
 /// bounding the product. An ordinary install is one worker plus the supervisor,
-/// which is already 60s of worst case — enough for a caller that allows 60s to
-/// kill the command before it can report anything, turning a stop that failed
-/// into a stop with no verdict at all. The sweep now shares one budget.
+/// which is already 60s of worst case against a caller that commonly allows 60s,
+/// so the command was killed before it could report anything, turning a stop
+/// that failed into a stop with no verdict at all.
+///
+/// Sizing it is not free choice. `stop_timeout()`'s 30s was picked as a
+/// PER-IDENTITY margin over the daemon's ~25.25s hard bound, so reusing it as
+/// the whole-sweep budget leaves that 5s of margin to cover every identity after
+/// the first. One worker riding the full escalation would hand the supervisor
+/// 4.75s, and a supervisor reported `timeout` fails the command just as loudly
+/// as a hang. The budget is therefore derived from the daemon's bound rather
+/// than borrowed from a per-identity constant, and still leaves headroom under
+/// the 60s callers typically allow.
 fn stop_all_budget() -> Duration {
-    stop_timeout()
+    DAEMON_FORCE_EXIT_WORST_CASE
+        .saturating_add(SUPERVISOR_STOP_RESERVE)
+        .max(stop_timeout())
 }
 
-/// Budget left for the next identity in a sweep.
+/// Budget left before `deadline`.
 ///
 /// Reaching zero does not skip an identity: the stop request is still delivered,
 /// and only the wait for the process to disappear is what the exhausted budget
 /// gives up. The identity is then reported `timeout`, which is the honest
-/// outcome — the request went out and this command did not stay to watch.
+/// outcome, since the request went out and this command did not stay to watch.
 fn remaining_budget(deadline: Instant) -> Duration {
     deadline.saturating_duration_since(Instant::now())
 }
@@ -947,7 +967,14 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
     // One budget for the whole sweep. Each identity below waits only for what
     // is left of it, so this command's bound is the budget rather than the
     // budget multiplied by however many daemons happen to be running.
+    //
+    // Workers stop against an earlier deadline so the supervisor, which stops
+    // last, cannot be starved by them. Without that reserve a single worker
+    // riding its force-exit escalation leaves the supervisor a few seconds, and
+    // a supervisor reported `timeout` fails the command exactly as loudly as
+    // the hang this change exists to remove.
     let deadline = Instant::now() + stop_all_budget();
+    let worker_deadline = deadline - SUPERVISOR_STOP_RESERVE;
     let mut reports: Vec<StopReport> = Vec::new();
 
     // A live supervisor is the only authoritative registry of every repo
@@ -1018,7 +1045,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
         let outcome = stop_worker_at(
             &kin_root,
             daemon.pid,
-            remaining_budget(deadline),
+            remaining_budget(worker_deadline),
             uninstall_root,
         )?;
         if outcome.is_success() {
@@ -1042,8 +1069,12 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
                 let already = reports.iter().any(|r| r.pid == pid);
                 if !already && is_process_alive(pid) {
                     let working_dir = kin_root.parent().unwrap_or(&kin_root).to_path_buf();
-                    let outcome =
-                        stop_worker_at(&kin_root, pid, remaining_budget(deadline), uninstall_root)?;
+                    let outcome = stop_worker_at(
+                        &kin_root,
+                        pid,
+                        remaining_budget(worker_deadline),
+                        uninstall_root,
+                    )?;
                     if outcome.is_success() {
                         remove_stale_daemon_files(&kin_root);
                     }
@@ -1076,7 +1107,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
     }
 
     if let Some(install_root) = uninstall_root {
-        stop_install_owned_daemons(install_root, remaining_budget(deadline), &mut reports)?;
+        stop_install_owned_daemons(install_root, deadline, &mut reports)?;
     }
 
     if reports.is_empty() {
@@ -1254,9 +1285,14 @@ fn legacy_managed_identity(
 
 fn stop_install_owned_daemons(
     install_root: &Path,
-    wait: Duration,
+    deadline: Instant,
     reports: &mut Vec<StopReport>,
 ) -> Result<()> {
+    // Takes the sweep DEADLINE, not a remaining-budget snapshot. A snapshot is
+    // re-spent by every process on every pass, so the real bound here would be
+    // passes x processes x budget rather than the budget the caller meant.
+    // Recomputing against the deadline keeps the whole sweep inside one bound.
+    //
     // A second pass catches a worker spawned while the supervisor was exiting;
     // the retained startup authority means no successor supervisor can appear.
     for _ in 0..3 {
@@ -1281,7 +1317,12 @@ fn stop_install_owned_daemons(
             match process.kind {
                 ManagedDaemonKind::Worker { repo_root } => {
                     let kin_root = repo_root.join(".kin");
-                    let outcome = stop_worker_at(&kin_root, process.pid, wait, Some(install_root))?;
+                    let outcome = stop_worker_at(
+                        &kin_root,
+                        process.pid,
+                        remaining_budget(deadline),
+                        Some(install_root),
+                    )?;
                     if outcome.is_success() {
                         remove_stale_daemon_files(&kin_root);
                     }
@@ -1293,7 +1334,11 @@ fn stop_install_owned_daemons(
                     });
                 }
                 ManagedDaemonKind::Supervisor => {
-                    let outcome = stop_supervisor_pid(process.pid, wait, Some(install_root))?;
+                    let outcome = stop_supervisor_pid(
+                        process.pid,
+                        remaining_budget(deadline),
+                        Some(install_root),
+                    )?;
                     reports.push(StopReport {
                         kind: "supervisor",
                         label: "supervisor".to_string(),
@@ -1534,6 +1579,38 @@ mod tests {
         std::fs::write(kin_root.join("daemon.pid"), "not-a-pid").unwrap();
         std::fs::write(kin_root.join("daemon.port"), "99999999").unwrap();
         assert_eq!(repo_daemon_recorded_endpoint(&kin_root), (None, None));
+    }
+
+    #[test]
+    fn the_sweep_budget_cannot_be_consumed_by_one_wedged_daemon() {
+        // The failure this closes: `--all` stops identities in sequence and the
+        // supervisor goes last. A worker that rides its force-exit escalation
+        // spends ~25.25s, and when the whole-sweep budget was the 30s
+        // per-identity constant that left the supervisor 4.75s. A supervisor
+        // reported `timeout` fails the command exactly as loudly as the hang
+        // this change exists to remove, so the sweep has to clear one full
+        // escalation AND still fund the tail.
+        let budget = stop_all_budget();
+        assert!(
+            budget >= DAEMON_FORCE_EXIT_WORST_CASE + SUPERVISOR_STOP_RESERVE,
+            "sweep budget {budget:?} must fund one full force-exit escalation \
+             plus the supervisor reserve"
+        );
+
+        // What the sweep actually hands the supervisor after a worst-case
+        // worker, computed the way `stop_all_inner` computes it.
+        let sweep_start = Instant::now();
+        let worker_deadline = (sweep_start + budget) - SUPERVISOR_STOP_RESERVE;
+        let after_wedged_worker = sweep_start + DAEMON_FORCE_EXIT_WORST_CASE;
+        assert!(
+            worker_deadline >= after_wedged_worker,
+            "a single wedged worker must not exhaust the workers' share"
+        );
+        let supervisor_share = (sweep_start + budget) - after_wedged_worker;
+        assert!(
+            supervisor_share >= SUPERVISOR_STOP_RESERVE,
+            "supervisor was left {supervisor_share:?}, less than its reserve"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1721,7 +1721,11 @@ mod tests {
                     "daemon scan authorized an outside process through lexical traversal"
                 );
                 let mut reports = Vec::new();
-                stop_install_owned_daemons(&install_root, Duration::from_secs(5), &mut reports)?;
+                stop_install_owned_daemons(
+                    &install_root,
+                    Instant::now() + Duration::from_secs(5),
+                    &mut reports,
+                )?;
                 anyhow::ensure!(
                     reports.iter().any(|report| {
                         report.pid == managed_child.0.id() && report.outcome.is_success()

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -14,6 +14,11 @@
 //! pidfd, native Windows uses a process handle, and macOS uses an authenticated
 //! cooperative endpoint whose request names the expected birth identity. The
 //! wait is a ceiling, not a fixed delay.
+//!
+//! `--all` bounds the sweep, not just each step in it. Stopping identities in
+//! sequence under a per-identity ceiling left the command's real bound
+//! proportional to how many daemons happened to be running, so `stop --all`
+//! could outlive its caller's patience and be killed before reporting anything.
 
 use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
@@ -81,6 +86,29 @@ fn stop_timeout() -> Duration {
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(30);
     Duration::from_secs(secs)
+}
+
+/// How long the whole `--all` sweep may take, as opposed to how long any one
+/// identity may take.
+///
+/// `--all` stops identities in sequence, so giving each the full per-identity
+/// ceiling made the command's real bound `identities × ceiling` with nothing
+/// bounding the product. An ordinary install is one worker plus the supervisor,
+/// which is already 60s of worst case — enough for a caller that allows 60s to
+/// kill the command before it can report anything, turning a stop that failed
+/// into a stop with no verdict at all. The sweep now shares one budget.
+fn stop_all_budget() -> Duration {
+    stop_timeout()
+}
+
+/// Budget left for the next identity in a sweep.
+///
+/// Reaching zero does not skip an identity: the stop request is still delivered,
+/// and only the wait for the process to disappear is what the exhausted budget
+/// gives up. The identity is then reported `timeout`, which is the honest
+/// outcome — the request went out and this command did not stay to watch.
+fn remaining_budget(deadline: Instant) -> Duration {
+    deadline.saturating_duration_since(Instant::now())
 }
 
 /// Outcome of a graceful stop request against one recorded pid.
@@ -916,7 +944,10 @@ async fn stop_all(json: bool, quiet: bool) -> Result<()> {
 }
 
 async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) -> Result<()> {
-    let wait = stop_timeout();
+    // One budget for the whole sweep. Each identity below waits only for what
+    // is left of it, so this command's bound is the budget rather than the
+    // budget multiplied by however many daemons happen to be running.
+    let deadline = Instant::now() + stop_all_budget();
     let mut reports: Vec<StopReport> = Vec::new();
 
     // A live supervisor is the only authoritative registry of every repo
@@ -967,7 +998,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
     // the registry snapshot and supervisor exit.
     if uninstall_root.is_some() {
         if let (Some(pid), Some(identity)) = (sup_pid, supervisor_identity.as_ref()) {
-            let outcome = stop_supervisor_identity(identity, wait);
+            let outcome = stop_supervisor_identity(identity, remaining_budget(deadline));
             reports.push(StopReport {
                 kind: "supervisor",
                 label: "supervisor".to_string(),
@@ -984,7 +1015,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
             daemon.display_name.clone()
         };
         let kin_root = Path::new(&daemon.repo_root).join(".kin");
-        let outcome = stop_worker_at(&kin_root, daemon.pid, wait, uninstall_root)?;
+        let outcome = stop_worker_at(&kin_root, daemon.pid, remaining_budget(deadline), uninstall_root)?;
         if outcome.is_success() {
             remove_stale_daemon_files(&kin_root);
         }
@@ -1006,7 +1037,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
                 let already = reports.iter().any(|r| r.pid == pid);
                 if !already && is_process_alive(pid) {
                     let working_dir = kin_root.parent().unwrap_or(&kin_root).to_path_buf();
-                    let outcome = stop_worker_at(&kin_root, pid, wait, uninstall_root)?;
+                    let outcome = stop_worker_at(&kin_root, pid, remaining_budget(deadline), uninstall_root)?;
                     if outcome.is_success() {
                         remove_stale_daemon_files(&kin_root);
                     }
@@ -1025,7 +1056,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
     // workers first, supervisor last. Full uninstall already stopped it above.
     if uninstall_root.is_none() {
         if let (Some(pid), Some(identity)) = (sup_pid, supervisor_identity.as_ref()) {
-            let outcome = stop_supervisor_identity(identity, wait);
+            let outcome = stop_supervisor_identity(identity, remaining_budget(deadline));
             if outcome.is_success() {
                 remove_stale_supervisor_files();
             }
@@ -1039,7 +1070,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
     }
 
     if let Some(install_root) = uninstall_root {
-        stop_install_owned_daemons(install_root, wait, &mut reports)?;
+        stop_install_owned_daemons(install_root, remaining_budget(deadline), &mut reports)?;
     }
 
     if reports.is_empty() {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -176,8 +176,20 @@ pub struct RegisteredRepoDaemon {
 /// /daemons`. The caller supplies a supervisor URL it already resolved (e.g. via
 /// [`ensure_supervisor_running`] or [`supervisor_recorded_endpoint`]); this does
 /// not itself start a supervisor.
+/// Bound on the supervisor topology fetch.
+///
+/// `kin daemon stop --all` awaits this before it stops anything, so an
+/// unbounded fetch is an unbounded stop: a supervisor that accepts the
+/// connection and never answers holds the whole command open with no identity
+/// yet signalled and no verdict to print. The supervisor only reads its own
+/// in-memory registry, so a healthy one answers immediately and this ceiling is
+/// never approached.
+const SUPERVISOR_TOPOLOGY_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub async fn fetch_registered_daemons(supervisor_url: &str) -> Result<Vec<RegisteredRepoDaemon>> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(SUPERVISOR_TOPOLOGY_TIMEOUT)
+        .build()?;
     let mut request = client.get(format!("{}/daemons", supervisor_url.trim_end_matches('/')));
     if let Some(token) = supervisor_auth_token() {
         request = request.bearer_auth(token);

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -67,6 +67,10 @@ sysinfo = "0.39"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+# Chains a shutdown handler alongside tokio's own SIGTERM/SIGINT registration
+# (tokio registers through this same crate) so arming the force-exit backstop
+# never depends on the async runtime being schedulable.
+signal-hook-registry = "1.4"
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { version = "0.61", features = [

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -912,16 +912,13 @@ async fn request_daemon_shutdown(
         )
             .into_response();
     };
+    // `shutdown` is a clone of the daemon's cancel channel, which is the exact
+    // watch value the escalation watchdog polls, so accepting a cooperative
+    // request already starts the force-exit countdown. Nothing further is
+    // needed here, and nothing here is runtime-independent: reaching this line
+    // at all requires a schedulable runtime.
     match shutdown.send(true) {
-        Ok(()) => {
-            // Accepting the request commits this process to exiting, so the
-            // force-exit backstop starts counting down here. On macOS this is
-            // the whole stop path — there is no signal behind it — and leaving
-            // the countdown to a task the runtime may never schedule is what
-            // let a saturated daemon absorb a stop request and keep running.
-            crate::daemon::note_shutdown_requested();
-            (StatusCode::ACCEPTED, Json(json!({"stopping": true}))).into_response()
-        }
+        Ok(()) => (StatusCode::ACCEPTED, Json(json!({"stopping": true}))).into_response(),
         Err(error) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({"error": format!("shutdown channel closed: {error}")})),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -913,7 +913,15 @@ async fn request_daemon_shutdown(
             .into_response();
     };
     match shutdown.send(true) {
-        Ok(()) => (StatusCode::ACCEPTED, Json(json!({"stopping": true}))).into_response(),
+        Ok(()) => {
+            // Accepting the request commits this process to exiting, so the
+            // force-exit backstop starts counting down here. On macOS this is
+            // the whole stop path — there is no signal behind it — and leaving
+            // the countdown to a task the runtime may never schedule is what
+            // let a saturated daemon absorb a stop request and keep running.
+            crate::daemon::note_shutdown_requested();
+            (StatusCode::ACCEPTED, Json(json!({"stopping": true}))).into_response()
+        }
         Err(error) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({"error": format!("shutdown channel closed: {error}")})),

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -564,20 +564,124 @@ fn parse_owner_watch_pid(raw: Option<&str>, self_pid: u32) -> Option<i32> {
     Some(pid)
 }
 
+/// Shutdown requested through a path that no scheduler can starve.
+///
+/// Written from a real OS signal handler, so every write must stay
+/// async-signal-safe: one relaxed atomic store, no allocation, no locking, no
+/// logging.
+static SHUTDOWN_REQUESTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Has shutdown been requested through a runtime-independent path?
+pub fn shutdown_requested() -> bool {
+    SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Record a shutdown request from a caller that is not a signal handler.
+///
+/// The cooperative `/shutdown` endpoint is the caller that matters: accepting a
+/// request commits this process to exiting, so the force-exit backstop has to
+/// start counting down at the moment of acceptance rather than at the moment
+/// some later task manages to get scheduled.
+pub fn note_shutdown_requested() {
+    SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Arm the runtime-independent shutdown flag from signal delivery itself.
+///
+/// Registered through `signal_hook_registry`, which chains handlers, so tokio's
+/// own SIGTERM/SIGINT registration keeps driving the graceful path unchanged.
+/// This handler exists only so the force-exit backstop is armed by the kernel
+/// delivering the signal rather than by the runtime's willingness to poll a
+/// future.
+#[cfg(unix)]
+pub fn install_shutdown_signal_handler() {
+    for signal in [libc::SIGTERM, libc::SIGINT] {
+        // SAFETY: the handler body performs a single relaxed atomic store and
+        // calls nothing that is not async-signal-safe.
+        let registered = unsafe {
+            signal_hook_registry::register(signal, || {
+                SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
+            })
+        };
+        if let Err(error) = registered {
+            warn!(
+                signal,
+                error = %error,
+                "failed to arm the runtime-independent shutdown flag; \
+                 force-exit escalation falls back to in-runtime arming"
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub fn install_shutdown_signal_handler() {}
+
 /// Has shutdown been signalled by any path?
 ///
-/// `is_shutdown` is the state flag set by the propagation task; `cancel` is the
-/// watch-channel flag that every shutdown trigger (SIGTERM/SIGINT, idle timeout,
-/// owner death, any task exiting) sets synchronously at the moment it fires.
+/// Three independent sources, because the force-exit backstop must not depend
+/// on the runtime it exists to rescue:
+/// - `os_requested`: set by the SIGTERM/SIGINT handler itself, or by the
+///   cooperative `/shutdown` endpoint at the moment it accepts the request.
+/// - `cancel`: the watch-channel flag every in-runtime shutdown trigger sets.
+/// - `is_shutdown`: the state flag the propagation task writes.
 ///
-/// The escalation watchdog arms on EITHER. Keying it on `is_shutdown` alone made
-/// the force-exit backstop depend on a tokio task running: the only writer of
-/// `is_shutdown` is the propagation task, so a wedged or saturated async runtime
-/// silently disarmed the very backstop that exists for the wedged case. `cancel`
-/// is set synchronously by the signal handler itself, so the backstop is now
-/// armed by the signal rather than by the scheduler's willingness to run a task.
-fn shutdown_signalled(is_shutdown: bool, cancel: bool) -> bool {
-    is_shutdown || cancel
+/// Only `os_requested` survives a saturated runtime. Both other flags are
+/// written from inside it: the SIGTERM arm of `select_with_signals` sets
+/// `cancel`, but that arm is a future the runtime has to poll, and the
+/// propagation task that writes `is_shutdown` is a task the runtime has to
+/// schedule. A reconciliation batch occupying every worker thread with
+/// synchronous work therefore disarmed the backstop that exists for precisely
+/// that case, and the daemon outlived its documented grace with no bound at
+/// all — a stop request that never terminated anything.
+fn shutdown_signalled(is_shutdown: bool, cancel: bool, os_requested: bool) -> bool {
+    is_shutdown || cancel || os_requested
+}
+
+/// Spawn the shutdown-escalation watchdog: a plain OS thread — deliberately
+/// NOT a tokio task — so it stays runnable even while the async runtime is
+/// tearing down or saturated. Once shutdown is signalled it grants a bounded
+/// grace period for the drain plus final flush to finish, then force-exits.
+///
+/// This is the hard backstop against two zombies. A blocking embedding batch
+/// mid GPU-compute cannot observe the cancel signal, so runtime teardown can
+/// otherwise block forever and leave a headless, SIGTERM-immune CPU zombie that
+/// still races kvec writes. A reconciliation batch that occupies every runtime
+/// worker with synchronous work is the same failure from the other direction:
+/// nothing inside the runtime runs, so nothing inside the runtime can arm this.
+///
+/// `is_shutdown` is taken as a probe rather than a flag so the production call
+/// site keeps reading `DaemonState` while a test can model the runtime whose
+/// propagation task never runs at all.
+pub fn spawn_shutdown_escalation_watchdog<F>(
+    is_shutdown: F,
+    cancel: tokio::sync::watch::Receiver<bool>,
+    grace: Duration,
+) where
+    F: Fn() -> bool + Send + 'static,
+{
+    if let Err(error) = std::thread::Builder::new()
+        .name("kin-shutdown-watchdog".to_string())
+        .spawn(move || {
+            while !shutdown_signalled(is_shutdown(), *cancel.borrow(), shutdown_requested()) {
+                std::thread::sleep(SHUTDOWN_WATCH_POLL);
+            }
+            std::thread::sleep(grace);
+            // Still alive after the grace period → the graceful path is wedged
+            // (a blocking embed batch the runtime drop is waiting on, or a
+            // reconciliation batch holding every worker thread). Force the whole
+            // process down so a stop request always results in actual
+            // termination — no zombie, and no unbounded stop.
+            eprintln!(
+                "kin-daemon: graceful shutdown exceeded {}s grace — forcing process exit to prevent a CPU zombie",
+                grace.as_secs()
+            );
+            std::process::exit(0);
+        })
+    {
+        warn!(error = %error, "failed to spawn shutdown-escalation watchdog");
+    }
 }
 
 /// Is the process with this PID still alive?
@@ -990,6 +1094,7 @@ pub async fn run_with_authority(
                         .is_shutdown
                         .load(std::sync::atomic::Ordering::Relaxed),
                     *watch_cancel_rx.borrow(),
+                    shutdown_requested(),
                 ) {
                     return;
                 }
@@ -1102,51 +1207,21 @@ pub async fn run_with_authority(
         }
     });
 
-    // Shutdown-escalation watchdog. A plain OS thread — deliberately
-    // NOT a tokio task — so it stays runnable even while the async runtime is
-    // tearing down. Once graceful shutdown is signalled it grants a bounded
-    // grace period for the drain + final flush to finish, then force-exits.
-    // This is the hard backstop against the embed-worker zombie: a blocking
-    // embedding batch mid GPU-compute cannot observe the cancel signal, so
-    // runtime teardown can otherwise block forever and leave a headless,
-    // SIGTERM-immune CPU zombie that still races kvec writes.
-    //
-    // Armed by `shutdown_signalled`, i.e. the cancel watch-channel OR
-    // `is_shutdown`. Watching `is_shutdown` alone was a latent hole: its only
-    // writer is the propagation task above, so the backstop against a wedged
-    // runtime was itself gated on that runtime scheduling a task. The cancel
-    // flag is set synchronously by whichever path triggers shutdown
-    // (SIGTERM/SIGINT, idle timeout, owner death, any task exiting), so the
-    // grace period now starts when the signal lands. Neither flag is ever set
-    // during normal operation, so this still cannot fire on a healthy daemon.
+    // Arm the runtime-independent shutdown flag before the reconciliation loop
+    // can start occupying worker threads. Neither this flag nor the watchdog
+    // below is ever set during normal operation, so neither can fire on a
+    // healthy daemon.
+    install_shutdown_signal_handler();
     let escalation_state = Arc::clone(&state);
-    let escalation_cancel = cancel_rx.clone();
-    let escalation_grace = shutdown_escalation_grace();
-    if let Err(error) = std::thread::Builder::new()
-        .name("kin-shutdown-watchdog".to_string())
-        .spawn(move || {
-            while !shutdown_signalled(
-                escalation_state
-                    .is_shutdown
-                    .load(std::sync::atomic::Ordering::Relaxed),
-                *escalation_cancel.borrow(),
-            ) {
-                std::thread::sleep(SHUTDOWN_WATCH_POLL);
-            }
-            std::thread::sleep(escalation_grace);
-            // Still alive after the grace period → the graceful path is wedged
-            // (almost certainly a blocking embed batch the runtime drop is
-            // waiting on). Force the whole process down so SIGTERM always
-            // results in actual termination — no zombie.
-            eprintln!(
-                "kin-daemon: graceful shutdown exceeded {}s grace — forcing process exit to prevent a CPU zombie",
-                escalation_grace.as_secs()
-            );
-            std::process::exit(0);
-        })
-    {
-        warn!(error = %error, "failed to spawn shutdown-escalation watchdog");
-    }
+    spawn_shutdown_escalation_watchdog(
+        move || {
+            escalation_state
+                .is_shutdown
+                .load(std::sync::atomic::Ordering::Relaxed)
+        },
+        cancel_rx.clone(),
+        shutdown_escalation_grace(),
+    );
 
     // Spawn projection rebuild in background — VFS needs it but locate doesn't.
     // The reconcile loop and API server can start immediately.
@@ -2431,8 +2506,9 @@ async fn select_with_signals(
 mod tests {
     use super::{
         drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
-        parse_duration_secs, parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now,
-        shutdown_signalled, watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
+        note_shutdown_requested, parse_duration_secs, parse_owner_watch_pid, shutdown_requested,
+        should_enable_lsp_enrichment, should_flush_now, shutdown_signalled,
+        watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
         DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -2901,41 +2977,44 @@ mod tests {
     #[test]
     fn escalation_backstop_arms_on_the_signal_not_on_a_scheduled_task() {
         // A healthy daemon never arms the force-exit backstop.
-        assert!(!shutdown_signalled(false, false));
+        assert!(!shutdown_signalled(false, false, false));
 
-        // The regression this closes: the cancel watch-channel is set
-        // synchronously by whichever path triggers shutdown, while `is_shutdown`
-        // is written only by a tokio task. Keying the backstop on `is_shutdown`
-        // alone meant a wedged or saturated runtime — precisely the case the
-        // backstop exists for — silently disarmed it, because the propagation
-        // task never ran. Cancel alone must arm it.
-        assert!(shutdown_signalled(false, true));
+        // Each source arms it on its own.
+        assert!(shutdown_signalled(false, true, false));
+        assert!(shutdown_signalled(true, false, false));
 
-        // The propagation-task path still arms it, including when the cancel
-        // receiver has already been observed and reset by another consumer.
-        assert!(shutdown_signalled(true, false));
-        assert!(shutdown_signalled(true, true));
+        // The one that matters: both in-runtime flags unset, because a
+        // saturated runtime polls neither the SIGTERM future that sets `cancel`
+        // nor the propagation task that writes `is_shutdown`. The OS handler
+        // must arm the backstop by itself, or a stop request against a busy
+        // daemon has no bound at all.
+        assert!(shutdown_signalled(false, false, true));
     }
 
     #[test]
-    fn escalation_arm_loop_fires_when_only_the_cancel_channel_is_set() {
-        // Faithful model of the escalation watchdog's arm loop running on the
-        // real primitives: an AtomicBool standing in for `state.is_shutdown` and
-        // the daemon's actual cancel watch-channel. `is_shutdown` is
-        // deliberately never written — that is precisely what a wedged or
-        // saturated runtime looks like, since the propagation task is its only
-        // writer and it never gets scheduled. The force-exit backstop must still
-        // arm, because SIGTERM sets the cancel flag synchronously.
-        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    fn escalation_arm_loop_fires_when_only_the_os_handler_ran() {
+        // The escalation watchdog's arm loop on the real primitives: an
+        // AtomicBool standing in for `state.is_shutdown`, the daemon's actual
+        // cancel watch-channel, and a flag standing in for the process-global
+        // one the signal handler writes.
+        //
+        // Neither in-runtime flag is ever written here, which is exactly what a
+        // saturated runtime looks like: the SIGTERM future that would set
+        // `cancel` is never polled, and the propagation task that would write
+        // `is_shutdown` is never scheduled. Only the OS handler ran.
+        let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
         let is_shutdown = Arc::new(AtomicBool::new(false));
+        let os_requested = Arc::new(AtomicBool::new(false));
         let armed = Arc::new(AtomicBool::new(false));
 
         let loop_is_shutdown = Arc::clone(&is_shutdown);
+        let loop_os_requested = Arc::clone(&os_requested);
         let loop_armed = Arc::clone(&armed);
         std::thread::spawn(move || {
             while !shutdown_signalled(
                 loop_is_shutdown.load(Ordering::Relaxed),
                 *cancel_rx.borrow(),
+                loop_os_requested.load(Ordering::Relaxed),
             ) {
                 std::thread::sleep(Duration::from_millis(5));
             }
@@ -2946,9 +3025,9 @@ mod tests {
         // sits disarmed rather than counting down to a force-exit.
         assert!(!armed.load(Ordering::Relaxed));
 
-        // Exactly what the SIGTERM arm of `select_with_signals` does — and only
-        // that. No tokio task runs in this test at all.
-        cancel_tx.send(true).expect("cancel receiver alive");
+        // Exactly what the signal handler does, and only that: one relaxed
+        // store. No tokio task runs in this test at all.
+        os_requested.store(true, Ordering::Relaxed);
 
         // Bounded wait rather than join(): a regression here must fail the test,
         // not hang CI until the job timeout.
@@ -2959,13 +3038,29 @@ mod tests {
 
         assert!(
             armed.load(Ordering::Relaxed),
-            "cancel alone must arm the force-exit backstop; keying it on \
-             is_shutdown made the wedged-runtime backstop depend on the runtime"
+            "the OS handler alone must arm the force-exit backstop; keying it \
+             only on flags written from inside the runtime made the \
+             saturated-runtime backstop depend on that runtime"
         );
         assert!(
             !is_shutdown.load(Ordering::Relaxed),
             "is_shutdown was never set — the backstop must not depend on it"
         );
+    }
+
+    #[test]
+    fn cooperative_shutdown_acceptance_arms_the_backstop() {
+        // macOS stop has no signal behind it: the CLI POSTs /shutdown and the
+        // endpoint accepting the request is the whole commitment to exit. That
+        // acceptance has to arm the same runtime-independent flag, or a daemon
+        // whose runtime wedges right after accepting absorbs the stop request
+        // and keeps running.
+        // Deliberately no "not yet armed" precondition: the flag is
+        // process-global and terminal by design, so asserting its initial value
+        // would make this test depend on which other test ran first.
+        note_shutdown_requested();
+        assert!(shutdown_requested());
+        assert!(shutdown_signalled(false, false, shutdown_requested()));
     }
 
     #[test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -577,16 +577,6 @@ pub fn shutdown_requested() -> bool {
     SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Record a shutdown request from a caller that is not a signal handler.
-///
-/// The cooperative `/shutdown` endpoint is the caller that matters: accepting a
-/// request commits this process to exiting, so the force-exit backstop has to
-/// start counting down at the moment of acceptance rather than at the moment
-/// some later task manages to get scheduled.
-pub fn note_shutdown_requested() {
-    SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
-}
-
 /// Arm the runtime-independent shutdown flag from signal delivery itself.
 ///
 /// Registered through `signal_hook_registry`, which chains handlers, so tokio's
@@ -594,25 +584,47 @@ pub fn note_shutdown_requested() {
 /// This handler exists only so the force-exit backstop is armed by the kernel
 /// delivering the signal rather than by the runtime's willingness to poll a
 /// future.
+///
+/// A real signal is deliberately the ONLY writer of [`SHUTDOWN_REQUESTED`]. The
+/// flag is process-global and never cleared, and the watchdog it arms ends the
+/// process with `exit(0)`, so a non-signal writer would let one caller latch the
+/// flag and a later, unrelated watchdog inherit it. In a test binary that
+/// truncates the run and still reports success. Keeping signal delivery as the
+/// sole writer makes the latch mean what it says.
+///
+/// Registration also replaces SIGTERM's default disposition, because
+/// signal-hook-registry skips a `SIG_DFL` previous handler rather than chaining
+/// to it. From this call until tokio registers its own listener, a SIGTERM sets
+/// only this flag and death comes from the watchdog at grace rather than
+/// instantly. Every step between the two is a `tokio::spawn` with no top-level
+/// await, so the window is sub-millisecond and stays inside the documented
+/// bound, but it is a real window and the watchdog must be spawned right after
+/// this call rather than later.
 #[cfg(unix)]
 pub fn install_shutdown_signal_handler() {
-    for signal in [libc::SIGTERM, libc::SIGINT] {
-        // SAFETY: the handler body performs a single relaxed atomic store and
-        // calls nothing that is not async-signal-safe.
-        let registered = unsafe {
-            signal_hook_registry::register(signal, || {
-                SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
-            })
-        };
-        if let Err(error) = registered {
-            warn!(
-                signal,
-                error = %error,
-                "failed to arm the runtime-independent shutdown flag; \
-                 force-exit escalation falls back to in-runtime arming"
-            );
+    // `SigId` has no `Drop`, so every call appends another action to the signal
+    // slot permanently. Production installs once; the guard keeps the `pub` API
+    // from leaking that footgun to any other caller.
+    static INSTALLED: std::sync::Once = std::sync::Once::new();
+    INSTALLED.call_once(|| {
+        for signal in [libc::SIGTERM, libc::SIGINT] {
+            // SAFETY: the handler body performs a single relaxed atomic store
+            // and calls nothing that is not async-signal-safe.
+            let registered = unsafe {
+                signal_hook_registry::register(signal, || {
+                    SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
+                })
+            };
+            if let Err(error) = registered {
+                warn!(
+                    signal,
+                    error = %error,
+                    "failed to arm the runtime-independent shutdown flag; \
+                     force-exit escalation falls back to in-runtime arming"
+                );
+            }
         }
-    }
+    });
 }
 
 #[cfg(not(unix))]
@@ -2506,9 +2518,8 @@ async fn select_with_signals(
 mod tests {
     use super::{
         drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
-        note_shutdown_requested, parse_duration_secs, parse_owner_watch_pid,
-        should_enable_lsp_enrichment, should_flush_now, shutdown_requested, shutdown_signalled,
-        watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
+        parse_duration_secs, parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now,
+        shutdown_signalled, watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
         DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -3046,21 +3057,6 @@ mod tests {
             !is_shutdown.load(Ordering::Relaxed),
             "is_shutdown was never set — the backstop must not depend on it"
         );
-    }
-
-    #[test]
-    fn cooperative_shutdown_acceptance_arms_the_backstop() {
-        // macOS stop has no signal behind it: the CLI POSTs /shutdown and the
-        // endpoint accepting the request is the whole commitment to exit. That
-        // acceptance has to arm the same runtime-independent flag, or a daemon
-        // whose runtime wedges right after accepting absorbs the stop request
-        // and keeps running.
-        // Deliberately no "not yet armed" precondition: the flag is
-        // process-global and terminal by design, so asserting its initial value
-        // would make this test depend on which other test ran first.
-        note_shutdown_requested();
-        assert!(shutdown_requested());
-        assert!(shutdown_signalled(false, false, shutdown_requested()));
     }
 
     #[test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2506,8 +2506,8 @@ async fn select_with_signals(
 mod tests {
     use super::{
         drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
-        note_shutdown_requested, parse_duration_secs, parse_owner_watch_pid, shutdown_requested,
-        should_enable_lsp_enrichment, should_flush_now, shutdown_signalled,
+        note_shutdown_requested, parse_duration_secs, parse_owner_watch_pid,
+        should_enable_lsp_enrichment, should_flush_now, shutdown_requested, shutdown_signalled,
         watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
         DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -1358,6 +1358,24 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
     // via KIN_SUPERVISOR_REAP_DISABLE.
     spawn_rogue_daemon_reaper(Arc::clone(&state), shutdown_rx.clone());
 
+    // The supervisor is stopped LAST in a `kin daemon stop --all` sweep, and
+    // until now it was the one identity in that sweep with no hard bound on how
+    // long stopping it could take. Its only shutdown paths are the tokio task
+    // below and axum's graceful shutdown, which waits for in-flight connections
+    // to finish; a request against a wedged repo daemon therefore holds the
+    // supervisor open with nothing to end it. The CLI then reports a timeout
+    // for a supervisor that was never going to exit, and a stop that worked on
+    // every worker still fails.
+    //
+    // Same backstop the repo daemon uses: arming is runtime-independent, and
+    // the watchdog is a plain OS thread that force-exits at grace.
+    crate::daemon::install_shutdown_signal_handler();
+    crate::daemon::spawn_shutdown_escalation_watchdog(
+        || false,
+        shutdown_rx.clone(),
+        crate::daemon::shutdown_escalation_grace(),
+    );
+
     #[cfg(unix)]
     {
         let signal_shutdown = shutdown_tx.clone();

--- a/crates/kin-daemon/tests/shutdown_escalation.rs
+++ b/crates/kin-daemon/tests/shutdown_escalation.rs
@@ -30,6 +30,22 @@ use std::time::{Duration, Instant};
 /// during an ordinary suite run.
 const SATURATED_WORKER_ROOT: &str = "KIN_TEST_SATURATED_SHUTDOWN_ROOT";
 
+/// Same, for the healthy-runtime worker that proves the graceful path still
+/// wins the race on a daemon that is not starved.
+const GRACEFUL_WORKER_ROOT: &str = "KIN_TEST_GRACEFUL_SHUTDOWN_ROOT";
+
+/// Grace the graceful worker is given: long enough that a force-exit could
+/// never be mistaken for the graceful path finishing. The whole point of that
+/// test is to distinguish the two, so this must stay far above
+/// [`GRACEFUL_EXIT_BUDGET`].
+const GRACEFUL_WORKER_GRACE_SECS: u64 = 30;
+
+/// How long the parent waits for the healthy worker to exit after SIGTERM.
+/// Must stay well below [`GRACEFUL_WORKER_GRACE_SECS`]: exceeding it means the
+/// tokio signal path never observed the signal and only the backstop could
+/// still end the process.
+const GRACEFUL_EXIT_BUDGET: Duration = Duration::from_secs(8);
+
 /// Grace the worker grants before force-exiting, fed through the same
 /// `KIN_DAEMON_SHUTDOWN_GRACE_SECS` knob production reads. Short so the test is
 /// quick; the shipped default is 25s.
@@ -136,6 +152,117 @@ fn stop_terminates_a_daemon_whose_runtime_is_saturated() {
         );
         std::thread::sleep(Duration::from_millis(50));
     }
+}
+
+/// The backstop must not become the ordinary way daemons stop.
+///
+/// Chaining a handler onto SIGTERM is only safe if tokio's own registration
+/// still fires: tokio registers through the same `signal-hook-registry`, and
+/// handlers chain rather than replace. If that were ever untrue, the graceful
+/// path would go silent and every stop would degrade to a force-exit that skips
+/// the final flush, the derived-CAS barrier, and endpoint retirement. The
+/// saturated test above cannot catch that, because a force-exit also satisfies
+/// "the process exited".
+///
+/// This one distinguishes them by clock: the worker gets a 30s grace and is
+/// required to exit within 8s. Only the tokio signal path can do that, so a
+/// pass here means the graceful path observed the signal rather than the
+/// backstop rescuing a broken one.
+///
+/// Nothing about the daemon's own SIGKILL-based test helpers covers this: they
+/// reap daemons with `start_kill`, so no existing test sends SIGTERM at all.
+#[test]
+fn a_healthy_daemon_still_stops_through_the_graceful_path() {
+    let root = tempfile::tempdir().expect("scratch root for the graceful worker");
+    let ready = root.path().join("graceful.ready");
+
+    let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+    command
+        .args(["--exact", "graceful_daemon_shutdown_worker", "--nocapture"])
+        .env(GRACEFUL_WORKER_ROOT, root.path())
+        .env(
+            "KIN_DAEMON_SHUTDOWN_GRACE_SECS",
+            GRACEFUL_WORKER_GRACE_SECS.to_string(),
+        )
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut worker = WorkerGuard(command.spawn().expect("spawn graceful daemon worker"));
+
+    let deadline = Instant::now() + READY_BUDGET;
+    while !ready.is_file() {
+        assert!(
+            worker.0.try_wait().expect("poll worker").is_none(),
+            "worker exited before it was listening for a signal"
+        );
+        assert!(Instant::now() < deadline, "worker never reported readiness");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let pid = i32::try_from(worker.0.id()).expect("worker pid fits a pid_t");
+    // SAFETY: `pid` is this test's own direct child, which has not been reaped.
+    assert_eq!(
+        unsafe { libc::kill(pid, libc::SIGTERM) },
+        0,
+        "deliver SIGTERM to the healthy worker"
+    );
+
+    let deadline = Instant::now() + GRACEFUL_EXIT_BUDGET;
+    loop {
+        if let Some(status) = worker.0.try_wait().expect("poll worker") {
+            assert_eq!(
+                status.code(),
+                Some(0),
+                "the graceful path exits 0 of its own accord"
+            );
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "a healthy daemon did not stop through the graceful path within {}s, \
+             despite a {}s force-exit grace. Chaining the runtime-independent \
+             handler onto SIGTERM must not displace tokio's own registration, \
+             or every stop silently degrades to a force-exit that skips the \
+             final flush and endpoint retirement.",
+            GRACEFUL_EXIT_BUDGET.as_secs(),
+            GRACEFUL_WORKER_GRACE_SECS
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Exact worker entrypoint: the daemon's shutdown wiring on a healthy runtime.
+/// Inert unless [`GRACEFUL_WORKER_ROOT`] is set.
+#[test]
+fn graceful_daemon_shutdown_worker() {
+    let Some(root) = std::env::var_os(GRACEFUL_WORKER_ROOT) else {
+        return;
+    };
+    let ready = PathBuf::from(root).join("graceful.ready");
+
+    spawn_parent_death_watchdog();
+    spawn_wall_clock_cap();
+
+    kin_daemon::daemon::install_shutdown_signal_handler();
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    kin_daemon::daemon::spawn_shutdown_escalation_watchdog(
+        || false,
+        cancel_rx,
+        kin_daemon::daemon::shutdown_escalation_grace(),
+    );
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build the healthy runtime");
+    runtime.block_on(async move {
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("register the tokio SIGTERM listener");
+        // Published after registration, so a signal arriving immediately after
+        // is still latched by tokio and delivered to `recv`.
+        std::fs::write(&ready, b"listening").expect("publish readiness");
+        sigterm.recv().await;
+        let _ = cancel_tx.send(true);
+    });
 }
 
 /// Exact worker entrypoint: the daemon's shutdown wiring on a runtime with no

--- a/crates/kin-daemon/tests/shutdown_escalation.rs
+++ b/crates/kin-daemon/tests/shutdown_escalation.rs
@@ -71,11 +71,7 @@ fn stop_terminates_a_daemon_whose_runtime_is_saturated() {
 
     let mut command = Command::new(std::env::current_exe().expect("current test executable"));
     command
-        .args([
-            "--exact",
-            "saturated_daemon_shutdown_worker",
-            "--nocapture",
-        ])
+        .args(["--exact", "saturated_daemon_shutdown_worker", "--nocapture"])
         .env(SATURATED_WORKER_ROOT, root.path())
         .env(
             "KIN_DAEMON_SHUTDOWN_GRACE_SECS",

--- a/crates/kin-daemon/tests/shutdown_escalation.rs
+++ b/crates/kin-daemon/tests/shutdown_escalation.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end proof that a stop request terminates a daemon whose async runtime
+//! is saturated.
+//!
+//! The shipped daemon documents a hard bound: shutdown is signalled, a grace
+//! period covers the drain plus final flush, and a force-exit watchdog ends the
+//! process if the graceful path does not. That watchdog runs on a plain OS
+//! thread, but every flag that armed it was written from inside the async
+//! runtime — the SIGTERM arm of `select_with_signals` sets the cancel channel,
+//! and a spawned task writes `is_shutdown`. A reconciliation batch doing
+//! synchronous admission work over a large observation set occupies the runtime
+//! and starves both, so the bound did not hold in the one case it exists for:
+//! `kin daemon stop` delivered its request, waited, and reported a timeout
+//! against a daemon that was still running.
+//!
+//! The worker below is that daemon in miniature: real signal wiring, real
+//! watchdog, real grace config, and a runtime with no thread left to poll
+//! anything. If arming depends on the runtime, the worker never exits.
+
+#![cfg(unix)]
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Names the scratch directory the worker publishes readiness into. Its
+/// presence is also what selects worker mode, so the same `#[test]` is inert
+/// during an ordinary suite run.
+const SATURATED_WORKER_ROOT: &str = "KIN_TEST_SATURATED_SHUTDOWN_ROOT";
+
+/// Grace the worker grants before force-exiting, fed through the same
+/// `KIN_DAEMON_SHUTDOWN_GRACE_SECS` knob production reads. Short so the test is
+/// quick; the shipped default is 25s.
+const WORKER_GRACE_SECS: u64 = 2;
+
+/// How long the parent waits for the worker to actually exit after SIGTERM.
+/// Comfortably above the grace plus the watchdog's poll interval, and well
+/// under the wall-clock cap the worker holds itself to, so a cap firing can
+/// never be mistaken for a pass.
+const EXIT_BUDGET: Duration = Duration::from_secs(20);
+
+/// Budget for the worker to reach a saturated runtime.
+const READY_BUDGET: Duration = Duration::from_secs(30);
+
+/// Last-resort cap on the worker's lifetime. A spin loop that escaped its test
+/// would peg a core for as long as the machine stayed up.
+const WORKER_WALL_CLOCK_CAP: Duration = Duration::from_secs(60);
+
+/// Worker exit code when the parent died first.
+const EXIT_ORPHANED: i32 = 70;
+
+/// Worker exit code when the wall-clock cap fired.
+const EXIT_CAPPED: i32 = 71;
+
+/// Kills the worker however this test ends, including on an assertion unwind.
+struct WorkerGuard(Child);
+
+impl Drop for WorkerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn stop_terminates_a_daemon_whose_runtime_is_saturated() {
+    let root = tempfile::tempdir().expect("scratch root for the saturated worker");
+    let ready = root.path().join("saturated.ready");
+
+    let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+    command
+        .args([
+            "--exact",
+            "saturated_daemon_shutdown_worker",
+            "--nocapture",
+        ])
+        .env(SATURATED_WORKER_ROOT, root.path())
+        .env(
+            "KIN_DAEMON_SHUTDOWN_GRACE_SECS",
+            WORKER_GRACE_SECS.to_string(),
+        )
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut worker = WorkerGuard(command.spawn().expect("spawn saturated daemon worker"));
+
+    // Readiness is published from inside the task that consumes the runtime's
+    // only worker thread, so observing the marker proves the runtime is already
+    // wedged rather than merely busy. Signalling before that point would test
+    // an idle daemon and pass with or without a working backstop.
+    let deadline = Instant::now() + READY_BUDGET;
+    while !ready.is_file() {
+        assert!(
+            worker.0.try_wait().expect("poll worker").is_none(),
+            "worker exited before it reported a saturated runtime"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "worker never saturated its runtime"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let pid = i32::try_from(worker.0.id()).expect("worker pid fits a pid_t");
+    // SAFETY: `pid` is this test's own direct child, which has not been reaped.
+    assert_eq!(
+        unsafe { libc::kill(pid, libc::SIGTERM) },
+        0,
+        "deliver SIGTERM to the saturated worker"
+    );
+
+    let deadline = Instant::now() + EXIT_BUDGET;
+    loop {
+        if let Some(status) = worker.0.try_wait().expect("poll worker") {
+            assert_ne!(
+                status.code(),
+                Some(EXIT_ORPHANED),
+                "worker exited because it was orphaned, not because the stop request landed"
+            );
+            assert_ne!(
+                status.code(),
+                Some(EXIT_CAPPED),
+                "worker exited on its wall-clock cap, not because the stop request landed"
+            );
+            assert_eq!(
+                status.code(),
+                Some(0),
+                "the force-exit backstop exits 0; any other code means something else ended the worker"
+            );
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "a SIGTERM'd daemon whose runtime is saturated never exited within {}s. \
+             The force-exit backstop is armed only by flags written from inside \
+             that runtime, so a starved runtime leaves nothing to arm it and \
+             `kin daemon stop` has no bound at all.",
+            EXIT_BUDGET.as_secs()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Exact worker entrypoint: the daemon's shutdown wiring on a runtime with no
+/// thread left to poll it. Inert unless [`SATURATED_WORKER_ROOT`] is set.
+#[test]
+fn saturated_daemon_shutdown_worker() {
+    let Some(root) = std::env::var_os(SATURATED_WORKER_ROOT) else {
+        return;
+    };
+    let ready = PathBuf::from(root).join("saturated.ready");
+
+    // Both guards run on plain OS threads, so a saturated runtime cannot
+    // disable the things that stop this process from outliving its test.
+    spawn_parent_death_watchdog();
+    spawn_wall_clock_cap();
+
+    // The daemon's production wiring, called as the daemon calls it.
+    kin_daemon::daemon::install_shutdown_signal_handler();
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    kin_daemon::daemon::spawn_shutdown_escalation_watchdog(
+        // `is_shutdown` is written by a spawned task and nothing else, so on a
+        // saturated runtime it is never written at all. Model that honestly
+        // rather than handing the watchdog a flag the real daemon would not
+        // have set.
+        || false,
+        cancel_rx,
+        kin_daemon::daemon::shutdown_escalation_grace(),
+    );
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .expect("build the saturated runtime");
+    runtime.block_on(async move {
+        // Construct the listener first: tokio registers its own SIGTERM handler
+        // here, so the graceful path is genuinely wired and merely starved,
+        // which is the daemon's real state and not a weaker one.
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("register the tokio SIGTERM listener");
+        tokio::spawn(async move {
+            sigterm.recv().await;
+            let _ = cancel_tx.send(true);
+        });
+        // Let the worker thread poll that listener once so it is parked on the
+        // signal before anything saturates the runtime.
+        tokio::task::yield_now().await;
+
+        let marker = ready.clone();
+        tokio::spawn(async move {
+            // Publishing from inside the saturating task is what makes the
+            // marker mean "the runtime is wedged" rather than "the worker
+            // started".
+            std::fs::write(&marker, b"saturated").expect("publish readiness");
+            loop {
+                std::hint::spin_loop();
+            }
+        });
+
+        // Consume this thread too, once the worker thread is provably gone.
+        // Leaving it parked would let the runtime drive its signal driver here
+        // instead, and the wedge under test would not be a wedge.
+        while !ready.is_file() {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        loop {
+            std::hint::spin_loop();
+        }
+    });
+}
+
+fn spawn_parent_death_watchdog() {
+    std::thread::spawn(|| loop {
+        // SAFETY: `getppid` takes no arguments and cannot fail.
+        if unsafe { libc::getppid() } == 1 {
+            std::process::exit(EXIT_ORPHANED);
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    });
+}
+
+fn spawn_wall_clock_cap() {
+    std::thread::spawn(|| {
+        std::thread::sleep(WORKER_WALL_CLOCK_CAP);
+        std::process::exit(EXIT_CAPPED);
+    });
+}


### PR DESCRIPTION
## What was wrong

The install proof hangs on 4 of 5 platforms with `spawnSync .../kin ETIMEDOUT`
during `kin daemon stop --all --json`.

Evidence, since the failing legs decide what this can claim to fix. Run
`30824472582` at `c512114e` is the one that shows this: macos-latest,
macos-15-intel, ubuntu-24.04-arm and ubuntu-latest all fail with
`between MCP calls: failed to stop installed daemons: Error: spawnSync ... ETIMEDOUT`.
windows-latest fails there too but on an unrelated error, so it is not part of
this family. On the macOS leg the log shows 61.4s of silence between the last
output and the timeout, which is the harness killing a command that produced no
verdict at all.

Worth noting for anyone tracing this from the issue: run `30726272851`, the one
linked from #586, does NOT show this signature. Its three failing legs fail on
embedding coverage and `kin-health.json` instead. The stop hang is the later run.

Provenance, confirmed with `git log -S`: both `stop_all_inner` and the harness's
`stopDaemons` helper with its 60s `spawnSync` bound were introduced by `c512114e`
(PR 582), the current main tip. So this is a regression surfaced by that commit
rather than ancient debt. What 582 added is a sweep that fans out over every
identity in sequence; what it exposed are two older defects that a
single-daemon stop never reached, namely the runtime-armed backstop on workers
and the supervisor having no backstop at all.

Several defects produce the observed shape, and each was verified by reading the
shipped code rather than inferred from the symptom.

**The daemon's hard bound was not a bound.** `crates/kin-daemon/src/daemon.rs`
documents shutdown as signal, then a grace period, then a force-exit watchdog
that ends the process no matter what. The watchdog is correctly a plain OS
thread rather than a tokio task, but every flag that armed it was written from
inside the async runtime. The SIGTERM arm of `select_with_signals` sets the
cancel watch channel, and that arm is a future the runtime has to poll. The
propagation task that writes `is_shutdown` is a task the runtime has to
schedule. The reconciliation loop does synchronous, non yielding admission work
while holding the coordination gate and the reconciler write lock, so a large
batch occupies the runtime and starves both arming paths. The backstop was
therefore disarmed in exactly the case it exists for, and the documented 25s
bound did not hold at all. On Linux the stop is a SIGTERM that tokio never
observes. On macOS the stop is a cooperative `/shutdown` POST that is accepted
and then absorbed. Same defect from both directions.

An existing unit test asserted the opposite, and its comment claimed SIGTERM
"sets the cancel flag synchronously". That is false about the real daemon: the
test hand rolled its own thread and called `cancel_tx.send(true)` itself, so it
could not fail no matter what the production wiring did.

**`stop --all` bounded each step but never the total.** `stop_all_inner` handed
every identity the full 30s per identity ceiling and stopped them in sequence, so
the command's real bound was identities multiplied by the ceiling. An ordinary
install is one worker plus the supervisor, which is 60s of worst case against a
caller that allows 60s. The command was killed before it could print its JSON
verdict, turning a stop that failed into a stop with no verdict at all.

## What changed

Register a chained SIGTERM and SIGINT handler through `signal-hook-registry`,
which is the same crate tokio registers its own handler through, so both run and
the graceful path is unchanged. The handler body is a single relaxed atomic
store, which is async signal safe. The escalation watchdog arms on that flag as
well as the two existing ones, so the chain from signal delivery to
`process::exit` now involves no tokio scheduling.

To be precise about what that does and does not cover, because an earlier
revision of this description overstated it. The cooperative `/shutdown` endpoint
already armed the watchdog before this change: its sender is a clone of the
daemon's cancel channel, which is the exact watch value the watchdog polls. So
nothing on the cooperative path is runtime-independent, and the signal handler is
unreachable on macOS, which never sends SIGTERM. The signal handler fixes the
Linux legs; Windows has no SIGTERM path here (the handler install is a no-op off Unix)
and its stop is bounded by TerminateProcess plus the sweep budget. What fixes the
macOS leg is the supervisor work below.

**The supervisor had no force-exit backstop at all**, and it is stopped last.
Its only shutdown paths were a tokio task and axum's graceful shutdown, which
waits for in-flight connections, so a request against a wedged repo daemon held
it open with nothing to end it. It now installs the same runtime-independent
handler and escalation watchdog the repo daemon uses. This is the leg that
actually produced the macOS timeouts.

Bound the whole `--all` sweep with one shared budget instead of a per identity
ceiling, and size that budget from the daemon's force-exit bound rather than
borrowing the per identity constant. The old 30s was chosen as a per identity
margin over the daemon's 25.25s, so reusing it for the whole sweep left 4.75s for
everything after the first identity. Workers now stop against an earlier deadline
so the supervisor's share cannot be spent by them. Exhausting the budget still
delivers every stop request and gives up only the wait, so an identity that runs
out is reported `timeout`, and the command still returns and prints its verdict.

`stop_install_owned_daemons` took a remaining budget snapshot and re-spent it per
process per pass, so its real bound was passes times processes times budget. It
now takes the deadline and recomputes.

The supervisor topology fetch had no timeout at all and is awaited before any
identity is stopped, so a supervisor that accepted the connection and never
answered held the entire command open with nothing signalled and no verdict to
print. It is now bounded.

The watchdog spawn is extracted into `spawn_shutdown_escalation_watchdog` so a
test can exercise the real wiring rather than a model of it, and
`install_shutdown_signal_handler` is guarded by a `Once` because
`signal-hook-registry` ids have no `Drop` and every call would otherwise append
another action permanently.

Signal delivery is deliberately the only writer of the process-global flag. It is
never cleared and the watchdog it arms exits zero, so a non-signal writer would
let one caller latch it and an unrelated later watchdog inherit that latch, which
in a test binary truncates the run and still reports success.

## Red then green

`crates/kin-daemon/tests/shutdown_escalation.rs` spawns a worker that is the
daemon's shutdown wiring in miniature: the real handler install, the real
watchdog, the real grace config read through `KIN_DAEMON_SHUTDOWN_GRACE_SECS`,
and a runtime whose single worker thread and `block_on` thread are both consumed
by non yielding work. Readiness is published from inside the saturating task, so
the parent cannot deliver SIGTERM before the runtime is provably wedged and
accidentally test an idle daemon. `is_shutdown` is modelled as never written,
which is what a starved runtime actually produces.

Falsified by neutering the signal handler body in `daemon.rs` and rerunning:

- with the arming neutered: FAILED, "a SIGTERM'd daemon whose runtime is
  saturated never exited within 20s", after 20.03s
- with the fix restored: ok, finished in 2.27s, which matches the 2s grace

A parent death watchdog and a wall clock cap keep the spin loop from outliving
the test, and both of their exit codes are asserted against so neither can be
mistaken for a clean stop.

That test alone is not sufficient, and the gap is worth naming. It asserts the
process exited, and a force exit satisfies that just as well as a graceful
shutdown does. If chaining onto SIGTERM ever displaced tokio's own registration,
every stop would quietly degrade to a force exit that skips the final flush, the
derived CAS barrier, and endpoint retirement, and that test would still pass.
Nothing else in the suite covers it either: the daemon test helpers reap with
`start_kill`, so no other test sends SIGTERM at all.

`a_healthy_daemon_still_stops_through_the_graceful_path` distinguishes the two by
clock. The worker gets a 30s force exit grace and is required to exit within 8s,
which only the tokio signal path can achieve. Falsified the same way, by making
the worker's `sigterm.recv()` unreachable:

- graceful path dead: **FAILED** at 8.04s, and the saturated test still passed,
  which is exactly the blind spot being closed
- restored: ok, both pass, 2.35s

## Gate

Run in an isolated lane worktree with its own target directory.

- `cargo fmt --all -- --check`: clean
- clippy `--all-targets --all-features` with the ci.yml allowlist under
  `RUSTFLAGS=-Dwarnings`: exit 0
- `cargo build --all-targets --all-features` under `RUSTFLAGS=-Dwarnings`: exit 0
- `cargo test --workspace`: exit 0, 104 test binaries, zero failures, run under
  the kin-lane daemon lock

All four were rerun after the final edit.

## Scope

`crates/kin-daemon/**` shutdown paths plus the kin-cli daemon stop path.
`loop_runner.rs` is read but not modified, so there is no overlap with the ingest
scope work in flight. `install-proof.yml` is not touched: the product fix is what
makes stop correct regardless of reconciliation workload, so no wait bound in CI
needed relaxing.

## Not claiming

This fixes the stop hang. It does not by itself green the install proof, which
also depends on the ingest scope defect and on the channel and packaging work
tracked separately. Issue #586 is referenced as the failure family and left open
for the recovery to close when proof actually greens.

Not claiming the signal handler fixes macOS. It cannot: macOS never sends SIGTERM
to a daemon, so that handler is unreachable there. The macOS legs are addressed by
the supervisor backstop, the sweep budget sizing and the topology fetch bound, all
of which are platform independent. An earlier revision of this description claimed
the cooperative endpoint armed a runtime-independent backstop, which was wrong and
is corrected above.

Not claiming a measured before-and-after against install-proof itself. The
platform legs and their failure mode are read from the run logs; the fixes are
verified by the local gate and by targeted falsification, not by a green
install-proof run.

Not claiming the force-exit backstop is a cancellable countdown. It is not: once
armed it sleeps the grace and exits, so clean completion wins only by the process
exiting first. That is pre-existing behavior and unchanged here, but it is a race
rather than a bound that gets called off.

Closes FIR-1853
Refs FIR-1839
Refs #586

