### PR TITLE
Bind fixture Git's global config to a path Git will open

### DIFF
--- a/crates/kin-cli/tests/windows_authority_order.rs
+++ b/crates/kin-cli/tests/windows_authority_order.rs
@@ -127,13 +127,39 @@ fn authority_order_worker() {
             "{key} did not retain its final safe binding"
         );
     }
-    #[cfg(windows)]
-    assert_eq!(std::env::var("GIT_CONFIG_GLOBAL").as_deref(), Ok("NUL"));
     #[cfg(unix)]
     assert_eq!(
         std::env::var("GIT_CONFIG_GLOBAL").as_deref(),
-        Ok("/dev/null")
+        Ok("/dev/null"),
+        "the final scrub did not empty the global Git config scope"
     );
+    // Windows has no path that behaves like `/dev/null` here: `NUL` is a
+    // reserved device name that Git rejects outright, so the scrub must hand
+    // Git a real, readable, empty file instead.
+    #[cfg(not(unix))]
+    {
+        let global = PathBuf::from(
+            std::env::var_os("GIT_CONFIG_GLOBAL")
+                .expect("the final scrub bound a global Git config"),
+        );
+        let metadata = std::fs::metadata(&global).unwrap_or_else(|error| {
+            panic!(
+                "global Git config {} is not a readable path: {error}",
+                global.display()
+            )
+        });
+        assert!(
+            metadata.is_file(),
+            "global Git config {} is not a regular file",
+            global.display()
+        );
+        assert_eq!(
+            metadata.len(),
+            0,
+            "global Git config {} is not empty",
+            global.display()
+        );
+    }
 
     let expected_git_date =
         std::env::var(EXPECTED_GIT_DATE_ENV).expect("expected fixture Git date");

--- a/crates/kin-git/src/test_support.rs
+++ b/crates/kin-git/src/test_support.rs
@@ -445,20 +445,49 @@ pub fn isolate_fixture_git(command: &mut Command) {
         .env("GIT_PAGER", "cat")
         .env("GIT_ALLOW_PROTOCOL", "file")
         .env("GIT_PROTOCOL_FROM_USER", "0")
+        .env("GIT_CONFIG_GLOBAL", empty_global_git_config())
         .env("PATH", host_path)
         .env("KIN_VFS_DISABLE", "1");
-    #[cfg(unix)]
-    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
-    #[cfg(windows)]
-    command.env("GIT_CONFIG_GLOBAL", "NUL");
-    #[cfg(not(any(unix, windows)))]
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        command
-            .get_current_dir()
-            .unwrap_or_else(|| Path::new("."))
-            .join(".kin-test-global-gitconfig"),
-    );
+}
+
+/// Path a fixture binds to `GIT_CONFIG_GLOBAL` so the global scope resolves to
+/// no configuration at all.
+///
+/// `GIT_CONFIG_GLOBAL` replaces the global scope rather than adding to it, so
+/// an empty file is what silences `$HOME/.gitconfig` and its XDG sibling.
+///
+/// Unix names `/dev/null`, which Git opens and reads as that empty file. No
+/// other target has an equivalent path. Windows in particular does not:
+/// `NUL` is a reserved device name rather than a file, and Git refuses it with
+/// `fatal: unable to access 'NUL': Invalid argument`, so every fixture launch
+/// fails instead of being isolated. Git accepts any readable file, so the
+/// remaining targets share one real empty file, created once per test process.
+/// It deliberately lives in its own temporary directory rather than in the
+/// repository under test, where it would otherwise surface as untracked
+/// content in the fixtures this function exists to keep clean.
+#[cfg(unix)]
+fn empty_global_git_config() -> &'static OsStr {
+    OsStr::new("/dev/null")
+}
+
+#[cfg(not(unix))]
+fn empty_global_git_config() -> &'static OsStr {
+    static EMPTY_GLOBAL_GIT_CONFIG: std::sync::OnceLock<std::path::PathBuf> =
+        std::sync::OnceLock::new();
+    EMPTY_GLOBAL_GIT_CONFIG
+        .get_or_init(|| {
+            // Kept past the initializing command instead of being dropped with
+            // it: every later fixture launch in this process reuses the file.
+            let directory = tempfile::Builder::new()
+                .prefix("kin-git-global-config-")
+                .tempdir()
+                .expect("create empty global Git config directory")
+                .keep();
+            let path = directory.join("gitconfig");
+            std::fs::write(&path, b"").expect("write empty global Git config");
+            path
+        })
+        .as_os_str()
 }
 
 /// Environment-only equivalent of [`isolate_fixture_git`] for process-group
@@ -496,7 +525,7 @@ fn isolate_fixture_guardian_environment_with_path(
         .env("GIT_PAGER", "cat")
         .env("GIT_ALLOW_PROTOCOL", "file")
         .env("GIT_PROTOCOL_FROM_USER", "0")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_GLOBAL", empty_global_git_config())
         .env("PATH", host_path)
         .env("KIN_VFS_DISABLE", "1");
 }


### PR DESCRIPTION
## What was wrong

`crates/kin-git/src/test_support.rs` bound `GIT_CONFIG_GLOBAL` to `"NUL"` under
`#[cfg(windows)]`. `NUL` is a reserved Windows device name, not a file, and Git rejects
it as a config path with `fatal: unable to access 'NUL': Invalid argument`. Because
`isolate_fixture_git` is reapplied immediately before every fixture launch, that made
*every* fixture Git command fail on a native Windows host rather than isolating it.

The branch had never executed anywhere. There was no Win32 test host to run it until the
QEMU Windows 11 guest came up on 2026-08-04, and the first run of the suite on a real NT
kernel attributed 8 of its 26 failures to this single line.

## Evidence this is the cause

Falsified **both ways inside the guest**, rather than reasoned about
(`.kin-coord/reports/night-20260804-nutm.md`, "nvm2 CONTINUATION" section, group (A);
gate log `.kin-dev/winvm/windows-check.log`):

```
GIT_CONFIG_GLOBAL=NUL             -> fatal: unable to access 'NUL': Invalid argument
GIT_CONFIG_GLOBAL=C:\empty-file   -> Initialized empty Git repository in C:/gitnultest/.git/
```

Every `kin-core` `git_init::tests` failure in that run carried the identical stderr:

```
git ["init", "--initial-branch=main"] failed
stderr: fatal: unable to access 'NUL': Invalid argument
```

## The fix

The three per-platform literals collapse into one helper, `empty_global_git_config()`:

- Unix keeps `/dev/null`, which Git opens and reads as an empty file.
- Every other target — Windows included — shares one **real empty file**, created once
  per test process. That is the mechanism the pre-existing non-Unix, non-Windows branch
  already reached for; Windows now uses it instead of a device name.

`GIT_CONFIG_GLOBAL` *replaces* the global scope rather than adding to it, so an empty
file is exactly what silences `$HOME/.gitconfig` and its XDG sibling. Isolation strength
is unchanged.

The file deliberately lives in its own temp directory rather than in the repository under
test — the path the old non-Unix branch used. On Windows that branch would now actually
run, and a `.kin-test-global-gitconfig` written into the fixture repo would surface as
untracked content in the very fixtures this function exists to keep clean.

`isolate_fixture_guardian_environment_with_path` stops carrying its own copy of the Unix
literal and calls the same helper, so the two paths cannot drift.

`crates/kin-cli/tests/windows_authority_order.rs` asserted the literal `"NUL"` on Windows
and so would have gone red against the fix. It now asserts the property that actually has
to hold — the bound path is a readable, empty, regular file — instead of pinning a
spelling.

## Verification, and what it does and does not prove

**The Windows branch cannot execute on this macOS host.** Stating that plainly, because
the rest of the local evidence is compile-time and suite-level, not Win32 runtime.

Local, macOS (lane worktree, isolated `CARGO_TARGET_DIR`):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features` under the full ci.yml allowlist with
  `RUSTFLAGS="-D warnings"` — clean, whole workspace
- `cargo test -p kin-git` — **71 passed, 0 failed**
- `cargo test -p kin-core --lib git_init` — **15 passed, 0 failed** (the module whose 8
  Windows failures this closes)
- `cargo test -p kin-cli --test windows_authority_order` — **10 passed, 0 failed**

Windows **compile** evidence, and its own falsification:

- `cargo check -p kin-git --all-targets --target x86_64-pc-windows-msvc` passes, so the
  new `#[cfg(not(unix))]` body genuinely type-checks for Windows.
- That check was falsified before being trusted: a deliberate type error planted inside
  the `#[cfg(not(unix))]` body **fails the Windows target** (`error[E0308]` on that exact
  line) while the **same tree still passes the host target**. So the cross-check really
  does compile the new code, and the macOS build really is blind to it. The probe was
  reverted and the file diffed byte-identical against its pre-probe state.
- `kin-cli` cannot be cross-compiled on this host (`ring`'s C build wants Windows headers
  that are not present), so the new `#[cfg(not(unix))]` block in
  `windows_authority_order.rs` was type-checked by temporarily forcing its cfg on, then
  reverted. It uses only cross-platform `std::fs` APIs.

**Executable Windows evidence comes from CI's Windows job**, plus a re-run of
`bin/kin-dev windows-check` in the guest. The falsifier there is already in the tree and
is not cfg-gated:
`kin_git::test_support::tests::fixture_git_ignores_global_config_attributes_trace_and_format_authority`
launches real Git through the fixture and asserts a hostile `~/.gitconfig` is ignored —
the same launch path the 8 proven failures came through.

## Deliberately not in this PR

The same `NUL` literal appears at **four product-code sites**, outside any `#[cfg(test)]`
module:

- `crates/kin-migrate/src/scanner.rs:184` (`isolate_git_process`)
- `crates/kin-cli/src/commands/bench_meta.rs:719`
- `crates/kin-cli/src/commands/setup.rs:2378`
- `crates/kin-cli/src/commands/eject.rs:688`

By the same falsification, `kin migrate`, `kin bench meta`, `kin setup`, and `kin eject`
would each fail when they shell out to Git on a real Windows host. That is a product
defect of the same class and a strictly larger blast radius than FIR-1883, which is
scoped to test support. It needs its own ticket and its own Windows evidence rather than
being smuggled into a test-only fix. `packages/kin-mcp` carries the literal too
(`test/index.test.js:197`, `test/smoke-first-run.mjs:111`) and should be triaged with it.

No behavior change on Unix: `/dev/null` is bound exactly as before.

Closes FIR-1883
