### PR TITLE
Free the release mint from advisory flakes and stop blind release retries

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -287,11 +287,15 @@ jobs:
           #
           # Failing STEPS are the primary evidence and the job's own conclusion
           # is deliberately not a filter on them. A job whose leg is cancelled
-          # when a sibling fails still reports its own failed step, and reading
-          # the job conclusion first would drop exactly that step and report a
-          # repeat as two different failures. The job-level fallback exists only
-          # for a job that failed while recording no failing step at all, such
-          # as a runner startup failure, which would otherwise be unreadable.
+          # when a sibling fails can still carry its own failed step, and
+          # reading the job conclusion first would drop exactly that step and
+          # report a repeat as two different failures. That shape did not appear
+          # in the runs this classifier was built from, so treating steps as
+          # primary is hardening rather than the repair; it can only ever find
+          # more evidence than a job-primary read, never less. The job-level
+          # fallback exists only for a job that failed while recording no
+          # failing step at all, such as a runner startup failure, which would
+          # otherwise be unreadable.
           signatures="${RUNNER_TEMP:-/tmp}/release-recovery-signatures"
           : > "$signatures"
           unknown=0
@@ -330,6 +334,13 @@ jobs:
           done
           latest="$(tail -1 "$signatures")"
           previous="$(tail -2 "$signatures" | head -1)"
+          # How many distinct signatures the whole run produced. This is
+          # reported, never acted on: the stop decision is last-two equality,
+          # because that is the earliest point at which a repeat is established.
+          # The two only ever differ on a run that already spent its budget, and
+          # they are kept apart so the alert can state which one it observed
+          # instead of asserting the stronger claim on both.
+          distinct="$(sort -u "$signatures" | wc -l | tr -d '[:space:]')"
           repeated=false
           if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] &&
              [ "$latest" = "$previous" ]; then
@@ -338,8 +349,9 @@ jobs:
           {
             echo "unknown=$unknown"
             echo "repeated=$repeated"
+            echo "distinct=$distinct"
           } >> "$GITHUB_OUTPUT"
-          echo "attempts=$ATTEMPTS unknown=$unknown repeated=$repeated"
+          echo "attempts=$ATTEMPTS unknown=$unknown repeated=$repeated distinct=$distinct"
           echo "latest failing steps: $latest"
 
       - name: Re-run failed jobs
@@ -379,6 +391,7 @@ jobs:
           EXHAUSTED: ${{ steps.resolve.outputs.exhausted }}
           UNKNOWN: ${{ steps.classify.outputs.unknown }}
           REPEATED: ${{ steps.classify.outputs.repeated }}
+          DISTINCT: ${{ steps.classify.outputs.distinct }}
         run: |
           set -euo pipefail
           # Advice given before classification is wrong in the direction that
@@ -412,7 +425,19 @@ jobs:
             advice="At least one attempt could not be read or carried no concrete failed step, so neither a deterministic nor a transient cause is established. Inspect the unrecorded attempts before choosing a same-release rerun or a source-fixed recut."
           elif [ "${REPEATED:-false}" = true ]; then
             verdict="repeated failure signature"
-            advice="Every observed attempt failed in the same job and step set, so another immediate rerun is unlikely to help. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
+            # The stop rule is last-two equality, so a run that reached the end
+            # of its budget is one whose earlier attempts differed: an identical
+            # pair would have stopped it at two. Saying "every attempt" there
+            # would contradict the per-attempt list printed below and send an
+            # operator straight past the differing attempt, which is the
+            # evidence that the cause is not purely deterministic. The stronger
+            # sentence is therefore earned only by an all-attempts count of one,
+            # and an absent or unreadable count takes the narrower claim.
+            if [ "${DISTINCT:-0}" = 1 ]; then
+              advice="Every observed attempt failed in the same job and step set, so another immediate rerun is unlikely to help. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
+            else
+              advice="The two most recent attempts failed in the same job and step set, so another immediate rerun is unlikely to help. Earlier attempts failed differently, which is evidence in its own right that the cause is not purely deterministic, so read the whole per-attempt list below before choosing a remedy. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
+            fi
           else
             verdict="varying failure signatures"
             advice="The observed failing job and step sets differed, which is consistent with the transient shape this controller exists for. Diagnose and rerun the same release rather than cutting a newer version unless the logs identify a source-bound defect."

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -255,10 +255,98 @@ jobs:
           echo "abandoned=true" >> "$GITHUB_OUTPUT"
           echo "::notice::${TAG} at ${SHA} is reconciled by abandonment: ${RECORD} retires it in favour of its recorded successor, so no retry is dispatched, no alert is filed, and this reconcile concludes success."
 
+      # A retry budget spent on a failure that cannot vary is the most
+      # expensive thing this controller can do: three identical ~45-minute
+      # Release attempts confirm what the second one already established, and
+      # every minute of it is release latency. Classification therefore has to
+      # happen BEFORE the next rerun is requested, not only after the budget is
+      # gone. The alert step below already reasoned about the signature, but it
+      # ran only once retries were exhausted, so it could describe a
+      # deterministic failure and never prevent one.
+      #
+      # This step never fails the job. An unreadable attempt must leave the
+      # controller exactly as it was — retrying, because a transient API error
+      # is not evidence that the release failure is deterministic — so every
+      # read is guarded and every unhappy path degrades to "unrecorded", which
+      # the repeat test refuses to count.
+      - name: Classify the failure signature across attempts
+        id: classify
+        if: >-
+          steps.resolve.outputs.needed == 'true' &&
+          steps.record.outputs.abandoned != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.resolve.outputs.run_id }}
+          ATTEMPTS: ${{ steps.resolve.outputs.attempt }}
+        run: |
+          set -euo pipefail
+          # The signature is the whole set of failing job and step pairs for one
+          # attempt, sorted, so a matrix failure whose legs queue in a different
+          # order each time still compares equal.
+          #
+          # Failing STEPS are the primary evidence and the job's own conclusion
+          # is deliberately not a filter on them. A job whose leg is cancelled
+          # when a sibling fails still reports its own failed step, and reading
+          # the job conclusion first would drop exactly that step and report a
+          # repeat as two different failures. The job-level fallback exists only
+          # for a job that failed while recording no failing step at all, such
+          # as a runner startup failure, which would otherwise be unreadable.
+          signatures="${RUNNER_TEMP:-/tmp}/release-recovery-signatures"
+          : > "$signatures"
+          unknown=0
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            signature=""
+            # Pages are slurped and filtered in one pass. `--paginate` with an
+            # inline query applies the query per page, which would emit one line
+            # per page and break the one-line-per-attempt mapping below.
+            if attempt_jobs="$(gh api --paginate --slurp \
+              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs?per_page=100" \
+              2>/dev/null)"; then
+              signature="$(jq -r '
+                [ .[].jobs[] as $job
+                  | $job.steps[]?
+                  | select(.conclusion == "failure")
+                  | "\($job.name) / \(.name)"
+                ] | unique | join("; ")' <<< "$attempt_jobs" 2>/dev/null)" \
+                || signature=""
+              if [ -z "$signature" ]; then
+                signature="$(jq -r '
+                  [ .[].jobs[]
+                    | select(.conclusion == "failure" or .conclusion == "timed_out")
+                    | "\(.name) / <no failing step recorded>"
+                  ] | unique | join("; ")' <<< "$attempt_jobs" 2>/dev/null)" \
+                  || signature=""
+              fi
+            fi
+            if [ -z "$signature" ]; then
+              unknown=$((unknown + 1))
+              # Deliberately constant rather than attempt-numbered, so two
+              # unreadable attempts never compare equal to each other by
+              # accident of text. The unknown count is what rejects them.
+              signature="unrecorded"
+            fi
+            printf '%s\n' "$signature" >> "$signatures"
+          done
+          latest="$(tail -1 "$signatures")"
+          previous="$(tail -2 "$signatures" | head -1)"
+          repeated=false
+          if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] &&
+             [ "$latest" = "$previous" ]; then
+            repeated=true
+          fi
+          {
+            echo "unknown=$unknown"
+            echo "repeated=$repeated"
+          } >> "$GITHUB_OUTPUT"
+          echo "attempts=$ATTEMPTS unknown=$unknown repeated=$repeated"
+          echo "latest failing steps: $latest"
+
       - name: Re-run failed jobs
         if: >-
           steps.resolve.outputs.needed == 'true' &&
           steps.resolve.outputs.retry == 'true' &&
+          steps.classify.outputs.repeated != 'true' &&
           steps.record.outputs.abandoned != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -275,7 +363,10 @@ jobs:
       - name: Alert after automatic retries are exhausted
         if: >-
           steps.resolve.outputs.needed == 'true' &&
-          steps.resolve.outputs.exhausted == 'true' &&
+          (
+            steps.resolve.outputs.exhausted == 'true' ||
+            steps.classify.outputs.repeated == 'true'
+          ) &&
           steps.record.outputs.abandoned != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -285,6 +376,9 @@ jobs:
           RUN_ID: ${{ steps.resolve.outputs.run_id }}
           RUN_URL: ${{ steps.resolve.outputs.url }}
           ATTEMPTS: ${{ steps.resolve.outputs.attempt }}
+          EXHAUSTED: ${{ steps.resolve.outputs.exhausted }}
+          UNKNOWN: ${{ steps.classify.outputs.unknown }}
+          REPEATED: ${{ steps.classify.outputs.repeated }}
         run: |
           set -euo pipefail
           # Advice given before classification is wrong in the direction that
@@ -296,65 +390,40 @@ jobs:
           # diagnosis can establish that root cause.
           #
           # The signature is the whole set of failing job and step pairs per
-          # attempt. It is deliberately not called root-cause proof: step
-          # identity is cheap and needs no log download, but a persistent
-          # registry or notarization outage can repeat at the same step too.
-          # A repeated signature changes the immediate recommendation and tells
-          # the operator where to start; the logs still decide rerun versus recut.
+          # attempt, computed once by the classify step above and read here.
+          # It is deliberately not called root-cause proof: step identity is
+          # cheap and needs no log download, but a persistent registry or
+          # notarization outage can repeat at the same step too. A repeated
+          # signature changes the immediate recommendation and tells the
+          # operator where to start; the logs still decide rerun versus recut.
           #
-          # The set is sorted and joined rather than reduced to its first
-          # element. The jobs API returns jobs in job-id order, ids are minted
-          # at queue time, and parallel matrix legs queue in a different order
-          # on each attempt, so the first failing job of a matrix failure is a
-          # coin flip. Taking it would report three identical failures of the
-          # same step as three different ones and recommend another immediate
-          # rerun without surfacing the repeated shape.
-          #
-          # Pages are slurped and filtered in one pass. `--paginate` with an
-          # inline query applies the query per page, which would emit one line
-          # per page and break the one-line-per-attempt mapping below.
-          signatures="$(mktemp)"
-          unknown=0
-          for attempt in $(seq 1 "$ATTEMPTS"); do
-            if attempt_jobs="$(gh api --paginate --slurp \
-              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${attempt}/jobs?per_page=100" \
-              2>/dev/null)"; then
-              signature="$(jq -r '
-                [ .[].jobs[]
-                  | select(.conclusion == "failure")
-                  | { job: .name,
-                      step: ( .steps[]?
-                              | select(.conclusion == "failure")
-                              | .name ) }
-                  | "\(.job) / \(.step)"
-                ] | unique | join("; ")' <<< "$attempt_jobs" 2>/dev/null)" \
-                || signature=""
-            else
-              signature=""
-            fi
-            if [ -z "$signature" ]; then
-              unknown=$((unknown + 1))
-              # Deliberately constant rather than attempt-numbered. A numbered
-              # placeholder would make unreadable attempts differ from each
-              # other, so the distinct-signature count alone would reject them
-              # and the unknown count below would never be what decided it. The
-              # guard against classifying an unreadable run has to be the one
-              # doing the work, not a spare wheel behind an accident of text.
-              signature="unrecorded"
-            fi
-            printf '%s\n' "$signature" >> "$signatures"
-          done
-          distinct="$(sort -u "$signatures" | wc -l | tr -d ' ')"
-          failing_steps="$(head -1 "$signatures")"
-          if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] && [ "$distinct" -eq 1 ]; then
-            verdict="repeated failure signature"
-            advice="Every observed attempt failed in the same job and step set, so another immediate rerun is unlikely to help. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
-          elif [ "$unknown" -ne 0 ]; then
+          # Classification has exactly one implementation, in the step that acts
+          # on it. Recomputing it here would let the reason this controller
+          # stopped retrying disagree with the reason it reports.
+          signatures="${RUNNER_TEMP:-/tmp}/release-recovery-signatures"
+          if [ ! -s "$signatures" ]; then
+            # Unreachable while classify guards this step, and harmless if that
+            # ever changes: an absent file is not evidence of anything.
+            printf 'unrecorded\n' > "$signatures"
+          fi
+          failing_steps="$(tail -1 "$signatures")"
+          if [ "${UNKNOWN:-1}" -ne 0 ]; then
             verdict="indeterminate"
             advice="At least one attempt could not be read or carried no concrete failed step, so neither a deterministic nor a transient cause is established. Inspect the unrecorded attempts before choosing a same-release rerun or a source-fixed recut."
+          elif [ "${REPEATED:-false}" = true ]; then
+            verdict="repeated failure signature"
+            advice="Every observed attempt failed in the same job and step set, so another immediate rerun is unlikely to help. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
           else
             verdict="varying failure signatures"
             advice="The observed failing job and step sets differed, which is consistent with the transient shape this controller exists for. Diagnose and rerun the same release rather than cutting a newer version unless the logs identify a source-bound defect."
+          fi
+          # Say which of the two stop conditions actually ended the retries. A
+          # repeat stop deliberately leaves retry budget unspent, so reporting
+          # it as exhaustion would misdescribe both the state and the remedy.
+          if [ "${REPEATED:-false}" = true ] && [ "${EXHAUSTED:-true}" != true ]; then
+            opening="$(printf "The automatic release controller stopped retrying \`%s\` at \`%s\` after %s attempt(s): the failing-step signature repeated exactly, so the remaining retry budget would only have bought another identical failure." "$TAG" "$SHA" "$ATTEMPTS")"
+          else
+            opening="$(printf "The automatic release controller exhausted its retries for \`%s\` at \`%s\` after %s attempt(s)." "$TAG" "$SHA" "$ATTEMPTS")"
           fi
 
           # A mint that reported failure on a release it had already created
@@ -384,8 +453,7 @@ jobs:
           if [ -z "$existing" ]; then
             body="$(mktemp)"
             {
-              printf "The automatic release controller exhausted its retries for \`%s\` at \`%s\` after %s attempt(s).\n\n" \
-                "$TAG" "$SHA" "$ATTEMPTS"
+              printf '%s\n\n' "$opening"
               printf 'Release run: %s (id %s)\n\n' "$RUN_URL" "$RUN_ID"
               printf 'Classification: **%s**. %s\n\n' "$verdict" "$advice"
               printf 'Failing step per attempt:\n\n'
@@ -403,5 +471,9 @@ jobs:
               --body-file "$body" \
               >/dev/null
           fi
-          echo "::error::${TAG} exhausted its automatic retries after ${ATTEMPTS} attempt(s), ${verdict}, failing steps: ${failing_steps}: ${RUN_URL}"
+          if [ "${REPEATED:-false}" = true ] && [ "${EXHAUSTED:-true}" != true ]; then
+            echo "::error::${TAG} stopped retrying after ${ATTEMPTS} attempt(s), ${verdict}, repeated failing steps: ${failing_steps}: ${RUN_URL}"
+          else
+            echo "::error::${TAG} exhausted its automatic retries after ${ATTEMPTS} attempt(s), ${verdict}, failing steps: ${failing_steps}: ${RUN_URL}"
+          fi
           exit 1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -138,7 +138,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RAW_TAG: ${{ github.event.client_payload.tag }}
           RAW_SHA: ${{ github.event.client_payload.sha }}
-          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           git fetch origin \
@@ -153,10 +152,16 @@ jobs:
               tag="$RAW_TAG"
               sha="$(printf '%s' "$RAW_SHA" | tr '[:upper:]' '[:lower:]')"
               ;;
-            workflow_run)
-              sha="$WORKFLOW_SHA"
-              ;;
-            schedule)
+            workflow_run|schedule)
+              # Both automatic arms read the same freshly fetched protected
+              # main. A trigger decides only when to look, never which commit to
+              # release, so the event's own head sha is deliberately not an
+              # input here: a rerun of an older CI run carries that run's sha,
+              # which resolves the version main carried then rather than the
+              # version it carries now. Reading main HEAD costs nothing, since
+              # the required-check gate re-derives everything from the resolved
+              # commit anyway, and it denies the event path a stale-candidate
+              # class the scheduled path structurally cannot reach.
               sha="$(git rev-parse refs/remotes/origin/main)"
               ;;
             *)

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -47,12 +47,24 @@ concurrency:
 jobs:
   mint-release-tag:
     name: Mint release tag
+    # Any completed CI run for a main push is an occasion to evaluate a mint,
+    # whatever that run concluded in aggregate. The aggregate conclusion is not
+    # a release verdict and is deliberately not consulted here: a ci.yml run
+    # carries jobs beyond the release-critical ones, so a single non-required
+    # red — an advisory Windows or coverage leg — turns the whole run red and
+    # would silence this trigger on most main pushes, leaving the schedule as
+    # the only automatic path. "Verify required checks are green" below is the
+    # authority. It binds each reviewed required context to its exact workflow
+    # id, path, push event, branch, and head sha, judges that context's own
+    # conclusion, and explicitly refuses to let a producing run's aggregate
+    # conclusion veto through it. This trigger therefore decides only when to
+    # look, never whether the commit is releasable, which is exactly the
+    # division the scheduled path already runs under.
     if: >-
       github.event_name != 'workflow_run' ||
       (
         github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'main' &&
-        github.event.workflow_run.conclusion == 'success'
+        github.event.workflow_run.head_branch == 'main'
       )
     runs-on: ubuntu-latest
     # The automatic path waits for release-critical checks to settle, so the

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -5462,6 +5462,17 @@ def assert_recovery_stops_on_repeated_signature(release_recovery: str) -> None:
     driven by the real jobs API shapes rather than by a stub's canned answer.
     """
 
+    classify_at = release_recovery.index(
+        "      - name: Classify the failure signature across attempts\n"
+    )
+    rerun_at = release_recovery.index("      - name: Re-run failed jobs\n")
+    if classify_at > rerun_at:
+        raise AssertionError(
+            "release recovery must classify the failure signature before it "
+            "requests any rerun, because a rerun issued ahead of the verdict "
+            "is exactly the blind retry this controller exists to prevent"
+        )
+
     source = recovery_step_script(
         release_recovery,
         "      - name: Classify the failure signature across attempts\n",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -4826,6 +4826,7 @@ def execute_recovery_escalation(
                 "EXHAUSTED": "true" if len(attempt_signatures) >= 3 else "false",
                 "UNKNOWN": classifier_outputs.get("unknown", ""),
                 "REPEATED": classifier_outputs.get("repeated", ""),
+                "DISTINCT": classifier_outputs.get("distinct", ""),
             }
         )
         completed = subprocess.run(
@@ -4863,6 +4864,11 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         )
     for needle in (
         "Classification: **repeated failure signature**",
+        # The strongest claim the alert can make, and it is only earned when
+        # every attempt really did produce one signature. Pinning the sentence
+        # itself is what keeps the all-attempts count from being deleted as
+        # redundant to the last-two stop rule it does not duplicate.
+        "Every observed attempt failed in the same job and step set",
         "another immediate rerun is unlikely to help",
         "recut only after confirming a source-bound defect",
         "preserve this tag for a same-release rerun if the cause is external",
@@ -4877,6 +4883,35 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     if "a rerun cannot reach a different outcome" in body:
         raise AssertionError(
             f"step identity was overstated as root-cause proof: {body}"
+        )
+
+    # The only shape that can reach the exhausted alert with a repeat verdict.
+    # The controller stops at two identical attempts, so a run that spent all
+    # three necessarily failed differently first, and the verdict text has to
+    # describe the equality the classifier actually established rather than
+    # claiming every attempt matched. Claiming it would contradict the
+    # per-attempt list three lines below it and send an operator past attempt 1,
+    # which is the evidence that the cause is not purely deterministic.
+    _, tail_repeat_body = execute_recovery_escalation(
+        release_recovery,
+        [("publish", "Push image"), compile_failure, compile_failure],
+    )
+    for needle in (
+        "Classification: **repeated failure signature**",
+        "The two most recent attempts failed in the same job and step set",
+        "Earlier attempts failed differently",
+        "- attempt 1: publish / Push image",
+        "- attempt 3: build-artifacts (x86_64-unknown-linux-musl) / Build release binaries",
+    ):
+        if needle not in tail_repeat_body:
+            raise AssertionError(
+                "a repeat established only across the last two attempts was not "
+                f"reported as one: {needle!r}: {tail_repeat_body}"
+            )
+    if "Every observed attempt failed in the same job and step set" in tail_repeat_body:
+        raise AssertionError(
+            "the alert claimed every attempt failed identically while its own "
+            f"per-attempt list shows attempt 1 differing: {tail_repeat_body}"
         )
 
     # The stop that spends one confirmation instead of the whole budget. The
@@ -5392,6 +5427,30 @@ def assert_mint_trigger_survives_advisory_flakes(release_tag: str) -> None:
                 f"reviewed default-branch push it evaluates: {clause}"
             )
 
+    # A widened trigger must not widen what the mint may release. The event's
+    # own head sha is the only stale-capable input into the candidate: a rerun
+    # of an older CI run carries the sha main held then, so resolving from it
+    # selects the version of that moment rather than the version main carries
+    # now, which is a class the scheduled arm structurally cannot reach. Both
+    # automatic arms therefore read one freshly fetched protected main, and the
+    # trigger stays a decision about when to look.
+    resolve = workflow_step_source(
+        "release-tag",
+        release_tag,
+        "      - name: Resolve exact coherent release commit\n",
+    )
+    if "workflow_run.head_sha" in resolve:
+        raise AssertionError(
+            "the release mint must not resolve its release candidate from the "
+            "triggering CI run's head sha, because a rerun of an older run "
+            "carries a stale one and the trigger decides only when to look"
+        )
+    if 'sha="$(git rev-parse refs/remotes/origin/main)"' not in resolve:
+        raise AssertionError(
+            "the release mint's automatic path must resolve its candidate from "
+            "the freshly fetched protected main it just verified"
+        )
+
 
 def assert_recovery_stops_on_repeated_signature(release_recovery: str) -> None:
     """A deterministic failure must cost one confirmation, not the whole budget.
@@ -5423,6 +5482,26 @@ def assert_recovery_stops_on_repeated_signature(release_recovery: str) -> None:
             f"a differing second failure was reported as deterministic: {outputs}"
         )
 
+    # The stop rule is last-two equality, not all-attempts equality, and the two
+    # are only distinguishable on this shape. A failure that reproduces after a
+    # differing first attempt still has to stop, because the budget it would
+    # spend buys another identical failure. The all-attempts count is reported
+    # beside it rather than deciding it, so the alert can say which of the two
+    # it observed instead of asserting the stronger one either way.
+    outputs = execute_recovery_classifier(
+        source, [notarize, compile_failure, compile_failure]
+    )
+    if outputs.get("repeated") != "true":
+        raise AssertionError(
+            "a failure that reproduced after a differing first attempt was not "
+            f"read as a repeat: {outputs}"
+        )
+    if outputs.get("distinct") != "2":
+        raise AssertionError(
+            "the all-attempts signature count did not observe the differing "
+            f"first attempt: {outputs}"
+        )
+
     # One attempt cannot repeat anything. Stopping here would retire a release
     # on its first failure and defeat the controller's entire purpose.
     outputs = execute_recovery_classifier(source, [compile_failure])
@@ -5444,11 +5523,14 @@ def assert_recovery_stops_on_repeated_signature(release_recovery: str) -> None:
             f"the retries: {outputs}"
         )
 
-    # The shape that produced the wrong answer in production: when one matrix
-    # leg fails, its siblings are cancelled, and a cancelled job still carries
-    # the step that actually failed. Filtering on the job's own conclusion
-    # first drops exactly that evidence and reads a repeat as two unreadable
-    # attempts, which retries a deterministic failure to the end of the budget.
+    # A shape GitHub can produce, hardened against rather than observed here:
+    # when one matrix leg fails its siblings can be cancelled, and a cancelled
+    # job still carries the step that actually failed. Filtering on the job's
+    # own conclusion first drops exactly that evidence and reads a repeat as two
+    # unreadable attempts, which retries a deterministic failure to the end of
+    # the budget. The runs this classifier was built from carried no cancelled
+    # job at all, so a step-primary read is defence and not the repair: what
+    # cost three attempts there was classifying only once the budget was gone.
     cancelled = ("build-artifacts (aarch64-unknown-linux-musl)", "Build release binaries", "cancelled")
     outputs = execute_recovery_classifier(source, [cancelled, cancelled])
     if outputs.get("repeated") != "true":

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -4523,13 +4523,12 @@ def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
                 )
 
 
-def recovery_escalation_source(release_recovery: str) -> str:
-    """Extract the escalation step exactly as the recovery controller runs it."""
+def recovery_step_script(release_recovery: str, anchor: str) -> str:
+    """Extract a recovery step's script exactly as the controller runs it."""
 
-    anchor = "      - name: Alert after automatic retries are exhausted\n"
     if anchor not in release_recovery:
         raise AssertionError(
-            "release-recovery no longer carries the escalation step"
+            f"release-recovery no longer carries {anchor.strip()!r}"
         )
     start = release_recovery.index(anchor)
     remainder = release_recovery[start + 1 :]
@@ -4543,78 +4542,160 @@ def recovery_escalation_source(release_recovery: str) -> str:
     return textwrap.dedent(step[step.index(marker) + len(marker) :])
 
 
-def execute_recovery_escalation(
-    source: str,
-    attempt_signatures: list[tuple[str, str] | None],
-    *,
-    release: dict[str, object] | None = None,
-    release_error: str | None = None,
-) -> tuple[subprocess.CompletedProcess[str], str]:
-    """Run the escalation against scripted attempt jobs and release state.
+def recovery_escalation_source(release_recovery: str) -> str:
+    """Extract the escalation step exactly as the recovery controller runs it."""
 
-    The `gh` stub answers `-q` by running the real `jq`, so the workflow's own
-    query decides the signature. A stub that returned canned answers would
-    exercise the shell and leave the jq that does the classifying unproven.
+    return recovery_step_script(
+        release_recovery,
+        "      - name: Alert after automatic retries are exhausted\n",
+    )
+
+
+RECOVERY_CLASSIFIER_ANCHOR = (
+    "      - name: Classify the failure signature across attempts\n"
+)
+RECOVERY_FIXTURE_RUN_ID = "4242"
+
+
+def write_attempt_job_fixtures(
+    responses: Path,
+    attempt_signatures: list[object],
+) -> None:
+    """Write one jobs-API response per attempt in the shape GitHub returns.
+
+    A failure entry is `(job, step)`, or `(job, step, job_conclusion)` when the
+    job's own conclusion differs from its failing step's — the shape a matrix
+    leg takes when a sibling's failure cancels it mid-step. A `None` step is a
+    job that failed while recording no failing step at all.
     """
+
+    for index, signature in enumerate(attempt_signatures, start=1):
+        if signature is None:
+            continue
+        # A single failing job makes the jobs API's ordering irrelevant,
+        # which is the shape production never produces for a matrix
+        # failure. Every attempt therefore carries its failures in the
+        # order given, so a caller can vary it the way real queue-time job
+        # ids do.
+        failures = [signature] if isinstance(signature, tuple) else list(signature)
+        jobs: list[dict[str, object]] = [
+            {
+                "name": "Preflight",
+                "conclusion": "success",
+                "steps": [{"name": "Checkout", "conclusion": "success"}],
+            }
+        ]
+        for failure in failures:
+            job, step_name = failure[0], failure[1]
+            job_conclusion = failure[2] if len(failure) > 2 else "failure"
+            steps: list[dict[str, object]] = [
+                {"name": "Checkout", "conclusion": "success"}
+            ]
+            if step_name is not None:
+                steps.append({"name": step_name, "conclusion": "failure"})
+            jobs.append(
+                {
+                    "name": job,
+                    "conclusion": job_conclusion,
+                    "steps": steps,
+                }
+            )
+        payload = {"jobs": jobs}
+        target = (
+            f"repos_firelock-ai_kin_actions_runs_{RECOVERY_FIXTURE_RUN_ID}"
+            f"_attempts_{index}_jobs"
+        )
+        (responses / target).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def read_step_outputs(path: Path) -> dict[str, str]:
+    outputs: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return outputs
+
+
+def run_recovery_classifier_in(
+    root: Path,
+    source: str,
+    attempt_signatures: list[object],
+) -> dict[str, str]:
+    """Run the classifier inside a prepared fixture root and return its outputs.
+
+    The root must already carry `responses/` and the `gh` stub in `bin/`. The
+    classifier's signature file lands in this same directory because the alert
+    step reads it from RUNNER_TEMP, which is how the two steps share one
+    classification inside a single job.
+
+    The classifier decides whether a retry is spent, so it must never fail the
+    reconcile job: a controller that dies here neither retries nor alerts, and
+    the release lane silently stops moving. That is asserted on every run
+    rather than in one dedicated case.
+    """
+
+    script = root / "classify.sh"
+    script.write_text(source, encoding="utf-8")
+    outputs_file = root / "classifier-output"
+    outputs_file.write_text("", encoding="utf-8")
+    environment = dict(os.environ)
+    environment["PATH"] = f"{root / 'bin'}{os.pathsep}{environment['PATH']}"
+    environment.update(
+        {
+            "FIXTURE": str(root),
+            "GH_TOKEN": "fixture",
+            "REPO": "firelock-ai/kin",
+            "RUN_ID": RECOVERY_FIXTURE_RUN_ID,
+            "ATTEMPTS": str(len(attempt_signatures)),
+            "RUNNER_TEMP": str(root),
+            "GITHUB_OUTPUT": str(outputs_file),
+        }
+    )
+    completed = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=60,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "the recovery classifier must never fail the reconcile job, "
+            "because a controller that dies here neither retries nor alerts: "
+            f"{completed.stdout}{completed.stderr}"
+        )
+    return read_step_outputs(outputs_file)
+
+
+def execute_recovery_classifier(
+    source: str,
+    attempt_signatures: list[object],
+) -> dict[str, str]:
+    """Run the classifier against scripted attempt jobs and return its outputs."""
 
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
-        script = root / "escalate.sh"
-        script.write_text(source, encoding="utf-8")
         responses = root / "responses"
         responses.mkdir()
-        run_id = "4242"
-        for index, signature in enumerate(attempt_signatures, start=1):
-            if signature is None:
-                continue
-            # A single failing job makes the jobs API's ordering irrelevant,
-            # which is the shape production never produces for a matrix
-            # failure. Every attempt therefore carries its failures in the
-            # order given, so a caller can vary it the way real queue-time job
-            # ids do.
-            failures = [signature] if isinstance(signature, tuple) else list(signature)
-            jobs: list[dict[str, object]] = [
-                {
-                    "name": "Preflight",
-                    "conclusion": "success",
-                    "steps": [{"name": "Checkout", "conclusion": "success"}],
-                }
-            ]
-            for job, step_name in failures:
-                jobs.append(
-                    {
-                        "name": job,
-                        "conclusion": "failure",
-                        "steps": [
-                            {"name": "Checkout", "conclusion": "success"},
-                            {"name": step_name, "conclusion": "failure"},
-                        ],
-                    }
-                )
-            payload = {"jobs": jobs}
-            target = (
-                f"repos_firelock-ai_kin_actions_runs_{run_id}"
-                f"_attempts_{index}_jobs"
-            )
-            (responses / target).write_text(json.dumps(payload), encoding="utf-8")
-        release_response = responses / "repos_firelock-ai_kin_releases_tags_v9.9.9"
-        if release is not None and release_error is not None:
-            raise AssertionError("release fixture cannot be both readable and failed")
-        if release is not None:
-            release_response.write_text(
-                json.dumps(release),
-                encoding="utf-8",
-            )
-        if release_error is not None:
-            Path(f"{release_response}.error").write_text(
-                release_error,
-                encoding="utf-8",
-            )
+        write_attempt_job_fixtures(responses, attempt_signatures)
         binaries = root / "bin"
         binaries.mkdir()
-        (binaries / "gh").write_text(
-            textwrap.dedent(
-                """\
+        write_recovery_gh_stub(binaries)
+        return run_recovery_classifier_in(root, source, attempt_signatures)
+
+
+def write_recovery_gh_stub(binaries: Path) -> None:
+    """A `gh` that answers `-q` with the real `jq`.
+
+    A stub that returned canned answers would exercise the shell and leave the
+    jq that does the classifying unproven.
+    """
+
+    (binaries / "gh").write_text(
+        textwrap.dedent(
+            """\
                 #!/usr/bin/env bash
                 set -uo pipefail
                 case "$1" in
@@ -4671,10 +4752,60 @@ def execute_recovery_escalation(
                     ;;
                 esac
                 """
-            ),
-            encoding="utf-8",
+        ),
+        encoding="utf-8",
+    )
+    (binaries / "gh").chmod(0o755)
+
+
+def execute_recovery_escalation(
+    release_recovery: str,
+    attempt_signatures: list[object],
+    *,
+    release: dict[str, object] | None = None,
+    release_error: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the reconcile's classify and alert steps the way the job runs them.
+
+    The alert no longer computes the signature itself; it reports what the
+    classifier that spent or withheld the retry decided. Driving the two steps
+    in order, through one runner temp directory and the classifier's real step
+    outputs, is what keeps this a test of the controller rather than of a
+    hand-copied duplicate of its logic.
+    """
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        script = root / "escalate.sh"
+        script.write_text(
+            recovery_escalation_source(release_recovery), encoding="utf-8"
         )
-        (binaries / "gh").chmod(0o755)
+        responses = root / "responses"
+        responses.mkdir()
+        write_attempt_job_fixtures(responses, attempt_signatures)
+        binaries = root / "bin"
+        binaries.mkdir()
+        write_recovery_gh_stub(binaries)
+        # The real classifier, run first and into this same runner temp, so the
+        # alert reads the signature file and outputs the controller produced.
+        classifier_outputs = run_recovery_classifier_in(
+            root,
+            recovery_step_script(release_recovery, RECOVERY_CLASSIFIER_ANCHOR),
+            attempt_signatures,
+        )
+        release_response = responses / "repos_firelock-ai_kin_releases_tags_v9.9.9"
+        if release is not None and release_error is not None:
+            raise AssertionError("release fixture cannot be both readable and failed")
+        if release is not None:
+            release_response.write_text(
+                json.dumps(release),
+                encoding="utf-8",
+            )
+        if release_error is not None:
+            Path(f"{release_response}.error").write_text(
+                release_error,
+                encoding="utf-8",
+            )
         environment = dict(os.environ)
         environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
         environment.update(
@@ -4684,9 +4815,17 @@ def execute_recovery_escalation(
                 "REPO": "firelock-ai/kin",
                 "TAG": "v9.9.9",
                 "SHA": RELEASE_GATE_FIXTURE_SHA,
-                "RUN_ID": run_id,
-                "RUN_URL": f"https://example.invalid/runs/{run_id}",
+                "RUN_ID": RECOVERY_FIXTURE_RUN_ID,
+                "RUN_URL": (
+                    f"https://example.invalid/runs/{RECOVERY_FIXTURE_RUN_ID}"
+                ),
                 "ATTEMPTS": str(len(attempt_signatures)),
+                "RUNNER_TEMP": str(root),
+                # resolve declares exhaustion at the third attempt; the alert
+                # distinguishes that from a repeat stop that left budget unspent.
+                "EXHAUSTED": "true" if len(attempt_signatures) >= 3 else "false",
+                "UNKNOWN": classifier_outputs.get("unknown", ""),
+                "REPEATED": classifier_outputs.get("repeated", ""),
             }
         )
         completed = subprocess.run(
@@ -4711,11 +4850,10 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     preserve that distinction before it tells an operator to burn a version.
     """
 
-    source = recovery_escalation_source(release_recovery)
     compile_failure = ("build-artifacts (x86_64-unknown-linux-musl)", "Build release binaries")
 
     repeated, body = execute_recovery_escalation(
-        source,
+        release_recovery,
         [compile_failure, compile_failure, compile_failure],
     )
     if repeated.returncode == 0:
@@ -4741,8 +4879,36 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
             f"step identity was overstated as root-cause proof: {body}"
         )
 
+    # The stop that spends one confirmation instead of the whole budget. The
+    # alert still fires, and it must not describe unspent budget as exhausted:
+    # the remedy for a repeat differs from the remedy for a run that tried
+    # everything, and the tag is still eligible for a same-release rerun.
+    stopped, stopped_body = execute_recovery_escalation(
+        release_recovery,
+        [compile_failure, compile_failure],
+    )
+    if stopped.returncode == 0:
+        raise AssertionError(
+            "a confirmed repeat did not raise the release alarm: "
+            f"{stopped.stdout}{stopped.stderr}"
+        )
+    for needle in (
+        "Classification: **repeated failure signature**",
+        "stopped retrying",
+        "after 2 attempt(s)",
+    ):
+        if needle not in stopped_body:
+            raise AssertionError(
+                f"a repeat stop was not reported as one: {needle!r}: {stopped_body}"
+            )
+    if "exhausted its retries" in stopped_body:
+        raise AssertionError(
+            "a repeat stop that left retry budget unspent was reported as "
+            f"exhaustion: {stopped_body}"
+        )
+
     _, transient_body = execute_recovery_escalation(
-        source,
+        release_recovery,
         [
             ("build-artifacts (x86_64-apple-darwin)", "Notarize"),
             ("publish", "Push image"),
@@ -4763,7 +4929,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     # repeated. Claiming deterministic from an unreadable attempt would retire
     # a recoverable release on a transient API error.
     _, unreadable_body = execute_recovery_escalation(
-        source,
+        release_recovery,
         [compile_failure, None, compile_failure],
     )
     for needle in (
@@ -4799,7 +4965,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
         "Build kin-cli + kin-daemon (native)",
     )
     _, matrix_body = execute_recovery_escalation(
-        source,
+        release_recovery,
         [[aarch64, x86_64], [x86_64, aarch64], [aarch64, x86_64]],
     )
     if "Classification: **repeated failure signature**" not in matrix_body:
@@ -4811,7 +4977,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     # Every attempt unreadable is the case that isolates the unknown count.
     # The signatures all match each other, so nothing but that count stands
     # between a total read failure and a verdict of "deterministic, recut it".
-    _, blind_body = execute_recovery_escalation(source, [None, None, None])
+    _, blind_body = execute_recovery_escalation(release_recovery, [None, None, None])
     if "Classification: **indeterminate**" not in blind_body:
         raise AssertionError(
             "a run whose attempts could not be read at all was classified "
@@ -4821,7 +4987,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     # A mint that reported failure on a release it had already created would
     # otherwise send this controller to repair a healthy release.
     _, existing_release_body = execute_recovery_escalation(
-        source,
+        release_recovery,
         [compile_failure, compile_failure, compile_failure],
         release={
             "draft": False,
@@ -4844,7 +5010,7 @@ def assert_recovery_escalation_classifies(release_recovery: str) -> None:
     # network failure is unknown state and must never be rewritten as "no
     # Release", which would send repair after an object that may exist.
     _, unreadable_release_body = execute_recovery_escalation(
-        source,
+        release_recovery,
         [compile_failure, compile_failure, compile_failure],
         release_error="gh: API rate limit exceeded (HTTP 403)\n",
     )
@@ -5174,6 +5340,145 @@ def assert_selector_arguments(
         )
 
 
+def assert_mint_trigger_survives_advisory_flakes(release_tag: str) -> None:
+    """The event-driven mint must evaluate on any completed main-push CI run.
+
+    ci.yml carries jobs beyond the release-critical ones, so its aggregate
+    conclusion goes red whenever a non-required advisory leg flakes, which is
+    most main pushes. Gating the workflow_run trigger on that aggregate made
+    the event path hostage to a flake and left the schedule as the only
+    automatic mint, which GitHub then failed to deliver for roughly four hours.
+    The mint's own "Verify required checks are green" step is the release
+    authority: it binds each reviewed required context to its exact producing
+    workflow and explicitly refuses to let that producer's aggregate conclusion
+    veto through it. A trigger that re-imposes the aggregate contradicts the
+    gate it precedes and can only ever subtract mint occasions.
+    """
+
+    block = workflow_job_blocks(release_tag).get("mint-release-tag")
+    if block is None:
+        raise AssertionError("release-tag no longer declares the mint job")
+    guard: list[str] = []
+    inside = False
+    for line in block.splitlines():
+        stripped = line.strip()
+        if not inside:
+            if stripped.startswith("if:"):
+                inside = True
+                guard.append(stripped)
+            continue
+        if stripped.startswith("runs-on:"):
+            break
+        if stripped.startswith("#"):
+            continue
+        guard.append(stripped)
+    active = "\n".join(guard)
+    if not inside:
+        raise AssertionError("the release mint no longer guards its triggers")
+    if "github.event.workflow_run.conclusion" in active:
+        raise AssertionError(
+            "the release mint's workflow_run trigger must not consult the CI "
+            "run's aggregate conclusion: a single non-required advisory flake "
+            "reds that aggregate and would silence the event-driven mint, "
+            "leaving only the schedule GitHub is free not to deliver"
+        )
+    for clause in (
+        "github.event.workflow_run.event == 'push'",
+        "github.event.workflow_run.head_branch == 'main'",
+    ):
+        if clause not in active:
+            raise AssertionError(
+                "the release mint's workflow_run trigger must still pin the "
+                f"reviewed default-branch push it evaluates: {clause}"
+            )
+
+
+def assert_recovery_stops_on_repeated_signature(release_recovery: str) -> None:
+    """A deterministic failure must cost one confirmation, not the whole budget.
+
+    The controller exists for transient failures. A failure that reproduces
+    with an identical failing-step signature is not transient in any way a
+    rerun can fix, and each blind retry costs a full Release run. The classifier
+    therefore runs BEFORE the rerun is requested, and its verdict has to be
+    driven by the real jobs API shapes rather than by a stub's canned answer.
+    """
+
+    source = recovery_step_script(
+        release_recovery,
+        "      - name: Classify the failure signature across attempts\n",
+    )
+    compile_failure = ("build-artifacts (x86_64-unknown-linux-musl)", "Build release binaries")
+    notarize = ("build-artifacts (aarch64-apple-darwin)", "Notarize")
+
+    outputs = execute_recovery_classifier(source, [compile_failure, compile_failure])
+    if outputs.get("repeated") != "true":
+        raise AssertionError(
+            "a second identical failing-step signature did not stop the retry "
+            f"budget: {outputs}"
+        )
+
+    outputs = execute_recovery_classifier(source, [compile_failure, notarize])
+    if outputs.get("repeated") != "false":
+        raise AssertionError(
+            f"a differing second failure was reported as deterministic: {outputs}"
+        )
+
+    # One attempt cannot repeat anything. Stopping here would retire a release
+    # on its first failure and defeat the controller's entire purpose.
+    outputs = execute_recovery_classifier(source, [compile_failure])
+    if outputs.get("repeated") != "false":
+        raise AssertionError(
+            f"a single first failure was treated as a repeat: {outputs}"
+        )
+
+    # A transient API error is not evidence that the release failure repeats.
+    outputs = execute_recovery_classifier(source, [compile_failure, None])
+    if outputs.get("repeated") != "false" or outputs.get("unknown") == "0":
+        raise AssertionError(
+            f"an unreadable attempt was folded into a repeat verdict: {outputs}"
+        )
+    outputs = execute_recovery_classifier(source, [None, None])
+    if outputs.get("repeated") != "false":
+        raise AssertionError(
+            "two unreadable attempts compared equal to each other and stopped "
+            f"the retries: {outputs}"
+        )
+
+    # The shape that produced the wrong answer in production: when one matrix
+    # leg fails, its siblings are cancelled, and a cancelled job still carries
+    # the step that actually failed. Filtering on the job's own conclusion
+    # first drops exactly that evidence and reads a repeat as two unreadable
+    # attempts, which retries a deterministic failure to the end of the budget.
+    cancelled = ("build-artifacts (aarch64-unknown-linux-musl)", "Build release binaries", "cancelled")
+    outputs = execute_recovery_classifier(source, [cancelled, cancelled])
+    if outputs.get("repeated") != "true":
+        raise AssertionError(
+            "a failing step inside a cancelled matrix leg was not read as "
+            f"failure evidence: {outputs}"
+        )
+
+    # A job that failed while recording no failing step at all — a runner
+    # startup failure — is still a signature, not an unreadable attempt.
+    startup = ("publish", None, "failure")
+    outputs = execute_recovery_classifier(source, [startup, startup])
+    if outputs.get("repeated") != "true" or outputs.get("unknown") != "0":
+        raise AssertionError(
+            f"a job-level failure with no failing step was unreadable: {outputs}"
+        )
+
+    # The order matrix legs queue in must not decide the verdict.
+    aarch64 = ("Build (kin-linux-aarch64)", "Build kin-cli + kin-daemon (native)")
+    x86_64 = ("Build (kin-linux-x86_64)", "Build kin-cli + kin-daemon (native)")
+    outputs = execute_recovery_classifier(
+        source, [[aarch64, x86_64], [x86_64, aarch64]]
+    )
+    if outputs.get("repeated") != "true":
+        raise AssertionError(
+            "a matrix failure that repeated identically was classified by the "
+            f"order its legs happened to queue in: {outputs}"
+        )
+
+
 def assert_recovery_record_authority(release_recovery: str) -> None:
     """Recovery must decide abandonment through the rail's own selector.
 
@@ -5233,6 +5538,10 @@ def assert_recovery_abandonment_stand_down(release_recovery: str) -> None:
     condition = "steps.record.outputs.abandoned != 'true'"
     for marker, duty in (
         ("name: Re-run failed jobs", "bounded retry"),
+        (
+            "name: Classify the failure signature across attempts",
+            "failure-signature classification",
+        ),
         (
             "name: Alert after automatic retries are exhausted",
             "exhausted-retry alert",
@@ -5958,7 +6267,6 @@ def main() -> None:
         "checks: read",
         "github.event.workflow_run.event == 'push'",
         "github.event.workflow_run.head_branch == 'main'",
-        "github.event.workflow_run.conclusion == 'success'",
         "repository_dispatch:",
         "types: [release_tag]",
         "github.event.action",
@@ -6281,6 +6589,9 @@ def main() -> None:
         '.head_repository.full_name == $repo',
         "rerun-failed-jobs",
         '[ "$attempt" -ge 3 ]',
+        "name: Classify the failure signature across attempts",
+        "steps.classify.outputs.repeated != 'true'",
+        "steps.classify.outputs.repeated == 'true'",
         "Release blocked after automatic retries",
         "scripts/abandoned-release-tags.json",
         "scripts/select-admissible-release-tag.py",
@@ -9388,6 +9699,10 @@ def main() -> None:
     assert_recovery_escalation_classifies(
         RELEASE_RECOVERY.read_text(encoding="utf-8")
     )
+    assert_recovery_stops_on_repeated_signature(
+        RELEASE_RECOVERY.read_text(encoding="utf-8")
+    )
+    assert_mint_trigger_survives_advisory_flakes(release_tag)
 
     with tempfile.TemporaryDirectory() as directory:
         fixture_directory = Path(directory)


### PR DESCRIPTION
## HOLD — do not enqueue before v0.4.9 publishes

`release-tag.yml` executes from `main` for its dispatch paths, so changing it
mid-mint is forbidden. **This PR holds until the release captain sequences it
post-release.** Reviewed and green is the goal here; landing is not.

Closes FIR-1889
Refs FIR-1900 (item 5)

---

## 1. The mint's event path was hostage to a non-required flake (FIR-1889)

`release-tag.yml`'s `workflow_run` trigger required
`github.event.workflow_run.conclusion == 'success'`. That aggregate is red
whenever any non-required CI job flakes — the "Windows authority tests" leg
(FIR-1867) does exactly this on most main pushes — so every `workflow_run`
evaluation skipped the mint job entirely and the 15-minute cron became the only
automatic path. GitHub then delivered no cron ticks for ~4 hours (last genuine
tick ~05:02Z, drought through ~09:00Z) and the lane sat mintable and unminted
until break-glass `repository_dispatch` was used.

**Fix:** the `workflow_run` path now evaluates on any *completed* main-push CI
run. `types: [completed]` still bounds it to finished runs; `event == 'push'`
and `head_branch == 'main'` are unchanged.

### Proof that the internal binding is the real authority

Read directly from `release-tag.yml`'s "Verify required checks are green" step,
which runs on every path including the scheduled one:

- `REQUIRED_CHECKS` is the reviewed, presence-required release-critical set
  (`Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)`, `DCO Sign-off`,
  `cargo-deny`, `gitleaks (full history)`, `Windows installer + vector-free
  release build`). "Windows authority tests" is **not** in it.
- Each required context is matched to `expected_provenance` — exact workflow id,
  path, `push` event, `main` branch, and head sha — and **its own** conclusion
  must be `success` (`DCO Sign-off` may be `skipped`).
- The producing run's aggregate conclusion is explicitly refused as a verdict.
  Verbatim from the source: *"The producing run carries jobs beyond the
  release-critical ones, so its aggregate conclusion is not a release verdict. A
  red coverage or npm-launcher job turns the whole ci.yml run red and would
  otherwise veto through every required context that run produces"* — it is
  recorded in `degraded_producers` and announced, never a veto.
- A red non-required check becomes a `downgraded` announcement; an unfinished
  one becomes `unwaited`. `pending` exits 2 and is retried up to 60 passes, so a
  commit whose required checks are still running is waited for, not lost.

So the mint already decides releasability from required contexts alone. The
trigger's `conclusion == 'success'` clause re-imposed exactly the aggregate veto
the gate deliberately declines, and could only ever subtract mint occasions.
The trigger now decides *when to look*, never *whether the commit is releasable*
— which is precisely how the scheduled path has always worked.

Two required contexts (`cargo-deny` from `sast.yml`, `gitleaks (full history)`
from `secret-scan.yml`) are not produced by the CI run the trigger watches, so
"before: job skipped" in the table below describes the ci.yml-produced contexts
exactly and the other two only by way of the same trigger being silenced.

### 1a. The trigger decides only *when* to look, so it no longer chooses *what*

Widening a trigger must not widen what the mint may release. The `workflow_run`
arm resolved its candidate from `github.event.workflow_run.head_sha`, which the
scheduled arm never does — it reads `origin/main` HEAD. That head sha is the one
stale-capable input into the release candidate: a **rerun of an older CI run**
carries the sha main held at that time, so the arm could resolve the version of
that moment rather than the version main carries now.

This was reachable before the trigger change too (any stale rerun concluding
`success` took the same path), but widening the trigger widens the exposure, so
it is closed here rather than left as a follow-up:

- With v0.4.7 untagged and below `v0.4.8`, a rerun landing at that commit fails
  `release-intent.mjs` monotonicity and **reds the mint job** — a live band
  today (0.4.0, 0.4.1, 0.4.2, 0.4.7 all sit untagged on main's first-parent
  `Cargo.toml` history).
- Latent, and empty today: a stale sha at an untagged version *above* the newest
  tag that main has since moved past could mint a tag for a version the fleet
  skipped. The scheduled path structurally cannot do this.

**Fix:** both automatic arms now resolve from the freshly fetched protected
main, and `WORKFLOW_SHA` is removed as an input entirely. The required-check
gate re-derives everything from the resolved commit regardless, so main HEAD
costs nothing and eliminates both cases. Pinned by two new assertions in
`assert_mint_trigger_survives_advisory_flakes`.

### Truth table — `release-tag.yml` mint job

| Trigger case | Before | After |
|---|---|---|
| CI on main push, aggregate red from non-required flake only | **job skipped** (mint never evaluated) | job runs; required-check gate admits; **mint proceeds** |
| CI on main push, all green | job runs, mint proceeds | unchanged |
| CI on main push, a **required** context red | job skipped | job runs; gate errors on that context; **refuses (fails)** — now loudly instead of silently |
| CI on main push, required checks still running | job skipped | job runs; gate reports `pending`, retries up to 60 passes, then mints or times out |
| CI on main push completing **`cancelled` / `timed_out` / `startup_failure` / `skipped`** | job skipped | job runs; if the version is already tagged it is a green no-op, otherwise required contexts read non-success and the job **fails closed** |
| Late-completing **rerun of an older main-push CI run** | job ran only on a `success` conclusion, and resolved the candidate from that run's stale head sha | job runs on any completion, and now resolves from `origin/main` HEAD like the schedule — the stale-candidate class is gone |
| CI on a **pull_request** or `merge_group` event | skipped (`event != 'push'`) | skipped — unchanged |
| CI on a non-main branch | skipped (`head_branch != 'main'`) | skipped — unchanged |
| CI still in progress | not delivered (`types: [completed]`) | unchanged |
| `schedule` | runs (guard is `event_name != 'workflow_run'`) | unchanged |
| `repository_dispatch` (break glass) | runs; actor/ref/sha guard | unchanged |

Net: a commit whose *required* checks pass now gets its event-driven mint even
when an advisory leg flaked, and every newly-reached class either fails closed
or is a green no-op. Nothing that was refused before is admitted now.

The decline-escalation counter already skips `skipped` mint jobs (it was written
for `workflow_run` firing on every completed CI run), so the extra PR and
`merge_group` evaluations keep being ignored by it. No change needed there.

## 2. Recovery burned its whole retry budget on deterministic failures (FIR-1900 item 5)

`release-recovery.yml` re-ran a failed Release run up to `attempt >= 3` with no
determinism test. Run `30894704670` cost three identical ~45-minute attempts on
a deterministic failure. The controller already knew how to compare failing-step
signatures — but only in the "Alert after automatic retries are exhausted" step,
i.e. *after* the budget was gone. **The ordering was the production defect:** it
could describe a deterministic failure and never prevent one.

**Fix:** a new "Classify the failure signature across attempts" step runs
**before** the rerun is requested. If the latest attempt's failing-step
signature equals the previous attempt's, no rerun is dispatched and the existing
alert path fires immediately, naming the repeated signature. A deterministic
failure now costs **one confirmation (2 attempts)** instead of 3.

### Robust signature extraction

- **Step-level failures are primary.** The set is every step with
  `conclusion == "failure"` in any job, *regardless of the parent job's
  conclusion*. This is **defensive hardening, not a repair of an observed
  failure**: GitHub can cancel a matrix leg's siblings when one fails, and a
  cancelled job still carries the step that actually failed, so a job-primary
  read would drop exactly that evidence. It is **not** the shape that cost three
  attempts — all three attempts of `30894704670` carry **zero** cancelled jobs,
  and the old job-primary query returns byte-identical output on those real
  payloads. Step-primary can only ever find more evidence than job-primary,
  never less, which is why it is worth doing anyway.
- **Job-level fallback** only for a job that failed or timed out while recording
  no failing step (runner startup failure), so that is a signature rather than
  an unreadable attempt.
- **Sorted set** (`unique`), so matrix legs queueing in a different order each
  attempt still compare equal. Real shape, verified: attempts of run
  `30627672394` returned the two failing legs aarch64-first, then x86_64-first,
  then aarch64-first again.
- **Never fails the reconcile job.** Every read is guarded; any unhappy path
  degrades to `unrecorded`, which the repeat test refuses to count. A transient
  API error therefore leaves the controller retrying exactly as before — asserted
  on every classifier run in the suite.

### The stop rule is last-two equality, and the alert now says only that

The stop compares the **last two** attempts, because that is the earliest point
a repeat is established. A consequence: reaching attempt 3 with a repeat verdict
requires the earlier attempts to have differed, since an identical pair stops
the controller at two. The alert's verdict prose still read *"Every observed
attempt failed in the same job and step set"*, which on that shape is false and
contradicts the per-attempt table printed three lines below it, sending an
operator past the differing attempt — the evidence that the cause is not purely
deterministic.

**Fix:** the classifier now also reports how many **distinct** signatures the
whole run produced. That count is reported, never acted on — the stop decision
is unchanged — and the alert earns *"Every observed attempt…"* only from a count
of one, otherwise stating that the two most recent attempts matched and that
earlier ones differed. An absent or unreadable count takes the narrower claim.

### Truth table — recovery reconcile

| Case | Before | After |
|---|---|---|
| attempt 1 failed | rerun | rerun (nothing to compare) — unchanged |
| attempt 2, signature **differs** from attempt 1 | rerun | rerun — unchanged |
| attempt 2, signature **identical** to attempt 1 | rerun (burns attempt 3) | **no rerun**; alert fires, verdict `repeated failure signature`, `distinct=1`, prose says every attempt matched |
| attempt 2, identical but one attempt **unreadable** | rerun | rerun (unknown ≠ 0 blocks the stop) — unchanged |
| attempt 2, failing step inside a **cancelled** matrix leg | rerun | signature read from the step; stop on repeat |
| attempt 3 reached, all three signatures identical | alert, `exhausted`, "every observed attempt" | unchanged in verdict and prose; only reachable when an earlier read was transiently unknown or a human drove the reruns |
| attempt 3 reached, **last two match but attempt 1 differed** | alert, `exhausted`, verdict `varying failure signatures` — the deterministic repeat across the last two attempts went unrecognized | alert, `exhausted`, verdict `repeated failure signature`; prose states the last-two equality and points at the differing earlier attempt |
| attempt 3 reached, all signatures differ | alert, `exhausted`, `varying failure signatures` | unchanged |
| tag has reviewed abandonment record | stand down, no rerun/alert | unchanged (classifier also stands down) |
| a Release run is active | reconcile deferred | unchanged |
| historical/lower tag than latest stable | ignored | unchanged |

The alert issue also distinguishes the two stop reasons: a repeat stop says
*"stopped retrying … after 2 attempt(s): the failing-step signature repeated
exactly"* rather than claiming exhaustion, because the remedy differs and the
tag is still eligible for a same-release rerun.

### Single classification authority

The alert step no longer recomputes the signature — it reads the file and
outputs the classifier produced. Duplicating the extraction would let the reason
the controller *stopped retrying* disagree with the reason it *reports*.

## Preserved safety properties

- Reconcile ordering: resolve → checkout record → reconcile record → **classify**
  → rerun → alert. The abandonment reconcile still precedes every action.
- Active-run guard in `resolve` untouched.
- Preserved-attempt semantics untouched (`rerun-failed-jobs` still preserves
  attempts; the mint's prior-stable gate reads the same `matching_count` state,
  and re-runs mint no new run records, so stopping at 2 cannot change it).
- Abandonment stand-down now covers the classifier too, so an abandoned tag
  spends no API budget.
- `attempt >= 3` exhaustion rule unchanged.

## Verification (workflows cannot run locally)

- `scripts/test-release-workflow-authority.py`: **green** at the rebased head
  (baseline captured green before any edit, green after).
- `actionlint .github/workflows/release-tag.yml .github/workflows/release-recovery.yml`:
  **clean**, no findings.
- YAML parse: both files parse; job/step guards and step order dumped and
  matched against intent.
- The authority suite gained real coverage rather than relaxed pins:
  - `assert_mint_trigger_survives_advisory_flakes` — the mint's trigger must not
    consult the aggregate conclusion, must still pin push + main, must not
    resolve its candidate from the triggering run's head sha, and must resolve
    from the freshly fetched protected main.
  - `assert_recovery_stops_on_repeated_signature` — drives the **real classifier
    script** against scripted jobs-API payloads through a `gh` stub that answers
    `-q` with real `jq`, so the workflow's own query decides the verdict.
  - The escalation harness now runs classify → alert in order through one
    RUNNER_TEMP with the classifier's real step outputs, so the alert is tested
    as the job actually runs it rather than as a hand-copied duplicate.
  - `assert_recovery_escalation_classifies` covers `[A,A,A]`, `[A,B,B]`,
    `[A,B,C]`, and the unreadable shapes, so the two verdict prose branches are
    both pinned.
  - The removed pin (`conclusion == 'success'` for release-tag) is replaced by a
    positive assertion that it must not come back. The identical strings in
    `release-train.yml` and `publish-release-installers.yml` (workflow name
    "Publish Release Follow-Ups") are untouched, as are their suite pins.

### Falsification — every new check was proven able to fail

Each mutation was applied to the real source, the suite re-run, and the
unmutated baseline re-confirmed green on both sides of the battery.

| Mutation | Caught by |
|---|---|
| restore `conclusion == 'success'` on the mint trigger | `assert_mint_trigger_survives_advisory_flakes` |
| drop the `head_branch == 'main'` pin | `assert_mint_trigger_survives_advisory_flakes` |
| restore `sha="$WORKFLOW_SHA"` as the candidate | `assert_mint_trigger_survives_advisory_flakes` ("must not resolve its release candidate from the triggering CI run's head sha") |
| stop resolving the automatic arm from `origin/main` | `assert_mint_trigger_survives_advisory_flakes` ("must resolve its candidate from the freshly fetched protected main") |
| reintroduce the job-conclusion filter (drops cancelled-leg failed steps) | `assert_recovery_stops_on_repeated_signature` (reads `unknown=2` on the fixture) |
| neuter the previous-attempt comparison | `assert_recovery_stops_on_repeated_signature` |
| drop the `unknown == 0` guard (unreadable attempts count as repeats) | `assert_recovery_stops_on_repeated_signature` |
| stop on the very first failure | `assert_recovery_stops_on_repeated_signature` |
| delete the all-attempts `distinct` count | `assert_recovery_escalation_classifies` (`[A,A,A]` loses "Every observed attempt…") |
| bypass the last-two prose branch (always claim every attempt matched) | `assert_recovery_escalation_classifies` (`[A,B,B]`) |
| revert the stop rule to all-attempts equality | `assert_recovery_escalation_classifies` (`[A,B,B]` never reaches a repeat verdict) |
| remove the classifier's abandonment stand-down | `assert_recovery_abandonment_stand_down` |
| delete the rerun's `repeated != 'true'` guard | `main()` policy pin list |

## Evidence

- Skipped mint runs (flake-hostage trigger): `30891005604`, `30892271567`,
  `30893135198`, `30893563786`.
- Main CI run `30891042651` (`215f7fed`) — completed/failure on the advisory
  flake alone, which is what silenced those four.
- Recovery triple-retry on Release run `30894704670`; re-read here, all three
  attempts, to confirm it carries no cancelled job and that the ordering, not
  the query shape, is what cost the attempts.
- Matrix leg ordering across attempts of Release run `30627672394`, re-read here.

## Out of scope, filed as an observation

`release-train.yml` carries the same `workflow_run` + `conclusion == 'success'`
shape and is presumably hostage to the same flake for release-PR preparation.
Not touched here — different controller, different blast radius, and this PR is
already release-rail-critical. Worth its own ticket.

`Windows installer + vector-free release build` is a required release context
that can conclude `SKIPPED` under diff-scope classification while
`skippable_required` in the mint contains only `DCO Sign-off`. Pre-existing
(FIR-1860 territory), harmless in practice because a version-bump commit always
widens the scope, and untouched here.

