### PR TITLE
Bind the global Git config to a path that reads empty and refuses writes

### DIFF
--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -712,19 +712,8 @@ fn finalize_bench_git_process_with_ambient(
         .env("GIT_ALLOW_PROTOCOL", "file")
         .env("GIT_PROTOCOL_FROM_USER", "0")
         .env("GIT_NO_REPLACE_OBJECTS", "1")
-        .env("GIT_OPTIONAL_LOCKS", "0");
-    #[cfg(unix)]
-    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
-    #[cfg(windows)]
-    command.env("GIT_CONFIG_GLOBAL", "NUL");
-    #[cfg(not(any(unix, windows)))]
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        command
-            .get_current_dir()
-            .unwrap_or_else(|| Path::new("."))
-            .join(".kin-empty-global-gitconfig"),
-    );
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config());
 }
 
 fn is_bench_git_authority_env(key: &std::ffi::OsStr) -> bool {
@@ -852,6 +841,32 @@ mod tests {
         assert_eq!(
             configured_command_env(&command, "GIT_OPTIONAL_LOCKS"),
             Some(Some(OsString::from("0")))
+        );
+    }
+
+    /// `kin bench meta` shells out to Git through this boundary, so the global
+    /// config it binds has to be a path Git can actually open. Binding the
+    /// reserved Windows device name `NUL` made Git fail with
+    /// `fatal: unable to access 'NUL': Invalid argument` on a real Windows
+    /// host, which failed the meta capture rather than isolating it.
+    #[test]
+    fn bench_git_boundary_binds_an_openable_empty_global_config() {
+        let mut command = Command::new("git");
+        finalize_bench_git_process_with_ambient(
+            &mut command,
+            OsStr::new("trusted-host-path"),
+            std::iter::empty(),
+        );
+
+        let bound = configured_command_env(&command, "GIT_CONFIG_GLOBAL")
+            .flatten()
+            .expect("the bench-meta Git boundary bound a global config");
+        let contents = fs::read(&bound).unwrap_or_else(|error| {
+            panic!("bound global Git config {bound:?} is not readable: {error}")
+        });
+        assert!(
+            contents.is_empty(),
+            "bound global Git config {bound:?} carries configuration"
         );
     }
 

--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -861,12 +861,14 @@ mod tests {
         let bound = configured_command_env(&command, "GIT_CONFIG_GLOBAL")
             .flatten()
             .expect("the bench-meta Git boundary bound a global config");
-        let contents = fs::read(&bound).unwrap_or_else(|error| {
-            panic!("bound global Git config {bound:?} is not readable: {error}")
-        });
+        assert_eq!(
+            bound,
+            kin_git::empty_global_git_config(),
+            "the bench-meta Git boundary stopped routing through the shared helper"
+        );
         assert!(
-            contents.is_empty(),
-            "bound global Git config {bound:?} carries configuration"
+            Path::new(&bound).is_absolute(),
+            "bound global Git config {bound:?} is a bare name, not an absolute path"
         );
     }
 

--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -681,11 +681,8 @@ fn finalize_eject_git_process(command: &mut Command, host_path: &OsStr) {
     command
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_NO_REPLACE_OBJECTS", "1")
-        .env("GIT_OPTIONAL_LOCKS", "0");
-    #[cfg(unix)]
-    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
-    #[cfg(windows)]
-    command.env("GIT_CONFIG_GLOBAL", "NUL");
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config());
 }
 
 fn is_eject_git_process_authority(key: &std::ffi::OsStr) -> bool {
@@ -734,6 +731,30 @@ fn sync_directory(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod git_process_boundary_tests {
     use super::*;
+
+    /// `kin eject` shells out to Git through this boundary, so the global
+    /// config it binds has to be a path Git can actually open. Binding the
+    /// reserved Windows device name `NUL` made Git fail with
+    /// `fatal: unable to access 'NUL': Invalid argument` on a real Windows
+    /// host, which failed the eject proof rather than isolating it.
+    #[test]
+    fn eject_git_boundary_binds_an_openable_empty_global_config() {
+        let mut command = Command::new("git");
+        finalize_eject_git_process(&mut command, OsStr::new("/host/bin"));
+
+        let bound = command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new("GIT_CONFIG_GLOBAL"))
+            .and_then(|(_, value)| value)
+            .expect("the eject Git boundary bound a global config");
+        let contents = fs::read(bound).unwrap_or_else(|error| {
+            panic!("bound global Git config {bound:?} is not readable: {error}")
+        });
+        assert!(
+            contents.is_empty(),
+            "bound global Git config {bound:?} carries configuration"
+        );
+    }
 
     #[test]
     fn eject_git_boundary_scrubs_repository_vfs_and_loader_authority() {

--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -747,12 +747,14 @@ mod git_process_boundary_tests {
             .find(|(key, _)| *key == OsStr::new("GIT_CONFIG_GLOBAL"))
             .and_then(|(_, value)| value)
             .expect("the eject Git boundary bound a global config");
-        let contents = fs::read(bound).unwrap_or_else(|error| {
-            panic!("bound global Git config {bound:?} is not readable: {error}")
-        });
+        assert_eq!(
+            bound,
+            kin_git::empty_global_git_config(),
+            "the eject Git boundary stopped routing through the shared helper"
+        );
         assert!(
-            contents.is_empty(),
-            "bound global Git config {bound:?} carries configuration"
+            Path::new(bound).is_absolute(),
+            "bound global Git config {bound:?} is a bare name, not an absolute path"
         );
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13835,12 +13835,14 @@ mod tests {
         let bound = configured_command_env(&command, "GIT_CONFIG_GLOBAL")
             .flatten()
             .expect("the setup Git boundary bound a global config");
-        let contents = std::fs::read(&bound).unwrap_or_else(|error| {
-            panic!("bound global Git config {bound:?} is not readable: {error}")
-        });
+        assert_eq!(
+            bound,
+            kin_git::empty_global_git_config(),
+            "the setup Git boundary stopped routing through the shared helper"
+        );
         assert!(
-            contents.is_empty(),
-            "bound global Git config {bound:?} carries configuration"
+            Path::new(&bound).is_absolute(),
+            "bound global Git config {bound:?} is a bare name, not an absolute path"
         );
     }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -2507,19 +2507,8 @@ fn finalize_setup_git_authority_process_with_ambient(
         .env("GIT_ALLOW_PROTOCOL", "file")
         .env("GIT_PROTOCOL_FROM_USER", "0")
         .env("GIT_NO_REPLACE_OBJECTS", "1")
-        .env("GIT_OPTIONAL_LOCKS", "0");
-    #[cfg(unix)]
-    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
-    #[cfg(windows)]
-    command.env("GIT_CONFIG_GLOBAL", "NUL");
-    #[cfg(not(any(unix, windows)))]
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        command
-            .get_current_dir()
-            .unwrap_or_else(|| Path::new("."))
-            .join(".kin-empty-global-gitconfig"),
-    );
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config());
 }
 
 fn is_setup_git_authority_env(key: &std::ffi::OsStr) -> bool {
@@ -13826,6 +13815,32 @@ mod tests {
         assert_eq!(
             configured_command_env(&command, "GIT_OPTIONAL_LOCKS"),
             Some(Some(OsString::from("0")))
+        );
+    }
+
+    /// `kin setup` shells out to Git through this boundary, so the global
+    /// config it binds has to be a path Git can actually open. Binding the
+    /// reserved Windows device name `NUL` made Git fail with
+    /// `fatal: unable to access 'NUL': Invalid argument` on a real Windows
+    /// host, which failed setup rather than isolating it.
+    #[test]
+    fn setup_git_boundary_binds_an_openable_empty_global_config() {
+        let mut command = Command::new("git");
+        finalize_setup_git_authority_process_with_ambient(
+            &mut command,
+            OsStr::new("trusted-host-path"),
+            std::iter::empty(),
+        );
+
+        let bound = configured_command_env(&command, "GIT_CONFIG_GLOBAL")
+            .flatten()
+            .expect("the setup Git boundary bound a global config");
+        let contents = std::fs::read(&bound).unwrap_or_else(|error| {
+            panic!("bound global Git config {bound:?} is not readable: {error}")
+        });
+        assert!(
+            contents.is_empty(),
+            "bound global Git config {bound:?} carries configuration"
         );
     }
 

--- a/crates/kin-cli/tests/bench_meta_json.rs
+++ b/crates/kin-cli/tests/bench_meta_json.rs
@@ -8,8 +8,6 @@ mod common;
 
 use common::Command;
 
-const NULL_GIT_CONFIG: &str = if cfg!(windows) { "NUL" } else { "/dev/null" };
-
 #[test]
 fn bench_meta_json_reports_cache_key_dimensions() {
     let repo = tempdir().expect("temp repo");
@@ -17,7 +15,7 @@ fn bench_meta_json_reports_cache_key_dimensions() {
         .arg("bench-meta")
         .arg("--json")
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .current_dir(repo.path())
         .output()
         .expect("run kin bench-meta");
@@ -128,7 +126,7 @@ fn bench_meta_prepared_state_json_reports_repo_specific_cache_keys() {
         .arg("--json")
         .arg("--prepared-state")
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .current_dir(repo.path())
         .output()
         .expect("run kin bench-meta --prepared-state");

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -27,11 +27,6 @@ mod common;
 
 use common::Command;
 
-#[cfg(windows)]
-const NULL_GIT_CONFIG: &str = "NUL";
-#[cfg(not(windows))]
-const NULL_GIT_CONFIG: &str = "/dev/null";
-
 struct IsolatedDaemon {
     child: Option<common::RuntimeOwnedChild>,
 }
@@ -105,7 +100,7 @@ fn run_git(path: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .current_dir(path)
         .output()
         .expect("run git");

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -10,16 +10,11 @@ mod common;
 
 use common::Command;
 
-#[cfg(windows)]
-const NULL_GIT_CONFIG: &str = "NUL";
-#[cfg(not(windows))]
-const NULL_GIT_CONFIG: &str = "/dev/null";
-
 fn run_git(path: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .current_dir(path)
         .output()
         .expect("run git");

--- a/crates/kin-cli/tests/repository_stash.rs
+++ b/crates/kin-cli/tests/repository_stash.rs
@@ -26,16 +26,11 @@ use common::Command;
 /// authority. Sealing is defined over graph-owned changes, so the workspace has
 /// to be dirty in authority before a seal has anything to do.
 const ADMISSION_TIMEOUT: Duration = Duration::from_secs(120);
-#[cfg(windows)]
-const NULL_GIT_CONFIG: &str = "NUL";
-#[cfg(not(windows))]
-const NULL_GIT_CONFIG: &str = "/dev/null";
-
 fn require_git(path: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .current_dir(path)
         .output()
         .expect("run git");
@@ -56,7 +51,7 @@ fn run_kin(
         .kin_command()
         .args(args)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
         .current_dir(repo)
         .output()

--- a/crates/kin-cli/tests/repository_status.rs
+++ b/crates/kin-cli/tests/repository_status.rs
@@ -14,16 +14,11 @@ mod common;
 
 use common::Command;
 
-#[cfg(windows)]
-const NULL_GIT_CONFIG: &str = "NUL";
-#[cfg(not(windows))]
-const NULL_GIT_CONFIG: &str = "/dev/null";
-
 fn run_git(path: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .current_dir(path)
         .output()
         .expect("run git");

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1520,10 +1520,7 @@ mod tests {
         let output = kin_git::test_support::fixture_git_in(repo)
             .args(args)
             .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env(
-                "GIT_CONFIG_GLOBAL",
-                if cfg!(windows) { "NUL" } else { "/dev/null" },
-            )
+            .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
             .output()
             .unwrap_or_else(|error| panic!("run git {args:?}: {error}"));
         assert!(

--- a/crates/kin-git/src/authority.rs
+++ b/crates/kin-git/src/authority.rs
@@ -152,10 +152,7 @@ mod tests {
             .args(args)
             .current_dir(repository)
             .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env(
-                "GIT_CONFIG_GLOBAL",
-                if cfg!(windows) { "NUL" } else { "/dev/null" },
-            )
+            .env("GIT_CONFIG_GLOBAL", crate::empty_global_git_config())
             .output()
             .unwrap();
         assert!(

--- a/crates/kin-git/src/global_config.rs
+++ b/crates/kin-git/src/global_config.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Empty global Git configuration for Kin's Git-process authority boundaries.
+//!
+//! Every Kin surface that shells out to Git binds `GIT_CONFIG_GLOBAL` so the
+//! ambient global configuration scope cannot steer the child. This module owns
+//! the single answer to "what path means no global configuration", because the
+//! answer is not the same on every target and getting it wrong disables Git
+//! entirely rather than degrading isolation.
+
+use std::ffi::OsStr;
+
+/// Path to bind to `GIT_CONFIG_GLOBAL` so Git resolves the global configuration
+/// scope to no configuration at all.
+///
+/// `GIT_CONFIG_GLOBAL` *replaces* the global scope rather than adding to it, so
+/// an empty file is exactly what silences `$HOME/.gitconfig` and its XDG
+/// sibling.
+///
+/// Unix names `/dev/null`, which Git opens and reads as that empty file. No
+/// other target has an equivalent path, and Windows in particular does not:
+/// `NUL` is a reserved device name rather than a file, and Git refuses it with
+/// `fatal: unable to access 'NUL': Invalid argument`. A boundary that bound
+/// `NUL` therefore failed every Git command it was meant to isolate. Git
+/// accepts any readable file, so the remaining targets share one real empty
+/// file, created once per process.
+///
+/// The returned lifetime is deliberately `'static`. Callers mutate a
+/// [`std::process::Command`] and return before that command is spawned, so a
+/// file owned by the calling function would already be unlinked by the time Git
+/// opened it. Tying the file to the process instead removes that failure mode
+/// from the call sites rather than asking each of them to re-derive it.
+///
+/// The file lives in a fresh temporary directory rather than at a predictable
+/// path. Callers are authority boundaries: a path another process can
+/// pre-create is a path it can pre-fill with a hostile global configuration,
+/// which is the exact authority the boundary exists to remove.
+///
+/// Creating that file is the only fallible step, and it fails loudly. Silently
+/// leaving `GIT_CONFIG_GLOBAL` unbound would hand the child the ambient global
+/// scope from inside the function whose whole purpose is to take it away.
+#[cfg(unix)]
+pub fn empty_global_git_config() -> &'static OsStr {
+    OsStr::new("/dev/null")
+}
+
+#[cfg(not(unix))]
+pub fn empty_global_git_config() -> &'static OsStr {
+    use std::path::PathBuf;
+    use std::sync::OnceLock;
+
+    static EMPTY_GLOBAL_GIT_CONFIG: OnceLock<PathBuf> = OnceLock::new();
+    EMPTY_GLOBAL_GIT_CONFIG
+        .get_or_init(|| {
+            // Kept past the command that first asked for it: every later Git
+            // launch in this process reuses the same file.
+            let directory = tempfile::Builder::new()
+                .prefix("kin-empty-global-gitconfig-")
+                .tempdir()
+                .expect("create empty global Git config directory")
+                .keep();
+            let path = directory.join("gitconfig");
+            std::fs::write(&path, b"").expect("write empty global Git config");
+            path
+        })
+        .as_os_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::empty_global_git_config;
+
+    /// The property Git actually needs, asserted on every target: the bound
+    /// path opens and yields no configuration. `NUL` fails this on Windows,
+    /// where it is a device rather than a file, and fails it on every other
+    /// target, where nothing of that name exists at all.
+    #[test]
+    fn bound_path_opens_and_reads_as_empty() {
+        let path = empty_global_git_config();
+        let contents = std::fs::read(path).unwrap_or_else(|error| {
+            panic!("global Git config {path:?} is not a readable path: {error}")
+        });
+        assert!(
+            contents.is_empty(),
+            "global Git config {path:?} carries {} bytes of configuration",
+            contents.len()
+        );
+    }
+
+    /// The path outlives any one command, so repeated boundary applications in
+    /// a process bind the same file rather than racing to recreate it.
+    #[test]
+    fn bound_path_is_stable_within_the_process() {
+        assert_eq!(empty_global_git_config(), empty_global_git_config());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_binds_the_null_device() {
+        assert_eq!(
+            empty_global_git_config(),
+            std::ffi::OsStr::new("/dev/null"),
+            "Unix lost the path Git already reads as an empty config"
+        );
+    }
+
+    /// Off Unix there is no device Git will open, so the bound path has to be a
+    /// real, empty, regular file.
+    #[cfg(not(unix))]
+    #[test]
+    fn non_unix_binds_an_empty_regular_file() {
+        let path = empty_global_git_config();
+        let metadata = std::fs::metadata(path)
+            .unwrap_or_else(|error| panic!("global Git config {path:?} is not a path: {error}"));
+        assert!(
+            metadata.is_file(),
+            "global Git config {path:?} is not a regular file"
+        );
+        assert_eq!(metadata.len(), 0, "global Git config {path:?} is not empty");
+    }
+}

--- a/crates/kin-git/src/global_config.rs
+++ b/crates/kin-git/src/global_config.rs
@@ -32,10 +32,10 @@ use std::ffi::OsStr;
 /// opened it. Tying the file to the process instead removes that failure mode
 /// from the call sites rather than asking each of them to re-derive it.
 ///
-/// The file lives in a fresh temporary directory rather than at a predictable
-/// path. Callers are authority boundaries: a path another process can
-/// pre-create is a path it can pre-fill with a hostile global configuration,
-/// which is the exact authority the boundary exists to remove.
+/// The file is a freshly created temporary rather than a predictable path.
+/// Callers are authority boundaries: a path another process can pre-create is a
+/// path it can pre-fill with a hostile global configuration, which is the exact
+/// authority the boundary exists to remove.
 ///
 /// Creating that file is the only fallible step, and it fails loudly. Silently
 /// leaving `GIT_CONFIG_GLOBAL` unbound would hand the child the ambient global
@@ -53,15 +53,20 @@ pub fn empty_global_git_config() -> &'static OsStr {
     static EMPTY_GLOBAL_GIT_CONFIG: OnceLock<PathBuf> = OnceLock::new();
     EMPTY_GLOBAL_GIT_CONFIG
         .get_or_init(|| {
-            // Kept past the command that first asked for it: every later Git
-            // launch in this process reuses the same file.
-            let directory = tempfile::Builder::new()
+            // `tempfile` creates the file already empty, so the config needs no
+            // write of its own — there is no content to put in it.
+            //
+            // `keep` persists it past the command that first asked for it:
+            // every later Git launch in this process reuses the same file.
+            let (file, path) = tempfile::Builder::new()
                 .prefix("kin-empty-global-gitconfig-")
-                .tempdir()
-                .expect("create empty global Git config directory")
-                .keep();
-            let path = directory.join("gitconfig");
-            std::fs::write(&path, b"").expect("write empty global Git config");
+                .tempfile()
+                .expect("create empty global Git config")
+                .keep()
+                .expect("persist empty global Git config");
+            // Closed before any child is spawned: Windows will not hand Git a
+            // second handle to a file this process still holds open.
+            drop(file);
             path
         })
         .as_os_str()

--- a/crates/kin-git/src/global_config.rs
+++ b/crates/kin-git/src/global_config.rs
@@ -6,8 +6,8 @@
 //! Every Kin surface that shells out to Git binds `GIT_CONFIG_GLOBAL` so the
 //! ambient global configuration scope cannot steer the child. This module owns
 //! the single answer to "what path means no global configuration", because the
-//! answer is not the same on every target and getting it wrong disables Git
-//! entirely rather than degrading isolation.
+//! answer is not the same on every target and getting it wrong either disables
+//! Git entirely or turns a loud failure into a silent one.
 
 use std::ffi::OsStr;
 
@@ -15,31 +15,39 @@ use std::ffi::OsStr;
 /// scope to no configuration at all.
 ///
 /// `GIT_CONFIG_GLOBAL` *replaces* the global scope rather than adding to it, so
-/// an empty file is exactly what silences `$HOME/.gitconfig` and its XDG
-/// sibling.
+/// binding a path Git reads as empty is what silences `$HOME/.gitconfig` and its
+/// XDG sibling.
 ///
-/// Unix names `/dev/null`, which Git opens and reads as that empty file. No
-/// other target has an equivalent path, and Windows in particular does not:
-/// `NUL` is a reserved device name rather than a file, and Git refuses it with
-/// `fatal: unable to access 'NUL': Invalid argument`. A boundary that bound
-/// `NUL` therefore failed every Git command it was meant to isolate. Git
-/// accepts any readable file, so the remaining targets share one real empty
-/// file, created once per process.
+/// Unix names `/dev/null`. It reads as empty, and a `--global` write to it fails
+/// loudly (`error: could not lock config file /dev/null`) rather than being
+/// swallowed.
 ///
-/// The returned lifetime is deliberately `'static`. Callers mutate a
-/// [`std::process::Command`] and return before that command is spawned, so a
-/// file owned by the calling function would already be unlinked by the time Git
-/// opened it. Tying the file to the process instead removes that failure mode
-/// from the call sites rather than asking each of them to re-derive it.
+/// No other target has that path, and Windows in particular does not. `NUL` is a
+/// reserved device name rather than a file; Git refuses it outright with
+/// `fatal: unable to access 'NUL': Invalid argument`, so a boundary that bound
+/// it failed the very Git commands it existed to isolate.
 ///
-/// The file is a freshly created temporary rather than a predictable path.
-/// Callers are authority boundaries: a path another process can pre-create is a
-/// path it can pre-fill with a hostile global configuration, which is the exact
-/// authority the boundary exists to remove.
+/// Off Unix the binding is instead **a path inside a directory that does not
+/// exist**, which reproduces both halves of `/dev/null`'s behavior:
 ///
-/// Creating that file is the only fallible step, and it fails loudly. Silently
-/// leaving `GIT_CONFIG_GLOBAL` unbound would hand the child the ambient global
-/// scope from inside the function whose whole purpose is to take it away.
+/// - Reads are clean. Git tolerates an absent global config and resolves the
+///   scope to nothing, so the ambient global scope is fully suppressed.
+/// - Writes fail loudly. Git cannot create its lockfile beneath a missing
+///   parent, so `git config --global ...` errors instead of silently persisting.
+///
+/// That second half is the reason this is not simply a real empty file. A shared
+/// empty file is *writable*: a stray `--global` write succeeds, persists, and is
+/// then read by every later Git launch in the process, silently poisoning on
+/// Windows the exact isolation this function provides, where Unix would have
+/// failed loudly. Both behaviors were falsified against Git 2.55.0 on a native
+/// Windows 11 ARM64 host, including a control proving the probe could see an
+/// ambient `[user] name` when `GIT_CONFIG_GLOBAL` was unset.
+///
+/// Nothing is created, so this performs no filesystem operation, leaks no
+/// temporary directory, and cannot fail. The path is deterministic; on Windows
+/// `%TEMP%` is per-user, so pre-creating it requires already being that user,
+/// who could edit `$HOME/.gitconfig` directly and gains nothing. Every caller
+/// also binds `GIT_CONFIG_NOSYSTEM=1`.
 #[cfg(unix)]
 pub fn empty_global_git_config() -> &'static OsStr {
     OsStr::new("/dev/null")
@@ -53,21 +61,11 @@ pub fn empty_global_git_config() -> &'static OsStr {
     static EMPTY_GLOBAL_GIT_CONFIG: OnceLock<PathBuf> = OnceLock::new();
     EMPTY_GLOBAL_GIT_CONFIG
         .get_or_init(|| {
-            // `tempfile` creates the file already empty, so the config needs no
-            // write of its own — there is no content to put in it.
-            //
-            // `keep` persists it past the command that first asked for it:
-            // every later Git launch in this process reuses the same file.
-            let (file, path) = tempfile::Builder::new()
-                .prefix("kin-empty-global-gitconfig-")
-                .tempfile()
-                .expect("create empty global Git config")
-                .keep()
-                .expect("persist empty global Git config");
-            // Closed before any child is spawned: Windows will not hand Git a
-            // second handle to a file this process still holds open.
-            drop(file);
-            path
+            // The intermediate directory is deliberately never created: its
+            // absence is what makes a `--global` write fail instead of persist.
+            std::env::temp_dir()
+                .join("kin-absent-global-gitconfig")
+                .join("gitconfig")
         })
         .as_os_str()
 }
@@ -75,53 +73,64 @@ pub fn empty_global_git_config() -> &'static OsStr {
 #[cfg(test)]
 mod tests {
     use super::empty_global_git_config;
+    use std::path::Path;
 
-    /// The property Git actually needs, asserted on every target: the bound
-    /// path opens and yields no configuration. `NUL` fails this on Windows,
-    /// where it is a device rather than a file, and fails it on every other
-    /// target, where nothing of that name exists at all.
+    /// Asserted on every target, and the reason it is worth asserting: `NUL` is
+    /// a bare reserved device name, so it is not absolute anywhere. This single
+    /// property fails against the defect on Unix and Windows alike.
     #[test]
-    fn bound_path_opens_and_reads_as_empty() {
-        let path = empty_global_git_config();
-        let contents = std::fs::read(path).unwrap_or_else(|error| {
-            panic!("global Git config {path:?} is not a readable path: {error}")
-        });
+    fn bound_path_is_absolute() {
+        let path = Path::new(empty_global_git_config());
         assert!(
-            contents.is_empty(),
-            "global Git config {path:?} carries {} bytes of configuration",
-            contents.len()
+            path.is_absolute(),
+            "global Git config {path:?} is not an absolute path, so it is a bare \
+             name Git resolves against its own working directory"
         );
     }
 
-    /// The path outlives any one command, so repeated boundary applications in
-    /// a process bind the same file rather than racing to recreate it.
+    /// The binding outlives any one command, so repeated boundary applications
+    /// in a process agree rather than racing to derive different paths.
     #[test]
     fn bound_path_is_stable_within_the_process() {
         assert_eq!(empty_global_git_config(), empty_global_git_config());
     }
 
+    /// Unix keeps the device Git already reads as an empty config and refuses
+    /// to lock for writing.
     #[cfg(unix)]
     #[test]
     fn unix_binds_the_null_device() {
         assert_eq!(
             empty_global_git_config(),
             std::ffi::OsStr::new("/dev/null"),
-            "Unix lost the path Git already reads as an empty config"
+            "Unix lost the path Git reads as empty and refuses to lock"
         );
+        let contents = std::fs::read("/dev/null").expect("read /dev/null");
+        assert!(contents.is_empty(), "/dev/null did not read as empty");
     }
 
-    /// Off Unix there is no device Git will open, so the bound path has to be a
-    /// real, empty, regular file.
+    /// Off Unix the guarantee is structural: the config path is absent, and so
+    /// is its parent. The absent parent is what makes `git config --global`
+    /// fail to take a lockfile instead of silently persisting.
     #[cfg(not(unix))]
     #[test]
-    fn non_unix_binds_an_empty_regular_file() {
-        let path = empty_global_git_config();
-        let metadata = std::fs::metadata(path)
-            .unwrap_or_else(|error| panic!("global Git config {path:?} is not a path: {error}"));
+    fn non_unix_binds_an_absent_path_under_an_absent_parent() {
+        let path = Path::new(empty_global_git_config());
         assert!(
-            metadata.is_file(),
-            "global Git config {path:?} is not a regular file"
+            !path.exists(),
+            "global Git config {path:?} exists, so Git would read it"
         );
-        assert_eq!(metadata.len(), 0, "global Git config {path:?} is not empty");
+        let parent = path.parent().expect("bound path has a parent directory");
+        assert!(
+            !parent.exists(),
+            "parent {parent:?} exists, so a --global write could create the \
+             config there and silently poison every later Git launch"
+        );
+        assert!(
+            parent
+                .parent()
+                .is_some_and(|grandparent| grandparent == std::env::temp_dir()),
+            "bound path {path:?} is not anchored in the per-user temp directory"
+        );
     }
 }

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -24,6 +24,7 @@ fn kin_process_group_guardian_worker() {
 pub mod admission_history;
 pub mod authority;
 pub mod error;
+pub mod global_config;
 pub mod lossless;
 pub mod preflight;
 pub mod repository_export;
@@ -40,6 +41,7 @@ pub use error::{
     GitCheckoutFilterFact, GitError, LocalGitHookExecutability, LocalGitHookFact, LocalGitHookKind,
     RegisteredGitWorktreeFact, RegisteredGitWorktreeKind, Result, UnsealedContentGap,
 };
+pub use global_config::empty_global_git_config;
 pub use lossless::{
     capture_lossless_git_repository, rehydrate_lossless_git_repository,
     sync_git_repository_for_authority_handoff, GitObjectFormat, GitRehydrationResult,

--- a/crates/kin-index/tests/cross_repo_xref_admission.rs
+++ b/crates/kin-index/tests/cross_repo_xref_admission.rs
@@ -307,10 +307,7 @@ where
         .args(args)
         .current_dir(repo)
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env(
-            "GIT_CONFIG_GLOBAL",
-            if cfg!(windows) { "NUL" } else { "/dev/null" },
-        )
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .env("HOME", repo)
         .output()
         .unwrap()

--- a/crates/kin-migrate/src/scanner.rs
+++ b/crates/kin-migrate/src/scanner.rs
@@ -298,12 +298,14 @@ mod tests {
             .find(|(key, _)| *key == OsStr::new("GIT_CONFIG_GLOBAL"))
             .and_then(|(_, value)| value)
             .expect("the migration Git boundary bound a global config");
-        let contents = std::fs::read(bound).unwrap_or_else(|error| {
-            panic!("bound global Git config {bound:?} is not readable: {error}")
-        });
+        assert_eq!(
+            bound,
+            kin_git::empty_global_git_config(),
+            "the migration Git boundary stopped routing through the shared helper"
+        );
         assert!(
-            contents.is_empty(),
-            "bound global Git config {bound:?} carries configuration"
+            Path::new(bound).is_absolute(),
+            "bound global Git config {bound:?} is a bare name, not an absolute path"
         );
     }
 

--- a/crates/kin-migrate/src/scanner.rs
+++ b/crates/kin-migrate/src/scanner.rs
@@ -12,10 +12,6 @@ use tracing::info;
 use crate::error::{MigrateError, Result};
 use crate::MigrationProcessHost;
 
-#[cfg(windows)]
-const NULL_GIT_CONFIG: &str = "NUL";
-#[cfg(not(windows))]
-const NULL_GIT_CONFIG: &str = "/dev/null";
 const MIGRATION_GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const MIGRATION_GIT_CAPTURE_LIMIT: u64 = 1024 * 1024;
 
@@ -181,7 +177,7 @@ fn isolate_git_process(command: &mut Command, host_path: &OsStr) {
         .env("PATH", host_path)
         .env("KIN_VFS_DISABLE", "1")
         .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", NULL_GIT_CONFIG)
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
         .env("GIT_OPTIONAL_LOCKS", "0")
         .env("GIT_TERMINAL_PROMPT", "0");
 }
@@ -274,10 +270,41 @@ mod tests {
         }
         assert_eq!(
             envs.get("GIT_CONFIG_GLOBAL"),
-            Some(&Some(NULL_GIT_CONFIG.to_string()))
+            Some(&Some(
+                kin_git::empty_global_git_config()
+                    .to_string_lossy()
+                    .into_owned()
+            ))
         );
         assert_eq!(envs.get("KIN_VFS_DISABLE"), Some(&Some("1".to_string())));
         assert!(envs.get("PATH").is_some_and(Option::is_some));
+    }
+
+    /// `kin migrate` shells out to Git through this boundary, so the global
+    /// config it binds has to be a path Git can actually open. Binding the
+    /// reserved Windows device name `NUL` made Git fail with
+    /// `fatal: unable to access 'NUL': Invalid argument` on a real Windows
+    /// host, which failed the scan rather than isolating it.
+    #[test]
+    fn product_git_boundary_binds_an_openable_empty_global_config() {
+        let mut command = Command::new("git");
+        let resolution_cwd = std::env::current_dir().unwrap();
+        let host_path =
+            absolute_host_search_path(kin_core::shims::unshimmed_path(), &resolution_cwd).unwrap();
+        isolate_git_process(&mut command, &host_path);
+
+        let bound = command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new("GIT_CONFIG_GLOBAL"))
+            .and_then(|(_, value)| value)
+            .expect("the migration Git boundary bound a global config");
+        let contents = std::fs::read(bound).unwrap_or_else(|error| {
+            panic!("bound global Git config {bound:?} is not readable: {error}")
+        });
+        assert!(
+            contents.is_empty(),
+            "bound global Git config {bound:?} carries configuration"
+        );
     }
 
     #[cfg(unix)]

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import cp from 'node:child_process';
 import crypto from 'node:crypto';
-import { readFileSync, statSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
@@ -37,22 +37,27 @@ import {
   runGit
 } from './smoke-first-run.mjs';
 
-test('the empty global Git config is a path Git will open on every platform', () => {
+test('the empty global Git config resolves to no configuration on every platform', () => {
   // Off Windows, `/dev/null` is the path Git already reads as an empty config.
   assert.equal(emptyGlobalGitConfig('linux'), os.devNull);
   assert.equal(emptyGlobalGitConfig('darwin'), os.devNull);
 
   // On Windows `os.devNull` is the reserved `NUL` device rather than a file,
-  // and Git refuses it outright, so that branch has to materialize a real one.
+  // and Git refuses it outright, so that branch names a path under an absent
+  // parent: reads resolve to nothing and a `--global` write fails loudly.
   const windows = emptyGlobalGitConfig('win32');
   assert.notEqual(windows, 'NUL');
-  const stats = statSync(windows);
-  assert.equal(stats.isFile(), true, `${windows} is not a regular file`);
-  assert.equal(stats.size, 0, `${windows} is not empty`);
-  assert.equal(readFileSync(windows, 'utf8'), '');
+  assert.equal(path.isAbsolute(windows), true, `${windows} is not absolute`);
+  // Nothing is created: the absent parent is what makes a `--global` write fail
+  // loudly instead of persisting into a file every later Git launch would read.
+  assert.equal(existsSync(windows), false, `${windows} should not exist`);
+  assert.equal(
+    existsSync(path.dirname(windows)),
+    false,
+    `${path.dirname(windows)} should not exist`
+  );
 
-  // The file outlives any single child, so repeated calls reuse it rather than
-  // racing to recreate a path a spawned Git may already have open.
+  // Deterministic, so repeated boundary applications agree.
   assert.equal(emptyGlobalGitConfig('win32'), windows);
 });
 
@@ -217,13 +222,11 @@ test('first-run smoke scrubs mixed-case Windows authority names', () => {
   assert.equal(env.PATH, 'C:\\Git\\cmd;C:\\Windows\\System32');
   // `NUL` is a reserved Windows device, not a file: Git refuses it with
   // `fatal: unable to access 'NUL': Invalid argument` and every isolated Git
-  // command fails. Assert the property Git actually needs — a readable, empty,
-  // regular file — rather than pinning a spelling. Simulating win32 makes the
-  // Windows branch really create that file, so this runs on any host.
-  const globalConfig = statSync(env.GIT_CONFIG_GLOBAL);
-  assert.equal(globalConfig.isFile(), true, `${env.GIT_CONFIG_GLOBAL} is not a regular file`);
-  assert.equal(globalConfig.size, 0, `${env.GIT_CONFIG_GLOBAL} is not empty`);
-  assert.equal(readFileSync(env.GIT_CONFIG_GLOBAL, 'utf8'), '');
+  // command fails. Assert the property Git actually needs rather than pinning a
+  // spelling: an absolute path that resolves to no configuration.
+  assert.notEqual(env.GIT_CONFIG_GLOBAL, 'NUL');
+  assert.equal(path.isAbsolute(env.GIT_CONFIG_GLOBAL), true);
+  assert.equal(env.GIT_CONFIG_GLOBAL, emptyGlobalGitConfig('win32'));
   assert.equal(env.KIN_VFS_DISABLE, '1');
   const inheritedNames = Object.keys(env).map(name => name.toLowerCase());
   for (const name of [

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import cp from 'node:child_process';
 import crypto from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
@@ -30,10 +31,30 @@ test('MCP auto-init boolean accepts the generated env-contract vocabulary', () =
 import {
   absoluteHostPath,
   createSmokeFixtureContext,
+  emptyGlobalGitConfig,
   hermeticSmokeEnv,
   initializeGitFixture,
   runGit
 } from './smoke-first-run.mjs';
+
+test('the empty global Git config is a path Git will open on every platform', () => {
+  // Off Windows, `/dev/null` is the path Git already reads as an empty config.
+  assert.equal(emptyGlobalGitConfig('linux'), os.devNull);
+  assert.equal(emptyGlobalGitConfig('darwin'), os.devNull);
+
+  // On Windows `os.devNull` is the reserved `NUL` device rather than a file,
+  // and Git refuses it outright, so that branch has to materialize a real one.
+  const windows = emptyGlobalGitConfig('win32');
+  assert.notEqual(windows, 'NUL');
+  const stats = statSync(windows);
+  assert.equal(stats.isFile(), true, `${windows} is not a regular file`);
+  assert.equal(stats.size, 0, `${windows} is not empty`);
+  assert.equal(readFileSync(windows, 'utf8'), '');
+
+  // The file outlives any single child, so repeated calls reuse it rather than
+  // racing to recreate a path a spawned Git may already have open.
+  assert.equal(emptyGlobalGitConfig('win32'), windows);
+});
 
 async function exists(filePath) {
   try {
@@ -194,7 +215,15 @@ test('first-run smoke scrubs mixed-case Windows authority names', () => {
 
   assert.equal(env.Safe_Sentinel, 'preserved');
   assert.equal(env.PATH, 'C:\\Git\\cmd;C:\\Windows\\System32');
-  assert.equal(env.GIT_CONFIG_GLOBAL, 'NUL');
+  // `NUL` is a reserved Windows device, not a file: Git refuses it with
+  // `fatal: unable to access 'NUL': Invalid argument` and every isolated Git
+  // command fails. Assert the property Git actually needs — a readable, empty,
+  // regular file — rather than pinning a spelling. Simulating win32 makes the
+  // Windows branch really create that file, so this runs on any host.
+  const globalConfig = statSync(env.GIT_CONFIG_GLOBAL);
+  assert.equal(globalConfig.isFile(), true, `${env.GIT_CONFIG_GLOBAL} is not a regular file`);
+  assert.equal(globalConfig.size, 0, `${env.GIT_CONFIG_GLOBAL} is not empty`);
+  assert.equal(readFileSync(env.GIT_CONFIG_GLOBAL, 'utf8'), '');
   assert.equal(env.KIN_VFS_DISABLE, '1');
   const inheritedNames = Object.keys(env).map(name => name.toLowerCase());
   for (const name of [

--- a/packages/kin-mcp/test/smoke-first-run.mjs
+++ b/packages/kin-mcp/test/smoke-first-run.mjs
@@ -16,7 +16,7 @@
 // binaries and spawns a real daemon, so it runs on demand / in release CI.
 
 import cp from 'node:child_process';
-import { constants as fsConstants, mkdtempSync, writeFileSync } from 'node:fs';
+import { constants as fsConstants } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -93,34 +93,34 @@ export function absoluteHostPath({
     .join(delimiter);
 }
 
-let windowsEmptyGlobalGitConfig = null;
-
 /**
  * Path to bind to `GIT_CONFIG_GLOBAL` so Git resolves the global configuration
  * scope to no configuration at all.
  *
- * Off Windows this is `os.devNull` — `/dev/null`, which Git opens and reads as
- * an empty file. On Windows `os.devNull` is the reserved `NUL` device rather
- * than a file, and Git refuses it with
- * `fatal: unable to access 'NUL': Invalid argument`, failing every Git command
- * the boundary was meant to isolate. Git accepts any readable file, so Windows
- * gets one real empty file instead, created once per process and reused after
- * that so it outlives any single child.
+ * Off Windows this is `os.devNull` - `/dev/null`, which reads as empty and
+ * refuses a `--global` write.
+ *
+ * On Windows `os.devNull` is the reserved `NUL` device rather than a file, and
+ * Git refuses it outright with
+ * `fatal: unable to access 'NUL': Invalid argument`. The binding there is
+ * instead a path inside a directory that is deliberately never created, which
+ * reproduces both halves of `/dev/null`: reads resolve to nothing, and a
+ * `--global` write fails loudly because Git cannot take a lockfile beneath a
+ * missing parent.
+ *
+ * A real empty file would satisfy only the first half. It is writable, so a
+ * stray `--global` write persists and every later Git launch reads it - a
+ * silent poisoning on Windows where Unix fails loudly. Both behaviors were
+ * falsified against Git 2.55.0 on a native Windows 11 ARM64 host.
  *
  * `platform` is a parameter rather than a read of `process.platform` so tests
- * can exercise the Windows branch — and therefore really create and check the
- * file — on any host.
+ * can exercise the Windows branch on any host.
  */
 export function emptyGlobalGitConfig(platform = process.platform) {
   if (platform !== 'win32') {
     return os.devNull;
   }
-  if (windowsEmptyGlobalGitConfig === null) {
-    const directory = mkdtempSync(path.join(os.tmpdir(), 'kin-empty-global-gitconfig-'));
-    windowsEmptyGlobalGitConfig = path.join(directory, 'gitconfig');
-    writeFileSync(windowsEmptyGlobalGitConfig, '');
-  }
-  return windowsEmptyGlobalGitConfig;
+  return path.join(os.tmpdir(), 'kin-absent-global-gitconfig', 'gitconfig');
 }
 
 export function hermeticSmokeEnv({

--- a/packages/kin-mcp/test/smoke-first-run.mjs
+++ b/packages/kin-mcp/test/smoke-first-run.mjs
@@ -16,7 +16,7 @@
 // binaries and spawns a real daemon, so it runs on demand / in release CI.
 
 import cp from 'node:child_process';
-import { constants as fsConstants } from 'node:fs';
+import { constants as fsConstants, mkdtempSync, writeFileSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -93,6 +93,36 @@ export function absoluteHostPath({
     .join(delimiter);
 }
 
+let windowsEmptyGlobalGitConfig = null;
+
+/**
+ * Path to bind to `GIT_CONFIG_GLOBAL` so Git resolves the global configuration
+ * scope to no configuration at all.
+ *
+ * Off Windows this is `os.devNull` — `/dev/null`, which Git opens and reads as
+ * an empty file. On Windows `os.devNull` is the reserved `NUL` device rather
+ * than a file, and Git refuses it with
+ * `fatal: unable to access 'NUL': Invalid argument`, failing every Git command
+ * the boundary was meant to isolate. Git accepts any readable file, so Windows
+ * gets one real empty file instead, created once per process and reused after
+ * that so it outlives any single child.
+ *
+ * `platform` is a parameter rather than a read of `process.platform` so tests
+ * can exercise the Windows branch — and therefore really create and check the
+ * file — on any host.
+ */
+export function emptyGlobalGitConfig(platform = process.platform) {
+  if (platform !== 'win32') {
+    return os.devNull;
+  }
+  if (windowsEmptyGlobalGitConfig === null) {
+    const directory = mkdtempSync(path.join(os.tmpdir(), 'kin-empty-global-gitconfig-'));
+    windowsEmptyGlobalGitConfig = path.join(directory, 'gitconfig');
+    writeFileSync(windowsEmptyGlobalGitConfig, '');
+  }
+  return windowsEmptyGlobalGitConfig;
+}
+
 export function hermeticSmokeEnv({
   sourceEnv = process.env,
   hostPath,
@@ -108,7 +138,7 @@ export function hermeticSmokeEnv({
   }
 
   Object.assign(env, {
-    GIT_CONFIG_GLOBAL: platform === 'win32' ? 'NUL' : os.devNull,
+    GIT_CONFIG_GLOBAL: emptyGlobalGitConfig(platform),
     GIT_CONFIG_NOSYSTEM: '1',
     GIT_ATTR_NOSYSTEM: '1',
     GIT_TERMINAL_PROMPT: '0',

--- a/scripts/prove-windows-npm-first-run.mjs
+++ b/scripts/prove-windows-npm-first-run.mjs
@@ -35,6 +35,7 @@ import {
   resolveCachedBinaryPath,
   resolveDaemonBinaryPath,
 } from '../packages/kin-mcp/src/index.js';
+import { emptyGlobalGitConfig } from '../packages/kin-mcp/test/smoke-first-run.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.dirname(path.dirname(scriptPath));
@@ -172,7 +173,7 @@ function hermeticEnv({ root, managedBinDir }) {
   setEnv(env, 'APPDATA', appData);
   setEnv(env, 'XDG_CONFIG_HOME', xdgConfig);
   setEnv(env, 'XDG_CACHE_HOME', xdgCache);
-  setEnv(env, 'GIT_CONFIG_GLOBAL', process.platform === 'win32' ? 'NUL' : os.devNull);
+  setEnv(env, 'GIT_CONFIG_GLOBAL', emptyGlobalGitConfig());
   setEnv(env, 'GIT_CONFIG_NOSYSTEM', '1');
   setEnv(env, 'GIT_ATTR_NOSYSTEM', '1');
   setEnv(env, 'GIT_TERMINAL_PROMPT', '0');


### PR DESCRIPTION
## What was wrong

Four **product-code** sites bound `GIT_CONFIG_GLOBAL` to the literal `"NUL"` under
`#[cfg(windows)]`, outside any `#[cfg(test)]` boundary:

- `crates/kin-migrate/src/scanner.rs` (`isolate_git_process`)
- `crates/kin-cli/src/commands/bench_meta.rs` (`finalize_bench_git_process_with_ambient`)
- `crates/kin-cli/src/commands/setup.rs` (`finalize_setup_git_authority_process_with_ambient`)
- `crates/kin-cli/src/commands/eject.rs` (`finalize_eject_git_process`)

`NUL` is a reserved Windows device name, not a file. Each of these functions is the *final*
mutation applied immediately before a bounded spawn, so where Git rejects that binding,
every Git command launched by `kin migrate`, `kin bench meta`, `kin setup` and `kin eject`
fails rather than being isolated.

`eject.rs` additionally had only `#[cfg(unix)]` and `#[cfg(windows)]` arms, so on any other
target it bound **nothing at all** and leaked the ambient global scope.

### How much of Windows this actually breaks — stated precisely

Rejection of `NUL` is **environment-dependent**, and the earlier version of this description
overstated it as universal. Both observations are real:

| environment | Git | `GIT_CONFIG_GLOBAL=NUL` |
|---|---|---|
| Windows 11 **ARM64** guest (QEMU, local) | 2.55.0.windows.3 | **rejected** — `fatal: unable to access 'NUL': Invalid argument` |
| GitHub `windows-latest` (**x86_64**) | 2.55.0.windows.3 | **tolerated** — `kin-git authority::tests` passes on `main` while binding it |

So the same Git version string behaves differently across those two hosts, and the honest
claim is "`NUL` is rejected on at least one supported native Windows configuration", not
"always". That is still a product defect worth fixing, and the fix is strictly safer in both
environments, but the blast radius is narrower than first written.

Direct evidence for the ARM64 leg, from this branch running in the guest:

```
require_git -> git ["init"] failed: stderr=fatal: unable to access 'NUL': Invalid argument
```

## The fix

One shared helper, `kin_git::empty_global_git_config() -> &'static OsStr`, in a new
`crates/kin-git/src/global_config.rs`.

- **Unix**: `/dev/null`, unchanged. It reads as empty *and* refuses a `--global` write
  (`error: could not lock config file /dev/null`).
- **Every other target**: a path inside a directory that is **deliberately never created**.

### Why an absent path and not a real empty file

An earlier revision of this PR used a real empty file. That reproduces only half of what
`/dev/null` does. `/dev/null` refuses writes; a shared empty file accepts them, and the
write persists for every later Git launch in the process — a silent poisoning, on Windows,
of the exact isolation these boundaries exist to provide, where unix fails loudly.

Falsified on the native Windows 11 ARM64 host against Git 2.55.0, **with a control** proving
the probe could see an ambient `[user] name` when `GIT_CONFIG_GLOBAL` was unset (without
that control, every "suppressed" row below would be unfalsifiable):

| binding | `git init` | `rev-parse` | ambient `user.name` seen | `git config --global` write |
|---|---|---|---|---|
| **control** — unset | 0 | `true` | `HOSTILE_AMBIENT` | 0 |
| `NUL` | **128** | fatal | fatal | **128** |
| empty regular file | 0 | `true` | *(suppressed)* | **0 — persisted**, file became `[user] name = PROBE_WROTE` |
| **absent directory** | 0 | `true` | *(suppressed)* | **255** — `could not lock config file …: No such file or directory`, and the directory was **not** created |

Creating nothing also means the helper performs **no filesystem operation**. It therefore
leaks no temporary directory, has no fallible step and so no panic path, and needs **no
`scripts/zero-file-search-allowlist.json` exemption** — the allowlist is unmodified in this
PR, and all three guards pass. That removes an entire class of follow-up rather than
declaring an exemption for it.

Determinism is deliberate: on Windows `%TEMP%` is per-user, so pre-creating the path
requires already being that user, who could edit `$HOME/.gitconfig` directly and gains
nothing. Every caller also binds `GIT_CONFIG_NOSYSTEM=1`.

### Why `kin-git`

Every crate carrying the literal — `kin-cli`, `kin-migrate`, `kin-index`, `kin-daemon`, and
`kin-git` itself — **already depends on `kin-git` directly**, so the helper reaches all of
them with **zero new dependency edges** and no cycle. It lives in a normal module rather
than `test_support.rs`, which is gated behind `#[cfg(any(test, feature = "test-support"))]`
and unreachable from product code.

The `'static` return is about the call sites, not about keeping a file alive: every caller
mutates a `Command` and returns *before* that command is spawned, so the binding must not
be scoped to the calling function.

### Also converted

Test helpers carrying the identical literal, all reachable without new dependency edges:
`crates/kin-cli/tests/{repository_status,graph_status_after_admission,init_json,repository_stash,bench_meta_json}.rs`,
`crates/kin-index/tests/cross_repo_xref_admission.rs`, `crates/kin-daemon/src/mcp_commit.rs`
(test module), `crates/kin-git/src/authority.rs` (test module).

**A copy deliberately remains** at `crates/kin-git/src/test_support.rs` — that file is
PR #597's scope and touching it here would guarantee a merge conflict. So this PR does not
convert *every* copy in the tree, and the commit history should not be read as claiming it
does.

Two of the conversions above are **presently inert on Windows**: `authority.rs` and
`mcp_commit.rs` route through `FixtureGitCommand`, whose `prepare_for_launch()` re-applies
`isolate_fixture_git()` and re-binds `GIT_CONFIG_GLOBAL` itself, discarding the caller's
value. They are correct and become effective when #597 lands; they should not be counted as
already-fixed Windows paths.

`packages/kin-mcp` gets the same treatment via one exported `emptyGlobalGitConfig(platform)`,
and `scripts/prove-windows-npm-first-run.mjs` — the Windows npm first-run **proof** — carried
the literal too, so that proof was itself launching Git through a rejected binding.

### Tests assert the property, not the spelling

The universal assertion is that the bound path **is absolute**, which is false for the bare
device name `NUL` on every platform, so it is a real falsifier on Linux and macOS CI too.
Off unix the tests additionally assert the path *and its parent* are absent — the property
that makes a `--global` write fail rather than persist.

This matters because the pre-existing assertions could never have caught the bug: they
compared the bound value against the same `NULL_GIT_CONFIG` constant that produced it.

## Verification

Local, macOS (lane worktree, isolated `CARGO_TARGET_DIR`):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features` under the full ci.yml allowlist with
  `RUSTFLAGS="-D warnings"` — clean workspace-wide
- `python3 scripts/verify-zero-file-search.py`, `bash scripts/zero_file_search_guard.sh`,
  `python3 scripts/falsify-zero-file-search.py .` — **all exit 0, allowlist unmodified**
- `cargo test -p kin-git` — 74 passed / 0 failed
- `cargo test -p kin-migrate` — 50 passed / 0 failed
- `cargo test -p kin-cli --lib` — **1137 passed / 0 failed**
- `packages/kin-mcp`: `npm run lint` clean, `npm test` — 21 passed / 0 failed
- `cargo check -p kin-git --all-targets --target x86_64-pc-windows-msvc` — clean

### Native Windows runtime evidence

`kin-cli` was compiled and run **in the Windows 11 ARM64 guest** against this branch, with
CI's exact flags (`-p kin-cli --no-default-features --lib -- --test-threads=1`). This is the
first time kin-cli has built there at all; the previous ceiling was `-p kin-core --lib`,
because ring's build script needs clang on `aarch64-pc-windows-msvc`.

All three product-boundary tests pass on a real NT kernel:

```
commands::setup::tests::setup_git_boundary_binds_an_openable_empty_global_config ... ok
commands::bench_meta::tests::bench_git_boundary_binds_an_openable_empty_global_config ... ok
commands::eject::git_process_boundary_tests::eject_git_boundary_binds_an_openable_empty_global_config ... ok
```

(That run was against the empty-file revision; 965 passed / 40 failed overall. Of the
failures, six trace to `require_git` → `isolate_fixture_git` → `"NUL"` — i.e. **#597's
defect**, reached before any product code runs — and the rest are pre-existing Windows
failures unrelated to this change, reported separately rather than fixed here.)

## What this does not prove

- **`kin-migrate` and `kin-cli` cannot be cross-compiled on this host.** Confirmed
  firsthand: `ring`'s C build wants absent Windows headers, and `kin-migrate` additionally
  fails the `tree-sitter-*` C builds. Their Windows compile evidence comes from CI.
- **The absent-path design has not yet been exercised by a full in-guest kin-cli run.** Its
  read/write semantics were falsified directly against Git in that guest (table above), and
  the unit tests assert the structural property, but the 965-test run predates it.
- **Two `kin-cli` integration tests were not run locally**: `repository_stash` and
  `graph_status_after_admission` spawn real daemons, and another lane held the fleet
  `daemon` and `gpu` locks throughout. Their conversions are mechanical and type-check.

## Deliberately not in this PR

`crates/kin-git/src/test_support.rs` and `crates/kin-cli/tests/windows_authority_order.rs`
are #597's scope. Whichever of the two lands second should collapse #597's private
`empty_global_git_config` onto this public helper. A reviewer seeing residual red Windows
kin-cli tests on this branch should attribute them to #597's `NUL` binding, not to this PR.

Follow-up, not blocking: `scripts/prove-windows-npm-first-run.mjs` now imports a helper from
`packages/kin-mcp/test/`, which is a proof script reaching into a package's test tree.

No behavior change on Unix: `/dev/null` is bound exactly as before.

Closes FIR-1888
