### PR TITLE
Stop the entrypoint deleting a workspace it cannot rebuild

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -178,3 +178,12 @@ jobs:
           if printf '%s\n' "$out_bad" | grep -qi "Permission denied"; then echo "::error::leaked a bare mkdir permission-denied death"; exit 1; fi
           echo "unwritable workspace: loud fatal + exit 1, no bare mkdir death"
           echo "::endgroup::"
+
+      # The smoke above boots with nothing mounted under .kin, so it models the
+      # kin-daemon pod and never the kin-registry pod, which mounts its
+      # published-crates disk at <repo>/.kin/packages. That gap is where a
+      # regression that emptied the disk on every start survived. This proves the
+      # entrypoint leaves a mounted volume alone and refuses rather than deleting
+      # through it, and that it still re-initializes when nothing is at risk.
+      - name: Entrypoint contract with a volume mounted inside .kin
+        run: bash scripts/test-entrypoint-workspace-mount.sh kin:ci

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if ! mkdir -p "${WORKSPACE_DIR}/.kin" 2>/dev/null || [ ! -w "${WORKSPACE_DIR}/.k
     exit 1
 fi
 
-KIN_DIR="${WORKSPACE_DIR}/.kin"
+KIN_DIR="$(cd "${WORKSPACE_DIR}/.kin" && pwd -P)"
 
 # Paths every layout version creates. HEAD, objects/ and kindb/graph.kndb were
 # git-shaped artifacts of the pre-authority layout and are NOT produced by a

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,10 +21,45 @@ if ! mkdir -p "${WORKSPACE_DIR}/.kin" 2>/dev/null || [ ! -w "${WORKSPACE_DIR}/.k
     exit 1
 fi
 
+KIN_DIR="${WORKSPACE_DIR}/.kin"
+
+# Paths every layout version creates. HEAD, objects/ and kindb/graph.kndb were
+# git-shaped artifacts of the pre-authority layout and are NOT produced by a
+# current `kin init`, so testing for them was unconditionally true and turned the
+# branch below into an unconditional wipe on every start. These four are present
+# in both the pre-authority and the current layout, so an existing repository of
+# either vintage is left alone and the daemon decides whether it can open it.
+layout_is_materialized() {
+    [ -f "${KIN_DIR}/manifest.json" ] \
+        && [ -f "${KIN_DIR}/config.toml" ] \
+        && [ -f "${KIN_DIR}/version" ] \
+        && [ -d "${KIN_DIR}/kindb" ]
+}
+
+# Refuse to delete a tree that has a filesystem mounted inside it. The registry
+# pod mounts its published-crates volume at .kin/packages, and `rm -rf` unlinks
+# the volume's contents before it fails EBUSY on the mount point itself, so the
+# destructive path loses data first and crashloops second.
+kin_dir_contains_mount() {
+    [ -r /proc/self/mountinfo ] || return 1
+    while read -r _ _ _ _ mount_point _; do
+        case "${mount_point}" in
+            "${KIN_DIR}" | "${KIN_DIR}"/*) return 0 ;;
+        esac
+    done < /proc/self/mountinfo
+    return 1
+}
+
 # Materialize a real Kin repo layout. Re-init only when the tree is missing or
 # incomplete so an existing repo on a persistent volume is never clobbered.
-if [ ! -f "${WORKSPACE_DIR}/.kin/manifest.json" ] || [ ! -f "${WORKSPACE_DIR}/.kin/config.toml" ] || [ ! -f "${WORKSPACE_DIR}/.kin/HEAD" ] || [ ! -d "${WORKSPACE_DIR}/.kin/objects" ] || [ ! -f "${WORKSPACE_DIR}/.kin/kindb/graph.kndb" ]; then
-    rm -rf "${WORKSPACE_DIR}/.kin"
+if ! layout_is_materialized; then
+    if kin_dir_contains_mount; then
+        echo "[entrypoint] FATAL: '${KIN_DIR}' is not a materialized Kin layout, but a filesystem is mounted inside it." >&2
+        echo "[entrypoint] Refusing to re-initialize, because that deletes the mounted volume's contents before it fails on the mount point." >&2
+        echo "[entrypoint] Prepare the repository before anything is mounted under .kin, or mount that volume outside the repository." >&2
+        exit 1
+    fi
+    rm -rf "${KIN_DIR}"
     kin init "${WORKSPACE_DIR}"
 fi
 

--- a/scripts/test-entrypoint-workspace-mount.sh
+++ b/scripts/test-entrypoint-workspace-mount.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Entrypoint contract for a workspace that has a volume mounted INSIDE `.kin`.
+#
+# The kin-registry Deployment mounts its published-crates disk at
+# `<repo>/.kin/packages`, so the entrypoint's re-init branch runs `rm -rf` over a
+# directory containing a live mount. `rm -rf` unlinks the volume's contents and
+# only then fails EBUSY on the mount point itself, which loses data first and
+# crashloops second.
+#
+# The existing entrypoint smoke boots the daemon with nothing mounted under
+# `.kin`, so it models the kin-daemon pod and never the registry pod. That gap is
+# where a regression that silently emptied the published-crates disk survived: the
+# completeness test required `.kin/HEAD`, `.kin/objects` and `.kin/kindb/graph.kndb`,
+# which the pre-authority layout created and the current layout does not, so the
+# test was unconditionally true and every start took the destructive branch.
+#
+# Usage: scripts/test-entrypoint-workspace-mount.sh <image-ref>
+
+set -euo pipefail
+
+IMAGE="${1:?usage: test-entrypoint-workspace-mount.sh <image-ref>}"
+PAYLOAD="published-crate-payload"
+WORKSPACE_VOLUME=""
+PACKAGES_VOLUME=""
+CID=""
+
+cleanup() {
+  [ -n "${CID}" ] && docker rm -f "${CID}" >/dev/null 2>&1 || true
+  [ -n "${WORKSPACE_VOLUME}" ] && docker volume rm -f "${WORKSPACE_VOLUME}" >/dev/null 2>&1 || true
+  [ -n "${PACKAGES_VOLUME}" ] && docker volume rm -f "${PACKAGES_VOLUME}" >/dev/null 2>&1 || true
+  CID=""; WORKSPACE_VOLUME=""; PACKAGES_VOLUME=""
+}
+trap cleanup EXIT
+
+# Substring test that never routes the decision through a pipeline's exit status.
+contains() {
+  case "$1" in
+    *"$2"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Fresh workspace + packages volumes, with the packages volume seeded so its
+# destruction is observable. Returns via the globals above.
+new_fixture() {
+  WORKSPACE_VOLUME="kin-entrypoint-ws-${RANDOM}-$$"
+  PACKAGES_VOLUME="kin-entrypoint-pkgs-${RANDOM}-$$"
+  docker volume create "${WORKSPACE_VOLUME}" >/dev/null
+  docker volume create "${PACKAGES_VOLUME}" >/dev/null
+  # Volumes start root-owned; the image runs as uid 999.
+  docker run --rm --user 0:0 \
+    -v "${WORKSPACE_VOLUME}:/w" -v "${PACKAGES_VOLUME}:/p" \
+    --entrypoint /bin/sh "${IMAGE}" -c \
+    "chmod 1777 /w; printf '%s\n' '${PAYLOAD}' > /p/kin-db-0.0.0.crate; chown -R 999:999 /p"
+}
+
+# Prepare the repository the way the pod's init container does: workspace volume
+# only, no packages volume mounted yet. `break_layout` removes one file that every
+# layout version creates, which is what an interrupted init leaves behind.
+prepare_repo() {
+  local break_layout="${1:-no}"
+  local script='set -eu
+mkdir -p /w/repo
+kin init /w/repo >/dev/null 2>&1'
+  if [ "${break_layout}" = "break" ]; then
+    script="${script}
+rm -f /w/repo/.kin/manifest.json"
+  fi
+  docker run --rm --user 999:999 -v "${WORKSPACE_VOLUME}:/w" \
+    --entrypoint /bin/sh "${IMAGE}" -c "${script}"
+}
+
+payload_survived() {
+  local seen
+  seen="$(docker run --rm -v "${PACKAGES_VOLUME}:/p" --entrypoint /bin/sh "${IMAGE}" \
+    -c 'cat /p/kin-db-0.0.0.crate 2>/dev/null || true')"
+  contains "${seen}" "${PAYLOAD}"
+}
+
+fail() { echo "::error::$1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. A materialized repository with the packages volume mounted inside `.kin`
+#    must boot untouched. This is the running registry pod.
+# ---------------------------------------------------------------------------
+echo "==> [mounted-intact] boot a prepared repo with a volume mounted inside .kin"
+new_fixture
+prepare_repo
+CID="$(docker run -d --user 999:999 \
+  -v "${WORKSPACE_VOLUME}:/w" -v "${PACKAGES_VOLUME}:/w/repo/.kin/packages" \
+  -e KIN_WORKSPACE_DIR=/w/repo -e KIN_STORAGE=local -e KIN_DISABLE_SPINE=1 \
+  "${IMAGE}" --port 4219)"
+started=""
+for _ in $(seq 1 30); do
+  logs="$(docker logs "${CID}" 2>&1 || true)"
+  if contains "${logs}" "Starting kin-daemon"; then started=1; break; fi
+  if [ "$(docker inspect -f '{{.State.Running}}' "${CID}" 2>/dev/null || echo false)" != "true" ]; then break; fi
+  sleep 1
+done
+logs="$(docker logs "${CID}" 2>&1 || true)"
+docker rm -f "${CID}" >/dev/null 2>&1 || true; CID=""
+[ -n "${started}" ] || { echo "${logs}"; fail "prepared repo did not reach daemon start with a volume mounted inside .kin"; }
+payload_survived || fail "entrypoint DESTROYED the mounted volume's contents on a prepared repository"
+echo "==> [mounted-intact] OK"
+cleanup
+
+# ---------------------------------------------------------------------------
+# 2. An INCOMPLETE repository with a volume mounted inside `.kin` must refuse
+#    loudly and leave the volume alone, never `rm -rf` through the mount.
+# ---------------------------------------------------------------------------
+echo "==> [mounted-incomplete] refuse to re-initialize over a mounted volume"
+new_fixture
+prepare_repo break
+set +e
+out="$(docker run --rm --user 999:999 \
+  -v "${WORKSPACE_VOLUME}:/w" -v "${PACKAGES_VOLUME}:/w/repo/.kin/packages" \
+  -e KIN_WORKSPACE_DIR=/w/repo -e KIN_STORAGE=local -e KIN_DISABLE_SPINE=1 \
+  "${IMAGE}" --port 4219 2>&1)"
+rc=$?
+set -e
+echo "${out}"
+[ "${rc}" -ne 0 ] || fail "entrypoint exited 0 on an incomplete layout wrapping a mounted volume"
+contains "${out}" "mounted inside it" || fail "refusal did not name the mount as the reason"
+contains "${out}" "Refusing to re-initialize" || fail "refusal did not state what it declined to do"
+payload_survived || fail "entrypoint DESTROYED the mounted volume's contents before refusing"
+echo "==> [mounted-incomplete] OK"
+cleanup
+
+# ---------------------------------------------------------------------------
+# 3. An incomplete repository with NOTHING mounted inside `.kin` must still
+#    re-initialize, so the refusal above cannot be implemented by never
+#    re-initializing at all.
+# ---------------------------------------------------------------------------
+echo "==> [unmounted-incomplete] still re-initializes when no volume is at risk"
+new_fixture
+prepare_repo break
+CID="$(docker run -d --user 999:999 -v "${WORKSPACE_VOLUME}:/w" \
+  -e KIN_WORKSPACE_DIR=/w/repo -e KIN_STORAGE=local -e KIN_DISABLE_SPINE=1 \
+  "${IMAGE}" --port 4219)"
+started=""
+for _ in $(seq 1 30); do
+  logs="$(docker logs "${CID}" 2>&1 || true)"
+  if contains "${logs}" "Starting kin-daemon"; then started=1; break; fi
+  if [ "$(docker inspect -f '{{.State.Running}}' "${CID}" 2>/dev/null || echo false)" != "true" ]; then break; fi
+  sleep 1
+done
+logs="$(docker logs "${CID}" 2>&1 || true)"
+restored=""
+docker exec "${CID}" sh -c 'test -f /w/repo/.kin/manifest.json' >/dev/null 2>&1 && restored=1
+docker rm -f "${CID}" >/dev/null 2>&1 || true; CID=""
+[ -n "${started}" ] || { echo "${logs}"; fail "incomplete unmounted layout did not reach daemon start"; }
+[ -n "${restored}" ] || fail "incomplete unmounted layout was not re-initialized"
+echo "==> [unmounted-incomplete] OK"
+
+echo "==> entrypoint workspace-mount contract passed for ${IMAGE}"


### PR DESCRIPTION
## The defect

`docker-entrypoint.sh` re-initializes the workspace unless all five of
`.kin/manifest.json`, `.kin/config.toml`, `.kin/HEAD`, `.kin/objects` and
`.kin/kindb/graph.kndb` exist. The last three are artifacts of the pre-authority
layout. A current `kin init` produces none of them, measured against the shipped
v0.4.6 image:

```
PRESENT .kin/manifest.json     PRESENT .kin/config.toml
ABSENT  .kin/HEAD              ABSENT  .kin/objects      ABSENT .kin/kindb/graph.kndb
```

So the condition is unconditionally true and **every container start** runs
`rm -rf "$KIN_WORKSPACE_DIR/.kin"` and rebuilds.

Nothing in the entrypoint changed to cause this. The layout underneath it did.
Same file at v0.3.4 creates all five, so the guard was satisfiable and the
destructive branch never ran. The v2 layout silently turned it into an
unconditional wipe.

## Why it is a data-loss bug, not a wasteful one

On a pod whose workspace is an `emptyDir` the wipe merely repeats work, which is
why it went unnoticed. The `kin-registry` Deployment mounts its published-crates
PVC at `<repo>/.kin/packages`, **inside** the deleted directory. `rm -rf`
recurses into a mount and unlinks its contents before failing `EBUSY` on the
mount point, so the start destroys the published crates and then crashloops.

Reproduced in the pod's two-stage shape (init container prepares the repo as uid
999; app container then mounts the PVC inside `.kin`):

| Image | Result | Seeded crate |
|---|---|---|
| v0.3.4 | `Running=true`, reached `Starting kin-daemon` | survived |
| v0.4.6 | `ExitCode=1`, `rm: cannot remove ...: Device or resource busy` | **DESTROYED** |

Same harness, same mounts, only the image differs, so the test distinguishes
rather than always reporting one answer.

## The fix

Test the four paths every layout version materializes (`manifest.json`,
`config.toml`, `version`, `kindb/`), verified present in both v0.3.4 and v0.4.6.
A repository of either vintage is therefore left alone for the daemon to open or
reject on its own terms, which preserves the existing loud refusal on a legacy
tree instead of silently re-creating it.

Then refuse outright when the tree is incomplete **and** something is mounted
inside it, reading `/proc/self/mountinfo` so no extra tooling is required.
Destroying an operator's volume is not an acceptable route to a clean state.

## The missing coverage this restores

The existing entrypoint smoke boots with nothing mounted under `.kin`, so it
models the kin-daemon pod and never the kin-registry pod. That is the gap the
regression lived in. `scripts/test-entrypoint-workspace-mount.sh` adds three
cases and is wired into `docker.yml`, which already builds `kin:ci` per PR:

- prepared repo + volume mounted inside `.kin` -> boots, volume untouched
- incomplete repo + volume mounted inside `.kin` -> refuses loudly, volume untouched
- incomplete repo, nothing mounted -> still re-initializes

That third case matters: it stops the refusal being implemented by never
re-initializing at all.

Falsified against both images:

```
kin:entrypoint-fixed                  EXIT=0   all three cases OK
ghcr.io/firelock-ai/kin@sha256:ad18ffb6  EXIT=1   fails at [mounted-intact]
```

`actionlint` clean on the workflow.

## Why this is urgent

This blocks promoting any v0.4.4+ daemon image onto kin-registry. Production is
currently on v0.3.4 and healthy for the measured reason above, so the promotion
pipeline has been correctly refusing to ship this since v0.4.4.

Refs FIR-1844

## Exposure

**Production was never exposed.** The `kin-daemon` and `kin-registry` Deployments
run `kin-daemon:e75570c9...` (v0.3.4), which materializes all five paths the old
guard tested, so the destructive branch never ran there. Pods are Running with 0
restarts. The damage is reachable only by promoting a v0.4.4+ image onto
`kin-registry`, which the promotion gate has been refusing since v0.4.4.

Severity is P0 by class rather than by current impact: the failure destroys data
*before* it reports an error, so a single rollout would have emptied the
published-crates disk and then crashlooped, with the loss already committed by the
time the container exited non-zero.

## Related defect, not fixed here

`KINLAB_KIN_DAEMON_IMAGE` in firelock-ai/kinlab pins
`kin-daemon:0705457d...`, a kin commit from 2026-07-03 first tagged v0.2.10. Any
`Promote To Prod` dispatch today would therefore roll the running daemon **down**
from v0.3.4 to that v0.2.10-era image: a silent production downgrade sitting in
repository-variable configuration, unrelated to this change.

The update path rides this fix: once a release carries the corrected entrypoint,
that pin should move to the fixed image, and only then does a dispatch both verify
promotion auth and deploy something intended.

Refs FIR-1844


## Review addenda (captain, post-verdict)

The reviewer reproduced a guard bypass via an unnormalized KIN_WORKSPACE_DIR (trailing slash or symlinked component defeats the literal case patterns against canonical mountinfo paths, destroying the payload); its tested one-line remedy landed as the canonicalization commit. The reviewer also ran the gate against the v0.3.4 image running in production today: it fails at the mounted-incomplete case with the same EBUSY, so deleting through the mount predates v0.4.4; what v0.4.4 changed is making the destructive branch unconditional. Production is protected today only because its tree satisfies the completeness check. The Docker Image Build job that carries this gate is not a required context and has no merge_group trigger, so the coverage this restores is observational on PRs until that wiring changes.
