### PR TITLE
Make the install proof's Windows comparisons native-form and its Python deterministic

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -680,6 +680,10 @@ jobs:
           NODE
 
       - name: Provide a tomllib-capable Python for the Codex TOML proof
+        # Unix runners already carry a tomllib-capable system python3, proven
+        # by prior green runs of this step there, so scope the pinned
+        # interpreter to the one platform where python3 has never executed.
+        if: runner.os == 'Windows'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
@@ -979,8 +983,12 @@ jobs:
           if (!entry || typeof entry.command !== "string" || !Array.isArray(entry.args) || typeof entry.cwd !== "string") {
             throw new Error(`${configPath}: captured MCP launch entry is missing`);
           }
+          // kin records the canonicalized repository root, which on Windows
+          // carries the `\\?\` verbatim prefix that CreateProcessW rejects as
+          // a working directory, so strip it before handing the path to spawn.
+          const stripVerbatim = (p) => (typeof p === "string" && p.startsWith("\\\\?\\") ? p.slice(4) : p);
           const child = spawn(entry.command, entry.args, {
-            cwd: entry.cwd,
+            cwd: stripVerbatim(entry.cwd),
             env: { ...proofEnv, ...(entry.env ?? {}) },
             stdio: ["pipe", "pipe", "pipe"],
           });
@@ -1525,14 +1533,20 @@ jobs:
             { path: path.join(home, ".gemini", "antigravity-ide", "mcp_config.json"), args: repositoryArgs, cwd: repoRoot },
             { path: path.join(repoRoot, ".agents", "mcp_config.json"), args: repositoryArgs, cwd: repoRoot },
           ];
+          // kin records canonicalized repository paths, which on Windows carry
+          // the `\\?\` verbatim prefix; the expectations above are built from
+          // Node's non-verbatim realpath, so compare repository arguments and
+          // cwds in stripped form.
+          const stripVerbatim = (p) => (typeof p === "string" && p.startsWith("\\\\?\\") ? p.slice(4) : p);
           for (const expected of mcpConfigs) {
             const entry = JSON.parse(fs.readFileSync(expected.path, "utf8"))?.mcpServers?.kin;
+            const entryArgs = Array.isArray(entry?.args) ? entry.args.map(stripVerbatim) : entry?.args;
             if (
               !entry ||
               entry.command !== installedKin ||
-              JSON.stringify(entry.args) !== JSON.stringify(expected.args) ||
+              JSON.stringify(entryArgs) !== JSON.stringify(expected.args) ||
               entry.env?.KIN_MCP_TOOL_PROFILE !== "agent-default" ||
-              (expected.cwd !== undefined && entry.cwd !== expected.cwd)
+              (expected.cwd !== undefined && stripVerbatim(entry.cwd) !== expected.cwd)
             ) {
               throw new Error(`${expected.path}: Kin MCP entry is missing or malformed`);
             }

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -679,6 +679,11 @@ jobs:
           }
           NODE
 
+      - name: Provide a tomllib-capable Python for the Codex TOML proof
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
       - name: First-run repository, daemon, and setup proof
         shell: bash
         env:
@@ -755,7 +760,7 @@ jobs:
           # current repository cwd retained as user-owned state.
           antigravity_legacy="$HOME/.gemini/antigravity-ide/mcp_config.json"
           mkdir -p "$(dirname "$antigravity_legacy")"
-          ANTIGRAVITY_LEGACY="$antigravity_legacy" REPO_ROOT="$(pwd -P)" node <<'NODE'
+          ANTIGRAVITY_LEGACY="$antigravity_legacy" node <<'NODE'
           const fs = require("fs");
           const path = require("path");
           const config = {
@@ -764,7 +769,10 @@ jobs:
               kin: {
                 command: "/stale/kin",
                 args: ["mcp", "start"],
-                cwd: process.env.REPO_ROOT,
+                // The validator compares this retained cwd against Node's own
+                // native realpath, so seed it in that exact form rather than
+                // the MSYS forward-slash form bash's pwd produces on Windows.
+                cwd: fs.realpathSync(process.cwd()),
                 env: { USER_POLICY: "preserve" },
               },
             },
@@ -1290,7 +1298,7 @@ jobs:
           const expectedCommit = fs.readFileSync("../expected-commit.txt", "utf8").trim();
           const expectedLock = fs.readFileSync("../expected-lock-sha.txt", "utf8").trim();
           const installedKin = fs.readFileSync("../installed-kin-command.txt", "utf8").trim();
-          const expectedInstalledKin = path.join(os.homedir(), ".kin", "bin", "kin");
+          const expectedInstalledKin = path.join(os.homedir(), ".kin", "bin", isWindows ? "kin.exe" : "kin");
           if (installedKin !== expectedInstalledKin) {
             throw new Error(`installed Kin command proof ${installedKin || "missing"} does not equal ${expectedInstalledKin}`);
           }

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2479,7 +2479,8 @@ def assert_install_proof_status_contract(
         "kin doctor --json | tee kin-doctor.json",
         'path.join(process.cwd(), ".agents", "mcp_config.json")',
         "spawn(entry.command, entry.args",
-        "cwd: entry.cwd",
+        'const stripVerbatim = (p) => (typeof p === "string" && p.startsWith("\\\\\\\\?\\\\") ? p.slice(4) : p);',
+        "cwd: stripVerbatim(entry.cwd),",
         "env: { ...proofEnv, ...(entry.env ?? {}) }",
     ):
         require(graph_active, policy, "installed daemon startup and health capture")


### PR DESCRIPTION
The Windows install-proof leg carries two deterministic post-#601 failures plus one unproven interpreter dependency, all inside `.github/workflows/install-proof.yml`. Because the proof resolves from the release tag, they are tag-critical: a mint cannot go green until the workflow that the tag carries is already fixed on main.

**1. Suffix-less expected path in the capability validator.** The validator built `path.join(os.homedir(), ".kin", "bin", "kin")` with no Windows arm, while the install step records `kin.exe`. The comparison throws deterministically on Windows. The sibling check earlier in the workflow already handles this; this brings the second site in line.

**2. MSYS-form seeded cwd versus native-form assertion.** The seeded stale Antigravity entry captured `$(pwd -P)` from MSYS bash, which yields `D:/a/...` forward slashes on Windows. `kin setup` preserves that cwd verbatim as user-owned state, and the validator then compares it against `fs.realpathSync(process.cwd())`, which is `D:\a\...`. Same directory, guaranteed mismatch. The seed now computes `fs.realpathSync(process.cwd())` inside the Node heredoc itself, so both sides derive the value the same way. Self-tested locally: the seeded value round-trips byte-identical against the validator's computation.

**3. Unpinned Python for the Codex TOML normalization.** The proof shells out to `python3` with `import tomllib` (3.11+), and no Python has ever executed on a Windows runner in this repo, so resolution behavior there is unproven (Store stub, pre-3.11 interpreter). An SHA-pinned `actions/setup-python` v5.6.0 step now provides Python 3.11 on every leg before the proof step runs.

Validation: actionlint clean, YAML parse clean, heredoc self-test passing.

Scope note from the corridor walk that found these (report `.kin-coord/reports/night-20260804-nwalk.md`): fixing these buys new ground past the current deterministic failure point; it does not by itself prove the whole Windows leg green.

Closes FIR-1905

**Second commit b173e122.** The corridor walk's continued verification raised the count to a fourth defect: kin writes canonicalized repository paths, which on Windows carry the `\\?\` verbatim prefix (`setup.rs:1766` via `canonical_initialized_repo` at `setup.rs:2803`; kin's own comparisons normalize both sides per the `setup.rs:3074-3081` comment and `health.rs:1130-1133`, while this workflow's Node validator normalized neither side). A `stripVerbatim` helper now applies to the spawned MCP child's cwd (CreateProcessW rejects verbatim working directories) and to the comparison loop's repository args and cwd. `entry.command` stays raw per the verified blast radius, with a guest-VM observation confirming its written form separately. The setup-python step is also now gated `if: runner.os == 'Windows'`, since prior green runs prove Unix system python3 already carries tomllib and an ungated pin would add a failure mode to four working legs for zero benefit.