### PR TITLE
Resolve the Windows home from the profile the environment names

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -14,8 +14,8 @@ use serde_json::Value;
 
 use crate::commands::auth::default_base_url_for_health;
 use crate::commands::setup::{
-    check_binary_in_path, configured_mcp_launcher, detect_shell, hook_filename, kin_dir, shell_rc,
-    shim_filename, CANONICAL_NPM_MCP_COMMAND, CANONICAL_NPM_MCP_PACKAGE,
+    check_binary_in_path, configured_mcp_launcher, detect_shell, home_dir, hook_filename, kin_dir,
+    shell_rc, shim_filename, CANONICAL_NPM_MCP_COMMAND, CANONICAL_NPM_MCP_PACKAGE,
 };
 use crate::daemon_client::{InstalledStartupProtocol, SupervisorStartupSentinel};
 
@@ -877,10 +877,13 @@ struct McpClient {
 }
 
 pub(crate) fn mcp_client_config_paths() -> Vec<(&'static str, &'static str, PathBuf)> {
-    let home = directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf());
-    let home = match home {
-        Some(h) => h,
-        None => return Vec::new(),
+    // Shares `setup::home_dir` deliberately. An unresolvable home here is not an
+    // error any caller sees — it is an empty client list, so setup would report
+    // success having configured nothing. Resolving the home by a stricter rule
+    // than the rest of setup uses is how that silence gets triggered.
+    let home = match home_dir() {
+        Ok(home) => home,
+        Err(_) => return Vec::new(),
     };
     let mut paths = vec![
         (
@@ -1328,7 +1331,7 @@ fn check_setup_ledger() -> HealthCheck {
 }
 
 fn check_editor() -> HealthCheck {
-    let home = directories::BaseDirs::new().map(|d| d.home_dir().to_path_buf());
+    let home = home_dir().ok();
     let extensions_glob = home.as_ref().map(|h| h.join(".vscode").join("extensions"));
 
     let detected = extensions_glob

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -994,10 +994,65 @@ struct SetupPlan {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn home_dir() -> Result<PathBuf> {
-    directories::BaseDirs::new()
-        .map(|d| d.home_dir().to_path_buf())
-        .context("could not determine home directory")
+/// The home directory every setup artifact is written relative to.
+///
+/// `directories::BaseDirs::new()` resolves a Windows home only when
+/// `FOLDERID_Profile`, `FOLDERID_RoamingAppData` **and** `FOLDERID_LocalAppData`
+/// all resolve — each of them existence-verified, because the crate passes
+/// `dwFlags = 0` — and it never reads `USERPROFILE`. A profile root carrying no
+/// `AppData` subtree therefore collapses the whole constructor to `None`, and
+/// setup aborts with "could not determine home directory" before writing
+/// anything. That is not hypothetical: it is exactly how the public install
+/// proof's isolated-home leg fails on `windows-latest`, where the isolated
+/// profile is a bare directory.
+///
+/// So on Windows the profile root the environment explicitly names wins, then
+/// the profile-only known-folder lookup, and the AppData-requiring constructor
+/// is only the last resort. Preferring the explicit name is also what keeps an
+/// isolated home *isolated*: a lookup that answers from the machine's own known
+/// folders would quietly resolve the real profile instead of the override, so a
+/// caller that believed it had redirected the home would be writing to the
+/// user's real one.
+///
+/// Unix is deliberately untouched and stays on `BaseDirs`, which already reads
+/// `HOME` first and falls back to the passwd database.
+pub(crate) fn home_dir() -> Result<PathBuf> {
+    resolve_home_dir(
+        cfg!(windows),
+        |key| env::var_os(key),
+        || directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+        || directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+    )
+    .context("could not determine home directory")
+}
+
+/// The platform-conditional policy behind [`home_dir`], with the platform, the
+/// environment, and both OS lookups taken as arguments.
+///
+/// The Windows arm is a runtime branch rather than a `#[cfg]` block on purpose:
+/// gated behind `cfg`, it would be compiled — and therefore tested — only on
+/// the one platform this fleet has no host for, which is how the defect above
+/// survived to a release proof. As written it is compiled and exercised on
+/// every host, and it reads nothing ambient, so a test states the whole
+/// environment it is asserting against.
+///
+/// `known_profile_root` is the profile-only lookup (`FOLDERID_Profile` on
+/// Windows); `base_dirs_home` is the stricter `BaseDirs` constructor.
+fn resolve_home_dir(
+    windows: bool,
+    var_os: impl Fn(&str) -> Option<OsString>,
+    known_profile_root: impl FnOnce() -> Option<PathBuf>,
+    base_dirs_home: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    if windows {
+        // An empty value is not a home; every Windows tool that reads this
+        // name treats it the same as unset.
+        if let Some(profile) = var_os("USERPROFILE").filter(|value| !value.is_empty()) {
+            return Some(PathBuf::from(profile));
+        }
+        return known_profile_root().or_else(base_dirs_home);
+    }
+    base_dirs_home()
 }
 
 pub(crate) fn kin_dir() -> Result<PathBuf> {
@@ -3125,7 +3180,7 @@ fn current_mcp_repair_targets_excluding_with_topology(
 
     let mut targets = Vec::new();
     let mut paths = crate::commands::health::mcp_client_config_paths();
-    if let Some(home) = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()) {
+    if let Ok(home) = home_dir() {
         paths.push((
             "antigravity",
             "Google Antigravity legacy",
@@ -13771,6 +13826,138 @@ mod tests {
             .get_envs()
             .find(|(candidate, _)| *candidate == OsStr::new(key))
             .map(|(_, value)| value.map(OsStr::to_os_string))
+    }
+
+    /// The install proof's isolated Windows home, verbatim: `USERPROFILE` names
+    /// a directory that exists but carries no `AppData` subtree, so the
+    /// AppData-requiring `BaseDirs` constructor collapses to `None`. That
+    /// `None` used to be the entire answer, and `kin setup` aborted with "could
+    /// not determine home directory" before writing a single artifact.
+    #[test]
+    fn windows_home_resolves_an_isolated_profile_with_no_app_data_subtree() {
+        let isolated = PathBuf::from(r"D:\a\_temp\kin-proof-claude-fallback-home");
+
+        let resolved = resolve_home_dir(
+            true,
+            |key| (key == "USERPROFILE").then(|| isolated.as_os_str().to_os_string()),
+            // Whichever known-folder lookup the bare profile defeats, the
+            // resolution must not depend on it.
+            || None,
+            || None,
+        );
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(isolated.as_path()),
+            "a Windows profile root with no AppData subtree must still resolve"
+        );
+    }
+
+    /// The explicitly named profile beats whatever the machine's own known
+    /// folders report. Losing that ordering does not fail loudly: setup would
+    /// succeed against the real profile while the caller believed it had
+    /// redirected the home, which both writes where it must not and turns the
+    /// isolated leg of the install proof into a test of nothing.
+    #[test]
+    fn windows_home_prefers_the_named_profile_over_the_machine_profile() {
+        let isolated = PathBuf::from(r"D:\a\_temp\kin-proof-claude-fallback-home");
+        let machine = PathBuf::from(r"C:\Users\runneradmin");
+
+        let resolved = resolve_home_dir(
+            true,
+            |key| (key == "USERPROFILE").then(|| isolated.as_os_str().to_os_string()),
+            || Some(machine.clone()),
+            || Some(machine.clone()),
+        );
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(isolated.as_path()),
+            "an explicit USERPROFILE must outrank the machine's known folders"
+        );
+    }
+
+    /// Without a usable `USERPROFILE`, Windows falls through the profile-only
+    /// lookup and only then to the stricter constructor — and still reports
+    /// `None` when nothing resolves, so a genuinely homeless environment keeps
+    /// failing loudly instead of inventing a path.
+    #[test]
+    fn windows_home_falls_through_profile_root_then_base_dirs() {
+        let profile = PathBuf::from(r"C:\Users\runneradmin");
+        let base_dirs = PathBuf::from(r"C:\Users\stricter");
+
+        for unusable in [None, Some(OsString::new())] {
+            let resolved = resolve_home_dir(
+                true,
+                |_| unusable.clone(),
+                || Some(profile.clone()),
+                || Some(base_dirs.clone()),
+            );
+            assert_eq!(
+                resolved.as_deref(),
+                Some(profile.as_path()),
+                "an unset or empty USERPROFILE must fall through to the profile lookup"
+            );
+        }
+
+        assert_eq!(
+            resolve_home_dir(true, |_| None, || None, || Some(base_dirs.clone())).as_deref(),
+            Some(base_dirs.as_path()),
+            "the stricter constructor is still the last resort, not a removed step"
+        );
+        assert_eq!(
+            resolve_home_dir(true, |_| None, || None, || None),
+            None,
+            "no resolvable home must stay an error rather than a guess"
+        );
+    }
+
+    /// Unix keeps exactly the resolution it had — the `BaseDirs` answer
+    /// verbatim, including its `None`. `USERPROFILE` is a Windows name and must
+    /// not become a Unix input, and the profile-only lookup must not run there.
+    #[test]
+    fn unix_home_resolution_is_untouched_by_the_windows_arm() {
+        let base_dirs = PathBuf::from("/Users/runner");
+        let stray = PathBuf::from("/tmp/kin-proof-claude-fallback-home");
+
+        assert_eq!(
+            resolve_home_dir(
+                false,
+                |_| Some(stray.as_os_str().to_os_string()),
+                || Some(stray.clone()),
+                || Some(base_dirs.clone()),
+            )
+            .as_deref(),
+            Some(base_dirs.as_path()),
+            "Unix must ignore both Windows sources"
+        );
+        assert_eq!(
+            resolve_home_dir(
+                false,
+                |_| Some(stray.as_os_str().to_os_string()),
+                || Some(stray.clone()),
+                || None,
+            ),
+            None,
+            "Unix must keep failing exactly where BaseDirs fails"
+        );
+    }
+
+    /// The wiring, not just the policy: on this platform `home_dir` is still
+    /// the `BaseDirs` expression it was before the Windows arm existed.
+    ///
+    /// Both sides read the real environment, so the read is taken inside the
+    /// mutation domain — otherwise a neighbouring test's scoped `HOME` could
+    /// land between the two calls and fail this on a lie.
+    #[cfg(unix)]
+    #[test]
+    fn unix_home_dir_still_resolves_exactly_what_base_dirs_reports() {
+        let _domain = EnvVarGuard::new();
+
+        assert_eq!(
+            home_dir().ok(),
+            directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes FIR-1892

## What fails today

The Public Install Proof's `windows-latest` job dies in step 7, "First-run repository,
daemon, and setup proof":

```
Error: could not determine home directory
##[error]Process completed with exit code 1.
```

The failing command is the **second** `kin setup` in that step — the Claude
fallback-writer sub-proof at `.github/workflows/install-proof.yml:796-811`, which runs
setup with `HOME`/`USERPROFILE` pointed at a bare `$RUNNER_TEMP` directory containing only
`.claude/config.json`. The first `kin setup` in the same step, under the real environment,
passes three seconds earlier.

`shell_rc()` is the first statement of `apply_plan()`, so setup aborts before writing a
single artifact.

## Why

`crates/kin-cli/src/commands/setup.rs:997` resolved the home with
`directories::BaseDirs::new()`. Read against the vendored sources rather than assumed:

- `directories-5.0.1/src/win.rs::base_dirs()` returns `Some` **only** when
  `FOLDERID_Profile`, `FOLDERID_RoamingAppData` **and** `FOLDERID_LocalAppData` all
  resolve — any one `None` collapses the constructor;
- `dirs-sys-0.4.1` calls `SHGetKnownFolderPath(&id, 0, …)`, i.e. `dwFlags = 0`, so
  `KF_FLAG_DONT_VERIFY` is not set and each folder is existence-verified;
- it never reads `USERPROFILE`.

A profile root with no `AppData` subtree therefore cannot resolve. `KIN_HOME` does not
rescue it: `kin_dir()` short-circuits on it, `shell_rc()` does not.

Pre-existing product defect, not a regression — `home_dir()` is byte-identical at v0.4.6
and has used `BaseDirs` since `0d40eef9`. It became visible because `c512114e` (#582)
removed `if: runner.os != 'Windows'` from that step and `68945139` (#585) let steps 5/6
pass so step 7 could finally execute.

**Not the failure:** `registry permission repair is only supported on Unix` in the same
job log comes from `crates/kin-core/src/registry.rs:522` and is the deliberate negative
control that step 6 asserts must fail. Step 6 concluded `success`. Nothing in this PR
touches it — please don't chase that line.

Full diagnosis: `.kin-coord/reports/night-20260804-nstop.md` §7/§9 (nstop lane).

## The fix

`home_dir()` now resolves through a `resolve_home_dir()` policy:

- **Windows:** a non-empty `USERPROFILE` wins; then the profile-**only** known-folder
  lookup (`directories::UserDirs::new()`, which on Windows requires `FOLDERID_Profile`
  alone — `directories-5.0.1/src/win.rs::user_dirs()`); then the AppData-requiring
  `BaseDirs` as a last resort. No resolvable home still fails loudly.
- **Everywhere else:** the old expression, verbatim — `BaseDirs::new()`, including its
  `None`. `BaseDirs` on Unix already reads `HOME` first (`dirs-sys-0.4.1/src/lib.rs:33`),
  so there is nothing to change there, and a test asserts the byte-identity.

Preferring the explicitly named profile is also what keeps an isolated home *isolated*: a
lookup answering from the machine's own known folders would resolve the real profile
instead of the override, so the sub-proof would silently stop testing the writer it exists
to test — and would write into the real user's home.

Applied at both `setup.rs` sites (`home_dir()` and the Antigravity legacy MCP path), plus
`health.rs`'s `mcp_client_config_paths()` and `check_editor()`, which resolved the home by
the same stricter rule. `mcp_client_config_paths()` is in scope on purpose: it is what
turns a home into the Claude config path this sub-proof exercises, it is called *by*
setup, and its failure mode is an **empty client list** — so leaving it behind would have
converted a loud failure into `kin setup` reporting success having configured nothing.

No new dependency and no new `unsafe`: `UserDirs` comes from the `directories = "5"`
kin-cli already pins.

### Why the Windows arm is a runtime branch, not `#[cfg(windows)]`

Behind a `cfg`, the arm would be compiled — and therefore tested — only on the one
platform this fleet has no host for, which is how the original defect reached a release
proof. `resolve_home_dir` takes the platform, the environment reader and both OS lookups
as arguments, so the Windows arm is type-checked **and executed** by the suite on macOS
and Linux, and the tests mutate zero real environment state.

## Falsification

The three Windows tests were run against today's policy (the resolver body temporarily
reverted to the unconditional `BaseDirs` expression) and fail exactly as production does:

```
windows_home_resolves_an_isolated_profile_with_no_app_data_subtree ... FAILED
  left: None                                  <- the production collapse
 right: Some("D:\\a\\_temp\\kin-proof-claude-fallback-home")
windows_home_prefers_the_named_profile_over_the_machine_profile ... FAILED
  left: Some("C:\\Users\\runneradmin")        <- the isolation-fake hazard
windows_home_falls_through_profile_root_then_base_dirs ... FAILED
```

Both Unix tests pass under the old policy *and* the new one — which is the point: they
assert Unix did not move.

## Known next domino (deliberately NOT in this PR)

The fallback `claude` shim at `install-proof.yml:803-804` is written as a `#!/bin/sh`
script with no `.exe`/`.cmd` case, so PATHEXT-based detection will not find it on Windows
once setup gets past the home error. Workflow edits ride separately (proof runs resolve
from tags), so this PR stays product-only.

## Native Windows coverage comes for free on this PR

The `Windows authority tests` leg already runs
`cargo test -p kin-cli --no-default-features --lib windows -- --test-threads=1`
(`ci.yml`, `run_required_filter "kin-cli Windows modules" "windows"`). The three new tests
are named `windows_home_*` and the Unix-identity one is
`unix_home_resolution_is_untouched_by_the_windows_arm`, so **all four are matched by that
filter and execute natively on `windows-latest`** in this PR's own CI — the arm is not
merely compiled for Windows, it is run there, on every PR, permanently.

## CI state on this PR: 21 green, 3 skipped, 1 red — and the red is FIR-1867, not this change

`Windows authority tests` fails on
`commands::setup::tests::native_full_uninstall_runtime_executes_retirement_and_user_path_cleanup`
with `timed out waiting for the native-test deferred-cleanup release`. That is
[FIR-1867](https://linear.app/firelock-ai/issue/FIR-1867), and it is **already red on
`main` at this PR's base commit** — verified by pulling the job log for run
`30892302861` (main @ `35ca3f7e`, job `91936990336`), which fails on the same test with the
same message, and by runs `30891042651` and `30889686912` where it is likewise the only
failing job.

Inside that same job, one step earlier, this PR's own tests ran and passed natively:

```
kin-cli Windows modules: filter 'windows' matched 33 test(s)
test commands::setup::tests::unix_home_resolution_is_untouched_by_the_windows_arm ... ok
test commands::setup::tests::windows_home_falls_through_profile_root_then_base_dirs ... ok
test commands::setup::tests::windows_home_prefers_the_named_profile_over_the_machine_profile ... ok
test commands::setup::tests::windows_home_resolves_an_isolated_profile_with_no_app_data_subtree ... ok
```

Local gate: `cargo fmt --all -- --check`, `cargo test -p kin-cli --lib`
(1139 passed / 0 failed), and `RUSTFLAGS="-D warnings" cargo clippy -p kin-cli
--all-targets --all-features` with `ci.yml`'s allowlist verbatim — all clean. Also run
natively end-to-end on an `aarch64-pc-windows-msvc` guest at this exact commit: 4 passed,
0 failed.
