### PR TITLE
Ship native Windows semantic vector search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,8 +392,9 @@ jobs:
       # contract. The installer leg asserts the same behavior against the
       # release binary, but it runs only on the landing push, so on its own it
       # can report an admission change no earlier than a required check
-      # failing on a release commit. The feature set matches the installer
-      # leg's so both legs drive the same build of the command.
+      # failing on a release commit. This leg builds without default features
+      # and the installer leg builds with them, so the shared script asserts
+      # the same refusals against both feature sets of the command.
       - name: Build the Windows binaries the admission and npm assertions drive
         shell: bash
         run: |
@@ -532,7 +533,7 @@ jobs:
             -p kin-cli -p kin-daemon
           sccache --show-stats
 
-      - name: Verify Windows build provenance and disabled features
+      - name: Verify Windows build provenance and feature set
         shell: bash
         run: |
           set -euo pipefail
@@ -1086,9 +1087,9 @@ jobs:
       # Nothing else on these legs resolves kin-cli without its default
       # features, so a break that appears only with `vector` and `embeddings`
       # off compiles clean here and reaches main behind a green required
-      # context. The Windows job covers that configuration for the msvc target
-      # and runs three filtered subsets of the library, so the cases asserting
-      # the vector-free path execute in this step and nowhere else.
+      # context. The Windows authority job covers that configuration for the
+      # msvc target through filtered subsets of the library, so the cases
+      # asserting the featureless path execute in this step and nowhere else.
       # `RUSTFLAGS: -D warnings` is set at workflow level, so the unused-import
       # shape this class first took fails the step rather than warning.
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,12 @@ jobs:
           node ./scripts/prove-windows-npm-first-run.mjs
 
   windows-installer:
-    name: Windows installer + vector-free release build
+    # Renamed from "Windows installer + vector-free release build" when native
+    # vector search shipped on Windows. The name is not decoration: release-tag.yml
+    # resolves this exact string out of REQUIRED_CHECKS to decide whether Windows
+    # evidence exists for a release sha, so a name still claiming "vector-free"
+    # would be the mint's own authority asserting the opposite of what it built.
+    name: Windows installer + vector release build
     needs: changes
     # Deliberately off the pull-request path. This leg cold-builds the whole
     # dependency graph in the release profile for x86_64-pc-windows-msvc and
@@ -471,24 +476,47 @@ jobs:
             ~/.cargo/git
             target
             ${{ runner.temp }}/sccache
-          key: windows-vectorless-cargo-${{ hashFiles('Cargo.lock') }}
+          # Cache key renamed with the feature set. The vectorless key indexed a
+          # dependency graph with no ndarray, tokenizers, hnsw or onig in it, so
+          # restoring from it would warm almost nothing and would report a hit
+          # while doing so.
+          key: windows-vector-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            windows-vectorless-cargo-
+            windows-vector-cargo-
 
-      - name: Assert vector-free feature graph
+      # Windows ships native vector search, so this asserts the feature graph in
+      # both directions rather than only forbidding features. `vector` and
+      # `embeddings` must be reachable, or the leg would silently certify a
+      # degraded build; `metal` and `accelerate` must not be, because those are
+      # macOS-only backends whose activation lives in a
+      # `cfg(target_os = "macos")` dependency block and must never unify in here.
+      #
+      # `grep -c` rather than `grep -q`: under `pipefail` a `-q` match closes the
+      # pipe early and the SIGPIPE fails the step, which reads exactly like the
+      # feature being absent. Reading a file cannot invert the guard that way.
+      - name: Assert the Windows feature graph
         shell: bash
         run: |
           set -euo pipefail
           cargo tree --locked --target x86_64-pc-windows-msvc \
-            -p kin-daemon --no-default-features -e features -i kin-db \
+            -p kin-daemon -e features -i kin-db \
             | tee "$RUNNER_TEMP/kin-db-feature-tree.txt"
-          if grep -Eq 'kin-db feature "(vector|embeddings|metal|accelerate)"' \
-            "$RUNNER_TEMP/kin-db-feature-tree.txt"; then
-            echo "::error::Windows vector-free build still enables a heavy kin-db feature"
-            exit 1
-          fi
+          for required in vector embeddings; do
+            if [ "$(grep -Ec "kin-db feature \"${required}\"" \
+              "$RUNNER_TEMP/kin-db-feature-tree.txt")" -eq 0 ]; then
+              echo "::error::Windows release build is missing kin-db feature ${required}"
+              exit 1
+            fi
+          done
+          for forbidden in metal accelerate; do
+            if [ "$(grep -Ec "kin-db feature \"${forbidden}\"" \
+              "$RUNNER_TEMP/kin-db-feature-tree.txt")" -ne 0 ]; then
+              echo "::error::Windows build pulled the macOS-only kin-db feature ${forbidden}"
+              exit 1
+            fi
+          done
 
-      - name: Build Windows release binaries without vector features
+      - name: Build Windows release binaries with vector features
         shell: bash
         env:
           # Compile cache keyed per crate, so a Cargo.lock change warm-starts
@@ -501,7 +529,7 @@ jobs:
           CARGO_INCREMENTAL: "0"
         run: |
           cargo build --locked --release --target x86_64-pc-windows-msvc \
-            -p kin-cli -p kin-daemon --no-default-features
+            -p kin-cli -p kin-daemon
           sccache --show-stats
 
       - name: Verify Windows build provenance and disabled features
@@ -544,10 +572,18 @@ jobs:
               `does not match tracked Git bytes ${expectedLock}`
             );
           }
-          for (const feature of ["vector", "embeddings", "metal"]) {
-            if (meta.feature_flags.includes(feature)) {
-              throw new Error(`Windows vector-free build unexpectedly enabled ${feature}`);
+          // The shipped binary must report the features it was built with, not
+          // merely resolve them in the dependency graph. `metal` tracks the
+          // compiled backend rather than the marker cargo feature
+          // (bench_meta.rs `metal_active()` is `cfg!(target_os = "macos")`), so
+          // a correct Windows build reports vector and embeddings and no metal.
+          for (const feature of ["vector", "embeddings"]) {
+            if (!meta.feature_flags.includes(feature)) {
+              throw new Error(`Windows release build did not enable ${feature}`);
             }
+          }
+          if (meta.feature_flags.includes("metal")) {
+            throw new Error("Windows release build reported the macOS-only metal backend");
           }
           NODE
 

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -1426,11 +1426,11 @@ jobs:
               throw new Error(`${label}: unknown embedding coverage state ${coverage.state ?? "missing"}`);
             }
           };
+          if (cliMeta.embeddings?.vector_enabled !== true || cliMeta.embeddings?.embeddings_enabled !== true) {
+            throw new Error(`${runnerOs} bench metadata does not prove vector and embedding support`);
+          }
           if (!isWindows) {
             validateEmbeddingCoverage(status.embedding_coverage, "kin-status.json");
-            if (cliMeta.embeddings?.vector_enabled !== true || cliMeta.embeddings?.embeddings_enabled !== true) {
-              throw new Error(`${runnerOs} bench metadata does not prove vector and embedding support`);
-            }
           }
           const reports = ["kin-health.json", "kin-doctor.json"].map((path) => [
             path,
@@ -1519,7 +1519,7 @@ jobs:
                   check.status === "healthy" ||
                   check.status === "unsupported"
               );
-            if (report.healthy !== true && (isWindows || !onlyPendingEmbeddingsBlocks)) {
+            if (report.healthy !== true && !onlyPendingEmbeddingsBlocks) {
               throw new Error(
                 `${path}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
               );
@@ -1531,9 +1531,7 @@ jobs:
               }
             }
             const semanticReadiness = checks.get("semantic_query_readiness")?.status;
-            const allowedSemanticReadiness = isWindows
-              ? ["unsupported"]
-              : ["healthy", "stale"];
+            const allowedSemanticReadiness = ["healthy", "stale"];
             if (!allowedSemanticReadiness.includes(semanticReadiness)) {
               throw new Error(
                 `${path}: semantic_query_readiness is ${semanticReadiness ?? "missing"}, expected ${allowedSemanticReadiness.join(" or ")}`

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -558,12 +558,15 @@ jobs:
           if (meta.dependency_provenance !== expectedLock) {
             throw new Error(`installed Windows Cargo.lock provenance ${meta.dependency_provenance ?? "missing"} does not match release source ${expectedLock}`);
           }
+          // What a user actually installed, not what CI built. `metal_enabled`
+          // tracks the compiled backend rather than the marker cargo feature,
+          // so it stays false on Windows even with default features on.
           if (
-            meta.embeddings?.vector_enabled !== false ||
-            meta.embeddings?.embeddings_enabled !== false ||
+            meta.embeddings?.vector_enabled !== true ||
+            meta.embeddings?.embeddings_enabled !== true ||
             meta.embeddings?.metal_enabled !== false
           ) {
-            throw new Error("installed Windows CLI does not prove the vector-free feature contract");
+            throw new Error("installed Windows CLI does not prove the vector feature contract");
           }
 
           const authority = JSON.parse(fs.readFileSync("kin-windows-registry-authority.json", "utf8"));

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -793,7 +793,7 @@ jobs:
             DCO Sign-off
             cargo-deny
             gitleaks (full history)
-            Windows installer + vector-free release build
+            Windows installer + vector release build
         run: |
           set -euo pipefail
           gh api "repos/$REPO/actions/runs/$CURRENT_RUN_ID" \
@@ -907,7 +907,7 @@ jobs:
                   "push",
                   release_branch,
               ),
-              "Windows installer + vector-free release build": (
+              "Windows installer + vector release build": (
                   245803170,
                   ".github/workflows/ci.yml",
                   "push",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             artifact: kin-windows-x86_64
             shim_name: kin_vfs_shim.dll
-            skip_vector: true
+            # kin-vfs only. This row used to carry `skip_vector: true`, which
+            # gated BOTH the vector feature set and the kin-vfs build, so
+            # shipping vectors on Windows by deleting that one key would also
+            # have started building an LD_PRELOAD libc interceptor for msvc.
+            # The two are unrelated and are now named separately.
+            skip_vfs: true
             cross: false
 
     steps:
@@ -554,17 +559,16 @@ jobs:
         if: ${{ !matrix.cross }}
         shell: bash
         run: |
-          FLAGS=""
-          if [ "$SKIP_VECTOR" = "true" ]; then
-            FLAGS="--no-default-features"
-          fi
           # The daemon is the runtime: `kin init` works without it but
           # `kin status`/`kin search`/the MCP server all require kin-daemon on
           # PATH, so a clean public install must ship it alongside `kin`.
-          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon $FLAGS
+          #
+          # Every platform now builds the same default feature set. Windows was
+          # the only leg that stripped it, and dropping that split is what puts
+          # native vector search in the shipped Windows archive.
+          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon
         env:
           TARGET: ${{ matrix.target }}
-          SKIP_VECTOR: ${{ matrix.skip_vector }}
 
       - name: Build kin-cli + kin-daemon (cross)
         if: ${{ matrix.cross }}
@@ -590,7 +594,7 @@ jobs:
           TARGET: ${{ matrix.target }}
 
       - name: Build kin-vfs (native)
-        if: ${{ !matrix.cross && !matrix.skip_vector }}
+        if: ${{ !matrix.cross && !matrix.skip_vfs }}
         working-directory: kin-vfs
         shell: bash
         run: |
@@ -617,7 +621,6 @@ jobs:
         shell: bash
         env:
           TARGET: ${{ matrix.target }}
-          SKIP_VECTOR: ${{ matrix.skip_vector }}
         run: |
           set -euo pipefail
           case "$RUNNER_ARCH:$TARGET" in
@@ -639,7 +642,7 @@ jobs:
           "$kin_bin" bench-meta --json > "$provenance_dir/kin-build-meta.json"
           expected_sha="$(git rev-parse HEAD)"
 
-          EXPECTED_SHA="$expected_sha" SKIP_VECTOR="$SKIP_VECTOR" PROVENANCE_DIR="$provenance_dir" node <<'NODE'
+          EXPECTED_SHA="$expected_sha" PROVENANCE_DIR="$provenance_dir" node <<'NODE'
           const crypto = require("crypto");
           const fs = require("fs");
           const expected = process.env.EXPECTED_SHA;
@@ -674,12 +677,25 @@ jobs:
               `does not match tagged Cargo.lock ${tagLockSha}`
             );
           }
-          if (process.env.SKIP_VECTOR === "true") {
-            for (const feature of ["vector", "embeddings", "metal"]) {
-              if (meta.feature_flags.includes(feature)) {
-                throw new Error(`vector-free release unexpectedly enabled ${feature}`);
-              }
+          // Every published archive now carries semantic search. This used to
+          // run only for the one leg that stripped the features, which meant no
+          // leg ever asserted they were PRESENT; a silent feature regression on
+          // any platform would have shipped green. Assert it everywhere.
+          //
+          // `metal` reports the compiled backend rather than the marker cargo
+          // feature (bench_meta.rs `metal_active()` is
+          // `cfg!(target_os = "macos")`), so it is expected on macOS and is a
+          // defect anywhere else.
+          for (const feature of ["vector", "embeddings"]) {
+            if (!meta.feature_flags.includes(feature)) {
+              throw new Error(`release build for ${process.env.TARGET} did not enable ${feature}`);
             }
+          }
+          const expectMetal = process.env.TARGET.includes("apple-darwin");
+          if (meta.feature_flags.includes("metal") !== expectMetal) {
+            throw new Error(
+              `release build for ${process.env.TARGET} reported metal=${meta.feature_flags.includes("metal")}, expected ${expectMetal}`
+            );
           }
           NODE
 

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -13,9 +13,17 @@
 #   - It fetches a ~522 MB model. On every pull request that is a tax nobody
 #     asked for, and on the release-gating installer leg it would make the mint
 #     hostage to huggingface.co being reachable.
-#   - It produces no check run on a pull request or merge group, so it can never
-#     become a required context by accident. The workflow-job census in
-#     scripts/test-release-workflow-authority.py pins that.
+#   - As written it produces no check run on a pull request or merge group, so
+#     it is not a required-context producer.
+#
+# That last property is NOT enforced anywhere, and an earlier version of this
+# comment wrongly claimed it was. The workflow-job census in
+# scripts/test-release-workflow-authority.py pins this workflow's path, job id
+# and display name, but it never reads `on:` triggers: adding `pull_request:`
+# here leaves the suite green (falsified directly, both ways). So keeping this
+# dispatch-only is a review responsibility, not a guarded invariant. Anyone
+# adding a trigger is adding a check run to every pull request, plus a ~522 MB
+# model fetch and a ~45 minute Windows release build.
 #
 # Run it when the vector-carrying Windows surface changes, and paste the run URL
 # into the change that claims Windows semantic search works.

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Native Windows semantic vector search, executed rather than compiled.
+#
+# Everything else that touches vectors on Windows is compile-time evidence: the
+# feature graph resolves, the binary reports its flags, the archive packages.
+# None of that shows that embedding inference has ever RUN on Windows, and until
+# this workflow existed nothing in the fleet had. That gap is the whole reason
+# the platform shipped vector-free, so it gets its own executed proof.
+#
+# `workflow_dispatch` only, deliberately:
+#   - It fetches a ~522 MB model. On every pull request that is a tax nobody
+#     asked for, and on the release-gating installer leg it would make the mint
+#     hostage to huggingface.co being reachable.
+#   - It produces no check run on a pull request or merge group, so it can never
+#     become a required context by accident. The workflow-job census in
+#     scripts/test-release-workflow-authority.py pins that.
+#
+# Run it when the vector-carrying Windows surface changes, and paste the run URL
+# into the change that claims Windows semantic search works.
+name: Windows vector proof
+
+# No inputs. `workflow_dispatch` already selects the ref to run against, so an
+# input feeding `actions/checkout`'s `ref:` would add an injection surface and
+# buy nothing.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: never
+
+jobs:
+  windows-vector-proof:
+    name: Windows semantic vector search proof
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - name: Preserve tracked bytes on Windows
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Install sccache
+        uses: taiki-e/install-action@v2
+        with:
+          tool: sccache
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            ${{ runner.temp }}/sccache
+          key: windows-vector-proof-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            windows-vector-proof-
+
+      # Keyed on the model id rather than the lock: the download is invariant
+      # across source changes, and a cold fetch is most of this job's wall clock.
+      - name: Cache the Hugging Face hub
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/huggingface
+          key: windows-hf-hub-nomic-embed-text-v1.5
+
+      # Release profile, not debug. The embedding backend is pure-Rust matmul;
+      # an unoptimised build makes the timings meaningless and the run long
+      # enough to hit the job timeout.
+      - name: Build kin with vector features
+        shell: bash
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_DIR: ${{ runner.temp }}/sccache
+          CARGO_INCREMENTAL: "0"
+        run: |
+          set -euo pipefail
+          cargo build --locked --release --target x86_64-pc-windows-msvc \
+            -p kin-cli -p kin-daemon
+          sccache --show-stats
+
+      - name: Prove the built binary carries vectors
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin_dir="target/x86_64-pc-windows-msvc/release"
+          "$bin_dir/kin.exe" bench-meta --json > "$RUNNER_TEMP/bench-meta.json"
+          node <<'NODE'
+          const fs = require("fs");
+          const meta = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/bench-meta.json`, "utf8"));
+          for (const feature of ["vector", "embeddings"]) {
+            if (!meta.feature_flags.includes(feature)) {
+              throw new Error(`Windows proof binary did not enable ${feature}`);
+            }
+          }
+          if (meta.feature_flags.includes("metal")) {
+            throw new Error("Windows proof binary reported the macOS-only metal backend");
+          }
+          console.log(`feature_flags: ${meta.feature_flags.join(",")}`);
+          NODE
+
+      # Admission takes exact Git import or an empty native directory and
+      # refuses a populated non-Git one, so the fixture is a real Git worktree.
+      - name: Seed a fixture repository and admit it
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin_dir="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release"
+          mkdir -p "$RUNNER_TEMP/vector-fixture"
+          cd "$RUNNER_TEMP/vector-fixture"
+          git init -q
+          git config user.email ci@firelock.ai
+          git config user.name ci
+          # Distinct topics with no shared vocabulary, so a semantic hit cannot
+          # be explained by a lexical match on the query term.
+          printf 'def parse_configuration_file(path):\n    """Read settings from disk."""\n    return {}\n' > settings.py
+          printf 'def compute_checksum(data):\n    """Hash a byte buffer."""\n    return 0\n' > hashing.py
+          printf 'def send_email_notification(to, body):\n    """Deliver a message to a recipient."""\n    return True\n' > mailer.py
+          git add -A
+          git commit -qm "fixture"
+          "$bin_dir/kin.exe" init 2>&1 | tee "$RUNNER_TEMP/kin-init.txt"
+
+      - name: Embed the fixture on native Windows
+        shell: bash
+        working-directory: ${{ runner.temp }}/vector-fixture
+        run: |
+          set -euo pipefail
+          bin_dir="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release"
+          export PATH="$bin_dir:$PATH"
+          # First run pays the model download. Bound it so a network stall fails
+          # visibly instead of burning the whole job budget.
+          embed_start=$(date +%s)
+          kin.exe embed --max-seconds 1800 --json | tee "$RUNNER_TEMP/kin-embed.json"
+          echo "embed_wall_seconds=$(( $(date +%s) - embed_start ))" \
+            | tee "$RUNNER_TEMP/kin-embed-timing.txt"
+          kin.exe status --json | tee "$RUNNER_TEMP/kin-status.json"
+
+      - name: Query the embedded graph
+        shell: bash
+        working-directory: ${{ runner.temp }}/vector-fixture
+        run: |
+          set -euo pipefail
+          export PATH="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release:$PATH"
+          # "credentials" appears in none of the fixture files, so a ranked hit
+          # is the embedding arm answering, not a substring match.
+          kin.exe search credentials --semantic --json \
+            | tee "$RUNNER_TEMP/kin-semantic-search.json"
+          kin.exe locate "how are settings loaded" --json --explain --max-files 5 \
+            | tee "$RUNNER_TEMP/kin-locate.json"
+
+      - name: Assert the runtime proved semantic search
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("fs");
+          const temp = process.env.RUNNER_TEMP;
+          const read = (name) => JSON.parse(fs.readFileSync(`${temp}/${name}`, "utf8"));
+
+          const embed = read("kin-embed.json");
+          if (embed.time_limited === true) {
+            throw new Error(`embedding hit its time bound before completing: ${JSON.stringify(embed)}`);
+          }
+          if (embed.pending_entities !== 0 || embed.pending_artifacts !== 0) {
+            throw new Error(`embedding did not reach full coverage: ${JSON.stringify(embed)}`);
+          }
+
+          const status = read("kin-status.json");
+          const coverage = status.embedding_coverage;
+          if (!coverage || coverage.state !== "observed") {
+            throw new Error(`status could not observe embedding coverage: ${JSON.stringify(coverage ?? null)}`);
+          }
+          // The whole point of the run: inference actually produced vectors on
+          // Windows. A zero here is the vector-free outcome wearing a green
+          // check, which is exactly what this workflow exists to catch.
+          if (!(coverage.indexed > 0)) {
+            throw new Error(`Windows embedding produced no indexed vectors: ${JSON.stringify(coverage)}`);
+          }
+          console.log(`indexed=${coverage.indexed} source=${coverage.source}`);
+
+          // `kin locate --json` is an object carrying `files[]` and, when the
+          // retrieval arms degrade, `degradations[]`. A vector-free build is
+          // exactly the case that records vector_index/feature_disabled here,
+          // so its ABSENCE is what proves the vector arm actually served.
+          const locate = read("kin-locate.json");
+          const disabled = (locate.degradations ?? []).filter(
+            (d) => d.component === "vector_index" && d.reason === "feature_disabled"
+          );
+          if (disabled.length > 0) {
+            throw new Error(`locate reported the vector index as feature_disabled: ${JSON.stringify(disabled)}`);
+          }
+          if (!Array.isArray(locate.files) || locate.files.length === 0) {
+            throw new Error(`locate returned no ranked files: ${JSON.stringify(locate).slice(0, 800)}`);
+          }
+
+          // `kin search --json` is a top-level array of entity records, each
+          // carrying `name` and `file`. Any other shape means the contract
+          // moved and this assertion stopped meaning what it says.
+          const search = read("kin-semantic-search.json");
+          if (!Array.isArray(search)) {
+            throw new Error(`kin search --json was not an array: ${JSON.stringify(search).slice(0, 400)}`);
+          }
+          if (search.length === 0) {
+            throw new Error("semantic search returned no ranked results");
+          }
+          if (!search.every((record) => typeof record.file === "string")) {
+            throw new Error(`kin search records lack a file field: ${JSON.stringify(search).slice(0, 400)}`);
+          }
+          console.log(
+            `semantic search returned ${search.length} ranked results; ` +
+            `locate returned ${locate.files.length} files`
+          );
+          NODE
+
+      - name: Upload proof artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-vector-proof
+          path: |
+            ${{ runner.temp }}/kin-*.json
+            ${{ runner.temp }}/kin-*.txt
+          if-no-files-found: warn

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -210,17 +210,23 @@ jobs:
             `embedded_entities=${embed.embedded_entities} index=${embed.vector_index_path}`
           );
 
-          // `kin status` coverage is captured as DIAGNOSTIC here, not as a gate.
-          // On Windows the daemon does not stay resident between CLI
-          // invocations, and `kin status` deliberately never starts one, so any
-          // read of it races the daemon's lifetime and returns
-          // unobserved/no_running_daemon regardless of what was actually
-          // embedded. Both the CI runner and a native aarch64 Windows guest
-          // reproduced that with the read placed AFTER a query that does start a
-          // daemon, so it is the surface that is wrong, not the ordering.
+          // `kin status` coverage is captured as DIAGNOSTIC here, not as a gate,
+          // because reading it is a timing race rather than a measurement.
+          // `kin status` deliberately never starts a daemon, so it reports
+          // whatever is running when it happens to run: if the daemon from the
+          // preceding command has already exited, it correctly reports
+          // unobserved/no_running_daemon no matter how much was embedded. Three
+          // runs here hit exactly that, which is what moved the assertion off it.
           //
-          // Gating on it would be gating on a race. The embed command's own
-          // report above is the direct evidence and is what this asserts.
+          // It is NOT that Windows cannot observe coverage. An earlier version of
+          // this comment said so and was wrong: on a native Windows host with a
+          // live daemon, `kin status --json` returns
+          // {"state":"observed","source":"live_query_graph","indexed":6954,...}.
+          // The field works; only its availability at an arbitrary moment does not.
+          //
+          // So gate on the embed command's own report above, which is the direct
+          // output of the process that did the work and depends on nothing still
+          // being alive afterwards.
           const status = read("kin-status.json");
           console.log(`status embedding_coverage (diagnostic): ${JSON.stringify(status.embedding_coverage ?? null)}`);
 

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -203,18 +203,19 @@ jobs:
             `embedded_entities=${embed.embedded_entities} index=${embed.vector_index_path}`
           );
 
+          // `kin status` coverage is captured as DIAGNOSTIC here, not as a gate.
+          // On Windows the daemon does not stay resident between CLI
+          // invocations, and `kin status` deliberately never starts one, so any
+          // read of it races the daemon's lifetime and returns
+          // unobserved/no_running_daemon regardless of what was actually
+          // embedded. Both the CI runner and a native aarch64 Windows guest
+          // reproduced that with the read placed AFTER a query that does start a
+          // daemon, so it is the surface that is wrong, not the ordering.
+          //
+          // Gating on it would be gating on a race. The embed command's own
+          // report above is the direct evidence and is what this asserts.
           const status = read("kin-status.json");
-          const coverage = status.embedding_coverage;
-          if (!coverage || coverage.state !== "observed") {
-            throw new Error(`status could not observe embedding coverage: ${JSON.stringify(coverage ?? null)}`);
-          }
-          // The whole point of the run: inference actually produced vectors on
-          // Windows. A zero here is the vector-free outcome wearing a green
-          // check, which is exactly what this workflow exists to catch.
-          if (!(coverage.indexed > 0)) {
-            throw new Error(`Windows embedding produced no indexed vectors: ${JSON.stringify(coverage)}`);
-          }
-          console.log(`indexed=${coverage.indexed} source=${coverage.source}`);
+          console.log(`status embedding_coverage (diagnostic): ${JSON.stringify(status.embedding_coverage ?? null)}`);
 
           // `kin locate --json` is an object carrying `files[]` and, when the
           // retrieval arms degrade, `degradations[]`. A vector-free build is

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -23,7 +23,7 @@
 # here leaves the suite green (falsified directly, both ways). So keeping this
 # dispatch-only is a review responsibility, not a guarded invariant. Anyone
 # adding a trigger is adding a check run to every pull request, plus a ~522 MB
-# model fetch and a ~45 minute Windows release build.
+# model fetch and a ~30 minute job, of which the release build is ~23 minutes.
 #
 # Run it when the vector-carrying Windows surface changes, and paste the run URL
 # into the change that claims Windows semantic search works.

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -153,7 +153,6 @@ jobs:
           kin.exe embed --max-seconds 1800 --json | tee "$RUNNER_TEMP/kin-embed.json"
           echo "embed_wall_seconds=$(( $(date +%s) - embed_start ))" \
             | tee "$RUNNER_TEMP/kin-embed-timing.txt"
-          kin.exe status --json | tee "$RUNNER_TEMP/kin-status.json"
 
       - name: Query the embedded graph
         shell: bash
@@ -167,6 +166,12 @@ jobs:
             | tee "$RUNNER_TEMP/kin-semantic-search.json"
           kin.exe locate "how are settings loaded" --json --explain --max-files 5 \
             | tee "$RUNNER_TEMP/kin-locate.json"
+          # `kin status` deliberately does not auto-start the daemon, and the
+          # daemon `kin embed` used has exited by now. Read it AFTER the queries
+          # above, which do start one. Reading it earlier returns
+          # state=unobserved reason=no_running_daemon, which is a dead harness
+          # rather than a shortfall, and is exactly how the first run failed.
+          kin.exe status --json | tee "$RUNNER_TEMP/kin-status.json"
 
       - name: Assert the runtime proved semantic search
         shell: bash
@@ -184,6 +189,19 @@ jobs:
           if (embed.pending_entities !== 0 || embed.pending_artifacts !== 0) {
             throw new Error(`embedding did not reach full coverage: ${JSON.stringify(embed)}`);
           }
+          // Assert on the embed command's OWN report, not only on the status
+          // read below. Zero pending is satisfied vacuously by a run that
+          // embedded nothing, so the count that proves inference ran has to be
+          // checked directly and at its source.
+          if (!(embed.embedded_entities > 0)) {
+            throw new Error(`embedding produced no entity vectors: ${JSON.stringify(embed)}`);
+          }
+          if (!embed.vector_index_path) {
+            throw new Error(`embedding wrote no vector index: ${JSON.stringify(embed)}`);
+          }
+          console.log(
+            `embedded_entities=${embed.embedded_entities} index=${embed.vector_index_path}`
+          );
 
           const status = read("kin-status.json");
           const coverage = status.embedding_coverage;

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -24,8 +24,17 @@ name: Windows vector proof
 # No inputs. `workflow_dispatch` already selects the ref to run against, so an
 # input feeding `actions/checkout`'s `ref:` would add an injection surface and
 # buy nothing.
+#
+# TEMPORARY, REMOVE BEFORE MERGE: `workflow_dispatch` is only dispatchable once
+# the file exists on the default branch, which makes it unrunnable on the very
+# branch that introduces it. The push trigger below is scoped to this one lane
+# branch purely so the proof can produce evidence pre-merge. It runs the same
+# job body the dispatch path will.
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - chore/lane-nwvec-kin
 
 permissions:
   contents: read

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -25,16 +25,13 @@ name: Windows vector proof
 # input feeding `actions/checkout`'s `ref:` would add an injection surface and
 # buy nothing.
 #
-# TEMPORARY, REMOVE BEFORE MERGE: `workflow_dispatch` is only dispatchable once
-# the file exists on the default branch, which makes it unrunnable on the very
-# branch that introduces it. The push trigger below is scoped to this one lane
-# branch purely so the proof can produce evidence pre-merge. It runs the same
-# job body the dispatch path will.
+# Note for whoever next changes this file: `workflow_dispatch` only becomes
+# dispatchable once the workflow exists on the default branch, so it cannot be
+# run on the branch that introduces or renames it. Proving a change here
+# pre-merge needs a temporary `push:` trigger scoped to that branch, removed
+# before merge. That is how run 30969196206 was produced.
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - chore/lane-nwvec-kin
 
 permissions:
   contents: read

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -22,8 +22,10 @@
 # and display name, but it never reads `on:` triggers: adding `pull_request:`
 # here leaves the suite green (falsified directly, both ways). So keeping this
 # dispatch-only is a review responsibility, not a guarded invariant. Anyone
-# adding a trigger is adding a check run to every pull request, plus a ~522 MB
-# model fetch and a ~30 minute job, of which the release build is ~23 minutes.
+# adding a trigger is adding a check run to every pull request. Run 30969196206
+# measured 36 minutes end to end, of which the release build is 23 and the
+# post-job cargo cache save is 5. The ~522 MB model fetch is inside that, in the
+# embed step, and only because the hub cache missed on that run.
 #
 # Run it when the vector-carrying Windows surface changes, and paste the run URL
 # into the change that claims Windows semantic search works.

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1038,7 +1038,12 @@ pub(crate) fn home_dir() -> Result<PathBuf> {
 ///
 /// `known_profile_root` is the profile-only lookup (`FOLDERID_Profile` on
 /// Windows); `base_dirs_home` is the stricter `BaseDirs` constructor.
-fn resolve_home_dir(
+///
+/// Visible to the crate because the Hugging Face cache probe in
+/// `crate::retrieval_profile` mirrors the same layout and must resolve the home
+/// the same way. A second resolver there is what produced the `HOME`-only
+/// lookup that never matched on Windows.
+pub(crate) fn resolve_home_dir(
     windows: bool,
     var_os: impl Fn(&str) -> Option<OsString>,
     known_profile_root: impl FnOnce() -> Option<PathBuf>,

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -24,7 +24,8 @@
 //!   budget when its model is already cached locally, and the embedding
 //!   seed floor actually rejects near-orthogonal noise.
 
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Set once by the daemon's serving entrypoint. The cross-encoder's
@@ -208,9 +209,57 @@ pub fn cosine_to_relevance(cosine: f32) -> f32 {
 /// dependency; a false negative merely means the reranker stays off by
 /// default until the model is fetched explicitly.
 pub fn cross_encoder_model_cached(model_id: &str) -> bool {
-    let base = std::env::var_os("HF_HOME").map(PathBuf::from).or_else(|| {
-        std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache/huggingface"))
-    });
+    let base = hf_cache_base(
+        cfg!(windows),
+        |key| std::env::var_os(key),
+        || directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+        || directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+    );
+    cached_under_base(base.as_deref(), model_id)
+}
+
+/// The root `hf-hub` would resolve its cache under, given the platform and the
+/// environment.
+///
+/// `hf-hub` reads `HF_HOME` first and otherwise falls back to
+/// `dirs::home_dir()/.cache/huggingface` (`hf-hub-0.5.0/src/lib.rs:42-54`), so
+/// this mirrors that shape and defers the home itself to the one resolver the
+/// crate already has.
+///
+/// Taken as arguments rather than gated behind `cfg` for the reason
+/// [`crate::commands::setup::resolve_home_dir`] spells out: a `cfg`-gated
+/// Windows arm is compiled, and therefore tested, only on the platform this
+/// fleet has no host for. That is precisely how the `HOME`-only lookup this
+/// replaces survived — `HOME` is not a Windows name, so the probe answered
+/// "absent" on Windows even with the model fully downloaded, and the reranker
+/// silently stayed off instead of failing.
+///
+/// One divergence is deliberate and worth naming: on Windows `dirs::home_dir()`
+/// is `FOLDERID_Profile` (`dirs-6.0.0/src/win.rs:5`) while `resolve_home_dir`
+/// prefers a non-empty `USERPROFILE`. They agree unless `USERPROFILE` has been
+/// redirected away from the known-folder profile, and following the redirect is
+/// what keeps an isolated home isolated. When they do disagree the probe under-
+/// reports, which this function's contract already permits: a false negative
+/// only leaves the reranker off until the model is fetched explicitly.
+fn hf_cache_base(
+    windows: bool,
+    var_os: impl Fn(&str) -> Option<OsString>,
+    known_profile_root: impl FnOnce() -> Option<PathBuf>,
+    base_dirs_home: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    // An empty value is not a path; treat it the same as unset rather than
+    // resolving the cache relative to the working directory.
+    if let Some(hf_home) = var_os("HF_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(hf_home));
+    }
+    crate::commands::setup::resolve_home_dir(windows, var_os, known_profile_root, base_dirs_home)
+        .map(|home| home.join(".cache").join("huggingface"))
+}
+
+/// Whether `model_id` has a resolved snapshot under an already-resolved cache
+/// root. Split from the root lookup so the layout and the home policy fail
+/// independently.
+fn cached_under_base(base: Option<&Path>, model_id: &str) -> bool {
     let Some(base) = base else {
         return false;
     };
@@ -344,5 +393,184 @@ mod tests {
             !accuracy.cross_encoder_default(false),
             "an unset default must never trigger a mid-query model download"
         );
+    }
+
+    /// Reads only the names it is given, so a test states the whole environment
+    /// it is asserting against and nothing ambient can leak in.
+    fn env_of(pairs: &[(&str, &Path)]) -> impl Fn(&str) -> Option<OsString> + use<> {
+        let pairs: Vec<(String, OsString)> = pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.as_os_str().to_os_string()))
+            .collect();
+        move |key| {
+            pairs
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.clone())
+        }
+    }
+
+    fn stage_cached_model(home: &Path, model_id: &str) {
+        let dir = home
+            .join(".cache")
+            .join("huggingface")
+            .join("hub")
+            .join(format!("models--{}", model_id.replace('/', "--")))
+            .join("snapshots")
+            .join("0123456789abcdef");
+        std::fs::create_dir_all(&dir).unwrap();
+    }
+
+    const CE_MODEL: &str = "cross-encoder/ms-marco-MiniLM-L-6-v2";
+
+    /// Windows names the profile root `USERPROFILE` and does not set `HOME`, so
+    /// a `HOME`-only lookup reports every model absent no matter what is on
+    /// disk. This is the regression: it fails against the previous lookup and
+    /// passes against the shared resolver.
+    #[test]
+    fn probe_finds_a_cached_model_under_a_windows_shaped_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path();
+        stage_cached_model(profile, CE_MODEL);
+
+        let base = hf_cache_base(true, env_of(&[("USERPROFILE", profile)]), || None, || None);
+
+        assert_eq!(
+            base,
+            Some(profile.join(".cache").join("huggingface")),
+            "a Windows home must resolve from USERPROFILE"
+        );
+        assert!(
+            cached_under_base(base.as_deref(), CE_MODEL),
+            "a fully downloaded model under a Windows profile must read as cached"
+        );
+    }
+
+    /// The negative arm, so the positive above cannot pass by answering `true`
+    /// unconditionally.
+    #[test]
+    fn probe_reports_absent_when_no_model_is_cached() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path();
+
+        let base = hf_cache_base(true, env_of(&[("USERPROFILE", profile)]), || None, || None);
+
+        assert_eq!(base, Some(profile.join(".cache").join("huggingface")));
+        assert!(
+            !cached_under_base(base.as_deref(), CE_MODEL),
+            "an empty cache must report absent"
+        );
+    }
+
+    /// A profile root that exists but holds no `AppData` subtree collapses the
+    /// `BaseDirs` constructor to `None`. `USERPROFILE` must still win, which is
+    /// the same failure mode the setup resolver was hardened against.
+    #[test]
+    fn windows_probe_prefers_the_named_profile_over_both_lookups() {
+        let temp = tempfile::tempdir().unwrap();
+        let named = temp.path().join("named");
+        let known = temp.path().join("known-folder");
+        std::fs::create_dir_all(&named).unwrap();
+        stage_cached_model(&named, CE_MODEL);
+
+        let base = hf_cache_base(
+            true,
+            env_of(&[("USERPROFILE", &named)]),
+            || Some(known.clone()),
+            || Some(known.clone()),
+        );
+
+        assert_eq!(base, Some(named.join(".cache").join("huggingface")));
+        assert!(cached_under_base(base.as_deref(), CE_MODEL));
+    }
+
+    /// With `USERPROFILE` unset or empty the known-folder profile answers, so an
+    /// environment that names nothing still resolves.
+    #[test]
+    fn windows_probe_falls_back_to_the_known_folder_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        let known = temp.path();
+        stage_cached_model(known, CE_MODEL);
+
+        for env in [env_of(&[]), env_of(&[("USERPROFILE", Path::new(""))])] {
+            let base = hf_cache_base(true, env, || Some(known.to_path_buf()), || None);
+            assert_eq!(base, Some(known.join(".cache").join("huggingface")));
+            assert!(cached_under_base(base.as_deref(), CE_MODEL));
+        }
+    }
+
+    /// Unix keeps resolving through `BaseDirs`, which reads `HOME` first and
+    /// otherwise falls back to the passwd database, and must never consult
+    /// `USERPROFILE`.
+    #[test]
+    fn unix_probe_resolves_through_base_dirs_and_ignores_userprofile() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let windows_only = temp.path().join("windows-only");
+        std::fs::create_dir_all(&home).unwrap();
+        stage_cached_model(&home, CE_MODEL);
+
+        let base = hf_cache_base(
+            false,
+            env_of(&[("USERPROFILE", &windows_only)]),
+            || Some(windows_only.clone()),
+            || Some(home.clone()),
+        );
+
+        assert_eq!(base, Some(home.join(".cache").join("huggingface")));
+        assert!(cached_under_base(base.as_deref(), CE_MODEL));
+    }
+
+    /// `HF_HOME` is the cache root itself, not a home, and outranks every home
+    /// lookup on both platforms. An empty value is not a path and must read as
+    /// unset rather than resolving relative to the working directory.
+    #[test]
+    fn hf_home_outranks_the_resolved_home_and_ignores_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let hf_home = temp.path().join("hf");
+        let profile = temp.path().join("profile");
+        std::fs::create_dir_all(&profile).unwrap();
+        std::fs::create_dir_all(
+            hf_home
+                .join("hub")
+                .join(format!("models--{}", CE_MODEL.replace('/', "--")))
+                .join("snapshots")
+                .join("0123456789abcdef"),
+        )
+        .unwrap();
+
+        for windows in [true, false] {
+            let base = hf_cache_base(
+                windows,
+                env_of(&[("HF_HOME", &hf_home), ("USERPROFILE", &profile)]),
+                || Some(profile.clone()),
+                || Some(profile.clone()),
+            );
+            assert_eq!(base, Some(hf_home.clone()), "HF_HOME is the cache root");
+            assert!(cached_under_base(base.as_deref(), CE_MODEL));
+
+            let empty = hf_cache_base(
+                windows,
+                env_of(&[("HF_HOME", Path::new("")), ("USERPROFILE", &profile)]),
+                || Some(profile.clone()),
+                || Some(profile.clone()),
+            );
+            assert_eq!(
+                empty,
+                Some(profile.join(".cache").join("huggingface")),
+                "an empty HF_HOME must read as unset"
+            );
+        }
+    }
+
+    /// No resolvable home at all is the one case that legitimately answers
+    /// `None`, and it must report absent rather than probing a relative path.
+    #[test]
+    fn probe_reports_absent_without_any_resolvable_home() {
+        for windows in [true, false] {
+            let base = hf_cache_base(windows, env_of(&[]), || None, || None);
+            assert_eq!(base, None);
+            assert!(!cached_under_base(base.as_deref(), CE_MODEL));
+        }
     }
 }

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -241,6 +241,13 @@ pub fn cross_encoder_model_cached(model_id: &str) -> bool {
 /// what keeps an isolated home isolated. When they do disagree the probe under-
 /// reports, which this function's contract already permits: a false negative
 /// only leaves the reranker off until the model is fetched explicitly.
+///
+/// That divergence is measured, not inferred. On a native Windows host with
+/// both `HOME` and `USERPROFILE` pointed at an isolated directory, `hf-hub`
+/// still wrote its 522 MB cache under the known-folder profile and left the
+/// isolated home empty. Preferring `USERPROFILE` is still the right side to err
+/// on: reporting a model cached that `hf-hub` would not find there is a false
+/// POSITIVE, and that costs a download in the middle of a query.
 fn hf_cache_base(
     windows: bool,
     var_os: impl Fn(&str) -> Option<OsString>,

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -130,7 +130,7 @@ The single job refuses — before any tag is created — unless **all** hold:
    - `DCO Sign-off`
    - `cargo-deny`
    - `gitleaks (full history)`
-   - `Windows installer + vector-free release build`
+   - `Windows installer + vector release build`
 
    This reviewed list is the authority for release admission. The active `main`
    ruleset should carry the same contexts, but the mint does not read mutable

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -35,8 +35,9 @@ binary hash. GitHub signs an artifact attestation over the final archives and
 aggregate manifest before the prerelease is created.
 
 The Windows archive is a release-blocking target. Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories.
-The archive is vector-free, checksum-protected, and GitHub-attested, but it is
-not OS-code-signed by this pipeline. Windows VFS projection is not shipped.
+The archive carries semantic vector search, and is checksum-protected and
+GitHub-attested, but it is not OS-code-signed by this pipeline. Windows VFS
+projection is not shipped.
 
 Every tag is first published as a non-latest prerelease. The anonymous install
 proof installs all five archives (Linux x86_64/aarch64, macOS x86_64/aarch64,

--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -20,13 +20,14 @@ Two parts of Kin are built around Unix runtime mechanics:
   `.kin` repository is published. Without an admitted repository, graph,
   lexical, daemon/query, repository setup, MCP, and review flows have no
   supported native-Windows starting point.
-- **Semantic vector search** ships enabled on Linux/macOS. The repository-free
-  native Windows CLI artifact (`kin-windows-x86_64.zip`) is built vector-free
-  (`--no-default-features`).
+- **Semantic vector search** ships enabled on every published platform. The
+  native Windows CLI artifact (`kin-windows-x86_64.zip`) is built with the same
+  default feature set as Linux and macOS, so semantic search and embedding are
+  compiled in rather than stripped. Embedding runs on the portable CPU backend;
+  the Metal GPU backend is macOS-only and is not part of any Windows build.
 
-Running under WSL2 gives you the complete, vector-enabled Kin with working
-filesystem projection and the same behavior the project tests and benchmarks
-against.
+Running under WSL2 gives you the complete Kin with working filesystem
+projection and the same behavior the project tests and benchmarks against.
 
 ## Setup
 
@@ -76,10 +77,10 @@ irm https://get.kinlab.dev/install.ps1 | iex
 
 The installer prints the admission limitation before downloading, verifies the
 download's SHA-256 checksum, and installs the x86_64 CLI release shape. It does
-not run repository setup or claim a usable native repository. The archive is
-vector-free and does not provide transparent filesystem projection; native
-Windows health reports repository, daemon, semantic-query, and VFS readiness as
-missing or unsupported.
+not run repository setup or claim a usable native repository. The archive
+carries semantic vector search but does not provide transparent filesystem
+projection; native Windows health reports repository, daemon, semantic-query,
+and VFS readiness as missing or unsupported.
 
 No native Windows ARM64 archive is published. Use WSL2, or run x64 PowerShell
 under Windows x64 emulation to install the x86_64 archive for repository-free

--- a/packages/kin-mcp/README.md
+++ b/packages/kin-mcp/README.md
@@ -64,9 +64,8 @@ For a pinned version:
 - macOS, Linux, or native Windows x64
 - A Kin-initialized repository (`kin init`)
 
-The native Windows archive is vector-free and does not include transparent
-filesystem projection. Use WSL2 when you need vectors or projection; the core
-graph, lexical, daemon, and MCP workflow runs natively on Windows x64.
+The native Windows archive carries semantic vector search but does not include
+transparent filesystem projection. Use WSL2 when you need projection.
 
 ## Cache
 

--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -249,7 +249,8 @@ function guidedProvisioningFailure(error) {
     '  - Install Kin directly and run `kin setup` to configure your agent, then point',
     '    this wrapper at it with KIN_MCP_KIN_BINARY=/path/to/kin.',
     '  - Or retry on a supported target (macOS, Linux, or Windows x64).',
-    '    Native Windows is vector-free; use WSL2 when you need vectors or projection.',
+    '    Native Windows carries semantic vector search but no filesystem projection;',
+    '    use WSL2 when you need projection.',
     '  - Or override the release source with KIN_MCP_RELEASE_BASE_URL if you mirror releases.'
   ].join('\n');
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -390,7 +390,7 @@ foreach ($bin in @("kin.exe", "kin-daemon.exe", "kin-vfs.exe")) {
 }
 
 # Move the projection shim if the archive bundled it. The native Windows release
-# is vector-free and ships no shim, so this is normally absent.
+# ships no projection client, so this is normally absent.
 $HaveShim = $false
 $shimSrc = Join-Path $TmpDir "kin_vfs_shim.dll"
 if (Test-Path $shimSrc) {

--- a/scripts/prove-windows-npm-first-run.mjs
+++ b/scripts/prove-windows-npm-first-run.mjs
@@ -4,7 +4,7 @@
 
 // Offline first-run integration proof for Kin's two public npm surfaces.
 //
-// The Windows CI job builds the real vector-free kin.exe + kin-daemon.exe and
+// The Windows authority job builds the real kin.exe + kin-daemon.exe and
 // passes their absolute paths through KIN_NPM_PROOF_{KIN,DAEMON}_BIN. This
 // script copies those exact bytes into each package's real managed layout and
 // drives:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -254,7 +254,7 @@ REQUIRED_RELEASE_CHECKS = (
     "DCO Sign-off",
     "cargo-deny",
     "gitleaks (full history)",
-    "Windows installer + vector-free release build",
+    "Windows installer + vector release build",
 )
 DOCS_ONLY_WORKFLOW_HEADER = textwrap.dedent(
     """\
@@ -450,7 +450,7 @@ CI_JOB_DISPLAY_NAMES = {
     "dco": "DCO Sign-off",
     "npm-launchers": "npm launcher tests",
     "windows-authority-tests": "Windows authority tests",
-    "windows-installer": "Windows installer + vector-free release build",
+    "windows-installer": "Windows installer + vector release build",
     "changes": "Classify diff scope",
     "check-docs-only": "Check & Test",
     "check": "Check & Test",
@@ -535,6 +535,13 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/secret-scan.yml": {
         "gitleaks": "gitleaks (full history)",
     },
+    # workflow_dispatch only, so it publishes no check run on a pull request or
+    # merge group and cannot satisfy or become a required context. Registered
+    # here because this census is the thing that would otherwise let a second
+    # required-context producer appear unreviewed.
+    ".github/workflows/windows-vector-proof.yml": {
+        "windows-vector-proof": "Windows semantic vector search proof",
+    },
 }
 EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
@@ -548,7 +555,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/release.yml",
         "build",
-    ): "4708a5968103aa4c624423fd5a67c5c183969919773e52c9cc204b2c9983c90b",
+    ): "ffde401b1343930965ae6a2a89ca3a81b2996af5821b332f65de7eba874e2be2",
     (
         ".github/workflows/release.yml",
         "verify_npm_published",
@@ -572,7 +579,7 @@ REQUIRED_CHECK_JOB_PRODUCERS = {
     "gitleaks (full history)": {
         (".github/workflows/secret-scan.yml", "gitleaks"),
     },
-    "Windows installer + vector-free release build": {
+    "Windows installer + vector release build": {
         (".github/workflows/ci.yml", "windows-installer"),
     },
 }
@@ -597,7 +604,7 @@ REQUIRED_RELEASE_CHECK_PROVENANCE = {
         ".github/workflows/secret-scan.yml",
         "push",
     ),
-    "Windows installer + vector-free release build": (
+    "Windows installer + vector release build": (
         245_803_170,
         ".github/workflows/ci.yml",
         "push",
@@ -1018,8 +1025,10 @@ def windows_node_validator_fixture() -> tuple[
                 "kin_source_known": True,
                 "dependency_provenance": VALIDATOR_FIXTURE_LOCK,
                 "embeddings": {
-                    "vector_enabled": False,
-                    "embeddings_enabled": False,
+                    "vector_enabled": True,
+                    "embeddings_enabled": True,
+                    # Metal is the macOS-only compiled backend, not the marker
+                    # cargo feature, so it stays false on a correct Windows build.
                     "metal_enabled": False,
                 },
             },
@@ -1314,17 +1323,20 @@ def assert_windows_node_validator_behavior(step: str) -> None:
             "d" * 64,
         ),
         (
-            "vector feature enabled",
+            "vector feature disabled",
             "kin-windows-bench-meta.json",
             ("embeddings", "vector_enabled"),
-            True,
+            False,
         ),
         (
-            "embedding feature enabled",
+            "embedding feature disabled",
             "kin-windows-bench-meta.json",
             ("embeddings", "embeddings_enabled"),
-            True,
+            False,
         ),
+        # Metal stays a negative control in the same direction: it is the
+        # macOS-only compiled backend, so a Windows archive claiming it is
+        # still the defect this rejects.
         (
             "Metal feature enabled",
             "kin-windows-bench-meta.json",
@@ -2466,8 +2478,8 @@ def assert_install_proof_repo_free_windows_proof(repo_free: str) -> None:
         "meta.kin_dirty !== false",
         "meta.kin_source_known !== true",
         "meta.dependency_provenance !== expectedLock",
-        "meta.embeddings?.vector_enabled !== false",
-        "meta.embeddings?.embeddings_enabled !== false",
+        "meta.embeddings?.vector_enabled !== true",
+        "meta.embeddings?.embeddings_enabled !== true",
         "meta.embeddings?.metal_enabled !== false",
         'authority.checks[0]?.state !== "unsupported"',
         '["repo_init", "missing"]',
@@ -7190,9 +7202,9 @@ def main() -> None:
             'meta.dependency_provenance !== ""',
         ),
         (
-            "the Windows leg stops proving its vector-free feature contract",
-            "meta.embeddings?.vector_enabled !== false",
+            "the Windows leg stops proving its vector feature contract",
             "meta.embeddings?.vector_enabled !== true",
+            "meta.embeddings?.vector_enabled !== false",
         ),
         (
             "the Windows registry-authority repair negative control disappears",
@@ -8671,7 +8683,7 @@ def main() -> None:
     installer_end = ci_workflow.index("\n  changes:", installer_start)
     installer_job = ci_workflow[installer_start:installer_end]
     for policy in (
-        "name: Windows installer + vector-free release build",
+        "name: Windows installer + vector release build",
         "github.event_name != 'pull_request'",
         "needs.changes.outputs.docs_only != 'true'",
     ):
@@ -9243,7 +9255,7 @@ def main() -> None:
         "DCO Sign-off",
         "cargo-deny",
         "gitleaks (full history)",
-        "Windows installer + vector-free release build",
+        "Windows installer + vector release build",
         "missing required check: {name}",
         "required check not green: {name}",
         "ambiguous required check: {name}",
@@ -9844,7 +9856,7 @@ def main() -> None:
     ) -> None:
         check = required_check_fixture(
             check_runs,
-            "Windows installer + vector-free release build",
+            "Windows installer + vector release build",
         )
         check["head_sha"] = "2" * 40
 
@@ -9853,7 +9865,7 @@ def main() -> None:
         "required check is attached to the wrong head sha",
         (
             "required check has wrong head sha: "
-            "Windows installer + vector-free release build"
+            "Windows installer + vector release build"
         ),
         change_required_check_head,
     )

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -535,10 +535,14 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/secret-scan.yml": {
         "gitleaks": "gitleaks (full history)",
     },
-    # workflow_dispatch only, so it publishes no check run on a pull request or
-    # merge group and cannot satisfy or become a required context. Registered
-    # here because this census is the thing that would otherwise let a second
-    # required-context producer appear unreviewed.
+    # workflow_dispatch only, so as written it publishes no check run on a pull
+    # request or merge group. Registered here because this census is what would
+    # otherwise let a new job's NAME appear unreviewed.
+    #
+    # It does not follow that the dispatch-only property is protected: this
+    # census reads job names and never `on:` triggers, so adding
+    # `pull_request:` to that workflow leaves the suite green. Verified by
+    # injecting the trigger and re-running.
     ".github/workflows/windows-vector-proof.yml": {
         "windows-vector-proof": "Windows semantic vector search proof",
     },


### PR DESCRIPTION
Windows was the only release leg built `--no-default-features`, so the published
`kin-windows-x86_64.zip` carried no vector or embedding support at all. Every platform now
builds the same default feature set, the assertions that pinned the vector-free shape are
inverted in both directions, and native Windows semantic search is proven by execution rather
than by compilation.

## The matrix key was doing two unrelated jobs

`skip_vector: true` on the Windows row selected `--no-default-features` **and** gated
`Build kin-vfs (native)` at `release.yml:593`. Deleting that one key would also have started
building an LD_PRELOAD/DYLD libc interceptor for `x86_64-pc-windows-msvc`.

It is split rather than deleted: the Windows row now carries `skip_vfs: true` and `:593` reads
that. kin-vfs behavior on Windows is byte-for-byte unchanged, and Windows packaging already
tolerates absent VFS binaries (`-ErrorAction SilentlyContinue`, `release.yml:912-913`).

## The required context is renamed, and the ruleset moves with it

`Windows installer + vector-free release build` becomes
`Windows installer + vector release build`.

The name is not a label. `release-tag.yml` resolves that exact string out of `REQUIRED_CHECKS`
to decide whether Windows evidence exists and is green on a release sha. Keeping it would leave
the release mint's own authority naming a "vector-free release build" as the proof for a release
that ships vectors, in the one place an operator would look to answer what proves Windows.

Eleven surfaces carry the name and all move together:

| Surface | Location |
|---|---|
| Job display name | `.github/workflows/ci.yml:423-429` |
| Mint `REQUIRED_CHECKS` | `.github/workflows/release-tag.yml:779` |
| Mint provenance map key | `.github/workflows/release-tag.yml:893` |
| `REQUIRED_RELEASE_CHECKS` | `scripts/test-release-workflow-authority.py:257` |
| `CI_JOB_DISPLAY_NAMES` | `scripts/test-release-workflow-authority.py:453` |
| `REQUIRED_CHECK_JOB_PRODUCERS` | `scripts/test-release-workflow-authority.py:575` |
| Workflow-id provenance table | `scripts/test-release-workflow-authority.py:600` |
| Main-only admission needle | `scripts/test-release-workflow-authority.py:8674` |
| Release-gate fixture required set | `scripts/test-release-workflow-authority.py:9246` |
| Wrong-head-sha falsification | `scripts/test-release-workflow-authority.py:9847,9856` |
| Operator documentation | `docs/release-bot.md:133` |

A twelfth surface, the `main` branch ruleset, cannot be changed from a pull request and is
updated as part of landing this.

Each rename was falsified rather than assumed. Reverting the job name alone turns the suite red
on the workflow-job census; reverting `REQUIRED_CHECKS` alone turns it red on the reviewed
required set; both restore green.

## Assertions are two-directional, not merely inverted

`bench_meta.rs:308` defines `metal_active()` as `cfg!(target_os = "macos")`, and records that the
cargo feature is vestigial for "is Metal built". A vectored Windows build therefore reports
`vector,embeddings` and no `metal`. So:

- **Feature graph** (`ci.yml`): `kin-db`'s `vector` and `embeddings` must be reachable, and
  `metal` and `accelerate` must not be. Counted with `grep -Ec` rather than `grep -q`, because
  under `pipefail` a `-q` match closes the pipe and the SIGPIPE reads exactly like the feature
  being absent.
- **Shipped binary** (`ci.yml`, `release.yml`): must report `vector` and `embeddings`, with
  `metal` expected if and only if the target is `apple-darwin`.

Resolving the same tree both ways confirms the guard distinguishes: for
`x86_64-pc-windows-msvc`, `vector` and `embeddings` are present with `metal` and `accelerate` at
zero; on a macOS host `metal` and `accelerate` appear three times each. Both halves can fail.

`release.yml`'s feature check previously ran only on the leg that stripped the features, so no
leg ever asserted they were present and a silent feature regression on Linux or macOS would have
shipped green. It now runs on every native leg whose artifact the runner can execute; the
`RUNNER_ARCH:$TARGET` case at `release.yml:626-631` still exits 0 for a cross-architecture
artifact.

## Surfaces that asserted Windows is vector-free

`install-proof.yml:566` asserted the installed Windows CLI proves `vector_enabled === false`.
That leg is `continue-on-error` and fails earlier today, so the assertion gates no release, but
it is the mint's own record of what Windows ships. It is inverted, along with its
falsification needle at `test-release-workflow-authority.py:7193`, the known-good validator
fixture at `:1021`, and that fixture's negative controls at `:1319-1331`. The suite executes the
validator against the fixture, so fixture and assertion had to move together. `metal` remains a
negative control in the same direction.

The same file's installed-capability proof asserted the vector-free answer twice more, for the
CLI a user actually installed. `semantic_query_readiness` was pinned to `unsupported` on
Windows, and Windows alone was denied the pre-embed `stale` tolerance the Unix legs are granted.
Neither holds once vectors ship: the vector arm of `check_semantic_query_readiness` returns
`unsupported` only outside a Kin repository, and inside one with a reachable daemon it reports
the runtime, which is `stale` while embeddings are pending. Both now allow `healthy` or `stale`
on every OS, which is strictly more permissive than the assertions they replace. The binary
metadata assertion that the installed CLI carries vector and embedding support moves out of the
Unix-only block and runs everywhere, while `embedding_coverage` validation stays Unix-only,
because on Windows asserting it would be asserting a timing race rather than a capability, for
the FIR-1921 reason below.

Public copy in `docs/windows-wsl2.md`, `docs/security/signing-and-update-trust.md`,
`packages/kin-mcp/README.md`, `packages/kin-mcp/src/index.js` and `scripts/install.ps1` no
longer describes the archive as vector-free. The `index.js` line is the only one of these a user
is shown by a running product rather than by reading. Two `ci.yml` comments and the npm
first-run proof header now name the job that still covers the featureless msvc configuration,
which is the authority job rather than the installer, and the Windows provenance step is renamed
because it asserts enabled features now instead of disabled ones. The native-Windows admission
posture is deliberately untouched.

## The Hugging Face cache probe never matched on Windows

`retrieval_profile.rs` read `HOME` to locate the hub cache. `HOME` is not a Windows name, so
`cross_encoder_model_cached()` returned false permanently there even with the model fully
downloaded, and the cross-encoder reranker silently never turned on.

It now resolves through `resolve_home_dir()` (`commands/setup.rs:1042`, promoted to
`pub(crate)`), so the crate has one home resolver rather than two. The probe splits into
`hf_cache_base()` for the home policy and `cached_under_base()` for the cache layout so the two
fail independently, and `hf_cache_base` takes the platform and environment as arguments rather
than sitting behind `cfg(windows)`, for the reason `setup.rs:1030-1036` already records: a
cfg-gated Windows arm is compiled and tested only on the one platform this fleet has no host for.

The fix is falsified: implementing the seam with the previous `HOME`-only policy fails 6 of 12
tests on the policy rather than the plumbing; the shared resolver passes 12 of 12. Coverage spans
a Windows-shaped home, an empty cache, `USERPROFILE` outranking both OS lookups, the known-folder
fallback including an empty `USERPROFILE`, the Unix arm ignoring `USERPROFILE`, `HF_HOME`
precedence on both platforms with its empty-value case, and no resolvable home.

One divergence is deliberate and documented at the call site: `hf-hub` resolves through
`dirs::home_dir()`, which on Windows is `FOLDERID_Profile` (`dirs-6.0.0/src/win.rs:5`), while
`resolve_home_dir` prefers a non-empty `USERPROFILE`. They agree unless `USERPROFILE` has been
redirected, and preferring it is the safe side to err on, because the opposite error is a false
positive that costs a download in the middle of a query. Measured: on a native Windows host with
both names redirected to an isolated directory, `hf-hub` still wrote its cache under the
known-folder profile.

## Executed runtime proof

`.github/workflows/windows-vector-proof.yml` is new and `workflow_dispatch`-only. It builds
release with vectors on `windows-latest`, seeds a three-file Git fixture, then runs `kin init`,
`kin embed`, `kin search --semantic` and `kin locate --explain`, asserting the binary's feature
flags, full embedding coverage from the embed command's own report, the absence of a
`vector_index`/`feature_disabled` degradation, and ranked results.

It is dispatch-only because it fetches a ~522 MB model, which is a tax on every pull request and
would make the release mint hostage to huggingface.co. That property is a review responsibility
rather than an enforced invariant: the authority suite's job census pins this workflow's path,
job id and display name, but never reads `on:` triggers.

The proof gates on `kin embed`'s own report rather than on `kin status` coverage. `kin status`
deliberately never starts a daemon, so it reports whatever happens to be running when it runs:
once the daemon from the preceding command has exited it returns
`unobserved`/`no_running_daemon` no matter how much was embedded, which three runs here hit.
The field itself is not broken. On a native Windows host with a live daemon,
`kin status --json` returns `{"state":"observed","source":"live_query_graph","indexed":6954,...}`,
so this is an availability race rather than a missing capability, and it is tracked as FIR-1921.
The status read is retained as a printed diagnostic so the race stays visible instead of being
masked, and can become an assertion again once FIR-1921 lands.

Results, on the shipping architecture: the C surface including `onig_sys` compiles on
`windows-latest`; the binary reports `embeddings,vector` and no `metal`; embedding produced 12
entity vectors with zero pending and wrote `graph.kvec` in 136 seconds including the model
download; semantic search returned 5 ranked results and locate returned 3 files, with no
`feature_disabled` degradation. A native `aarch64-pc-windows-msvc` host independently embedded a
137-file ripgrep fixture (3477 entities, 6954 vectors, zero pending) in 1943 seconds at a 1748 MB
peak daemon working set, returning 10 ranked hits over real ripgrep code.

The Arm A figures come from run `30969196206`, executed at `c3191d32` rather than at this head.
Every commit since changes only workflow assertions, public copy and the authority suite, with
no Rust source, manifest or lock touched and no change to the proof job's body, so the binaries
that run produced measured the same product this head builds.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` under CI's lint
allowlist with `RUSTFLAGS=-D warnings`, `cargo build --all-targets`, `cargo test --workspace
--no-fail-fast`, and both featureless package tests all pass. The eight CI guard scripts pass.
`scripts/test-release-workflow-authority.py` passes, with red-then-green confirmed on the rename
surfaces. `actionlint` is clean on all five changed or added workflows.




Refs FIR-1285
Refs FIR-1949
Refs FIR-1921
