### PR TITLE
Judge an unreaped daemon corpse dead instead of still running

### DIFF
--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1668,6 +1668,61 @@ mod tests {
         assert!(message.contains("4242"), "{message}");
     }
 
+    /// The reported outcome for a daemon whose parent never reaps it.
+    ///
+    /// This is the shape the install proof hit on every Unix leg: the MCP
+    /// server starts a repo daemon and stays alive, so when the stop request is
+    /// delivered and honoured, the exited daemon lingers as an unreaped corpse.
+    /// `kill(pid, 0)` keeps answering for it, so the wait loop never concluded
+    /// and every identity was reported `timeout` — a stop that worked, reported
+    /// as a stop that failed.
+    ///
+    /// Asserts the outcome the user actually sees rather than the primitive
+    /// beneath it. The wait is deliberately generous: without a corpse-aware
+    /// liveness probe this returns `Timeout` after burning all of it, so the
+    /// test fails on the verdict rather than on being slow.
+    #[cfg(unix)]
+    #[test]
+    fn stopping_a_daemon_whose_parent_never_reaps_it_reports_stopped() {
+        // `exec` so the signalled PID is the process that actually dies, rather
+        // than a shell that leaves an orphan behind.
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exec sleep 30")
+            .spawn()
+            .expect("spawn a stand-in daemon");
+        let identity = process_identity(child.id())
+            .expect("read the stand-in daemon's birth identity")
+            .expect("a running stand-in daemon has an identity");
+
+        let wait = Duration::from_secs(10);
+        #[cfg(target_os = "macos")]
+        let outcome = stop_identity_cooperatively(&identity, wait, |expected| {
+            // Model the cooperative `/shutdown` endpoint accepting the request:
+            // on macOS the daemon is asked over HTTP rather than signalled.
+            let killed = unsafe { libc::kill(expected.pid() as libc::pid_t, libc::SIGTERM) };
+            assert_eq!(
+                killed, 0,
+                "the stand-in daemon must accept the stop request"
+            );
+            Ok(true)
+        });
+        #[cfg(not(target_os = "macos"))]
+        let outcome = stop_identity_graceful(&identity, wait);
+
+        // Nothing waited on the child before the outcome above was decided,
+        // which is the condition under test. Reap afterwards so the corpse does
+        // not outlive the test.
+        let reaped = child.wait();
+        assert_eq!(
+            outcome,
+            StopOutcome::Stopped,
+            "a daemon that honoured the stop request must be reported stopped even when \
+             its parent has not reaped it"
+        );
+        reaped.expect("reap the stand-in daemon");
+    }
+
     #[cfg(windows)]
     #[test]
     fn native_managed_daemon_scan_canonicalizes_and_rejects_traversal() -> Result<()> {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1982,7 +1982,13 @@ fn process_is_unreaped_corpse(pid: libc::pid_t) -> bool {
                 expected as i32,
             )
         };
-        if written == expected as i32 {
+        // `proc_pidinfo` reports failure as a zero return with `errno` set, so
+        // only zero is a result whose `errno` is this call's. A short non-zero
+        // return is undocumented and would leave `errno` holding whatever an
+        // earlier, unrelated call left there — and reading a stale `ESRCH` out
+        // of it would declare a LIVE daemon stopped, which is the one direction
+        // this must never fail in.
+        if written != 0 {
             return false;
         }
         // Permission to inspect is already established by the caller's

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1923,6 +1923,84 @@ impl ProcessLiveness {
     }
 }
 
+/// Whether a Linux `/proc/<pid>/stat` line describes a zombie.
+///
+/// Split out from the probe below, and compiled under `test` on every platform,
+/// so this is not code that only ever builds on one target. Reading the wrong
+/// field is the failure mode that matters: it would answer "not a corpse"
+/// forever, which is exactly the bug being fixed, and it would do so silently.
+#[cfg(any(target_os = "linux", test))]
+fn linux_stat_line_is_zombie(stat: &str) -> bool {
+    // Field 3 is the state character. `comm` (field 2) is parenthesized and may
+    // itself contain spaces and `)`, and it is the only field that can, so the
+    // state is the first whitespace-separated field after `comm`'s FINAL
+    // closing delimiter.
+    stat.rsplit_once(')')
+        .and_then(|(_, rest)| rest.split_whitespace().next())
+        .is_some_and(|state| state == "Z")
+}
+
+/// Has this PID already terminated, with only an unreaped process-table entry
+/// left behind?
+///
+/// `kill(pid, 0)` succeeds against a zombie, so a liveness probe built on the
+/// signal check alone reports a daemon that has already exited as still
+/// running — for as long as whichever process started it stays alive without
+/// waiting on it. That is the ordinary shape of an agent session: the MCP
+/// server starts a repo daemon, keeps running, and never reaps it, so `kin
+/// daemon stop` could watch the corpse for any length of time and never see it
+/// go away.
+///
+/// Reporting a zombie dead is affirmative rather than a guess, and it is
+/// strictly safer than the alternative: the process has terminated, it cannot
+/// execute, it holds no port, and its PID cannot be reused until it is reaped,
+/// so no successor can inherit a decision made here.
+///
+/// Callers must have established same-credential access first (this is only
+/// reached after `kill(pid, 0)` succeeded). Anything short of affirmative
+/// evidence of a corpse answers `false` and leaves the caller's conservative
+/// path intact.
+#[cfg(unix)]
+fn process_is_unreaped_corpse(pid: libc::pid_t) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            return false;
+        };
+        linux_stat_line_is_zombie(&stat)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut info = unsafe { std::mem::zeroed::<libc::proc_bsdinfo>() };
+        let expected = std::mem::size_of::<libc::proc_bsdinfo>();
+        let written = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut _,
+                expected as i32,
+            )
+        };
+        if written == expected as i32 {
+            return false;
+        }
+        // Permission to inspect is already established by the caller's
+        // successful `kill(pid, 0)`, so `ESRCH` here is the kernel reporting
+        // that the process is gone rather than that this caller may not look.
+        // `EPERM` and every other failure stay indeterminate.
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        // No affirmative corpse probe on this platform. Never guess: an
+        // unrecognised Unix keeps the conservative "signalable means alive"
+        // answer it had before.
+        let _ = pid;
+        false
+    }
+}
+
 /// Classify whether a process with the given PID exists.
 pub fn process_liveness(pid: u32) -> ProcessLiveness {
     #[cfg(unix)]
@@ -1931,7 +2009,13 @@ pub fn process_liveness(pid: u32) -> ProcessLiveness {
             return ProcessLiveness::Dead;
         };
         if unsafe { libc::kill(pid, 0) } == 0 {
-            return ProcessLiveness::Alive;
+            // Signalable is not the same as running: an exited child whose
+            // parent has not waited on it still answers `kill(pid, 0)`.
+            return if process_is_unreaped_corpse(pid) {
+                ProcessLiveness::Dead
+            } else {
+                ProcessLiveness::Alive
+            };
         }
         return match std::io::Error::last_os_error().raw_os_error() {
             Some(libc::ESRCH) => ProcessLiveness::Dead,
@@ -9175,6 +9259,154 @@ mod tests {
             "the current process must be observable as alive"
         );
         assert_eq!(process_liveness(std::process::id()), ProcessLiveness::Alive);
+    }
+
+    /// A child that has exited but has not been waited on is a corpse, not a
+    /// running daemon.
+    ///
+    /// This is the exact topology of an agent session: a long-lived MCP server
+    /// starts a repo daemon and never reaps it, so `kill(pid, 0)` keeps
+    /// answering for the daemon after it exits. Judging that "alive" is what
+    /// made `kin daemon stop --all` report `timeout` for a daemon that had
+    /// already stopped, no matter how long it waited.
+    ///
+    /// Deliberately never calls `wait()` before the assertion — reaping is the
+    /// thing whose absence is under test.
+    #[cfg(unix)]
+    #[test]
+    fn a_terminated_child_that_was_never_reaped_is_not_alive() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exit 0")
+            .spawn()
+            .expect("spawn a child that exits immediately");
+        let pid = child.id();
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut liveness = process_liveness(pid);
+        while liveness != ProcessLiveness::Dead && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+            liveness = process_liveness(pid);
+        }
+
+        // Reap before asserting so a failure cannot leak the corpse into the
+        // rest of the test binary, but assert on what was observed while it
+        // was still unreaped.
+        let reaped = child.wait();
+        assert_eq!(
+            liveness,
+            ProcessLiveness::Dead,
+            "an exited child nobody waited on must read as dead, not as a live daemon"
+        );
+        reaped.expect("reap the child");
+    }
+
+    /// The Linux state field is read from the right place.
+    ///
+    /// Runs on every platform: the `/proc` read is Linux-only, but a parser
+    /// that picks the wrong field would report every corpse as still running,
+    /// which is indistinguishable from having no fix at all.
+    #[test]
+    fn linux_stat_state_is_read_after_the_command_name() {
+        assert!(linux_stat_line_is_zombie(
+            "4242 (kin-daemon) Z 4240 4242 0 0 -1 4194560 0 0"
+        ));
+        assert!(!linux_stat_line_is_zombie(
+            "4242 (kin-daemon) S 4240 4242 0 0 -1 4194560 0 0"
+        ));
+        assert!(!linux_stat_line_is_zombie(
+            "4242 (kin-daemon) R 4240 4242 0 0 -1 4194560 0 0"
+        ));
+        // `comm` may contain spaces and its own parentheses, which is why the
+        // FINAL `)` is the delimiter. A naive first-`)` split reads "weird" as
+        // the state and answers "not a zombie" for a real corpse.
+        assert!(linux_stat_line_is_zombie(
+            "4242 (weird ) name) Z 4240 4242 0 0 -1 4194560 0 0"
+        ));
+        assert!(!linux_stat_line_is_zombie(
+            "4242 (weird ) name) S 4240 4242 0 0 -1 4194560 0 0"
+        ));
+        // A truncated or unparseable line is never affirmative evidence.
+        assert!(!linux_stat_line_is_zombie("4242 (kin-daemon)"));
+        assert!(!linux_stat_line_is_zombie(""));
+    }
+
+    /// The corpse probe must not be a blanket "dead": a child that is genuinely
+    /// running has to keep reading alive, or the fix above would turn every
+    /// stop into a false success.
+    #[cfg(unix)]
+    #[test]
+    fn a_running_child_is_still_alive() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exec sleep 30")
+            .spawn()
+            .expect("spawn a long-running child");
+        let pid = child.id();
+
+        std::thread::sleep(Duration::from_millis(250));
+        let liveness = process_liveness(pid);
+        let identity = process_identity(pid);
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(
+            liveness,
+            ProcessLiveness::Alive,
+            "a running child must not be mistaken for a corpse"
+        );
+        assert!(
+            matches!(identity, Ok(Some(_))),
+            "a running child must still have a readable birth identity, got {identity:?}"
+        );
+    }
+
+    /// The stop path decides purely on `process_identity_is_current(..) ==
+    /// Ok(false)`. An unreaped corpse must reach that verdict, otherwise the
+    /// wait loop runs its whole budget and reports `timeout` for a process that
+    /// is already gone.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreaped_corpse_is_not_the_current_incarnation() {
+        // Hold the child open on stdin so its identity can be recorded while it
+        // is unambiguously live. A fabricated identity would compare unequal
+        // for a live process too, which would make this test pass without the
+        // fix — the recorded incarnation has to be the real one.
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("read _; exit 0")
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn a child that waits for stdin");
+        let pid = child.id();
+
+        let identity = process_identity(pid)
+            .expect("read the live child's birth identity")
+            .expect("a running child has an identity");
+        assert!(
+            matches!(process_identity_is_current(&identity), Ok(true)),
+            "control: the recorded identity must be current while the child runs"
+        );
+
+        // Closing stdin ends the child. Nothing waits on it, so it stays in the
+        // process table as a corpse — which is the state under test.
+        drop(child.stdin.take());
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut verdict = process_identity_is_current(&identity);
+        while !matches!(verdict, Ok(false)) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(25));
+            verdict = process_identity_is_current(&identity);
+        }
+
+        let reaped = child.wait();
+        assert!(
+            matches!(verdict, Ok(false)),
+            "an exited, unreaped child must compare as a finished incarnation so the \
+             stop wait can conclude; got {verdict:?}"
+        );
+        reaped.expect("reap the child");
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

Every Unix leg of the v0.4.8 install proof (run `30894704670`, tag `v0.4.8` =
`35ca3f7e`) failed identically at `stopDaemons("between MCP calls")`:

```
Error: between MCP calls: failed to stop installed daemons:
Error: one or more Kin daemons did not stop: kin-install-proof (pid X), supervisor (pid Y)
```

The binary's own verdict, from the uploaded artifact `kin-install-proof/kin-mcp-daemon-stop.txt`
(ubuntu-latest), is the useful part, because the same command succeeds ~30s earlier
in the same step:

```
before MCP startup: status=0
  repo-daemon kin-install-proof pid 2482 -> "stopped"
  supervisor                    pid 2458 -> "stopped"     all_stopped: true

between MCP calls: status=1
  repo-daemon kin-install-proof pid 2668 -> "timeout"
  supervisor                    pid 2644 -> "timeout"     all_stopped: false
```

Same machine, same binary, same repo. The only thing that differs between the two
stops is **who the daemon's parent is**. The first pair was started by an earlier
short-lived `kin` invocation that has since exited, so they were reparented to
init/launchd and reaped the instant they died. The second pair was started by the
**MCP server process, which stays alive for the whole step** (its `kin_daemon_spawn`
lines are in `kin-mcp-err.txt` at 09:37:08.877–09:37:09.142) and never waits on them.

`kin daemon stop` concludes an identity has stopped only when its recorded process
incarnation stops being current, and that rested on `kill(pid, 0)`. **A zombie
answers `kill(pid, 0)`.** So the stop request was delivered and honoured, the daemon
exited, and the command went on watching the corpse until its budget ran out:

- `process_liveness` (`daemon_client.rs:1927`) returned `Alive` for the corpse;
- so `process_identity` never reached its `Ok(None)` early return, and instead
  returned `Err("cannot read birth identity …")` on macOS (`daemon_client.rs:2131`)
  or `Ok(Some(same identity))` on Linux, since `/proc/<pid>/stat` survives a zombie
  with an unchanged `starttime`;
- and `stop_identity_graceful` / `stop_identity_cooperatively` only ever break out
  on `Ok(false)`, so both kept polling to the deadline and returned `Timeout`.

Measured, not inferred. A probe using the exact production libc calls
(`kill(pid, 0)` + `proc_pidinfo(PROC_PIDTBSDINFO)`) against a deliberately unreaped
child on macOS:

| state | `kill(pid,0)` | `proc_pidinfo` |
|---|---|---|
| self / live child | Alive | READABLE |
| pid 1 (live, not ours) | EPERM | EPERM |
| **unreaped corpse** | **Alive** | **ESRCH** |
| reaped | ESRCH | ESRCH |

The only thing separating "stopped" from "timeout" was whether somebody had reaped
the corpse — not whether the daemon had terminated.

The macOS legs discriminate this against the competing explanations. They report
`timeout`, **not** `SignalFailed`. On macOS the stop is a cooperative `POST /shutdown`,
and `stop_identity_cooperatively` returns `SignalFailed` when that POST errors — which
is what a connection-refused against an already-dead daemon produces. `Timeout` is only
reachable when the POST returned **HTTP 2xx**. So the daemon was provably alive,
serving, and *accepting the shutdown request* when asked; it was not already gone, not
wedged beforehand, and not unreachable. It accepted the stop and then stopped being
observable.

### This is not a CI artifact

That is the ordinary shape of an agent session, not a corner case. The MCP server
used by Claude Code / Cursor / Codex starts a repo daemon, keeps running, and never
reaps it. So `kin daemon stop --all` reports failure for daemons it successfully
stopped in the most common agent topology, and `stop_all_for_uninstall` — i.e. `kin
uninstall` — fails the same way.

That last part is not an extrapolation: `stop_all_for_uninstall` (daemon.rs:874) calls
`stop_all_inner(false, true, Some(install_root))`, the same sweep, which bails on
`!all_stopped`.

### Attribution, since #588 was the standing suspect

Not a #588 regression. `git show v0.4.6:.github/workflows/install-proof.yml` has **no
`stopDaemons` and no revival assertion at all** — the mid-MCP stop arrived with
`c512114e` (#582), which also introduced `stop_all_inner`. v0.4.6 passing macos-15-intel
is therefore not evidence this path ever worked; v0.4.6 never exercised it. What #588
changed is the symptom: before it the sweep spent 30s per identity and node's 60s
`spawnSync` killed it (`ETIMEDOUT`, run `30824472582`); after it the sweep returns in
35.25s and prints an honest `timeout`. Same defect, finally legible. The product defect
predates both.

## What changed

One primitive. `process_liveness` now reports an **affirmed** corpse as `Dead`.

- **Linux**: the state field of `/proc/<pid>/stat` is `Z`.
- **macOS**: `proc_pidinfo` answers `ESRCH`. `kill(pid, 0)` has already succeeded at
  that point, so same-credential access is established and `ESRCH` is the kernel
  saying the process is gone rather than that this caller may not look. `EPERM` and
  every other failure stay indeterminate and keep the previous conservative answer.
- **Other Unix / Windows**: unchanged. Windows never had this defect —
  `GetExitCodeProcess` already reports a terminated process as `Dead` with a handle
  open, which is consistent with the Windows leg failing this run on an unrelated
  error (`could not determine home directory`, tracked separately).

This is strictly safer than what it replaces, which is worth being explicit about
given how carefully the surrounding code avoids PID reuse: a zombie has terminated,
it cannot execute, it holds no port, and **its PID cannot be reused until it is
reaped**, so reporting it dead can never redirect a decision onto a successor.

Every consumer was read, not assumed. `process_liveness`/`is_process_alive` has 8
non-test consumer files — supervisor registry pruning and twin detection (×8), lifecycle
owner stamps including `owners().find(is_process_alive)` (×4), session registry (×1),
eject (×1), plus the stop paths. In all of them the real question is "can this process
still serve or still own something?", which a corpse cannot, so each gets more correct
and none gets less safe.

`kin-daemon-spawn` keeps its own private `process_liveness` and is untouched. It does
not need this, and the reason is the crux: `startup_disposition` calls `child.try_wait()`
first, which *reaps*, because that code owns the `Child`. The CLI stop path is a
different process with no handle to wait on — which is exactly why the liveness
primitive, and not the caller, had to learn what a corpse is.

Fixing the primitive fixes each caller in place rather than patching the stop loop:
`process_identity` already answers `Ok(None)` whenever liveness is `Dead` on every
platform, so the stop wait, endpoint-ownership retirement, and the uninstall sweep all
become correct with no change at those sites.

## Red then green

Every test was falsified by neutering `process_is_unreaped_corpse` to `return false`
and rerunning.

`stopping_a_daemon_whose_parent_never_reaps_it_reports_stopped` asserts the outcome a
user actually sees, not the primitive underneath:

- neutered: **FAILED** — `left: Timeout, right: Stopped`, after burning all 10s
- restored: ok, 0.25s

`a_terminated_child_that_was_never_reaped_is_not_alive` and
`an_unreaped_corpse_is_not_the_current_incarnation`:

- neutered: **FAILED** — `left: Alive, right: Dead`, and
  `got Err(Custom { kind: PermissionDenied, error: "cannot read birth identity for
  process 10342" })`, which is the CI failure mechanism reproduced verbatim
- restored: both ok

Two controls exist so the fix cannot degrade into a blanket "dead", which would turn
every stop into a false success. `a_running_child_is_still_alive` and
`process_liveness_recognizes_the_current_process` **passed in both directions**.

`an_unreaped_corpse_is_not_the_current_incarnation` holds its child open on stdin so
the recorded identity is the real one. A fabricated identity compares unequal for a
live process too, so that version of the test passed without the fix — it was written,
observed to be unfalsifiable, and replaced.

`linux_stat_line_is_zombie` is compiled under `test` on every platform and unit-tested
there, so the Linux branch is not code that only ever builds on one target. Its cases
include a `comm` containing both a space and a `)`, because a naive first-`)` split
reads `weird` as the state and answers "not a corpse" forever — silently, which is the
same shape as the bug being fixed.

## Gate

Run in an isolated lane worktree with its own target directory.

- `cargo fmt --all -- --check`: clean
- clippy `--all-targets --all-features` with the ci.yml 45-lint allowlist under
  `RUSTFLAGS=-Dwarnings`: exit 0
- `cargo build --all-targets --all-features` under `RUSTFLAGS=-Dwarnings`: exit 0
- `cargo test -p kin-cli --lib`: **1139 passed, 0 failed**

## Not claiming

Not claiming this greens the install proof. It removes the failure all four Unix legs
actually hit; the Windows leg fails earlier on an unrelated home-directory defect that
is not touched here.

Not claiming a measured before-and-after against install-proof itself. The mechanism is
proven by local falsification in both directions and by the run logs and artifacts, not
by a green proof run.

Not claiming the corpse leak is fixed. The MCP revival path
(`crates/kin-mcp/src/daemon_delegate.rs`) still drops the `Child` without reaping, so a
zombie lingers per revival. That is bounded and separate, and left out deliberately
rather than folded in.

Not claiming the sweep budget is right. `stop_all_budget()` hands the worker
`25.25s - preamble` against a daemon's own 25.25s hard bound, and the supervisor 10s
against the same bound, so an identity that genuinely rides its force-exit escalation is
reported `timeout` by arithmetic. Real, separate, and ticketed rather than fixed here —
the honest repair is to make daemons observably stop, which is what this does.

Refs FIR-1871


---
Review addenda (captain, discharging nrev-600's conditions): the consumer audit table in this
body is incomplete by one: kin-daemon/src/daemon.rs:707 `watched_process_is_alive` is a third,
zombie-blind liveness implementation feeding the orphan-shutdown watchdog at daemon.rs:1113.
It is pre-existing, deliberately untouched by this PR, and now tracked as its own ticket
(unify onto this PR's primitive) because a leaked owner corpse means that watchdog never
fires. Also noting per the review: macos-latest still carries the FIR-1877 embedding-coverage
race independently of this fix, and the empirical sweep behind this PR's safety argument
(685 signalable processes, exactly the four real zombies flagged Dead, zero inversions) is
recorded in night-20260804-nrev-600.md with the probe retained under .kin-coord/reports/nrev600/.
