### PR TITLE
Syntax-check install.sh on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,18 @@ jobs:
           bash -n ./scripts/verify-npm-release.sh
           bash -n ./scripts/assert-windows-init-contract.sh
           bash -n ./scripts/verify-base-image-pins.sh
+          # install.sh is the public installer users pipe straight into a shell,
+          # and the one with no pull-request syntax check. Its only `sh -n` runs
+          # in publish-release-installers.yml, which triggers on `workflow_run`
+          # after Release completes, so it cannot fail until a tag exists and a
+          # tag cannot be un-cut. `#!/usr/bin/env sh` is why this is `sh -n` and
+          # not the `bash -n` used for the bash-only scripts above.
+          #
+          # install.ps1 needs no line here. scripts/test-install-checksum.ps1
+          # parses it on every pull request in windows-authority-tests, under
+          # both PowerShell 7 and Windows PowerShell 5.1, and that job is held
+          # unconditional by the release-authority test.
+          sh -n ./scripts/install.sh
 
   windows-authority-tests:
     name: Windows authority tests


### PR DESCRIPTION
## Correction to this PR's original premise

The first revision claimed **neither** installer is parsed on a pull request and added
checks for both. **That was half wrong, and the error is instructive.**

`install.ps1` **is** parsed on every pull request. `scripts/test-install-checksum.ps1:74`
calls `[Parser]::ParseFile` on it and throws on any parse error, and that script runs in
the `windows-authority-tests` job under **both** PowerShell 7 and Windows PowerShell 5.1.
Neither the job nor either step carries an `if:`, and the release-authority test enforces
that the job stays unconditional.

The original search looked for `ParseFile`, `PSScriptAnalyzer`, `pwsh -`, `sh -n`,
`bash -n` and `shellcheck` **in `.github/workflows/*.yml` only**. The parse lives inside a
script the workflow *calls*, so no grep over workflow files could ever have found it. An
absence in the workflow files is not an absence in CI. Re-running the same search across
`*.ps1`, `*.py`, `*.sh`, `*.mjs`, `*.js`, `*.cjs` and `*.yml` found it immediately.

The `install.ps1` half of this change is therefore withdrawn as redundant. Adding it
would also have shipped a comment asserting something false about CI coverage, which is
precisely the defect class FIR-1979 was opened for.

## What remains, and is real

**`install.sh` has no pull-request syntax check.** Its only `sh -n` is
`publish-release-installers.yml:175`, whose trigger is:

```yaml
on:
  workflow_run:
    workflows: ["Release"]
    types: [completed]
```

That runs only after Release completes, so it cannot fail until a tag exists — and a tag
cannot be un-cut. A syntax error in `install.sh` passes every PR check, lands on `main`,
survives into a tag, and is first detected by the publish follow-up, where the cheapest
recovery is a whole new release.

The asymmetry still stands, and is the reason this is worth fixing: the same step already
runs `bash -n` on four internal release scripts — `publish-npm-release.sh`,
`verify-npm-release.sh`, `assert-windows-init-contract.sh`, `verify-base-image-pins.sh` —
none of which any user executes. The one file every Unix user pipes straight into a shell
was the omission.

## What changed

One command, in the existing syntax-check block in `npm-launchers`:

```sh
sh -n ./scripts/install.sh
```

`install.sh` is `#!/usr/bin/env sh`. Checking a POSIX shell script with `bash -n` would
accept bashisms the real interpreter rejects, so it takes `sh -n` rather than the
`bash -n` used above it.

## Falsification

Verified under **both** busybox `ash` and Debian `dash`; the latter is what `/bin/sh` is
on Ubuntu runners. macOS `sh` is bash-in-sh-mode and would have been the wrong
interpreter to trust.

| Case | busybox `ash` | Debian `dash` |
| --- | --- | --- |
| real file | exit 0 | exit 0 |
| unterminated string planted | **exit 2**, `Syntax error: "(" unexpected` | **exit 2**, same |
| path does not exist | **exit 2**, `cannot open` | **exit 2**, same |

The wrong-path case matters because the publish copy reads `release-source/scripts/` and
this one reads `scripts/`; a check aimed at a path that does not exist must fail rather
than report success. It fails.

`actionlint` passes, and was itself falsified — a deliberately bad runner label makes it
exit 1, so the pass is evidence rather than a no-op.

## Verification

- `scripts/test-release-workflow-authority.py`: exit 0 (it pins `ci.yml`)
- `actionlint .github/workflows/ci.yml`: exit 0
- `test_install_optional_vfs.py`, `test_installer_parity.py`,
  `test-npm-automatic-release.py`, `test-verify-npm-release.py`: all exit 0

## Not claiming

That `install.sh` is currently broken — it parses clean today. This closes the window in
which a broken one could reach a tag. No `${{ }}` interpolation is introduced, so no
workflow-injection surface is added.

Closes FIR-1987

