### PR TITLE
Fail closed when a release gate assertion is defined but never runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,6 +776,14 @@ jobs:
       - name: Validate installer checksum fixtures
         run: python3 scripts/test-install-checksum.py
 
+      # Runs before the suites it polices: a gate whose assertion lost its call
+      # site still exits 0, so passing those suites proves nothing until this
+      # step confirms every check in them is still reachable and still runs on
+      # pull requests. scripts/test-release-workflow-authority.py asserts this
+      # step exists, so the pair cannot be half-removed.
+      - name: Validate that every release gate assertion still runs
+        run: python3 scripts/test-assertion-reachability.py
+
       - name: Validate mandatory Homebrew release outcome gate
         run: python3 scripts/test-homebrew-release-gate.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,11 +776,15 @@ jobs:
       - name: Validate installer checksum fixtures
         run: python3 scripts/test-install-checksum.py
 
-      # Runs before the suites it polices: a gate whose assertion lost its call
-      # site still exits 0, so passing those suites proves nothing until this
-      # step confirms every check in them is still reachable and still runs on
-      # pull requests. scripts/test-release-workflow-authority.py asserts this
-      # step exists, so the pair cannot be half-removed.
+      # A gate whose assertion lost its call site still exits 0, so passing the
+      # suites this polices proves nothing until this step confirms every check
+      # in them is still reachable and still runs on pull requests. Ordering is
+      # not what makes that true and is not claimed: this step precedes the
+      # other two within this job, but test-release-workflow-authority.py also
+      # runs in the npm-launchers job, which shares no dependency with this one,
+      # so the two are unordered. Either way a red gate reds the pull request.
+      # scripts/test-release-workflow-authority.py asserts this step exists, so
+      # the pair cannot be half-removed.
       - name: Validate that every release gate assertion still runs
         run: python3 scripts/test-assertion-reachability.py
 

--- a/scripts/test-assertion-reachability.py
+++ b/scripts/test-assertion-reachability.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Fail closed when a gate's assertion is defined but nothing ever runs it.
+
+A guard that cannot run is indistinguishable from a guard that passes. The
+release authority suite lost `assert_windows_public_support_contract` to a
+stale-base merge: one pull request added the helper plus its call site, a
+second branched before it and merged after, and the squash removed the call
+site while leaving the definition behind. No conflict, no red, nothing to
+review, and a Windows public-support claim went unpoliced.
+
+This gate makes that condition visible. For every covered suite it answers two
+questions the suites cannot answer about themselves:
+
+1. Is every `assert_*` / `test_*` helper reachable from code that actually
+   executes? Reachability, not mere mention: a cluster of helpers that only
+   call each other is still dead.
+2. Is the suite itself invoked from a pull-request-triggered CI job? A suite
+   that runs only after merge polices nothing at review time.
+
+The second question is what keeps this file honest. `ci.yml` runs this gate,
+and the release authority suite asserts that wiring exists, so neither gate can
+be removed without the other going red.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = ROOT / ".github" / "workflows"
+CI = WORKFLOWS / "ci.yml"
+
+# Prefixes that name a check rather than a plumbing helper. An orphaned
+# `assert_*` or `test_*` is a policy that silently stopped being enforced; an
+# orphaned formatting helper is merely dead code and is not this gate's job.
+HELPER_PREFIXES = ("assert_", "test_")
+
+COVERED_SUITES = (
+    "scripts/test-release-workflow-authority.py",
+    "scripts/test-homebrew-release-gate.py",
+    "scripts/test-assertion-reachability.py",
+)
+
+
+def strip_docstrings(tree: ast.AST) -> None:
+    """Drop docstrings so a prose mention cannot pass for a call site.
+
+    Comments never reach the AST, so a `# see assert_foo` note cannot keep a
+    dead helper alive. Docstrings are string constants and would, which would
+    let a helper documented but never invoked read as reachable.
+    """
+
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list) or not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            del body[0]
+
+
+def referenced_names(nodes: list[ast.AST]) -> set[str]:
+    """Every name the given code could resolve a function through.
+
+    Deliberately wider than "calls". A helper is counted as used when it is
+    named at all: called directly, passed bare into a dispatch table, wrapped
+    in a `lambda`, applied as a decorator, or reached through `getattr` with a
+    literal string. Narrowing this to `ast.Call` would flag the 49 table-
+    registered `test_*` helpers in the Homebrew gate, and a gate that cries
+    wolf gets switched off, which recreates the bug it was built to prevent.
+
+    A name used only through a computed string (`getattr(mod, "assert_" + x)`)
+    is invisible here by construction. Naming it in a module-level tuple of
+    strings is enough to record the use, because an exact string constant
+    counts as a reference.
+    """
+
+    names: set[str] = set()
+    for root in nodes:
+        for node in ast.walk(root):
+            if isinstance(node, ast.Name):
+                names.add(node.id)
+            elif isinstance(node, ast.Attribute):
+                names.add(node.attr)
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                names.add(node.value)
+    return names
+
+
+def orphaned_helpers(source: str, label: str) -> list[str]:
+    """Return the covered helpers unreachable from code that executes.
+
+    Roots are the module's own top-level statements, which is what the
+    interpreter runs on import. Everything else is reached, or is not.
+    """
+
+    tree = ast.parse(source, filename=label)
+    strip_docstrings(tree)
+
+    functions: dict[str, ast.AST] = {}
+    module_statements: list[ast.AST] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions[node.name] = node
+        else:
+            module_statements.append(node)
+
+    edges = {name: referenced_names([node]) for name, node in functions.items()}
+
+    reachable: set[str] = set()
+    pending = [name for name in referenced_names(module_statements) if name in functions]
+    while pending:
+        name = pending.pop()
+        if name in reachable:
+            continue
+        reachable.add(name)
+        pending.extend(
+            ref for ref in edges[name] if ref in functions and ref not in reachable
+        )
+
+    return sorted(
+        name
+        for name in functions
+        if name.startswith(HELPER_PREFIXES) and name not in reachable
+    )
+
+
+def invokes(workflow: str, suite: str) -> bool:
+    """Whether a workflow line actually runs the suite.
+
+    Exact match on the whole line, not a search for the path. A workflow can
+    name a script in a comment, in a step name, or as `run: # python3 <path>`,
+    and every one of those leaves the path present while running nothing. The
+    suite is invoked either as its own line inside a `run: |` block or as the
+    scalar of a one-line `run:`, so those are the two forms that count.
+    """
+
+    command = f"python3 {suite}"
+    accepted = {command, f"run: {command}", f"python3 ./{suite}"}
+    return any(line.strip() in accepted for line in workflow.splitlines())
+
+
+def assert_no_orphaned_helpers(suite: str) -> None:
+    path = ROOT / suite
+    if not path.is_file():
+        raise AssertionError(f"covered suite is missing: {suite}")
+    orphans = orphaned_helpers(path.read_text(encoding="utf-8"), suite)
+    if orphans:
+        raise AssertionError(
+            f"{suite} defines checks nothing runs: {', '.join(orphans)}. "
+            "Restore the call site, delete the helper, or - if it is reached "
+            "through a computed name - record that use in a module-level tuple "
+            "of strings."
+        )
+
+
+def assert_suite_runs_on_pull_requests(suite: str, ci_source: str) -> None:
+    """A suite that no pull request runs cannot stop anything from landing."""
+
+    header = ci_source.split("\njobs:", maxsplit=1)[0]
+    if "pull_request:" not in header:
+        raise AssertionError("ci.yml no longer runs on pull requests")
+    if not invokes(ci_source, suite):
+        raise AssertionError(
+            f"ci.yml has no step running {suite}; a gate that runs nowhere "
+            "reports green for a policy it never checked"
+        )
+
+
+ORPHAN_FIXTURE = textwrap.dedent(
+    '''
+    """A suite whose helper lost its call site to a stale-base merge."""
+
+    def assert_reached(value):
+        raise AssertionError(value)
+
+
+    def assert_stranded(value):
+        raise AssertionError(value)
+
+
+    def main():
+        assert_reached("checked")
+
+
+    main()
+    '''
+)
+
+INDIRECTION_FIXTURE = textwrap.dedent(
+    '''
+    """Every reference style this gate must treat as a live call site."""
+
+    def assert_called_directly(value):
+        raise AssertionError(value)
+
+
+    def assert_registered_in_a_table(value):
+        raise AssertionError(value)
+
+
+    def assert_wrapped_in_a_lambda(value):
+        raise AssertionError(value)
+
+
+    def assert_named_for_getattr(value):
+        raise AssertionError(value)
+
+
+    def assert_reached_only_through_a_helper(value):
+        raise AssertionError(value)
+
+
+    def run_indirectly(value):
+        assert_reached_only_through_a_helper(value)
+
+
+    DYNAMIC_USE = ("assert_named_for_getattr",)
+
+    CHECKS = (assert_registered_in_a_table,)
+
+
+    def main():
+        assert_called_directly("direct")
+        for check in CHECKS:
+            check("table")
+        deferred = lambda: assert_wrapped_in_a_lambda("lambda")
+        deferred()
+        for name in DYNAMIC_USE:
+            globals()[name]("getattr")
+        run_indirectly("helper")
+
+
+    main()
+    '''
+)
+
+MUTUAL_ORPHAN_FIXTURE = textwrap.dedent(
+    '''
+    """Two helpers that call only each other are still dead."""
+
+    def assert_ping(value):
+        assert_pong(value)
+
+
+    def assert_pong(value):
+        assert_ping(value)
+
+
+    def main():
+        return None
+
+
+    main()
+    '''
+)
+
+
+def assert_detector_reports_a_stranded_helper() -> None:
+    orphans = orphaned_helpers(ORPHAN_FIXTURE, "orphan-fixture")
+    if orphans != ["assert_stranded"]:
+        raise AssertionError(
+            f"detector must name the stranded helper alone, reported: {orphans}"
+        )
+
+
+def assert_detector_ignores_indirect_call_sites() -> None:
+    orphans = orphaned_helpers(INDIRECTION_FIXTURE, "indirection-fixture")
+    if orphans:
+        raise AssertionError(
+            f"detector cried wolf on live indirect call sites: {orphans}"
+        )
+
+
+def assert_wiring_check_rejects_a_disabled_step() -> None:
+    """A named-but-not-run script must not read as wired."""
+
+    suite = "scripts/example-gate.py"
+    wired = (
+        "      - name: Validate example gate\n"
+        f"        run: python3 {suite}\n"
+    )
+    if not invokes(wired, suite):
+        raise AssertionError("wiring check missed a real one-line run: step")
+    if not invokes(f"        run: |\n          python3 {suite}\n", suite):
+        raise AssertionError("wiring check missed a real run-block invocation")
+
+    disabled = {
+        "commented-out step": f"        # run: python3 {suite}\n",
+        "commented-out command": f"        run: # python3 {suite}\n",
+        "mention in a step name": f"      - name: replaces {suite}\n",
+        "mention in a comment": f"      # {suite} used to run here\n",
+    }
+    for label, workflow in disabled.items():
+        if invokes(workflow, suite):
+            raise AssertionError(f"wiring check accepted a {label}")
+
+
+def assert_detector_reports_a_mutually_recursive_cluster() -> None:
+    orphans = orphaned_helpers(MUTUAL_ORPHAN_FIXTURE, "mutual-orphan-fixture")
+    if orphans != ["assert_ping", "assert_pong"]:
+        raise AssertionError(
+            f"detector must report a closed unreachable cluster, reported: {orphans}"
+        )
+
+
+def main() -> None:
+    # Prove the detector still discriminates before trusting it on real files.
+    # A gate that reports nothing and a gate that reports everything are both
+    # useless, and only a falsification arm tells the two apart.
+    assert_detector_reports_a_stranded_helper()
+    assert_detector_ignores_indirect_call_sites()
+    assert_detector_reports_a_mutually_recursive_cluster()
+    assert_wiring_check_rejects_a_disabled_step()
+
+    ci_source = CI.read_text(encoding="utf-8")
+    for suite in COVERED_SUITES:
+        assert_no_orphaned_helpers(suite)
+        assert_suite_runs_on_pull_requests(suite, ci_source)
+
+    print(
+        f"{len(COVERED_SUITES)} gate suites run on pull requests and define no "
+        "check that nothing calls"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except AssertionError as error:
+        print(f"assertion reachability gate failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -57,6 +57,8 @@ ABANDONED_TAGS = ROOT / "scripts" / "abandoned-release-tags.json"
 TAG_SELECTOR = ROOT / "scripts" / "select-admissible-release-tag.py"
 ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
 TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
+ASSERTION_REACHABILITY = ROOT / "scripts" / "test-assertion-reachability.py"
+ASSERTION_REACHABILITY_POLICY = "scripts/test-assertion-reachability.py"
 TRUSTED_POLICY_PREFIX = "refs/remotes/origin/main:"
 TAG_LISTING_FORMAT = (
     "--format='%(refname:strip=2) "
@@ -3122,6 +3124,40 @@ def real_check_job_authority_source(job: str) -> str:
         if len(line) - len(line.lstrip()) == 2
     )
     return "\n".join(authority)
+
+
+def assert_assertion_reachability_gate_wired(workflow: str) -> None:
+    """Keep the gate that proves this suite's own checks are reachable.
+
+    This suite cannot notice that one of its assertions stopped being called;
+    that is how `assert_windows_public_support_contract` sat defined and
+    unreferenced after a stale-base merge removed its call site. A separate
+    gate answers that question, and this assertion is the other half of the
+    pair: the reachability gate reports an orphaned check in this file, and
+    this check reports a reachability gate that CI no longer runs. Removing
+    either one turns the other red, so neither can be lost quietly.
+    """
+
+    # Match the invocation exactly rather than searching for the path. A
+    # substring search accepts `run: # python3 <path>`, which leaves the path
+    # in a line that does not itself start with `#` while running nothing.
+    # active_lines() is the wrong tool here for a second reason: it strips
+    # `/* */` for the shell and JavaScript it is normally handed, and ci.yml
+    # holds a bare `docs/*` glob and a later `**/Cargo.lock` that the pattern
+    # spans as one 24KB comment, taking most of the check job with it.
+    command = f"python3 {ASSERTION_REACHABILITY_POLICY}"
+    invocations = {command, f"run: {command}"}
+    if not any(line.strip() in invocations for line in workflow.splitlines()):
+        raise AssertionError(
+            "ci.yml must run "
+            f"{ASSERTION_REACHABILITY_POLICY}; without it an assertion can lose "
+            "its call site and keep reporting green"
+        )
+    if not ASSERTION_REACHABILITY.is_file():
+        raise AssertionError(
+            f"{ASSERTION_REACHABILITY_POLICY} is missing; the release gates "
+            "would no longer prove their own checks run"
+        )
 
 
 def assert_check_consumer_authority(workflow: str) -> None:
@@ -9041,6 +9077,34 @@ def main() -> None:
     classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(ci_workflow)
+    assert_assertion_reachability_gate_wired(ci_workflow)
+    expect_assertion(
+        "ci.yml drops the step that proves every assertion still runs",
+        "ci.yml must run",
+        lambda: assert_assertion_reachability_gate_wired(
+            ci_workflow.replace(ASSERTION_REACHABILITY_POLICY, "scripts/absent.py")
+        ),
+    )
+    expect_assertion(
+        "the reachability gate survives only as a commented-out ci.yml step",
+        "ci.yml must run",
+        lambda: assert_assertion_reachability_gate_wired(
+            ci_workflow.replace(
+                f"run: python3 {ASSERTION_REACHABILITY_POLICY}",
+                f"# run: python3 {ASSERTION_REACHABILITY_POLICY}",
+            )
+        ),
+    )
+    expect_assertion(
+        "the reachability step keeps its path but comments out the command",
+        "ci.yml must run",
+        lambda: assert_assertion_reachability_gate_wired(
+            ci_workflow.replace(
+                f"run: python3 {ASSERTION_REACHABILITY_POLICY}",
+                f"run: # python3 {ASSERTION_REACHABILITY_POLICY}",
+            )
+        ),
+    )
     assert_check_consumer_authority(ci_workflow)
     consumer_blocks = workflow_job_blocks(ci_workflow)
     docs_only_check = consumer_blocks["check-docs-only"]


### PR DESCRIPTION
Closes FIR-1979
Closes FIR-1944

## The class, not the instance

`assert_windows_public_support_contract` sat defined and uncalled in the release authority suite. PR #584 added the helper, its call site and eight falsification arms. PR #582 branched before #584 and merged a day later; its squash removed the call site and all eight arms while leaving the definitions behind. No conflict, no red, nothing to review — and a Windows public-support claim went unpoliced.

kin#634 wires that one helper back up. It fixes the instance. Nothing in it would catch the next one, and the next one arrives the same way: a guard that cannot run is indistinguishable from a guard that passes.

This adds `scripts/test-assertion-reachability.py`, which answers the two questions a gate suite cannot answer about itself:

1. Is every `assert_*` / `test_*` helper **reachable from code that executes**?
2. Is the suite **invoked by a job that pull requests actually run**?

Covers the release authority suite, the Homebrew release gate, and itself.

## Why the AST, not grep

A textual search cannot tell a definition from a call, so `grep 'name('` matches the `def` line and reports every helper healthy. Narrowing it to call syntax fails the other way: the Homebrew gate registers **49** `test_*` helpers as bare names in a dispatch tuple and calls them through a loop variable, so a call-syntax check would report all 49 as orphans on day one. A gate that cries wolf gets switched off, which recreates the bug it exists to prevent.

The AST gives exact name binding. Deliberately permissive about what counts as a use — direct call, table entry, `lambda`, decorator, or a literal string for `getattr`. A name reached only through a computed string is invisible by construction; listing it in a module-level tuple of strings is enough to record the use, and the failure message says so.

Two refinements beyond "is it mentioned":

- **Reachability from module roots**, not mere mention, so a cluster of helpers that only call each other is still reported dead.
- **Docstrings dropped**, so prose cannot pass for a call site. Comments never reach the AST anyway; this makes docstrings behave the same way.

## Closing the loop

A new gate is itself a candidate for the bug it polices. So the two halves police each other:

- `ci.yml` runs the reachability gate, and it checks its own wiring plus both suites'.
- The authority suite asserts that `ci.yml` runs the reachability gate.

Removing either half turns the other red.

Both wiring checks match the invocation as a **whole line**. A falsification arm caught this during development: searching for the script path accepts `run: # python3 <path>`, which leaves the path present on a line that does not itself start with `#`, while running nothing.

## A latent hazard found on the way

`active_lines()` is deliberately not used to read `ci.yml`. It strips `/* */` with `re.DOTALL` for the shell and JavaScript it is normally handed. `ci.yml` holds a bare `docs/*` glob at line 697 and a later `**/Cargo.lock` at line 1183, which that pattern spans as one comment — **deleting 23,927 characters**, most of the `check` job, before any assertion sees it.

Every existing caller passes a small job or step block, so no current assertion is affected and nothing here changes `active_lines()`. Flagging it because the next whole-file caller inherits a check that silently reasons about a mutilated document. Worth a follow-up ticket; not fixed here, since changing it mid-release would alter 25 call sites' behavior.

## Falsification

Two-sided, because a check that flags everything is as useless as one that flags nothing.

Stranding each helper in turn — redirecting every reference away from it, as the real squash did — is caught, each reported **by name**:

| suite | helpers | stranded and caught | missed | orphans at rest |
|---|---|---|---|---|
| release authority | 48 | **48 / 48** | 0 | 0 |
| Homebrew gate | 52 | **52 / 52** | 0 | 0 |

Removing a *single* call site of a helper that has several correctly does **not** fire; `assert_check_consumer_authority` has 7 references and `assert_docs_only_classifier_guard` has 10, and both stay reachable until the last one goes.

Run against unmodified `main`, the gate independently rediscovers the original defect and names exactly one function out of 48:

```
scripts/test-release-workflow-authority.py defines checks nothing runs:
assert_windows_public_support_contract
```

The gate also carries its own falsification arms, run every time it runs in CI, so its ability to discriminate is proven continuously rather than once.

## Merge order

kin#634 has landed (`58c0f85e`), and this branch is rebased onto current `main`
(`1c239a84`, v0.5.5). The orphan this gate was built to catch is therefore
already wired back up, and the earlier expectation that CI here would be red for
exactly that reason no longer applies.

Verified on the rebased tree, not on a computed merge:

- `test-assertion-reachability.py` -> `3 gate suites run on pull requests and define no check that nothing calls`
- `test-release-workflow-authority.py` -> pass
- `test-homebrew-release-gate.py` -> `49 Homebrew release gate tests passed`

The reciprocal pair was falsified live on that same tree: replacing the
`test-assertion-reachability.py` invocation in `ci.yml` with `echo skipped`
turns the authority suite red naming the missing invocation, and restoring it
turns it green again.

## Ordering claim withdrawn

A second commit softens the step comment in `ci.yml`. It said the gate runs
before the suites it polices, which is true inside job `check` but not in
general: `test-release-workflow-authority.py` also runs in job `npm-launchers`,
the two jobs share only `needs: changes`, and nothing orders them. The guarantee
never came from ordering. A red gate reds the pull request whichever job
finishes first, and that is what the comment now says.

Two non-blocking follow-ups from verification are filed as FIR-2004: an
informational report class for transitively-dead non-gate helpers, and an
`except SyntaxError` arm so an unparseable covered suite fails closed with the
gate's own message instead of a traceback.

## Not claiming

The CI-wiring check confirms `ci.yml` triggers on `pull_request` and contains the invocation. It does not parse job-level `if:` conditions, so a step moved behind a push-only guard would still read as wired. Narrower than the reachability check by design, and stated rather than overclaimed.

