### PR TITLE
Release Kin v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-05
+
+### Fixed
+
+- Treat a path absent at the current generation as history, not an authority gap (#617)
+
+### Changed
+
+- Refresh README banner, lead, and demo copy (#613)
+- Embed the measured ripgrep impact capture in the README demo slot (#619)
+
 ## [0.5.0] - 2026-08-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,14 +3055,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "age",
  "anyhow",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon-spawn"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fs2",
  "libc",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cap-std",
  "chrono",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notifier-macos"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "block2",
  "objc2 0.6.4",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "kin-notify"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-model",
  "serde",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -91,7 +91,7 @@ toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
 unicode-ident = "1"
-kin-spine = { version = "0.5.0", path = "../kin-spine" }
+kin-spine = { version = "0.5.1", path = "../kin-spine" }
 
 [dev-dependencies]
 kin-core = { workspace = true, features = ["test-support"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "kin-model",
  "serde",

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Version bump to 0.5.1 across the workspace manifest, kin-cli's kin-spine path pin, the three npm package manifests, both lockfiles (workspace members only; verified zero external dependency movement), and the changelog.

Dependency pins are unchanged from v0.5.0: kin-model =0.7.5 and kin-db =0.7.12, verified present in both the manifest and the regenerated lock.

Landing order constraint: this PR must merge AFTER #617 (the fix this release exists to ship) and after #613. It is deliberately NOT enqueued until #617 is merged, so the first main commit carrying 0.5.1 cannot exist without the fix in its ancestry.
