### PR TITLE
Wait for the daemon to die before retiring its endpoint, and report a survivor

### DIFF
--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1487,7 +1487,14 @@ fn finish_stop_with_output(
             failed.join(", ")
         );
     }
-    if !endpoints_retired {
+    // Deliberately NOT raised on the quiet path. `quiet` is full uninstall's
+    // nested stop, and uninstall's job is to leave no PROCESS running: it
+    // re-verifies exactly that through its own quiescence fence, which reads
+    // processes and not endpoint records. A leftover pid file inside some repo
+    // does not keep an install alive, and refusing to uninstall over one would
+    // turn a reporting improvement into a command the operator cannot complete.
+    // A surviving process still fails uninstall, above, as it always has.
+    if !quiet && !endpoints_retired {
         // The process died and its endpoint did not, so `status`, autostart, and
         // every other reader of `daemon.pid` still see a published owner for this
         // repo. Reporting success here is what made the failure invisible.
@@ -1507,6 +1514,58 @@ fn finish_stop_with_output(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn stop_report(preserved: Option<PreservedDaemonEndpoint>) -> StopReport {
+        StopReport {
+            kind: "repo-daemon",
+            label: "repo".to_string(),
+            pid: 4242,
+            outcome: StopOutcome::Stopped,
+            preserved_endpoint: preserved,
+        }
+    }
+
+    /// A stop whose endpoint survived must fail, and must name the survivor.
+    #[test]
+    fn a_surviving_endpoint_fails_the_stop_and_names_the_pid_file() {
+        let preserved = crate::daemon_client::preserved_daemon_endpoint_for_test(
+            Path::new("/repo/.kin/daemon.pid"),
+            "recorded owner pid 4242 never became affirmatively dead",
+        );
+        let error = finish_stop_with_output(
+            "current-repo",
+            &[stop_report(Some(preserved))],
+            false,
+            false,
+        )
+        .expect_err("a published endpoint outliving a confirmed stop is a failure");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("/repo/.kin/daemon.pid"),
+            "the operator needs the path, not just a verdict: {rendered}"
+        );
+
+        // The falsification: the identical report with nothing preserved passes,
+        // so the assertion above is about the survivor and not about the shape
+        // of the report.
+        finish_stop_with_output("current-repo", &[stop_report(None)], false, false)
+            .expect("a retired endpoint is a clean stop");
+    }
+
+    /// Full uninstall's nested stop must not be blocked by a leftover pid file.
+    /// Uninstall's contract is that no PROCESS survives, which it re-verifies
+    /// itself; refusing over an endpoint record would leave the operator unable
+    /// to complete the command.
+    #[test]
+    fn the_uninstall_path_is_not_blocked_by_a_surviving_endpoint() {
+        let preserved = crate::daemon_client::preserved_daemon_endpoint_for_test(
+            Path::new("/repo/.kin/daemon.pid"),
+            "recorded owner pid 4242 never became affirmatively dead",
+        );
+        finish_stop_with_output("all", &[stop_report(Some(preserved))], false, true)
+            .expect("a leftover endpoint record does not keep an install alive");
+    }
+
     #[cfg(windows)]
     use std::fs;
 

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -29,9 +29,9 @@ use crate::daemon_client::{
     process_identity_is_current, read_endpoint_owner_record, read_supervisor_owner_record,
     remove_stale_daemon_files, remove_stale_supervisor_files, repo_daemon_owner_path,
     repo_daemon_pid_path, repo_daemon_port_path, repo_daemon_recorded_endpoint,
-    supervisor_owner_path, supervisor_pid_path, supervisor_port_path, supervisor_recorded_endpoint,
-    try_acquire_supervisor_startup_lock_in_dir, ProcessIdentity, RegisteredRepoDaemon,
-    SupervisorStartupLock,
+    retire_stopped_daemon_endpoint, supervisor_owner_path, supervisor_pid_path,
+    supervisor_port_path, supervisor_recorded_endpoint, try_acquire_supervisor_startup_lock_in_dir,
+    PreservedDaemonEndpoint, ProcessIdentity, RegisteredRepoDaemon, SupervisorStartupLock,
 };
 
 /// Liveness of a recorded daemon/supervisor endpoint. Pure classification of the
@@ -885,6 +885,34 @@ struct StopReport {
     label: String,
     pid: u32,
     outcome: StopOutcome,
+    /// The endpoint this stop should have retired, when it survived the attempt.
+    ///
+    /// A stopped process whose `daemon.pid` is still published is not a stopped
+    /// daemon as far as any later reader is concerned: `status`, autostart, and
+    /// every other surface read that file to decide who owns the repo.
+    preserved_endpoint: Option<PreservedDaemonEndpoint>,
+}
+
+/// Retire the endpoint of a worker whose stop attempt is over, and hand back the
+/// survivor for the report.
+///
+/// A worker that was never running keeps the old best-effort hygiene: there was
+/// no teardown to wait out, and a record that outlives an unrelated process is
+/// not this command's failure to report.
+fn retire_worker_endpoint(
+    kin_root: &Path,
+    outcome: &StopOutcome,
+) -> Option<PreservedDaemonEndpoint> {
+    match outcome {
+        StopOutcome::Stopped => retire_stopped_daemon_endpoint(kin_root)
+            .preserved()
+            .cloned(),
+        StopOutcome::NotRunning => {
+            let _ = remove_stale_daemon_files(kin_root);
+            None
+        }
+        StopOutcome::Timeout | StopOutcome::SignalFailed(_) => None,
+    }
 }
 
 async fn stop_current_repo(json: bool) -> Result<()> {
@@ -904,7 +932,7 @@ async fn stop_current_repo(json: bool) -> Result<()> {
     let Some(pid) = pid else {
         // Nothing live to stop. Clear any stale endpoint files so a later status
         // does not report a dead endpoint.
-        remove_stale_daemon_files(&kin_root);
+        let _ = remove_stale_daemon_files(&kin_root);
         if json {
             let payload = serde_json::json!({
                 "schema": "kin.daemon-stop.v1",
@@ -921,14 +949,13 @@ async fn stop_current_repo(json: bool) -> Result<()> {
     };
 
     let outcome = stop_worker_at(&kin_root, pid, stop_timeout(), None)?;
-    if outcome.is_success() {
-        remove_stale_daemon_files(&kin_root);
-    }
+    let preserved_endpoint = retire_worker_endpoint(&kin_root, &outcome);
     let report = vec![StopReport {
         kind: "repo-daemon",
         label: label.clone(),
         pid,
         outcome,
+        preserved_endpoint,
     }];
     finish_stop("current-repo", &report, json)
 }
@@ -1031,6 +1058,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
                 label: "supervisor".to_string(),
                 pid,
                 outcome,
+                preserved_endpoint: None,
             });
         }
     }
@@ -1048,14 +1076,13 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
             remaining_budget(worker_deadline),
             uninstall_root,
         )?;
-        if outcome.is_success() {
-            remove_stale_daemon_files(&kin_root);
-        }
+        let preserved_endpoint = retire_worker_endpoint(&kin_root, &outcome);
         reports.push(StopReport {
             kind: "repo-daemon",
             label,
             pid: daemon.pid,
             outcome,
+            preserved_endpoint,
         });
     }
 
@@ -1075,14 +1102,13 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
                         remaining_budget(worker_deadline),
                         uninstall_root,
                     )?;
-                    if outcome.is_success() {
-                        remove_stale_daemon_files(&kin_root);
-                    }
+                    let preserved_endpoint = retire_worker_endpoint(&kin_root, &outcome);
                     reports.push(StopReport {
                         kind: "repo-daemon",
                         label: repo_label(&working_dir),
                         pid,
                         outcome,
+                        preserved_endpoint,
                     });
                 }
             }
@@ -1102,6 +1128,7 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
                 label: "supervisor".to_string(),
                 pid,
                 outcome,
+                preserved_endpoint: None,
             });
         }
     }
@@ -1323,14 +1350,13 @@ fn stop_install_owned_daemons(
                         remaining_budget(deadline),
                         Some(install_root),
                     )?;
-                    if outcome.is_success() {
-                        remove_stale_daemon_files(&kin_root);
-                    }
+                    let preserved_endpoint = retire_worker_endpoint(&kin_root, &outcome);
                     reports.push(StopReport {
                         kind: "repo-daemon",
                         label: repo_label(&repo_root),
                         pid: process.pid,
                         outcome,
+                        preserved_endpoint,
                     });
                 }
                 ManagedDaemonKind::Supervisor => {
@@ -1344,6 +1370,7 @@ fn stop_install_owned_daemons(
                         label: "supervisor".to_string(),
                         pid: process.pid,
                         outcome,
+                        preserved_endpoint: None,
                     });
                 }
                 ManagedDaemonKind::Unknown => bail!(
@@ -1381,6 +1408,11 @@ fn finish_stop_with_output(
     quiet: bool,
 ) -> Result<()> {
     let all_stopped = reports.iter().all(|r| r.outcome.is_success());
+    // Reported separately from `all_stopped`, which stays a statement about
+    // processes. A daemon can stop and still leave its endpoint published, and
+    // collapsing the two would reintroduce the ambiguity: every later reader
+    // treats `daemon.pid` as the live owner of the repo.
+    let endpoints_retired = reports.iter().all(|r| r.preserved_endpoint.is_none());
 
     if quiet {
         // The caller owns user-facing output. We still evaluate every result
@@ -1389,12 +1421,19 @@ fn finish_stop_with_output(
         let stopped: Vec<_> = reports
             .iter()
             .map(|r| {
-                serde_json::json!({
+                let mut entry = serde_json::json!({
                     "kind": r.kind,
                     "label": r.label,
                     "pid": r.pid,
                     "result": r.outcome.detail(),
-                })
+                });
+                if let Some(preserved) = &r.preserved_endpoint {
+                    entry["preserved_endpoint"] = serde_json::json!({
+                        "pid_path": preserved.pid_path().display().to_string(),
+                        "reason": preserved.reason(),
+                    });
+                }
+                entry
             })
             .collect();
         let payload = serde_json::json!({
@@ -1402,6 +1441,7 @@ fn finish_stop_with_output(
             "scope": scope,
             "stopped": stopped,
             "all_stopped": all_stopped,
+            "endpoints_retired": endpoints_retired,
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
@@ -1423,7 +1463,15 @@ fn finish_stop_with_output(
             };
             println!("  {line}");
         }
-        if all_stopped {
+        for r in reports {
+            if let Some(preserved) = &r.preserved_endpoint {
+                println!(
+                    "  {} (pid {}): endpoint NOT retired: {preserved}",
+                    r.label, r.pid
+                );
+            }
+        }
+        if all_stopped && endpoints_retired {
             println!("All targeted Kin daemons stopped.");
         }
     }
@@ -1437,6 +1485,20 @@ fn finish_stop_with_output(
         bail!(
             "one or more Kin daemons did not stop: {}",
             failed.join(", ")
+        );
+    }
+    if !endpoints_retired {
+        // The process died and its endpoint did not, so `status`, autostart, and
+        // every other reader of `daemon.pid` still see a published owner for this
+        // repo. Reporting success here is what made the failure invisible.
+        let preserved: Vec<String> = reports
+            .iter()
+            .filter_map(|r| r.preserved_endpoint.as_ref())
+            .map(PreservedDaemonEndpoint::to_string)
+            .collect();
+        bail!(
+            "Kin daemons stopped but their endpoints were not retired: {}",
+            preserved.join(", ")
         );
     }
     Ok(())

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2632,28 +2632,35 @@ pub fn retire_stopped_daemon_endpoint(kin_root: &Path) -> DaemonEndpointCleanup 
 }
 
 fn retire_daemon_endpoint(kin_root: &Path, teardown_budget: Duration) -> DaemonEndpointCleanup {
-    retire_daemon_endpoint_with_probe(kin_root, teardown_budget, process_liveness)
+    retire_daemon_endpoint_with_probe(kin_root, teardown_budget, |root, pid| {
+        // Judged against the recorded incarnation, not the bare PID. After the
+        // publisher exits, its number starts naming whatever the kernel handed
+        // it next, and a bare probe then reports a live stranger as the endpoint
+        // owner forever. Waiting a bounded window and then FAILING the stop over
+        // that would turn a recycled PID into a loud, permanent, wrong error on
+        // a command operators run constantly.
+        endpoint_owner_liveness(root, pid).authorizes_cleanup()
+    })
 }
 
-/// Wait, boundedly, for a process to become affirmatively dead, and answer with
-/// the last observation either way.
+/// Wait, boundedly, for an endpoint's recorded owner to be affirmatively gone.
 ///
 /// A zero budget probes exactly once, which is what the hygiene paths did before
 /// any of this waited.
-fn wait_for_affirmative_death(
+fn wait_until_retirable(
+    kin_root: &Path,
     pid: u32,
     budget: Duration,
-    liveness: &mut impl FnMut(u32) -> ProcessLiveness,
-) -> ProcessLiveness {
+    retirable: &mut impl FnMut(&Path, u32) -> bool,
+) -> bool {
     let deadline = Instant::now() + budget;
     loop {
-        let observed = liveness(pid);
-        if observed.authorizes_cleanup() {
-            return observed;
+        if retirable(kin_root, pid) {
+            return true;
         }
         let now = Instant::now();
         if now >= deadline {
-            return observed;
+            return false;
         }
         std::thread::sleep(
             ENDPOINT_TEARDOWN_POLL_INTERVAL.min(deadline.saturating_duration_since(now)),
@@ -2661,15 +2668,15 @@ fn wait_for_affirmative_death(
     }
 }
 
-/// The liveness probe is injectable because the two arms that matter here are
-/// decisions, not observations: whether the wait actually retries, and whether a
-/// refused cleanup is reported. Both are invisible to a test that can only run
-/// against real processes on one platform, and the Windows arm is precisely
-/// where the refusal was observed.
+/// The probe is injectable because the two arms that matter here are decisions,
+/// not observations: whether the wait actually retries, and whether a refused
+/// cleanup is reported. Both are invisible to a test that can only run against
+/// real processes on one platform, and the Windows arm is precisely where the
+/// refusal was observed.
 fn retire_daemon_endpoint_with_probe(
     kin_root: &Path,
     teardown_budget: Duration,
-    mut liveness: impl FnMut(u32) -> ProcessLiveness,
+    mut retirable: impl FnMut(&Path, u32) -> bool,
 ) -> DaemonEndpointCleanup {
     // Read the pid before the wait so the wait has something to watch, then take
     // the snapshot after it. A dying daemon unlinks its own endpoint on the way
@@ -2678,12 +2685,12 @@ fn retire_daemon_endpoint_with_probe(
     // record this call exists to retire.
     let judged_pid = read_pid_file(kin_root);
     if let Some(pid) = judged_pid {
-        wait_for_affirmative_death(pid, teardown_budget, &mut liveness);
+        wait_until_retirable(kin_root, pid, teardown_budget, &mut retirable);
     }
 
     let recorded = daemon_endpoint_snapshot(kin_root);
     let preserved_reason = match recorded.pid {
-        Some(pid) if liveness(pid).authorizes_cleanup() => {
+        Some(pid) if retirable(kin_root, pid) => {
             match retire_daemon_endpoint_if_unchanged(kin_root, recorded) {
                 DaemonEndpointRetirement::Retired => None,
                 preserved => Some(preserved.preserved_reason()),
@@ -8686,22 +8693,18 @@ mod tests {
         assert_eq!(preserved.pid_path(), repo_daemon_pid_path(root));
     }
 
-    /// A probe answering `Alive` for the first `alive_probes` calls and `Dead`
+    /// A probe refusing retirement for the first `refusals` calls and allowing it
     /// after, so the wait's retry is exercised as a decision rather than as a
     /// timing accident. Counts every call so a caller can prove how many probes
     /// a budget actually spent.
-    fn flipping_liveness(
-        alive_probes: usize,
+    fn probe_that_flips_after(
+        refusals: usize,
         calls: std::rc::Rc<std::cell::Cell<usize>>,
-    ) -> impl FnMut(u32) -> ProcessLiveness {
-        move |_| {
+    ) -> impl FnMut(&Path, u32) -> bool {
+        move |_, _| {
             let seen = calls.get();
             calls.set(seen + 1);
-            if seen < alive_probes {
-                ProcessLiveness::Alive
-            } else {
-                ProcessLiveness::Dead
-            }
+            seen >= refusals
         }
     }
 
@@ -8715,7 +8718,7 @@ mod tests {
         let cleanup = retire_daemon_endpoint_with_probe(
             root,
             Duration::from_secs(5),
-            flipping_liveness(3, calls.clone()),
+            probe_that_flips_after(3, calls.clone()),
         );
 
         assert_eq!(cleanup, DaemonEndpointCleanup::Retired);
@@ -8737,8 +8740,11 @@ mod tests {
         write_endpoint_files(root, 4242, 51000);
 
         let calls = std::rc::Rc::new(std::cell::Cell::new(0));
-        let cleanup =
-            retire_daemon_endpoint_with_probe(root, Duration::ZERO, flipping_liveness(3, calls));
+        let cleanup = retire_daemon_endpoint_with_probe(
+            root,
+            Duration::ZERO,
+            probe_that_flips_after(3, calls),
+        );
 
         assert!(cleanup.preserved().is_some());
         assert!(root.join("daemon.pid").exists());
@@ -8750,9 +8756,8 @@ mod tests {
         let root = dir.path();
         write_endpoint_files(root, 4242, 51000);
 
-        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_| {
-            ProcessLiveness::Unknown
-        });
+        let cleanup =
+            retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_, _| false);
 
         let preserved = cleanup.preserved().expect(
             "an endpoint that outlived a confirmed stop must be reported, not warned about",
@@ -8776,11 +8781,11 @@ mod tests {
         // successor daemon would. Preserving that record is correct, and calling
         // it a failed stop would be a false alarm.
         let republished = std::cell::Cell::new(false);
-        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::ZERO, |_| {
+        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::ZERO, |_, _| {
             if !republished.replace(true) {
                 write_endpoint_files(root, 4243, 51001);
             }
-            ProcessLiveness::Unknown
+            false
         });
 
         assert_eq!(cleanup, DaemonEndpointCleanup::Superseded);
@@ -8794,12 +8799,42 @@ mod tests {
         std::fs::write(root.join("daemon.pid"), "indeterminate").unwrap();
         std::fs::write(root.join("daemon.port"), "51000").unwrap();
 
-        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_| {
-            panic!("an unparseable record names no process to probe")
-        });
+        let cleanup =
+            retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_, _| {
+                panic!("an unparseable record names no process to probe")
+            });
 
         assert!(cleanup.preserved().is_some());
         assert!(root.join("daemon.pid").exists());
+    }
+
+    /// A recycled PID must not become a loud, permanent, WRONG stop failure.
+    ///
+    /// This is what forced the retirement probe to judge the recorded
+    /// incarnation rather than the bare PID. Reporting a preserved endpoint is
+    /// only worth doing if the report is right, and a bare probe answers `Alive`
+    /// about a live stranger holding the dead publisher's number — forever. The
+    /// old code merely warned about that and moved on; a bounded wait followed by
+    /// a nonzero exit would have promoted it to a hard error on a command
+    /// operators run constantly.
+    #[test]
+    fn a_recycled_pid_does_not_fail_a_stop_that_worked() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let pid =
+            write_attributed_endpoint_files(root, recycled_identity_for_this_process(), 51000);
+        // The bare probe every earlier version used still calls this PID alive:
+        // it is this test process.
+        assert_eq!(process_liveness(pid), ProcessLiveness::Alive);
+
+        let cleanup = retire_stopped_daemon_endpoint(root);
+
+        assert_eq!(
+            cleanup,
+            DaemonEndpointCleanup::Retired,
+            "the daemon that published this endpoint is gone, so the stop succeeded"
+        );
+        assert!(!root.join("daemon.pid").exists());
     }
 
     #[test]
@@ -8807,9 +8842,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
 
-        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_| {
-            panic!("there is no recorded owner to probe")
-        });
+        let cleanup =
+            retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_, _| {
+                panic!("there is no recorded owner to probe")
+            });
 
         assert_eq!(cleanup, DaemonEndpointCleanup::Retired);
     }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2562,6 +2562,22 @@ impl PreservedDaemonEndpoint {
     }
 }
 
+/// Build a preserved-endpoint value so the CLI's stop-report tests can exercise
+/// the exit-code decision without standing up a daemon.
+///
+/// Hidden rather than `#[cfg(test)]`: the report lives in another module, and a
+/// `cfg(test)` item is invisible to it.
+#[doc(hidden)]
+pub fn preserved_daemon_endpoint_for_test(
+    pid_path: &Path,
+    reason: &str,
+) -> PreservedDaemonEndpoint {
+    PreservedDaemonEndpoint {
+        pid_path: pid_path.to_path_buf(),
+        reason: reason.to_string(),
+    }
+}
+
 impl fmt::Display for PreservedDaemonEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} survives ({})", self.pid_path.display(), self.reason)

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2538,14 +2538,156 @@ fn endpoint_owner_liveness_with_probes(
     })
 }
 
+/// An endpoint that survived a retirement attempt, and why.
+///
+/// `daemon.pid` is what publishes an endpoint, so a record left behind is a
+/// standing claim on the repo that outlives the daemon it names. Carrying the
+/// path and the reason together is what lets a caller report the survivor
+/// instead of only knowing that something went wrong.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreservedDaemonEndpoint {
+    pid_path: PathBuf,
+    reason: String,
+}
+
+impl PreservedDaemonEndpoint {
+    /// The pid file still publishing the endpoint.
+    pub fn pid_path(&self) -> &Path {
+        &self.pid_path
+    }
+
+    /// Why retirement did not happen.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+impl fmt::Display for PreservedDaemonEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} survives ({})", self.pid_path.display(), self.reason)
+    }
+}
+
+/// What a retirement attempt left on disk.
+///
+/// `#[must_use]` on purpose. Discarding this verdict is the defect this type
+/// exists to close: retirement is conditional on a liveness probe, the skip is
+/// silent, and a caller that ignores the answer reports a clean stop while the
+/// stopped daemon's endpoint stays published.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub enum DaemonEndpointCleanup {
+    /// Nothing publishes the judged endpoint any more: it was retired here or
+    /// was already gone.
+    Retired,
+    /// The record on disk names a different daemon than the one judged, so it
+    /// belongs to a successor and preserving it is the correct outcome.
+    Superseded,
+    /// The judged endpoint is still published.
+    Preserved(PreservedDaemonEndpoint),
+}
+
+impl DaemonEndpointCleanup {
+    /// The surviving endpoint, when the judged one was preserved.
+    pub fn preserved(&self) -> Option<&PreservedDaemonEndpoint> {
+        match self {
+            Self::Preserved(preserved) => Some(preserved),
+            Self::Retired | Self::Superseded => None,
+        }
+    }
+}
+
+/// How long a caller that has just confirmed a stop waits for the operating
+/// system to finish tearing the process down before judging its endpoint.
+///
+/// A stop returns as soon as the daemon's incarnation stops answering; process
+/// teardown completes afterwards, and until it does a liveness probe can answer
+/// `Alive` or an indeterminate `Unknown`. Both refuse cleanup, and the refusal
+/// is permanent because nothing retries it, so one probe taken inside that
+/// window preserves a dead daemon's endpoint for good.
+const ENDPOINT_TEARDOWN_BUDGET: Duration = Duration::from_secs(5);
+
+const ENDPOINT_TEARDOWN_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
 /// Remove a repo worker daemon's pid/port endpoint files. The daemon deletes
-/// these itself on graceful shutdown; `kin daemon stop` also calls this after a
-/// confirmed stop so a later `status` never reports the dead endpoint as stale.
-pub fn remove_stale_daemon_files(kin_root: &Path) {
+/// these itself on graceful shutdown; hygiene paths call this to clear a record
+/// left behind by a daemon that is already gone.
+///
+/// Probes liveness once, so a caller that has *just* stopped the daemon should
+/// call [`retire_stopped_daemon_endpoint`] instead: this probe would run inside
+/// the teardown window it needs to wait out.
+pub fn remove_stale_daemon_files(kin_root: &Path) -> DaemonEndpointCleanup {
+    retire_daemon_endpoint(kin_root, Duration::ZERO)
+}
+
+/// Retire the endpoint of a worker daemon whose stop was just confirmed.
+///
+/// Waits boundedly for the recorded owner to become affirmatively dead before
+/// deciding, and reports what happened. Both halves matter: without the wait the
+/// decision is a coin flip against process teardown, and without the report a
+/// lost coin flip is invisible to the operator and to every later reader of the
+/// endpoint.
+pub fn retire_stopped_daemon_endpoint(kin_root: &Path) -> DaemonEndpointCleanup {
+    retire_daemon_endpoint(kin_root, ENDPOINT_TEARDOWN_BUDGET)
+}
+
+fn retire_daemon_endpoint(kin_root: &Path, teardown_budget: Duration) -> DaemonEndpointCleanup {
+    retire_daemon_endpoint_with_probe(kin_root, teardown_budget, process_liveness)
+}
+
+/// Wait, boundedly, for a process to become affirmatively dead, and answer with
+/// the last observation either way.
+///
+/// A zero budget probes exactly once, which is what the hygiene paths did before
+/// any of this waited.
+fn wait_for_affirmative_death(
+    pid: u32,
+    budget: Duration,
+    liveness: &mut impl FnMut(u32) -> ProcessLiveness,
+) -> ProcessLiveness {
+    let deadline = Instant::now() + budget;
+    loop {
+        let observed = liveness(pid);
+        if observed.authorizes_cleanup() {
+            return observed;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return observed;
+        }
+        std::thread::sleep(
+            ENDPOINT_TEARDOWN_POLL_INTERVAL.min(deadline.saturating_duration_since(now)),
+        );
+    }
+}
+
+/// The liveness probe is injectable because the two arms that matter here are
+/// decisions, not observations: whether the wait actually retries, and whether a
+/// refused cleanup is reported. Both are invisible to a test that can only run
+/// against real processes on one platform, and the Windows arm is precisely
+/// where the refusal was observed.
+fn retire_daemon_endpoint_with_probe(
+    kin_root: &Path,
+    teardown_budget: Duration,
+    mut liveness: impl FnMut(u32) -> ProcessLiveness,
+) -> DaemonEndpointCleanup {
+    // Read the pid before the wait so the wait has something to watch, then take
+    // the snapshot after it. A dying daemon unlinks its own endpoint on the way
+    // out, so a snapshot captured mid-teardown is a torn read, and the
+    // unchanged-comparison would then refuse to act on it — preserving the very
+    // record this call exists to retire.
+    let judged_pid = read_pid_file(kin_root);
+    if let Some(pid) = judged_pid {
+        wait_for_affirmative_death(pid, teardown_budget, &mut liveness);
+    }
+
     let recorded = daemon_endpoint_snapshot(kin_root);
-    match recorded.pid {
-        Some(pid) if process_liveness(pid).authorizes_cleanup() => {
-            let _ = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
+    let preserved_reason = match recorded.pid {
+        Some(pid) if liveness(pid).authorizes_cleanup() => {
+            match retire_daemon_endpoint_if_unchanged(kin_root, recorded) {
+                DaemonEndpointRetirement::Retired => None,
+                preserved => Some(preserved.preserved_reason()),
+            }
         }
         Some(pid) => {
             warn!(
@@ -2553,16 +2695,52 @@ pub fn remove_stale_daemon_files(kin_root: &Path) {
                 repo = %kin_root.display(),
                 "preserving daemon endpoint because its recorded owner may still be alive"
             );
+            Some(format!(
+                "recorded owner pid {pid} never became affirmatively dead"
+            ))
         }
         None if !recorded.pid_exists => {
-            let _ = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
+            match retire_daemon_endpoint_if_unchanged(kin_root, recorded) {
+                DaemonEndpointRetirement::Retired => None,
+                preserved => Some(preserved.preserved_reason()),
+            }
         }
         None => {
             warn!(
                 repo = %kin_root.display(),
                 "preserving daemon endpoint because its PID record is unparseable"
             );
+            Some("its PID record is unparseable".to_string())
         }
+    };
+
+    match preserved_reason {
+        None => DaemonEndpointCleanup::Retired,
+        Some(reason) => classify_preserved_endpoint(kin_root, judged_pid, reason),
+    }
+}
+
+/// Decide whether a refused retirement actually left the judged endpoint
+/// published.
+///
+/// Only that case is a defect. A record that now names a different daemon is a
+/// successor's, and reporting a successor as a failed stop would be a false
+/// alarm on a command operators run constantly.
+fn classify_preserved_endpoint(
+    kin_root: &Path,
+    judged_pid: Option<u32>,
+    reason: String,
+) -> DaemonEndpointCleanup {
+    let pid_path = repo_daemon_pid_path(kin_root);
+    let current_pid = read_pid_file(kin_root);
+    if current_pid.is_none() && !pid_path.exists() {
+        // Nothing publishes an endpoint here: another participant retired it
+        // while this call was deciding. Nothing was preserved.
+        return DaemonEndpointCleanup::Retired;
+    }
+    match (current_pid, judged_pid) {
+        (Some(current), Some(judged)) if current != judged => DaemonEndpointCleanup::Superseded,
+        _ => DaemonEndpointCleanup::Preserved(PreservedDaemonEndpoint { pid_path, reason }),
     }
 }
 
@@ -8498,10 +8676,142 @@ mod tests {
         let root = dir.path();
         write_endpoint_files(root, std::process::id(), 51000);
 
-        remove_stale_daemon_files(root);
+        let cleanup = remove_stale_daemon_files(root);
 
         assert_eq!(read_pid_file(root), Some(std::process::id()));
         assert_eq!(read_port_file(root), Some(51000));
+        let preserved = cleanup
+            .preserved()
+            .expect("a live owner's endpoint is preserved, and the caller must be told");
+        assert_eq!(preserved.pid_path(), repo_daemon_pid_path(root));
+    }
+
+    /// A probe answering `Alive` for the first `alive_probes` calls and `Dead`
+    /// after, so the wait's retry is exercised as a decision rather than as a
+    /// timing accident. Counts every call so a caller can prove how many probes
+    /// a budget actually spent.
+    fn flipping_liveness(
+        alive_probes: usize,
+        calls: std::rc::Rc<std::cell::Cell<usize>>,
+    ) -> impl FnMut(u32) -> ProcessLiveness {
+        move |_| {
+            let seen = calls.get();
+            calls.set(seen + 1);
+            if seen < alive_probes {
+                ProcessLiveness::Alive
+            } else {
+                ProcessLiveness::Dead
+            }
+        }
+    }
+
+    #[test]
+    fn stopped_endpoint_retirement_waits_out_a_teardown_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        let calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        let cleanup = retire_daemon_endpoint_with_probe(
+            root,
+            Duration::from_secs(5),
+            flipping_liveness(3, calls.clone()),
+        );
+
+        assert_eq!(cleanup, DaemonEndpointCleanup::Retired);
+        assert!(!root.join("daemon.pid").exists());
+        assert!(!root.join("daemon.port").exists());
+        assert!(
+            calls.get() > 1,
+            "a single probe cannot have observed the flip; the wait must retry"
+        );
+    }
+
+    #[test]
+    fn a_single_probe_would_have_preserved_the_same_endpoint() {
+        // The falsification of the test above: the identical fixture, decided on
+        // one probe, keeps the endpoint. Without this, "retired" says nothing
+        // about whether the wait did any work.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        let calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        let cleanup =
+            retire_daemon_endpoint_with_probe(root, Duration::ZERO, flipping_liveness(3, calls));
+
+        assert!(cleanup.preserved().is_some());
+        assert!(root.join("daemon.pid").exists());
+    }
+
+    #[test]
+    fn a_permanently_indeterminate_owner_reports_the_surviving_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_| {
+            ProcessLiveness::Unknown
+        });
+
+        let preserved = cleanup.preserved().expect(
+            "an endpoint that outlived a confirmed stop must be reported, not warned about",
+        );
+        assert_eq!(preserved.pid_path(), repo_daemon_pid_path(root));
+        assert!(
+            preserved.reason().contains("4242"),
+            "the reason must name the owner that never died: {}",
+            preserved.reason()
+        );
+        assert!(root.join("daemon.pid").exists());
+    }
+
+    #[test]
+    fn a_successors_endpoint_is_not_reported_as_a_failed_retirement() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        // Republish under a different pid at the instant the wait ends, the way a
+        // successor daemon would. Preserving that record is correct, and calling
+        // it a failed stop would be a false alarm.
+        let republished = std::cell::Cell::new(false);
+        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::ZERO, |_| {
+            if !republished.replace(true) {
+                write_endpoint_files(root, 4243, 51001);
+            }
+            ProcessLiveness::Unknown
+        });
+
+        assert_eq!(cleanup, DaemonEndpointCleanup::Superseded);
+        assert_eq!(read_pid_file(root), Some(4243));
+    }
+
+    #[test]
+    fn an_unparseable_pid_record_is_a_preserved_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.pid"), "indeterminate").unwrap();
+        std::fs::write(root.join("daemon.port"), "51000").unwrap();
+
+        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_| {
+            panic!("an unparseable record names no process to probe")
+        });
+
+        assert!(cleanup.preserved().is_some());
+        assert!(root.join("daemon.pid").exists());
+    }
+
+    #[test]
+    fn an_absent_endpoint_is_retired_rather_than_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let cleanup = retire_daemon_endpoint_with_probe(root, Duration::from_millis(120), |_| {
+            panic!("there is no recorded owner to probe")
+        });
+
+        assert_eq!(cleanup, DaemonEndpointCleanup::Retired);
     }
 
     #[test]

--- a/crates/kin-cli/tests/daemon_stop.rs
+++ b/crates/kin-cli/tests/daemon_stop.rs
@@ -67,6 +67,24 @@ fn wait_until_dead(pid: u32, timeout: Duration) {
     }
 }
 
+/// Wait for a path to disappear, the file-side analogue of `wait_until_dead`.
+///
+/// Process death and endpoint retirement are two different events, and the stop
+/// path decides the second one against a liveness probe that can still read
+/// `Alive` — or an indeterminate `Unknown` — for a moment after the first. This
+/// wait is what makes the assertion below a statement about the product rather
+/// than about which of the two events the test happened to observe first.
+///
+/// It cannot weaken the assertion: the caller asserts after the wait, so an
+/// endpoint that genuinely never retires exhausts the deadline and fails exactly
+/// as loudly as before.
+fn wait_until_gone(path: &Path, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 #[test]
 fn daemon_status_and_stop_lifecycle() {
     let root = tempfile::tempdir().expect("temp root");
@@ -140,6 +158,7 @@ fn daemon_status_and_stop_lifecycle() {
         !is_process_alive(worker_pid),
         "worker daemon pid {worker_pid} still alive after `kin daemon stop`"
     );
+    wait_until_gone(&pid_path, Duration::from_secs(5));
     assert!(
         !pid_path.exists(),
         "daemon.pid must be cleared after a confirmed stop"


### PR DESCRIPTION
Closes FIR-1991

## The defect

`kin daemon stop` can report a confirmed stop and leave `daemon.pid` behind
permanently. Because `daemon.pid` is what publishes an endpoint, the survivor is
a standing claim on the repo that outlives the daemon it names, and `status`,
autostart, and every other reader believe it.

The mechanism is a race frozen by a missing retry, not a missing wait in the
test:

1. `stop_worker_at` returns success as soon as the daemon's incarnation stops
   answering. The operating system finishes tearing the process down afterwards.
2. `remove_stale_daemon_files` then probed liveness **once** and retired the
   endpoint only for `ProcessLiveness::Dead`. `Alive` and the indeterminate
   `Unknown` both skipped retirement with a `warn!`.
3. Nothing retried the skip, so a probe that landed inside the teardown window
   decided the endpoint's fate for good.
4. The function returned `()`, so the skip was structurally invisible to its
   caller and `kin daemon stop` exited 0 regardless.

That is also the whole intermittency: whether the endpoint retires depends on
which side of teardown a single probe lands on, and the answer is not stable
across runs. It is why `daemon_status_and_stop_lifecycle` failed on `main` three
times on 2026-08-05 and passed the rest of the time, and why #641's five-second
wait in the test could never have fixed it. By the time that wait started, the
decision not to remove had already been made.

## The fix

**Wait for affirmative death before deciding.** `retire_stopped_daemon_endpoint`
polls the recorded owner's liveness for up to five seconds and only then judges
the endpoint. Hygiene callers keep the single-probe behavior through
`remove_stale_daemon_files`, which is now the zero-budget case of the same code.

**Propagate the outcome.** Retirement returns `DaemonEndpointCleanup`, which is
`#[must_use]`, and the stop path carries a preserved endpoint into its report. A
stop whose endpoint survives now prints the pid file and the reason and exits
nonzero.

**Do not cry wolf about a successor.** A record that has come to name a
different daemon is a successor's, and preserving it is correct, so it is
reported as `Superseded` rather than as a failed stop.

**Snapshot after the wait, not before.** A dying daemon unlinks its own endpoint
on the way out, so a snapshot captured mid-teardown is a torn read, and the
existing unchanged-comparison would then correctly refuse to act on it. Waiting
first also removes the sibling `LifecycleContended` and `SingletonHeld`
preservations that a still-exiting daemon's own locks could cause.

`all_stopped` in the JSON payload keeps its meaning of "every process stopped".
Endpoint retirement is a new additive `endpoints_retired` field plus an optional
per-entry `preserved_endpoint`, so no consumer loses a field it reads today.

## Judging the right thing before failing loud

A second commit changes the probe from `process_liveness` to
`endpoint_owner_liveness`. Reporting a preserved endpoint is only worth doing if
the report is right, and the bare-PID probe answers `Alive` about a live stranger
that inherited the dead publisher's number, permanently. Warning about that and
moving on was survivable. A bounded wait followed by a nonzero exit would have
promoted a recycled PID into a hard error on a command operators run constantly.

`endpoint_owner_liveness` prefers the incarnation recorded in `daemon.owner` and
falls back to the bare PID only for a legacy endpoint published before
attribution existed, so nothing regresses for an old endpoint. One probe still
decides one question, so the wait and the cleanup decision cannot disagree, and
the wait is still what closes the teardown race: mid-teardown the recorded
identity still resolves, the probe refuses, and the loop retries.

`a_recycled_pid_does_not_fail_a_stop_that_worked` pins it, using the same forged
same-PID-different-incarnation fixture the existing recycled-PID test uses, and
asserting first that the bare probe would have said `Alive`.

## Where the new failure is raised, and where it is not

A third commit keeps the endpoint-survivor exit off full uninstall's nested
stop. Uninstall's contract is that no PROCESS survives, and it re-verifies
exactly that through its own quiescence fence, which reads processes rather than
endpoint records. A leftover pid file inside some repo does not keep an install
alive, so refusing to uninstall over one would turn a reporting improvement into
a command the operator cannot complete. A surviving PROCESS still fails uninstall
exactly as it always has.

## Verification

Two-sided, and the negative side is in the suite:

- `stopped_endpoint_retirement_waits_out_a_teardown_window` drives an injected
  probe that answers `Alive` three times and then `Dead`. The endpoint retires
  and the probe is proven to have been called more than once.
- `a_single_probe_would_have_preserved_the_same_endpoint` runs the identical
  fixture with a zero budget and the endpoint survives. Without it, "retired"
  would say nothing about whether the wait did any work.
- `a_permanently_indeterminate_owner_reports_the_surviving_endpoint` asserts the
  propagation: an owner that never dies yields a preserved endpoint naming
  `daemon.pid` and the pid that never died.
- `a_successors_endpoint_is_not_reported_as_a_failed_retirement` republishes
  under a different pid mid-decision and asserts `Superseded`.
- The end-to-end regression is #641's bounded pid-file wait, absorbed here
  unchanged. It goes deterministically green exactly when the race closes, and
  #641 already proved on its own CI that it fails loud rather than vacuously
  when the endpoint genuinely never disappears.

Local: `cargo test -p kin-cli --lib` 1185 passed / 0 failed; `cargo fmt --all
--check` clean; `cargo clippy --all-targets --all-features` clean under the CI
allowlist with `RUSTFLAGS=-Dwarnings`. The `daemon_stop` end-to-end suite was
not run locally because another lane held the daemon runtime lock; it runs on
all three platforms in CI.

## Not claiming

The Windows open-handle/`ACCESS_DENIED` hypothesis is neither proven nor needed:
the wait covers `Alive` and `Unknown` alike. This does not address FIR-1887's
macOS report of processes surviving a zero-exit stop, which is a different
failure; the shared classifier finding is recorded there. The sibling latent
defect where a process legitimately exiting 259 is forever `Alive` to
`classify_windows_process_probe` is unchanged and separately ticketed.


