### PR TITLE
Release Kin v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-04
+
+### Changed
+
+- Bind the deferred-uninstall wait to the child and wait for its helper to complete (#604)
+- Free the release mint from advisory flakes and stop blind release retries (#605)
+- Read the host-binding fixtures as scripts rather than exec targets (#606)
+- Serve entity source projections from held repository authority (#608)
+- Settle status embedding coverage over a transient unobservable window (#609)
+- Declare the Windows install-proof leg experimental and pin that posture (#612)
+
 ## [0.4.9] - 2026-08-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,14 +3055,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "fs2",
  "libc",
@@ -3259,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.11"
+version = "0.7.12"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2532191f03526a5567ef9b63f69f0a47b97612cbd84c74cef3246c7128616e84"
+checksum = "06913633eb8e8eba69ae2ab343e3992f5cd17e0a786dbc6b9882fdc313f4e025"
 dependencies = [
  "bincode",
  "bstr",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3476,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.4"
+version = "0.7.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "faabe132c031fdce5f245a65c20771c603821418f24625e66003c2d3a0c1df89"
+checksum = "6c63c8f3dbc38fbbcea9f7781c234c97e65f944987a22b0590ac1068df3db3ff"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-model",
  "serde",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",
@@ -6618,7 +6618,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.9"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]
@@ -124,7 +124,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.4", registry = "kin" }
+kin-model = { version = "=0.7.5", registry = "kin" }
 kin-blobs = { version = "=0.1.4", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.11", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.12", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.3.0", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -91,7 +91,7 @@ toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
 unicode-ident = "1"
-kin-spine = { version = "0.4.9", path = "../kin-spine" }
+kin-spine = { version = "0.5.0", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-core = { workspace = true, features = ["test-support"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.4"
+version = "0.7.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "faabe132c031fdce5f245a65c20771c603821418f24625e66003c2d3a0c1df89"
+checksum = "6c63c8f3dbc38fbbcea9f7781c234c97e65f944987a22b0590ac1068df3db3ff"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -35,6 +35,13 @@
       "reason": "The install proof frozen at this tag fails on every leg for two pre-existing defects the tag cannot receive fixes for. On the Unix legs, a daemon spawned by the long-lived MCP server is never reaped, and the liveness probe accepts the zombie as alive because kill with signal zero succeeds against a corpse, so a stop that was delivered and honoured is reported as a timeout at the proof's mid-MCP stop step. On the Windows leg, setup resolves the home through a lookup that requires the full profile and AppData tree to exist, so the proof's bare runner-temp home collapses to none before setup can run. Both the proof workflow and the binary resolve from the tag, the repairs landed on main only after it, and automatic release recovery exhausted all three attempts with the same signatures.",
       "superseded_by": "v0.4.9",
       "failed_release_run_id": "30894704670"
+    },
+    {
+      "tag": "v0.4.9",
+      "sha": "0a95bec85595b22e4ee60c6ac9a261250de7fa5a",
+      "reason": "The public install proof frozen at this tag fails on three of its five legs, and the tag can receive none of the repairs. The macos-15-intel and ubuntu-24.04-arm legs fail the installed-capability proof: the tagged binary reports embedding coverage as unobserved with reason graph_mutation_in_flight, so the proof reads a transient window in which the graph is still being mutated as a failure to prove complete coverage rather than waiting for it to settle. The failure is a race and not a fixed property of the platform, which is why the same two legs pass on some attempts and a third Unix leg failed on the first attempt. The windows-latest leg fails separately at the graph and MCP tool-call proof, where the daemon port file the step reads never appears. Both the proof workflow and the binary resolve from the tag, and the repairs landed on main only after it, so no later change to main can reach the failing steps. All three attempts of the cited run failed and automatic release recovery exhausted its bounded retries. The only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, so the tag never became the finalized Latest release and nothing downstream of the proof ever ran.",
+      "superseded_by": "v0.5.0",
+      "failed_release_run_id": "30947137583"
     }
   ]
 }


### PR DESCRIPTION
## Pin moves folded in (captain amendment, head 8d5e6304)

This is the combined release change: alongside the version bump it moves kin-model `=0.7.4` to `=0.7.5` and kin-db `=0.7.11` to `=0.7.12`, carrying the FIR-1925 admission fix (legacy zero-padded tree modes; flask-class repositories) into the release. Root and fuzz locks re-locked patch-off; every moved row keeps its `sparse+` registry source and checksum. Landing this PR makes its squash the v0.5.0 tag anchor with the fix resolvable; the mint dispatcher independently refuses to tag a squash whose manifest or lock lacks these pins.

## What moved

One commit, the same nine-file shape as #603:

- **Five lockstep version surfaces** 0.4.9 → 0.5.0: `Cargo.toml`
  `[workspace.package]`, the `kin-spine` path-dependency pin in
  `crates/kin-cli/Cargo.toml`, and `packages/kin/package.json`,
  `packages/kin-mcp/package.json`, `packages/boundary-contracts/package.json`.
  `kin-db` is untouched — it tracks an external registry crate.
- **Both lockfiles refreshed** with `cargo update --workspace`. The movement is
  workspace members only: 23 rows in `Cargo.lock`, 1 in `fuzz/Cargo.lock`, no
  external dependency resolution changed. Every external `kin-*` row keeps its
  `sparse+https://kinlab.ai/registry/cargo/` source and checksum
  (`kin-db 0.7.11`, `kin-model 0.7.4`, `kin-lsp 0.6.5`, `kin-infer 0.2.43`,
  `kin-vfs-core 0.3.0`, `kin-blobs 0.1.4`, `kin-search 0.1.4`,
  `kin-vector 0.1.8`).
- **A 0.5.0 changelog section** carrying the five changes this release ships,
  plus the install proof's Windows leg becoming experimental and
  non-release-gating (that change lands separately and ships here).
- **The reviewed v0.4.9 abandonment record** in
  `scripts/abandoned-release-tags.json`, superseded by v0.5.0.

## Why

The v0.4.9 lane cannot finish at the tag. Its public install proof
(run 30947137583) failed all three attempts, and automatic release recovery
exhausted its bounded retries:

- `macos-15-intel` and `ubuntu-24.04-arm` fail the installed-capability proof
  with `Unix status did not prove complete observed embedding coverage:
  {"state":"unobserved","reason":"graph_mutation_in_flight"}` — a transient
  window in which the graph is still being mutated, read as a failure to prove
  coverage rather than waited out. It is a race, not a platform property, which
  is why a third Unix leg failed on the first attempt and passed later.
- `windows-latest` fails separately at the graph and MCP tool-call proof, where
  the daemon port file it reads never appears.

Both the proof workflow and the binary resolve from the tag, so no change to
main can reach those steps. The tag's only release object is the unpromoted
prerelease published before proof, so it never became Latest; Latest is still
v0.3.6. v0.5.0 ships the batch that fixes the race.

## Verification

- `node scripts/release-intent.mjs` → `v0.5.0 is a coherent release — ready to
  tag` (workspace, all three npm packages, the `kin-spine` pin, and the
  changelog section all agree at 0.5.0).
- `cargo metadata --locked` clean for both the root workspace and `fuzz/`.
- Selector self-tested against the real tag listing:
  reconcile and mint-v0.5.0 both anchor v0.3.6; minting v0.4.9 is refused as an
  abandoned tag; a corrupted record sha is refused loudly on the waiver/tag
  mismatch.
- `scripts/extract-release-notes.mjs --version 0.5.0` rolls the abandoned
  v0.4.9, v0.4.8, v0.4.6, v0.4.5, v0.4.4 sections forward into the v0.5.0 notes
  under the carried-forward notice, so no burned lane's notes are lost.
- `python3 scripts/test-release-workflow-authority.py` passes; the release
  policy node suite passes 67/67.

## Sequencing: this must land last

The tag mint normalizes a tag to the **first** reviewed first-parent main commit
carrying the workspace version (`.github/workflows/release-tag.yml`, the
`automatic` branch). If this bump lands before #604, #605, #606, #608, #609 and
#612, v0.5.0 tags this commit and excludes every change it claims to ship — the
v0.4.9 failure verbatim. Land those six first, then this.

The branch is currently based on `0a95bec8`, the tip of main at the time it was
cut. The batch does not touch any of these nine files, so the hosted queue's
rebase is clean.

## Notes for the captain

- The Windows-leg changelog entry cites #612 ("Declare the Windows install-proof
  leg experimental and pin that posture"), which is open. #612 must land before
  this PR for that line to be true.
- v0.4.7 is untagged and therefore not in the abandonment record, so its
  changelog section is not carried into these notes. Pre-existing, and worth a
  decision separately from this release.

Ticket linkage handled at merge time by the captain.

