### PR TITLE
Read the host-binding fixtures as scripts rather than exec targets

### DIFF
--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -830,7 +830,30 @@ mod git_process_boundary_tests {
         let host_path = absolute_eject_host_search_path("bin", &resolution_cwd).unwrap();
         let git = which::which_in("git", Some(&host_path), &resolution_cwd).unwrap();
         assert!(git.is_absolute(), "host Git binding remained relative");
-        let output = Command::new(git).current_dir(&child_cwd).output().unwrap();
+        // `sh` reads the binding as a script operand instead of `exec` taking
+        // it as a program. That is the command line `exec` was already
+        // building: the fixture carries a `#!/bin/sh` line, so the kernel ran
+        // `/bin/sh <binding>` in the child's directory and passed the path
+        // exactly as given. A binding that stayed relative therefore still
+        // reaches the hostile copy below and still fails, because `sh`
+        // resolves a relative operand against its own working directory just
+        // as `exec` resolves a relative program path.
+        //
+        // What the spelling drops is a false failure. `exec` refuses with
+        // `ETXTBSY` while any process holds the target inode open for
+        // writing, and a sibling test thread's in-flight spawn
+        // transiently owns a duplicate of the descriptor the `write` above
+        // opened. Nothing here can close that window. The kernel counts
+        // writers per inode, so materializing under a temporary name and
+        // renaming into place carries the same count across; and the offending
+        // descriptor lives in a child process this test never names. Ceasing
+        // to be an `exec` target is what removes the exposure.
+        let output = Command::new("/bin/sh")
+            .arg(&git)
+            .current_dir(&child_cwd)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
         assert_eq!(output.stdout, b"trusted");
     }
 

--- a/crates/kin-git/src/test_support.rs
+++ b/crates/kin-git/src/test_support.rs
@@ -1961,7 +1961,25 @@ mod tests {
             std::env::split_paths(&host_path).all(|entry| entry.is_absolute()),
             "fixture host PATH retained a child-cwd-relative entry"
         );
-        let output = Command::new("kin-fixture-helper")
+        // The search still runs for real, and still runs from the child's
+        // working directory, which is where a relative PATH entry would reach
+        // the hostile copy; what changes is that the helper it finds is read
+        // by `sh` as a script operand instead of being handed to `exec` as a
+        // program. `sh` resolves that operand against its own working
+        // directory exactly as `exec` resolves a relative program path, so a
+        // relative entry still fails this assertion. What the indirection
+        // drops is a false failure: `exec` refuses with `ETXTBSY` while any
+        // process holds the target inode open for writing, and a sibling test
+        // thread's in-flight spawn transiently owns a duplicate of the
+        // descriptor the `write` above opened. Nothing here can close that
+        // window. The kernel counts writers per inode, so materializing under
+        // a temporary name and renaming into place carries the same count
+        // across; and the offending descriptor lives in a child process this
+        // test never names. Ceasing to be an `exec` target is what removes the
+        // exposure.
+        let output = Command::new("/bin/sh")
+            .arg("-c")
+            .arg(r#"exec /bin/sh "$(command -v kin-fixture-helper)""#)
             .current_dir(&child_root)
             .env("PATH", host_path)
             .output()

--- a/crates/kin-migrate/src/scanner.rs
+++ b/crates/kin-migrate/src/scanner.rs
@@ -334,7 +334,30 @@ mod tests {
         let host_path = absolute_host_search_path("bin", &resolution_cwd).unwrap();
         let git = which::which_in("git", Some(&host_path), &resolution_cwd).unwrap();
         assert!(git.is_absolute(), "host Git binding remained relative");
-        let output = Command::new(git).current_dir(&child_cwd).output().unwrap();
+        // `sh` reads the binding as a script operand instead of `exec` taking
+        // it as a program. That is the command line `exec` was already
+        // building: the fixture carries a `#!/bin/sh` line, so the kernel ran
+        // `/bin/sh <binding>` in the child's directory and passed the path
+        // exactly as given. A binding that stayed relative therefore still
+        // reaches the hostile copy below and still fails, because `sh`
+        // resolves a relative operand against its own working directory just
+        // as `exec` resolves a relative program path.
+        //
+        // What the spelling drops is a false failure. `exec` refuses with
+        // `ETXTBSY` while any process holds the target inode open for
+        // writing, and a sibling test thread's in-flight spawn
+        // transiently owns a duplicate of the descriptor the `write` above
+        // opened. Nothing here can close that window. The kernel counts
+        // writers per inode, so materializing under a temporary name and
+        // renaming into place carries the same count across; and the offending
+        // descriptor lives in a child process this test never names. Ceasing
+        // to be an `exec` target is what removes the exposure.
+        let output = Command::new("/bin/sh")
+            .arg(&git)
+            .current_dir(&child_cwd)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
         assert_eq!(output.stdout, b"trusted");
     }
 


### PR DESCRIPTION
`commands::eject::git_process_boundary_tests::relative_host_path_is_bound_absolutely_before_eject_changes_child_cwd`
panicked with `Os error 26, kind: ExecutableFileBusy` under parallel featureless runs,
evicting merge groups on a required context.

## Mechanism

The test materializes a `#!/bin/sh` fixture and then executes that same file:

```rust
std::fs::write(&trusted, "#!/bin/sh\nprintf trusted\n").unwrap();  // opens O_WRONLY, writes, closes
...
let output = Command::new(git).current_dir(&child_cwd).output().unwrap();  // execs that inode
```

`exec` refuses with `ETXTBSY` when the target inode's writer count is nonzero. The writing
thread's own descriptor is already closed and is `O_CLOEXEC`, so the only possible holder
is another *process* — a sibling test thread's in-flight spawn. On Linux `posix_spawn` is
`clone(CLONE_VM|CLONE_VFORK)` + `execve` without `CLONE_FILES`, so the child receives a
copy of the whole descriptor table at clone time. A clone landing inside another thread's
`fs::write` window hands that child a duplicate write descriptor to the file this test is
about to exec, and `O_CLOEXEC` does not help: `deny_write_access` runs when the new binary
is opened, before close-on-exec descriptors are dropped. Same race as golang/go#22315.

Nothing on the writer's side closes that window, which rules out the usual remedies:

- **Atomic rename does not fix it.** The writer count belongs to the *inode*, not the
  path, so writing under a temporary name and renaming into place carries the same
  elevated count across the rename.
- **Closing write handles before the spawn is already done.** `fs::write` drops its
  handle; the offending descriptor is in a process this test never names.
- **A bounded `ETXTBSY` retry** would only tolerate the race, and can still lose.

## Fix

Stop making a test-written file an `exec` target: hand the fixture to `sh` as a script
operand, so it is read as data. `/bin/sh` is never opened for writing by the test process,
so `deny_write_access` on it cannot fail.

For the two direct-path sites the equivalence is literal rather than approximate. The
fixture carries a `#!/bin/sh` line, so `execve(git)` already caused the kernel to run
`/bin/sh <git>` in the child's directory, passing the path exactly as given. The new call
is the command line the kernel was constructing — with the script's inode no longer an
`exec` target. A binding that stayed relative still reaches the hostile copy and still
fails.

Three sites carry this shape — the reported one plus two clones that would have flaked
next:

| File | Test |
|---|---|
| `crates/kin-cli/src/commands/eject.rs` | `relative_host_path_is_bound_absolutely_before_eject_changes_child_cwd` |
| `crates/kin-migrate/src/scanner.rs` | `relative_host_path_is_bound_absolutely_before_child_cwd_changes` (verbatim clone) |
| `crates/kin-git/src/test_support.rs` | `relative_host_path_stays_bound_after_fixture_child_cwd_changes` |

The third resolves through PATH rather than a direct path, so it keeps a genuine POSIX
PATH search run by the shell from the child's cwd
(`sh -c 'exec /bin/sh "$(command -v kin-fixture-helper)"'`) rather than substituting an
in-process `which_in` — it still exercises the search a spawned child would perform.

The `empty_global_git_config` boundary tests were audited alongside these: they assert on
`Command::get_envs()` and never spawn, so they carry no exposure.

## The proof is structural, and that is a measured conclusion rather than a shrug

The race could not be reproduced on the development host, and the reason is not a lack of
patience — the precondition cannot exist there. Two standalone measurements:

1. Race harness — 8 threads spawning processes against 4 threads doing
   write → chmod → exec, 20s: **12,575 execs, 0 ETXTBSY**.
2. Direct kernel-property probe — hold a write handle open on the file, then exec it:
   `#!` script **succeeded**; a real Mach-O binary **succeeded**.

macOS enforces `ETXTBSY` for neither shape, and Darwin's `posix_spawn` is a single
kernel-side operation, so the fork→exec window is absent too. The flake belongs to the
**ubuntu-latest** leg of the `check` matrix, where Linux does enforce it on `#!` scripts
(`deny_write_access` in `do_open_execat` runs before binfmt dispatch).

The structural claim is exact: after this change, no file the test process wrote is ever an
`exec` target, so the kernel check that produced `Os error 26` is never applied to a file
these tests can have a writer for.

## Mutation check

Injecting the regression each test exists to catch (a host binding / PATH entry that stayed
child-cwd-relative) confirms both formulations still detect it, so the rewritten assertions
are not vacuous:

```
eject:        FAILED   left: [104,111,115,116,105,108,101] ("hostile")   right: "trusted"
test_support: FAILED   left: [104,111,115,116,105,108,101] ("hostile")   right: "trusted"
```

## Gate

`RUSTFLAGS="-D warnings"`, isolated worktree and target directory:

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p kin-cli -p kin-git -p kin-migrate --all-targets --all-features` with the
  ci.yml allowlist — clean
- `cargo test -p kin-cli --lib --no-default-features` (CI's flaking configuration) —
  **1139 passed, 0 failed**
- `cargo test -p kin-git --lib --features test-support` — 74 passed, 0 failed
- `cargo test -p kin-migrate --lib` — 50 passed, 0 failed
- Repeat loop: 120 iterations of the boundary tests at `--test-threads=32` under sustained
  fork pressure — **0 failures**. This ran on the host that never enforced `ETXTBSY`, so it
  shows the rewritten tests are stable and no new flake was introduced; it is not evidence
  about the Linux race.

## Follow-up worth its own ticket

The same write-an-executable-then-exec-it shape exists at fixture sites where the exec is
performed by *product* code, so this indirection is not available there and a different
remedy would be needed — `crates/kin-cli/src/commands/bench_meta.rs:881`
(`write_bench_fake_git`), `crates/kin-cli/src/commands/setup.rs:14042`, and
`crates/kin-cli/src/commands/update.rs:17193,17293`. Left out of scope here.
(`crates/kin-notify/src/lib.rs:994` has the shape but is a macOS-only path, and macOS was
measured above not to enforce `ETXTBSY`, so it is not exposed.)

Closes FIR-1899
