### PR TITLE
Add a repo map and architecture diagram to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,11 @@ flowchart TD
         editor["kin-editor for VS Code"]
     end
 
-    subgraph runtime["Kin runtime"]
-        daemon["kin daemon"]
-        authority["Graph authority<br/>entities, relations, changes, provenance"]
-        vfs["kin-vfs<br/>transparent file projection"]
-    end
-
-    subgraph layers["Storage and retrieval"]
-        db["kin-db<br/>graph storage, snapshots,<br/>index, text and vector search"]
-        prims["kin-model, kin-blobs, kin-search,<br/>kin-vector, kin-infer, kin-lsp"]
-    end
-
+    daemon["kin daemon"]
+    authority["Graph authority<br/>entities, relations, changes, provenance"]
+    db["kin-db<br/>graph storage, snapshots,<br/>index, text and vector search"]
+    prims["kin-model, kin-blobs, kin-search,<br/>kin-vector, kin-infer, kin-lsp"]
+    vfs["kin-vfs<br/>transparent file projection"]
     tools["Editors, compilers, build systems"]
     git["Git<br/>import and export boundary"]
     kinlab["KinLab<br/>hosted collaboration and control plane"]

--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ flowchart TD
         editor["kin-editor for VS Code"]
     end
 
-    subgraph core["kin"]
+    subgraph runtime["Kin runtime"]
         daemon["kin daemon"]
         authority["Graph authority<br/>entities, relations, changes, provenance"]
+        vfs["kin-vfs<br/>transparent file projection"]
     end
 
     subgraph layers["Storage and retrieval"]
-        db["kin-db<br/>graph storage, snapshots, index, text and vector search"]
+        db["kin-db<br/>graph storage, snapshots,<br/>index, text and vector search"]
         prims["kin-model, kin-blobs, kin-search,<br/>kin-vector, kin-infer, kin-lsp"]
     end
 
-    vfs["kin-vfs<br/>transparent file projection"]
     tools["Editors, compilers, build systems"]
     git["Git<br/>import and export boundary"]
     kinlab["KinLab<br/>hosted collaboration and control plane"]
@@ -106,10 +106,10 @@ flowchart TD
     mcp --> daemon
     editor --> daemon
     daemon --> authority
-    authority --> db
-    db --> prims
     authority --> vfs
     vfs --> tools
+    authority --> db
+    db --> prims
     git -->|"kin init imports"| authority
     authority -->|"kin git export"| git
     authority -->|"publish and sync"| kinlab

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Underneath those surfaces are the layers the system is built from:
 | **[kin-lsp](https://github.com/firelock-ai/kin-lsp)** | Language-server enrichment feeding the semantic layer. |
 
 These are implementation layers of one system, not separate products a new user
-needs to assemble. The install path below is the only one a user runs.
+needs to assemble. None of them is installed separately.
 
 ## Open source and the Kin ecosystem
 

--- a/README.md
+++ b/README.md
@@ -106,13 +106,12 @@ flowchart TD
     mcp --> daemon
     editor --> daemon
     daemon --> authority
-    authority --> vfs
-    vfs --> tools
     authority --> db
     db --> prims
-    git -->|"kin init imports"| authority
-    authority -->|"kin git export"| git
+    authority <-->|"kin init imports, kin git export"| git
     authority -->|"publish and sync"| kinlab
+    authority --> vfs
+    vfs --> tools
 ```
 
 Underneath those surfaces are the layers the system is built from:

--- a/README.md
+++ b/README.md
@@ -63,9 +63,72 @@ Kin is one system with a few clear public surfaces:
 | **[Kin MCP](docs/mcp-tools.md)** | Typed graph tools for AI agents, bundled into `kin` and launched with `kin mcp start`. |
 | **[KinLab](https://kinlab.ai)** | Hosted collaboration and control plane. Public repository connection is not a first-run flow yet. |
 
-Supporting repositories provide graph storage, retrieval, embeddings, blobs,
-language enrichment, and reproducible proof. They are implementation layers,
-not separate products a new user needs to assemble.
+## How the pieces fit
+
+Kin is the semantic system of record for AI-written software, and everything in
+the map below either reaches that authority or supports it. Humans and AI agents
+come in through the CLI, the bundled MCP server, or the VS Code extension. All
+three ask the same daemon, and the daemon answers from graph authority rather
+than by re-reading the tree. `kin-vfs` projects that same graph back through
+ordinary filesystem calls, so editors, compilers, and build systems keep seeing
+files. Git sits beside the graph as an import and export boundary rather than as
+an answer path, and KinLab is the hosted layer over the same authority.
+
+```mermaid
+flowchart TD
+    people["Humans and AI agents"]
+
+    subgraph surfaces["Access surfaces"]
+        cli["kin CLI"]
+        mcp["Kin MCP server"]
+        editor["kin-editor for VS Code"]
+    end
+
+    subgraph core["kin"]
+        daemon["kin daemon"]
+        authority["Graph authority<br/>entities, relations, changes, provenance"]
+    end
+
+    subgraph layers["Storage and retrieval"]
+        db["kin-db<br/>graph storage, snapshots, index, text and vector search"]
+        prims["kin-model, kin-blobs, kin-search,<br/>kin-vector, kin-infer, kin-lsp"]
+    end
+
+    vfs["kin-vfs<br/>transparent file projection"]
+    tools["Editors, compilers, build systems"]
+    git["Git<br/>import and export boundary"]
+    kinlab["KinLab<br/>hosted collaboration and control plane"]
+
+    people --> cli
+    people --> mcp
+    people --> editor
+    cli --> daemon
+    mcp --> daemon
+    editor --> daemon
+    daemon --> authority
+    authority --> db
+    db --> prims
+    authority --> vfs
+    vfs --> tools
+    git -->|"kin init imports"| authority
+    authority -->|"kin git export"| git
+    authority -->|"publish and sync"| kinlab
+```
+
+Underneath those surfaces are the layers the system is built from:
+
+| Layer | Role |
+| --- | --- |
+| **[kin-db](https://github.com/firelock-ai/kin-db)** | Graph storage, snapshots, indexing, text search, and vector search. |
+| **[kin-model](https://github.com/firelock-ai/kin-model)** | Canonical types and domain models shared across the stack. |
+| **[kin-blobs](https://github.com/firelock-ai/kin-blobs)** | Content-addressable blob storage. |
+| **[kin-search](https://github.com/firelock-ai/kin-search)** | Lexical search primitives and staged retrieval. |
+| **[kin-vector](https://github.com/firelock-ai/kin-vector)** | Vector and nearest-neighbor substrate. |
+| **[kin-infer](https://github.com/firelock-ai/kin-infer)** | Inference and embedding substrate. |
+| **[kin-lsp](https://github.com/firelock-ai/kin-lsp)** | Language-server enrichment feeding the semantic layer. |
+
+These are implementation layers of one system, not separate products a new user
+needs to assemble. The install path below is the only one a user runs.
 
 ## Open source and the Kin ecosystem
 


### PR DESCRIPTION
## What

Adds a "How the pieces fit" section to the README, holding a Mermaid flowchart
of the runtime path and a table that gives each supporting layer a one-line
role and its repository link. It replaces the two-sentence supporting
repositories note that sat under the surfaces table and said less.

## Why

The README named the public surfaces but never showed how they connect, and it
listed the supporting repositories in prose without saying what any of them
does or where to find one. A reader could not tell from it that the CLI, the
bundled MCP server, and the editor extension all reach the same daemon, that
answers come from graph authority rather than from re-reading the tree, or that
Git is an import and export boundary rather than an answer path.

## How

The diagram is a classic Mermaid flowchart rather than architecture-beta, since
GitHub's support for the beta renderer is unverified and a diagram that fails to
render is worse than no diagram.

Three layout revisions were driven by what the GitHub renderer actually did with
the source, not by how the source read:

- The first version put the daemon and graph authority in their own cluster.
  Dagre sized that cluster from the edges fanning out beneath it and rendered a
  wide, mostly empty box.
- Moving kin-vfs inside the cluster filled the width but left the authority and
  kin-db at opposite sides, so the edge between them was routed as a long
  horizontal line passing through the Git and KinLab boxes. Rendered, that read
  as a KinLab to Git to kin-db chain that does not exist.
- Dropping the runtime and storage clusters removed the distortion. The same
  nodes and edges lay out as short diagonals from one hub. The access-surfaces
  grouping stays because it rendered without distortion in every revision.

The two Git edges were also collapsed into one bidirectional link carrying both
command names, which removes the upward back-edge that dagre had been routing
around.

## Testing

- Diagram render verified on this branch's README at github.com, in the page
  itself rather than through a local Mermaid CLI. GitHub hands the block to its
  viewscreen iframe and it draws as a flowchart, with no parse error and no raw
  source shown. Screenshot retained as evidence.
- Every repository linked in the new table was confirmed public via the GitHub
  API before pushing, since link-check.yml runs on README changes.
- README checked for non-ASCII bytes and em dashes, both zero, with a control
  proving the check can fail.
- No Rust changed, so cargo test, clippy, and fmt are not applicable here.

Signed-off-by: Troy Fortin <troy@firelock.ai>
