### PR TITLE
Serve entity source projections from held repository authority

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -3806,27 +3806,31 @@ fn run_with_graph_capture_budgeted(
         );
     }
     result.degradations = degradations;
+    // ONE held authority for BOTH projections below.
+    //
+    // They run back to back over the same symbol set in the same request, and
+    // every locate entry point -- `POST /locate`, the fused `semantic_locate`
+    // arm, multi-query, `kin locate --snippets` -- funnels through here. An
+    // authority open is a full recovery and the committed state a body's
+    // artifact-identity binding needs is a whole-history replay, so a session
+    // per function pays both twice for one answer, and a session per read pays
+    // them once per definition symbol. That per-symbol shape is the FIR-1897
+    // defect itself, and holding it here is what keeps it off this path.
+    //
+    // Constructing the session performs no IO, so hoisting it above the
+    // `opts.enabled` guards inside both callees costs a disabled request
+    // nothing.
+    let held_authority =
+        kin_mcp::handlers::common::HeldSourceAuthority::new(graph, repository_authority);
     // Project bounded inline snippets from graph-owned content (no extra IO on
     // the working tree). No-op unless requested; the early budget-exhausted
     // return above carries no symbols, so it needs no snippets.
-    attach_snippets(
-        &mut result,
-        graph,
-        &snippet_opts,
-        repository_authority,
-        source_scope,
-    )?;
+    attach_snippets(&mut result, &held_authority, &snippet_opts, source_scope)?;
     // Re-project the ranked symbols into the graph-native PRIMARY surface: a
     // single globally-ranked entity list (file demoted to provenance). Reuses the
     // snippet projection's bounds; the daemon caches the full ranking and windows
     // one page. No-op unless the agent/JSON surface requested snippets.
-    build_entity_view(
-        &mut result,
-        graph,
-        &snippet_opts,
-        repository_authority,
-        source_scope,
-    )?;
+    build_entity_view(&mut result, &held_authority, &snippet_opts, source_scope)?;
     Ok(result)
 }
 
@@ -15441,22 +15445,20 @@ fn collect_explain_for_file(
 /// scorer derives its predicted symbol set from `symbols[].name`, which is
 /// unchanged), so retrieval scoring and proof are unaffected. A no-op unless
 /// `opts.enabled`.
+///
+/// Takes the request's held authority rather than a binding, so it cannot open
+/// a second one: the caller's session is the only authority on this path, and
+/// the graph it reads entities from is the one that session is bound to.
 pub fn attach_snippets(
     result: &mut LocateResult,
-    graph: &kin_db::InMemoryGraph,
+    held_authority: &kin_mcp::handlers::common::HeldSourceAuthority<'_, kin_db::InMemoryGraph>,
     opts: &SnippetOptions,
-    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
 ) -> Result<()> {
     if !opts.enabled || !opts.bodies {
         return Ok(());
     }
-    // One held authority for the whole result set. Every symbol on every file
-    // resolves against the same repository state, so opening authority and
-    // replaying committed history per symbol repeats identical work once per
-    // snippet rather than once per request.
-    let held_authority =
-        kin_mcp::handlers::common::HeldSourceAuthority::new(graph, repository_authority);
+    let graph = held_authority.store();
     for file in result.files.iter_mut() {
         if file.symbols.is_empty() {
             continue;
@@ -15483,7 +15485,7 @@ pub fn attach_snippets(
             };
             if let Some(source) =
                 kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
-                    &held_authority,
+                    held_authority,
                     entity,
                     opts.max_lines,
                     opts.max_chars,
@@ -15524,20 +15526,22 @@ fn match_symbol_entity<'a>(
 /// ([`kin_mcp::handlers::common::read_entity_source_excerpt_detailed`]) every
 /// agent surface uses — never a working-tree read. `None` means the entity has
 /// no source coordinates; graph/tree/blob gaps are errors.
+///
+/// Reads through the request's held authority. The one-shot entry point builds a
+/// fresh session per call, which is correct for a single-entity surface and is
+/// the FIR-1897 defect here: this runs once per definition symbol on a page.
 fn bounded_entity_body_with_note(
-    graph: &kin_db::InMemoryGraph,
+    held_authority: &kin_mcp::handlers::common::HeldSourceAuthority<'_, kin_db::InMemoryGraph>,
     entity: &kin_model::Entity,
     max_lines: usize,
     max_chars: usize,
-    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
 ) -> Result<Option<String>> {
-    let Some(source) = kin_mcp::handlers::common::read_entity_source_excerpt_detailed(
-        graph,
+    let Some(source) = kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
+        held_authority,
         entity,
         max_lines,
         max_chars,
-        repository_authority,
         source_scope,
     )?
     else {
@@ -15574,16 +15578,22 @@ fn bounded_entity_body_with_note(
 /// (and `total_ranked`); the daemon then caches it and windows a single page via
 /// [`apply_entity_page`]. No filesystem read. A no-op unless `opts.enabled`
 /// (the agent/JSON surface), so the human/in-process path is unchanged.
+///
+/// Takes the SAME held authority [`attach_snippets`] just used. Both walk the
+/// same symbol set in the same request, so a body here resolves against
+/// authority and committed state already derived; deriving them again per
+/// definition symbol is the FIR-1897 shape, and it reaches every locate entry
+/// point because they all funnel through [`run_with_graph_capture_budgeted`].
 pub fn build_entity_view(
     result: &mut LocateResult,
-    graph: &kin_db::InMemoryGraph,
+    held_authority: &kin_mcp::handlers::common::HeldSourceAuthority<'_, kin_db::InMemoryGraph>,
     opts: &SnippetOptions,
-    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
 ) -> Result<()> {
     if !opts.enabled {
         return Ok(());
     }
+    let graph = held_authority.store();
     // (file_rank, LocateEntity) so global ranking can tie-break on file order.
     let mut ranked: Vec<(usize, LocateEntity)> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
@@ -15613,11 +15623,10 @@ pub fn build_entity_view(
             // still projected.
             let body = if opts.bodies && sym.definition {
                 bounded_entity_body_with_note(
-                    graph,
+                    held_authority,
                     entity,
                     opts.max_lines,
                     opts.max_chars,
-                    repository_authority,
                     source_scope,
                 )?
                 .or_else(|| sym.snippet.clone())
@@ -17036,9 +17045,8 @@ mod tests {
         };
         build_entity_view(
             &mut result,
-            &graph,
+            &kin_mcp::handlers::common::HeldSourceAuthority::new(&graph, None),
             &SnippetOptions::default(),
-            None,
             kin_mcp::handlers::common::EntitySourceScope::WorkspaceHead,
         )
         .unwrap();

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15451,6 +15451,12 @@ pub fn attach_snippets(
     if !opts.enabled || !opts.bodies {
         return Ok(());
     }
+    // One held authority for the whole result set. Every symbol on every file
+    // resolves against the same repository state, so opening authority and
+    // replaying committed history per symbol repeats identical work once per
+    // snippet rather than once per request.
+    let held_authority =
+        kin_mcp::handlers::common::HeldSourceAuthority::new(graph, repository_authority);
     for file in result.files.iter_mut() {
         if file.symbols.is_empty() {
             continue;
@@ -15475,14 +15481,15 @@ pub fn attach_snippets(
             let Some(entity) = match_symbol_entity(&entities, sym) else {
                 continue;
             };
-            if let Some(source) = kin_mcp::handlers::common::read_entity_source_excerpt_detailed(
-                graph,
-                entity,
-                opts.max_lines,
-                opts.max_chars,
-                repository_authority,
-                source_scope,
-            )? {
+            if let Some(source) =
+                kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
+                    &held_authority,
+                    entity,
+                    opts.max_lines,
+                    opts.max_chars,
+                    source_scope,
+                )?
+            {
                 sym.snippet = Some(source.body);
                 filled += 1;
             }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -24825,6 +24825,119 @@ mod tests {
         );
     }
 
+    /// Install a page of committed, body-bearing definitions in distinct files.
+    ///
+    /// Distinct files AND distinct commits on purpose: each
+    /// `install_repository_file` is its own change, so the entities are
+    /// introduced by different changes. That is the shape a real retrieval page
+    /// has, and it is the one where a per-result authority open multiplies.
+    fn install_locate_page(state: &Arc<DaemonState>, page: usize) {
+        for index in 0..page {
+            let path = format!("src/config{index}.py");
+            let source =
+                format!("def parse_config{index}(path):\n    return {{\"which\": {index}}}\n");
+            install_repository_file(state, &path, source.as_bytes());
+            install_working_copy_file(state, &path, source.as_bytes(), false);
+            let mut entity = test_entity(&format!("parse_config{index}"), &path);
+            entity.span = Some(SourceSpan {
+                file: kin_model::FilePathId::new(&path),
+                start_byte: 0,
+                end_byte: source.len(),
+                start_line: 0,
+                start_col: 0,
+                end_line: 1,
+                end_col: 24,
+            });
+            // The fused ranker reads this preview to decide an entity is a
+            // definition rather than a bare reference, and only definitions get
+            // bodies. Without it this fixture would exercise the reference path,
+            // which projects nothing and would make the bound below vacuous.
+            entity.metadata.extra.insert(
+                "embedding_body_preview".to_string(),
+                json!(source.lines().next().unwrap()),
+            );
+            state.graph.upsert_entity(&entity).unwrap();
+        }
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Bodies projected on a `semantic_locate` page, by whichever key the arm
+    /// used. Both are the same graph-owned projection; the count is what matters.
+    fn bodies_projected(payload: &serde_json::Value) -> usize {
+        payload["entities"]
+            .as_array()
+            .map(|hits| {
+                hits.iter()
+                    .filter(|hit| {
+                        hit.get("snippet").and_then(|v| v.as_str()).is_some()
+                            || hit.get("body").and_then(|v| v.as_str()).is_some()
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    /// The FUSED `semantic_locate` page opens repository authority ONCE.
+    ///
+    /// This is the call-site regression test for FIR-1897 on the arm `POST
+    /// /locate` always uses, that `pipeline: "fused"` selects, that multi-query
+    /// forces, and that `KIN_PROFILE=accuracy-v1` selects. It runs the real MCP
+    /// dispatch route, so what it bounds is the shipped path rather than a
+    /// primitive: fused locate funnels into `run_with_graph_capture_budgeted`,
+    /// which projects bodies TWICE over the same symbol set -- once in
+    /// `attach_snippets` and again in `build_entity_view`. Holding one session
+    /// across both is the whole fix; reverting either to the one-shot entry point
+    /// compiles, changes no output, and must fail HERE.
+    ///
+    /// The assertion is on COUNTS, never on elapsed time. An authority open is a
+    /// full recovery that re-verifies every persisted body against its content
+    /// address, so it costs whatever the store is worth and a timing assertion on
+    /// a four-file fixture would pass just as readily with the defect present.
+    /// The count is the query path's own property and the one that must stay flat
+    /// as the store grows.
+    ///
+    /// It counts opens ON THIS THREAD rather than process-wide: this binary runs
+    /// tests in parallel and several siblings project bodies, so a delta on the
+    /// global counter is not this test's own number.
+    #[tokio::test]
+    async fn semantic_locate_fused_page_opens_repository_authority_once() {
+        const PAGE: usize = 4;
+        let state = test_state();
+        install_locate_page(&state, PAGE);
+        let app = router(state);
+
+        let before = kin_mcp::handlers::common::repository_authority_opens_on_this_thread();
+        let fused = call_semantic_locate(
+            app,
+            json!({
+                "query": "parse config",
+                "limit": 5,
+                "pipeline": "fused",
+                "include_snippet": true
+            }),
+        )
+        .await;
+        let opens = kin_mcp::handlers::common::repository_authority_opens_on_this_thread() - before;
+
+        // Non-vacuity first. A page that projected fewer than two bodies cannot
+        // tell "one open per request" apart from "one open per body", so the
+        // bound below would pass without meaning anything.
+        let projected = bodies_projected(&fused);
+        assert!(
+            projected >= 2,
+            "the fixture must project at least two bodies for the bound to mean anything; \
+             projected {projected}: {fused}"
+        );
+        assert_eq!(
+            opens, 1,
+            "a fused locate page projected {projected} bodies and must have opened repository \
+             authority exactly once; opening per projected body is FIR-1897, and it reaches this \
+             arm through both `attach_snippets` and `build_entity_view`"
+        );
+    }
+
     /// A legacy locate must not be able to empty an agent's live cursor.
     ///
     /// `POST /locate` maps `{snippets, entity_surface}` onto THREE projections, and

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -24904,6 +24904,20 @@ mod tests {
     #[tokio::test]
     async fn semantic_locate_fused_page_opens_repository_authority_once() {
         const PAGE: usize = 4;
+        // Take scheduling out of the result. Every locate phase gate is a
+        // wall-clock decision resolved from the environment, and a host stalled
+        // long enough to exhaust one makes the pipeline skip discovery and
+        // return `Ok` with no files -- which reads at the assertions below
+        // exactly like the regression they exist to catch. `0` is the unbounded
+        // sentinel for these knobs, so this asserts the open COUNT rather than
+        // how much CPU a loaded CI runner happened to grant the query.
+        let _budget = kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_TOTAL_TIMEOUT_SECS", "0")
+            .with("KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS", "0")
+            .with("KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS", "0")
+            .with("KIN_LOCATE_PHASE_MULTIHOP_SECS", "0")
+            .with("KIN_LOCATE_PHASE_TEXT_SEARCH_SECS", "0")
+            .with("KIN_LOCATE_PHASE_SOURCE_TEXT_SECS", "0")
+            .with("KIN_LOCATE_PHASE_SCORING_SECS", "0");
         let state = test_state();
         install_locate_page(&state, PAGE);
         let app = router(state);

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6008,6 +6008,14 @@ fn build_semantic_locate_result(
     } else {
         None
     };
+    // Hold authority ONCE for this request. Opening it is a full authority
+    // recovery and the committed state a snippet's artifact-identity binding
+    // needs is a whole-history replay, and neither varies across the hits on a
+    // page: the daemon holds the loaded graph precisely so a query serves from
+    // it. Deriving both per hit is what made a 40-candidate page perform 40
+    // recoveries and 40 replays, and took a real repository out of service.
+    let held_authority =
+        kin_mcp::handlers::common::HeldSourceAuthority::new(graph, repository_authority.as_ref());
 
     let graph_version = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
     let granularity_token = format!("sem:{}", if file_granularity { "file" } else { "entity" });
@@ -6171,10 +6179,9 @@ fn build_semantic_locate_result(
         // read and no silent graph-gap downgrade.
         let snippet = if include_snippet {
             if let kin_db::ResolvedRetrievalItem::Entity(entity) = &item {
-                match kin_mcp::handlers::common::read_bounded_entity_snippet(
-                    graph,
+                match kin_mcp::handlers::common::read_bounded_entity_snippet_held(
+                    &held_authority,
                     entity,
-                    repository_authority.as_ref(),
                     source_scope,
                 ) {
                     Ok(snippet) => snippet,

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -3,10 +3,11 @@
 
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 use kin_model::change::TreeEntry;
 use kin_model::entity::{Entity, EntityKind, SourceSpan};
-use kin_model::graph::{EntityFilter, GraphStore};
+use kin_model::graph::{ChangeStore, EntityFilter, GraphStore};
 use kin_model::ids::{
     EntityId, Hash256, IntentId, LanguageId, RepoPath, SemanticChangeId, SessionId,
 };
@@ -21,8 +22,11 @@ thread_local! {
     pub static LAST_READ_SOURCE: std::cell::Cell<&'static str> = std::cell::Cell::new("unknown");
 }
 
+use super::repository_authority::{ActiveRepositoryAuthority, WorkspaceReadSample};
 use crate::error::{McpError, Result};
 use kin_core::LocalRepositoryAuthorityBinding;
+
+pub use super::repository_authority::REPOSITORY_AUTHORITY_OPEN_COUNT;
 use kin_spine::{classify_spine_probe, SpineProbe, SpineQuery};
 
 // ── Parameter extraction helpers ──
@@ -449,12 +453,24 @@ pub fn trace_body<G: GraphStore>(
     entity: &Entity,
     repository_authority: Option<&LocalRepositoryAuthorityBinding>,
 ) -> Result<String> {
-    Ok(read_entity_source_excerpt_detailed(
-        store,
+    trace_body_held(
+        &HeldSourceAuthority::new(store, repository_authority),
+        entity,
+    )
+}
+
+/// A trace step's body, served from authority this request already holds. A
+/// trace walks a chain and reads a body per step, so the per-read variant costs
+/// one authority recovery and one whole-history replay per step.
+pub fn trace_body_held<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+) -> Result<String> {
+    Ok(read_entity_source_excerpt_detailed_held(
+        held,
         entity,
         MCP_SOURCE_MAX_LINES,
         MCP_SOURCE_MAX_CHARS,
-        repository_authority,
         EntitySourceScope::WorkspaceHead,
     )?
     .map(|source| source.body)
@@ -827,13 +843,29 @@ pub fn evaluate_trace_chain<G: GraphStore>(
     input_literal: i64,
     repository_authority: Option<&LocalRepositoryAuthorityBinding>,
 ) -> Result<Option<Vec<TraceEvaluationStep>>> {
+    evaluate_trace_chain_held(
+        &HeldSourceAuthority::new(store, repository_authority),
+        chain,
+        input_literal,
+    )
+}
+
+/// Evaluate a trace chain from authority this request already holds.
+///
+/// The walk reads at least two bodies per step plus one per constant, so this is
+/// the variant a request must use; the per-read one multiplies a full authority
+/// recovery by the chain length.
+pub fn evaluate_trace_chain_held<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    chain: &[Entity],
+    input_literal: i64,
+) -> Result<Option<Vec<TraceEvaluationStep>>> {
+    let store = held.store();
     let mut constant_values = HashMap::new();
     for step in chain {
-        let body = trace_body(store, step, repository_authority)?;
+        let body = trace_body_held(held, step)?;
         for constant in trace_constants_for_step(store, step, &body)? {
-            if let Some(value) =
-                parse_trace_constant_value(&trace_body(store, &constant, repository_authority)?)
-            {
+            if let Some(value) = parse_trace_constant_value(&trace_body_held(held, &constant)?) {
                 constant_values
                     .entry(constant.name.clone())
                     .or_insert(value);
@@ -845,7 +877,7 @@ pub fn evaluate_trace_chain<G: GraphStore>(
     let mut evaluation = Vec::new();
 
     for step in chain.iter().rev() {
-        let body = trace_body(store, step, repository_authority)?;
+        let body = trace_body_held(held, step)?;
         let Some((value, detail)) =
             evaluate_trace_step_body(&body, input_literal, &function_values, &constant_values)
         else {
@@ -1301,6 +1333,20 @@ fn graph_source_gap(message: impl Into<String>) -> McpError {
     )))
 }
 
+/// The text a retained authority failure must replay verbatim.
+///
+/// A session opens authority once and reports that same failure to every read
+/// that needed it, so the failure has to survive as text. `McpError::Context`
+/// prints a `context error: ` prefix, so retaining the Display string and
+/// re-wrapping it would nest that prefix once per replay and drift the message
+/// away from the one a single read reports.
+fn retained_gap_message(error: McpError) -> String {
+    match error {
+        McpError::Context(message) => message,
+        other => other.to_string(),
+    }
+}
+
 /// Which graph-owned repository state a source projection resolves against.
 ///
 /// `EntitySourceScope::WorkspaceHead` reads the workspace's exact graph-owned
@@ -1340,12 +1386,11 @@ pub enum EntitySourceScope {
 /// Callers use this to enforce artifact-identity binding where history can
 /// support it, so a replay that cannot answer must not turn into a read failure.
 fn committed_introducing_change<G: GraphStore>(
-    store: &G,
+    held: &HeldSourceAuthority<'_, G>,
     entity: &Entity,
     change_id: &SemanticChangeId,
 ) -> Option<SemanticChangeId> {
-    store
-        .resolve_graph_at(change_id)
+    held.graph_at(change_id)
         .ok()?
         .entity_revisions
         .get(&entity.id)?
@@ -1409,10 +1454,180 @@ pub fn span_source_coherence(
     }
 }
 
+/// One request's held repository authority and the committed states its source
+/// reads derive from.
+///
+/// A source read needs three things a store cannot answer on its own: an open
+/// repository authority (for the workspace tree and the source blobs), the
+/// committed graph state at the change being read, and the tree at the change
+/// that introduced an entity. Each is expensive and each is a pure function of
+/// the store plus a change id, so deriving them once per REQUEST and deriving
+/// them once per RESULT are the same answer at very different cost. Before this
+/// type existed the projection derived all three per entity, which is what made
+/// a 40-candidate `semantic_locate` perform 40 authority opens and 40 whole-
+/// history replays and put a real repository out of service.
+///
+/// The reuse is sound because it is scoped, not cached. The session borrows ONE
+/// store snapshot for its whole life, so a memoized replay is byte-identical to
+/// the replay it replaces -- `resolve_graph_at` is deterministic in (store,
+/// change). Nothing survives the request: a later request opens authority again
+/// and sees whatever the store holds then. There is deliberately no process-wide
+/// cache here, because that is the shape that can serve authority the store has
+/// already moved past.
+///
+/// Reusing one sample is also strictly MORE coherent than re-sampling per
+/// entity. [`WorkspaceReadSample`] exists because pairing a tree from one
+/// generation with provenance from another is a real defect; sampling once per
+/// entity reintroduced exactly that hazard across a result set, where page 1 of
+/// a response could describe a generation page 40 no longer read from.
+///
+/// Everything is derived lazily. An entity with no span or no file origin needs
+/// no authority at all, and must keep returning "no source" rather than an
+/// authority error, so constructing a session neither opens authority nor
+/// replays anything.
+///
+/// [`WorkspaceReadSample`]: super::repository_authority::WorkspaceReadSample
+pub struct HeldSourceAuthority<'store, G: GraphStore> {
+    store: &'store G,
+    binding: Option<LocalRepositoryAuthorityBinding>,
+    /// One open attempt for the session. The error is retained as its message so
+    /// every entity that needs authority reports the same gap this session hit,
+    /// instead of re-attempting a recovery that already failed.
+    authority: std::sync::OnceLock<std::result::Result<ActiveRepositoryAuthority, String>>,
+    head_sample: std::sync::OnceLock<std::result::Result<Arc<WorkspaceReadSample>, String>>,
+    graph_at: Mutex<HashMap<SemanticChangeId, Arc<kin_model::graph::ResolvedGraphState>>>,
+    tree_at: Mutex<HashMap<SemanticChangeId, Arc<kin_model::ResolvedTree>>>,
+    /// Replays this session actually performed, as opposed to served from its
+    /// memo. The bound a query path has to hold is on this number, not on
+    /// elapsed time, so it is observable.
+    replays: AtomicU64,
+}
+
+impl<'store, G: GraphStore> HeldSourceAuthority<'store, G> {
+    /// Hold authority for one request against one store snapshot.
+    ///
+    /// `repository_authority` is the startup-pinned binding, not an open: this
+    /// constructor performs no IO. A `None` binding is an ordinary state (a
+    /// daemon serving hosted snapshot authority), and only a read that actually
+    /// needs local authority turns it into a gap.
+    pub fn new(
+        store: &'store G,
+        repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    ) -> Self {
+        Self {
+            store,
+            binding: repository_authority.cloned(),
+            authority: std::sync::OnceLock::new(),
+            head_sample: std::sync::OnceLock::new(),
+            graph_at: Mutex::new(HashMap::new()),
+            tree_at: Mutex::new(HashMap::new()),
+            replays: AtomicU64::new(0),
+        }
+    }
+
+    /// Whole-history replays this session performed. A query path that derives
+    /// committed state per request holds this at a small constant; one that
+    /// derives it per result does not.
+    pub fn replays_performed(&self) -> u64 {
+        self.replays.load(Ordering::SeqCst)
+    }
+
+    /// The store this session is bound to, for graph reads that ride alongside
+    /// the source projection in the same walk.
+    pub fn store(&self) -> &'store G {
+        self.store
+    }
+
+    fn authority(&self) -> Result<&ActiveRepositoryAuthority> {
+        match self.authority.get_or_init(|| {
+            let binding = self.binding.as_ref().ok_or_else(|| {
+                "graph authority gap: this MCP runtime has no startup-pinned local repository \
+                 authority binding"
+                    .to_string()
+            })?;
+            ActiveRepositoryAuthority::open(binding).map_err(retained_gap_message)
+        }) {
+            Ok(authority) => Ok(authority),
+            Err(message) => Err(record_graph_source_gap(McpError::Context(message.clone()))),
+        }
+    }
+
+    /// The one instant of workspace authority this request reads at.
+    fn workspace_sample(&self) -> Result<&WorkspaceReadSample> {
+        match self.head_sample.get_or_init(|| {
+            self.authority()
+                .and_then(|authority| authority.workspace_sample())
+                .map(Arc::new)
+                .map_err(retained_gap_message)
+        }) {
+            Ok(sample) => Ok(sample.as_ref()),
+            Err(message) => Err(record_graph_source_gap(McpError::Context(message.clone()))),
+        }
+    }
+
+    /// The committed graph state at `change`, replayed at most once per session.
+    ///
+    /// The store's own error is returned unwrapped so each call site keeps the
+    /// message it already reports for a failed replay.
+    fn graph_at(
+        &self,
+        change: &SemanticChangeId,
+    ) -> std::result::Result<Arc<kin_model::graph::ResolvedGraphState>, <G as ChangeStore>::Error>
+    {
+        if let Some(state) = self.memo_hit(&self.graph_at, change) {
+            return Ok(state);
+        }
+        // The replay runs with no lock held: it is the expensive step, and a
+        // session shared across threads must not serialize on it. Losing the
+        // race costs one redundant replay and cannot produce a different answer,
+        // because the store is fixed for the session's life.
+        let resolved = Arc::new(self.store.resolve_graph_at(change)?);
+        self.replays.fetch_add(1, Ordering::SeqCst);
+        Ok(self.memo_fill(&self.graph_at, *change, resolved))
+    }
+
+    /// The repository tree at `change`, replayed at most once per session.
+    fn tree_at(
+        &self,
+        change: &SemanticChangeId,
+    ) -> std::result::Result<Arc<kin_model::ResolvedTree>, <G as ChangeStore>::Error> {
+        if let Some(tree) = self.memo_hit(&self.tree_at, change) {
+            return Ok(tree);
+        }
+        let resolved = Arc::new(self.store.resolve_tree_at(change)?);
+        self.replays.fetch_add(1, Ordering::SeqCst);
+        Ok(self.memo_fill(&self.tree_at, *change, resolved))
+    }
+
+    fn memo_hit<T>(
+        &self,
+        memo: &Mutex<HashMap<SemanticChangeId, Arc<T>>>,
+        change: &SemanticChangeId,
+    ) -> Option<Arc<T>> {
+        memo.lock()
+            .expect("held source authority memo is never poisoned")
+            .get(change)
+            .map(Arc::clone)
+    }
+
+    fn memo_fill<T>(
+        &self,
+        memo: &Mutex<HashMap<SemanticChangeId, Arc<T>>>,
+        change: SemanticChangeId,
+        resolved: Arc<T>,
+    ) -> Arc<T> {
+        Arc::clone(
+            memo.lock()
+                .expect("held source authority memo is never poisoned")
+                .entry(change)
+                .or_insert(resolved),
+        )
+    }
+}
+
 fn resolve_entity_source_authority<G: GraphStore>(
-    store: &G,
+    held: &HeldSourceAuthority<'_, G>,
     entity: &Entity,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
     scope: EntitySourceScope,
 ) -> Result<Option<(ExactEntitySource, Vec<u8>, SourceSpan)>> {
     LAST_READ_SOURCE.with(|f| f.set("unknown"));
@@ -1430,14 +1645,7 @@ fn resolve_entity_source_authority<G: GraphStore>(
         )));
     }
 
-    let authority = super::repository_authority::ActiveRepositoryAuthority::open(
-        repository_authority.ok_or_else(|| {
-            graph_source_gap(
-                "this MCP runtime has no startup-pinned local repository authority binding",
-            )
-        })?,
-    )
-    .map_err(record_graph_source_gap)?;
+    let authority = held.authority()?;
 
     let path = RepoPath::from_utf8(recorded_origin.0.clone()).map_err(|error| {
         graph_source_gap(format!(
@@ -1469,9 +1677,7 @@ fn resolve_entity_source_authority<G: GraphStore>(
             // to all describe one instant. Reading the tree from one snapshot and
             // the change id from another let a response pair generation N's bytes
             // with generation N+1's provenance, with nothing serializing the two.
-            let sample = authority
-                .workspace_sample()
-                .map_err(record_graph_source_gap)?;
+            let sample = held.workspace_sample()?;
             let workspace = &sample.workspace;
             let artifact = workspace
                 .tree
@@ -1514,9 +1720,9 @@ fn resolve_entity_source_authority<G: GraphStore>(
             // prior binding to contradict, and rejecting it was exactly the false
             // gap that closed body reads on fresh clones.
             if let Some(introduced_by) =
-                committed_introducing_change(store, entity, &source_change_id)
+                committed_introducing_change(held, entity, &source_change_id)
             {
-                let introduced_tree = store.resolve_tree_at(&introduced_by).map_err(|error| {
+                let introduced_tree = held.tree_at(&introduced_by).map_err(|error| {
                     graph_source_gap(format!(
                         "cannot resolve entity {} introduction tree at {introduced_by}: {error}",
                         entity.id
@@ -1555,7 +1761,7 @@ fn resolve_entity_source_authority<G: GraphStore>(
         // the tree at the same change, so this replaces a separate tree
         // resolution rather than adding to it.
         EntitySourceScope::At(source_change_id) => {
-            let committed = store.resolve_graph_at(&source_change_id).map_err(|error| {
+            let committed = held.graph_at(&source_change_id).map_err(|error| {
                 graph_source_gap(format!(
                     "cannot resolve committed repository state at {source_change_id}: {error}"
                 ))
@@ -1591,15 +1797,12 @@ fn resolve_entity_source_authority<G: GraphStore>(
             // Bind the entity revision to the artifact identity that occupied its
             // path when that revision was introduced. A later path reuse must not
             // make an old entity read bytes from a different artifact.
-            let introduced_tree =
-                store
-                    .resolve_tree_at(&revision.introduced_by)
-                    .map_err(|error| {
-                        graph_source_gap(format!(
-                            "cannot resolve entity {} introduction tree at {}: {error}",
-                            entity.id, revision.introduced_by
-                        ))
-                    })?;
+            let introduced_tree = held.tree_at(&revision.introduced_by).map_err(|error| {
+                graph_source_gap(format!(
+                    "cannot resolve entity {} introduction tree at {}: {error}",
+                    entity.id, revision.introduced_by
+                ))
+            })?;
             let introduced_artifact = introduced_tree.artifact_at_path(&path).ok_or_else(|| {
                 graph_source_gap(format!(
                     "entity {} revision {} was introduced without an artifact at '{}'",
@@ -1695,6 +1898,13 @@ fn resolve_entity_source_authority<G: GraphStore>(
     )))
 }
 
+/// One-shot body projection: holds authority for the duration of this ONE read.
+///
+/// Correct for a single-entity surface (`get_entity_source`, `get_entity_body`).
+/// A surface that projects many entities for one request must instead build one
+/// [`HeldSourceAuthority`] and call
+/// [`read_entity_source_excerpt_detailed_held`], or it pays a full authority
+/// recovery and a whole-history replay per result.
 pub fn read_entity_source_excerpt_detailed<G: GraphStore>(
     store: &G,
     entity: &Entity,
@@ -1703,8 +1913,24 @@ pub fn read_entity_source_excerpt_detailed<G: GraphStore>(
     repository_authority: Option<&LocalRepositoryAuthorityBinding>,
     scope: EntitySourceScope,
 ) -> Result<Option<ExactEntitySource>> {
-    let Some((mut source, bytes, span)) =
-        resolve_entity_source_authority(store, entity, repository_authority, scope)?
+    read_entity_source_excerpt_detailed_held(
+        &HeldSourceAuthority::new(store, repository_authority),
+        entity,
+        max_lines,
+        max_chars,
+        scope,
+    )
+}
+
+/// Body projection served from authority this request already holds.
+pub fn read_entity_source_excerpt_detailed_held<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    max_lines: usize,
+    max_chars: usize,
+    scope: EntitySourceScope,
+) -> Result<Option<ExactEntitySource>> {
+    let Some((mut source, bytes, span)) = resolve_entity_source_authority(held, entity, scope)?
     else {
         return Ok(None);
     };
@@ -1778,12 +2004,29 @@ pub fn read_bounded_entity_snippet<G: GraphStore>(
     repository_authority: Option<&LocalRepositoryAuthorityBinding>,
     scope: EntitySourceScope,
 ) -> Result<Option<String>> {
-    Ok(read_entity_source_excerpt_detailed(
-        store,
+    read_bounded_entity_snippet_held(
+        &HeldSourceAuthority::new(store, repository_authority),
+        entity,
+        scope,
+    )
+}
+
+/// Bounded snippet served from authority this request already holds.
+///
+/// This is the variant every retrieval surface must use. A retrieval result set
+/// projects one snippet per hit, so opening authority and replaying history per
+/// hit multiplies process-startup work by the page size -- the defect that made
+/// `semantic_locate` unusable on a real repository.
+pub fn read_bounded_entity_snippet_held<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    scope: EntitySourceScope,
+) -> Result<Option<String>> {
+    Ok(read_entity_source_excerpt_detailed_held(
+        held,
         entity,
         RETRIEVAL_SNIPPET_MAX_LINES,
         RETRIEVAL_SNIPPET_MAX_CHARS,
-        repository_authority,
         scope,
     )?
     .map(|source| source.body))
@@ -2114,14 +2357,28 @@ pub fn focal_context_json<G: GraphStore>(
     compact: bool,
     repository_authority: Option<&LocalRepositoryAuthorityBinding>,
 ) -> Result<serde_json::Value> {
+    focal_context_json_held(
+        &HeldSourceAuthority::new(store, repository_authority),
+        entity,
+        compact,
+    )
+}
+
+/// The focal entity's context projection, served from authority this request
+/// already holds. A context pack projects the focal entity and then every
+/// dependency it carries, so all of those reads belong to one session.
+pub fn focal_context_json_held<G: GraphStore>(
+    held: &HeldSourceAuthority<'_, G>,
+    entity: &Entity,
+    compact: bool,
+) -> Result<serde_json::Value> {
     let start_line = entity_presentation_start_line(entity);
     let end_line = entity_presentation_end_line(entity);
-    let source_excerpt = read_entity_source_excerpt_detailed(
-        store,
+    let source_excerpt = read_entity_source_excerpt_detailed_held(
+        held,
         entity,
         MCP_SOURCE_MAX_LINES,
         MCP_SOURCE_MAX_CHARS,
-        repository_authority,
         EntitySourceScope::WorkspaceHead,
     )?;
     let source = LAST_READ_SOURCE.with(|f| f.get());

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -26,7 +26,9 @@ use super::repository_authority::{ActiveRepositoryAuthority, WorkspaceReadSample
 use crate::error::{McpError, Result};
 use kin_core::LocalRepositoryAuthorityBinding;
 
-pub use super::repository_authority::REPOSITORY_AUTHORITY_OPEN_COUNT;
+pub use super::repository_authority::{
+    repository_authority_opens_on_this_thread, REPOSITORY_AUTHORITY_OPEN_COUNT,
+};
 use kin_spine::{classify_spine_probe, SpineProbe, SpineQuery};
 
 // ── Parameter extraction helpers ──
@@ -1010,6 +1012,12 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
     let mut grouped: HashMap<String, ReferenceRow> = HashMap::new();
 
+    // One held authority for the whole reference set. This projects a body per
+    // REFERENCING entity, so it is the same multi-entity shape the retrieval
+    // surfaces have: deriving authority and committed state per row pays a full
+    // authority recovery and a whole-history replay once per caller found.
+    let held = HeldSourceAuthority::new(store, repository_authority);
+
     for rel in store
         .get_all_relations_for_entity(entity_id)
         .map_err(McpError::graph)?
@@ -1029,12 +1037,8 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
 
         let file_path = entity.file_origin.as_ref().map(|path| path.0.clone());
         let key = reference_row_key(file_path.as_deref(), &entity.name);
-        let snippet = read_bounded_entity_snippet(
-            store,
-            &entity,
-            repository_authority,
-            EntitySourceScope::WorkspaceHead,
-        )?;
+        let snippet =
+            read_bounded_entity_snippet_held(&held, &entity, EntitySourceScope::WorkspaceHead)?;
         let entry = grouped.entry(key).or_insert_with(|| ReferenceRow {
             entity_id: Some(source_entity_id.to_string()),
             name: entity.name.clone(),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -486,10 +486,10 @@ pub fn assemble_entity_sources_response(
 /// `GraphSourceRecord` (debug-formatted kind, `to_string` language, raw
 /// file path) so the row shape is identical whichever path resolved it.
 fn resolve_entity_source_generic<G: GraphStore>(
-    store: &G,
+    held: &HeldSourceAuthority<'_, G>,
     id: &str,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
 ) -> ResolvedEntitySource {
+    let store = held.store();
     let entity_id = match parse_entity_id(id) {
         Ok(entity_id) => entity_id,
         Err(_) => {
@@ -501,12 +501,11 @@ fn resolve_entity_source_generic<G: GraphStore>(
     };
     match store.get_entity(&entity_id) {
         Ok(Some(entity)) => {
-            match read_entity_source_excerpt_detailed(
-                store,
+            match read_entity_source_excerpt_detailed_held(
+                held,
                 &entity,
                 DEFAULT_SOURCE_MAX_LINES,
                 DEFAULT_SOURCE_MAX_BYTES,
-                repository_authority,
                 EntitySourceScope::WorkspaceHead,
             ) {
                 Ok(Some(source)) => ResolvedEntitySource::Found(EntitySourceRow {
@@ -557,9 +556,11 @@ pub fn handle_get_entity_sources<G: GraphStore>(
     repository_authority: Option<&LocalRepositoryAuthorityBinding>,
 ) -> Result<ToolCallResult> {
     let (entity_ids, opts) = parse_batch_source_args(args)?;
+    // A batch is one request: it holds authority once for every id it resolves.
+    let held = HeldSourceAuthority::new(store, repository_authority);
     let resolved = entity_ids
         .iter()
-        .map(|id| resolve_entity_source_generic(store, id, repository_authority))
+        .map(|id| resolve_entity_source_generic(&held, id))
         .collect();
     Ok(assemble_entity_sources_response(resolved, &opts))
 }
@@ -626,8 +627,13 @@ pub fn handle_get_context_pack<G: GraphStore>(
     let focal_entry = pack.focal_entities.first();
     let focal_entity = store.get_entity(&entity_id).map_err(McpError::graph)?;
 
+    // One held authority for the whole pack. A pack projects the focal entity
+    // and then a body per dependency it carries, so deriving authority per
+    // projection multiplies a full recovery by the pack's size.
+    let held = HeldSourceAuthority::new(store, repository_authority);
+
     let focal_json = if let (Some(_), Some(entity)) = (focal_entry, &focal_entity) {
-        focal_context_json(store, entity, compact, repository_authority)?
+        focal_context_json_held(&held, entity, compact)?
     } else {
         serde_json::json!(null)
     };
@@ -650,12 +656,11 @@ pub fn handle_get_context_pack<G: GraphStore>(
             });
             if !compact {
                 obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
-                let body = read_entity_source_excerpt_detailed(
-                    store,
+                let body = read_entity_source_excerpt_detailed_held(
+                    &held,
                     &e,
                     MCP_SOURCE_MAX_LINES,
                     MCP_SOURCE_MAX_CHARS,
-                    repository_authority,
                     EntitySourceScope::WorkspaceHead,
                 )?;
                 let source = LAST_READ_SOURCE.with(|f| f.get());
@@ -1602,6 +1607,10 @@ pub fn handle_explore_codebase<G: GraphStore>(
     use kin_context::{build_context_pack, estimate_tokens, ContextOptions};
     use kin_model::context::TokenBudget;
 
+    // One held authority for the whole exploration: the trace rendering below
+    // reads a body per chain step and per constant it finds.
+    let held = HeldSourceAuthority::new(store, repository_authority);
+
     let query = get_string_param(args, "query")?;
     let strategy = args
         .get("strategy")
@@ -1779,7 +1788,7 @@ pub fn handle_explore_codebase<G: GraphStore>(
 
                         let outgoing_calls =
                             outgoing_related_entities(store, &step.id, &[RelationKind::Calls])?;
-                        let step_body = trace_body(store, step, repository_authority)?;
+                        let step_body = trace_body_held(&held, step)?;
                         let constants = trace_constants_for_step(store, step, &step_body)?;
 
                         if !push_with_budget(
@@ -1839,8 +1848,7 @@ pub fn handle_explore_codebase<G: GraphStore>(
                                     output.push_str("  ... (truncated)\n");
                                     break;
                                 }
-                                let constant_body =
-                                    trace_body(store, constant, repository_authority)?;
+                                let constant_body = trace_body_held(&held, constant)?;
                                 if !push_indented_body(
                                     &mut output,
                                     &mut tokens_used,
@@ -1857,7 +1865,7 @@ pub fn handle_explore_codebase<G: GraphStore>(
 
                 if let Some(input_literal) = trace_query.input_literal {
                     if let Some(evaluation) =
-                        evaluate_trace_chain(store, &chain, input_literal, repository_authority)?
+                        evaluate_trace_chain_held(&held, &chain, input_literal)?
                     {
                         if push_with_budget(
                             &mut output,

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5317,6 +5317,108 @@ mod tests {
         assert!(error.to_string().contains("does not describe these bytes"));
     }
 
+    /// A page of retrieval hits derives repository authority ONCE, not once per
+    /// hit.
+    ///
+    /// This is the bound FIR-1897 was filed on. `semantic_locate` fans a client
+    /// `limit: 5` out to 40 daemon candidates, and the body projection re-opened
+    /// the persisted authority and replayed the whole committed history for each
+    /// one, so on a 23,683-blob store a single query ran past 44 minutes with no
+    /// vector frame anywhere in the profile.
+    ///
+    /// The assertion is on COUNTS, not on elapsed time. An authority open is a
+    /// full recovery and a replay walks all of history, so both cost whatever the
+    /// store is worth; only their number is the query path's own property, and it
+    /// is the one that has to stay flat as the store grows. A timing assertion on
+    /// a tiny fixture would pass just as readily with the defect present.
+    ///
+    /// The second arm is the falsification. The one-shot entry point holds
+    /// authority for exactly one read, which is the shape the whole projection
+    /// had before this fix, and it must visibly regress both counts on the same
+    /// fixture. Without it this test could be passing because the fixture is
+    /// cheap rather than because the query path changed.
+    #[test]
+    fn a_retrieval_page_derives_repository_authority_once() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+
+        // A page of distinct entities in distinct files, all committed by one
+        // change, which is the ordinary shape of a retrieval result set.
+        const PAGE: usize = 6;
+        let mut store = EmptyStore::default();
+        let mut page = Vec::with_capacity(PAGE);
+        for index in 0..PAGE {
+            let content = format!("export function hit{index}() {{ return {index}; }}\n");
+            let hash = blob_store.write(content.as_bytes()).unwrap();
+            let file_id = FilePathId::new(format!("src/hit{index}.ts"));
+            store.file_hashes.insert(file_id.clone(), hash);
+            let entity = whole_file_entity(&file_id, &content, Some(hash));
+            store.entities_by_id.insert(entity.id, entity.clone());
+            page.push(entity);
+        }
+        install_empty_store_exact_tree(&mut store, dir.path());
+        let authority = test_repository_authority(dir.path());
+
+        let opens = || REPOSITORY_AUTHORITY_OPEN_COUNT.load(std::sync::atomic::Ordering::SeqCst);
+
+        // Held arm: one session serves the whole page.
+        let held = HeldSourceAuthority::new(&store, Some(&authority));
+        let before_held = opens();
+        for (index, entity) in page.iter().enumerate() {
+            let snippet =
+                read_bounded_entity_snippet_held(&held, entity, EntitySourceScope::WorkspaceHead)
+                    .expect("every fixture entity has coherent graph-owned source")
+                    .expect("every fixture entity has source coordinates");
+            assert!(
+                snippet.contains(&format!("hit{index}")),
+                "hit {index} must serve its own body, not another entity's: {snippet}"
+            );
+        }
+        let held_opens = opens() - before_held;
+        assert_eq!(
+            held_opens, 1,
+            "a {PAGE}-hit page must open repository authority once; opening per hit is what \
+             multiplied a full authority recovery by the page size"
+        );
+        // Every hit resolves against the same base change, so the committed state
+        // is one replay and the introducing tree is one more. Neither scales with
+        // the page.
+        assert_eq!(
+            held.replays_performed(),
+            2,
+            "committed state and the introducing tree are request-invariant here, so the page \
+             must replay history twice in total, not twice per hit"
+        );
+
+        // Falsification: the pre-fix shape, one session per read, on this exact
+        // fixture. If the counts above were an artifact of the fixture rather
+        // than of the fix, these would match them.
+        let before_one_shot = opens();
+        for entity in &page {
+            read_bounded_entity_snippet(
+                &store,
+                entity,
+                Some(&authority),
+                EntitySourceScope::WorkspaceHead,
+            )
+            .expect("the one-shot projection reads the same fixture")
+            .expect("every fixture entity has source coordinates");
+        }
+        assert_eq!(
+            opens() - before_one_shot,
+            PAGE as u64,
+            "the one-shot projection must still open once per read; if it does not, this test \
+             cannot tell a held session apart from the defect it was written to catch"
+        );
+    }
+
     /// True when committed history records no active revision for `entity`, which
     /// is the condition that skips the artifact-identity binding.
     fn committed_introducing_change_is_absent(store: &EmptyStore, entity: &Entity) -> bool {

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5334,9 +5334,11 @@ mod tests {
     ///
     /// The second arm is the falsification. The one-shot entry point holds
     /// authority for exactly one read, which is the shape the whole projection
-    /// had before this fix, and it must visibly regress both counts on the same
-    /// fixture. Without it this test could be passing because the fixture is
-    /// cheap rather than because the query path changed.
+    /// had before this fix, and it must visibly regress the open count on the
+    /// same fixture. Without it this test could be passing because the fixture is
+    /// cheap rather than because the query path changed. Only the OPEN count is
+    /// observable on that arm: it builds its session internally, so its replay
+    /// count is unreachable from here and is deliberately not claimed.
     #[test]
     fn a_retrieval_page_derives_repository_authority_once() {
         let _lock = ENV_MUTEX
@@ -5366,7 +5368,14 @@ mod tests {
         install_empty_store_exact_tree(&mut store, dir.path());
         let authority = test_repository_authority(dir.path());
 
-        let opens = || REPOSITORY_AUTHORITY_OPEN_COUNT.load(std::sync::atomic::Ordering::SeqCst);
+        // Opens on THIS thread, not process-wide. The global counter is the
+        // honest process total, but a delta taken across a section of one test
+        // is not that test's own number in a parallel binary. This assertion
+        // used to be sound only because every kin-mcp test that can open
+        // authority happens to hold `ENV_MUTEX`, which is a property of the
+        // whole binary that nothing enforces; the lock below is still needed for
+        // `KIN_SOURCE_ROOT`, but the count no longer depends on it.
+        let opens = common::repository_authority_opens_on_this_thread;
 
         // Held arm: one session serves the whole page.
         let held = HeldSourceAuthority::new(&store, Some(&authority));
@@ -5387,14 +5396,19 @@ mod tests {
             "a {PAGE}-hit page must open repository authority once; opening per hit is what \
              multiplied a full authority recovery by the page size"
         );
-        // Every hit resolves against the same base change, so the committed state
-        // is one replay and the introducing tree is one more. Neither scales with
-        // the page.
+        // The invariant, stated exactly. Every hit resolves against the SAME base
+        // change, so the committed state is ONE replay however long the page is.
+        // The introducing TREE is keyed by `introduced_by`, which varies per
+        // entity, so it is one replay per DISTINCT introducing change -- not one
+        // per hit, and not a constant. This fixture commits all six entities in
+        // one change, so D = 1 and the total is 2; that 2 is a property of the
+        // fixture, and only the formula below is the property of the fix.
+        let distinct_introducing_changes = 1;
         assert_eq!(
             held.replays_performed(),
-            2,
-            "committed state and the introducing tree are request-invariant here, so the page \
-             must replay history twice in total, not twice per hit"
+            1 + distinct_introducing_changes,
+            "the page must replay committed state once and the introducing tree once per \
+             distinct introducing change, not either of them once per hit"
         );
 
         // Falsification: the pre-fix shape, one session per read, on this exact
@@ -5414,6 +5428,102 @@ mod tests {
         assert_eq!(
             opens() - before_one_shot,
             PAGE as u64,
+            "the one-shot projection must still open once per read; if it does not, this test \
+             cannot tell a held session apart from the defect it was written to catch"
+        );
+    }
+
+    /// `find_references` derives repository authority ONCE, not once per caller.
+    ///
+    /// `collect_graph_reference_rows` projects a bounded body per REFERENCING
+    /// entity, so it has the same multi-entity shape as a retrieval page and had
+    /// the same defect: a full authority recovery and a whole-history replay per
+    /// caller found. It was missed when FIR-1897 was first scoped because the
+    /// surface reads relations rather than running retrieval, and the ticket was
+    /// written about `semantic_locate`.
+    ///
+    /// Same counting discipline as the page test above, and the same second arm
+    /// so a cheap fixture cannot be mistaken for a fixed one.
+    #[test]
+    fn find_references_derives_repository_authority_once() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+
+        // One target plus several callers, each in its own file, which is what a
+        // real `find_references` answer looks like.
+        const CALLERS: usize = 5;
+        let mut store = EmptyStore::default();
+        let install = |store: &mut EmptyStore, name: &str| -> Entity {
+            let content = format!("export function {name}() {{ return \"{name}\"; }}\n");
+            let hash = blob_store.write(content.as_bytes()).unwrap();
+            let file_id = FilePathId::new(format!("src/{name}.ts"));
+            store.file_hashes.insert(file_id.clone(), hash);
+            let entity = whole_file_entity(&file_id, &content, Some(hash));
+            store.insert_test_entity(entity.clone());
+            entity
+        };
+        let target = install(&mut store, "target");
+        let callers: Vec<Entity> = (0..CALLERS)
+            .map(|index| install(&mut store, &format!("caller{index}")))
+            .collect();
+        for caller in &callers {
+            store.insert_test_calls_relation(caller, &target);
+        }
+        install_empty_store_exact_tree(&mut store, dir.path());
+        let authority = test_repository_authority(dir.path());
+
+        let opens = common::repository_authority_opens_on_this_thread;
+
+        let before_held = opens();
+        let rows = collect_graph_reference_rows(
+            &store,
+            &target.id,
+            &[RelationKind::Calls],
+            Some(&authority),
+        )
+        .expect("every fixture caller has coherent graph-owned source");
+        let held_opens = opens() - before_held;
+
+        // Non-vacuity: the bound means nothing unless bodies were actually
+        // projected for more than one caller.
+        assert_eq!(
+            rows.len(),
+            CALLERS,
+            "every caller must be reported: {rows:?}"
+        );
+        assert_eq!(
+            rows.iter().filter(|row| row.snippet.is_some()).count(),
+            CALLERS,
+            "every reported caller must carry its graph-owned body: {rows:?}"
+        );
+        assert_eq!(
+            held_opens, 1,
+            "a {CALLERS}-caller reference set must open repository authority once; opening per \
+             caller is the FIR-1897 shape on the `find_references` surface"
+        );
+
+        // Falsification: the pre-fix shape, one session per row, same fixture.
+        let before_one_shot = opens();
+        for caller in &callers {
+            read_bounded_entity_snippet(
+                &store,
+                caller,
+                Some(&authority),
+                EntitySourceScope::WorkspaceHead,
+            )
+            .expect("the one-shot projection reads the same fixture")
+            .expect("every fixture caller has source coordinates");
+        }
+        assert_eq!(
+            opens() - before_one_shot,
+            CALLERS as u64,
             "the one-shot projection must still open once per read; if it does not, this test \
              cannot tell a held session apart from the defect it was written to catch"
         );

--- a/crates/kin-mcp/src/handlers/repository_authority.rs
+++ b/crates/kin-mcp/src/handlers/repository_authority.rs
@@ -89,8 +89,21 @@ pub(crate) struct WorkspaceReadSample {
     pub base_change_id: SemanticChangeId,
 }
 
+/// How many times this process has opened repository authority.
+///
+/// An open is a full authority recovery -- decode the persisted snapshot, then
+/// re-verify every persisted body against its content address -- so its cost is
+/// a property of the store, not of the request. That makes the open COUNT, not
+/// the wall clock, the honest thing for a test to bound: a query path that opens
+/// once per request stays O(1) here no matter how large the store gets, and one
+/// that opens per candidate does not. Public because the surfaces that must hold
+/// that bound (`semantic_locate`, `kin locate --snippets`) live in other crates.
+pub static REPOSITORY_AUTHORITY_OPEN_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 impl ActiveRepositoryAuthority {
     pub(crate) fn open(binding: &LocalRepositoryAuthorityBinding) -> Result<Self> {
+        REPOSITORY_AUTHORITY_OPEN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let manager = binding.open_manager().map_err(|error| {
             McpError::Context(format!(
                 "graph authority gap: cannot open retained repository authority: {error}"

--- a/crates/kin-mcp/src/handlers/repository_authority.rs
+++ b/crates/kin-mcp/src/handlers/repository_authority.rs
@@ -101,9 +101,34 @@ pub(crate) struct WorkspaceReadSample {
 pub static REPOSITORY_AUTHORITY_OPEN_COUNT: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+thread_local! {
+    static REPOSITORY_AUTHORITY_OPENS_ON_THREAD: std::cell::Cell<u64> =
+        const { std::cell::Cell::new(0) };
+}
+
+/// Repository-authority opens performed so far ON THE CALLING THREAD.
+///
+/// [`REPOSITORY_AUTHORITY_OPEN_COUNT`] is the honest process total, but a delta
+/// taken across a section of one test is not that test's own number: test
+/// binaries run in parallel, and any sibling test that projects a body lands in
+/// the same counter. A bound asserted on the process total is therefore sound
+/// only while no concurrent test opens authority, which is a property of the
+/// whole binary that nothing enforces and every new test can silently break.
+///
+/// This count is immune to that, because another thread's opens are not in it.
+/// The one thing a caller must ensure is that the request it is measuring runs
+/// on the thread doing the measuring -- an off-thread open is invisible here, so
+/// a measured section that hands its work to a worker reads zero. That failure
+/// mode is loud rather than silent for the assertion these tests make (`== 1`
+/// fails on a zero), which is why it is the right way round.
+pub fn repository_authority_opens_on_this_thread() -> u64 {
+    REPOSITORY_AUTHORITY_OPENS_ON_THREAD.with(std::cell::Cell::get)
+}
+
 impl ActiveRepositoryAuthority {
     pub(crate) fn open(binding: &LocalRepositoryAuthorityBinding) -> Result<Self> {
         REPOSITORY_AUTHORITY_OPEN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        REPOSITORY_AUTHORITY_OPENS_ON_THREAD.with(|opens| opens.set(opens.get() + 1));
         let manager = binding.open_manager().map_err(|error| {
             McpError::Context(format!(
                 "graph authority gap: cannot open retained repository authority: {error}"


### PR DESCRIPTION
`semantic_locate` re-opened the persisted repository authority and replayed
committed history **once per candidate**. Sample-proven on the 23,683-blob kin
fixture store: 50.3% of the daemon's samples inside
`ActiveRepositoryAuthority::open -> load_authority_unlocked`, 45.4% inside
`committed_introducing_change -> ChangeStore::resolve_graph_at ->
replay_graph_state`, and **zero** samples in any vector/ANN frame. All 12
pre-registered tasks exceeded the 180s MCP timeout; one query ran past 44
minutes.

A client `limit: 5` fans out to `semantic_search{limit=40}`, but 40 is not the
enrichment count: the two index keys per entity (`Entity(E)` +
`EntityRevision(head)`) are deduped **before** the projection, and the retained
page is capped at `page_size * SEMANTIC_LOCATE_MAX_PAGES` (5). Realistic
enrichment is **~20 rows at `limit: 5`** (hard cap 25) and **~40 at `limit: 10`**
(hard cap 50) — so one tool call performed roughly that many authority
recoveries plus that many whole-history replays, not 40 and 80.

## Mechanism: plumbing on both halves

**The open.** `ActiveRepositoryAuthority::open` calls `binding.open_manager()` →
`kin_db::RepositoryAuthorityManager::open_with_payload_stats`, which decodes the
persisted snapshot, re-verifies **every** persisted body against its content
address (unconditional, linear in stored bytes), and replays all history unless
a durable validation record names those exact bytes. That is process-startup
work. `repository_authority.rs` already states the contract — bind identity and
a storage capability once at startup, then reuse the retained capability — and
what was threaded through was the cheap `LocalRepositoryAuthorityBinding`, while
every read site re-opened a manager from it. Correct for the one-shot CLI
process the helper was shaped for; a full recovery per result inside a daemon.

**The replays.** On a workspace-head read, `committed_introducing_change` is
called with `sample.base_change_id`, which is the **same change for every
candidate**. So the whole-history replay was not per-candidate data at all; it
was one identical replay repeated once per hit.

## Fix: serve from held state, request-scoped

`HeldSourceAuthority<'store, G>` holds one request's authority plus memos for
the committed states its reads derive from.

- Lazy: constructing it performs no IO, so an entity with no span still returns
  "no source" rather than an authority error. Behavior preserved exactly,
  including the error text (a retained failure keeps the `McpError::Context`
  payload rather than its Display string, so the prefix cannot nest).
- One open, one workspace sample, memoized `resolve_graph_at`/`resolve_tree_at`
  keyed by change id.
- **Not a cache.** The session borrows one store snapshot for its whole life and
  the replay is deterministic in (store, change), so a memo hit is
  byte-identical to the replay it replaces. Nothing survives the request; there
  is deliberately no process-wide cache, which is the shape that could serve
  authority the store has moved past.
- Holding one workspace sample is also **more** coherent than before:
  `WorkspaceReadSample` exists because pairing a tree from one generation with
  provenance from another is a real defect, and sampling per entity
  reintroduced that hazard across a result set.

Converted every surface that projects many entities for one request:
`semantic_locate` (both the cosine and the fused arm), `POST /locate` and
`kin locate --snippets`, `get_context_pack`, `get_entity_sources`,
`find_references`, and the explore trace rendering. Single-entity entry points
keep their signatures.

Two of those need calling out because earlier passes over this diff got them
wrong:

- **The entity view.** `build_entity_view` runs immediately after the snippet
  projection, over the same symbol set, in the same request — and projected a
  body through the one-shot entry point **once per definition symbol**. Every
  locate entry point funnels into it, so `POST /locate`, the fused
  `semantic_locate` arm, multi-query (which forces fused), and
  `KIN_PROFILE=accuracy-v1` all kept the defect. One session is now hoisted at
  the pipeline tail and passed to both projections, and both take the session
  **instead of** a graph and a binding — so neither has a binding in scope to
  open a second authority with, and reintroducing the per-symbol shape is a type
  error rather than a silent cost.
- **`find_references`.** `collect_graph_reference_rows` projects a body per
  **referencing entity** and opened authority per row. This was missed twice
  because the handler boundary was what got enumerated: the handler receives the
  binding and hands it to a shared helper in `common.rs`, where the loop is.
  Corroborating measurement: `find_references` returns in 1.36 s warm on a
  history-depth-1 store while timing out 3/3 on the full-history one, which is
  what a per-caller whole-history replay predicts. **FIR-1909 was filed believing
  this surface's cost was elsewhere and should be re-scoped** — this removes a
  cause that ticket does not name.

## Proof

The invariant this establishes, per request:

> **opens = 1 · graph replays = 1 · tree replays = one per DISTINCT introducing change**

Tree replays are keyed by `introduced_by`, which varies per entity, so on a page
introduced by D distinct changes the total is `1 + D` — approaching
`1 + page_size`. It is not a constant, and this PR does not make it one; it
removes the per-result multiplication of the open and the graph replay.

| bound | arm | measured | test |
|---|---|---|---|
| authority opens | held | **1** | `a_retrieval_page_derives_repository_authority_once` (6 entities) |
| authority opens | one-shot (prior shape) | **6** | same fixture, falsification arm |
| graph + tree replays | held | **1 + D**; D=1 in this fixture → 2 | same |
| authority opens | held | **1** | `find_references_derives_repository_authority_once` (5 callers) |
| authority opens | one-shot | **5** | same fixture, falsification arm |
| authority opens | fused route, end to end | **1** | `semantic_locate_fused_page_opens_repository_authority_once` |

Asserted on **counts, not elapsed time**: an open and a replay each cost whatever
the store is worth, so only their number is the query path's own property, and a
timing assertion on a small fixture would pass with the defect present. The
one-shot arm's *replay* count is deliberately not claimed — that entry point
builds its session internally, so the number is unreachable from the test.

The route test bounds the **call site**, not the primitive, and was falsified
before being trusted: reverting `build_entity_view` to the one-shot fails it at
5 opens vs 1, and giving each projection its own session fails it at 2 vs 1.

Opens are now also counted per thread, not only per process. A delta on the
process-wide counter taken inside one test of a parallel binary is not that
test's own number; it was previously sound only because every test that can open
authority happens to hold the environment lock, which nothing enforces.

**Gap, stated rather than left silent:** the daemon **cosine** call site has no
hermetic regression test, so reverting that one line there is invisible to the
suite. That arm answers straight from `graph.semantic_search`, which returns
nothing without a populated vector index, and populating one requires the real
768-dim query embedder (`CodeEmbedder::new()` loads, and on a cold host
downloads, the model). A flaky test on the retrieval path is worse than an
honest gap. The site was independently read and confirmed converted in review,
and the fused arm is covered end to end.

## What this does NOT fix

- **The enrichment multiplier is untouched — see FIR-1913.** This PR pulls the
  hoist-the-per-candidate-work lever and leaves the cut-the-multiplier lever
  entirely open: enrichment still runs over the over-fetched candidate set rather
  than only the rows a page returns. Closing FIR-1897 does **not** mean
  `semantic_locate` latency is solved.
- **The live harness rerun must precede FIR-1897's closure.** Every number above
  is hermetic and count-based. No latency claim is being made from this branch.
- **Depth-1 measurements are a lower bound on post-fix latency, not an estimate
  of it.** The history-depth-1 control ran against 657 blobs versus the full
  store's 23,683 — a 36x smaller body set — and `validate_all_authority_bodies`
  re-verifies every persisted body on every open, unconditionally and linear in
  stored bytes. This PR does not shrink that set at all; it pays it once per
  request instead of ~20 times. So post-fix latency on the deep store will be
  *worse* than the 49–112 s the depth-1 arm measured, and `limit: 10` may well
  still time out.

Closes FIR-1897
Refs FIR-1913
Refs FIR-1909
Refs FIR-1898
Refs FIR-1885

FIR-1898 (a client timeout not cancelling server-side work) is untouched here
and still open: this PR removes the work that made one query hold a repository
for 44 minutes, but a query that does hang still cannot be cancelled.
