### PR TITLE
Detect the operator's shell before PowerShell's environment markers

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1747,6 +1747,60 @@ mod tests {
         );
     }
 
+    /// A host that merely ships PowerShell exports `PSModulePath` into every
+    /// process, including the bash one the operator is actually using. The
+    /// installed bash integration is the one to judge; reading the PowerShell
+    /// marker first reported a working bash install as misconfigured and
+    /// pointed the operator at a `.ps1` profile their shell never loads.
+    #[test]
+    #[serial]
+    #[cfg(not(target_os = "windows"))]
+    fn shell_path_judges_the_named_shell_when_powershell_is_merely_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let kin_home = tmp.path().join("kin-home");
+        let hook_dir = kin_home.join("shell");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&hook_dir).unwrap();
+
+        let hook = hook_dir.join(hook_filename("bash"));
+        std::fs::write(&hook, "# kin-vfs test hook\n").unwrap();
+        std::fs::write(
+            home.join(".bashrc"),
+            format!(
+                "source \"{}\"\nexport PATH=\"{}:$PATH\"\n",
+                hook.display(),
+                kin_home.join("bin").display()
+            ),
+        )
+        .unwrap();
+
+        let _home = EnvVarGuard::set("HOME", &home);
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvVarGuard::unset("KIN_DIR");
+        let _shell = EnvVarGuard::set("SHELL", "/bin/bash");
+        let _ps_module_path =
+            EnvVarGuard::set("PSModulePath", "/opt/microsoft/powershell/7/Modules");
+        let _ps_version_table = EnvVarGuard::unset("PSVersionTable");
+        let _profile = EnvVarGuard::unset("PROFILE");
+        let _path = EnvVarGuard::set("PATH", "/usr/bin");
+
+        let check = check_shell_path();
+        assert_eq!(check.id, "shell_path");
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "installed bash integration should be healthy while pwsh is merely present; \
+             got {:?}: {}",
+            check.status,
+            check.detail
+        );
+        assert!(
+            check.detail.starts_with("bash "),
+            "detail should describe the bash integration: {}",
+            check.detail
+        );
+    }
+
     fn check_with(id: &str, status: HealthStatus) -> HealthCheck {
         HealthCheck::new(id, id, status, "")
     }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1120,10 +1120,31 @@ fn restore_shim_from_sources(dest: &Path, sources: &[PathBuf]) -> Result<Option<
     Ok(None)
 }
 
+/// Whether the environment carries PowerShell's markers.
+///
+/// `PSModulePath` is machine-scoped: the Windows installer sets it for every
+/// process, PowerShell exports it to its children on every platform, and hosted
+/// CI images that merely ship `pwsh` export it into shells that are not
+/// PowerShell at all. It therefore proves PowerShell is present, not that this
+/// process is running under it.
+fn powershell_environment_markers() -> bool {
+    env::var_os("PSModulePath").is_some() || env::var_os("PSVersionTable").is_some()
+}
+
 pub(crate) fn detect_shell() -> &'static str {
-    if env::var("PSModulePath").is_ok() || env::var("PSVersionTable").is_ok() {
+    // On Windows PowerShell is the shell Kin configures and its markers are the
+    // reliable signal. `SHELL` there is set by whatever POSIX layer (Git Bash,
+    // MSYS) launched the process and does not name the shell a user configures
+    // Kin for, so it must not outrank them.
+    if cfg!(target_os = "windows") && powershell_environment_markers() {
         return "powershell";
     }
+
+    // Everywhere else `SHELL` names the user's own shell and outranks the
+    // PowerShell markers, which on Unix say only that PowerShell exists on the
+    // machine. Reading the markers first detected bash and zsh operators as
+    // PowerShell, wrote the hook to a profile their shell never loads, and then
+    // reported the shell integration they were actually using as misconfigured.
     if let Ok(shell) = env::var("SHELL") {
         if shell.ends_with("/zsh") || shell.ends_with("/zsh-5") {
             return "zsh";
@@ -1135,6 +1156,13 @@ pub(crate) fn detect_shell() -> &'static str {
             return "fish";
         }
     }
+
+    // No POSIX shell named itself. The markers are the remaining evidence, so
+    // `pwsh` on Unix is still detected whenever `SHELL` cannot answer.
+    if powershell_environment_markers() {
+        return "powershell";
+    }
+
     "zsh"
 }
 
@@ -14256,6 +14284,49 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
 
         home.apply("KIN_HOME", Some(&preferred));
         assert_eq!(kin_dir().unwrap(), preferred);
+    }
+
+    #[test]
+    #[serial]
+    fn detect_shell_prefers_the_named_shell_over_ambient_powershell_markers() {
+        let mut shell_env = EnvVarGuard::unset("SHELL")
+            .without("PSModulePath")
+            .without("PSVersionTable");
+
+        // A hosted image that merely ships pwsh exports PSModulePath into every
+        // process, including a bash one. The shell is still bash.
+        shell_env.apply("PSModulePath", Some("/opt/microsoft/powershell/7/Modules"));
+        shell_env.apply("SHELL", Some("/bin/bash"));
+        if cfg!(target_os = "windows") {
+            assert_eq!(detect_shell(), "powershell");
+        } else {
+            assert_eq!(detect_shell(), "bash");
+        }
+
+        shell_env.apply("SHELL", Some("/bin/zsh"));
+        if cfg!(target_os = "windows") {
+            assert_eq!(detect_shell(), "powershell");
+        } else {
+            assert_eq!(detect_shell(), "zsh");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn detect_shell_uses_powershell_markers_when_no_posix_shell_names_itself() {
+        let mut shell_env = EnvVarGuard::unset("SHELL")
+            .without("PSModulePath")
+            .without("PSVersionTable");
+
+        assert_eq!(detect_shell(), "zsh");
+
+        shell_env.apply("PSModulePath", Some("/opt/microsoft/powershell/7/Modules"));
+        assert_eq!(detect_shell(), "powershell");
+
+        // An unrecognized login shell is not an answer either, so the markers
+        // still decide.
+        shell_env.apply("SHELL", Some("/usr/bin/false"));
+        assert_eq!(detect_shell(), "powershell");
     }
 
     #[test]


### PR DESCRIPTION
**DO NOT AUTO-LAND. Staged for the 0.4.8 path.** Do not `merge submit` or `merge drain`
this without a captain decision. See "Release timing" below: it may be worth landing
before the v0.4.7 mint instead.

## What was wrong

`detect_shell()` returned `powershell` whenever `PSModulePath` (or `PSVersionTable`) was
present, ahead of reading `SHELL`. That marker is machine-scoped, not session-scoped: the
Windows installer sets it for every process, PowerShell exports it to its children on
every platform, and hosted CI images that merely ship `pwsh` export it into shells that
are not PowerShell at all. Its presence proves PowerShell exists on the machine, not that
this process is running under it.

Consequences on a Unix host that has PowerShell installed and exported:

- `kin setup` (with no `--shell`) writes the hook to
  `~/.config/powershell/Microsoft.PowerShell_profile.ps1`, which the operator's bash or
  zsh never loads
- `kin setup status` / `kin doctor` then judge the PowerShell integration, report
  `shell_path=misconfigured`, and point the operator at a `.ps1` profile
- `kin doctor --fix` reinstalls the hook for the same mis-detected shell, so the repair
  cannot converge

## Observed failure

v0.4.6's release install proof (run 30762349762) failed its health gate on
`ubuntu-latest` and `ubuntu-24.04-arm` with:

```
"id": "shell_path",
"status": "misconfigured",
"detail": "powershell: hook missing at /home/runner/.kin/shell/kin-vfs.ps1; /home/runner/.config/powershell/Microsoft.PowerShell_profile.ps1 does not source the kin-vfs hook"
```

In the same job, `kin setup --shell bash` had already written
`/home/runner/.kin/shell/kin-vfs.bash` and the `.bashrc` source line, and the setup step's
own checklist printed `Shell integration ok  bash hook installed and sourced from
/home/runner/.bashrc`. The later step carried `SHELL=/bin/bash` in its environment and was
still judged as PowerShell, because the marker outranked it. The macOS legs reported
`shell_path` healthy: those runner images do not export the marker.

## The fix

Read `SHELL` first everywhere except Windows, where PowerShell genuinely is the shell Kin
configures and `SHELL` is set by whatever POSIX layer (Git Bash, MSYS) launched the
process. The markers still decide once `SHELL` has failed to name a shell, so `pwsh` on
Unix is still detected when it is the only evidence available.

Deliberate behavior change: a Unix operator running `kin setup` from inside `pwsh` while
`SHELL` names their bash/zsh login shell now gets bash/zsh configured instead of
PowerShell. That is the shell their `SHELL` names, and `--shell powershell` remains
available. The reverse error — every bash/zsh operator on a pwsh-bearing host being
detected as PowerShell — is the far larger population.

Windows behavior is unchanged: `PSModulePath` is set machine-wide there, so the first
branch still returns `powershell` exactly as before.

`env::var(..).is_ok()` became `env::var_os(..).is_some()` so a non-UTF-8 `PSModulePath`
(possible on Windows) still counts as present.

## Tests

Three, all hermetic, no daemon and no store:

- `detect_shell_prefers_the_named_shell_over_ambient_powershell_markers` — marker set plus
  `SHELL=/bin/bash` must resolve to bash (and to zsh for `/bin/zsh`)
- `detect_shell_uses_powershell_markers_when_no_posix_shell_names_itself` — no `SHELL`, or
  an unrecognized one, still resolves to powershell from the markers
- `shell_path_judges_the_named_shell_when_powershell_is_merely_installed` — end to end
  through `check_shell_path()` against a temp `HOME` carrying a real bash hook and
  `.bashrc`, with the marker set exactly as the runner has it: must be `Healthy` with a
  `bash ...` detail

The first was falsified against the pre-fix precedence before being kept: with the old
ordering it fails with `left: "powershell", right: "bash"`, the exact CI signature.

Local gates: `cargo fmt --all -- --check` clean; `cargo clippy -p kin-cli --all-targets`
under the ci.yml allowlist with `RUSTFLAGS=-Dwarnings` clean; `cargo test -p kin-cli --lib
--no-fail-fast` 1126 passed, 0 failed.

## What this deliberately does not do

The install proof is not touched. Two of its steps already `unset PSModulePath
PSVersionTable` before capturing health, and the step that writes `kin-health.json` does
not. Adding the unset there would also green the legs, but it would make the proof blind
to exactly this class of defect: the proof would then pass even with the detection bug
restored. Leaving that step reading the real ambient environment keeps it evidence.

## Release timing

`crates/kin-cli/src/commands/health.rs` is byte-identical between the `v0.4.6` tag and
`main`, and the `kin setup` invocations in the proof are identical too, so nothing on
`main` repairs this today. If the v0.4.7 mint fires before this lands, v0.4.7's proof will
red on both Linux legs for this same reason and is likely to need its own abandonment
record. Landing this before the mint is the cheaper path; that call belongs to the release
captain, which is why this PR is not queued.

## Separate, unfixed blocker on macos-latest

`macos-latest` failed the same run for an unrelated reason, not `shell_path` (its
`shell_path` was healthy):

```
Error: Unix status did not prove complete observed embedding coverage:
{"state":"unobserved","reason":"graph_mutation_in_flight"}
```

`EmbeddingCoverageUnobserved::GraphMutationInFlight` is documented in
`crates/kin-cli/src/commands/status.rs` as transient — a graph mutation batch was in
flight across every sampling attempt. `macos-15-intel` passed the same assertion. The
proof asserts against it with no retry, and that assertion is unchanged between `v0.4.6`
and `main`. This PR does not address it; it needs its own ticket.


---
Refs FIR-1875. Review record:
`.kin-coord/reports/night-20260804-nrev-593.md` (CONDITIONAL-GO; conditions are this note
and settled CI, both discharged before submit).

