### PR TITLE
Bind the deferred-uninstall wait to the child and wait for its helper to complete

### DIFF
--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -15346,9 +15346,14 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             Duration::from_secs(120),
             || {
                 // A journalled helper error is terminal: the helper writes its
-                // log on the way out, so no later poll can clear it.
+                // log on the way out, so no later poll can clear it. An empty
+                // log is the same journal still being written, so keep polling
+                // rather than reporting a terminal error with no text in it.
                 if success.helper_log.is_file() {
                     let log_content = fs::read_to_string(&success.helper_log).unwrap_or_default();
+                    if log_content.trim().is_empty() {
+                        return WindowsWaitState::Pending;
+                    }
                     return WindowsWaitState::Failed(format!(
                         "the deferred uninstall helper journalled a terminal error to {}:\n{}",
                         success.helper_log.display(),

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -15047,20 +15047,89 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         Ok(())
     }
 
+    /// What a Windows deferred-uninstall poll observed.
+    ///
+    /// `Failed` reports state that can never become `Satisfied`. Polling past it
+    /// only spends the remaining timeout and reprints the same terminal reason.
+    #[cfg(windows)]
+    enum WindowsWaitState {
+        Satisfied,
+        Pending,
+        Failed(String),
+    }
+
     #[cfg(windows)]
     fn wait_for_windows_condition(
         label: &str,
         timeout: Duration,
-        mut condition: impl FnMut() -> bool,
+        mut condition: impl FnMut() -> WindowsWaitState,
     ) -> Result<()> {
         let deadline = std::time::Instant::now() + timeout;
-        while std::time::Instant::now() < deadline {
-            if condition() {
-                return Ok(());
+        loop {
+            match condition() {
+                WindowsWaitState::Satisfied => return Ok(()),
+                WindowsWaitState::Failed(detail) => {
+                    anyhow::bail!("{label} failed before its deadline: {detail}")
+                }
+                WindowsWaitState::Pending => {}
+            }
+            if std::time::Instant::now() >= deadline {
+                anyhow::bail!("timed out waiting for {label}");
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-        anyhow::bail!("timed out waiting for {label}")
+    }
+
+    /// Run a test child that launches the production detached uninstall helper.
+    ///
+    /// The helper outlives the child by design. `Command::output` captures
+    /// through pipes, and `CreateProcess` hands every inheritable handle a
+    /// process holds to the process it spawns, so the child's pipe ends reach
+    /// the helper even though the helper's own stdio is the null device.
+    /// Reading those pipes to end-of-file therefore waits for the helper, not
+    /// for the child, while the helper waits for state this process publishes
+    /// only after the child has been reaped. Capturing into files instead keeps
+    /// the wait bound to the child's own lifetime.
+    #[cfg(windows)]
+    fn run_uninstall_test_child(
+        command: &mut Command,
+        capture_root: &Path,
+        tag: &str,
+    ) -> Result<std::process::Output> {
+        let stdout_path = capture_root.join(format!("{tag}-child-stdout.log"));
+        let stderr_path = capture_root.join(format!("{tag}-child-stderr.log"));
+        let stdout = fs::File::create(&stdout_path).with_context(|| {
+            format!(
+                "failed to create uninstall child stdout capture {}",
+                stdout_path.display()
+            )
+        })?;
+        let stderr = fs::File::create(&stderr_path).with_context(|| {
+            format!(
+                "failed to create uninstall child stderr capture {}",
+                stderr_path.display()
+            )
+        })?;
+        let status = command
+            .stdout(std::process::Stdio::from(stdout))
+            .stderr(std::process::Stdio::from(stderr))
+            .status()
+            .context("failed to run the native Windows uninstall test child")?;
+        Ok(std::process::Output {
+            status,
+            stdout: fs::read(&stdout_path).with_context(|| {
+                format!(
+                    "failed to read uninstall child stdout capture {}",
+                    stdout_path.display()
+                )
+            })?,
+            stderr: fs::read(&stderr_path).with_context(|| {
+                format!(
+                    "failed to read uninstall child stderr capture {}",
+                    stderr_path.display()
+                )
+            })?,
+        })
     }
 
     #[cfg(windows)]
@@ -15087,9 +15156,10 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
                 command.env_remove(WINDOWS_UNINSTALL_HELPER_RELEASE);
             }
         }
-        let output = command
-            .output()
-            .context("failed to launch the native Windows uninstall test child")?;
+        let capture_root = result_path
+            .parent()
+            .context("native uninstall child result path has no parent")?;
+        let output = run_uninstall_test_child(&mut command, capture_root, mode)?;
         if !output.status.success() {
             // If the child failed after launching the production helper, let
             // that helper finish before the caller restores the real User
@@ -15109,7 +15179,13 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
                     wait_for_windows_condition(
                         "failed child uninstall helper to exit before PATH restoration",
                         Duration::from_secs(45),
-                        || !helper_script.exists(),
+                        || {
+                            if helper_script.exists() {
+                                WindowsWaitState::Pending
+                            } else {
+                                WindowsWaitState::Satisfied
+                            }
+                        },
                     )?;
                 }
             }
@@ -15129,7 +15205,8 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
     ) -> Result<String> {
         let test_name =
             "commands::setup::tests::native_full_uninstall_runtime_executes_retirement_and_user_path_cleanup";
-        let output = Command::new(env::current_exe()?)
+        let mut command = Command::new(env::current_exe()?);
+        command
             .args([test_name, "--exact", "--nocapture"])
             .env(
                 WINDOWS_FULL_UNINSTALL_CHILD_MODE,
@@ -15137,9 +15214,12 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             )
             .env(WINDOWS_FULL_UNINSTALL_CHILD_ROOT, root)
             .env(WINDOWS_FULL_UNINSTALL_CHILD_RESULT, result_path)
-            .stdin(std::process::Stdio::null())
-            .output()
-            .context("failed to launch the parent-incarnation mismatch test child")?;
+            .stdin(std::process::Stdio::null());
+        let capture_root = result_path
+            .parent()
+            .context("parent-incarnation mismatch result path has no parent")?;
+        let output =
+            run_uninstall_test_child(&mut command, capture_root, "parent-incarnation-mismatch")?;
         anyhow::ensure!(
             output.status.success(),
             "parent-incarnation mismatch child failed:\nstdout:\n{}\nstderr:\n{}",
@@ -15265,15 +15345,25 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             "successful deferred uninstall",
             Duration::from_secs(120),
             || {
+                // A journalled helper error is terminal: the helper writes its
+                // log on the way out, so no later poll can clear it.
                 if success.helper_log.is_file() {
                     let log_content = fs::read_to_string(&success.helper_log).unwrap_or_default();
-                    eprintln!("deferred uninstall helper logged error:\n{log_content}");
-                    return false;
+                    return WindowsWaitState::Failed(format!(
+                        "the deferred uninstall helper journalled a terminal error to {}:\n{}",
+                        success.helper_log.display(),
+                        log_content.trim_end()
+                    ));
                 }
-                !success.incomplete_marker.exists()
+                if !success.incomplete_marker.exists()
                     && !success.retired.exists()
                     && !success.helper_ready.exists()
                     && !success.helper_ready_publishing.exists()
+                {
+                    WindowsWaitState::Satisfied
+                } else {
+                    WindowsWaitState::Pending
+                }
             },
         )?;
         let post_cleanup_lock = crate::commands::update::InstallRootLock::acquire(&success_root)
@@ -15325,7 +15415,13 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         wait_for_windows_condition(
             "failed deferred uninstall journal",
             Duration::from_secs(120),
-            || failure.helper_log.is_file(),
+            || {
+                if failure.helper_log.is_file() {
+                    WindowsWaitState::Satisfied
+                } else {
+                    WindowsWaitState::Pending
+                }
+            },
         )?;
         anyhow::ensure!(
             !failure.helper_ready.exists(),

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -15355,10 +15355,14 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
                         log_content.trim_end()
                     ));
                 }
+                // The helper removes its own script last, so its absence is what
+                // proves the teardown ran to completion rather than catching the
+                // helper part-way through it.
                 if !success.incomplete_marker.exists()
                     && !success.retired.exists()
                     && !success.helper_ready.exists()
                     && !success.helper_ready_publishing.exists()
+                    && !success.helper_script.exists()
                 {
                     WindowsWaitState::Satisfied
                 } else {
@@ -15416,7 +15420,12 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
             "failed deferred uninstall journal",
             Duration::from_secs(120),
             || {
-                if failure.helper_log.is_file() {
+                // The helper journals its refusal inside `catch` and only then
+                // clears the handshake artifacts in `finally`, removing its own
+                // script last. Waiting for the journal alone would observe the
+                // helper mid-teardown; waiting for the script to disappear
+                // proves the whole teardown ran.
+                if failure.helper_log.is_file() && !failure.helper_script.exists() {
                     WindowsWaitState::Satisfied
                 } else {
                     WindowsWaitState::Pending


### PR DESCRIPTION
`native_full_uninstall_runtime_executes_retirement_and_user_path_cleanup` hung ~434s on windows-latest, on `main`, and in the local QEMU guest, skipping every later step of the `Windows authority tests` job — including the native Windows admission-contract script.

## Root cause

The test driver runs a child process that launches the production detached PowerShell cleanup helper, then publishes the release file that helper polls for. The driver captured the child with `Command::output()`, which reads the child's stdout/stderr **pipes to end-of-file**. `CreateProcess` hands every inheritable handle a process holds to whatever it spawns, so the child's pipe ends reach the helper even though the helper's own stdio is the null device. End-of-file therefore waited on the *helper*, while the helper waited on a release file the driver publishes only after the child is reaped.

Deadlock, broken solely by the helper's 300s release deadline: 300 + the driver's 120s wait ≈ the 430–434s signature seen on all three platforms. Deterministic, not timing-sensitive — which is why raising the deadline (120s → 300s) only made the failure slower.

## Evidence (instrumented run, local QEMU Windows guest)

```
[diag 42ns]            release path written by driver: [C:\...\Temp\.tmpyqeabc\success-helper-release]
[diag 301.741060958s]  success child returned            <-- output() blocked 301.7s
[diag 301.742439958s]  reinstall probe returned          <-- 1.4ms, not the blocker
[diag 301.74268825s]   release file written, exists=true <-- ~2s after the helper had already died
```

During the hang only **one** `kin_cli` process was alive — the spawned child had already exited — while `powershell.exe` (the detached helper) was still running and `output()` had still not returned.

This also falsifies both hypotheses the issue named. The env var reached the helper intact (`release-wait-enter raw=[C:\...\success-helper-release]`), and the path was an ordinary drive-qualified path with nothing `Test-Path -LiteralPath` rejects — the helper's own timeout dump recorded `leaf=False any=False dirExists=True siblings=[handoff-mismatch,success,handoff-mismatch-result.txt,success-result.json]`. The helper never saw the release file because it had not been written yet.

## Fix

1. **Root cause** (`c888984d`). New `run_uninstall_test_child()` captures the child through files under the fixture directory and waits with `.status()`, binding the wait to the child's own lifetime. Applied to both children that launch a helper. Same commit converts `wait_for_windows_condition` from `FnMut() -> bool` to `FnMut() -> WindowsWaitState` (`Satisfied` / `Pending` / `Failed`): the success poll used to read a journalled helper error as "not done yet" and spend the remaining 120s reprinting it (2,282 copies in one CI run); it now fails immediately carrying the helper's own text. The loop also evaluates the condition before checking the deadline.
2. **Race the deadlock was masking** (`8495f6cb`). The helper journals its refusal in `catch` and only then clears the handshake artifacts in `finally`, removing its own script last. The driver treated the journal's appearance as completion and could assert on a ready handshake that was about to be removed. Both waits now require the helper script to be gone. This surfaced the moment the deadlock was fixed and would have become the next flake for whoever fixed it.
3. **Empty-journal read** (`0aa7b7a3`). `Out-File` creates the log then writes it; an empty log is now `Pending` rather than a terminal error with no text.

Test-module changes only; no product code touched.

## Verification (local QEMU Windows guest + macOS)

| Check | Result |
| --- | --- |
| Pre-fix hang reproduced | FAILED in **432.93s**, full mechanism decomposed |
| Post-fix single test at final head | **ok. 1 passed; 0 failed; 30.57s** |
| Abort path, proven by injecting a terminal helper error | FAILED in **13.75s** carrying the helper's message, instead of 120s of repeats |
| `cargo fmt` | clean |
| clippy, ci.yml allowlist, `-D warnings` | clean |
| `cargo test -p kin-cli --lib` (macOS) | **1147 passed; 0 failed** |

432.93s FAILED → 30.57s PASS.

## Follow-up filed: FIR-1903

The same handle-inheritance hazard is live in product code: `kin uninstall --all` spawns the deferred helper, so an inheritable stdout pipe from a calling shell or CI step reaches that helper and stays open until deferred cleanup finishes. `Stdio::null()` does not prevent it; it needs `bInheritHandles = FALSE` or an explicit handle list.

Closes FIR-1867

Review note from the adversarial pass: the Windows authority job still fails after this fix, on a pre-existing spawn-fence defect proven present at origin/main without this diff (PermissionDenied "managed install root identity changed after spawn admission"). That successor blindness is tracked as FIR-1907, so this PR closes only the deadlock itself and does not claim the authority job green.

Refs FIR-1907