### PR TITLE
Correct the native Windows support notice to match shipped behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ you can verify appears there.
 
 On Windows, run `irm https://get.kinlab.dev/install.ps1 | iex` in PowerShell.
 Native Windows support is early: repositories admit and graph and lexical
-queries answer natively, but this build has no semantic vector search yet and
-its end-to-end install proof is still maturing, so WSL2 remains the
+queries answer natively, but transparent filesystem projection is not shipped
+there and its end-to-end install proof is still maturing, so WSL2 remains the
 recommended path for full Kin.
 Read [Platform and maturity](#platform-and-maturity) below before choosing a
 Windows install path.
@@ -231,7 +231,7 @@ boundaries:
 | --- | --- | --- |
 | macOS, Apple Silicon and Intel | Native graph, vector, daemon, setup, MCP, and review surfaces ship in the release archive. | Shipped and exercised on both architectures. It uses `DYLD_INSERT_LIBRARIES`; SIP-protected or hardened programs may reject injection. |
 | Linux x86_64 and arm64 | `kin` and `kin-daemon` are static musl builds intended to run on glibc and musl distributions. | The public VFS executable and shim are GNU/glibc builds, not musl builds. Current artifacts require glibc 2.39; Alpine/musl and older-glibc distributions are not supported projection hosts. The arm64 release proof runs on Ubuntu 24.04. |
-| Native Windows x86_64 | Early support: repositories admit and graph and lexical queries answer natively, but this build ships without semantic vector search and its end-to-end install proof is still maturing. WSL2 remains the recommended path for full Kin. | Not shipped. Use WSL2 with a Linux distribution that meets the glibc boundary for projection. |
+| Native Windows x86_64 | Early support: repositories admit and graph and lexical queries answer natively, but MCP and review workflows are not yet covered end to end by the install proof. WSL2 remains the recommended path for full Kin. | Not shipped. Use WSL2 with a Linux distribution that meets the glibc boundary for projection. |
 
 First indexing reads the entire reachable Git history, so `kin init` on a
 large or long-lived repository takes minutes, not seconds, before embedding

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,11 +59,16 @@ On native Windows, use PowerShell:
 irm https://get.kinlab.dev/install.ps1 | iex
 ```
 
-Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories.
+Native Windows x86_64 support is early. Repository admission works: `kin init` imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience.
 The PowerShell installer prints that boundary before downloading anything. Native
 Windows ARM64 has no release archive; an x64 PowerShell process may use the x86_64
 archive under Windows emulation, but WSL2 is the recommended path. Follow the Linux
 flow inside WSL2; see [windows-wsl2.md](./windows-wsl2.md).
+
+Git for Windows sets `core.autocrlf=true` in its system config, which rewrites line
+endings on checkout. `kin init` admits only a worktree whose bytes match the committed
+tree, so it will refuse a repository cloned that way with `tracked blob ... bytes differ
+from the committed tree`. Run `git config --global core.autocrlf false` and clone again.
 
 ### Installer options
 

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -34,7 +34,7 @@ and the release includes an aggregate manifest binding the Kin and pinned
 binary hash. GitHub signs an artifact attestation over the final archives and
 aggregate manifest before the prerelease is created.
 
-The Windows archive is a release-blocking target. Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories.
+The Windows archive is a release-blocking target. Native Windows x86_64 support is early. Repository admission works: `kin init` imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience.
 The archive carries semantic vector search, and is checksum-protected and
 GitHub-attested, but it is not OS-code-signed by this pipeline. Windows VFS
 projection is not shipped.

--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -1,9 +1,9 @@
 # Windows: use WSL2
 
-Kin repository workflows are supported on **Linux and macOS**. Native Windows
-currently has no repository-admission path.
+Kin repository workflows are fully supported on **Linux and macOS**. Native
+Windows admits repositories, but does not yet carry the whole workflow.
 
-Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories.
+Native Windows x86_64 support is early. Repository admission works: `kin init` imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience.
 
 Use **WSL2 (Windows Subsystem for Linux 2)** running a Linux distribution for
 the supported Windows-hosted experience.
@@ -16,10 +16,11 @@ Two parts of Kin are built around Unix runtime mechanics:
   calls via `LD_PRELOAD` (Linux) / `DYLD_INSERT_LIBRARIES` (macOS). That
   interception model does not exist on native Windows, so the "any tool sees
   graph-backed files as normal files" experience is Linux/macOS only.
-- **Repository admission** currently fails closed on native Windows before a
-  `.kin` repository is published. Without an admitted repository, graph,
-  lexical, daemon/query, repository setup, MCP, and review flows have no
-  supported native-Windows starting point.
+- **MCP and review workflows** are not yet covered end to end on native Windows
+  by the public install proof, so WSL2 is the supported path for connecting
+  agents and running review. Repository admission itself is not the blocker:
+  `kin init` admits a Git repository on native Windows and publishes graph
+  authority, and graph, lexical, and daemon-backed queries answer from it.
 - **Semantic vector search** ships enabled on every published platform. The
   native Windows CLI artifact (`kin-windows-x86_64.zip`) is built with the same
   default feature set as Linux and macOS, so semantic search and embedding are
@@ -67,7 +68,7 @@ projection and the same behavior the project tests and benchmarks against.
    than under `/mnt/c`; cross-OS filesystem access through `/mnt/*` is
    noticeably slower and does not support the projection layer cleanly.
 
-## Native Windows binary (repository-free only)
+## Native Windows binary
 
 If you only need the core CLI and cannot use WSL2, install with PowerShell:
 
@@ -75,12 +76,19 @@ If you only need the core CLI and cannot use WSL2, install with PowerShell:
 irm https://get.kinlab.dev/install.ps1 | iex
 ```
 
-The installer prints the admission limitation before downloading, verifies the
-download's SHA-256 checksum, and installs the x86_64 CLI release shape. It does
-not run repository setup or claim a usable native repository. The archive
-carries semantic vector search but does not provide transparent filesystem
-projection; native Windows health reports repository, daemon, semantic-query,
-and VFS readiness as missing or unsupported.
+The installer prints the current support boundary before downloading, verifies
+the download's SHA-256 checksum, and installs the x86_64 CLI release shape. The
+archive carries semantic vector search but does not provide transparent
+filesystem projection, so `kin setup status` reports VFS readiness as
+unsupported on native Windows. Health checks run outside a Kin repository
+report repository, daemon, and semantic-query readiness as missing because they
+are repo-scoped; run them from inside an admitted repository.
+
+Git for Windows sets `core.autocrlf=true` in its system config, which rewrites
+line endings on checkout. `kin init` admits only a worktree whose bytes match
+the committed tree, so it refuses a repository cloned that way with `tracked
+blob ... bytes differ from the committed tree`. Run `git config --global
+core.autocrlf false` and clone again.
 
 No native Windows ARM64 archive is published. Use WSL2, or run x64 PowerShell
 under Windows x64 emulation to install the x86_64 archive for repository-free

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@ Kin coexists with Git and projects graph-owned truth back to a normal filesystem
 - [npm — MCP wrapper](https://www.npmjs.com/package/@kinlab/kin-mcp): `npx @kinlab/kin-mcp`
 - [GitHub Releases](https://github.com/firelock-ai/kin/releases): prebuilt binaries + checksums for macOS, Linux, and Windows
 
-Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories.
+Native Windows x86_64 support is early. Repository admission works: `kin init` imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience.
 
 ## First run (macOS, Linux, or WSL2)
 

--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -16,10 +16,10 @@ npx -y @kinlab/kin --version
 npx -y @kinlab/kin setup --intent agent --no-interactive
 ```
 
-Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories.
+Native Windows x86_64 support is early. Repository admission works: `kin init` imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience.
 No native Windows ARM64 archive is published. An x64 Node process under Windows
-emulation can provision the x86_64 archive for diagnostics; use WSL2 for the
-repository workflow documented below.
+emulation can provision the x86_64 archive; use WSL2 for the repository workflow
+documented below.
 
 ## What it does
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -48,7 +48,7 @@ function Test-KinTruthy([string]$Value) {
     return @("1", "true", "yes", "on") -contains $Value.Trim().ToLowerInvariant()
 }
 
-$NativeWindowsSupportNotice = "Native Windows x86_64 can install and run repository-free CLI diagnostics, but repository admission is currently unavailable: kin init fails closed, so graph, lexical, daemon, repository setup, MCP, and review workflows are unsupported. Use WSL2 for usable Kin repositories."
+$NativeWindowsSupportNotice = "Native Windows x86_64 support is early. Repository admission works: kin init imports a Git repository and publishes graph authority, and graph, lexical, and daemon-backed queries answer natively. Transparent filesystem projection is not shipped on Windows, and the end-to-end install proof does not yet cover MCP or review workflows there, so WSL2 remains the recommended path for the full Kin experience. If kin init reports that tracked bytes differ from the committed tree, Git for Windows checked the repository out with core.autocrlf=true from its system config; run 'git config --global core.autocrlf false' and clone again."
 
 function Resolve-KinWindowsArchiveArchitecture {
     param(


### PR DESCRIPTION
The shipped native-Windows support notice told every Windows user that repository admission was unavailable, that `kin init` fails closed, and that graph, lexical, daemon, and repository setup workflows were unsupported. That is false on the current release. Admission publishes complete graph authority on native Windows, and those queries answer from it. The paragraph sat verbatim on six public surfaces, including `llms.txt`, which is what agents read, and the live installer at get.kinlab.dev serves it before any download.

## What changed

Each clause was given its own verdict against measured behavior on a live Windows guest running the published `kin-windows-x86_64.zip`, verified against the release checksum sidecar, rather than being edited wholesale.

Removed as false:
- repository admission is unavailable / `kin init` fails closed
- graph, lexical, daemon, and repository setup workflows are unsupported

Kept because still true:
- native Windows support is early
- transparent filesystem projection is not shipped there
- WSL2 remains the recommended path

Stated instead of the removed text: the end-to-end install proof does not yet cover MCP or review workflows on native Windows. Those two were in the original list and are genuinely not established, so they are described as uncovered rather than as working.

`README.md` separately claimed the Windows archive ships without semantic vector search, while `docs/windows-wsl2.md`, `docs/security/signing-and-update-trust.md`, and `packages/kin-mcp/README.md` all described the same archive as carrying it. The repository contradicted itself. The archive is built with the same default feature set as the other platforms and reports `vector` and `embeddings` among its compiled features, so the README claims were removed as the incorrect half.

The Git for Windows line-ending default is now documented where a user first meets it. `core.autocrlf` is set in Git's **system** configuration, so `git config --global core.autocrlf` prints empty while checkout still rewrites tracked bytes, and admission then refuses the worktree. The failure is loud and correct, but the error does not name the remedy.

## Scope held deliberately

This change removes false statements. It does not add a capability claim.

Native Windows semantic vector search was exercised end to end and worked, but that measurement came from an ARM64 guest running the x86_64 build under emulation, so no copy here asserts that vector search works on native Windows. No latency or throughput figures are included.

The drift guard is intentionally left alone. `assert_windows_public_support_contract` in `scripts/test-release-workflow-authority.py` is defined once and called nowhere, and it reads a `PUBLIC_SUPPORT_NOTICE` binding that no longer exists in the file it reads from, so it would raise immediately if it were wired up. That is why six surfaces went stale with nothing turning red. Re-arming it requires rewriting the five phrases it pins, which is a separate change and is tracked separately.

`scripts/install.ps1` was parsed on a real Windows host after editing to confirm the notice string still compiles.

Closes FIR-1967
