### PR TITLE
Launch assistants through a per-CLI adapter registry with a semantic-only profile

### DIFF
--- a/crates/kin-cli/src/commands/assistant_adapter.rs
+++ b/crates/kin-cli/src/commands/assistant_adapter.rs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! One adapter per assistant CLI, in a registry.
+//!
+//! The adapter owns the full per-CLI contract: launch program, alias set, and
+//! the `--semantic-only` capability profile with a self-declared enforcement
+//! tier. `kin setup`'s registration writers and `kin with`'s launcher resolve
+//! assistants through this same registry, so a client cannot be registerable
+//! but not launchable, or instructed but not registered.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+
+/// How strongly an adapter can honor `--semantic-only` for its CLI.
+///
+/// The tier is printed at launch so the operator is never told a profile is
+/// enforced when the CLI only received guidance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnforcementTier {
+    /// The CLI's own permission layer refuses the denied tools.
+    Enforced,
+    /// The CLI receives instructions but nothing refuses a violation.
+    Instructed,
+    /// No profile exists for this CLI yet; the flag fails closed.
+    Unsupported,
+}
+
+impl EnforcementTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EnforcementTier::Enforced => "enforced",
+            EnforcementTier::Instructed => "instructed",
+            EnforcementTier::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// A file the profile writes before launch, relative to the profile directory.
+///
+/// The profile directory lives in session metadata, beside the projection
+/// root rather than inside it, so profile files never enter the reconciled
+/// delta.
+#[derive(Debug)]
+pub struct ProfileFile {
+    pub relative_path: PathBuf,
+    pub contents: String,
+    pub executable: bool,
+}
+
+/// Everything `kin with --semantic-only` must apply for one launch.
+#[derive(Debug)]
+pub struct SemanticOnlyProfile {
+    pub files: Vec<ProfileFile>,
+    /// Appended to the launch command before the task words, so flags bind to
+    /// the CLI rather than to the task text.
+    pub extra_args: Vec<OsString>,
+    pub tier: EnforcementTier,
+    /// One honest line printed at launch describing what is and is not held.
+    pub disclosure: String,
+}
+
+pub trait AssistantAdapter: Sync {
+    /// Canonical assistant id, also the daemon session vendor string.
+    fn id(&self) -> &'static str;
+    /// Accepted spellings besides the id.
+    fn aliases(&self) -> &'static [&'static str];
+    /// Binary `kin with` launches. The registry is an allowlist: an arbitrary
+    /// program name here would make `kin with` a second `kin exec` with none
+    /// of its argument discipline.
+    fn program(&self) -> &'static str;
+    /// Build the semantic-only profile, or refuse honestly.
+    ///
+    /// `windows` is a parameter rather than a cfg gate so both arms run in
+    /// tests on every host.
+    fn semantic_only(&self, profile_dir: &Path, windows: bool) -> Result<SemanticOnlyProfile>;
+}
+
+struct ClaudeAdapter;
+struct CodexAdapter;
+struct GeminiAdapter;
+
+/// Native tools Claude Code must refuse in a semantic-only session.
+const CLAUDE_DENIED_TOOLS: [&str; 3] = ["Grep", "Glob", "Read"];
+
+/// File-reading commands denied through Bash. Pure readers only: dual-use
+/// stream editors stay allowed so the preserved edit path keeps working, and
+/// the PreToolUse backstop still covers the named discovery tools.
+const CLAUDE_DENIED_BASH_READERS: [&str; 13] = [
+    "grep", "rg", "ag", "find", "fd", "cat", "head", "tail", "less", "more", "tree", "strings",
+    "ls",
+];
+
+const CLAUDE_HOOK_SCRIPT: &str = "deny-discovery.sh";
+const CLAUDE_SETTINGS_FILE: &str = "semantic-only-settings.json";
+
+impl AssistantAdapter for ClaudeAdapter {
+    fn id(&self) -> &'static str {
+        "claude"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["claude-code"]
+    }
+
+    fn program(&self) -> &'static str {
+        "claude"
+    }
+
+    fn semantic_only(&self, profile_dir: &Path, windows: bool) -> Result<SemanticOnlyProfile> {
+        let mut deny: Vec<String> = CLAUDE_DENIED_TOOLS.iter().map(|t| t.to_string()).collect();
+        deny.extend(
+            CLAUDE_DENIED_BASH_READERS
+                .iter()
+                .map(|c| format!("Bash({c}:*)")),
+        );
+
+        let mut settings = serde_json::json!({
+            "permissions": { "deny": deny }
+        });
+
+        let mut files = Vec::new();
+        // The hook is a deterministic backstop behind the deny rules: exit 2
+        // refuses the call and the stderr line reaches the model. It is a
+        // POSIX shell script, so it only exists on non-Windows launches; the
+        // deny rules above enforce on every platform.
+        if !windows {
+            let hook_path = profile_dir.join(CLAUDE_HOOK_SCRIPT);
+            settings["hooks"] = serde_json::json!({
+                "PreToolUse": [{
+                    "matcher": "Grep|Glob|Read",
+                    "hooks": [{
+                        "type": "command",
+                        "command": hook_path.display().to_string(),
+                    }]
+                }]
+            });
+            files.push(ProfileFile {
+                relative_path: PathBuf::from(CLAUDE_HOOK_SCRIPT),
+                contents: "#!/bin/sh\n\
+                           echo \"semantic-only session: native discovery is disabled; use Kin's \
+                           MCP tools (semantic_locate, get_context_pack, trace_data_flow)\" >&2\n\
+                           exit 2\n"
+                    .to_string(),
+                executable: true,
+            });
+        }
+
+        files.push(ProfileFile {
+            relative_path: PathBuf::from(CLAUDE_SETTINGS_FILE),
+            contents: serde_json::to_string_pretty(&settings)?,
+            executable: false,
+        });
+
+        let backstop = if windows {
+            "deny rules only, no hook backstop on Windows"
+        } else {
+            "deny rules plus PreToolUse backstop"
+        };
+        Ok(SemanticOnlyProfile {
+            extra_args: vec![
+                OsString::from("--settings"),
+                profile_dir.join(CLAUDE_SETTINGS_FILE).into_os_string(),
+            ],
+            files,
+            tier: EnforcementTier::Enforced,
+            disclosure: format!(
+                "semantic-only [enforced]: Grep/Glob/Read and file-reading Bash are refused \
+                 ({backstop}); Kin MCP tools, Edit, and Write stay available"
+            ),
+        })
+    }
+}
+
+impl AssistantAdapter for CodexAdapter {
+    fn id(&self) -> &'static str {
+        "codex"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    fn program(&self) -> &'static str {
+        "codex"
+    }
+
+    fn semantic_only(&self, _profile_dir: &Path, _windows: bool) -> Result<SemanticOnlyProfile> {
+        bail!(
+            "--semantic-only is enforced for claude only today; codex has no capability layer \
+             wired yet, and shipping guidance as if it were enforcement would overclaim the flag"
+        );
+    }
+}
+
+impl AssistantAdapter for GeminiAdapter {
+    fn id(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["gemini-cli"]
+    }
+
+    fn program(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn semantic_only(&self, _profile_dir: &Path, _windows: bool) -> Result<SemanticOnlyProfile> {
+        bail!(
+            "--semantic-only is enforced for claude only today; gemini has no capability layer \
+             wired yet, and shipping guidance as if it were enforcement would overclaim the flag"
+        );
+    }
+}
+
+static ADAPTERS: [&dyn AssistantAdapter; 3] = [&ClaudeAdapter, &CodexAdapter, &GeminiAdapter];
+
+/// Resolve an assistant spelling to its adapter.
+pub fn adapter_for(assistant: &str) -> Result<&'static dyn AssistantAdapter> {
+    let wanted = assistant.trim().to_ascii_lowercase();
+    for adapter in ADAPTERS {
+        if adapter.id() == wanted || adapter.aliases().contains(&wanted.as_str()) {
+            return Ok(adapter);
+        }
+    }
+    let known = ADAPTERS
+        .iter()
+        .map(|a| a.id())
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!("unknown assistant '{assistant}'; kin with supports: {known}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_resolves_every_alias_to_the_old_allowlist_programs() {
+        assert_eq!(adapter_for("claude").unwrap().program(), "claude");
+        assert_eq!(adapter_for("claude-code").unwrap().program(), "claude");
+        assert_eq!(adapter_for("Codex").unwrap().program(), "codex");
+        assert_eq!(adapter_for("gemini").unwrap().program(), "gemini");
+        assert_eq!(adapter_for("gemini-cli").unwrap().program(), "gemini");
+        assert!(adapter_for("vim").is_err());
+        assert!(adapter_for("").is_err());
+    }
+
+    #[test]
+    fn claude_profile_denies_discovery_and_keeps_the_edit_path() {
+        let dir = Path::new("/tmp/profile");
+        let profile = ClaudeAdapter.semantic_only(dir, false).unwrap();
+        assert_eq!(profile.tier, EnforcementTier::Enforced);
+
+        let settings = profile
+            .files
+            .iter()
+            .find(|f| f.relative_path == Path::new(CLAUDE_SETTINGS_FILE))
+            .expect("settings file present");
+        let parsed: serde_json::Value = serde_json::from_str(&settings.contents).unwrap();
+        let deny: Vec<String> = parsed["permissions"]["deny"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        for tool in CLAUDE_DENIED_TOOLS {
+            assert!(deny.contains(&tool.to_string()), "missing {tool}");
+        }
+        for reader in CLAUDE_DENIED_BASH_READERS {
+            assert!(
+                deny.contains(&format!("Bash({reader}:*)")),
+                "missing {reader}"
+            );
+        }
+        for kept in ["Edit", "Write", "Bash", "mcp__kin__semantic_locate"] {
+            assert!(!deny.contains(&kept.to_string()), "overdenies {kept}");
+        }
+
+        let hook = &parsed["hooks"]["PreToolUse"][0];
+        assert_eq!(hook["matcher"], "Grep|Glob|Read");
+        let script = profile
+            .files
+            .iter()
+            .find(|f| f.relative_path == Path::new(CLAUDE_HOOK_SCRIPT))
+            .expect("hook script present");
+        assert!(script.executable);
+        assert!(script.contents.contains("exit 2"));
+
+        let args: Vec<String> = profile
+            .extra_args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args[0], "--settings");
+        assert!(args[1].ends_with(CLAUDE_SETTINGS_FILE));
+    }
+
+    #[test]
+    fn claude_windows_arm_enforces_deny_rules_without_a_shell_hook() {
+        let profile = ClaudeAdapter
+            .semantic_only(Path::new("/tmp/profile"), true)
+            .unwrap();
+        assert_eq!(profile.tier, EnforcementTier::Enforced);
+        assert!(profile
+            .files
+            .iter()
+            .all(|f| f.relative_path != Path::new(CLAUDE_HOOK_SCRIPT)));
+        let settings = profile
+            .files
+            .iter()
+            .find(|f| f.relative_path == Path::new(CLAUDE_SETTINGS_FILE))
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&settings.contents).unwrap();
+        assert!(parsed.get("hooks").is_none());
+        assert!(profile.disclosure.contains("no hook backstop on Windows"));
+    }
+
+    #[test]
+    fn codex_and_gemini_fail_closed_instead_of_overclaiming() {
+        for name in ["codex", "gemini"] {
+            let err = adapter_for(name)
+                .unwrap()
+                .semantic_only(Path::new("/tmp/profile"), false)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("claude only"), "{name}: {err}");
+        }
+    }
+}

--- a/crates/kin-cli/src/commands/assistant_adapter.rs
+++ b/crates/kin-cli/src/commands/assistant_adapter.rs
@@ -5,14 +5,21 @@
 //!
 //! The adapter owns the full per-CLI contract: launch program, alias set, and
 //! the `--semantic-only` capability profile with a self-declared enforcement
-//! tier. `kin setup`'s registration writers and `kin with`'s launcher resolve
-//! assistants through this same registry, so a client cannot be registerable
-//! but not launchable, or instructed but not registered.
+//! tier. `kin with` resolves every assistant it launches through this registry,
+//! so the launcher has exactly one answer for which clients exist and what
+//! each one can honor.
+//!
+//! `kin setup`'s registration writers do not resolve through it yet. They carry
+//! their own client list and their own per-client config paths, so a client can
+//! currently be registerable by `kin setup` and not launchable by `kin with`.
+//! Moving those writers onto this registry is the intent; until that lands this
+//! registry is authoritative for launching only, and the setup list is
+//! authoritative for registration.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 
 /// How strongly an adapter can honor `--semantic-only` for its CLI.
 ///
@@ -40,14 +47,15 @@ impl EnforcementTier {
 
 /// A file the profile writes before launch, relative to the profile directory.
 ///
-/// The profile directory lives in session metadata, beside the projection
-/// root rather than inside it, so profile files never enter the reconciled
-/// delta.
+/// The profile directory is a sibling of the session projection under
+/// `.kin/runs/`, not a child of it: the reconcile scanner walks the projection
+/// only, so profile files can never be observed as working-tree changes, and
+/// the launched process's working directory is the projection, so they are not
+/// entries of the tree the subject agent works in.
 #[derive(Debug)]
 pub struct ProfileFile {
     pub relative_path: PathBuf,
     pub contents: String,
-    pub executable: bool,
 }
 
 /// Everything `kin with --semantic-only` must apply for one launch.
@@ -85,16 +93,234 @@ struct GeminiAdapter;
 /// Native tools Claude Code must refuse in a semantic-only session.
 const CLAUDE_DENIED_TOOLS: [&str; 3] = ["Grep", "Glob", "Read"];
 
-/// File-reading commands denied through Bash. Pure readers only: dual-use
-/// stream editors stay allowed so the preserved edit path keeps working, and
-/// the PreToolUse backstop still covers the named discovery tools.
+/// File-reading commands denied outright through Claude Code's own permission
+/// engine.
+///
+/// This list is not the boundary — [`semantic_only_bash_verdict`] is, and it
+/// refuses every command it cannot name. These rules are the second layer:
+/// a `PreToolUse` hook that cannot be executed is reported as a non-blocking
+/// error and the tool runs anyway, so the most common readers are also denied
+/// by a mechanism that needs no subprocess.
 const CLAUDE_DENIED_BASH_READERS: [&str; 13] = [
     "grep", "rg", "ag", "find", "fd", "cat", "head", "tail", "less", "more", "tree", "strings",
     "ls",
 ];
 
-const CLAUDE_HOOK_SCRIPT: &str = "deny-discovery.sh";
+/// Bash commands a semantic-only Claude session may run.
+///
+/// This is an allowlist, and the inversion is the point. A blocklist over a
+/// shell cannot be finished: `sed`, `awk`, `perl`, `python3`, `node`, `ruby`,
+/// `git show`, `od`, `base64`, `curl file://`, and a nested `claude -p` all
+/// put file contents on stdout, and every blocked spelling has an unblocked
+/// one (`egrep`, `/bin/cat`, `env cat`). A command this session cannot name is
+/// refused, so an unlisted reader is refused by default rather than by
+/// enumeration.
+///
+/// Membership rule: the command must emit a literal, report the working
+/// directory, or mutate the filesystem in a way `Edit` and `Write` cannot
+/// express. Nothing here can put the contents of a file it did not receive
+/// onto stdout.
+const CLAUDE_ALLOWED_BASH: [&str; 11] = [
+    "echo", "printf", "pwd", "true", "false", "mkdir", "rmdir", "touch", "mv", "rm", "chmod",
+];
+
+/// Path roots an allowed command may not name.
+///
+/// `mv src/a /dev/stdout` is a file read spelled as a move, and `/proc/self/*`
+/// re-exposes the launched process's own argv and environment. Neither needs a
+/// disallowed command, so the allowlist alone does not hold them.
+const CLAUDE_REFUSED_PATH_ROOTS: [&str; 3] = ["/dev/", "/proc/", "/sys/"];
+
+/// Tool names the semantic-only `PreToolUse` hook is asked to adjudicate.
+///
+/// Written in the documented matcher style — an unanchored alternation of tool
+/// names, plus the `mcp__.*` prefix form — rather than as an anchored regex,
+/// because the matcher's exact anchoring semantics are Claude Code's to define.
+/// [`semantic_only_guard_verdict`] therefore re-decides on the tool name it is
+/// actually handed instead of trusting the matcher to have selected precisely.
+const CLAUDE_HOOK_MATCHER: &str = "Bash|Grep|Glob|Read|mcp__.*";
+
+/// MCP tools that stay available: Kin's own semantic surface, which is what a
+/// semantic-only session is being pointed at.
+const CLAUDE_ALLOWED_MCP_PREFIX: &str = "mcp__kin__";
+
+/// Tools that only observe or end an already-adjudicated Bash call. The command
+/// they refer to passed [`semantic_only_bash_verdict`] before it ran, so its
+/// output cannot carry a file the session may not read.
+const CLAUDE_ALLOWED_BASH_FOLLOWUPS: [&str; 2] = ["BashOutput", "KillShell"];
+
 const CLAUDE_SETTINGS_FILE: &str = "semantic-only-settings.json";
+
+/// The largest `PreToolUse` payload the guard will read before refusing.
+const MAX_GUARD_PAYLOAD_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Whether one character may appear in a semantic-only Bash command.
+///
+/// This is the second allowlist, and it exists because prefix matching alone
+/// decides nothing on a shell: `echo $(cat f)`, `printf '%s' "$(<f)"`,
+/// `while read l; do echo "$l"; done < f`, `echo *`, and `mkdir x; cat f` all
+/// begin with a command that is allowed and end in a file read. Command
+/// substitution, redirection, pipes, sequencing, globbing, and escapes are
+/// spelled with characters, so refusing the characters refuses the whole class
+/// rather than the instances of it someone thought to list.
+fn is_allowed_bash_char(character: char) -> bool {
+    character.is_ascii_alphanumeric()
+        || matches!(
+            character,
+            ' ' | '-' | '_' | '.' | '/' | '=' | ':' | ',' | '+' | '%' | '\'' | '"'
+        )
+}
+
+/// What a semantic-only session points an assistant at instead.
+fn semantic_only_redirect() -> String {
+    format!(
+        "use Kin's MCP tools (semantic_locate, semantic_search, get_context_pack, \
+         trace_data_flow, find_references) to discover and read code, and Edit/Write to \
+         change it; Bash accepts only: {}",
+        CLAUDE_ALLOWED_BASH.join(", ")
+    )
+}
+
+/// Decide whether a semantic-only session may run one Bash command.
+///
+/// `Err` carries the line the assistant is shown, so a refusal teaches the
+/// replacement rather than only naming the rule.
+pub fn semantic_only_bash_verdict(command: &str) -> std::result::Result<(), String> {
+    let command = command.trim();
+    if command.is_empty() {
+        return Err(format!(
+            "semantic-only session: refusing an empty Bash command; {}",
+            semantic_only_redirect()
+        ));
+    }
+    if let Some(character) = command.chars().find(|c| !is_allowed_bash_char(*c)) {
+        return Err(format!(
+            "semantic-only session: refusing this Bash command because it contains {character:?}. \
+             Command substitution, redirection, pipes, sequencing, globbing, and escapes are \
+             refused because they turn an allowed command into a file read; {}",
+            semantic_only_redirect()
+        ));
+    }
+    let program = command.split(' ').next().unwrap_or_default();
+    if !CLAUDE_ALLOWED_BASH.contains(&program) {
+        return Err(format!(
+            "semantic-only session: refusing Bash command '{program}'. This session refuses every \
+             command it cannot name, because a list of blocked readers can always be spelled \
+             around; {}",
+            semantic_only_redirect()
+        ));
+    }
+    if let Some(root) = CLAUDE_REFUSED_PATH_ROOTS
+        .iter()
+        .find(|root| command.contains(**root))
+    {
+        return Err(format!(
+            "semantic-only session: refusing this Bash command because it names {root}, which \
+             turns an allowed command into a file read; {}",
+            semantic_only_redirect()
+        ));
+    }
+    Ok(())
+}
+
+/// Decide one Claude Code `PreToolUse` payload.
+///
+/// Fails closed on everything it cannot read: an unparseable payload, a missing
+/// tool name, a `Bash` call with no command string, and any tool the matcher
+/// selected that this function was not written to allow all refuse. A guard
+/// that allowed what it did not understand would be an audit of the payloads
+/// that happen to be well formed.
+pub fn semantic_only_guard_verdict(payload: &[u8]) -> std::result::Result<(), String> {
+    let refuse_unreadable = |detail: &str| {
+        Err(format!(
+            "semantic-only session: refusing this call because its hook payload {detail}; {}",
+            semantic_only_redirect()
+        ))
+    };
+
+    let Ok(payload) = serde_json::from_slice::<serde_json::Value>(payload) else {
+        return refuse_unreadable("is not readable JSON");
+    };
+    let Some(tool) = payload.get("tool_name").and_then(serde_json::Value::as_str) else {
+        return refuse_unreadable("names no tool");
+    };
+
+    if tool == "Bash" {
+        let Some(command) = payload
+            .get("tool_input")
+            .and_then(|input| input.get("command"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            return refuse_unreadable("is a Bash call carrying no command string");
+        };
+        return semantic_only_bash_verdict(command);
+    }
+    if tool.starts_with(CLAUDE_ALLOWED_MCP_PREFIX) || CLAUDE_ALLOWED_BASH_FOLLOWUPS.contains(&tool)
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "semantic-only session: refusing '{tool}'; {}",
+        semantic_only_redirect()
+    ))
+}
+
+/// `kin semantic-only-guard` — adjudicate one `PreToolUse` call on stdin.
+///
+/// Exit 2 is Claude Code's blocking refusal and routes stderr back to the
+/// model, which is why the refusal text is written to name a replacement.
+pub fn run_semantic_only_guard() -> Result<()> {
+    use std::io::Read as _;
+
+    let mut payload = Vec::new();
+    // Returning the IO error would exit 1, and every hook exit code except 2 is
+    // a non-blocking error that lets the tool run. A guard that cannot read its
+    // own input has to refuse explicitly, or failing to read is how a call gets
+    // through.
+    if let Err(error) = std::io::stdin()
+        .lock()
+        .take(MAX_GUARD_PAYLOAD_BYTES)
+        .read_to_end(&mut payload)
+    {
+        eprintln!(
+            "semantic-only session: refusing this call because its hook payload could not be \
+             read ({error}); {}",
+            semantic_only_redirect()
+        );
+        std::process::exit(2);
+    }
+    if let Err(refusal) = semantic_only_guard_verdict(&payload) {
+        eprintln!("{refusal}");
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+/// The `kin` binary the launched assistant calls back into for every guarded
+/// tool call.
+///
+/// Resolved from the running executable rather than left to the assistant's
+/// `PATH`: a hook command that cannot be executed is reported by Claude Code as
+/// a non-blocking error and the tool then runs, so an unresolvable guard would
+/// silently turn enforcement off.
+fn guard_program() -> Result<PathBuf> {
+    std::env::current_exe().context("resolve the kin executable for the semantic-only guard")
+}
+
+/// Quote one program path for the shell Claude Code runs a hook command in.
+///
+/// Hook commands are shell strings, so an unquoted repository path containing a
+/// space would split into a program and an argument. POSIX single quotes are
+/// exact and expand nothing; the Windows arm uses double quotes, which both
+/// `cmd.exe` and a POSIX shell honor, because which of the two runs there is
+/// Claude Code's choice and a Windows path cannot contain `"`.
+fn shell_quote_program(program: &Path, windows: bool) -> String {
+    let program = program.display().to_string();
+    if windows {
+        return format!("\"{program}\"");
+    }
+    format!("'{}'", program.replace('\'', r"'\''"))
+}
 
 impl AssistantAdapter for ClaudeAdapter {
     fn id(&self) -> &'static str {
@@ -117,58 +343,39 @@ impl AssistantAdapter for ClaudeAdapter {
                 .map(|c| format!("Bash({c}:*)")),
         );
 
-        let mut settings = serde_json::json!({
-            "permissions": { "deny": deny }
-        });
-
-        let mut files = Vec::new();
-        // The hook is a deterministic backstop behind the deny rules: exit 2
-        // refuses the call and the stderr line reaches the model. It is a
-        // POSIX shell script, so it only exists on non-Windows launches; the
-        // deny rules above enforce on every platform.
-        if !windows {
-            let hook_path = profile_dir.join(CLAUDE_HOOK_SCRIPT);
-            settings["hooks"] = serde_json::json!({
+        // The guard is this binary, not a script inside the profile. That is
+        // what makes the profile non-disarmable: `Edit`, `Write`, and `rm` stay
+        // available by design, so a hook script the session could delete or
+        // rewrite would be enforcement the subject holds the off switch for.
+        let guard = format!(
+            "{} semantic-only-guard",
+            shell_quote_program(&guard_program()?, windows)
+        );
+        let settings = serde_json::json!({
+            "permissions": { "deny": deny },
+            "hooks": {
                 "PreToolUse": [{
-                    "matcher": "Grep|Glob|Read",
-                    "hooks": [{
-                        "type": "command",
-                        "command": hook_path.display().to_string(),
-                    }]
+                    "matcher": CLAUDE_HOOK_MATCHER,
+                    "hooks": [{ "type": "command", "command": guard }]
                 }]
-            });
-            files.push(ProfileFile {
-                relative_path: PathBuf::from(CLAUDE_HOOK_SCRIPT),
-                contents: "#!/bin/sh\n\
-                           echo \"semantic-only session: native discovery is disabled; use Kin's \
-                           MCP tools (semantic_locate, get_context_pack, trace_data_flow)\" >&2\n\
-                           exit 2\n"
-                    .to_string(),
-                executable: true,
-            });
-        }
-
-        files.push(ProfileFile {
-            relative_path: PathBuf::from(CLAUDE_SETTINGS_FILE),
-            contents: serde_json::to_string_pretty(&settings)?,
-            executable: false,
+            }
         });
 
-        let backstop = if windows {
-            "deny rules only, no hook backstop on Windows"
-        } else {
-            "deny rules plus PreToolUse backstop"
-        };
         Ok(SemanticOnlyProfile {
             extra_args: vec![
                 OsString::from("--settings"),
                 profile_dir.join(CLAUDE_SETTINGS_FILE).into_os_string(),
             ],
-            files,
+            files: vec![ProfileFile {
+                relative_path: PathBuf::from(CLAUDE_SETTINGS_FILE),
+                contents: serde_json::to_string_pretty(&settings)?,
+            }],
             tier: EnforcementTier::Enforced,
             disclosure: format!(
-                "semantic-only [enforced]: Grep/Glob/Read and file-reading Bash are refused \
-                 ({backstop}); Kin MCP tools, Edit, and Write stay available"
+                "semantic-only [enforced]: Grep/Glob/Read are refused; Bash is refused unless the \
+                 command is one of {}; MCP tools other than Kin's are refused. Kin's MCP tools, \
+                 Edit, and Write stay available.",
+                CLAUDE_ALLOWED_BASH.join(", ")
             ),
         })
     }
@@ -238,6 +445,94 @@ pub fn adapter_for(assistant: &str) -> Result<&'static dyn AssistantAdapter> {
 mod tests {
     use super::*;
 
+    /// Every way of reading a file that the adversarial review of the original
+    /// blocklist enumerated, plus the blocklist's own entries.
+    ///
+    /// `sed` is the falsifying probe for this whole arm: the previous profile
+    /// blocked `grep` by name, so an acceptance written around `grep` passes
+    /// while enforcing almost nothing. `sed -n p FILE` reads any file and was
+    /// deliberately left allowed, so a guard that refuses `grep` and admits
+    /// `sed` is not enforcement.
+    const BYPASS_VECTORS: &[&str] = &[
+        // Stream editors the previous profile deliberately left allowed.
+        "sed -n p src/main.rs",
+        "sed '' src/main.rs",
+        "awk '{print}' src/main.rs",
+        "awk 1 src/main.rs",
+        // Nested shells.
+        "bash -c 'cat src/main.rs'",
+        "sh -c 'cat src/main.rs'",
+        "zsh -c 'cat src/main.rs'",
+        // Builtins and substitution.
+        "echo $(cat src/main.rs)",
+        "printf '%s' \"$(<src/main.rs)\"",
+        "while IFS= read -r l; do echo \"$l\"; done < src/main.rs",
+        "cat<src/main.rs",
+        // Interpreters.
+        "perl -ne print src/main.rs",
+        "perl -0777 -pe '' src/main.rs",
+        "python3 -c \"print(open('src/main.rs').read())\"",
+        "node -e \"process.stdout.write(require('fs').readFileSync('src/main.rs','utf8'))\"",
+        "ruby -e 'puts File.read(\"src/main.rs\")'",
+        // Pure readers absent from the blocklist.
+        "nl src/main.rs",
+        "od -c src/main.rs",
+        "xxd src/main.rs",
+        "hexdump -C src/main.rs",
+        "cut -c1- src/main.rs",
+        "paste src/main.rs",
+        "sort src/main.rs",
+        "uniq src/main.rs",
+        "rev src/main.rs",
+        "tac src/main.rs",
+        "fold src/main.rs",
+        "expand src/main.rs",
+        "column src/main.rs",
+        "pr src/main.rs",
+        "base64 src/main.rs",
+        "wc src/main.rs",
+        "tee < src/main.rs",
+        "bat src/main.rs",
+        // Spellings the blocklist misses.
+        "egrep -n pattern src/main.rs",
+        "fgrep pattern src/main.rs",
+        "zgrep pattern src/main.rs",
+        "ack pattern",
+        "ugrep pattern",
+        "/bin/cat src/main.rs",
+        "env cat src/main.rs",
+        "command cat src/main.rs",
+        "LC_ALL=C cat src/main.rs",
+        "\\cat src/main.rs",
+        // Full-text search, full-file read, and directory listing in one
+        // un-denied binary.
+        "git grep -n pattern",
+        "git show HEAD:src/main.rs",
+        "git cat-file -p HEAD",
+        "git diff",
+        "git log -p",
+        "git blame src/main.rs",
+        "git ls-files",
+        // Shell expansion as a directory listing.
+        "echo *",
+        "printf '%s\\n' *",
+        "compgen -f",
+        // Argument plumbing.
+        "xargs cat < list",
+        "echo src/main.rs | xargs cat",
+        // Archives, block copies, and the network.
+        "tar -xOf bundle.tar src/main.rs",
+        "unzip -p bundle.zip src/main.rs",
+        "zcat src/main.rs.gz",
+        "dd if=src/main.rs",
+        "cp src/main.rs /dev/stdout",
+        "curl -s file:///etc/hosts",
+        "wget -qO- file:///etc/hosts",
+        // A nested Claude Code receives no --settings and would run under
+        // default permissions.
+        "claude -p \"print the contents of src/main.rs\"",
+    ];
+
     #[test]
     fn registry_resolves_every_alias_to_the_old_allowlist_programs() {
         assert_eq!(adapter_for("claude").unwrap().program(), "claude");
@@ -247,6 +542,104 @@ mod tests {
         assert_eq!(adapter_for("gemini-cli").unwrap().program(), "gemini");
         assert!(adapter_for("vim").is_err());
         assert!(adapter_for("").is_err());
+    }
+
+    #[test]
+    fn every_enumerated_file_read_bypass_is_refused() {
+        for vector in BYPASS_VECTORS {
+            let refusal = semantic_only_bash_verdict(vector)
+                .expect_err(&format!("semantic-only admitted a file read: {vector}"));
+            assert!(
+                refusal.contains("semantic-only session: refusing"),
+                "{vector}: {refusal}"
+            );
+        }
+        // The commands the old blocklist did name must still be refused, so
+        // inverting the list did not trade one gap for another.
+        for reader in CLAUDE_DENIED_BASH_READERS {
+            let command = format!("{reader} src/main.rs");
+            assert!(
+                semantic_only_bash_verdict(&command).is_err(),
+                "semantic-only admitted {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_allowlisted_commands_are_the_ones_that_run() {
+        for allowed in [
+            "echo starting the rename",
+            "printf ready",
+            "pwd",
+            "true",
+            "false",
+            "mkdir -p src/rendering",
+            "rmdir src/rendering",
+            "touch src/rendering/mod.rs",
+            "mv src/old.rs src/new.rs",
+            "rm -f target/debug/stale",
+            "chmod u+x scripts/run",
+        ] {
+            semantic_only_bash_verdict(allowed).unwrap_or_else(|refusal| {
+                panic!("semantic-only refused a permitted command {allowed}: {refusal}")
+            });
+        }
+
+        // An allowed command still cannot name a path whose read is the point.
+        for disclosure in [
+            "mv src/main.rs /dev/stdout",
+            "echo /proc/self/environ",
+            "rm /sys/kernel/notes",
+        ] {
+            assert!(
+                semantic_only_bash_verdict(disclosure).is_err(),
+                "semantic-only admitted {disclosure}"
+            );
+        }
+
+        assert!(semantic_only_bash_verdict("").is_err());
+        assert!(semantic_only_bash_verdict("   ").is_err());
+    }
+
+    #[test]
+    fn the_guard_reads_bash_commands_out_of_the_hook_payload_and_fails_closed() {
+        let payload = |tool: &str, command: &str| {
+            serde_json::to_vec(&serde_json::json!({
+                "hook_event_name": "PreToolUse",
+                "tool_name": tool,
+                "tool_input": { "command": command }
+            }))
+            .unwrap()
+        };
+
+        semantic_only_guard_verdict(&payload("Bash", "mkdir -p src/rendering")).unwrap();
+        assert!(semantic_only_guard_verdict(&payload("Bash", "sed -n p src/main.rs")).is_err());
+
+        // The hook is also a backstop for the tools the deny rules name, so a
+        // deny rule that failed to apply is still refused here.
+        for denied in CLAUDE_DENIED_TOOLS {
+            assert!(
+                semantic_only_guard_verdict(&payload(denied, "")).is_err(),
+                "guard admitted {denied}"
+            );
+        }
+
+        // Kin's MCP surface is what the session is pointed at; another
+        // server's file reader is not.
+        semantic_only_guard_verdict(&payload("mcp__kin__semantic_locate", "")).unwrap();
+        semantic_only_guard_verdict(&payload("BashOutput", "")).unwrap();
+        assert!(semantic_only_guard_verdict(&payload("mcp__filesystem__read_file", "")).is_err());
+        assert!(semantic_only_guard_verdict(&payload("mcp__kinlab__read", "")).is_err());
+
+        // Anything unreadable is a refusal, not an admission.
+        assert!(semantic_only_guard_verdict(b"").is_err());
+        assert!(semantic_only_guard_verdict(b"not json").is_err());
+        assert!(semantic_only_guard_verdict(br#"{"tool_input":{"command":"pwd"}}"#).is_err());
+        assert!(semantic_only_guard_verdict(br#"{"tool_name":"Bash"}"#).is_err());
+        assert!(
+            semantic_only_guard_verdict(br#"{"tool_name":"Bash","tool_input":{"command":7}}"#)
+                .is_err()
+        );
     }
 
     #[test]
@@ -281,15 +674,31 @@ mod tests {
             assert!(!deny.contains(&kept.to_string()), "overdenies {kept}");
         }
 
+        // The hook must be aimed at Bash. Aimed at the denied tool names alone
+        // it would guard a door the deny rules already hold and cover none of
+        // the surface every bypass in `BYPASS_VECTORS` runs through.
         let hook = &parsed["hooks"]["PreToolUse"][0];
-        assert_eq!(hook["matcher"], "Grep|Glob|Read");
-        let script = profile
-            .files
-            .iter()
-            .find(|f| f.relative_path == Path::new(CLAUDE_HOOK_SCRIPT))
-            .expect("hook script present");
-        assert!(script.executable);
-        assert!(script.contents.contains("exit 2"));
+        assert_eq!(hook["matcher"], CLAUDE_HOOK_MATCHER);
+        assert!(
+            hook["matcher"].as_str().unwrap().contains("Bash"),
+            "the hook must see Bash"
+        );
+        let command = hook["hooks"][0]["command"].as_str().unwrap();
+        assert!(
+            command.ends_with(" semantic-only-guard"),
+            "the hook must call the guard: {command}"
+        );
+        assert!(
+            command.starts_with('\''),
+            "the guard program must be quoted for the hook shell: {command}"
+        );
+        assert!(
+            profile
+                .files
+                .iter()
+                .all(|f| f.relative_path != Path::new("deny-discovery.sh")),
+            "the guard must not be a script the session can delete or rewrite"
+        );
 
         let args: Vec<String> = profile
             .extra_args
@@ -300,24 +709,81 @@ mod tests {
         assert!(args[1].ends_with(CLAUDE_SETTINGS_FILE));
     }
 
+    /// The printed line is the operator's only description of what a
+    /// semantic-only launch holds, so it is asserted against the sets it
+    /// describes rather than against a copy of its own words.
     #[test]
-    fn claude_windows_arm_enforces_deny_rules_without_a_shell_hook() {
-        let profile = ClaudeAdapter
+    fn the_disclosure_describes_exactly_what_is_enforced() {
+        for windows in [false, true] {
+            let profile = ClaudeAdapter
+                .semantic_only(Path::new("/tmp/profile"), windows)
+                .unwrap();
+            let disclosure = &profile.disclosure;
+
+            assert!(disclosure.contains("[enforced]"), "{disclosure}");
+            for tool in CLAUDE_DENIED_TOOLS {
+                assert!(disclosure.contains(tool), "{tool} unnamed: {disclosure}");
+            }
+            for allowed in CLAUDE_ALLOWED_BASH {
+                assert!(
+                    disclosure.contains(allowed),
+                    "{allowed} unnamed: {disclosure}"
+                );
+                semantic_only_bash_verdict(allowed).unwrap_or_else(|refusal| {
+                    panic!("the disclosure names {allowed} but the guard refuses it: {refusal}")
+                });
+            }
+            // The claim the review falsified: the old line said file-reading
+            // Bash was refused while thirteen prefixes were. The line must not
+            // describe the Bash boundary as anything but the allowlist.
+            assert!(
+                disclosure.contains("Bash is refused unless"),
+                "{disclosure}"
+            );
+            assert!(
+                !disclosure.contains("backstop"),
+                "the disclosure must not credit coverage to a backstop: {disclosure}"
+            );
+            assert!(disclosure.contains("MCP tools other than Kin's are refused"));
+        }
+    }
+
+    /// Both platform arms carry the guard.
+    ///
+    /// The guard is the `kin` binary, so nothing about it needs a POSIX shell
+    /// script or an executable bit — which is what previously left the Windows
+    /// arm with deny rules and no hook at all.
+    #[test]
+    fn both_platform_arms_install_the_same_guard() {
+        let unix = ClaudeAdapter
+            .semantic_only(Path::new("/tmp/profile"), false)
+            .unwrap();
+        let windows = ClaudeAdapter
             .semantic_only(Path::new("/tmp/profile"), true)
             .unwrap();
-        assert_eq!(profile.tier, EnforcementTier::Enforced);
-        assert!(profile
-            .files
-            .iter()
-            .all(|f| f.relative_path != Path::new(CLAUDE_HOOK_SCRIPT)));
-        let settings = profile
-            .files
-            .iter()
-            .find(|f| f.relative_path == Path::new(CLAUDE_SETTINGS_FILE))
-            .unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&settings.contents).unwrap();
-        assert!(parsed.get("hooks").is_none());
-        assert!(profile.disclosure.contains("no hook backstop on Windows"));
+
+        for profile in [&unix, &windows] {
+            assert_eq!(profile.tier, EnforcementTier::Enforced);
+            assert_eq!(profile.files.len(), 1);
+            let parsed: serde_json::Value =
+                serde_json::from_str(&profile.files[0].contents).unwrap();
+            assert_eq!(
+                parsed["hooks"]["PreToolUse"][0]["matcher"],
+                CLAUDE_HOOK_MATCHER
+            );
+        }
+        assert_eq!(unix.disclosure, windows.disclosure);
+
+        let quoted = shell_quote_program(Path::new("/opt/kin tools/kin"), false);
+        assert_eq!(quoted, "'/opt/kin tools/kin'");
+        assert_eq!(
+            shell_quote_program(Path::new("/opt/it's/kin"), false),
+            r"'/opt/it'\''s/kin'"
+        );
+        assert_eq!(
+            shell_quote_program(Path::new(r"C:\Program Files\kin.exe"), true),
+            "\"C:\\Program Files\\kin.exe\""
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod approvals;
 pub mod assistant;
+pub mod assistant_adapter;
 pub mod audit;
 pub mod auth;
 pub mod backup;

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -1116,6 +1116,86 @@ mod tests {
         );
     }
 
+    /// A launch profile is not a session change.
+    ///
+    /// `kin with --semantic-only` generates the launched assistant's permission
+    /// settings before it starts. Those files describe the launch, not the
+    /// work, so admitting them would commit an assistant's profile into
+    /// repository authority on every clean exit — from the one flag whose
+    /// purpose is to keep the graph the only surface the assistant touches.
+    ///
+    /// The profile therefore lives beside the projection under `.kin/runs/`,
+    /// and this asserts the scanner cannot reach it from either direction: the
+    /// profile files exist, an ordinary file written inside the projection is
+    /// observed, and no profile path appears in the delta.
+    #[cfg(unix)]
+    #[test]
+    fn a_launch_profile_beside_the_projection_is_not_a_session_change() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("member.txt"), b"admitted\n").unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap();
+        let blobs = kin_blobs::BlobStore::new(layout.ingest_cas_dir()).unwrap();
+
+        let session_dir = layout.runs_dir().join("session-launch-profile-probe");
+        let request = crate::commands::session_workspace::SessionWorkspaceRequest {
+            session_dir: session_dir.display().to_string(),
+            strategy: None,
+            scope: None,
+        };
+        crate::commands::session_workspace::materialize_session_workspace(
+            &layout, &binding, &request,
+        )
+        .unwrap();
+
+        // Written through the production writer, so this binds to where
+        // `kin with` actually puts a profile rather than to a fixture of it.
+        let adapter = crate::commands::assistant_adapter::adapter_for("claude").unwrap();
+        let profile =
+            crate::commands::session_run::LaunchProfile::write(&layout.runs_dir(), adapter, false)
+                .unwrap();
+        let settings = profile.dir().join("semantic-only-settings.json");
+        assert!(
+            settings.is_file(),
+            "the profile must actually be on disk for this assertion to mean anything"
+        );
+        assert!(
+            !profile.dir().starts_with(&session_dir),
+            "the profile is inside the projection at {}",
+            profile.dir().display()
+        );
+
+        // A real working-tree change, so the scanner is demonstrably observing
+        // this projection rather than returning an empty delta.
+        std::fs::write(session_dir.join("member.txt"), b"edited in session\n").unwrap();
+
+        let observation =
+            observe_session_workspace(&layout, &binding, &session_dir, &blobs, false).unwrap();
+        let observed = observation
+            .deltas()
+            .iter()
+            .filter_map(|delta| delta.new_state().or_else(|| delta.old_state()))
+            .filter_map(|entry| entry.path.as_utf8())
+            .collect::<Vec<_>>();
+
+        assert!(
+            observed.contains(&"member.txt"),
+            "the scanner observed nothing, so this proves nothing: {observed:?}"
+        );
+        let profile_leaf = profile
+            .dir()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+        for path in &observed {
+            assert!(
+                !path.contains(profile_leaf) && !path.contains("semantic-only-settings.json"),
+                "a launch profile path reached repository authority: {path}"
+            );
+        }
+    }
+
     #[test]
     fn mass_deletion_requires_explicit_confirmation() {
         let source = (0..20)

--- a/crates/kin-cli/src/commands/session_run.rs
+++ b/crates/kin-cli/src/commands/session_run.rs
@@ -61,14 +61,121 @@ impl SessionProjection {
             .strip_prefix("session-")
             .unwrap_or(self.name.as_str())
     }
+}
 
-    /// Session-metadata scratch space beside the projection root.
+/// Directory-name prefix for a launch profile under `.kin/runs/`.
+///
+/// Deliberately not `session-`: every reader of `.kin/runs/` selects
+/// projections by that prefix — `resolve_session_directory` when picking the
+/// latest session, `validate_session_leaf` when accepting a named one, and
+/// [`discard`] when removing one — so a profile directory can never be
+/// mistaken for a session to reconcile, resolve, or delete.
+const LAUNCH_PROFILE_PREFIX: &str = "launch-profile-";
+
+/// The generated launch profile for one `kin with --semantic-only` process.
+///
+/// The profile is a sibling of the session projection under `.kin/runs/`, and
+/// both halves of that placement carry weight:
+///
+/// * The reconcile scanner walks the projection directory and nothing else, so
+///   a profile file can never be observed as a working-tree change and admitted
+///   into repository authority. A launch profile describes the launch, not the
+///   work, and committing an assistant's permission settings on every clean
+///   exit would be the opposite of what the flag is for.
+/// * The launched process's working directory is the projection, so the profile
+///   is not an entry of the tree the subject agent is working in.
+///
+/// A profile lives for exactly one child process. Its directory is removed on
+/// every path out of [`with`], including the failure paths, which is why the
+/// guard is armed by [`LaunchProfile::write`] before the first byte is written.
+pub struct LaunchProfile {
+    dir: PathBuf,
+    extra_args: Vec<OsString>,
+    disclosure: String,
+}
+
+impl LaunchProfile {
+    /// Build and write one assistant's semantic-only profile.
     ///
-    /// Files here live exactly as long as the session but are outside the
-    /// reconciled tree, so a launch profile can never enter the graph as a
-    /// working-tree change.
-    pub fn scratch_dir(&self) -> PathBuf {
-        self.dir.join("launch-profile")
+    /// Called before the projection is materialized and before any daemon
+    /// lease is registered: every step here is fallible, and a failure between
+    /// `register_lease` and `close` would abandon both the projection directory
+    /// and a live daemon session.
+    pub fn write(
+        runs_dir: &Path,
+        adapter: &dyn super::assistant_adapter::AssistantAdapter,
+        windows: bool,
+    ) -> Result<Self> {
+        let dir = runs_dir.join(format!("{LAUNCH_PROFILE_PREFIX}{}", uuid::Uuid::new_v4()));
+        let profile = adapter.semantic_only(&dir, windows)?;
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("create the launch profile directory {}", dir.display()))?;
+        let written = Self {
+            dir,
+            extra_args: profile.extra_args,
+            disclosure: profile.disclosure,
+        };
+        for file in &profile.files {
+            let path = written.dir.join(&file.relative_path);
+            std::fs::write(&path, &file.contents)
+                .with_context(|| format!("write the launch profile file {}", path.display()))?;
+        }
+        Ok(written)
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Flags the launched CLI needs to load this profile.
+    pub fn extra_args(&self) -> &[OsString] {
+        &self.extra_args
+    }
+
+    /// The one line printed at launch describing what the profile holds.
+    pub fn disclosure(&self) -> &str {
+        &self.disclosure
+    }
+}
+
+impl Drop for LaunchProfile {
+    fn drop(&mut self) {
+        if let Err(error) = remove_launch_profile(&self.dir) {
+            eprintln!(
+                "Kin: failed to remove the launch profile {}: {error:#}",
+                self.dir.display()
+            );
+        }
+    }
+}
+
+/// Remove a launch profile directory.
+///
+/// Re-checked here for the same reason [`discard`] re-checks a session path: a
+/// removal reached from a `Drop` must not be walkable into an arbitrary tree by
+/// a caller that constructed the value with a different path.
+fn remove_launch_profile(profile_dir: &Path) -> Result<()> {
+    let name = profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if !name.starts_with(LAUNCH_PROFILE_PREFIX) || name.len() == LAUNCH_PROFILE_PREFIX.len() {
+        bail!(
+            "refusing to remove {}: not a launch profile",
+            profile_dir.display()
+        );
+    }
+    if profile_dir.is_symlink() {
+        bail!(
+            "refusing to remove {}: launch profile path is a symlink",
+            profile_dir.display()
+        );
+    }
+    match std::fs::remove_dir_all(profile_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("remove the launch profile {}", profile_dir.display())),
     }
 }
 
@@ -510,13 +617,16 @@ pub async fn with(
 
     let adapter = super::assistant_adapter::adapter_for(&assistant)?;
     let program = adapter.program();
-    // Probe support before materializing: an unsupported assistant must
-    // refuse without minting a projection it would then leak.
-    if semantic_only {
-        adapter.semantic_only(Path::new(""), cfg!(windows))?;
-    }
 
     let layout = discover_layout()?;
+    // Write the profile before materializing. Every step of it is fallible —
+    // an unsupported assistant, a full disk, a read-only mount — and a failure
+    // after the projection exists would abandon the projection directory, and
+    // after `register_lease` a live daemon session with it.
+    let profile = semantic_only
+        .then(|| LaunchProfile::write(&layout.runs_dir(), adapter, cfg!(windows)))
+        .transpose()?;
+
     let mut projection = materialize(layout, None, None).await?;
     let session_id = register_lease(
         &mut projection,
@@ -536,27 +646,18 @@ pub async fn with(
     eprintln!("Session: {session_id}");
 
     let mut command = std::process::Command::new(program);
-    if semantic_only {
-        let scratch = projection.scratch_dir();
-        let profile = adapter.semantic_only(&scratch, cfg!(windows))?;
-        std::fs::create_dir_all(&scratch)?;
-        for file in &profile.files {
-            let path = scratch.join(&file.relative_path);
-            std::fs::write(&path, &file.contents)?;
-            #[cfg(unix)]
-            if file.executable {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
-            }
-        }
-        command.args(&profile.extra_args);
-        eprintln!("{}", profile.disclosure);
+    if let Some(profile) = &profile {
+        command.args(profile.extra_args());
+        eprintln!("{}", profile.disclosure());
     }
     if !task.is_empty() {
         command.args(&task);
     }
     let exit = run_in_session(&projection, command)?;
     close(&projection, exit, SessionCloseout::Reconcile).await?;
+    // `std::process::exit` runs no destructors, so the profile is removed here
+    // rather than left to drop on the way out of a non-zero exit.
+    drop(profile);
     if exit.code != 0 {
         std::process::exit(exit.code);
     }

--- a/crates/kin-cli/src/commands/session_run.rs
+++ b/crates/kin-cli/src/commands/session_run.rs
@@ -61,6 +61,15 @@ impl SessionProjection {
             .strip_prefix("session-")
             .unwrap_or(self.name.as_str())
     }
+
+    /// Session-metadata scratch space beside the projection root.
+    ///
+    /// Files here live exactly as long as the session but are outside the
+    /// reconciled tree, so a launch profile can never enter the graph as a
+    /// working-tree change.
+    pub fn scratch_dir(&self) -> PathBuf {
+        self.dir.join("launch-profile")
+    }
 }
 
 /// Materialize one disposable session projection through the daemon.
@@ -462,13 +471,11 @@ pub async fn open(
 }
 
 /// Assistants `kin with` knows how to launch.
+///
+/// Resolution lives in the adapter registry so the launcher and `kin setup`'s
+/// registration writers can never disagree about which assistants exist.
 pub fn assistant_program(assistant: &str) -> Result<&'static str> {
-    match assistant.trim().to_ascii_lowercase().as_str() {
-        "claude" | "claude-code" => Ok("claude"),
-        "codex" => Ok("codex"),
-        "gemini" | "gemini-cli" => Ok("gemini"),
-        other => bail!("unknown assistant '{other}'; kin with supports: claude, codex, gemini"),
-    }
+    Ok(super::assistant_adapter::adapter_for(assistant)?.program())
 }
 
 /// `kin with <assistant> [-- <task...>]`.
@@ -478,6 +485,7 @@ pub async fn with(
     passive_guidance: bool,
     restrict_discovery: bool,
     restrict_filesystem: bool,
+    semantic_only: bool,
     task: Vec<String>,
 ) -> Result<()> {
     if restrict_discovery || restrict_filesystem {
@@ -500,7 +508,14 @@ pub async fn with(
         );
     }
 
-    let program = assistant_program(&assistant)?;
+    let adapter = super::assistant_adapter::adapter_for(&assistant)?;
+    let program = adapter.program();
+    // Probe support before materializing: an unsupported assistant must
+    // refuse without minting a projection it would then leak.
+    if semantic_only {
+        adapter.semantic_only(Path::new(""), cfg!(windows))?;
+    }
+
     let layout = discover_layout()?;
     let mut projection = materialize(layout, None, None).await?;
     let session_id = register_lease(
@@ -521,6 +536,22 @@ pub async fn with(
     eprintln!("Session: {session_id}");
 
     let mut command = std::process::Command::new(program);
+    if semantic_only {
+        let scratch = projection.scratch_dir();
+        let profile = adapter.semantic_only(&scratch, cfg!(windows))?;
+        std::fs::create_dir_all(&scratch)?;
+        for file in &profile.files {
+            let path = scratch.join(&file.relative_path);
+            std::fs::write(&path, &file.contents)?;
+            #[cfg(unix)]
+            if file.executable {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
+            }
+        }
+        command.args(&profile.extra_args);
+        eprintln!("{}", profile.disclosure);
+    }
     if !task.is_empty() {
         command.args(&task);
     }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -855,6 +855,11 @@ enum Command {
         /// In native mode, block both filesystem discovery and direct file reads
         #[arg(long, conflicts_with = "restrict_discovery")]
         restrict_filesystem: bool,
+        /// Deny the assistant's native discovery tools for this launch, leaving
+        /// Kin's semantic tools as the only discovery surface; the enforcement
+        /// tier is printed at launch and differs per assistant
+        #[arg(long)]
+        semantic_only: bool,
         /// Task prompt
         #[arg(last = true)]
         task: Vec<String>,
@@ -3079,6 +3084,7 @@ fn main() -> Result<()> {
                     passive_guidance,
                     restrict_discovery,
                     restrict_filesystem,
+                    semantic_only,
                     task,
                 } => {
                     commands::capabilities::require_ready("with")?;
@@ -3088,6 +3094,7 @@ fn main() -> Result<()> {
                         passive_guidance,
                         restrict_discovery,
                         restrict_filesystem,
+                        semantic_only,
                         task,
                     )
                     .await

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -864,6 +864,12 @@ enum Command {
         #[arg(last = true)]
         task: Vec<String>,
     },
+    /// Hidden PreToolUse adjudicator for a `kin with --semantic-only` session.
+    ///
+    /// Reads one hook payload on stdin and exits 0 to permit or 2 to refuse.
+    /// The launched assistant calls this, not an operator.
+    #[command(hide = true)]
+    SemanticOnlyGuard,
     /// Retire tracked paths that ignore rules now cover. Reports without changing anything
     /// unless --confirm is given.
     PurgeIgnored {
@@ -2136,6 +2142,14 @@ fn main() -> Result<()> {
     }
     kin_buildinfo::retain_update_build_identity(&KIN_UPDATE_BUILD_IDENTITY);
     let cli = parse_cli_or_report_retired_command();
+    // The semantic-only guard runs once per tool call of a launched assistant
+    // and adjudicates a payload on stdin. It touches no repository, so it
+    // returns before the tracing subscriber, the environment audit, the pending
+    // MCP repair retry, and the tokio runtime: none of them would change its
+    // answer, and all of them would be charged to the subject's tool latency.
+    if matches!(cli.command, Command::SemanticOnlyGuard) {
+        return commands::assistant_adapter::run_semantic_only_guard();
+    }
     let command_name = current_command_name();
     let cwd = std::env::current_dir()?.display().to_string();
     let profile_out = cli
@@ -3098,6 +3112,11 @@ fn main() -> Result<()> {
                         task,
                     )
                     .await
+                }
+                // Adjudicated before the runtime starts; see the early return
+                // at the top of `main`.
+                Command::SemanticOnlyGuard => {
+                    commands::assistant_adapter::run_semantic_only_guard()
                 }
                 Command::Shell {
                     strategy,


### PR DESCRIPTION
Refs FIR-1891 (does not close it: the live falsifiable acceptance and the setup-writer unification remain).

## What this builds

- One `AssistantAdapter` registry owning per-CLI launch program, aliases, and the `--semantic-only` capability profile with a self-declared enforcement tier (enforced / instructed / unsupported). `kin with`'s launcher resolves every assistant through it.
- `kin with --semantic-only claude` generates a settings file that denies `Grep`, `Glob`, `Read` and thirteen file-reading Bash prefixes, and installs a `PreToolUse` hook aimed at **Bash** that adjudicates each command against an allowlist and fails closed.
- The hook command is the `kin` binary itself (`kin semantic-only-guard`, hidden), not a script inside the profile. `Edit`, `Write` and `rm` stay available by design, so a hook script the session could delete or rewrite would be enforcement whose off switch the subject holds.
- codex and gemini fail closed with an explicit message rather than shipping guidance dressed as enforcement.
- Platform is a parameter, not a cfg gate: both the unix and windows profile arms run in tests on every host, and both now carry the same guard.

## Why the Bash surface is an allowlist

A blocklist over a shell cannot be finished. `sed -n p F`, `awk '{print}' F`, `perl -ne print F`, `python3 -c "open(f).read()"`, `node -e`, `ruby -e`, `git show HEAD:F`, `git grep`, `nl`/`od`/`xxd`/`base64`/`cut`, `egrep`/`fgrep`, `bash -c 'cat F'`, `$(<F)`, `while read < F`, `echo *`, `curl file://`, `/bin/cat F`, `env cat F`, and a nested `claude -p` all read file contents, and every blocked spelling has an unblocked one. The guard therefore refuses every command it cannot name:

- **Command allowlist** (11): `echo, printf, pwd, true, false, mkdir, rmdir, touch, mv, rm, chmod` — emit a literal, report the working directory, or mutate the filesystem in a way `Edit` and `Write` cannot express.
- **Character allowlist**: alphanumerics, space, and `- _ . / = : , + % ' "`. Command substitution, redirection, pipes, sequencing, globbing and escapes are spelled with characters, so refusing the characters refuses the class rather than the instances of it someone thought to list.
- **Refused path roots**: `/dev/`, `/proc/`, `/sys/` — `mv src/a /dev/stdout` is a file read spelled as a move.
- **MCP**: `mcp__kin__*` is permitted; every other MCP tool is refused, which is what makes "Kin's semantic tools are the only discovery surface" true rather than aspirational.

The thirteen deny rules are retained as a second layer: a `PreToolUse` hook that cannot be executed is a non-blocking error and the tool then runs, so the most common readers are also denied by a mechanism needing no subprocess.

## Where the profile lives

Profile files are written to a `launch-profile-<uuid>` directory **under `.kin/runs/`, a sibling of the session projection**, never inside it. The reconcile scanner walks the projection directory and nothing else, so a profile file cannot be observed as a working-tree change and admitted into repository authority. The leaf name deliberately does not start with `session-`: every reader of `.kin/runs/` selects projections by that prefix, so a profile directory is never mistaken for a session to reconcile, resolve, discard, or report as stale. The directory is removed on every exit path, including the failure paths and the non-zero-exit `process::exit`.

It is also written **before** `materialize` and before `register_lease`, so its three fallible steps cannot abandon a projection directory or a live daemon session lease.

## Falsification arms in the module tests

1. `every_enumerated_file_read_bypass_is_refused` — 64 enumerated bypass vectors plus the 13 originally-blocked prefixes, each asserted refused. **Verified to fail against the previous 13-prefix blocklist**, first on `sed -n p src/main.rs`.
2. `a_launch_profile_beside_the_projection_is_not_a_session_change` — materializes a session, writes the profile through the production writer, edits a tracked file inside the projection, calls `observe_session_workspace`, and asserts the edit IS observed while no profile path is. **Verified to fail when the writer is moved back inside the projection.**
3. `the_disclosure_describes_exactly_what_is_enforced` — the printed line is asserted against the sets it describes, not against a copy of its own words: every denied tool and every allowlisted command must appear, every command it names must actually pass the guard, and it must not credit coverage to a "backstop".
4. `the_guard_reads_bash_commands_out_of_the_hook_payload_and_fails_closed` — empty, non-JSON, tool-less, command-less and non-string-command payloads all refuse.
5. Registry parity, overdeny arm (`Edit`/`Write`/`Bash`/kin MCP tools not denied), both platform arms, and codex/gemini refusal are retained from the previous revision.

## Corrections to the previous revision of this PR

- The claim that profile files lived "in session metadata beside the projection root" was **false**: `scratch_dir()` returned `self.dir.join("launch-profile")` and the daemon returns the session dir unchanged as `root`, so the profile was a direct child of the projection and both files — including a `0o755` shell script — were admitted into repository authority on every clean exit. Fixed and proven by test 2.
- The `PreToolUse` matcher was `"Grep|Glob|Read"` — the same three tools already denied outright — so it covered none of the Bash surface, and the disclosure's "file-reading Bash are refused" was false as printed. Fixed by aiming the hook at Bash with a fail-closed allowlist; the disclosure now states the boundary exactly.
- The module doc claimed `kin setup` and `kin with` resolve through the same registry, so a client "cannot be registerable but not launchable". `setup.rs` never calls `adapter_for`; it keeps its own client list and hardcodes per-client paths, so `cursor`, `antigravity`, `antigravity_workspace` and `windsurf` are exactly that. The comment now describes intent and names the gap. Unification remains out of scope here.

## Not claimed

- **No live refusal capture in CI.** The ticket's acceptance — `sed -n p <file>` refused inside a real `kin with --semantic-only claude` session, `semantic_locate` answering, removal restoring the tools — is still a manual acceptance step.
- **The Windows hook arm is untested against a live Claude Code on Windows.** The guard needs no POSIX shell or executable bit, which is why the arm exists at all, but only the generated settings are proven here.
- **Enforcement depends on the hook actually executing.** Claude Code reports an unrunnable hook command as a non-blocking error and then permits the tool. The guard is resolved from `current_exe()` rather than the assistant's `PATH` for that reason, and the thirteen deny rules are retained as the layer that survives it.
- **The allowlist is deliberately narrow.** A semantic-only session cannot run `cargo`, `npm`, `make`, or any interpreter, because none of them is provably free of file reads. That is a usability cost taken on purpose; the flag is opt-in per launch.
- **A hard kill leaks the profile directory.** `Drop` covers `?`-failures, panics, and the `process::exit` path; SIGKILL runs nothing. The residue is ~1 KB of JSON under `.kin/runs/`, inert and invisible to every reader of that directory. No sweeper was added on purpose: any age-based cleanup of `launch-profile-*` siblings can race a concurrent `kin with` session's live profile.
- **`SessionProjection` still has no `Drop`,** so `run_in_session` remains a fallible call between `register_lease` and `close`. That is pre-existing and identical across `exec`, `shell`, `open` and `with`; fixing it only here would make sibling surfaces disagree about what a failed spawn does. It wants one consistent change of its own.
