### PR TITLE
Gate the agent discovery reminder on a real MCP registration

### DIFF
--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1278,10 +1278,15 @@ fn claude_cli_filename() -> &'static str {
 /// drops it in `~/.local/bin`, which login shells add but non-login and CI
 /// shells frequently do not.
 ///
-/// Only artifacts Claude Code writes for itself count. The `~/.claude`
-/// directory does not: `kin setup` creates it to write the discovery reminder,
-/// so trusting it would let a previous setup run manufacture its own evidence
-/// of an install that never happened.
+/// The bare `~/.claude` directory never counts: `kin setup` creates it to
+/// write the discovery reminder, so trusting it would let a previous setup
+/// run manufacture its own evidence of an install that never happened.
+/// `~/.claude.json` is accepted even though `configure_claude_code` can
+/// create it, because non-interactive runs only configure clients this
+/// detection already admitted; the remaining self-evidence path is an
+/// operator explicitly selecting an undetected client in the advanced
+/// picker, which is a deliberate override rather than manufactured
+/// detection, and an uninstall excises Kin's key but leaves the file.
 fn claude_code_install_evidence(home: &Path) -> bool {
     home.join(".claude.json").exists()
         || home.join(".claude").join("settings.json").exists()
@@ -1865,7 +1870,8 @@ fn apply_discovery_reminders(
             if discovery_reminder_present(&path) {
                 println!(
                     "  {} {label} reminder is present at {} but Kin's MCP server is not \
-                     registered for it — `kin setup uninstall` removes the reminder",
+                     registered for it — `kin setup uninstall` removes it when a setup run \
+                     recorded it; an unrecorded reminder stays until removed by hand",
                     style("!").yellow(),
                     path.display()
                 );
@@ -15710,17 +15716,20 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
     fn each_instruction_file_is_gated_on_its_own_client() {
         let (_dir, home) = reminder_fixture();
 
-        let written = apply_discovery_reminders(&home, &[IDX_CLAUDE_CODE, IDX_CODEX]);
+        let written = apply_discovery_reminders(&home, &[IDX_CODEX]);
 
         assert_eq!(
             written
                 .iter()
                 .map(|(target, _)| *target)
                 .collect::<Vec<_>>(),
-            vec!["claude-md", "codex-agents"]
+            vec!["codex-agents"]
         );
         assert!(discovery_reminder_present(
             &home.join(".codex").join("AGENTS.md")
+        ));
+        assert!(!discovery_reminder_present(
+            &home.join(".claude").join("CLAUDE.md")
         ));
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1260,16 +1260,53 @@ const IDX_GEMINI: usize = 3;
 const IDX_WINDSURF: usize = 4;
 const IDX_ANTIGRAVITY: usize = 5;
 
+/// The Claude Code CLI filename, by platform.
+fn claude_cli_filename() -> &'static str {
+    if cfg!(windows) {
+        "claude.exe"
+    } else {
+        "claude"
+    }
+}
+
+/// Whether Claude Code itself has left evidence of an install in `home`.
+///
+/// Every other client gets a filesystem fallback beside its PATH probe, so a
+/// client installed outside the current `PATH` is still configured. Claude Code
+/// had only the PATH probe, which is why it alone was skipped when its CLI
+/// lives somewhere the invoking shell does not export — the native installer
+/// drops it in `~/.local/bin`, which login shells add but non-login and CI
+/// shells frequently do not.
+///
+/// Only artifacts Claude Code writes for itself count. The `~/.claude`
+/// directory does not: `kin setup` creates it to write the discovery reminder,
+/// so trusting it would let a previous setup run manufacture its own evidence
+/// of an install that never happened.
+fn claude_code_install_evidence(home: &Path) -> bool {
+    home.join(".claude.json").exists()
+        || home.join(".claude").join("settings.json").exists()
+        || home.join(".claude").join("config.json").exists()
+        || home
+            .join(".local")
+            .join("bin")
+            .join(claude_cli_filename())
+            .exists()
+}
+
 /// Detect installed AI assistants eligible for MCP auto-configuration.
 ///
 /// Detection heuristics per client:
-/// - Claude Code: `claude` binary on PATH
+/// - Claude Code: `claude` binary on PATH, or Claude Code's own state/config
+///   files, or the native installer's `~/.local/bin/claude`
 /// - Cursor: `cursor` binary on PATH, or `/Applications/Cursor.app`
 /// - Codex CLI: `codex` binary on PATH
 /// - Gemini CLI: `gemini` binary on PATH, or `~/.gemini` directory
 /// - Windsurf: `windsurf` binary on PATH, or `/Applications/Windsurf.app`
 fn detect_ai_assistants() -> Vec<AiAssistant> {
-    let claude_detected = check_binary_in_path("claude").is_some();
+    let claude_detected = check_binary_in_path("claude").is_some()
+        || home_dir()
+            .map(|home| claude_code_install_evidence(&home))
+            .unwrap_or(false);
     let cursor_detected = check_binary_in_path("cursor").is_some()
         || PathBuf::from("/Applications/Cursor.app").exists();
     let codex_detected = check_binary_in_path("codex").is_some();
@@ -1760,6 +1797,99 @@ fn inject_discovery_reminder(path: &PathBuf) -> Result<()> {
     fs::write(path, &content).with_context(|| format!("failed to write {}", path.display()))?;
 
     Ok(())
+}
+
+/// One agent instruction file setup can append the Kin-first discovery reminder
+/// to, paired with the client whose MCP registration makes that directive true.
+struct DiscoveryReminderTarget {
+    /// Assistant index whose MCP registration the directive depends on.
+    client: usize,
+    /// Human label used in setup output.
+    label: &'static str,
+    /// Stable ledger target id for the appended block.
+    ledger_target: &'static str,
+    path: PathBuf,
+}
+
+/// The instruction files setup can write, in output order.
+fn discovery_reminder_targets(home: &Path) -> Vec<DiscoveryReminderTarget> {
+    vec![
+        DiscoveryReminderTarget {
+            client: IDX_CLAUDE_CODE,
+            label: "Claude Code",
+            ledger_target: "claude-md",
+            path: home.join(".claude").join("CLAUDE.md"),
+        },
+        DiscoveryReminderTarget {
+            client: IDX_CODEX,
+            label: "Codex CLI",
+            ledger_target: "codex-agents",
+            path: home.join(".codex").join("AGENTS.md"),
+        },
+    ]
+}
+
+/// Whether Kin's discovery reminder is already appended to an instruction file.
+fn discovery_reminder_present(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .map(|content| content.contains(KIN_DISCOVERY_REMINDER))
+        .unwrap_or(false)
+}
+
+/// Append the Kin-first discovery reminder to each instruction file whose client
+/// this run registered, and report what was written as `(ledger target, path)`.
+///
+/// The reminder is a standing behavioral directive: it tells the agent to reach
+/// for Kin's semantic MCP tools before grep or raw file reads, in every
+/// repository, for every session. That instruction is only true for a client
+/// whose MCP server is actually registered, so each file is gated on its own
+/// client appearing in `registered_clients`. Writing it for an unregistered
+/// client aims the agent at tools that are not wired, and every call it makes
+/// fails.
+///
+/// `home` is taken by argument rather than resolved here so this is exercisable
+/// without mutating the process environment that the rest of the suite reads.
+fn apply_discovery_reminders(
+    home: &Path,
+    registered_clients: &[usize],
+) -> Vec<(&'static str, PathBuf)> {
+    let mut written = Vec::new();
+    for target in discovery_reminder_targets(home) {
+        let DiscoveryReminderTarget {
+            client,
+            label,
+            ledger_target,
+            path,
+        } = target;
+        if !registered_clients.contains(&client) {
+            if discovery_reminder_present(&path) {
+                println!(
+                    "  {} {label} reminder is present at {} but Kin's MCP server is not \
+                     registered for it — `kin setup uninstall` removes the reminder",
+                    style("!").yellow(),
+                    path.display()
+                );
+            } else {
+                println!(
+                    "  {} {label} reminder skipped — Kin's MCP server was not registered for it",
+                    style("→").cyan()
+                );
+            }
+            continue;
+        }
+        match inject_discovery_reminder(&path) {
+            Ok(()) => {
+                println!(
+                    "  {} {label} discovery reminder ensured ({})",
+                    style("✓").green(),
+                    path.display()
+                );
+                written.push((ledger_target, path));
+            }
+            Err(e) => println!("  {} {label} reminder failed: {e}", style("!").yellow()),
+        }
+    }
+    written
 }
 
 /// Check if a given MCP config file already has the "kin" server entry.
@@ -11527,6 +11657,10 @@ async fn apply_plan(
 
     // AI client MCP configuration.
     let mut configured_assistants: Vec<(String, Option<PathBuf>)> = Vec::new();
+    // Assistant indices whose MCP server this run actually registered. Gates the
+    // discovery reminders below so a directive is never written for a client
+    // Kin did not wire up.
+    let mut registered_clients: Vec<usize> = Vec::new();
     if plan.configure_mcp {
         println!("AI client MCP configuration:");
         for idx in &plan.mcp_assistant_indices {
@@ -11560,6 +11694,7 @@ async fn apply_plan(
                         a.name,
                         path.display()
                     );
+                    registered_clients.push(*idx);
                     configured_assistants.push((a.name.to_string(), Some(path)));
                 }
                 Some(Err(e)) => {
@@ -11585,22 +11720,18 @@ async fn apply_plan(
     }
 
     // Agent discovery reminders.
+    //
+    // The reminder is a standing behavioral directive: it tells the agent to
+    // reach for Kin's semantic MCP tools before grep or raw file reads, in every
+    // repository, for every session. That instruction is only true for a client
+    // whose MCP server is actually registered, so each instruction file is gated
+    // on its own client's registration succeeding this run. Writing it for an
+    // unregistered client aims the agent at tools that are not wired, and every
+    // call it makes fails.
+    let mut written_reminders: Vec<(&'static str, PathBuf)> = Vec::new();
     if plan.inject_discovery_reminders {
         println!("Agent discovery reminders:");
-        let home = home_dir()?;
-        for (label, path) in [
-            ("Claude Code", home.join(".claude").join("CLAUDE.md")),
-            ("Codex CLI", home.join(".codex").join("AGENTS.md")),
-        ] {
-            match inject_discovery_reminder(&path) {
-                Ok(()) => println!(
-                    "  {} {label} discovery reminder ensured ({})",
-                    style("✓").green(),
-                    path.display()
-                ),
-                Err(e) => println!("  {} {label} reminder failed: {e}", style("!").yellow()),
-            }
-        }
+        written_reminders = apply_discovery_reminders(&home_dir()?, &registered_clients);
         println!();
     }
 
@@ -11617,7 +11748,7 @@ async fn apply_plan(
 
     // Record what we wrote into the install ledger so `kin doctor` can verify it
     // and `kin setup uninstall` can remove exactly it.
-    record_setup_ledger(plan, shell_name);
+    record_setup_ledger(plan, shell_name, &written_reminders);
 
     Ok(configured_assistants)
 }
@@ -11649,7 +11780,18 @@ fn read_kin_mcp_entry(path: &Path) -> Option<serde_json::Value> {
 /// original install timestamps across idempotent re-runs. Ledger failures are
 /// non-fatal: setup already succeeded, so a ledger write error is a warning, not
 /// a setup failure.
-fn record_setup_ledger(plan: &SetupPlan, shell_name: &str) {
+///
+/// `written_reminders` carries the instruction files this run actually appended
+/// to, as `(ledger target, path)`. Only those are recorded, so the ledger never
+/// claims an artifact the registration gate declined to write. Entries recorded
+/// by an earlier run survive regardless: [`SetupLedger::record`] upserts and
+/// never prunes, so `kin setup uninstall` can still remove a reminder appended
+/// before that gate existed.
+fn record_setup_ledger(
+    plan: &SetupPlan,
+    shell_name: &str,
+    written_reminders: &[(&'static str, PathBuf)],
+) {
     use crate::commands::setup_ledger::{ArtifactKind, LedgerEntry, SetupLedger};
 
     let Ok(ledger_path) = crate::commands::setup_ledger::ledger_path() else {
@@ -11715,22 +11857,14 @@ fn record_setup_ledger(plan: &SetupPlan, shell_name: &str) {
         }
 
         if plan.inject_discovery_reminders {
-            if let Ok(home) = home_dir() {
-                for (target, path) in [
-                    ("claude-md", home.join(".claude").join("CLAUDE.md")),
-                    ("codex-agents", home.join(".codex").join("AGENTS.md")),
-                ] {
-                    let present = fs::read_to_string(&path)
-                        .map(|c| c.contains(KIN_DISCOVERY_REMINDER))
-                        .unwrap_or(false);
-                    if present {
-                        ledger.record(LedgerEntry::appended(
-                            ArtifactKind::DiscoveryReminder,
-                            target,
-                            path,
-                            KIN_DISCOVERY_REMINDER,
-                        ));
-                    }
+            for (target, path) in written_reminders {
+                if discovery_reminder_present(path) {
+                    ledger.record(LedgerEntry::appended(
+                        ArtifactKind::DiscoveryReminder,
+                        *target,
+                        path.clone(),
+                        KIN_DISCOVERY_REMINDER,
+                    ));
                 }
             }
         }
@@ -13584,6 +13718,7 @@ pub async fn uninstall(all: bool, dry_run: bool, force: bool, json: bool) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::setup_ledger::ArtifactKind;
     use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
 
@@ -15507,6 +15642,177 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         fs::write(&primary, b"{}\n").unwrap();
         assert_eq!(configure_claude_code().unwrap(), primary);
         assert!(read_kin_mcp_entry(&primary).is_some());
+    }
+
+    /// A temp home plus the ledger path a test drives directly.
+    fn reminder_fixture() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        (dir, home)
+    }
+
+    /// FIR-1878: the Kin-first directive is a standing instruction to prefer
+    /// Kin's MCP tools over grep and raw file reads, in every repository, for
+    /// every session. Writing it for a client whose MCP server setup never
+    /// registered points that agent at tools which are not wired.
+    ///
+    /// Models the reported first-install shape: Cursor registers, Claude Code
+    /// does not, and the run still reaches the reminder step. Against the
+    /// pre-fix code — an unconditional loop over both instruction files — this
+    /// fails on the `.claude/CLAUDE.md` assertion.
+    #[test]
+    fn discovery_reminder_is_withheld_from_a_client_kin_did_not_register() {
+        let (_dir, home) = reminder_fixture();
+
+        let written = apply_discovery_reminders(&home, &[IDX_CURSOR]);
+
+        assert!(
+            written.is_empty(),
+            "nothing may be reported as written, so the ledger cannot claim it either"
+        );
+        assert!(
+            !home.join(".claude").join("CLAUDE.md").exists(),
+            "a directive to prefer Kin's MCP tools must not be written for a client \
+             whose MCP server was never registered"
+        );
+        assert!(
+            !home.join(".codex").join("AGENTS.md").exists(),
+            "the same gate must hold for Codex"
+        );
+    }
+
+    /// The other half of the gate: once a client is registered the directive is
+    /// true for it, so it is written and reported for the ledger to track.
+    #[test]
+    fn discovery_reminder_follows_a_successful_registration() {
+        let (_dir, home) = reminder_fixture();
+
+        let written = apply_discovery_reminders(&home, &[IDX_CLAUDE_CODE]);
+
+        assert_eq!(
+            written,
+            vec![("claude-md", home.join(".claude").join("CLAUDE.md"))],
+            "only the registered client's reminder is written and reported"
+        );
+        assert!(discovery_reminder_present(
+            &home.join(".claude").join("CLAUDE.md")
+        ));
+        assert!(
+            !home.join(".codex").join("AGENTS.md").exists(),
+            "an unregistered sibling stays untouched in the same run"
+        );
+    }
+
+    /// Each instruction file is gated on its own client, not on any client
+    /// having been registered.
+    #[test]
+    fn each_instruction_file_is_gated_on_its_own_client() {
+        let (_dir, home) = reminder_fixture();
+
+        let written = apply_discovery_reminders(&home, &[IDX_CLAUDE_CODE, IDX_CODEX]);
+
+        assert_eq!(
+            written
+                .iter()
+                .map(|(target, _)| *target)
+                .collect::<Vec<_>>(),
+            vec!["claude-md", "codex-agents"]
+        );
+        assert!(discovery_reminder_present(
+            &home.join(".codex").join("AGENTS.md")
+        ));
+    }
+
+    /// Re-running setup must not append the block twice.
+    #[test]
+    fn discovery_reminder_injection_is_idempotent() {
+        let (_dir, home) = reminder_fixture();
+        let claude_md = home.join(".claude").join("CLAUDE.md");
+
+        apply_discovery_reminders(&home, &[IDX_CLAUDE_CODE]);
+        let once = fs::read_to_string(&claude_md).unwrap();
+        apply_discovery_reminders(&home, &[IDX_CLAUDE_CODE]);
+
+        assert_eq!(fs::read_to_string(&claude_md).unwrap(), once);
+    }
+
+    /// A reminder appended by a Kin that predates the gate stays removable:
+    /// uninstall excises exactly the recorded block and leaves the user's own
+    /// text alone.
+    #[test]
+    fn uninstall_excises_a_reminder_left_by_an_earlier_run() {
+        use crate::commands::setup_ledger::{uninstall_entry, LedgerEntry};
+
+        let (_dir, home) = reminder_fixture();
+        let claude_md = home.join(".claude").join("CLAUDE.md");
+        apply_discovery_reminders(&home, &[IDX_CLAUDE_CODE]);
+        let user_text = "# My own instructions\n\nKeep this.\n";
+        let with_user = format!("{user_text}{}", fs::read_to_string(&claude_md).unwrap());
+        fs::write(&claude_md, &with_user).unwrap();
+
+        let entry = LedgerEntry::appended(
+            ArtifactKind::DiscoveryReminder,
+            "claude-md",
+            claude_md.clone(),
+            KIN_DISCOVERY_REMINDER,
+        );
+        uninstall_entry(&entry, false, false);
+
+        let after = fs::read_to_string(&claude_md).unwrap();
+        assert!(
+            !after.contains(KIN_DISCOVERY_REMINDER),
+            "uninstall must remove the reminder block"
+        );
+        assert!(
+            after.contains("Keep this."),
+            "the user's own text must survive"
+        );
+    }
+
+    /// Claude Code was the only client detected by PATH alone. Its own state
+    /// file is install evidence, so a CLI outside the invoking shell's PATH —
+    /// the native installer's `~/.local/bin` in a non-login shell — is still
+    /// configured rather than silently skipped.
+    #[test]
+    fn claude_code_state_file_counts_as_install_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        assert!(!claude_code_install_evidence(&home));
+
+        fs::write(home.join(".claude.json"), b"{}\n").unwrap();
+        assert!(claude_code_install_evidence(&home));
+    }
+
+    #[test]
+    fn claude_code_native_install_path_counts_as_install_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let bin = home.join(".local").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        assert!(!claude_code_install_evidence(&home));
+
+        fs::write(bin.join(claude_cli_filename()), b"#!/bin/sh\n").unwrap();
+        assert!(claude_code_install_evidence(&home));
+    }
+
+    /// Detection must not be satisfiable by Kin's own output. `kin setup`
+    /// creates `~/.claude/CLAUDE.md` itself, so counting the directory would let
+    /// one run manufacture evidence of an install that never happened — and the
+    /// next run would register a client the user does not have.
+    #[test]
+    fn kin_written_claude_directory_is_not_install_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let claude = home.join(".claude");
+        fs::create_dir_all(&claude).unwrap();
+        fs::write(claude.join("CLAUDE.md"), KIN_DISCOVERY_REMINDER).unwrap();
+
+        assert!(
+            !claude_code_install_evidence(&home),
+            "Kin's own discovery reminder must never read as a Claude Code install"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What

`kin setup --intent agent` told Claude Code to prefer Kin's semantic MCP tools while
registering no Kin MCP server for it.

Reproduced against the first-install audit's exact conditions (hermetic `HOME`, reduced
`PATH`), on `99c84f6d`:

```
AI client MCP configuration:
  ✓ Cursor configured (…/.cursor/mcp.json)
  → Claude Code not detected — install from claude.ai/download

Agent discovery reminders:
  ✓ Claude Code discovery reminder ensured (…/.claude/CLAUDE.md)   ← written anyway
  ✓ Codex CLI discovery reminder ensured (…/.codex/AGENTS.md)      ← same, unregistered
```

`grep -rl mcpServers` over that HOME returned one file (Cursor). The user's **global,
all-projects** instruction file was still told to start every session with
`semantic_locate` / `get_context_pack` / `trace_data_flow`. Every such call fails, in
every repository, and the user blames Kin.

Two independent defects, both fixed here.

## Why it hit Claude Code specifically

Every other client pairs its PATH probe with a filesystem fallback — Cursor checks
`/Applications/Cursor.app`, Gemini checks `~/.gemini`, Antigravity checks four places.
Claude Code had **only** `which("claude")`. Its native installer drops the CLI in
`~/.local/bin`, which login shells export and non-login/CI shells frequently do not, so
Claude Code was the one client that could be installed and still read as absent.

Detection now also accepts Claude Code's own state/config files and that native-install
path. The bare `~/.claude` **directory** is deliberately excluded: `kin setup` creates it
itself to write the reminder, so counting it would let one run manufacture evidence of an
install that never happened and register a client the user does not have.

## The desync gate

The reminder is now written per instruction file **only when that client's own MCP
registration succeeded in the same run** — not when any client succeeded, and not merely
because the plan asked for reminders. The pair can no longer drift apart:

- `~/.claude/CLAUDE.md` requires the Claude Code registration
- `~/.codex/AGENTS.md` requires the Codex registration
- the install ledger records only what was actually written, so it cannot claim an
  artifact the gate declined
- a reminder already on disk without a registration is **reported**, not silently left,
  and stays removable — ledger records upsert and never prune, so `kin setup uninstall`
  still excises a block appended by a pre-gate Kin

## Scope decision: user scope, not project scope

Registration targets `~/.claude.json` (top-level `mcpServers`), matching what every other
client already does here — `~/.cursor/mcp.json`, `~/.gemini/settings.json`,
`~/.codex/config.toml` are all user-scope. `configure_claude_code()` and
`health.rs::evaluate_mcp_client` already agreed on that path; the gap was never the writer,
it was that detection never let the writer run.

Project scope was rejected on the audit's own evidence: the one workspace-scoped write Kin
already does (`<repo>/.agents/mcp_config.json` for Antigravity) is filed as a separate
defect (P1-8) for dropping an untracked file into the user's git repo. Adding a second
in-repo write to fix a P0 would have shipped a known P1.

## Test evidence

Eight new tests, none of which mutate the process environment — the reminder step now takes
`home` by argument, per the contract documented in `kin_core::test_env` ("when the code
under test resolves configuration that other code under test also resolves, the fix is to
take that configuration by argument").

**Falsified against the pre-fix logic before being trusted.** Removing only the gate and
re-running the shipped test:

```
  ✓ Claude Code discovery reminder ensured (…/home/.claude/CLAUDE.md)
  ✓ Codex CLI discovery reminder ensured (…/home/.codex/AGENTS.md)

panicked at crates/kin-cli/src/commands/setup.rs:15670:
  nothing may be reported as written, so the ledger cannot claim it either

test result: FAILED. 0 passed; 1 failed
```

Coverage: gate withholds for an unregistered client · writes for a registered one · each
file gated on its *own* client · injection idempotent · uninstall excises the block while
preserving the user's own surrounding text · three detection tests including the
"Kin's own output is not install evidence" guard.

End-to-end, on the built binary in a hermetic HOME:

| case | Claude registered | CLAUDE.md directive |
|---|---|---|
| no Claude Code present | no | **absent** (was: written) |
| `~/.claude.json` present, CLI off PATH | yes | present |
| `claude` on PATH | yes | present |

`kin setup uninstall` round-trips both new artifacts (`removed mcpServers.kin from
~/.claude.json`, `removed discovery reminder block from ~/.claude/CLAUDE.md`).

Existing clients are unchanged: Cursor's `mcp.json` is **byte-identical** pre-fix vs
post-fix, and identical whether or not Claude Code is configured.

Gate: `cargo fmt --check` exit 0 · `cargo clippy --all-targets --all-features` with the
ci.yml allowlist under `-Dwarnings` exit 0, zero errors · `cargo test -p kin-cli` exit 0
(1131 lib tests + all integration suites) · `kin-core`'s env-mutation guard test passes.

One process note worth recording: an earlier revision of these tests used `#[tokio::test]`
with `EnvVarGuard::set("HOME", …)` held across an `.await`. That passed in isolation and
turned an unrelated `commands::graph` test red in the full parallel run, because `#[serial]`
orders a test only against other serial tests while the rest of the suite reads `$HOME`
concurrently. It was caught by running the full suite with the new tests skipped (green) and
included (red), and fixed by removing the environment mutation entirely rather than by
widening `#[serial]`.

Targets the first train **after v0.4.8** unless the captain lands it sooner. Not enqueued —
queue order is the captain's tonight.

Closes FIR-1878


---
Scope note (captain, post-review): the ticket's third fix direction, a live round-trip of
one MCP tool call per configured agent, needs a running daemon and is deliberately split
out as FIR-1881 rather than silently dropped. Review record:
`.kin-coord/reports/night-20260804-nrev-596.md` (CONDITIONAL-GO; P1-596.1 test sharpened
to the codex-only mirror and falsified against the ungated build, P2-596.2 and P2-596.3
comment and warning text corrected, this note discharges P2-596.4).

