### PR TITLE
Restore the centering wrapper the banner swap orphaned

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="docs/assets/kin-banner.png" alt="Kin - Semantic Repository Substrate" width="100%" />
 </p>
 
+<div align="center">
+
 <h3>Software that remembers itself.</h3>
 
 <p><em>Exact context, not more.</em></p>


### PR DESCRIPTION
PR 590's banner swap removed the div align=center opener of the old picture-hero block but left its closer, leaving one orphaned closing tag and the hero lockup plus badge row rendering left-aligned under a centered banner on the flagship page. This restores the opener so the pair is matched and the lockup renders centered as designed. Found by the marketing pass (night-20260804-nmkt/README-marketing-check.md F2, tag counts verified there).