### PR TITLE
Split the bootstrap commit into named stages

### DIFF
--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -22,9 +22,9 @@ use kin_model::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tracing::info;
 #[cfg(unix)]
 use tracing::warn;
+use tracing::{info, info_span};
 
 use crate::config::KinConfig;
 use crate::error::{KinError, Result};
@@ -269,13 +269,16 @@ impl PreparedRepositoryInit {
                 Ok(bootstrap)
             }
             slot @ None => {
-                validate_bootstrap_transaction(
-                    transaction,
-                    repository_id,
-                    workspace_id,
-                    default_ref,
-                    initial_roots,
-                )?;
+                {
+                    let _span = info_span!("kin.init.commit.validate_bootstrap").entered();
+                    validate_bootstrap_transaction(
+                        transaction,
+                        repository_id,
+                        workspace_id,
+                        default_ref,
+                        initial_roots,
+                    )?;
+                }
                 let bootstrap = commit_bootstrap_transaction(
                     authority,
                     transaction,
@@ -1359,17 +1362,38 @@ fn commit_bootstrap_transaction<B>(
 where
     B: StorageBackend + 'static,
 {
-    let receipt = authority
-        .commit_repository_transaction(transaction.clone())
-        .map_err(graph_error)?;
-    let workspace = authority
-        .workspace_snapshot_binding(repository_id, &workspace_id)
-        .map_err(graph_error)?
-        .ok_or_else(|| {
-            KinError::Graph(format!(
-                "repository authority committed without workspace {workspace_id}"
-            ))
-        })?;
+    // The clone is measured separately from the commit it feeds. A bootstrap
+    // transaction carries every reachable external object and every change in
+    // history, so on a real repository this copies tens of thousands of records
+    // to satisfy an owned-parameter API, and the caller drops the original
+    // immediately afterwards. Whether that is worth removing is a measurement,
+    // not a guess, so it gets its own span rather than hiding inside the commit.
+    let owned_transaction = {
+        let _span = info_span!(
+            "kin.init.commit.clone_transaction",
+            external_objects = transaction.external_objects.len(),
+            changes = transaction.changes.len()
+        )
+        .entered();
+        transaction.clone()
+    };
+    let receipt = {
+        let _span = info_span!("kin.init.commit.authority_commit").entered();
+        authority
+            .commit_repository_transaction(owned_transaction)
+            .map_err(graph_error)?
+    };
+    let workspace = {
+        let _span = info_span!("kin.init.commit.workspace_binding").entered();
+        authority
+            .workspace_snapshot_binding(repository_id, &workspace_id)
+            .map_err(graph_error)?
+            .ok_or_else(|| {
+                KinError::Graph(format!(
+                    "repository authority committed without workspace {workspace_id}"
+                ))
+            })?
+    };
     if workspace.roots != receipt.roots_after {
         return Err(KinError::Graph(
             "repository bootstrap workspace is not bound to the committed roots".to_string(),
@@ -1379,6 +1403,7 @@ where
         .validate()
         .map_err(|error| KinError::Other(error.to_string()))?;
     let semantic_enrichment = {
+        let _span = info_span!("kin.init.commit.enrichment_summary").entered();
         let lease = authority.read_authority();
         if lease.roots() != &receipt.roots_after {
             return Err(KinError::Graph(


### PR DESCRIPTION
The bootstrap commit is the second largest phase of `kin init` and it was one
opaque span. Nobody had looked inside it, because until the init phase ladder it
had no span at all.

## Measured

| | anyhow (132 s init) | ripgrep (592 s init) |
| --- | ---: | ---: |
| `commit_bootstrap_transaction` | 23.8 s / **18.0%** | 138.6 s / **23.5%** |

Second only to copying the object closure.

## What this adds

Five named stages: `validate_bootstrap`, `clone_transaction`, `authority_commit`,
`workspace_binding`, `enrichment_summary`. No behavior change.

## What it already answered

The spans were built to test a specific candidate, and they killed it. The commit
calls `authority.commit_repository_transaction(transaction.clone())`, and a
bootstrap transaction carries every reachable external object plus every change in
history, so the clone looked like an obvious win to remove.

Measured on a run of this exact binary:

| stage | anyhow (22.1 s phase) | ripgrep (135.5 s phase) |
| --- | ---: | ---: |
| `commit.validate_bootstrap` | 300 ms / 1.4% | 2,192 ms / 1.6% |
| **`commit.clone_transaction`** | **7.3 ms / 0.03%** | **61 ms / 0.05%** |
| **`commit.authority_commit`** | **21,071 ms / 95.4%** | **128,492 ms / 94.8%** |
| `commit.workspace_binding` | 0.1 ms | 0.5 ms |
| `commit.enrichment_summary` | 0.9 ms | 7.5 ms |

Right about the volume, wrong about the cost: a `Vec` clone runs at memcpy speed
and this phase is not CPU-bound. **Do not spend on the ownership refactor.**

The useful result is the other column. The bootstrap commit is 95% one call into
kin-db, which together with `copy_captured_authority` (kin-db's `save_source_blob`)
means **kin-db owns roughly 57-62% of `kin init` and neither half has a kin-side
fix**. That is planning information nobody had this morning.

## Scope

`crates/kin-core/src/init.rs` only. Independent of #644, which touches
`git_init.rs`, `init_progress.rs`, `kin-git` and docs, and of #651, which touches
`kin-index`. Any landing order works. 481 kin-core tests green, fmt clean.

Refs FIR-2017. Answers its item 3 and rules out the clone; items 1 and 2 (the per-object
flock in kin-db save_source_blob, and the double durable write) stay open, so this does
not close it.
