### PR TITLE
Declare the Windows install-proof leg experimental and pin that posture

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -40,6 +40,14 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    # The Windows leg runs the full unconditional proof and uploads its
+    # artifacts, but its verdict does not yet gate the release: the installed
+    # daemon on Windows serves queries without publishing .kin/daemon.port, so
+    # the endpoint-provenance step cannot pass there yet. The release authority
+    # suite pins this posture to exactly the windows-latest row; a blocking
+    # Windows leg returns by deleting the experimental flag here and the
+    # posture assertion there in the same change.
+    continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +62,7 @@ jobs:
             setup-shell: zsh
           - os: windows-latest
             setup-shell: powershell
+            experimental: true
     steps:
       - name: Public install (Unix)
         if: runner.os != 'Windows'

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -544,7 +544,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/install-proof.yml",
         "install-proof",
-    ): "c5cd6bbfa99f45c84084d22aafe5e0bb038c2ee006404a58d72e19a0db69b46e",
+    ): "91bbe7dd412df4ade467a53be2618eb8199bc746b682ae5f27552649009446b4",
     (
         ".github/workflows/release.yml",
         "build",
@@ -2273,6 +2273,55 @@ def assert_install_proof_init_log_authority(first_run: str) -> None:
         raise AssertionError(
             "only the committed Git bootstrap may run between entering the "
             f"worktree kin init admits and admitting it; found {prelude}"
+        )
+
+
+def assert_install_proof_windows_experimental_posture(install_proof: str) -> None:
+    """Pin the declared experimental scope of the install-proof matrix.
+
+    The Windows leg still executes its full unconditional proof, but its
+    verdict is tolerated while the installed daemon does not publish an
+    endpoint file there. Tolerance is admitted only as the exact job-level
+    matrix guard, and the ``experimental: true`` flag only on the
+    ``windows-latest`` row. Anything looser — an unconditional
+    ``continue-on-error``, an experimental Unix row, or a value other than
+    ``true`` — silently removes a reviewed OS from the release gate, so each
+    is rejected here by name.
+    """
+
+    jobs = workflow_job_blocks(install_proof)
+    install_job = jobs.get("install-proof")
+    if install_job is None:
+        raise AssertionError(
+            "windows experimental posture lost the install-proof job"
+        )
+    job_fields = job_top_level_mapping_fields(install_job)
+    tolerance = [
+        value.strip() for key, value in job_fields if key == "continue-on-error"
+    ]
+    if tolerance != ["${{ matrix.experimental == true }}"]:
+        raise AssertionError(
+            "install-proof continue-on-error must be exactly the matrix "
+            f"experimental guard; found {tolerance}"
+        )
+    strategy_lines = active_lines(dynamic_job_context_source(install_job))
+    current_row: str | None = None
+    experimental_rows: list[str] = []
+    for line in strategy_lines:
+        if line.startswith("- os:"):
+            current_row = line.removeprefix("- os:").strip()
+        elif line == "experimental: true" and current_row is not None:
+            experimental_rows.append(current_row)
+        elif line.startswith("experimental"):
+            raise AssertionError(
+                "install-proof matrix rows admit only a literal "
+                f"`experimental: true`; found `{line}` under "
+                f"{current_row or 'no row'}"
+            )
+    if experimental_rows != ["windows-latest"]:
+        raise AssertionError(
+            "install-proof experimental rows must be exactly "
+            f"['windows-latest']; found {experimental_rows}"
         )
 
 
@@ -6581,6 +6630,53 @@ def main() -> None:
             expected,
             lambda mutated=install_proof.replace(original, mutation, 1): (
                 assert_install_proof_repo_steps_cover_windows(mutated)
+            ),
+        )
+
+    assert_install_proof_windows_experimental_posture(install_proof)
+    for label, original, mutation, expected in (
+        (
+            "the experimental flag spreads to a Unix matrix row",
+            "          - os: ubuntu-latest\n            setup-shell: bash\n",
+            "          - os: ubuntu-latest\n            setup-shell: bash\n"
+            "            experimental: true\n",
+            "exactly ['windows-latest']",
+        ),
+        (
+            "the install proof tolerates every leg unconditionally",
+            "    continue-on-error: ${{ matrix.experimental == true }}\n",
+            "    continue-on-error: true\n",
+            "matrix experimental guard",
+        ),
+        (
+            "the tolerance guard survives while the Windows flag disappears",
+            "            experimental: true\n",
+            "",
+            "exactly ['windows-latest']",
+        ),
+        (
+            "an experimental value other than a literal true appears",
+            "            experimental: true\n",
+            "            experimental: yes\n",
+            "literal `experimental: true`",
+        ),
+        (
+            "the tolerance guard disappears while the flag stays",
+            "    continue-on-error: ${{ matrix.experimental == true }}\n",
+            "",
+            "matrix experimental guard",
+        ),
+    ):
+        if original not in install_proof:
+            raise AssertionError(
+                "windows experimental posture falsification lost fixture for "
+                f"{label}: {original!r}"
+            )
+        expect_assertion(
+            label,
+            expected,
+            lambda mutated=install_proof.replace(original, mutation, 1): (
+                assert_install_proof_windows_experimental_posture(mutated)
             ),
         )
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2282,11 +2282,13 @@ def assert_install_proof_windows_experimental_posture(install_proof: str) -> Non
     The Windows leg still executes its full unconditional proof, but its
     verdict is tolerated while the installed daemon does not publish an
     endpoint file there. Tolerance is admitted only as the exact job-level
-    matrix guard, and the ``experimental: true`` flag only on the
-    ``windows-latest`` row. Anything looser — an unconditional
-    ``continue-on-error``, an experimental Unix row, or a value other than
-    ``true`` — silently removes a reviewed OS from the release gate, so each
-    is rejected here by name.
+    matrix guard — enforced as the single active ``continue-on-error``
+    mention in the entire job, so a step-level tolerance (which would spare
+    every leg, not one) cannot hide below the job header — and the
+    ``experimental: true`` flag only on the ``windows-latest`` row. Anything
+    looser — an unconditional ``continue-on-error``, a tolerated step, an
+    experimental Unix row, or a value other than ``true`` — silently removes
+    a reviewed OS from the release gate, so each is rejected here by name.
     """
 
     jobs = workflow_job_blocks(install_proof)
@@ -2303,6 +2305,17 @@ def assert_install_proof_windows_experimental_posture(install_proof: str) -> Non
         raise AssertionError(
             "install-proof continue-on-error must be exactly the matrix "
             f"experimental guard; found {tolerance}"
+        )
+    tolerance_mentions = [
+        line for line in active_lines(install_job) if "continue-on-error" in line
+    ]
+    if tolerance_mentions != [
+        "continue-on-error: ${{ matrix.experimental == true }}"
+    ]:
+        raise AssertionError(
+            "install-proof admits exactly one continue-on-error, the "
+            "job-level matrix experimental guard; a step-level tolerance "
+            f"would spare every leg; found {tolerance_mentions}"
         )
     strategy_lines = active_lines(dynamic_job_context_source(install_job))
     current_row: str | None = None
@@ -6665,6 +6678,20 @@ def main() -> None:
             "    continue-on-error: ${{ matrix.experimental == true }}\n",
             "",
             "matrix experimental guard",
+        ),
+        (
+            "a step-level tolerance spares every leg below the job header",
+            "      - name: Public install (Unix)\n",
+            "      - name: Public install (Unix)\n"
+            "        continue-on-error: true\n",
+            "exactly one continue-on-error",
+        ),
+        (
+            "a quoted-key tolerance hides on a step",
+            "      - name: Public install (Unix)\n",
+            "      - name: Public install (Unix)\n"
+            "        \"continue-on-error\": true\n",
+            "exactly one continue-on-error",
         ),
     ):
         if original not in install_proof:


### PR DESCRIPTION
## What

- `install-proof.yml`: job-level `continue-on-error: ${{ matrix.experimental == true }}` plus `experimental: true` on exactly the `windows-latest` matrix row. The leg still runs every unconditional proof step and uploads its artifacts; its verdict stops vetoing `install_proof.result`, so Promote no longer requires a Windows install-proof pass. The Windows BUILD proof is untouched and still hard-gates tag minting: release-tag.yml names the `Windows installer + vector-free release build` context in its required checks and refuses to mint unless it is green on the release sha. Only the install-proof verdict is tolerated.
- `scripts/test-release-workflow-authority.py`: new `assert_install_proof_windows_experimental_posture` pinning that exact posture (exact guard expression, windows-only flag, literal `true` only, and exactly ONE active continue-on-error mention in the entire job so a step-level tolerance cannot hide below the job header), seven registered falsifications, and the dynamic-context census hash updated for the reviewed matrix change.

## What this does NOT do

This PR alone does not unblock v0.5.0 promotion. Run 30947137583 failed three proof legs: windows-latest (the daemon endpoint gap this PR tolerates, FIR-1921) AND macos-15-intel AND ubuntu-24.04-arm (the embedding-coverage race, fixed by PR #609, in the merge queue). Promotion needs #609 landed and actually clearing both Unix legs; this PR only removes the Windows veto.

## Why

The v0.4.9 release run exhausted its bounded recovery with the Windows leg failing at the daemon endpoint-provenance step: the installed daemon served `kin search`/`kin locate` but published no `.kin/daemon.port` where the step reads it. Root cause and fix are tracked in FIR-1921; until the leg can pass on real releases, a blocking Windows leg means no release can promote. Announcement and install copy already state native Windows limits, so no outward claim depends on this leg. The existing `assert_install_proof_repo_steps_cover_windows` protections are untouched and still enforced: the row cannot be excluded, the steps cannot grow conditions, the runner stays the matrix OS.

## Verification

- Full authority suite green at 0c2f8aa9 (eleven falsifications executing: seven in the posture block, the five original plus step-level tolerance plus quoted-key spelling, and four pre-existing windows-coverage ones).
- Reverse falsification: the assertion raises on pristine origin/main bytes (`found []`), so posture removal cannot pass silently.
- `actionlint` clean on the workflow.
- Adversarial review at 3ab09a08: GO, zero P0s; the review confirmed GitHub's continue-on-error semantics against docs and the in-repo measured note (base-image-pins.yml), swept all eight live rulesets for install-proof coupling (none), and confirmed release-recovery only engages on failed runs so a tolerated leg burns no retries. This head adds the reviewer's P1 (step-level tolerance) and this body section (P2).
- The tolerated-leg composition through a CALLED reusable workflow into the caller's `needs.result` is proven empirically in both directions on live public runs (opentelemetry-operator e2e-reusable.yaml carries the byte-identical guard expression: runs 30896198903 and 30896113648 show a tolerated leg failing while the run concludes success and the needs gate passes; runs 30916631854 and 30911267421 show a non-tolerated leg failing the gate). This is idiom, not contract (actions/toolkit#1739 is an open request to change it); if GitHub ever changes the semantics, promotion re-blocks, failing safe.

Refs FIR-1921 (stays open; done means the daemon publishes its endpoint on Windows, the leg passes a real release run, this flag plus its posture assertion are deleted together, and the weekly install-proof canary regains a blocking Windows leg).
