### PR TITLE
Say which languages Kin parses, and say so when it parsed none

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -233,7 +233,36 @@ fn print_human_result(
         "  Semantic enrichment: {}",
         render_semantic_enrichment(semantic_enrichment)
     );
+    if let Some(notice) = semantic_absence_notice(semantic_enrichment) {
+        println!("{notice}");
+    }
     Ok(())
+}
+
+/// What to say when initialization produced no semantic entities at all.
+///
+/// Absence here was previously reported as a number and nothing else, and a
+/// repository whose languages Kin does not parse then answers every later query
+/// with an empty list — byte-identical to a query that legitimately found
+/// nothing. The two call for opposite next actions and the operator had no way
+/// to tell them apart, on any surface, in any output.
+///
+/// The wording is deliberately CONDITIONAL rather than diagnostic. This function
+/// knows that zero entities were extracted; it does NOT know whether that is
+/// because no admitted file had an adapter or because something went wrong for a
+/// language Kin does support, and asserting the first would be a confident guess
+/// dressed as a finding. Naming the possibility and handing over the command
+/// that settles it costs one line and cannot be wrong.
+fn semantic_absence_notice(enrichment: &SemanticEnrichmentStatus) -> Option<String> {
+    if !matches!(enrichment.presence, SemanticEnrichmentPresence::Absent) {
+        return None;
+    }
+    Some(
+        "  No semantic entities were extracted. If this repository's languages are not \
+         ones Kin parses, that is expected, and `kin languages` lists the ones it does; \
+         content and history are still under repository authority either way."
+            .to_string(),
+    )
 }
 
 fn render_semantic_enrichment(enrichment: &SemanticEnrichmentStatus) -> String {
@@ -269,4 +298,56 @@ fn initialized_raw_git_head(result: &kin_core::InitResult) -> Option<&kin_model:
         .as_ref()
         .and_then(|delta| delta.new.as_ref())
         .map(|authority| &authority.raw_head)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::status::SemanticEnrichmentView;
+
+    fn enrichment(
+        presence: SemanticEnrichmentPresence,
+        entities: usize,
+    ) -> SemanticEnrichmentStatus {
+        SemanticEnrichmentStatus {
+            view: SemanticEnrichmentView::DurableRepositoryAuthority,
+            authority_generation: 1,
+            workspace_generation: 1,
+            presence,
+            entity_count: entities,
+            relation_count: 0,
+            semantic_change_count: 0,
+            completion_attested: false,
+        }
+    }
+
+    /// A repository Kin could not extract anything from must SAY so and name the
+    /// command that explains why. Silence here is what made "no parser for my
+    /// language" indistinguishable from "my search was bad".
+    #[test]
+    fn an_empty_semantic_layer_points_at_the_supported_languages() {
+        let notice = semantic_absence_notice(&enrichment(SemanticEnrichmentPresence::Absent, 0))
+            .expect("absence must be explained, not merely counted");
+        assert!(
+            notice.contains("kin languages"),
+            "the notice must hand over the command that settles it: {notice}"
+        );
+        // The claim must stay conditional. Asserting the cause outright would be
+        // a guess: this code knows the count, not the reason.
+        assert!(
+            notice.contains("If this repository's languages are not"),
+            "the notice must not assert a cause it cannot know: {notice}"
+        );
+    }
+
+    /// The falsification: a repository that DID get semantics must print
+    /// nothing extra, or the notice is noise on every successful init rather
+    /// than a signal on the failing ones.
+    #[test]
+    fn a_repository_with_semantics_gets_no_notice() {
+        assert!(
+            semantic_absence_notice(&enrichment(SemanticEnrichmentPresence::Present, 19_405))
+                .is_none()
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/languages.rs
+++ b/crates/kin-cli/src/commands/languages.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin languages` — print the languages Kin extracts semantics from.
+//!
+//! Exists because the answer was previously unobtainable. A repository whose
+//! files have no adapter initializes successfully and then answers every query
+//! with an empty list, identically to a query that simply found nothing, and
+//! nothing anywhere named the reason. A stranger cannot tell "Kin does not parse
+//! this language" from "my search was bad", and the two call for opposite next
+//! actions.
+//!
+//! The list is READ FROM THE REGISTRY, never written down here. Admission asks
+//! `AdapterRegistry` which adapter matches an extension and there is no second
+//! gate, so the registry IS the supported set. A hardcoded list beside it would
+//! be a second statement of one fact, and the failure it produces is the worst
+//! kind: the command keeps answering confidently while the answer quietly stops
+//! being true.
+
+use anyhow::Result;
+use kin_parser::AdapterRegistry;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct SupportedLanguage {
+    /// Canonical language id, the same token `kin search --language` accepts.
+    pub language: String,
+    /// Every file extension this adapter claims, without a leading dot.
+    pub extensions: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LanguagesJson {
+    pub schema: &'static str,
+    pub count: usize,
+    pub languages: Vec<SupportedLanguage>,
+}
+
+/// The registry's contents, projected for display.
+///
+/// Registration order is preserved rather than sorted: it is the order admission
+/// consults adapters in, so a reader comparing this against behavior sees the
+/// same sequence the code takes.
+pub fn supported_languages() -> Vec<SupportedLanguage> {
+    AdapterRegistry::new()
+        .supported_languages_with_extensions()
+        .into_iter()
+        .map(|(language, extensions)| SupportedLanguage {
+            language: language.to_string(),
+            extensions: extensions.iter().map(|ext| (*ext).to_string()).collect(),
+        })
+        .collect()
+}
+
+pub async fn run(json: bool) -> Result<()> {
+    let languages = supported_languages();
+    if json {
+        let payload = LanguagesJson {
+            schema: "kin.languages.v1",
+            count: languages.len(),
+            languages,
+        };
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    println!("Kin extracts semantics from {} languages:", languages.len());
+    let width = languages
+        .iter()
+        .map(|entry| entry.language.len())
+        .max()
+        .unwrap_or(0);
+    for entry in &languages {
+        println!(
+            "  {:width$}  {}",
+            entry.language,
+            entry
+                .extensions
+                .iter()
+                .map(|ext| format!(".{ext}"))
+                .collect::<Vec<_>>()
+                .join(" "),
+            width = width
+        );
+    }
+    println!();
+    // The honest boundary, stated where someone is already asking the question.
+    // Kin still admits a file it cannot parse: it becomes repository authority
+    // with content and history, and only the semantic layer is absent. Saying
+    // "unsupported" without that distinction would read as "Kin refused my
+    // repository", which is not what happens.
+    println!(
+        "Files in other languages are still admitted as repository authority \
+         with their content and history. What they do not get is entities, \
+         relations, and the semantic search built on them."
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The command's list must equal the registry's, computed by iterating the
+    /// registry HERE too.
+    ///
+    /// A test that spelled out fourteen names would pass forever while the
+    /// command drifted, which is the drift this command exists to prevent, so
+    /// it must not be written that way.
+    #[test]
+    fn the_printed_set_is_the_registered_set() {
+        let registry = AdapterRegistry::new();
+        let registered: Vec<String> = registry
+            .supported_languages()
+            .into_iter()
+            .map(|language| language.to_string())
+            .collect();
+        let printed: Vec<String> = supported_languages()
+            .into_iter()
+            .map(|entry| entry.language)
+            .collect();
+        assert_eq!(printed, registered);
+        assert!(
+            !registered.is_empty(),
+            "an empty registry would make every assertion here vacuous"
+        );
+    }
+
+    /// Every language reports at least one extension, and every extension is
+    /// bare (no leading dot) so it can be compared against a path suffix.
+    #[test]
+    fn every_language_reports_matchable_extensions() {
+        for entry in supported_languages() {
+            assert!(
+                !entry.extensions.is_empty(),
+                "{} claims no extension, so nothing could ever route to it",
+                entry.language
+            );
+            for ext in &entry.extensions {
+                assert!(
+                    !ext.starts_with('.'),
+                    "{} reports extension {ext:?} with a leading dot; the registry \
+                     matches bare extensions and the two forms would silently disagree",
+                    entry.language
+                );
+            }
+        }
+    }
+
+    /// Each reported extension must actually route to the language that claims
+    /// it, so the printed table is a statement about behavior rather than about
+    /// a struct.
+    ///
+    /// Shared extensions are the exception this asserts around: `.h` is claimed
+    /// by C and disambiguated to C++ by content, so the check is that SOME
+    /// adapter accepts every printed extension and that no extension is printed
+    /// which routes nowhere.
+    #[test]
+    fn every_printed_extension_routes_to_an_adapter() {
+        let registry = AdapterRegistry::new();
+        for entry in supported_languages() {
+            for ext in &entry.extensions {
+                assert!(
+                    registry.get_by_extension(ext).is_some(),
+                    "{} prints extension {ext:?} that routes to no adapter",
+                    entry.language
+                );
+            }
+        }
+        assert!(
+            registry
+                .get_by_extension("kin-not-a-real-extension")
+                .is_none(),
+            "the routing probe must be able to answer no, or the assertions above \
+             prove nothing"
+        );
+    }
+
+    #[test]
+    fn the_json_surface_carries_a_schema_and_a_count_that_match_the_list() {
+        let languages = supported_languages();
+        let payload = LanguagesJson {
+            schema: "kin.languages.v1",
+            count: languages.len(),
+            languages,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(value["schema"], "kin.languages.v1");
+        assert_eq!(
+            value["count"].as_u64().unwrap() as usize,
+            value["languages"].as_array().unwrap().len()
+        );
+        assert!(value["languages"][0]["language"].is_string());
+        assert!(value["languages"][0]["extensions"].is_array());
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod history;
 pub mod impact;
 pub mod init;
 pub mod intent;
+pub mod languages;
 pub mod locate;
 pub mod locate_cursor;
 pub mod locate_debug;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -669,6 +669,12 @@ enum Command {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    /// List the languages Kin extracts semantics from
+    Languages {
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Emit benchmark/runtime metadata for strict prepared-state cache keys
     #[command(hide = true)]
     BenchMeta {
@@ -2872,6 +2878,7 @@ fn main() -> Result<()> {
                     TelemetryAction::Purge => commands::telemetry::run_purge().await,
                 },
                 Command::Support { json } => commands::support::run(json).await,
+                Command::Languages { json } => commands::languages::run(json).await,
                 Command::BenchMeta {
                     json,
                     prepared_state,

--- a/crates/kin-parser/src/languages/mod.rs
+++ b/crates/kin-parser/src/languages/mod.rs
@@ -102,6 +102,22 @@ impl AdapterRegistry {
     pub fn supported_languages(&self) -> Vec<LanguageId> {
         self.adapters.iter().map(|a| a.language_id()).collect()
     }
+
+    /// Every registered adapter's language and the extensions it claims, in
+    /// registration order.
+    ///
+    /// This registry IS the supported set: admission asks it which adapter
+    /// matches an extension and there is no second gate, so anything that
+    /// reports Kin's supported languages must read THIS rather than keep its own
+    /// list. A separate list is a second statement of one fact, and the two can
+    /// only ever come to disagree — silently, because the disagreement looks
+    /// like a language simply not working.
+    pub fn supported_languages_with_extensions(&self) -> Vec<(LanguageId, &[&str])> {
+        self.adapters
+            .iter()
+            .map(|adapter| (adapter.language_id(), adapter.file_extensions()))
+            .collect()
+    }
 }
 
 impl Default for AdapterRegistry {


### PR DESCRIPTION
Refs FIR-1997

## The measured gap

On a corpus with zero files in any supported extension, `kin init` SUCCEEDS, and
then a symbol genuinely defined in the repository and a gibberish control return
byte-identical empty results, `rc=0`, with no mention of language, adapter, or
support anywhere in stdout, stderr, or the init output. Verified beside a working
control, so the silence is the finding rather than a broken measurement.

A stranger cannot tell "Kin does not parse this language" from "my search was
bad". Those call for opposite next actions, and Bash, Markdown, and config
repositories are everywhere, so this is a likely first-contact experience rather
than an edge case.

Kin already computed the deciding number. Init prints `Semantic enrichment:
absent (0 entities...)` and stops there, without saying what absence might mean
or where to look.

## `kin languages`

Prints each registered adapter's language and the extensions it claims, as a
human table or `--json`:

```
Kin extracts semantics from 14 languages:
  typescript  .ts .tsx
  javascript  .js .jsx .mjs .cjs
  python      .py .pyi
  go          .go
  java        .java
  rust        .rs
  c           .c .h
  cpp         .cpp .hpp .cc .cxx
  csharp      .cs
  ruby        .rb
  php         .php
  swift       .swift
  kotlin      .kt .kts
  hcl         .tf .tfvars
```

**The list is read from `AdapterRegistry`, never written down beside it.**
Admission asks the registry which adapter matches an extension and there is no
second gate, so the registry IS the supported set. A hardcoded copy would be a
second statement of one fact, and its failure mode is the worst kind: the command
keeps answering confidently while the answer quietly stops being true.

Registration order is preserved rather than sorted, because it is the order
admission consults adapters in, so a reader comparing the table against behavior
sees the sequence the code actually takes.

The trailing line states the boundary honestly: a file Kin cannot parse is still
admitted as repository authority with its content and history. Only the semantic
layer is absent. Saying "unsupported" without that would read as "Kin refused my
repository", which is not what happens.

## The init line

When enrichment came out absent, init now says so and points at the command.

The wording is **conditional on purpose**. This code knows the count; it does not
know the cause. Zero entities can also mean something went wrong for a language
Kin does support, and asserting "no adapter matched your files" would be a
confident guess dressed as a finding. Naming the possibility and handing over the
command that settles it costs one line and cannot be wrong.

**What I did NOT do, and why.** The spec's stronger version names the admitted
file count ("no semantic adapter matched any of the 27 admitted files").
`InitResult` and `DurableSemanticEnrichmentSummary` carry no admitted-path
census at the point that line prints, so producing it means reading the workspace
tree from graph truth. That is a real change rather than one line, and the
tempting shortcut — walking the working tree for extensions — is barred by the
zero-file-search authority rule and would have been wrong regardless. Filed as
what it is rather than approximated.

The JSON init payload is deliberately untouched. Its consumers read a fixed shape
and the notice belongs to the human surface until that contract grows somewhere
to carry one.

## Verification

Run, not just tested. `kin languages` and `kin languages --json` both executed
against the built binary: 14 languages, `count` equals the array length, schema
`kin.languages.v1`.

Tests, with the drift this command exists to prevent as the thing they check:

- `the_printed_set_is_the_registered_set` iterates the REGISTRY on both sides. A
  test that spelled out fourteen names would pass forever while the command
  drifted, so it must not be written that way. It also asserts the registry is
  non-empty, or every comparison would be vacuously true.
- `every_printed_extension_routes_to_an_adapter` checks the table is a statement
  about behavior rather than about a struct, and ends with a negative control: a
  nonsense extension must route nowhere, or the positive assertions prove
  nothing.
- `every_language_reports_matchable_extensions` pins the bare-extension form,
  since a leading dot would compare unequal against the registry's matching
  silently.
- `an_empty_semantic_layer_points_at_the_supported_languages` asserts both that
  the notice names `kin languages` AND that it stays conditional.
- `a_repository_with_semantics_gets_no_notice` is the falsification: a repository
  that DID get semantics prints nothing extra, so the notice is a signal on
  failing inits rather than noise on every one.

Local: `cargo test -p kin-cli --lib` 1199 passed / 0 failed, `cargo test -p
kin-parser --lib` 222 passed / 0 failed, `cargo fmt --all --check` clean, `cargo
clippy --all-targets --all-features` clean under the CI allowlist with
`RUSTFLAGS=-Dwarnings`.

Init's styled output is unaffected: `output_style.rs` enumerates the admission
labels it decorates and passes other indented lines through untouched, which the
comment there states as the intent.

## Not claiming

That this makes an unsupported repository useful. It makes the reason
discoverable, which is the gap that was measured. Nothing here changes which
languages are parsed, and nothing changes the `--json` surfaces.
