### PR TITLE
Qualify coverage_summary's number instead of stating it as repository fact

### DIFF
--- a/crates/kin-mcp/src/handlers/verification.rs
+++ b/crates/kin-mcp/src/handlers/verification.rs
@@ -58,16 +58,25 @@ pub fn handle_verify_entity<G: GraphStore>(
 }
 
 pub const COVERAGE_SUMMARY_DESC: &str = "\
-Get repo-wide test coverage at a glance: total entities, how many are covered, the \
-coverage ratio, and the list of entities still missing test proof. Reach for it to \
-assess current test health or find what's untested. Verification runs are not yet \
-bound to immutable source changes, so this advisory live view does not authorize a release. It's \
-the whole-repo counterpart to kin_verify_entity (one entity) and underlies \
-kin_release_check's proof requirement.";
+Get repo-wide proof coverage at a glance: total entities, how many carry a passing \
+verification run, the coverage ratio, and the list of entities still missing proof. \
+Reach for it to assess recorded test health or find what's unproven. Verification runs \
+are not yet bound to immutable source changes, so this advisory live view does not \
+authorize a release. It's the whole-repo counterpart to kin_verify_entity (one entity) \
+and underlies kin_release_check's proof requirement. \
+Read `coverage_trust` BEFORE treating a low or zero number as a fact about the \
+repository: this tool counts RECORDED VERIFICATION RUNS, never the repository's test \
+files, so a graph with no runs reports zero coverage while the code may be thoroughly \
+tested. `safe_to_conclude_uncovered` is false in exactly that case, which is the normal \
+state of a freshly-initialised repo. `population` names what `total_entities` counts — \
+the current-generation entity map, which is NOT the set retrieval ranks over, so it is \
+the wrong denominator for a completeness claim about everything semantic_locate can \
+return.";
 
 pub fn handle_coverage_summary<G: GraphStore>(store: &G) -> Result<ToolCallResult> {
-    let coverage = kin_review::passing_proof_coverage(store)
+    let (coverage, provenance) = kin_review::passing_proof_coverage_with_provenance(store)
         .map_err(|error| McpError::Review(error.to_string()))?;
+    let (safe_to_conclude_uncovered, reason) = provenance.coverage_trust();
 
     let result = serde_json::json!({
         "total_entities": coverage.total_entities,
@@ -75,6 +84,25 @@ pub fn handle_coverage_summary<G: GraphStore>(store: &G) -> Result<ToolCallResul
         "coverage_ratio": coverage.coverage_ratio,
         "missing_proof_count": coverage.missing_proof.len(),
         "missing_proof": coverage.missing_proof,
+        // What the coverage number was derived from. A zero with
+        // runs_observed == 0 counted nothing; it is not a finding about the
+        // repository, and the sibling retrieval tools already set this bar with
+        // their `negative.safe_to_conclude_absent` contract.
+        "coverage_trust": {
+            "safe_to_conclude_uncovered": safe_to_conclude_uncovered,
+            "reason": reason,
+            "trust": if safe_to_conclude_uncovered { "recorded" } else { "inconclusive" },
+            "runs_observed": provenance.runs_observed,
+            "entities_with_any_run": provenance.entities_with_any_run,
+            "counts": "recorded verification runs, never the repository's test files",
+        },
+        // What the denominator is. total_entities is the live current-generation
+        // entity map; retrieval ranks over the vector index, a separate
+        // structure that can retain entities this map no longer holds.
+        "population": {
+            "total_entities_counts": "current_generation_entities",
+            "note": "total_entities is the graph's live entity map. Retrieval (semantic_locate) ranks over the vector index, which is a separate structure and may contain entities absent from this map, so this is not the denominator for 'everything locate can return'.",
+        },
     });
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -41,9 +41,10 @@ pub use ranked_impact::{
 };
 pub use ref_graph::GraphAtRef;
 pub use release_gate::{
-    entities_touched_by_change, passing_proof_coverage, security_findings,
-    source_bound_release_proof_coverage, source_bound_release_proof_coverage_for_entities,
-    unapproved_changes, SecurityFinding, SecurityFindingCounts, SecuritySeverity, UnapprovedChange,
+    entities_touched_by_change, passing_proof_coverage, passing_proof_coverage_with_provenance,
+    security_findings, source_bound_release_proof_coverage,
+    source_bound_release_proof_coverage_for_entities, unapproved_changes, CoverageProvenance,
+    SecurityFinding, SecurityFindingCounts, SecuritySeverity, UnapprovedChange,
 };
 pub use review::{Review, SemanticReview};
 pub use risk::assess_risk;

--- a/crates/kin-review/src/release_gate.rs
+++ b/crates/kin-review/src/release_gate.rs
@@ -93,22 +93,88 @@ pub fn unapproved_changes<G: GraphStore>(
     Ok(unapproved)
 }
 
+/// What the coverage numbers were derived from, so a caller can tell a measured
+/// zero from a structural one.
+///
+/// `covered_entities: 0` has two entirely different meanings and the number
+/// alone cannot distinguish them: "runs exist and none of them prove anything"
+/// versus "no verification run has ever been recorded, so there was nothing to
+/// count". The second is the state of every freshly-initialised repository, and
+/// reported bare it reads as the confident claim *this code is untested* — a
+/// fact about the repository that this computation cannot know, because it
+/// never looks at the repository's tests, only at recorded run linkage.
+///
+/// `runs_observed` is the discriminator, and it is free: the coverage loop
+/// already fetches each entity's runs and currently discards everything except
+/// the `Passing` predicate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageProvenance {
+    /// Verification runs seen across all entities, in any status.
+    pub runs_observed: usize,
+    /// Entities linked to at least one run, in any status.
+    pub entities_with_any_run: usize,
+}
+
+impl CoverageProvenance {
+    /// Whether a zero (or low) coverage number may be read as a statement about
+    /// the repository, with the machine-stable reason naming which gate ruled.
+    ///
+    /// Mirrors the confidence-qualified-negative contract the retrieval tools
+    /// already carry: an absence is only authoritative when the substrate that
+    /// would have supplied evidence was actually populated.
+    pub fn coverage_trust(&self) -> (bool, &'static str) {
+        if self.runs_observed == 0 {
+            return (
+                false,
+                "no_runs_recorded: no verification run of any status exists in this graph, so the coverage number counts nothing and says nothing about whether the code is tested",
+            );
+        }
+        (
+            true,
+            "runs_recorded: verification runs exist in this graph, so the coverage number reflects recorded proof linkage",
+        )
+    }
+}
+
 /// Compute current, advisory proof coverage for a graph.
 ///
 /// Structural `Test -> Covers -> Entity` links describe intended coverage,
 /// but do not prove that a test ran or passed. Release proof therefore counts
 /// an entity only when at least one persisted `VerificationRun` linked through
 /// `run_proves_entity` has status `Passing`.
+///
+/// The population is the graph's **current-generation** entity map
+/// (`list_all_entities`), which is not the same set retrieval ranks over: the
+/// vector index is a separate structure and can retain entities this map no
+/// longer holds. A caller reasoning about repository completeness from
+/// `total_entities` is reasoning about the live map, and the surface says so.
 pub fn passing_proof_coverage<G: GraphStore>(store: &G) -> Result<CoverageSummary, ReviewError> {
+    Ok(passing_proof_coverage_with_provenance(store)?.0)
+}
+
+/// [`passing_proof_coverage`] plus the evidence needed to qualify it.
+///
+/// Prefer this at any surface that shows the number to a human or an agent;
+/// the bare form remains for callers that already know runs exist.
+pub fn passing_proof_coverage_with_provenance<G: GraphStore>(
+    store: &G,
+) -> Result<(CoverageSummary, CoverageProvenance), ReviewError> {
     let mut entities = store.list_all_entities().map_err(ReviewError::graph)?;
     entities.sort_by_key(|entity| entity.id.to_string());
 
     let mut covered_entities = 0_usize;
     let mut missing_proof = Vec::new();
+    let mut runs_observed = 0_usize;
+    let mut entities_with_any_run = 0_usize;
     for entity in &entities {
-        let has_passing_run = store
+        let runs = store
             .list_runs_proving_entity(&entity.id)
-            .map_err(ReviewError::graph)?
+            .map_err(ReviewError::graph)?;
+        runs_observed += runs.len();
+        if !runs.is_empty() {
+            entities_with_any_run += 1;
+        }
+        let has_passing_run = runs
             .iter()
             .any(|run| run.status == VerificationStatus::Passing);
         if has_passing_run {
@@ -124,12 +190,18 @@ pub fn passing_proof_coverage<G: GraphStore>(store: &G) -> Result<CoverageSummar
     } else {
         covered_entities as f64 / total_entities as f64
     };
-    Ok(CoverageSummary {
-        total_entities,
-        covered_entities,
-        coverage_ratio,
-        missing_proof,
-    })
+    Ok((
+        CoverageSummary {
+            total_entities,
+            covered_entities,
+            coverage_ratio,
+            missing_proof,
+        },
+        CoverageProvenance {
+            runs_observed,
+            entities_with_any_run,
+        },
+    ))
 }
 
 /// Compute proof coverage admissible for an immutable release source.
@@ -422,6 +494,139 @@ mod tests {
     use kin_model::provenance::{Actor, ActorId, Approval, ApprovalId};
     use kin_model::relation::{Relation, RelationOrigin};
     use kin_model::timestamp::Timestamp;
+
+    /// Record a verification run and link it as proving `entity_id`.
+    fn record_run(
+        store: &InMemoryGraph,
+        entity_id: &EntityId,
+        status: VerificationStatus,
+    ) -> kin_model::verification::VerificationRunId {
+        let run = kin_model::verification::VerificationRun {
+            run_id: kin_model::verification::VerificationRunId(Hash256::from_bytes([7; 32])),
+            test_ids: vec![],
+            status,
+            runner: kin_model::verification::TestRunner::Cargo,
+            started_at: Timestamp::now(),
+            finished_at: None,
+            duration_ms: None,
+            evidence_blob: None,
+            exit_code: None,
+        };
+        store
+            .create_verification_run(&run)
+            .expect("in-memory store must record a verification run");
+        store
+            .link_run_proves_entity(&run.run_id, entity_id)
+            .expect("in-memory store must link a run to an entity");
+        run.run_id
+    }
+
+    /// A graph with NO verification runs reports zero coverage, and says so.
+    ///
+    /// This is the state of every freshly-initialised repository. The number is
+    /// internally correct as "no recorded linkage" and completely wrong as the
+    /// claim "this code is untested", which is how a bare zero reads. The
+    /// provenance must mark it inconclusive so a caller cannot make that leap.
+    #[test]
+    fn zero_coverage_without_any_run_is_inconclusive() {
+        let store = InMemoryGraph::new();
+        let entity = entity("undertested", EntityKind::Function, Visibility::Public);
+        store.upsert_entity(&entity).expect("upsert");
+
+        let (coverage, provenance) =
+            passing_proof_coverage_with_provenance(&store).expect("coverage must compute");
+
+        assert_eq!(coverage.total_entities, 1);
+        assert_eq!(coverage.covered_entities, 0);
+        assert_eq!(provenance.runs_observed, 0);
+        assert_eq!(provenance.entities_with_any_run, 0);
+
+        let (safe, reason) = provenance.coverage_trust();
+        assert!(
+            !safe,
+            "a zero derived from no recorded runs must NOT be safe to read as 'uncovered'"
+        );
+        assert!(
+            reason.starts_with("no_runs_recorded:"),
+            "the reason must name the gate that ruled, got: {reason}"
+        );
+    }
+
+    /// A graph WITH a passing run reports coverage plainly and authoritatively.
+    ///
+    /// The other half of the two-sided test: the envelope must not be a blanket
+    /// disclaimer that fires always. When runs exist, the number means what it
+    /// says and `safe_to_conclude_uncovered` flips to true.
+    #[test]
+    fn coverage_with_recorded_runs_is_authoritative() {
+        let store = InMemoryGraph::new();
+        let covered = entity("covered", EntityKind::Function, Visibility::Public);
+        let bare = entity("bare", EntityKind::Function, Visibility::Public);
+        store.upsert_entity(&covered).expect("upsert");
+        store.upsert_entity(&bare).expect("upsert");
+        record_run(&store, &covered.id, VerificationStatus::Passing);
+
+        let (coverage, provenance) =
+            passing_proof_coverage_with_provenance(&store).expect("coverage must compute");
+
+        assert_eq!(coverage.total_entities, 2);
+        assert_eq!(coverage.covered_entities, 1);
+        assert_eq!(coverage.missing_proof, vec![bare.id]);
+        assert!(provenance.runs_observed >= 1);
+        assert_eq!(provenance.entities_with_any_run, 1);
+
+        let (safe, reason) = provenance.coverage_trust();
+        assert!(
+            safe,
+            "with runs recorded, the coverage number IS a statement about recorded proof"
+        );
+        assert!(
+            reason.starts_with("runs_recorded:"),
+            "the reason must name the gate that ruled, got: {reason}"
+        );
+    }
+
+    /// A run that exists but did NOT pass still makes the number meaningful.
+    ///
+    /// The discriminator is "was there anything to count", not "did anything
+    /// pass". A failing run is real evidence that verification ran, so a zero
+    /// alongside it is a genuine finding rather than an empty substrate.
+    #[test]
+    fn failing_run_still_makes_zero_coverage_conclusive() {
+        let store = InMemoryGraph::new();
+        let entity = entity("tried", EntityKind::Function, Visibility::Public);
+        store.upsert_entity(&entity).expect("upsert");
+        record_run(&store, &entity.id, VerificationStatus::Failing);
+
+        let (coverage, provenance) =
+            passing_proof_coverage_with_provenance(&store).expect("coverage must compute");
+
+        assert_eq!(coverage.covered_entities, 0, "a failing run proves nothing");
+        assert_eq!(
+            provenance.runs_observed, 1,
+            "but it IS a run, so the substrate is not empty"
+        );
+        let (safe, _) = provenance.coverage_trust();
+        assert!(
+            safe,
+            "zero-with-a-failing-run is a real finding, not an unpopulated substrate"
+        );
+    }
+
+    /// The bare wrapper must stay byte-identical to the provenance-carrying form.
+    #[test]
+    fn bare_wrapper_matches_provenance_form() {
+        let store = InMemoryGraph::new();
+        let entity = entity("same", EntityKind::Function, Visibility::Public);
+        store.upsert_entity(&entity).expect("upsert");
+        record_run(&store, &entity.id, VerificationStatus::Passing);
+
+        let bare = passing_proof_coverage(&store).expect("coverage");
+        let (paired, _) = passing_proof_coverage_with_provenance(&store).expect("coverage");
+        assert_eq!(bare.total_entities, paired.total_entities);
+        assert_eq!(bare.covered_entities, paired.covered_entities);
+        assert_eq!(bare.missing_proof, paired.missing_proof);
+    }
 
     fn entity(name: &str, kind: EntityKind, visibility: Visibility) -> Entity {
         Entity {


### PR DESCRIPTION
## The defect

`kin_coverage_summary` counts entities carrying a passing `VerificationRun`. On a graph with no runs recorded it reports `covered_entities: 0` — internally correct as "no proof linkage", and completely wrong as the claim it reads like: *this repository has no tests*. The tool never looks at the repository's tests at all.

Measured on a freshly-inited cobra: `covered_entities: 0 of 736`, no degraded field, no trust field, while the repo has 17 Go test files — one of which Kin's own `semantic_search` finds and `get_entity_source` reads.

That is the normal state of every freshly-initialised repo, so the first thing an agent learns about a new codebase is a confident falsehood. It is sharper than a crash because it looks like a normal, successful answer.

## The bar already exists in this product

An empty `semantic_search` carries `negative.safe_to_conclude_absent` precisely so absence cannot be mistaken for authority. Coverage now carries the same contract, in the same idiom.

## The discriminator is free

Whether *any* verification run exists is the thing that separates a measured zero from a structural one — and the coverage loop already fetches each entity's runs, then discards everything except the `Passing` predicate. `passing_proof_coverage_with_provenance` returns that evidence alongside the summary. The bare `passing_proof_coverage` wrapper is unchanged, so no existing consumer moves.

## What the response gains

- **`coverage_trust`** — `safe_to_conclude_uncovered`, a machine-stable `reason` naming which gate ruled, `runs_observed`, `entities_with_any_run`, and a plain statement that it counts recorded runs and *never* test files.
- **`population`** — `total_entities` is the **current-generation entity map**. Retrieval ranks over the vector index, a separate structure that can hold entities this map does not, so it is the wrong denominator for a completeness claim about everything `semantic_locate` can return. Confirmed from source: `list_all_entities` returns the live in-memory map.

## Tests are two-sided, and were falsified

Four tests, and I broke the discriminator to prove they can fail — `zero_coverage_without_any_run_is_inconclusive` then fails on its own assertion with its own message.

| case | asserts |
|---|---|
| no runs | zero is reported **inconclusive** |
| passing run | coverage is **authoritative** — the envelope is not a blanket disclaimer that always fires |
| **failing** run | zero stays **conclusive** — the question is whether anything was there to count, not whether it passed |
| both entry points | bare wrapper is identical to the provenance-carrying form |

There were no existing tests for `passing_proof_coverage` at all.

## Scope

`CoverageSummary` itself is untouched — it lives in **kin-model**, and extending it would force a cross-repo version bump for what is an MCP presentation fix.

## Gate

`cargo fmt --check`, `cargo clippy --all-targets` under the **exact CI allowlist** extracted from `ci.yml` (my first local run was stricter than CI and surfaced only pre-existing debt in untouched crates), `cargo build --all-targets`, and `cargo test --workspace --no-fail-fast` — all green.

Closes FIR-2028
