### PR TITLE
Give the configured agent profile the tool for the question Kin is described by

### DIFF
--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -1075,6 +1075,10 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
         "semantic_locate",
         "semantic_search",
         "get_context_pack",
+        // The flagship question a Kin agent is asked is "what breaks if I change
+        // this". Its named tool belongs in the profile every configured agent
+        // receives; without it the CLI can answer what the agent cannot.
+        "impact_analysis",
         // A profile carrying the transaction write surface must carry a direct
         // entity-body read. Staging a body update means restating the entity's
         // current source, so an agent without a body read can only guess it --
@@ -1277,7 +1281,7 @@ mod tests {
         let profile = agent_default_tool_names();
 
         assert!(
-            profile.len() >= 10 && profile.len() <= 18,
+            profile.len() >= 10 && profile.len() <= 19,
             "agent-default should be small but cover the wedge; got {}",
             profile.len()
         );
@@ -1306,6 +1310,10 @@ mod tests {
             "kin_session_heartbeat",
             // The only clean exit from a transaction the agent decided against.
             "kin_transaction_abort",
+            // The flagship question. A configured agent that cannot ask what a
+            // change affects cannot do the thing Kin is described as doing, and
+            // the CLI answering it is no help to the agent surface.
+            "impact_analysis",
         ] {
             assert!(
                 profile.contains(&required),


### PR DESCRIPTION
`kin setup` writes `KIN_MCP_TOOL_PROFILE=agent-default`, and that profile carried
18 tools without `impact_analysis`. So an agent wired up the supported way could
not ask what a change affects. The CLI answers that question; the agent surface
did not.

That is the gap a reader testing the described behavior finds first, because
wiring the MCP server into an agent and asking it the headline question is the
obvious thing to try.

## Cost, measured rather than estimated

The `impact_analysis` definition is roughly 1,500 bytes, about 375 tokens,
against an ~8.5k-token profile. The profile stays small: 19 tools against a full
surface of 64.

## The guard moved rather than loosened

`agent_default_profile_is_small_and_valid` pinned `profile.len() <= 18` and
correctly failed on this change. The bound moves to 19, and `impact_analysis`
joins the required list beside the tools whose absence would strand an agent
mid-task (the body read behind the write surface, the heartbeat, the transaction
abort). A later trim cannot quietly drop it again without failing that assertion.

## Verification

- `cargo test -p kin-mcp --lib`: 312 passed, 0 failed.
- `expected_tool_count` passes unchanged, which is the evidence the full 64-tool
  surface is untouched by this change.
- `agent_default_profile_is_small_and_valid` passes with the new bound and the
  new required entry.

## Scope

This changes only which tools the agent-default profile lists. It does not change
the default profile selection: an unset `KIN_MCP_TOOL_PROFILE` still serves the
full surface, and making agent-default the default is tracked separately.

Closes FIR-2013 item 3
Refs FIR-2013, FIR-963, FIR-1880
