### PR TITLE
Correct the Windows proof's account of when status can observe

### DIFF
--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -173,11 +173,21 @@ jobs:
             | tee "$RUNNER_TEMP/kin-semantic-search.json"
           kin.exe locate "how are settings loaded" --json --explain --max-files 5 \
             | tee "$RUNNER_TEMP/kin-locate.json"
-          # `kin status` deliberately does not auto-start the daemon, and the
-          # daemon `kin embed` used has exited by now. Read it AFTER the queries
-          # above, which do start one. Reading it earlier returns
-          # state=unobserved reason=no_running_daemon, which is a dead harness
-          # rather than a shortfall, and is exactly how the first run failed.
+          # `kin status` deliberately does not auto-start a daemon, so it reports
+          # whatever happens to be running at the instant it runs.
+          #
+          # An earlier version of this comment said to place the read after the
+          # queries above "which do start one", implying that ordering makes the
+          # read observe. It does not. Measured on a native Windows guest against
+          # a fully embedded store: a query does start a daemon, but that daemon
+          # is gone before the next process starts, so this read reports
+          # state=unobserved reason=no_running_daemon wherever it is placed, and
+          # returns that negative in under a second rather than hanging.
+          #
+          # Keeping it after the queries costs nothing, so it stays there, but do
+          # not read the placement as buying coverage. Nothing here depends on it:
+          # the read is captured as a diagnostic and every assertion below runs
+          # off `kin embed`'s own report instead.
           kin.exe status --json | tee "$RUNNER_TEMP/kin-status.json"
 
       - name: Assert the runtime proved semantic search
@@ -218,11 +228,16 @@ jobs:
           // unobserved/no_running_daemon no matter how much was embedded. Three
           // runs here hit exactly that, which is what moved the assertion off it.
           //
-          // It is NOT that Windows cannot observe coverage. An earlier version of
-          // this comment said so and was wrong: on a native Windows host with a
-          // live daemon, `kin status --json` returns
-          // {"state":"observed","source":"live_query_graph","indexed":6954,...}.
-          // The field works; only its availability at an arbitrary moment does not.
+          // Do not read that as "Windows cannot observe coverage" either. Both
+          // directions have been overstated in this comment before, so here is
+          // exactly what is and is not known. Every archived artifact from this
+          // job and from the guest reports unobserved/no_running_daemon. An
+          // earlier version of this comment cited a specific observed reading
+          // with an indexed count; that citation is withdrawn, because no
+          // artifact was ever archived behind it and a later run on the same
+          // store with the same binaries did not reproduce it. Whether this field
+          // can report observed on Windows at all is therefore open, and tracked
+          // by FIR-1943 rather than asserted here.
           //
           // So gate on the embed command's own report above, which is the direct
           // output of the process that did the work and depends on nothing still


### PR DESCRIPTION
Comments only in `.github/workflows/windows-vector-proof.yml`. No step, trigger, input, or assertion changes. Proved mechanically rather than asserted: every added and removed line in the diff begins with `#` or `//`, and the guard that checks this was falsified in both directions by injecting a real code change and confirming it reports the change, then confirming it is silent on this diff.

## What was wrong

**The status read's placement did not mean what the comment said.** The comment told the next reader to place the read after the queries "which do start one", implying the ordering makes it observe. Measured on a native Windows guest against a fully embedded store, using binaries whose mtimes and sizes match the archived Arm B pair byte for byte: a query does start a daemon, and that daemon is gone before the next process starts. `tasklist` immediately after the query matches nothing and a process sweep for any image name containing "kin" is empty; the run's `daemon.pid` and `daemon.port` are removed on exit. The following read reports `unobserved`/`no_running_daemon` in 0.6s, and 1.8s on a repeat.

The read stays where it is, because keeping it after the queries costs nothing, but the comment no longer claims the placement buys coverage.

**A cited reading had no artifact behind it.** The assertion block cited a specific observed reading with an indexed count as evidence the field works on Windows. Nothing was ever archived behind that citation, and the re-run above did not reproduce it. It is withdrawn rather than restated in the opposite direction: every archived artifact says unobserved, and whether the field can report observed on Windows at all is now left open here and tracked in FIR-1943 instead.

## Scope note

Flagging this rather than letting it pass unmentioned: the sequencing decision authorised a one-line correction of the first item. The second is the same defect class, in the same comment region, added by the same author in the same PR, and leaving a number in permanent history that no artifact supports is the failure this change exists to remove. Both are comments and neither touches behavior. Say the word and I will drop the second hunk.

## Verification

- comment-only guard, falsified both ways (reports a real code change, silent here)
- `actionlint` clean, exit 0
- both embedded `node` heredocs extracted and `node --check`ed, since a broken `//` block inside a `run:` string is invisible to a YAML linter
- branch based on `main` at the 616 squash, verified by comparing the worktree's actual HEAD against `origin/main` rather than trusting the tooling's printed base

## Evidence

`.kin-coord/reports/night-20260805-nwvec-impl-logs/armB-status-falsification/`, README first: four `tasklist` snapshots, both status reads, timings, endpoint-file state, and binary provenance.
