### PR TITLE
Release Kin v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind the global Git config to a path that reads empty and refuses writes (#599)
 - Judge an unreaped daemon corpse dead instead of still running (#600)
 - Resolve the Windows home from the profile the environment names (#601)
+- Give the install proof's fallback agent shim an executable Windows form (#602)
 
 ## [0.4.8] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-08-04
+
+### Changed
+
+- Bind fixture Git's global config to a path Git will open (#597)
+- Bind the global Git config to a path that reads empty and refuses writes (#599)
+- Judge an unreaped daemon corpse dead instead of still running (#600)
+- Resolve the Windows home from the profile the environment names (#601)
+- Give the install proof's fallback agent shim an executable Windows form (#602)
+
 ## [0.4.8] - 2026-08-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind the global Git config to a path that reads empty and refuses writes (#599)
 - Judge an unreaped daemon corpse dead instead of still running (#600)
 - Resolve the Windows home from the profile the environment names (#601)
-- Give the install proof's fallback agent shim an executable Windows form (#602)
 
 ## [0.4.8] - 2026-08-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,14 +3055,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "age",
  "anyhow",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "fs2",
  "libc",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-model",
  "serde",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "async-stream",
  "axum",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -91,7 +91,7 @@ toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
 unicode-ident = "1"
-kin-spine = { version = "0.4.8", path = "../kin-spine" }
+kin-spine = { version = "0.4.9", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-core = { workspace = true, features = ["test-support"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -28,6 +28,13 @@
       "reason": "The public install proof frozen at this tag fails its health gate on three of its four Unix legs: the tagged binary reports shell_path=misconfigured, which is fatal under the proof's own tolerance rule, and the validation leaves orphaned kin-daemon processes behind at cleanup. The daemon-lifecycle repairs landed on main only after the tag, and the proof workflow and binary both resolve from the tag, so no later change to main can reach the failing steps. All three attempts of the cited run failed with the same signature on macos-latest, ubuntu-latest, and ubuntu-24.04-arm, and automatic release recovery exhausted its bounded retries. The GitHub Release object for this tag became the finalized Latest release although no Release run ever succeeded and no terminal completion marker exists, so the prior-stable predicate cannot be satisfied by this lane.",
       "superseded_by": "v0.4.8",
       "failed_release_run_id": "30762349762"
+    },
+    {
+      "tag": "v0.4.8",
+      "sha": "35ca3f7e546ee5e4d27645dd853488849115de9a",
+      "reason": "The install proof frozen at this tag fails on every leg for two pre-existing defects the tag cannot receive fixes for. On the Unix legs, a daemon spawned by the long-lived MCP server is never reaped, and the liveness probe accepts the zombie as alive because kill with signal zero succeeds against a corpse, so a stop that was delivered and honoured is reported as a timeout at the proof's mid-MCP stop step. On the Windows leg, setup resolves the home through a lookup that requires the full profile and AppData tree to exist, so the proof's bare runner-temp home collapses to none before setup can run. Both the proof workflow and the binary resolve from the tag, the repairs landed on main only after it, and automatic release recovery exhausted all three attempts with the same signatures.",
+      "superseded_by": "v0.4.9",
+      "failed_release_run_id": "30894704670"
     }
   ]
 }


### PR DESCRIPTION
Hand-authored release per the selector's burned-version guidance, carrying the v0.4.8 abandonment record and the 0.4.9 lockstep bump in one reviewed change. v0.4.8's lane is unfinishable at the tag: the Unix legs report a stop timeout for stops that succeeded because an unreaped daemon corpse satisfies the liveness probe, and the Windows leg collapses resolving a bare profile home; both repairs (#600, #601) plus the proof shim form (#602) and the NUL config fixes (#597, #599) are on main only. Recovery exhausted three attempts with identical signatures (run 30894704670). Same shape as #591/#595: five lockstep version surfaces, workspace-only lock movement in both lockfiles, the 0.4.9 changelog section, plus the reviewed abandonment record (selector self-tested: reconcile and mint-v0.4.9 anchor v0.3.6, minting v0.4.8 refused, corrupted record refused). Refs FIR-1892, FIR-1889, FIR-1840.