### PR TITLE
Give the Claude fallback proof a Windows-discoverable agent shim

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -802,8 +802,17 @@ jobs:
           mkdir -p "$claude_fallback_home/.claude"
           mkdir -p "$claude_fallback_bin"
           printf '{}\n' > "$claude_fallback_home/.claude/config.json"
-          printf '#!/bin/sh\nexit 0\n' > "$claude_fallback_bin/claude"
-          chmod +x "$claude_fallback_bin/claude"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # Detection resolves this shim through which-rs, which on Windows
+            # treats a file as executable only when it carries a PATHEXT
+            # extension. An extension-less `#!/bin/sh` script is therefore
+            # invisible to detection here, so use a real .exe as the other
+            # agent shims in this workflow already do.
+            cp "$(command -v kin)" "$claude_fallback_bin/claude.exe"
+          else
+            printf '#!/bin/sh\nexit 0\n' > "$claude_fallback_bin/claude"
+            chmod +x "$claude_fallback_bin/claude"
+          fi
           claude_fallback_path="$claude_fallback_bin:$primary_home/.kin/bin:/usr/bin:/bin"
           HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
           KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \


### PR DESCRIPTION
## What this fixes

The install proof's Claude fallback sub-proof wrote its `claude` agent shim as an
extension-less `#!/bin/sh` script. Agent detection resolves that shim through
`which::which("claude")` (`crates/kin-cli/src/commands/setup.rs:1207`, called at
`:1339`), and which-rs treats a file as executable on Windows only when it carries a
PATHEXT extension. On the Windows leg the shim was therefore invisible, setup wrote no
Claude entry, and the cross-platform validator rejected the artifact.

Windows now gets a real `.exe` shim, exactly as the two surrounding agent-shim blocks
in this workflow already do (`:515-520` and `:737-748`, whose comment states the same
PATHEXT reason). The Unix legs are untouched: the change is inside an
`if [ "$RUNNER_OS" = "Windows" ]` branch and the `else` arm is the byte-identical
`printf` + `chmod` pair that was there before.

## Provenance

Two independent night reviews established this as the next Windows domino, both while
reviewing PR #601 (Windows home resolution):

- `night-20260804-nstop.md` section 9
- `night-20260804-nrev-601.md` finding F-5 and closing note, which recorded that the
  deferred shim domino would fail **loudly** rather than vacuously, because the
  validator asserts a well-formed `mcpServers.kin` entry for
  `kin-claude-fallback-config.json` (`install-proof.yml:1505`, checked at `:1511-1521`).

That loud-failure property is preserved. This PR changes only how the shim is written,
not what is validated.

## Evidence

The mechanism was verified by execution on a real Windows 11 ARM64 guest running Git
for Windows bash (the same bash GitHub Actions uses for `shell: bash`), against
which-rs v8 — the version `crates/kin-cli/Cargo.toml:78` pins:

```
NOTFOUND zzsh (cannot find binary path)     <- extension-less "#!/bin/sh\nexit 0", chmod +x
FOUND    zzcmd  -> ...\zzcmd.cmd
FOUND    zzprobe -> ...\zzprobe.exe
```

Matching source reading: `which-8.0.5/src/checker.rs::is_executable` short-circuits to
`true` only when `path.extension().is_some()` on Windows, otherwise falling through to
a `GetBinaryTypeW`-backed check that a shell script cannot pass;
`finder.rs:239-260` generates the PATHEXT candidates.

`.cmd` would work equally well. `.exe` was chosen so this file carries one convention
rather than two.

Also checked and deliberately **not** changed: `claude_fallback_path` keeps its
`$RUNNER_TEMP`-derived Windows-form element. On the same guest a Windows-form PATH
element resolved correctly through to a native child's Win32 PATH, so it is not a
second defect and churning it would widen this diff for nothing.

## Why it must precede the 0.4.9 bump

The install proof resolves the binaries under test from the release tag, so the tag
carries whatever workflow is on `main` when it is cut. If the mint runs before this
lands, the tag carries the broken shim and the Windows leg fails on a proof that cannot
be repaired without re-cutting.

## Honest limits

- No live `windows-latest` execution before merge. The Windows leg currently fails
  earlier, at "Windows admission contract proof", so no run has ever reached this step;
  the guest reproduces the mechanism, not the runner.
- This PR's own CI does not run the install proof. The v0.4.9 release DAG is the
  executable test.
- Not claiming the Windows leg now passes end to end, only that this specific
  detection failure is removed. PR #601 must land as well.

Refs FIR-1892
