### PR TITLE
Build the Windows daemon the authority tests drive before running them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,22 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # `daemon_status_and_stop_lifecycle` drives a real daemon, and the harness
+      # takes it from the `kin-daemon` beside the `kin` binary the test was
+      # built with. Every other `kin-daemon` invocation below compiles `--lib`,
+      # and the step that builds the binary runs after the tests, so nothing put
+      # a `kin-daemon.exe` in the msvc directory before the test read it. The
+      # harness covers a missing daemon by rebuilding one, which lands beside
+      # the test only when it carries the same `--target`, so a leg that omits
+      # this build depends on that rebuild rather than on its own inputs. The
+      # feature set matches the binary build below, so both produce one artifact.
+      - name: Build the sibling Windows daemon the authority tests drive
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --target x86_64-pc-windows-msvc \
+            -p kin-daemon --no-default-features --bin kin-daemon
+
       - name: Compile and run native Windows authority tests
         shell: bash
         run: |

--- a/crates/kin-cli/build.rs
+++ b/crates/kin-cli/build.rs
@@ -26,4 +26,12 @@ fn main() {
     if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
         println!("cargo::rustc-link-arg-bins=/STACK:16777216");
     }
+    // Cargo writes a `--target` build to `<target-dir>/<triple>/<profile>/` and
+    // a host build to `<target-dir>/<profile>/`, and tells the compiled code
+    // neither which of the two it is nor what triple it was built for. The test
+    // harness reuses the `kin-daemon` sitting beside its own `kin` binary and
+    // has to be able to rebuild one into that same directory, so it needs the
+    // triple to reproduce the layout it is reading from.
+    let target = std::env::var("TARGET").expect("cargo sets TARGET for build scripts");
+    println!("cargo::rustc-env=KIN_CLI_TARGET_TRIPLE={target}");
 }

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -3163,6 +3163,59 @@ fn daemon_compat(runtime: &IsolatedDaemonRuntime, path: &Path) -> Result<(), Str
     }
 }
 
+/// The `--target` a `kin-daemon` rebuild has to carry to land beside `kin`.
+///
+/// Cargo writes a build to `<target-dir>/<profile>/`, and moves it to
+/// `<target-dir>/<triple>/<profile>/` when it is given `--target`. The daemon
+/// this harness demands sits beside `CARGO_BIN_EXE_kin`, so a rebuild that
+/// drops the triple the test binary was built for writes a directory the
+/// compatibility check never reads: the rebuild succeeds and the check still
+/// reports the daemon missing, naming a path nothing ever wrote.
+///
+/// The triple is only in the path when cargo put it there, which is exactly
+/// when the rebuild needs it, so the layout answers the question directly.
+fn daemon_rebuild_target<'a>(kin_bin: &Path, triple: &'a str) -> Option<&'a str> {
+    let profile_parent = kin_bin.parent()?.parent()?;
+    (profile_parent.file_name()?.to_str() == Some(triple)).then_some(triple)
+}
+
+#[test]
+fn daemon_rebuild_follows_the_layout_its_own_binary_was_written_into() {
+    let triple = "x86_64-pc-windows-msvc";
+
+    assert_eq!(
+        daemon_rebuild_target(Path::new("/w/target/debug/kin"), triple),
+        None,
+        "a host build already writes the directory the check reads"
+    );
+    assert_eq!(
+        daemon_rebuild_target(
+            Path::new("/w/target/x86_64-pc-windows-msvc/debug/kin.exe"),
+            triple
+        ),
+        Some(triple),
+        "a cross build is only reachable by repeating its --target"
+    );
+    // A target directory relocated by CARGO_TARGET_DIR keeps the layout, so the
+    // triple component stays the whole signal and no path prefix is assumed.
+    assert_eq!(
+        daemon_rebuild_target(
+            Path::new("/lane/cargo-target/nwinfix/x86_64-pc-windows-msvc/debug/kin.exe"),
+            triple
+        ),
+        Some(triple),
+    );
+    assert_eq!(
+        daemon_rebuild_target(
+            Path::new("/w/target/aarch64-apple-darwin/debug/kin"),
+            triple
+        ),
+        None,
+        "a triple this binary was not built for must never be passed on"
+    );
+    assert_eq!(daemon_rebuild_target(Path::new("kin"), triple), None);
+}
+
 fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
     let kin_bin = PathBuf::from(env!("CARGO_BIN_EXE_kin"));
     let daemon_bin = kin_bin.with_file_name(format!("kin-daemon{}", std::env::consts::EXE_SUFFIX));
@@ -3173,6 +3226,10 @@ fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
     BUILD_DAEMON.get_or_init(|| {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let workspace_root = manifest_dir.ancestors().nth(2).expect("kin workspace root");
+        let mut args = vec!["build", "-p", "kin-daemon", "--bin", "kin-daemon"];
+        if let Some(target) = daemon_rebuild_target(&kin_bin, env!("KIN_CLI_TARGET_TRIPLE")) {
+            args.extend_from_slice(&["--target", target]);
+        }
         // This shells out to cargo from inside a cargo-driven test run, so it
         // contends for the build-directory lock with whatever else is building
         // this checkout. Cargo waits on that lock forever and prints only to
@@ -3180,7 +3237,7 @@ fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
         let mut build = Command::new(env!("CARGO"));
         scrub_inherited_kin_authority(build.inner_mut());
         let output = build
-            .args(["build", "-p", "kin-daemon", "--bin", "kin-daemon"])
+            .args(&args)
             .current_dir(workspace_root)
             .output_within(BUILD_TIMEOUT)
             .expect("run cargo build -p kin-daemon");

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2691,6 +2691,9 @@ def workflow_job_blocks(workflow: str) -> dict[str, str]:
 WINDOWS_DAEMON_SIBLING_BUILD = (
     "- name: Build the sibling Windows daemon the authority tests drive"
 )
+WINDOWS_DAEMON_COMPILE_STEP = (
+    "- name: Compile and run native Windows authority tests"
+)
 WINDOWS_DAEMON_LIFECYCLE_TEST = '"daemon_status_and_stop_lifecycle"'
 
 
@@ -2709,20 +2712,38 @@ def assert_windows_daemon_sibling_build(ci_job: str) -> None:
     than supplying its own input. Ordering is pinned as well as presence: this
     build sitting after the tests is how the leg failed for days while reporting
     a daemon missing from a directory the job did eventually populate.
+
+    Judged on active lines and scoped to the step's own block: the `--target`
+    that decides where the binary lands must appear inside the sibling build
+    step itself, and ordering compares step-name positions, so a comment
+    quoting the test name can neither satisfy a policy nor invert the order.
     """
 
-    for policy in (
-        WINDOWS_DAEMON_SIBLING_BUILD,
-        "-p kin-daemon --no-default-features --bin kin-daemon",
-    ):
-        require(ci_job, policy, "native Windows daemon lifecycle prerequisite")
-    if ci_job.index(WINDOWS_DAEMON_SIBLING_BUILD) > ci_job.index(
-        WINDOWS_DAEMON_LIFECYCLE_TEST
-    ):
+    active_job = "\n".join(active_lines(ci_job))
+    for step in (WINDOWS_DAEMON_SIBLING_BUILD, WINDOWS_DAEMON_COMPILE_STEP):
+        require(active_job, step, "native Windows daemon lifecycle prerequisite")
+    build_start = active_job.index(WINDOWS_DAEMON_SIBLING_BUILD)
+    compile_start = active_job.index(WINDOWS_DAEMON_COMPILE_STEP)
+    if build_start > compile_start:
         raise AssertionError(
             "native Windows daemon lifecycle prerequisite must build the msvc "
             "kin-daemon binary before the lifecycle test reads it"
         )
+    sibling_build_block = active_job[build_start:compile_start]
+    for policy in (
+        "-p kin-daemon --no-default-features --bin kin-daemon",
+        "--target x86_64-pc-windows-msvc",
+    ):
+        require(
+            sibling_build_block,
+            policy,
+            "native Windows daemon lifecycle prerequisite",
+        )
+    require(
+        active_job[compile_start:],
+        WINDOWS_DAEMON_LIFECYCLE_TEST,
+        "native Windows daemon lifecycle prerequisite",
+    )
 
 
 def assert_windows_npm_first_run_proof(ci_job: str, proof_source: str) -> None:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2688,6 +2688,43 @@ def workflow_job_blocks(workflow: str) -> dict[str, str]:
     return blocks
 
 
+WINDOWS_DAEMON_SIBLING_BUILD = (
+    "- name: Build the sibling Windows daemon the authority tests drive"
+)
+WINDOWS_DAEMON_LIFECYCLE_TEST = '"daemon_status_and_stop_lifecycle"'
+
+
+def assert_windows_daemon_sibling_build(ci_job: str) -> None:
+    """Require the Windows leg to build the daemon its lifecycle test drives.
+
+    The lifecycle test runs a real daemon, and the harness takes it from the
+    `kin-daemon` beside the `kin` binary the test was built with. Every other
+    `kin-daemon` invocation in the leg compiles `--lib`, which produces no
+    binary, so without an explicit build nothing writes one for that target
+    before the test reads it.
+
+    The harness does cover a missing daemon by rebuilding one, but a rebuild
+    lands beside the test only when it repeats the same `--target`, so a leg
+    that leaves the build to the harness is asserting a harness behavior rather
+    than supplying its own input. Ordering is pinned as well as presence: this
+    build sitting after the tests is how the leg failed for days while reporting
+    a daemon missing from a directory the job did eventually populate.
+    """
+
+    for policy in (
+        WINDOWS_DAEMON_SIBLING_BUILD,
+        "-p kin-daemon --no-default-features --bin kin-daemon",
+    ):
+        require(ci_job, policy, "native Windows daemon lifecycle prerequisite")
+    if ci_job.index(WINDOWS_DAEMON_SIBLING_BUILD) > ci_job.index(
+        WINDOWS_DAEMON_LIFECYCLE_TEST
+    ):
+        raise AssertionError(
+            "native Windows daemon lifecycle prerequisite must build the msvc "
+            "kin-daemon binary before the lifecycle test reads it"
+        )
+
+
 def assert_windows_npm_first_run_proof(ci_job: str, proof_source: str) -> None:
     """Require both public npm surfaces to pass a real native Windows first run.
 
@@ -7687,6 +7724,32 @@ def main() -> None:
     assert_windows_npm_first_run_proof(
         ci_jobs["windows-authority-tests"], windows_npm_proof
     )
+    assert_windows_daemon_sibling_build(ci_jobs["windows-authority-tests"])
+    windows_job = ci_jobs["windows-authority-tests"]
+    sibling_build_start = windows_job.index(WINDOWS_DAEMON_SIBLING_BUILD)
+    sibling_build_end = windows_job.index(
+        "      - name: Compile and run native Windows authority tests"
+    )
+    sibling_build_block = windows_job[sibling_build_start:sibling_build_end]
+    for label, mutated_job, expected in (
+        (
+            "the Windows leg stops building the daemon its lifecycle test drives",
+            windows_job.replace(sibling_build_block, "", 1),
+            "native Windows daemon lifecycle prerequisite",
+        ),
+        (
+            "the sibling daemon build drifts back after the tests that read it",
+            windows_job.replace(sibling_build_block, "", 1) + sibling_build_block,
+            "before the lifecycle test reads it",
+        ),
+    ):
+        expect_assertion(
+            label,
+            expected,
+            lambda mutated_job=mutated_job: assert_windows_daemon_sibling_build(
+                mutated_job
+            ),
+        )
     canonical_npm_provision = CANONICAL_NPM_PROVISION.read_text(encoding="utf-8")
     canonical_npm_provision_test = CANONICAL_NPM_PROVISION_TEST.read_text(
         encoding="utf-8"


### PR DESCRIPTION
`Windows authority tests` has failed identically on `main` and on every pull
request for days: 8 passed, 1 failed, always `daemon_status_and_stop_lifecycle`.
It is not a required context, so PRs have been landing over it, it has already
produced two false "blocked" diagnoses, and while it stays red it masks any real
Windows regression the leg exists to catch.

The build-identity guard is right. The job is wrong.

## Correction to the standing diagnosis

The red was being read as a stale cross-commit `kin-daemon.exe` carried into the
test step by the restored cargo cache. The log says otherwise. Run
`30954050156`, job `92142801364`, at `c2c68358`:

```
thread 'daemon_status_and_stop_lifecycle' panicked at crates\kin-cli\tests\common\mod.rs:3196:9:
kin-daemon at D:\a\kin\kin\target\x86_64-pc-windows-msvc\debug\kin-daemon.exe is
unusable after rebuild: D:\a\kin\kin\target\x86_64-pc-windows-msvc\debug\kin-daemon.exe
does not exist.
```

The variable part of that panic is `{reason}`, and the reason is
`does not exist`. "A daemon built from a different commit or working tree" is
static template text in the panic string, not the reason. A stale binary would
have produced `daemon build identity X does not match this test binary's Y` from
`daemon_compat_mismatch`. It did not, so the cache is not implicated: there is
no cross-commit `kin-daemon.exe` reaching the test step, because there is no
`kin-daemon.exe` there at all.

## Failing chain, as it stands on main

1. `daemon_status_and_stop_lifecycle` calls `runtime.daemon_bin()`
   (`crates/kin-cli/tests/common/mod.rs:989`), which resolves the daemon as a
   sibling of `CARGO_BIN_EXE_kin`, so
   `target/x86_64-pc-windows-msvc/debug/kin-daemon.exe`.
2. Nothing in the job writes that path first. Every `kin-daemon` invocation in
   the authority step is `--lib`, and the step that builds `--bin kin-daemon`
   runs two steps AFTER the tests.
3. `daemon_compat` returns `Err("... does not exist")`, so `fresh_daemon_bin`
   self-heals by shelling out to `cargo build -p kin-daemon --bin kin-daemon`,
   with no `--target`.
4. Cargo writes a host build to `<target-dir>/<profile>/` and a `--target` build
   to `<target-dir>/<triple>/<profile>/`. That rebuild therefore landed in
   `target/debug/kin-daemon.exe`.
5. The re-check reads the msvc path again. Still nothing. Panic.

The timing corroborates it. The other 8 tests finish inside one second at
`22:25:33`; the panic lands at `22:31:26`. That ~5m53s is the wasted rebuild, a
full default-features `kin-daemon` compiled on the runner and written where
nothing reads it.

## Fix chain, and why the failure cannot recur

1. A new step builds
   `--target x86_64-pc-windows-msvc -p kin-daemon --no-default-features
   --bin kin-daemon` after the cache restore and before the authority tests,
   writing exactly the path the harness reads.
2. That binary comes from the same checkout as the test binary, so
   `kin_buildinfo::sha_with_dirty` agrees and `daemon_compat` passes on the
   first check. The self-heal never runs and the job gets those ~6 minutes back.
3. The feature set matches the existing binary build step. `kin-cli` is declared
   `default-features = false` in `[workspace.dependencies]`, so
   `-p kin-daemon --no-default-features` and
   `-p kin-cli -p kin-daemon --no-default-features` resolve `kin-cli`
   identically and both steps produce one artifact, leaving the admission and
   npm proof steps downstream untouched.
4. `scripts/test-release-workflow-authority.py` now pins the build's presence
   AND its position ahead of `"daemon_status_and_stop_lifecycle"`, because the
   build sitting behind its consumer is precisely what this bug was.
5. Independently, `fresh_daemon_bin` now repeats the `--target` its own binary
   was written under, so a self-heal that does fire lands where the check looks.
   The triple comes from `KIN_CLI_TARGET_TRIPLE`, emitted by
   `crates/kin-cli/build.rs` from cargo's `TARGET`, compared against the path
   layout. This makes the guard's stated remedy true rather than decorative and
   covers cross-target runs outside CI.

The guard is not weakened. No test is skipped, filtered, or ignored, and the job
still runs on every event with no job-level `if:`.

## Falsification

| gate | mutation | result |
|---|---|---|
| authority suite | `ci.yml` reverted to `origin/main` bytes | exit 1, `native Windows daemon lifecycle prerequisite is missing required policy` |
| authority suite | `ci.yml` as fixed | exit 0 |
| authority suite | build block deleted, in-suite `expect_assertion` | raises, matched |
| authority suite | build block moved after the tests, in-suite `expect_assertion` | raises `before the lifecycle test reads it`, matched |
| harness unit test | `daemon_rebuild_target` stubbed to always return `None`, ie. pre-fix behavior | FAILED, `left: None, right: Some("x86_64-pc-windows-msvc")` |
| harness unit test | as fixed | ok |

The cargo layout rule in step 4 of the failing chain was measured before the
derivation was written: a probe crate built both ways puts `CARGO_BIN_EXE_probe`
at `target/debug/probe` and `target/aarch64-apple-darwin/debug/probe`.

## Local gates

`python3 ./scripts/test-release-workflow-authority.py` exit 0 ·
`actionlint .github/workflows/ci.yml` exit 0 · `cargo fmt -- --check` exit 0 ·
`python3 scripts/verify-zero-file-search.py` exit 0 ·
`bash scripts/zero_file_search_guard.sh` exit 0 ·
`cargo build --all-targets --locked` exit 0 ·
`cargo clippy --all-targets --all-features -- <ci.yml allowlist>` under
`RUSTFLAGS=-D warnings` exit 0 · the new harness unit test passes.

Not run locally, stated rather than glossed: the full
`cargo test -p kin-cli --no-default-features --lib --tests` step. Another lane
held the `daemon` and `gpu` locks for the whole window and that step spawns real
daemons. CI runs it here.

## What is proven where

The mechanism is verified locally and from the CI log. The FIX is verified by
CI, because the failure only manifests on a Windows runner and this lane has
none. `Windows authority tests` runs on `pull_request`, so THIS PR's own run is
the live test, not a proxy for it. The merge-group run is a second confirmation,
not the first.

Refs FIR-1929


---

**Post-review hardening (folded into the post-616 rebase).** The reviewer falsified two gaps in the new gate by execution: deleting `--target` from the sibling build left the suite green (the gate could not catch reintroduction of the very defect this PR fixes), and the ordering check indexed a bare substring over the whole job, so a comment quoting the test name inverted it into a false red. The gate now judges active lines only, scopes its policies to the sibling build step's own block (pinning `--target x86_64-pc-windows-msvc` inside it), and compares step-name positions for ordering. Falsified in all three directions on this head: suite passes on the real tree; deleting `--target` fails with "missing required policy: --target x86_64-pc-windows-msvc"; rewriting the explanatory comment to quote the test name stays green. The suite's existing removed-block and block-after-tests negative controls pass unchanged.
