### PR TITLE
Treat a path absent at the current generation as history, not an authority gap

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15483,15 +15483,24 @@ pub fn attach_snippets(
             let Some(entity) = match_symbol_entity(&entities, sym) else {
                 continue;
             };
-            if let Some(source) =
-                kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
-                    held_authority,
-                    entity,
-                    opts.max_lines,
-                    opts.max_chars,
-                    source_scope,
-                )?
-            {
+            // A symbol whose file the current workspace does not contain comes
+            // from history and carries no body today; it is skipped rather than
+            // failing the whole page, which is what any repository with a
+            // deleted or renamed file did.
+            let source = match kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
+                held_authority,
+                entity,
+                opts.max_lines,
+                opts.max_chars,
+                source_scope,
+            ) {
+                Ok(source) => source,
+                Err(error) if kin_mcp::handlers::common::is_absent_at_generation(&error) => {
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
+            if let Some(source) = source {
                 sym.snippet = Some(source.body);
                 filled += 1;
             }
@@ -15537,14 +15546,23 @@ fn bounded_entity_body_with_note(
     max_chars: usize,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
 ) -> Result<Option<String>> {
-    let Some(source) = kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
+    // No body exists for an entity the current workspace does not contain, and
+    // that is an ordinary answer on a store carrying history, not a read
+    // failure: the caller renders the hit without a body.
+    let source = match kin_mcp::handlers::common::read_entity_source_excerpt_detailed_held(
         held_authority,
         entity,
         max_lines,
         max_chars,
         source_scope,
-    )?
-    else {
+    ) {
+        Ok(source) => source,
+        Err(error) if kin_mcp::handlers::common::is_absent_at_generation(&error) => {
+            return Ok(None)
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let Some(source) = source else {
         return Ok(None);
     };
     let body = source.body;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6185,6 +6185,16 @@ fn build_semantic_locate_result(
                     source_scope,
                 ) {
                     Ok(snippet) => snippet,
+                    // A candidate the current workspace does not contain is
+                    // history, not a failure. Whole-history ingest means every
+                    // repository that ever deleted or renamed a file carries
+                    // such entities, so failing the call here made retrieval
+                    // unusable on essentially every real repository. The
+                    // candidate is dropped from a current-workspace ranking and
+                    // the page fills from the ones below it.
+                    Err(error) if kin_mcp::handlers::common::is_absent_at_generation(&error) => {
+                        continue;
+                    }
                     Err(error) => {
                         return kin_mcp::ToolCallResult::error(format!(
                             "semantic_locate could not read graph-owned source for entity {}: \

--- a/crates/kin-mcp/src/error.rs
+++ b/crates/kin-mcp/src/error.rs
@@ -18,6 +18,19 @@ pub enum McpError {
     #[error("context error: {0}")]
     Context(String),
 
+    /// An entity's recorded source path does not exist at the workspace's
+    /// current generation.
+    ///
+    /// This is graph truth answering completely, not authority failing: the
+    /// graph ingests whole history, so it carries entities for files that were
+    /// deleted or renamed at some point and are absent from the current
+    /// workspace. It is a property of ONE entity, so a surface projecting many
+    /// entities skips that candidate; a surface asked for exactly this entity
+    /// still reports it. Kept apart from [`McpError::Context`] so callers
+    /// classify it by type rather than by matching message text.
+    #[error("entity absent at workspace generation: {0}")]
+    WorkspaceAbsent(String),
+
     #[error("review error: {0}")]
     Review(String),
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -468,15 +468,24 @@ pub fn trace_body_held<G: GraphStore>(
     held: &HeldSourceAuthority<'_, G>,
     entity: &Entity,
 ) -> Result<String> {
-    Ok(read_entity_source_excerpt_detailed_held(
+    // A step whose file the current workspace does not contain has no body to
+    // show, which is the same outcome as an entity with no projectable span and
+    // takes the same signature fallback. The trace keeps walking; one historical
+    // step does not end the chain.
+    let source = match read_entity_source_excerpt_detailed_held(
         held,
         entity,
         MCP_SOURCE_MAX_LINES,
         MCP_SOURCE_MAX_CHARS,
         EntitySourceScope::WorkspaceHead,
-    )?
-    .map(|source| source.body)
-    .unwrap_or_else(|| entity.signature.clone()))
+    ) {
+        Ok(source) => source,
+        Err(error) if is_absent_at_generation(&error) => None,
+        Err(error) => return Err(error),
+    };
+    Ok(source
+        .map(|source| source.body)
+        .unwrap_or_else(|| entity.signature.clone()))
 }
 
 pub fn looks_like_constant_identifier(token: &str) -> bool {
@@ -1037,8 +1046,20 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
 
         let file_path = entity.file_origin.as_ref().map(|path| path.0.clone());
         let key = reference_row_key(file_path.as_deref(), &entity.name);
-        let snippet =
-            read_bounded_entity_snippet_held(&held, &entity, EntitySourceScope::WorkspaceHead)?;
+        // A referencing entity the current workspace does not contain is a
+        // reference from history, not a caller of this code today, so it is not
+        // reported as one. Failing the whole reference set over it -- the shape
+        // this had -- made `find_references` unusable on any repository that
+        // ever deleted a file.
+        let snippet = match read_bounded_entity_snippet_held(
+            &held,
+            &entity,
+            EntitySourceScope::WorkspaceHead,
+        ) {
+            Ok(snippet) => snippet,
+            Err(error) if is_absent_at_generation(&error) => continue,
+            Err(error) => return Err(error),
+        };
         let entry = grouped.entry(key).or_insert_with(|| ReferenceRow {
             entity_id: Some(source_entity_id.to_string()),
             name: entity.name.clone(),
@@ -1335,6 +1356,41 @@ fn graph_source_gap(message: impl Into<String>) -> McpError {
         "graph authority gap: {}",
         message.into()
     )))
+}
+
+/// The entity's path does not exist at the workspace's current generation.
+///
+/// Deliberately NOT a [`graph_source_gap`]. Authority did not fail here and
+/// nothing is missing that the graph promised: the graph ingests whole history,
+/// so it carries entities for files a repository deleted or renamed, and the
+/// current workspace correctly does not contain them. Counting this as a graph
+/// miss would report every ordinary repository with a deletion in its history as
+/// a broken store, and typing it as a gap is what made one historical candidate
+/// fatal to a whole retrieval page.
+fn entity_absent_at_generation(
+    entity: &Entity,
+    path: &str,
+    generation: impl std::fmt::Display,
+    workspace_id: impl std::fmt::Display,
+) -> McpError {
+    LAST_READ_SOURCE.with(|f| f.set("absent-at-generation"));
+    McpError::WorkspaceAbsent(format!(
+        "entity {} ({}) records its source at '{path}', which the workspace does not contain at \
+         generation {generation}; the graph carries this entity from history, so it has no body \
+         in the current workspace (workspace {workspace_id})",
+        entity.id, entity.name
+    ))
+}
+
+/// True when `error` reports an entity absent from the current generation.
+///
+/// The predicate a multi-entity projection uses to skip one candidate while
+/// still failing loudly on every genuine authority gap: a tree that cannot be
+/// sampled, a blob the graph promised and cannot produce, a span that does not
+/// describe its bytes, or a path reused by a different artifact all remain
+/// fatal.
+pub fn is_absent_at_generation(error: &McpError) -> bool {
+    matches!(error, McpError::WorkspaceAbsent(_))
 }
 
 /// The text a retained authority failure must replay verbatim.
@@ -1683,16 +1739,22 @@ fn resolve_entity_source_authority<G: GraphStore>(
             // with generation N+1's provenance, with nothing serializing the two.
             let sample = held.workspace_sample()?;
             let workspace = &sample.workspace;
+            // Absence from the current tree is graph truth answering, not
+            // authority failing: the store carries history, and a file deleted
+            // or renamed upstream is legitimately not here. Typed apart from a
+            // gap so a multi-entity projection can skip THIS candidate while a
+            // genuinely unservable path below still fails the read.
             let artifact = workspace
                 .tree
                 .artifact_at_path(&path)
                 .cloned()
                 .ok_or_else(|| {
-                    graph_source_gap(format!(
-                        "entity {} points at '{}' but that path is absent from workspace {} at \
-                         generation {}",
-                        entity.id, recorded_origin.0, workspace.workspace_id, workspace.generation
-                    ))
+                    entity_absent_at_generation(
+                        entity,
+                        &recorded_origin.0,
+                        workspace.generation,
+                        workspace.workspace_id,
+                    )
                 })?;
             let source_change_id = sample.base_change_id;
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -656,13 +656,24 @@ pub fn handle_get_context_pack<G: GraphStore>(
             });
             if !compact {
                 obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
-                let body = read_entity_source_excerpt_detailed_held(
+                // A dependency whose file the current workspace does not contain
+                // is still a dependency graph truth asserts, so it stays in the
+                // pack and says why it has no body. Dropping it would shrink a
+                // structural answer silently, and failing here would lose the
+                // whole pack over one entity that history explains.
+                let (body, absent_reason) = match read_entity_source_excerpt_detailed_held(
                     &held,
                     &e,
                     MCP_SOURCE_MAX_LINES,
                     MCP_SOURCE_MAX_CHARS,
                     EntitySourceScope::WorkspaceHead,
-                )?;
+                ) {
+                    Ok(body) => (body, None),
+                    Err(error) if is_absent_at_generation(&error) => {
+                        (None, Some(error.to_string()))
+                    }
+                    Err(error) => return Err(error),
+                };
                 let source = LAST_READ_SOURCE.with(|f| f.get());
                 obj["source"] = serde_json::json!(source);
                 // Same rule as the focal body: a dependency's `body` is the
@@ -678,7 +689,9 @@ pub fn handle_get_context_pack<G: GraphStore>(
                     }
                     None => {
                         obj["body"] = serde_json::Value::Null;
-                        obj["body_unavailable"] = serde_json::json!(entity_body_gap_reason(&e));
+                        obj["body_unavailable"] = serde_json::json!(
+                            absent_reason.unwrap_or_else(|| entity_body_gap_reason(&e))
+                        );
                     }
                 }
             }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5433,6 +5433,210 @@ mod tests {
         );
     }
 
+    /// An entity the current workspace does not contain is history, not a gap.
+    ///
+    /// FIR-1935. The graph ingests whole reachable history, so it carries
+    /// entities for files a repository deleted or renamed -- on the first
+    /// repository this was tried against, `httpx/models.py`, deleted in 2020.
+    /// The body projection reported that absence as an authority gap, and every
+    /// surface projecting many entities turned one such candidate into a failed
+    /// request.
+    ///
+    /// Three entities, and the middle one is the fix:
+    /// - a live entity still projects its body, so the fix did not cost reads,
+    /// - an entity whose path the workspace tree does not carry is classified as
+    ///   history, which is what lets a page skip it,
+    /// - a path the tree DOES carry whose bytes the graph cannot produce is
+    ///   still a hard failure. Without that arm this test would pass just as
+    ///   readily against a blanket swallow, which is the fix a hurry would have
+    ///   written and which would have hidden every real projection break.
+    #[test]
+    fn an_entity_absent_at_the_current_generation_is_history_not_an_authority_gap() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_trace_source_registry();
+        let dir = tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+
+        let mut store = EmptyStore::default();
+
+        // Live: in the workspace tree at the current generation.
+        let live_content = "export function live() { return 1; }\n";
+        let live_hash = blob_store.write(live_content.as_bytes()).unwrap();
+        let live_file = FilePathId::new("src/live.ts");
+        store.file_hashes.insert(live_file.clone(), live_hash);
+        let live = whole_file_entity(&live_file, live_content, Some(live_hash));
+        store.insert_test_entity(live.clone());
+
+        // Historical: the graph holds the entity AND its bytes, and the current
+        // workspace tree does not carry the path because history deleted it.
+        // Every coordinate the projection needs is present except the one thing
+        // that is legitimately gone, so nothing but the deletion can explain a
+        // failure here.
+        //
+        // It is admitted to the store AFTER the tree is installed, and that
+        // ordering is forced rather than cosmetic: admission refuses a
+        // transaction that "leaves entity ... on repository path ... absent from
+        // the staged tree", so this state cannot be minted inside one change at
+        // all. It arises the way it arose on `httpx` -- from history, across
+        // changes -- and the runtime condition the projection actually meets is
+        // an entity in hand whose path the CURRENT tree lacks. That is what this
+        // reproduces.
+        let deleted_content = "export function deleted() { return 2; }\n";
+        let deleted_hash = blob_store.write(deleted_content.as_bytes()).unwrap();
+        let deleted_file = FilePathId::new("src/deleted.ts");
+        let deleted = whole_file_entity(&deleted_file, deleted_content, Some(deleted_hash));
+
+        install_empty_store_exact_tree(&mut store, dir.path());
+
+        // Unservable: a path the workspace tree DOES carry, whose recorded span
+        // was derived from other bytes. The graph owes an answer here and cannot
+        // give a sound one, which is the genuine authority gap this fix must not
+        // swallow.
+        //
+        // This is the gap the fixture can actually express. Two others were
+        // tried first and are refused by admission itself, which is worth
+        // recording: a tree entry whose blob is absent from the CAS is rejected
+        // ("absent from immutable source CAS"), and a change leaving an entity
+        // on a path absent from its staged tree is rejected too. The store will
+        // not hold those shapes, so they cannot be reproduced here.
+        let mut unservable = live.clone();
+        unservable.id = EntityId::new();
+        unservable.metadata.extra.insert(
+            "blob_hash".into(),
+            serde_json::Value::String(Hash256::from_bytes([42; 32]).to_string()),
+        );
+        store.insert_test_entity(deleted.clone());
+        let authority = test_repository_authority(dir.path());
+        let held = HeldSourceAuthority::new(&store, Some(&authority));
+
+        let snippet =
+            read_bounded_entity_snippet_held(&held, &live, EntitySourceScope::WorkspaceHead)
+                .expect("a live entity must still project its body")
+                .expect("the live entity has source coordinates");
+        assert!(
+            snippet.contains("return 1"),
+            "the live entity must serve its own body: {snippet}"
+        );
+
+        let error =
+            read_bounded_entity_snippet_held(&held, &deleted, EntitySourceScope::WorkspaceHead)
+                .expect_err("the current workspace holds no body for a deleted file");
+        assert!(
+            common::is_absent_at_generation(&error),
+            "a file history deleted must classify as history, not as an authority gap: {error}"
+        );
+        assert!(
+            error.to_string().contains("src/deleted.ts"),
+            "the message must name the path that is gone: {error}"
+        );
+
+        let error =
+            read_bounded_entity_snippet_held(&held, &unservable, EntitySourceScope::WorkspaceHead)
+                .expect_err("bytes the graph promised and cannot serve must fail the read");
+        assert!(
+            !common::is_absent_at_generation(&error),
+            "a path the tree carries whose blob is unreadable is a real gap and must stay fatal; \
+             classifying it as history is how this fix would become a blanket swallow: {error}"
+        );
+    }
+
+    /// One caller deleted by history does not cost the whole reference set.
+    ///
+    /// The page-level half of FIR-1935, on the multi-entity surface this crate
+    /// owns: `find_references` projects a body per referencing entity, so before
+    /// the fix a single historical caller propagated its error out of the loop
+    /// and the call returned nothing at all. The daemon's `semantic_locate` had
+    /// the identical shape and is what the ticket was filed on.
+    ///
+    /// The assertion that matters is that the LIVE callers come back. A test
+    /// that only asserted the call no longer errors would also pass if the fix
+    /// dropped every row.
+    #[test]
+    fn a_reference_set_survives_a_caller_whose_file_history_deleted() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_trace_source_registry();
+        let dir = tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+
+        const LIVE_CALLERS: usize = 3;
+        let mut store = EmptyStore::default();
+        let install = |store: &mut EmptyStore, name: &str| -> Entity {
+            let content = format!("export function {name}() {{ return \"{name}\"; }}\n");
+            let hash = blob_store.write(content.as_bytes()).unwrap();
+            let file_id = FilePathId::new(format!("src/{name}.ts"));
+            store.file_hashes.insert(file_id.clone(), hash);
+            let entity = whole_file_entity(&file_id, &content, Some(hash));
+            store.insert_test_entity(entity.clone());
+            entity
+        };
+        let target = install(&mut store, "target");
+        let live: Vec<Entity> = (0..LIVE_CALLERS)
+            .map(|index| install(&mut store, &format!("caller{index}")))
+            .collect();
+        for caller in &live {
+            store.insert_test_calls_relation(caller, &target);
+        }
+        install_empty_store_exact_tree(&mut store, dir.path());
+
+        // The deleted caller joins the graph AFTER the tree is installed: its
+        // path is absent from the current workspace, which admission forbids
+        // within a single change and which history produces across changes. Its
+        // bytes are written, so only the deletion can explain a failed read.
+        let deleted_content = "export function deleted_caller() { return 0; }\n";
+        let deleted_hash = blob_store.write(deleted_content.as_bytes()).unwrap();
+        let deleted_file = FilePathId::new("src/deleted_caller.ts");
+        let deleted = whole_file_entity(&deleted_file, deleted_content, Some(deleted_hash));
+        store.insert_test_entity(deleted.clone());
+        store.insert_test_calls_relation(&deleted, &target);
+
+        let authority = test_repository_authority(dir.path());
+
+        let rows = collect_graph_reference_rows(
+            &store,
+            &target.id,
+            &[RelationKind::Calls],
+            Some(&authority),
+        )
+        .expect("one caller deleted by history must not fail the whole reference set");
+
+        assert_eq!(
+            rows.len(),
+            LIVE_CALLERS,
+            "every live caller must be reported and the deleted one must not be: {rows:?}"
+        );
+        assert!(
+            rows.iter().all(|row| row.snippet.is_some()),
+            "every reported caller must still carry its graph-owned body: {rows:?}"
+        );
+        // Keyed on file_path, NOT on name: every fixture entity is named
+        // "alpha", so a name-based assertion here could not fail and would be
+        // no evidence at all.
+        assert!(
+            !rows
+                .iter()
+                .any(|row| row.file_path.as_deref() == Some("src/deleted_caller.ts")),
+            "a caller whose file the current workspace does not contain is not a caller today: \
+             {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.file_path.as_deref() == Some("src/caller0.ts")),
+            "the live callers must be the rows that came back: {rows:?}"
+        );
+    }
+
     /// `find_references` derives repository authority ONCE, not once per caller.
     ///
     /// `collect_graph_reference_rows` projects a bounded body per REFERENCING


### PR DESCRIPTION
**Ships in v0.5.1.** `semantic_locate` is broken on the shipped v0.5.0 artifact for
essentially every real repository, and this is the fix.

Closes FIR-1935
Refs FIR-1945
Refs FIR-1946

## The defect

v0.5.0 ingests whole reachable history (1,523 changes on `encode/httpx`), so the graph
holds entities for files that existed at any point. The current workspace holds only the
current checkout. When the body projection met an entity whose recorded path is absent
from the current workspace tree, it reported that as a **graph authority gap**, and the
surfaces that project many entities propagated that error out of their loop, so one
candidate for a long-deleted file returned nothing for the whole request.

Found by `nstranger` on the shipped artifact, installed through the public curl path, after
the documented `init` + `setup` + `embed` flow:

```
semantic_locate could not read graph-owned source for entity 422e81a4-…:
context error: graph authority gap: entity 422e81a4-… points at 'httpx/models.py'
but that path is absent from workspace af1b0702-… at generation 0
```

`httpx/models.py` was deleted on 2020-01-28 in commit `82dc6f3`. It is not a broken
projection. It is a file that stopped existing six years ago.

## Severity calibration

**Not every post-embed locate fails. It is strictly candidate-dependent.** The call dies
only when a candidate that survives into the projection loop carries a `file_origin` the
current workspace tree does not contain. Queries whose candidate set is entirely live
answer normally.

That resolves the contrast evidence rather than leaving it a puzzle: the flask probe was
pre-embed, so there was no vector index and therefore no candidates to project at all. Its
silence and this hard error are two different conditions.

The **pre-embed silent 0-results** case is a different cause (no candidates) and is
deliberately **out of scope here**, characterized rather than changed. It is FIR-1935's
sibling, not this PR.

The practical blast radius is still very large, because a repository with real history has
deleted files near almost every popular query.

## Code path

1. `crates/kin-mcp/src/handlers/common.rs` — `resolve_entity_source_authority`, the
   `EntitySourceScope::WorkspaceHead` arm. `workspace.tree.artifact_at_path(&path)` returns
   `None` and raises `graph_source_gap`. **The throw site**, and the source of the reported
   string.
2. `crates/kin-daemon/src/api.rs` — `semantic_locate`'s ranking loop, whose per-candidate
   `Err` arm did `return ToolCallResult::error(...)`. **What made it call-fatal**, and the
   surface the ticket was filed on.

This composes with PR 608 (FIR-1897) rather than fighting it: `HeldSourceAuthority`
memoizes only the authority OPEN and the workspace SAMPLE, both session-level, so a
per-entity outcome is never retained or replayed across candidates. 608's open/replay
bounds and its two counting tests are untouched.

**Four sibling surfaces had the identical shape** and were equally broken on any repository
with a deletion: `find_references`, CLI `kin locate` (2 sites), `get_context_pack`, and
`trace_data_flow`. Same root cause, same correction, fixed here rather than left to
resurface one ticket at a time.

## The fix

Absence at the current generation is **typed apart** from an authority gap
(`McpError::WorkspaceAbsent` plus an `is_absent_at_generation` predicate), because it is
graph truth answering completely rather than authority failing. Classification is by type,
never by matching message text.

- The daemon `semantic_locate` cosine arm and `find_references` **skip the candidate**.
  The locate loop bounds on `rows.len() >= max_rows`, so a skipped candidate lets the
  page fill from the ones below it and pages do not shrink.
- The CLI `kin locate` sites (which also serve the fused arm, `pipeline: "fused"` /
  `KIN_PROFILE=accuracy-v1`) **render the historical hit without a body** rather than
  dropping it: the snippet attach skips the body read and the entity stays in the result.
  The two arms therefore treat the same historical candidate differently; unifying that
  is a product decision deliberately deferred to FIR-1946 rather than smuggled into this
  hotfix. Before this fix both arms hard-errored, so neither behavior is a regression.
- Surfaces that **enumerate a structural relationship the graph asserts** (context pack
  dependencies) keep the entry and mark it through the existing `body_unavailable` field.
  Dropping it would silently shrink a structural answer.
- `trace_data_flow` takes the signature fallback it already takes when no body exists, so
  one historical step does not end the chain.

**Deliberately not a blanket swallow:**
- a path the tree DOES carry whose bytes cannot be soundly served still errors;
- the `EntitySourceScope::At(change)` history scope is untouched;
- single-entity surfaces asked for exactly this entity still report it;
- the absence no longer increments `GRAPH_MISS_COUNT`, because counting it would mark every
  ordinary repository with a deletion in its history as a broken store.

## Payload change, disclosed

Self-review turned up one thing worth stating rather than leaving for the reviewer to find:
this adds a **fourth** value to the `source` field that `get_context_pack` serializes per
dependency. It previously only ever held `graph`, `graph-miss`, or `unknown`; a dependency
absent at the current generation now reports `absent-at-generation`, alongside the
`body_unavailable` sentence naming the path and generation.

Checked before claiming it is safe:
- **Reachability** is exactly one payload. The other three sites that serialize this field
  read it after a `?`, so an absent error propagates instead of being rendered.
- **No schema constrains it** — `boundary-contracts` has no enum for this field.
- **No consumer switches on it**; every `graph-miss` occurrence outside the setter is
  test-assertion or guidance text.
- **No stale-value leak**: `resolve_entity_source_authority` resets the thread-local to
  `unknown` on entry (common.rs:1693), so the value cannot survive into an unrelated read
  on the same thread.

It is additive and honest, but it is a public payload change and reviewers should agree to
it deliberately rather than inherit it.

## Falsification

Two new tests. Against the fix, both pass:

```
test ...an_entity_absent_at_the_current_generation_is_history_not_an_authority_gap ... ok
test ...a_reference_set_survives_a_caller_whose_file_history_deleted ... ok
test result: ok. 2 passed; 0 failed
```

With the classification reverted to the pre-fix `graph_source_gap` and the API otherwise
intact, **both fail**, reproducing the reported message shape:

```
a file history deleted must classify as history, not as an authority gap: context error:
graph authority gap: FALSIFICATION ARM: entity 1dceb01b-… points at 'src/deleted.ts' but
that path is absent from workspace b8f97cab-… at generation 0

one caller deleted by history must not fail the whole reference set: Context("graph
authority gap: … 'src/deleted_caller.ts' … absent from workspace cc5661c6-… at generation 0")
test result: FAILED. 0 passed; 2 failed
```

The negative control lives in the same test: a path the tree carries whose recorded span
was derived from other bytes must still fail and must NOT classify as history. Without it
the test would pass just as readily against a blanket swallow.

### Three traps caught while building the fixture

- A change that leaves an entity on a path absent from its staged tree is **refused** by
  admission, and so is a tree entry whose blob is absent from the CAS. This state cannot be
  minted inside one change at all, which is itself evidence that it arises from history
  across changes, exactly the httpx shape. Both refusals are recorded in the test comments.
- `whole_file_entity` names every fixture entity `"alpha"`, so asserting the deleted caller
  is absent **by name** could never fail. Re-keyed on `file_path`, which actually differs.

## Gates — all green

DEV-LOCAL evidence, explicitly not a citable release-clean result.

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | rc=0 |
| `cargo clippy --all-targets --all-features` (CI allowlist) | rc=0 |
| `cargo build --all-targets` | rc=0 |
| `cargo test --workspace --no-fail-fast` | rc=0, 104 test binaries, zero failures |
| `scripts/zero_file_search_guard.sh` | rc=0 — answer paths are graph-clean |
| `scripts/falsify-zero-file-search.py .` | rc=0 — every enforced answer module fails its guards when poisoned |
| `scripts/check_runtime_boundaries.sh` | rc=0 |
| `scripts/check_private_repo_coupling.sh` | rc=0 |
| `actionlint` | nothing to run: no workflow file is touched |

The zero-file-search guard matters most here, since this edits answer/projection modules.
Its falsifier was run too, so the guard is known to fail when poisoned rather than only
known to pass.

A detour worth stating: plain `cargo clippy -- -D warnings` fails on
`too many arguments (8/7)` in `kin-daemon-spawn`, a crate this branch does not touch.
`-A clippy::too_many_arguments` is in CI's allowlist, so that is a pre-existing lint a
stricter-than-CI invocation surfaced, not a defect here.

## Acceptance — the reported call now answers

End-to-end on `encode/httpx`, the repository the ticket was filed against. Each arm got its
own pristine clone, embedded by its own binary, its own throwaway `HOME` and fresh daemon.
The only variable is the binary: `c38ce1a0 detached` (shipped v0.5.0) against
`c38ce1a0-dirty` (this branch).

Query verbatim from the report: `{"query": "follow redirects and build redirect request", "limit": 5}`

| | **SHIPPED v0.5.0** | **THIS BUILD** |
| --- | --- | --- |
| Latency | 48.78s | 7.78s |
| `isError` | **true** | **false** |
| Message | `entity 422e81a4-… points at 'httpx/models.py' but that path is absent from workspace af1b0702-… at generation 0` | none |
| `semantic_coverage` | — (died first) | **1.0** |
| Ranked / returned | 0 | **7 ranked, 5 returned** (the requested limit) |
| Bodies | none | **all 5 carry graph-owned snippets** |

```
Response.is_redirect             httpx/_models.py         0.660  snippet
codes.get_reason_phrase          httpx/_status_codes.py   0.648  snippet
StatusCode.get_reason_phrase     httpx/_status_codes.py   0.646  snippet
Response.has_redirect_location   httpx/_models.py         0.646  snippet
QueryParams.__str__              httpx/_models.py         0.644  snippet
```

`httpx/models.py`, deleted in 2020, is absent from the results: skipped, not served, not
fatal. `total_ranked: 7` against 5 returned demonstrates the page-fill claim on real data
rather than only in a fixture.

### A measurement trap that nearly produced a false verdict

The first post-fix arm returned **n=0 in 0.003s with no error**, which reads as "fixed, no
matches" and would have been wrong in the most damaging direction. Two instrument faults,
both found before the arm was believed:

1. **`--bin` and `-p` do not build the same binary.** `--bin kin --bin kin-daemon` produced
   a daemon reporting `Embeddings: 0/6257 indexed` where the shipped binary reported
   `6257/6257` — no vector index attached, so retrieval had nothing to rank. Rebuilding as
   release does (`-p kin-cli -p kin-daemon`) changed the daemon's size (61,061,520 →
   61,043,344 bytes) and flipped the reading to `6257/6257`.
2. **Probing mutated the store.** `kin graph status` advanced the clone from generation 0 to
   1 and orphaned the index built at generation 0, after which every arm on that clone read
   `semantic_coverage: 0.0`. The shipped arm naming `generation 0` against the contaminated
   arm's `generation 1` is what exposed it.

`n=0` with `error=false` is not a pass and was not reported as one.

