### PR TITLE
Tell a locate caller when nothing it asked for was actually found

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -55,6 +55,18 @@ pub struct LocateResult {
     /// Total entities in the full ranking behind this paged view.
     #[serde(default, skip_serializing_if = "is_zero_usize")]
     pub total_ranked: usize,
+    /// True when entities were ranked and NOT ONE of them was named by the
+    /// query: every hit is a fallback.
+    ///
+    /// The one-field answer to "did this query find anything, or did retrieval
+    /// just return its best guesses". A caller asking for a symbol that exists
+    /// nowhere gets a full page either way, and this is the difference between
+    /// the two cases. Deliberately a fact about the whole page rather than a
+    /// relevance floor: a floor would need a threshold on a composite score
+    /// whose scale is not comparable across queries, so it would drop real
+    /// answers to hide wrong ones. This reports; the caller decides.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub all_fallback: bool,
     pub files: Vec<LocateFileEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub debug: Option<LocateDebugInfo>,
@@ -223,6 +235,74 @@ fn is_zero_usize(value: &usize) -> bool {
     *value == 0
 }
 
+/// `serde` skip predicate: omit a `bool` field when it is `false`.
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// How a located entity relates to the query that surfaced it.
+///
+/// The distinction `kin search` already draws, on the surface agents actually
+/// read. A retrieval pipeline always returns its best candidates, so a query
+/// naming a symbol that exists nowhere still comes back with a full, confident
+/// page. Without this field the caller cannot tell that page from one where the
+/// query named a real symbol, because the scores look the same either way: they
+/// are composite ranks within a result set, not evidence that anything matched.
+///
+/// This never affects ranking or ordering. It is a statement about what the hit
+/// IS, computed from the same exact-token predicate the `semantic_locate`
+/// evidence object reports, so the two surfaces cannot drift apart.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LocateMatchKind {
+    /// A query token is this entity's name (or its last dotted segment). The
+    /// query asked for this symbol.
+    Name,
+    /// No query token named this entity; vector retrieval surfaced it from the
+    /// query's embedding. It is about the query, it is not the query.
+    Semantic,
+    /// No query token named this entity, and it came from the lexical/graph
+    /// pool. It shares content tokens with the query, not a name.
+    TextFallback,
+}
+
+/// Whether a query token IS this entity's name (or its last dotted segment).
+///
+/// The single definition of "the query named this symbol". `kin-daemon`'s
+/// `semantic_locate` evidence object calls this rather than keeping a second
+/// copy: one rule stated twice is one rule that can come to disagree with
+/// itself, and these two surfaces answer the same question about the same hit.
+pub fn query_names_entity(query: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let target = name.to_ascii_lowercase();
+    let last = target.rsplit('.').next().unwrap_or(&target).to_string();
+    query
+        .to_ascii_lowercase()
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .filter(|token| !token.is_empty())
+        .any(|token| token == target || token == last)
+}
+
+/// Classify one located entity against the query.
+///
+/// Falls back on the resolution origin only when the name did not match, so a
+/// name hit that also came through the vector pool is still reported as a name
+/// hit. An unattributed origin (the common case, since origin is populated under
+/// `--explain`) reports `TextFallback`: the honest reading of "no name matched
+/// and this surface cannot say which pool answered" is the weaker claim, not the
+/// stronger one.
+fn classify_locate_match(query: &str, name: &str, origin: &str) -> LocateMatchKind {
+    if query_names_entity(query, name) {
+        LocateMatchKind::Name
+    } else if origin == "vector" {
+        LocateMatchKind::Semantic
+    } else {
+        LocateMatchKind::TextFallback
+    }
+}
+
 /// A single ranked graph ENTITY surfaced by `kin locate` — the graph-native unit
 /// of the result. Unlike [`LocateSymbol`] (a file-attributed symbol), a
 /// `LocateEntity` is self-describing and act-on-able: it carries the entity's
@@ -257,6 +337,11 @@ pub struct LocateEntity {
     /// for the remainder. `None` on a graph/blob miss (coordinates only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
+    /// How this entity relates to the query: did the query NAME it, or did
+    /// content/embedding retrieval answer instead. See [`LocateMatchKind`].
+    /// Absent only on a record produced by a daemon predating the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_kind: Option<LocateMatchKind>,
     /// Where this entity lives. The file is provenance, not the result.
     pub provenance: LocateProvenance,
     /// Under multi-query RRF fusion, the query variants that surfaced this entity
@@ -3830,7 +3915,13 @@ fn run_with_graph_capture_budgeted(
     // single globally-ranked entity list (file demoted to provenance). Reuses the
     // snippet projection's bounds; the daemon caches the full ranking and windows
     // one page. No-op unless the agent/JSON surface requested snippets.
-    build_entity_view(&mut result, &held_authority, &snippet_opts, source_scope)?;
+    build_entity_view(
+        &mut result,
+        &held_authority,
+        &snippet_opts,
+        source_scope,
+        text,
+    )?;
     Ok(result)
 }
 
@@ -15607,6 +15698,7 @@ pub fn build_entity_view(
     held_authority: &kin_mcp::handlers::common::HeldSourceAuthority<'_, kin_db::InMemoryGraph>,
     opts: &SnippetOptions,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
+    query: &str,
 ) -> Result<()> {
     if !opts.enabled {
         return Ok(());
@@ -15667,6 +15759,7 @@ pub fn build_entity_view(
                     definition: sym.definition,
                     span: sym.span,
                     body,
+                    match_kind: Some(classify_locate_match(query, &entity.name, &sym.origin)),
                     provenance: LocateProvenance {
                         file: file_origin,
                         origin: sym.origin.clone(),
@@ -15695,6 +15788,14 @@ pub fn build_entity_view(
 
     result.entities = ranked.into_iter().map(|(_, entity)| entity).collect();
     result.total_ranked = result.entities.len();
+    // Computed over the FULL ranking, before the daemon windows a page. A
+    // per-page verdict would call a query successful because page 1 happened to
+    // hold the one name hit, and a fallback because page 2 did not.
+    result.all_fallback = !result.entities.is_empty()
+        && !result
+            .entities
+            .iter()
+            .any(|entity| entity.match_kind == Some(LocateMatchKind::Name));
     Ok(())
 }
 
@@ -15929,12 +16030,22 @@ pub fn fuse_locate_results(
         }
     }
 
+    // Recomputed over the FUSED set rather than inherited from the primary
+    // variant. Each variant classified its own hits against its own text, so a
+    // symbol named by ANY variant is a name hit for the fan-out, and carrying
+    // the primary's verdict forward would report a successful fan-out as
+    // all-fallback whenever the primary phrasing happened to miss.
+    let all_fallback = !entities.is_empty()
+        && !entities
+            .iter()
+            .any(|entity| entity.match_kind == Some(LocateMatchKind::Name));
     let primary = results.into_iter().next().unwrap_or_default();
     LocateResult {
         entities,
         next_cursor: None,
         page: 0,
         total_ranked: 0,
+        all_fallback,
         files,
         debug: primary.debug,
         semantic_coverage: primary.semantic_coverage,
@@ -16486,6 +16597,7 @@ mod tests {
             definition,
             span: Some([10, 20]),
             body: Some(format!("fn {name}() {{ /* … */ }}")),
+            match_kind: None,
             provenance: LocateProvenance {
                 file: Some(format!("src/{name}.rs")),
                 origin: "vector".to_string(),
@@ -16700,6 +16812,7 @@ mod tests {
             definition: true,
             span: None,
             body: None,
+            match_kind: None,
             provenance: LocateProvenance {
                 file: Some(path.to_string()),
                 origin: String::new(),
@@ -17043,6 +17156,142 @@ mod tests {
         assert_eq!(first_ids, second_ids);
     }
 
+    /// The positive control: a query that NAMES a symbol classifies as a name
+    /// hit, whichever pool surfaced it.
+    #[test]
+    fn a_query_that_names_a_symbol_is_a_name_match() {
+        assert_eq!(
+            classify_locate_match(
+                "cross_encoder_model_cached",
+                "cross_encoder_model_cached",
+                ""
+            ),
+            LocateMatchKind::Name
+        );
+        // Case and surrounding prose do not change the verdict, and neither does
+        // the seed pool: a name hit that also came through the vector arm is
+        // still a name hit.
+        assert_eq!(
+            classify_locate_match(
+                "where is Cross_Encoder_Model_Cached decided?",
+                "cross_encoder_model_cached",
+                "vector"
+            ),
+            LocateMatchKind::Name
+        );
+        // A dotted name is named by its last segment, the same way the exact
+        // name boost reads it.
+        assert_eq!(
+            classify_locate_match("call parse_request", "http.parse_request", ""),
+            LocateMatchKind::Name
+        );
+    }
+
+    /// The negative control, which is the whole point of the field: a query for
+    /// a symbol that exists nowhere still returns the retriever's best
+    /// candidates, and every one of them must be flagged as a fallback.
+    #[test]
+    fn a_nonexistent_symbol_leaves_every_hit_flagged_as_fallback() {
+        let absent = "kin_absent_symbol_negative_control";
+        for (name, origin, expected) in [
+            ("candidate", "", LocateMatchKind::TextFallback),
+            ("query_trace_matches", "text", LocateMatchKind::TextFallback),
+            ("exact_name_match", "vector", LocateMatchKind::Semantic),
+        ] {
+            assert_eq!(
+                classify_locate_match(absent, name, origin),
+                expected,
+                "no token of {absent} names {name}"
+            );
+            assert_ne!(
+                classify_locate_match(absent, name, origin),
+                LocateMatchKind::Name
+            );
+        }
+    }
+
+    /// A shared substring is not a name. Without this the field would classify
+    /// nearly everything as a name hit and answer nothing.
+    #[test]
+    fn a_merely_related_word_is_not_a_name_match() {
+        assert_eq!(
+            classify_locate_match(
+                "Where does Kin decide whether to use the reranker?",
+                "decide_review_with_graph",
+                ""
+            ),
+            LocateMatchKind::TextFallback
+        );
+        assert!(!query_names_entity("encoder", "cross_encoder_model_cached"));
+        assert!(!query_names_entity("", "anything"));
+        assert!(!query_names_entity("anything", ""));
+    }
+
+    #[test]
+    fn all_fallback_is_a_verdict_on_the_whole_ranking() {
+        let with_kind = |name: &str, kind| {
+            let mut entity = mk_locate_entity(name, 1.0, true);
+            entity.match_kind = Some(kind);
+            entity
+        };
+        // One name hit anywhere in the ranking means the query found something.
+        let found = fuse_locate_results(
+            vec!["q0".to_string(), "q1".to_string()],
+            vec![
+                fusion_result(vec![with_kind("a", LocateMatchKind::TextFallback)]),
+                fusion_result(vec![with_kind("b", LocateMatchKind::Name)]),
+            ],
+            60.0,
+        );
+        assert!(
+            !found.all_fallback,
+            "a name hit surfaced by a non-primary variant still counts as found"
+        );
+
+        let missed = fuse_locate_results(
+            vec!["q0".to_string(), "q1".to_string()],
+            vec![
+                fusion_result(vec![with_kind("a", LocateMatchKind::TextFallback)]),
+                fusion_result(vec![with_kind("b", LocateMatchKind::Semantic)]),
+            ],
+            60.0,
+        );
+        assert!(
+            missed.all_fallback,
+            "a full page of fallbacks is exactly what the caller needs told"
+        );
+
+        // An empty result is not a fallback verdict: nothing was returned to
+        // mislabel, and reporting one would make "no results" and "wrong
+        // results" look alike.
+        let empty = fuse_locate_results(
+            vec!["q0".to_string(), "q1".to_string()],
+            vec![fusion_result(vec![]), fusion_result(vec![])],
+            60.0,
+        );
+        assert!(!empty.all_fallback);
+    }
+
+    #[test]
+    fn match_kind_serializes_under_the_search_surface_vocabulary() {
+        let mut entity = mk_locate_entity("a", 1.0, true);
+        entity.match_kind = Some(LocateMatchKind::TextFallback);
+        let json = serde_json::to_value(&entity).unwrap();
+        assert_eq!(json["match_kind"].as_str(), Some("text_fallback"));
+        entity.match_kind = Some(LocateMatchKind::Name);
+        assert_eq!(
+            serde_json::to_value(&entity).unwrap()["match_kind"].as_str(),
+            Some("name")
+        );
+        // Absent rather than null on a record that predates the field, so an
+        // older daemon's payload still deserializes.
+        entity.match_kind = None;
+        assert!(serde_json::to_value(&entity)
+            .unwrap()
+            .get("match_kind")
+            .is_none());
+    }
+
     #[test]
     fn build_entity_view_is_noop_when_snippets_disabled() {
         let graph = kin_db::InMemoryGraph::new();
@@ -17066,6 +17315,7 @@ mod tests {
             &kin_mcp::handlers::common::HeldSourceAuthority::new(&graph, None),
             &SnippetOptions::default(),
             kin_mcp::handlers::common::EntitySourceScope::WorkspaceHead,
+            "query",
         )
         .unwrap();
         assert!(

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5733,16 +5733,11 @@ fn semloc_query_is_test_related(query: &str) -> bool {
 /// including the last dotted segment of a qualified name (e.g. query
 /// "constant.Raspbian" matches entity "Raspbian"). Tokens split on non-[a-z0-9_].
 fn semloc_query_has_exact_token(query: &str, name: &str) -> bool {
-    if name.is_empty() {
-        return false;
-    }
-    let target = name.to_ascii_lowercase();
-    let last = target.rsplit('.').next().unwrap_or(&target).to_string();
-    query
-        .to_ascii_lowercase()
-        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
-        .filter(|t| !t.is_empty())
-        .any(|tok| tok == target || tok == last)
+    // Delegated so the `match_evidence.name_match` this surface reports and the
+    // `match_kind` carried on every located entity are decided by ONE rule. Two
+    // copies of a predicate are two things to keep in step, and these two answer
+    // the same question about the same hit on the same response.
+    kin_cli::commands::locate::query_names_entity(query, name)
 }
 
 /// Re-rank PRIORITY for one cosine hit (LOWER = better rank). Pure: no graph.
@@ -10906,6 +10901,7 @@ mod tests {
             definition: true,
             span: None,
             body: None,
+            match_kind: None,
             provenance: LocateProvenance {
                 file: Some("src/lib.rs".into()),
                 origin: "vector".into(),
@@ -11025,6 +11021,7 @@ mod tests {
             definition: true,
             span: None,
             body: None,
+            match_kind: None,
             provenance: LocateProvenance {
                 file: Some("src/lib.rs".into()),
                 origin: String::new(),
@@ -11057,6 +11054,7 @@ mod tests {
             definition: true,
             span: Some([1, 2]),
             body: None,
+            match_kind: None,
             provenance: LocateProvenance {
                 file: Some("f.rs".into()),
                 origin: String::new(),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -109,7 +109,12 @@ model not cached, …), so a thin result set is attributable instead of silent. 
 the Kin daemon: retrieval runs against the daemon's live graph, so this tool returns an \
 error in offline/no-daemon mode. On an empty result the additive `negative` object's \
 `safe_to_conclude_absent` flag distinguishes an authoritative \"no match\" from \"not \
-yet embedded\".";
+yet embedded\". A NON-empty result needs the opposite check, because retrieval always \
+returns its best candidates: each hit carries `match_kind` (`name` when a query token is \
+that entity's name, else `semantic` or `text_fallback`), and the response carries \
+`all_fallback: true` when NOT ONE returned entity was named by the query. Asking for a \
+symbol that does not exist yields a full, confident-looking page with `all_fallback` set \
+— treat that as \"this symbol was not found\" rather than as the answer.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///


### PR DESCRIPTION
Closes FIR-1997

## What the dogfood run measured

The pre-registered answer key's NEGATIVE CONTROL, a symbol that exists nowhere in
the corpus, came back through `locate` with six confident results where the key
requires empty. It reproduced in both dogfood arms (report
`.kin-coord/reports/nstore2-gate2-arms-20260805.md` sections 6e and 6f), and it
is the one finding in that run that partial embedding coverage does not confound:
a retrieval pipeline returns its best candidates whether or not the thing asked
for exists.

Scores cannot answer this. A locate score is a composite rank inside a result
set, not evidence that anything matched, and the six wrong answers scored exactly
the way six right ones would.

## A correction to the ticket, from reading the source

FIR-1997 says the locate response carries no match discrimination at all. That is
true of `kin locate --json`, which is the surface the dogfood run actually
measured, and it is what this PR fixes. It is NOT true of `semantic_locate`:
`crates/kin-daemon/src/api.rs` already attaches `match_evidence.name_match`
(`exact` / `partial` / `none`) to every hit on both the cosine and fused arms.

So the gap was narrower than written, and also worse in one respect: two surfaces
of one query were answering the same question with two independent
implementations of the same predicate. This PR closes the gap and collapses the
duplication.

## The change

`LocateEntity` gains `match_kind`, using the vocabulary `kin search` already
established under FIR-1971:

- `name` — a query token IS this entity's name, or its last dotted segment. The
  query asked for this symbol.
- `semantic` — no query token named it; the vector arm surfaced it.
- `text_fallback` — no query token named it, and it came from the lexical/graph
  pool.

`LocateResult` gains `all_fallback`, true when entities were ranked and NOT ONE
was named by the query. That is the one-field version of "this query found
nothing, here are the retriever's guesses", and it is what an agent can branch on
without iterating.

Both are additive, both are `skip_serializing_if`-omitted at their defaults, and
neither participates in ranking or ordering.

Three details that are decisions rather than mechanics:

- **`all_fallback` is computed over the FULL ranking, before the daemon windows a
  page.** A per-page verdict would call a query found because page 1 happened to
  hold the one name hit and not-found because page 2 did not.
- **It is recomputed over a fused multi-query result, not inherited from the
  primary variant.** Each variant classifies its own hits against its own text, so
  a symbol named only by a secondary phrasing still counts as found; carrying the
  primary's verdict forward would report a successful fan-out as all-fallback.
- **An empty result is not `all_fallback`.** Nothing was returned to mislabel, and
  flagging it would make "no results" and "wrong results" look alike.

`kin-daemon`'s `semloc_query_has_exact_token` now delegates to the shared
`query_names_entity`, so `match_evidence.name_match` and `match_kind` are decided
by one rule. The MCP payload is built by serializing `LocateResult` directly, so
`semantic_locate` gains both fields with no separate wiring; its tool description
now tells an agent what they mean and what to do when `all_fallback` is set.

## No relevance floor, deliberately

FIR-1997 asks to consider one. A floor needs a threshold on a composite score
whose scale is not comparable across queries, corpora, or profiles, so it would
silently drop real answers in order to hide wrong ones, and the failure would look
identical to a graph gap. Reporting the fact and letting the caller decide is
strictly more information than truncating the list. Recorded here rather than left
as an unexplained omission.

## Verification

Two-sided, from the dogfood key's own controls:

- `a_query_that_names_a_symbol_is_a_name_match` — the POSITIVE control
  (`cross_encoder_model_cached`, which the key scores CORRECT at rank 1) classifies
  as `name`, including when it is embedded in prose, in a different case, or reached
  through the vector pool, and including a dotted name matched on its last segment.
- `a_nonexistent_symbol_leaves_every_hit_flagged_as_fallback` — the NEGATIVE
  control against the exact rank-1 answers both arms actually returned
  (`candidate`, `query_trace_matches`, `exact_name_match`): none classifies as
  `name`.
- `a_merely_related_word_is_not_a_name_match` — the falsification. A predicate
  loose enough to call everything a name hit would answer nothing, so the wrong
  answer the run recorded for "where is the reranker decided"
  (`decide_review_with_graph`) must classify as a fallback, and a shared substring
  must not count.
- `all_fallback_is_a_verdict_on_the_whole_ranking` — both directions across a
  fused two-variant result, plus the empty case.
- `match_kind_serializes_under_the_search_surface_vocabulary` — the wire strings,
  and absence rather than null on a record predating the field.

Local: `cargo test -p kin-cli --lib` 1190 passed / 0 failed, `cargo test -p
kin-daemon --lib` 636 passed / 0 failed, `cargo check --workspace --all-targets`
clean, `cargo fmt --all --check` clean, `cargo clippy --all-targets
--all-features` clean under the CI allowlist with `RUSTFLAGS=-Dwarnings`.

## Consumer tolerance, checked rather than assumed

Both fields are additive, which is safe in principle; the actual consumers were
read.

- `kin-editor` routes its semantic search through MCP `semantic_locate` and
  parses the reply with `parseEntitiesFromMcp`, which selects the `entities`
  array and maps each row through `normalizeEntity`. That reader names the fields
  it wants and ignores everything else, so an added key changes nothing for it.
- Nothing in `packages/boundary-contracts` pins the locate response shape, so no
  schema needed widening.
- `cargo check --workspace --all-targets` covers the in-repo consumers, including
  the daemon's MCP payload builder and `contextbench_locate`.

Nothing was REMOVED or renamed on either surface.

## Not claiming

This does not make the two wrong ranked answers right. Those were measured at 39%
embedding coverage and are confounded, as the report states. It changes what a
caller can KNOW about a result, not how results are ranked. It also does not
re-run the dogfood key end to end against a live daemon; the controls are
exercised as unit tests against the same query and answer strings the run
produced.

