### PR TITLE
Make the daemon pid-file assertion wait, and prove the leak is not a race

### DIFF
--- a/crates/kin-cli/tests/daemon_stop.rs
+++ b/crates/kin-cli/tests/daemon_stop.rs
@@ -67,6 +67,24 @@ fn wait_until_dead(pid: u32, timeout: Duration) {
     }
 }
 
+/// Wait for a path to disappear, the file-side analogue of `wait_until_dead`.
+///
+/// Process death and pid-file removal are two different events. The exiting
+/// daemon unlinks its own pid file, so a parent that has only observed the
+/// process leave can still see the path for a short window, and on Windows an
+/// open handle keeps an unlinked name visible for longer than it does on Unix.
+/// Asserting the file is gone the instant the process is gone therefore fails
+/// intermittently while describing the failure as a product defect.
+///
+/// This still fails when the file genuinely never goes away: the caller asserts
+/// after the wait, so a real leak times out and reports exactly as before.
+fn wait_until_gone(path: &Path, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 #[test]
 fn daemon_status_and_stop_lifecycle() {
     let root = tempfile::tempdir().expect("temp root");
@@ -140,6 +158,7 @@ fn daemon_status_and_stop_lifecycle() {
         !is_process_alive(worker_pid),
         "worker daemon pid {worker_pid} still alive after `kin daemon stop`"
     );
+    wait_until_gone(&pid_path, Duration::from_secs(5));
     assert!(
         !pid_path.exists(),
         "daemon.pid must be cleared after a confirmed stop"


### PR DESCRIPTION
Refs FIR-1991

## What this PR now establishes, which is not what it set out to do

`daemon_status_and_stop_lifecycle` asserted `daemon.pid` was gone immediately
after observing the worker process exit, with no wait between the two events.
The obvious reading was a race: the daemon unlinks its own pid file, and on
Windows an open handle can keep an unlinked name visible briefly, so a parent
that has only seen the process leave might still see the path.

**That reading is wrong, and this PR is the evidence.** The change adds
`wait_until_gone`, a bounded wait mirroring the `wait_until_dead` helper above
it, and gives the pid file five seconds to disappear before asserting. On this
PR the Windows authority tests still failed, at the same assertion:

```
thread panicked at crates\kin-cli\tests\daemon_stop.rs:162:5:
  daemon.pid must be cleared after a confirmed stop
```

The wait ran, exhausted its full deadline, and the file was still there. A
sub-second visibility window cannot explain a file that survives five seconds.
**`kin daemon stop` reports a confirmed stop and leaves `daemon.pid` behind.**

This is corroborated on another platform. On macOS, `kin daemon stop` was
observed returning zero while both the supervisor and the per-repo daemon
remained alive and had to be reaped by pid. The same shape appears in both
places: the stop path reports success before its cleanup is complete.

## What to do with this change

It is worth keeping on its own merits even though it does not make the test
green:

- It removes the timing hypothesis as a confound. Any future failure of this
  assertion is now known not to be a short visibility window, because the test
  waits.
- It fails loud rather than vacuously. Driving the wait against a path that
  never disappears exhausts the deadline and fires the assertion, rather than
  passing; the assertion keeps its full strength.
- The failure it reports is a real product defect, so the assertion is correct
  to fail. The test is not what needs fixing first.

The nearby `supervisor.pid` assertion is deliberately unchanged. It asserts a
file was never created at all, so waiting there would weaken it.

This does not close FIR-1991. The remaining work is in the daemon stop path,
not in the test.