### PR TITLE
Instrument every init phase and stop the terminal going silent

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -16,8 +16,9 @@ use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
     plan_semantic_git_import, preflight_git_migration, preflight_git_migration_after_publication,
-    seal_all_content_observation, AdmittedContentClosure, GitLocalIgnoreSourceKind,
+    seal_all_content_observation_observed, AdmittedContentClosure, GitLocalIgnoreSourceKind,
     GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
+    SealedContentSource,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
@@ -27,7 +28,7 @@ use kin_model::{
     RepositoryId, RepositoryTransaction, TreeDelta, WorkspaceExpectation, WorkspaceMutation,
     WorkspaceSemanticDelta,
 };
-use tracing::info;
+use tracing::{info, info_span};
 
 use crate::config::{
     GitBranchTrackingConfig, GitCoexistenceConfig, GitPushDefault, GitRemoteTransportConfig,
@@ -38,6 +39,7 @@ use crate::init::{
     prepare_repository_layout_at, publish_repository_layout_linearized, GraphOwnedContent,
     InitResult,
 };
+use crate::init_progress::{PhaseProgress, GIT_ADMISSION_PHASES};
 use crate::layout::KinLayout;
 use crate::manifest::KinManifest;
 
@@ -207,74 +209,172 @@ fn init_from_git_with_hooks(
     let capture_store = BlobStore::new(capture_dir.path().join("objects"))
         .map_err(|error| git_boundary_error("create capture CAS", error))?;
 
-    let snapshot = capture_lossless_git_repository(&source, repository_id, &capture_store)
-        .map_err(|error| git_boundary_error("capture exact Git repository", error))?;
-    let git_authority = build_git_external_authority(&snapshot, &capture_store)
-        .map_err(|error| git_boundary_error("build exact Git authority", error))?;
-    let semantic_plan = plan_semantic_git_import(&snapshot, &capture_store)
-        .map_err(|error| git_boundary_error("derive exact semantic Git history", error))?;
-    verify_material_workspace_seed(&semantic_plan.workspace_seed, &git_authority.material_head)?;
-    let semantic_plan = bind_historical_semantics(semantic_plan, &capture_store)?;
-    let admitted = admit_semantic_git_import(&semantic_plan, &capture_store)
-        .map_err(|error| git_boundary_error("derive branch-versioned admission policy", error))?;
-    let source_proof = preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
-        .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?;
+    let mut progress = PhaseProgress::new(GIT_ADMISSION_PHASES);
+
+    progress.begin("capture Git repository");
+    let snapshot = {
+        let _span = info_span!("kin.init.capture_git_repository").entered();
+        capture_lossless_git_repository(&source, repository_id, &capture_store)
+            .map_err(|error| git_boundary_error("capture exact Git repository", error))?
+    };
+
+    progress.begin("build Git authority");
+    let git_authority = {
+        let _span = info_span!(
+            "kin.init.build_git_authority",
+            objects = snapshot.objects.len()
+        )
+        .entered();
+        build_git_external_authority(&snapshot, &capture_store)
+            .map_err(|error| git_boundary_error("build exact Git authority", error))?
+    };
+
+    progress.begin("plan semantic import");
+    let semantic_plan = {
+        let _span = info_span!("kin.init.plan_semantic_import").entered();
+        let plan = plan_semantic_git_import(&snapshot, &capture_store)
+            .map_err(|error| git_boundary_error("derive exact semantic Git history", error))?;
+        verify_material_workspace_seed(&plan.workspace_seed, &git_authority.material_head)?;
+        plan
+    };
+
+    progress.begin("derive semantic history");
+    let semantic_plan = {
+        let _span = info_span!(
+            "kin.init.bind_historical_semantics",
+            changes = semantic_plan.commit_trees.len()
+        )
+        .entered();
+        bind_historical_semantics(semantic_plan, &capture_store)?
+    };
+
+    progress.begin("apply admission policy");
+    let admitted = {
+        let _span = info_span!("kin.init.admit_semantic_import").entered();
+        admit_semantic_git_import(&semantic_plan, &capture_store).map_err(|error| {
+            git_boundary_error("derive branch-versioned admission policy", error)
+        })?
+    };
+
+    progress.begin("prove Git source");
+    let source_proof = {
+        let _span = info_span!("kin.init.source_proof_staged").entered();
+        preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
+            .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?
+    };
 
     let final_kin_dir = source.join(".kin");
     let staging_dir = source_parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
     let config = config_for_source(&snapshot, &source_proof.remote_mapping)?;
-    let mut prepared =
-        prepare_repository_layout_at(&staging_dir, &final_kin_dir, config, manifest)?;
-    copy_captured_authority(&prepared, &snapshot, &capture_store, &source_proof)?;
-    let sealed_observation = seal_all_content_observation(&admitted, &prepared)
-        .map_err(|error| git_boundary_error("seal all-content observation", error))?;
+
+    progress.begin("stage repository layout");
+    let mut prepared = {
+        let _span = info_span!("kin.init.prepare_layout").entered();
+        prepare_repository_layout_at(&staging_dir, &final_kin_dir, config, manifest)?
+    };
+
+    progress.begin("copy Git objects");
+    {
+        let _span = info_span!(
+            "kin.init.copy_captured_authority",
+            objects = snapshot.objects.len()
+        )
+        .entered();
+        copy_captured_authority(
+            &prepared,
+            &snapshot,
+            &capture_store,
+            &source_proof,
+            &mut progress,
+        )?;
+    }
+
+    progress.begin("seal staged content");
+    let sealed_observation = {
+        let _span = info_span!("kin.init.seal_staged_content").entered();
+        seal_observed_content(&admitted, &prepared, &mut progress)
+            .map_err(|error| git_boundary_error("seal all-content observation", error))?
+    };
 
     let workspace_seed = admitted.workspace_seed.clone();
     let workspace_policy = admitted.workspace_policy().clone();
     let workspace_base_change_id = admitted.workspace_base_change_id();
-    let mut transaction = admitted
-        .into_generation_zero_repository_transaction(
-            &capture_store,
-            OperationId::new(),
-            prepared.initial_roots().clone(),
-            AuthorId::new("kin-git-import"),
-            "admit exact Git repository authority",
+
+    progress.begin("build bootstrap transaction");
+    let transaction = {
+        let _span = info_span!(
+            "kin.init.build_bootstrap_transaction",
+            observed_trees = sealed_observation.observed_trees,
+            observed_entries = sealed_observation.observed_entries
         )
-        .map_err(|error| git_boundary_error("construct Git bootstrap transaction", error))?;
-    bind_workspace_authority(
-        &mut transaction,
-        prepared.workspace_id(),
-        workspace_seed,
-        workspace_policy,
-        &source_proof,
-    )?;
-    transaction.git_authority_delta = Some(GitExternalAuthorityDelta::initialize(git_authority));
-    transaction
-        .validate()
-        .map_err(|error| KinError::Other(format!("invalid Git bootstrap transaction: {error}")))?;
-    prepared.commit_repository_bootstrap(&transaction)?;
+        .entered();
+        let mut transaction = admitted
+            .into_generation_zero_repository_transaction(
+                &capture_store,
+                OperationId::new(),
+                prepared.initial_roots().clone(),
+                AuthorId::new("kin-git-import"),
+                "admit exact Git repository authority",
+            )
+            .map_err(|error| git_boundary_error("construct Git bootstrap transaction", error))?;
+        bind_workspace_authority(
+            &mut transaction,
+            prepared.workspace_id(),
+            workspace_seed,
+            workspace_policy,
+            &source_proof,
+        )?;
+        transaction.git_authority_delta =
+            Some(GitExternalAuthorityDelta::initialize(git_authority));
+        transaction
+    };
+
+    progress.begin("validate bootstrap transaction");
+    {
+        let _span = info_span!("kin.init.validate_bootstrap_transaction").entered();
+        transaction.validate().map_err(|error| {
+            KinError::Other(format!("invalid Git bootstrap transaction: {error}"))
+        })?;
+    }
+
+    progress.begin("commit bootstrap transaction");
+    {
+        let _span = info_span!("kin.init.commit_bootstrap_transaction").entered();
+        prepared.commit_repository_bootstrap(&transaction)?;
+    }
 
     let mut result = publish_repository_layout_linearized(prepared, |publication| {
         before_final_source_proof();
-        let final_proof =
+        progress.begin("re-prove Git source");
+        let final_proof = {
+            let _span = info_span!("kin.init.source_proof_final").entered();
             preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
-                .map_err(|error| git_boundary_error("repeat final Git source proof", error))?;
+                .map_err(|error| git_boundary_error("repeat final Git source proof", error))?
+        };
         if final_proof != source_proof {
             return Err(KinError::Other(
                 "Git source proof changed before repository publication; retry from a fresh capture"
                     .to_string(),
             ));
         }
-        let published = publication.publish()?;
+        progress.begin("publish repository");
+        let published = {
+            let _span = info_span!("kin.init.publish_repository").entered();
+            publication.publish()?
+        };
         after_repository_publication();
-        let published_proof = preflight_git_migration_after_publication(
-            &source,
-            published.path(),
-            &snapshot,
-            &semantic_plan,
-            &capture_store,
-        )
-        .map_err(|error| git_boundary_error("prove Git source after publication", error))?;
+        progress.begin("prove Git source after publication");
+        let published_proof = {
+            let _span = info_span!("kin.init.source_proof_published").entered();
+            preflight_git_migration_after_publication(
+                &source,
+                published.path(),
+                &snapshot,
+                &semantic_plan,
+                &capture_store,
+            )
+            .map_err(|error| git_boundary_error("prove Git source after publication", error))?
+        };
         if published_proof != source_proof {
             return Err(KinError::Other(
                 "Git source proof changed across repository publication; published authority is \
@@ -294,8 +394,11 @@ fn init_from_git_with_hooks(
         // source proof above. The staged observation before publication is what
         // keeps a repository that cannot answer for its content from being
         // published at all. Neither site degrades into a filesystem read.
-        let published_observation =
-            seal_published_content_observation(published.path(), &semantic_plan)?;
+        progress.begin("seal published content");
+        let published_observation = {
+            let _span = info_span!("kin.init.seal_published_content").entered();
+            seal_published_content_observation(published.path(), &semantic_plan, &mut progress)?
+        };
         if published_observation.fingerprint != sealed_observation.fingerprint {
             return Err(KinError::Other(
                 "sealed all-content observation changed across repository publication; published \
@@ -303,6 +406,7 @@ fn init_from_git_with_hooks(
                     .to_string(),
             ));
         }
+        progress.finish("admitted exact Git repository");
         Ok(())
     })?;
     // Exact Git refs intentionally retain external-object targets, so the
@@ -337,6 +441,7 @@ fn init_from_git_with_hooks(
 fn seal_published_content_observation(
     published_kin_dir: &Path,
     closure: &impl AdmittedContentClosure,
+    progress: &mut PhaseProgress,
 ) -> Result<SealedContentObservation> {
     let layout = KinLayout::new(published_kin_dir.to_path_buf());
     let authority = RepositoryAuthorityManager::open(
@@ -348,10 +453,10 @@ fn seal_published_content_observation(
     #[cfg(all(unix, test))]
     if published_closure_is_diverged() {
         let diverged = DivergedClosure::from_closure(closure);
-        return seal_all_content_observation(&diverged, &content)
+        return seal_observed_content(&diverged, &content, progress)
             .map_err(|error| git_boundary_error("seal published all-content observation", error));
     }
-    seal_all_content_observation(closure, &content)
+    seal_observed_content(closure, &content, progress)
         .map_err(|error| git_boundary_error("seal published all-content observation", error))
 }
 
@@ -525,8 +630,14 @@ fn copy_captured_authority(
     snapshot: &LosslessGitRepository,
     capture_store: &BlobStore,
     proof: &GitMigrationPreflightProof,
+    progress: &mut PhaseProgress,
 ) -> Result<()> {
-    for record in &snapshot.objects {
+    let total_objects = snapshot.objects.len();
+    let report_every = progress_interval(total_objects);
+    for (copied, record) in snapshot.objects.iter().enumerate() {
+        if copied.is_multiple_of(report_every) {
+            progress.detail(format_args!("{copied}/{total_objects} objects"));
+        }
         let capture_hash = kin_blobs::Hash256::from_bytes(*record.body_hash.as_bytes());
         let body = capture_store.read(&capture_hash).map_err(|error| {
             git_boundary_error(
@@ -551,7 +662,32 @@ fn copy_captured_authority(
         }
         prepared.save_source_blob(input.body_hash, &input.body)?;
     }
+    progress.detail(format_args!("{total_objects}/{total_objects} objects"));
     Ok(())
+}
+
+/// How often a bounded walk should report, so a long phase stays visible
+/// without the reporting itself becoming the cost. Never zero, so the caller's
+/// modulo is always defined on an empty walk.
+fn progress_interval(total: usize) -> usize {
+    (total / 100).max(1)
+}
+
+/// Seal the staged closure, reporting the walk as it advances.
+fn seal_observed_content(
+    closure: &impl AdmittedContentClosure,
+    content: &impl SealedContentSource,
+    progress: &mut PhaseProgress,
+) -> kin_git::Result<SealedContentObservation> {
+    let mut report_every = 0usize;
+    seal_all_content_observation_observed(closure, content, &mut |done, total| {
+        if report_every == 0 {
+            report_every = progress_interval(total);
+        }
+        if done.is_multiple_of(report_every) || done == total {
+            progress.detail(format_args!("{done}/{total} trees"));
+        }
+    })
 }
 
 fn bind_workspace_authority(

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Per-phase progress reporting for exact Git repository admission.
+//!
+//! Admission runs a fixed ladder of phases, several of which walk the whole of
+//! a repository's history and take minutes on a large repository. The only
+//! output anywhere in the pipeline used to be the cross-file linker's bar,
+//! which belongs to one phase and finishes long before the command does, so a
+//! terminal could sit dead for minutes with no way to tell work from a hang.
+//!
+//! Every line goes to stderr, so machine-readable stdout stays clean. On a
+//! terminal a phase redraws in place and leaves one completed line behind with
+//! its elapsed time; off a terminal each phase prints a start line and an end
+//! line, and in-phase detail is throttled so a pipe is not flooded.
+
+use std::fmt::Arguments;
+use std::io::{IsTerminal, Write};
+use std::time::Instant;
+
+/// Number of phases in the exact Git admission ladder. A ladder that completes
+/// on a different count than this is a drift bug that would print `[16/15]` to
+/// a user, so [`PhaseProgress::finish`] asserts the two agree.
+pub(crate) const GIT_ADMISSION_PHASES: usize = 16;
+
+/// Erase the current line and return to column zero. Only ever written to a
+/// terminal, so a redirected log never receives escape bytes.
+const ERASE_LINE: &str = "\x1b[2K\r";
+
+/// Stderr phase reporter for a fixed-length phase ladder.
+pub(crate) struct PhaseProgress {
+    total: usize,
+    is_tty: bool,
+    index: usize,
+    label: &'static str,
+    detail_updates: usize,
+    phase_started: Instant,
+    started: Instant,
+    in_phase: bool,
+}
+
+impl PhaseProgress {
+    /// Start a reporter for a ladder of `total` phases.
+    pub(crate) fn new(total: usize) -> Self {
+        Self {
+            total,
+            is_tty: std::io::stderr().is_terminal(),
+            index: 0,
+            label: "",
+            detail_updates: 0,
+            phase_started: Instant::now(),
+            started: Instant::now(),
+            in_phase: false,
+        }
+    }
+
+    /// Enter the next phase. Closes any open phase first, so a caller cannot
+    /// leave a half-drawn line behind by forgetting to end one.
+    pub(crate) fn begin(&mut self, label: &'static str) {
+        if self.in_phase {
+            self.end();
+        }
+        self.index += 1;
+        self.label = label;
+        self.detail_updates = 0;
+        self.phase_started = Instant::now();
+        self.in_phase = true;
+        if self.is_tty {
+            self.write(format_args!(
+                "{ERASE_LINE}  [{:>2}/{}] {}...",
+                self.index, self.total, self.label
+            ));
+        } else {
+            self.writeln(format_args!(
+                "  [{:>2}/{}] {}...",
+                self.index, self.total, self.label
+            ));
+        }
+    }
+
+    /// Report progress within the current phase. Callers throttle their own
+    /// call rate; this throttles again off a terminal so a pipe stays readable.
+    pub(crate) fn detail(&mut self, detail: Arguments<'_>) {
+        if !self.in_phase {
+            return;
+        }
+        self.detail_updates += 1;
+        if self.is_tty {
+            self.write(format_args!(
+                "{ERASE_LINE}  [{:>2}/{}] {} {} | {:.1}s",
+                self.index,
+                self.total,
+                self.label,
+                detail,
+                self.phase_started.elapsed().as_secs_f64()
+            ));
+        } else if self.detail_updates <= 1 || self.detail_updates.is_multiple_of(10) {
+            self.writeln(format_args!(
+                "  [{:>2}/{}] {} {} | {:.1}s",
+                self.index,
+                self.total,
+                self.label,
+                detail,
+                self.phase_started.elapsed().as_secs_f64()
+            ));
+        }
+    }
+
+    /// Close the current phase, leaving one line carrying its elapsed time.
+    pub(crate) fn end(&mut self) {
+        if !self.in_phase {
+            return;
+        }
+        self.in_phase = false;
+        let elapsed = self.phase_started.elapsed().as_secs_f64();
+        let prefix = if self.is_tty { ERASE_LINE } else { "" };
+        self.writeln(format_args!(
+            "{prefix}  [{:>2}/{}] {} {:.1}s",
+            self.index, self.total, self.label, elapsed
+        ));
+    }
+
+    /// Close the ladder with one total-elapsed line.
+    ///
+    /// Only the success path finishes a ladder, so every declared phase must
+    /// have run. Asserting that here is what keeps the declared total and the
+    /// call sites from drifting apart unnoticed.
+    pub(crate) fn finish(&mut self, label: &str) {
+        debug_assert_eq!(
+            self.index, self.total,
+            "phase ladder completed {} of {} declared phases",
+            self.index, self.total
+        );
+        self.end();
+        self.writeln(format_args!(
+            "  {label} in {:.1}s",
+            self.started.elapsed().as_secs_f64()
+        ));
+    }
+
+    fn write(&self, args: Arguments<'_>) {
+        let mut stderr = std::io::stderr().lock();
+        // Progress is advisory: a closed or full stderr must never fail an
+        // admission that is otherwise proceeding correctly.
+        let _ = stderr.write_fmt(args);
+        let _ = stderr.flush();
+    }
+
+    fn writeln(&self, args: Arguments<'_>) {
+        let mut stderr = std::io::stderr().lock();
+        let _ = stderr.write_fmt(args);
+        let _ = stderr.write_all(b"\n");
+        let _ = stderr.flush();
+    }
+}
+
+impl Drop for PhaseProgress {
+    /// A phase abandoned by an early return still terminates its line, so an
+    /// error message is never appended to a half-drawn progress line.
+    fn drop(&mut self) {
+        if self.in_phase {
+            self.in_phase = false;
+            self.writeln(format_args!(""));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_phase_ladder_numbers_every_phase_it_enters() {
+        let mut progress = PhaseProgress::new(3);
+        assert_eq!(progress.index, 0);
+        progress.begin("first");
+        assert_eq!(progress.index, 1);
+        assert!(progress.in_phase);
+        progress.end();
+        assert!(!progress.in_phase);
+        progress.begin("second");
+        assert_eq!(progress.index, 2);
+    }
+
+    #[test]
+    fn beginning_a_phase_closes_the_previous_one() {
+        let mut progress = PhaseProgress::new(3);
+        progress.begin("first");
+        progress.begin("second");
+        assert_eq!(progress.index, 2);
+        assert!(progress.in_phase);
+    }
+
+    #[test]
+    fn detail_outside_a_phase_is_ignored() {
+        let mut progress = PhaseProgress::new(3);
+        progress.detail(format_args!("1/2"));
+        assert_eq!(progress.detail_updates, 0);
+        progress.begin("first");
+        progress.detail(format_args!("1/2"));
+        assert_eq!(progress.detail_updates, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "phase ladder completed 1 of 3 declared phases")]
+    fn finishing_short_of_the_declared_total_is_a_drift_bug() {
+        let mut progress = PhaseProgress::new(3);
+        progress.begin("first");
+        progress.finish("done");
+    }
+
+    #[test]
+    fn finishing_on_the_declared_total_is_accepted() {
+        let mut progress = PhaseProgress::new(2);
+        progress.begin("first");
+        progress.begin("second");
+        progress.finish("done");
+        assert_eq!(progress.index, 2);
+    }
+
+    #[test]
+    fn each_phase_restarts_its_detail_throttle() {
+        let mut progress = PhaseProgress::new(3);
+        progress.begin("first");
+        progress.detail(format_args!("1/2"));
+        progress.detail(format_args!("2/2"));
+        assert_eq!(progress.detail_updates, 2);
+        progress.begin("second");
+        assert_eq!(progress.detail_updates, 0);
+    }
+}

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod exact_tree;
 pub mod git_init;
 pub mod hooks;
 pub mod init;
+mod init_progress;
 pub mod layout;
 pub mod manifest;
 pub mod ranking;

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -59,7 +59,8 @@ pub use repository_export::{
     RepositoryGitExportPlan, RepositoryGitExportProof, RepositoryGitExportResult,
 };
 pub use sealed_observation::{
-    seal_all_content_observation, AdmittedContentClosure, ContentExclusionReason,
-    DeclaredContentExclusion, SealedContentCoverage, SealedContentObservation, SealedContentSource,
+    seal_all_content_observation, seal_all_content_observation_observed, AdmittedContentClosure,
+    ContentExclusionReason, DeclaredContentExclusion, SealedContentCoverage,
+    SealedContentObservation, SealedContentSource,
 };
 pub use semantic_import::{plan_semantic_git_import, GitWorkspaceSeed, SemanticGitImportPlan};

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -180,6 +180,22 @@ pub fn seal_all_content_observation(
     closure: &impl AdmittedContentClosure,
     content: &impl SealedContentSource,
 ) -> Result<SealedContentObservation> {
+    seal_all_content_observation_observed(closure, content, &mut |_, _| {})
+}
+
+/// Prove sealed all-content observation, reporting progress as it walks.
+///
+/// The observation is Sigma over every admitted tree of that tree's full entry
+/// count, so on a repository with deep history it runs for minutes. `observe`
+/// is called with `(trees_completed, trees_total)` after each tree so a caller
+/// can show that the walk is advancing. It changes nothing the observation
+/// proves: [`seal_all_content_observation`] is this function with an observer
+/// that does nothing.
+pub fn seal_all_content_observation_observed(
+    closure: &impl AdmittedContentClosure,
+    content: &impl SealedContentSource,
+    observe: &mut dyn FnMut(usize, usize),
+) -> Result<SealedContentObservation> {
     let mut coverage = SealedContentCoverage::default();
     let mut observed_entries = 0usize;
     let mut observed_trees = 0usize;
@@ -190,7 +206,9 @@ pub fn seal_all_content_observation(
     let mut non_utf8_paths = BTreeSet::<RepoPath>::new();
     let mut tree_digests = Vec::<Hash256>::new();
 
-    for tree in closure.admitted_trees() {
+    let admitted_trees = closure.admitted_trees();
+    let total_trees = admitted_trees.len();
+    for tree in admitted_trees {
         observed_trees += 1;
         // One digest per admitted tree over its exact (path, shape, body)
         // sequence. Counts alone cannot distinguish two closures that agree on
@@ -264,6 +282,7 @@ pub fn seal_all_content_observation(
             }
         }
         tree_digests.push(digest(&tree_content));
+        observe(observed_trees, total_trees);
     }
 
     // One gap per distinct unsealed body, so a report that lists every gap it

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -169,6 +169,53 @@ publication.
 - `--json`: report the exact committed repository/workspace authority result,
   including the semantic enrichment admission produced.
 
+### How long admission takes, and what it prints
+
+Admission is a one-time cost that scales with the size of your history rather
+than the size of your checkout, because every reachable commit's tree is
+observed and proven. On a small repository it takes seconds. On a repository
+with thousands of commits it takes minutes and can hold several gigabytes of
+memory while it runs.
+
+`kin init` prints its phase ladder to stderr so the terminal is never silent
+while that happens:
+
+```
+  [ 1/15] capture Git repository 1.4s
+  [ 2/15] build Git authority 0.2s
+  [ 3/15] plan semantic import 3.1s
+  [ 4/15] derive semantic history 41.7s
+  ...
+  [15/15] seal published content 12.9s
+  admitted exact Git repository in 118.3s
+```
+
+The long phases report their own progress while they run, so a phase that is
+walking history shows how far it has gone. Stdout stays clean, so
+`kin init --json` is still safe to pipe.
+
+### Profiling a slow command
+
+Every `kin` command can profile itself. No rebuild, no external profiler, and
+no debug symbols are needed:
+
+```sh
+# Print the hottest stages to stderr when the command finishes
+kin init --profile-summary
+
+# Write the full machine-readable profile to a file
+kin init --profile-out /tmp/kin-init-profile.json
+```
+
+`--profile-summary` (or `KIN_PROFILE_SUMMARY=1`) prints a ranked list of the
+slowest stages with their self time, plus peak CPU, peak resident memory, and
+peak thread count. `--profile-out` (or `KIN_PROFILE_OUT=<path>`) writes a JSON
+report carrying every instrumented span with its start and end offsets, a
+resource timeline sampled every 250 ms (`KIN_PROFILE_SAMPLE_MS`), and per-stage
+rollups. Use `--profile-out` when reporting a performance problem: it is the
+fastest way to say which phase owns the time rather than guessing from wall
+clock.
+
 ---
 
 ## 4. Add embeddings for semantic search


### PR DESCRIPTION
Exact Git admission runs sixteen phases and carried a tracing span for one of
them. Measured on published v0.5.5, `kin.init` self time was 79.0% on anyhow and
79.5% on ripgrep, so the profiler that already ships could not attribute four
fifths of the command, and every optimization decision after it was being made
against that blind spot.

## What changed

Each phase now enters an `info_span!`, so `--profile-out` attributes the whole
run and a `kin_blobs.write` call carries the phase that made it. That is what
names the passes behind the measured 7.00x write amplification, which is the
next question on the ladder.

Each phase also announces itself on stderr with the time it took, and the two
walks that iterate history report how far they have gone: copying the captured
object closure, and sealing all content. Before this the only progress anywhere
in admission was the cross-file linker's bar, which belongs to a phase measuring
about 2% of the bill and finishes minutes before the command returns. A user
watching a nine-minute init saw a bar complete and then a dead terminal, which
is indistinguishable from a hang.

```
  [ 1/16] capture Git repository 1.4s
  [ 2/16] build Git authority 0.2s
  ...
  [ 9/16] seal staged content 1840/2261 trees | 61.2s
  ...
  admitted exact Git repository in 118.3s
```

`seal_all_content_observation` gains an observed variant rather than a changed
signature; the original delegates to it with an observer that does nothing, so
nothing the seal proves changes.

Stdout is untouched, so `kin init --json` stays pipeable. On a terminal a phase
redraws in place; off a terminal it prints whole lines and throttles its detail,
so a pipe is not flooded.

## Why the guard can fail

The declared phase count and the call sites cannot drift apart silently.
Finishing the ladder asserts they agree, and the assertion was falsified rather
than assumed: setting the constant to 15 against a 16-phase ladder failed nine
admission tests with `phase ladder completed 16 of 15 declared phases`, and
restoring it returned 487 kin-core plus 74 kin-git tests to green.

## Docs

`--profile-out` and `--profile-summary` have existed since before v0.5.5,
produced every number above, and were mentioned nowhere a user would look. The
quickstart now documents both, what admission costs and why, and what it prints
while it runs.

Closes FIR-2000