### PR TITLE
Answer refs and impact from graph truth when a declaration owns no edges

### DIFF
--- a/crates/kin-cli/src/commands/declaration_neighbors.rs
+++ b/crates/kin-cli/src/commands/declaration_neighbors.rs
@@ -12,17 +12,27 @@
 //! reported no callers while the graph held callers for `Error::msg`,
 //! `Error::from`, and the rest, and the answer gave the reader no way to know.
 //!
-//! Two facts close that gap, and both are read out of graph truth: the members
+//! Two facts close that gap, and both are read out of graph truth: the entities
 //! the graph holds under the declaration's name, and the other graph identities
 //! carrying the same name that resolution did not choose. Nothing here consults
 //! the filesystem.
+//!
+//! Members are gathered by name qualification, not by edge, and the wording of
+//! every line built from them says so. The `Contains` edge a declaration owns
+//! reaches only its same-file members: the linker keys containment against a
+//! declaration in the same file, and a cross-file `impl` block has none, so
+//! `Error::chain` in `src/error.rs` is tied to `Error` in `src/lib.rs` by name
+//! alone. Collecting from edges would therefore drop exactly the members this
+//! exists to surface. The cost of the name is that two same-named declarations
+//! cannot be told apart, so a listing here is a claim about which entities share
+//! a name prefix and never a claim about which declaration owns them.
 
 use anyhow::Result;
 use kin_model::{Entity, EntityFilter, GraphStore, RelationKind};
 
-/// A member of a declaration, paired with how many distinct entities reference
-/// it. The count is the one `kin refs` reports for that member, so the note and
-/// the command it suggests cannot disagree.
+/// An entity whose name is qualified by the declaration's name, paired with how
+/// many distinct entities reference it. The count is the one `kin refs` reports
+/// for that member, so the note and the command it suggests cannot disagree.
 #[derive(Debug, Clone)]
 pub struct MemberSummary {
     pub name: String,
@@ -107,8 +117,10 @@ fn collect_members(
     relation_kinds: &[RelationKind],
 ) -> Result<Vec<MemberSummary>> {
     // The graph's name query is a case-insensitive substring match, so it also
-    // returns `OtherError::foo` for a `Error::` pattern. Only an exact prefix is
-    // a member of this declaration.
+    // returns `OtherError::foo` for a `Error::` pattern. Requiring an exact
+    // prefix drops those. What survives is every entity the name `Error::`
+    // qualifies, which is not the same set as the members this declaration owns
+    // when another declaration shares its name.
     let prefix = format!("{}::", target.name);
     let candidates = graph.query_entities(&EntityFilter {
         name_pattern: Some(prefix.clone()),

--- a/crates/kin-cli/src/commands/declaration_neighbors.rs
+++ b/crates/kin-cli/src/commands/declaration_neighbors.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What the graph still has to say about an entity whose incoming relations
+//! came back empty.
+//!
+//! `kin refs` and `kin impact` both resolve a name to one entity and then read
+//! that entity's incoming relations. When the entity owns none, a bare empty
+//! answer reads as "nothing depends on this", and for a type declaration that is
+//! false in a way a reader cannot detect. A Rust `struct`'s only graph edge is an
+//! outgoing `Contains` to its same-file members, so `kin refs Error` on `anyhow`
+//! reported no callers while the graph held callers for `Error::msg`,
+//! `Error::from`, and the rest, and the answer gave the reader no way to know.
+//!
+//! Two facts close that gap, and both are read out of graph truth: the members
+//! the graph holds under the declaration's name, and the other graph identities
+//! carrying the same name that resolution did not choose. Nothing here consults
+//! the filesystem.
+
+use anyhow::Result;
+use kin_model::{Entity, EntityFilter, GraphStore, RelationKind};
+
+/// A member of a declaration, paired with how many distinct entities reference
+/// it. The count is the one `kin refs` reports for that member, so the note and
+/// the command it suggests cannot disagree.
+#[derive(Debug, Clone)]
+pub struct MemberSummary {
+    pub name: String,
+    pub kind: String,
+    pub location: String,
+    pub referencing_entities: usize,
+}
+
+/// Another entity in the graph carrying the queried name.
+#[derive(Debug, Clone)]
+pub struct SiblingSummary {
+    pub name: String,
+    pub kind: String,
+    pub location: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DeclarationNeighbors {
+    /// Every `Name::member` the graph holds, most-referenced first.
+    pub members: Vec<MemberSummary>,
+    /// Same-name identities other than the one resolution chose.
+    pub siblings: Vec<SiblingSummary>,
+}
+
+impl DeclarationNeighbors {
+    /// Members that actually carry references. A member nothing points at adds
+    /// nothing to an answer explaining where the references went.
+    pub fn referenced_members(&self) -> impl Iterator<Item = &MemberSummary> {
+        self.members
+            .iter()
+            .filter(|member| member.referencing_entities > 0)
+    }
+
+    /// Members the graph places in `file`. A location is `path` or `path:line`,
+    /// so both spellings have to match.
+    pub fn members_in_file<'a>(
+        &'a self,
+        file: &str,
+    ) -> impl Iterator<Item = &'a MemberSummary> + 'a {
+        let exact = file.to_string();
+        let prefix = format!("{file}:");
+        self.members
+            .iter()
+            .filter(move |member| member.location == exact || member.location.starts_with(&prefix))
+    }
+}
+
+/// `path:line` for an entity, or just the path when the graph carries no span.
+///
+/// Location is projection metadata for the human reading the listing; the
+/// analysis itself is keyed on graph identity, never on paths.
+pub fn entity_location(entity: &Entity) -> Option<String> {
+    let path = entity.file_origin.as_ref().map(|f| f.0.clone())?;
+    Some(match entity.span.as_ref().map(|s| s.start_line) {
+        Some(line) => format!("{path}:{line}"),
+        None => path,
+    })
+}
+
+fn entity_kind_label(entity: &Entity) -> String {
+    format!("{:?}", entity.kind)
+}
+
+/// Read an entity's members and same-name siblings out of the graph.
+///
+/// `relation_kinds` is the kind set the caller's own answer was computed over,
+/// so a member's count means the same thing the caller's empty result did.
+pub fn collect(
+    graph: &impl GraphStore,
+    target: &Entity,
+    relation_kinds: &[RelationKind],
+) -> Result<DeclarationNeighbors> {
+    Ok(DeclarationNeighbors {
+        members: collect_members(graph, target, relation_kinds)?,
+        siblings: collect_siblings(graph, target)?,
+    })
+}
+
+fn collect_members(
+    graph: &impl GraphStore,
+    target: &Entity,
+    relation_kinds: &[RelationKind],
+) -> Result<Vec<MemberSummary>> {
+    // The graph's name query is a case-insensitive substring match, so it also
+    // returns `OtherError::foo` for a `Error::` pattern. Only an exact prefix is
+    // a member of this declaration.
+    let prefix = format!("{}::", target.name);
+    let candidates = graph.query_entities(&EntityFilter {
+        name_pattern: Some(prefix.clone()),
+        ..Default::default()
+    })?;
+
+    let mut members = Vec::new();
+    for entity in candidates {
+        if entity.id == target.id || !entity.name.starts_with(&prefix) {
+            continue;
+        }
+        if kin_index::is_external_reference_target(&entity) {
+            continue;
+        }
+        members.push(MemberSummary {
+            referencing_entities: crate::commands::refs::distinct_referencing_entities(
+                graph,
+                &entity.id,
+                relation_kinds,
+            )?,
+            kind: entity_kind_label(&entity),
+            location: entity_location(&entity).unwrap_or_else(|| "unknown".to_string()),
+            name: entity.name,
+        });
+    }
+    members.sort_by(|left, right| {
+        right
+            .referencing_entities
+            .cmp(&left.referencing_entities)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.location.cmp(&right.location))
+    });
+    Ok(members)
+}
+
+fn collect_siblings(graph: &impl GraphStore, target: &Entity) -> Result<Vec<SiblingSummary>> {
+    let candidates = graph.query_entities(&EntityFilter {
+        name_pattern: Some(target.name.clone()),
+        ..Default::default()
+    })?;
+
+    let mut siblings: Vec<SiblingSummary> = candidates
+        .into_iter()
+        .filter(|entity| {
+            entity.id != target.id
+                && entity.name == target.name
+                && !kin_index::is_external_reference_target(entity)
+        })
+        .map(|entity| SiblingSummary {
+            kind: entity_kind_label(&entity),
+            location: entity_location(&entity).unwrap_or_else(|| "unknown".to_string()),
+            name: entity.name,
+        })
+        .collect();
+    siblings.sort_by(|left, right| left.location.cmp(&right.location));
+    Ok(siblings)
+}
+
+/// How many members a note lists before summarizing the rest.
+pub const MAX_LISTED: usize = 5;
+
+/// Render `count` of `total` listed, or nothing when they are the same.
+pub fn and_more_suffix(listed: usize, total: usize) -> Option<String> {
+    (total > listed).then(|| format!("... and {} more", total - listed))
+}

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -354,6 +354,11 @@ const IMPACT_MEMBER_RELATION_KINDS: &[kin_model::RelationKind] = &[
 /// Naming those members, with the count a reader can verify, replaces an answer
 /// that looked like proof of no dependents with one that says where they are.
 ///
+/// The listing is gathered by name qualification and is worded as such, because
+/// containment reaches only same-file members and the cross-file ones are tied
+/// to the declaration by name alone. A declaration sharing its name with another
+/// must not be told the other's members are its own.
+///
 /// A target with no referenced members keeps the bare line. That is what keeps
 /// this from becoming a footer on every empty result.
 fn empty_impact_context(
@@ -371,10 +376,11 @@ fn empty_impact_context(
     };
 
     let mut lines = vec![format!(
-        "  {} member{} of '{}' do have dependents:",
+        "  {} entit{} named '{}::*' ha{} dependents:",
         referenced.len(),
-        if referenced.len() == 1 { "" } else { "s" },
-        target.name
+        if referenced.len() == 1 { "y" } else { "ies" },
+        target.name,
+        if referenced.len() == 1 { "s" } else { "ve" },
     )];
     for member in referenced
         .iter()
@@ -607,7 +613,9 @@ fn qualifier_miss_guidance(
         lines.push(format!("  {more}"));
     }
     if !members_in_scope.is_empty() {
-        lines.push(format!("Members of '{entity}' the graph does place there:"));
+        lines.push(format!(
+            "Entities named '{entity}::*' the graph does place there:"
+        ));
         for member in members_in_scope
             .iter()
             .take(crate::commands::declaration_neighbors::MAX_LISTED)

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -49,6 +49,30 @@ pub struct ImpactQuery {
     pub kind: Option<String>,
     pub signature: Option<String>,
     pub match_count: usize,
+    /// Identities the name alone resolves to, before `--file`, `--kind`, and
+    /// `--signature` narrow them. A structured caller whose qualifiers matched
+    /// nothing reads this to see what it could have qualified with, instead of
+    /// having to infer it from a count of zero.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub name_candidates: Vec<CandidateIdentity>,
+}
+
+/// One entity a name resolves to, in the spelling the human listing uses.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CandidateIdentity {
+    pub name: String,
+    pub kind: String,
+    pub location: String,
+}
+
+impl CandidateIdentity {
+    fn from_entity(entity: &kin_model::Entity) -> Self {
+        Self {
+            name: entity.name.clone(),
+            kind: format!("{:?}", entity.kind),
+            location: entity_location(entity).unwrap_or_else(|| "unknown".to_string()),
+        }
+    }
 }
 
 pub async fn run(
@@ -111,24 +135,61 @@ pub async fn build_impact_response(
     graph: &kin_db::InMemoryGraph,
     request: &ImpactRequest,
 ) -> Result<ImpactResponse> {
-    let mut matches = resolve_entities(graph, request)?;
-    matches.sort_by(|left, right| {
+    let ResolvedEntities {
+        mut matches,
+        mut name_matches,
+    } = resolve_entities(graph, request)?;
+    let stable_order = |left: &kin_model::Entity, right: &kin_model::Entity| {
         kin_review::StableEntityIdentity::from_entity(left)
             .cmp(&kin_review::StableEntityIdentity::from_entity(right))
             .then_with(|| left.id.cmp(&right.id))
-    });
+    };
+    matches.sort_by(stable_order);
+    name_matches.sort_by(stable_order);
 
-    let query = ImpactQuery {
+    let mut query = ImpactQuery {
         entity: request.entity.clone(),
         file: request.file.clone(),
         kind: request.kind.clone(),
         signature: request.signature.clone(),
         match_count: matches.len(),
+        name_candidates: Vec::new(),
     };
+    if name_matches.len() > 1 || matches.is_empty() {
+        query.name_candidates = name_matches
+            .iter()
+            .map(CandidateIdentity::from_entity)
+            .collect();
+    }
 
     if matches.is_empty() {
+        let qualifiers = active_qualifiers(request);
+        // A name that resolves to nothing at all is a genuine miss. A name that
+        // resolves and is then filtered out by the qualifiers is not, and must
+        // not be reported as one.
+        let lines = if name_matches.is_empty() || qualifiers.is_empty() {
+            impact_not_found_guidance(&request.entity)
+        } else {
+            let members_in_scope = match request.file.as_deref() {
+                Some(file) => crate::commands::declaration_neighbors::collect(
+                    graph,
+                    &name_matches[0],
+                    IMPACT_MEMBER_RELATION_KINDS,
+                )?
+                .members_in_file(file)
+                .map(|member| format!("{} ({}) @ {}", member.name, member.kind, member.location))
+                .collect(),
+                None => Vec::new(),
+            };
+            qualifier_miss_guidance(
+                &request.entity,
+                &qualifiers,
+                &name_matches,
+                &members_in_scope,
+            )
+        };
         return Ok(ImpactResponse {
-            lines: impact_not_found_guidance(&request.entity),
+            lines,
             schema_version: IMPACT_RESPONSE_SCHEMA_VERSION.to_string(),
             resolution: "not_found".to_string(),
             query,
@@ -150,6 +211,8 @@ pub async fn build_impact_response(
         });
     }
 
+    prefer_entities_owning_incoming_relations(graph, &mut matches)?;
+
     let target = &matches[0];
     let target_at = entity_location(target)
         .map(|loc| format!(" @ {loc}"))
@@ -163,6 +226,28 @@ pub async fn build_impact_response(
             "  Note: {} matches; showing the deterministic first match. Use --json with --file/--kind/--signature for fail-closed resolution.",
             matches.len()
         ));
+        // Naming the identities that were passed over is what lets a reader tell
+        // an answer about the wrong node from an answer about a node with
+        // nothing to report.
+        lines.push("  Other matches:".to_string());
+        for other in matches
+            .iter()
+            .skip(1)
+            .take(crate::commands::declaration_neighbors::MAX_LISTED)
+        {
+            lines.push(format!(
+                "    - {} ({:?}) @ {}",
+                other.name,
+                other.kind,
+                entity_location(other).unwrap_or_else(|| "unknown".to_string())
+            ));
+        }
+        if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
+            crate::commands::declaration_neighbors::MAX_LISTED,
+            matches.len() - 1,
+        ) {
+            lines.push(format!("    {more}"));
+        }
     }
 
     // 1. Local Impact, grouped by traversal distance so a reader can tell the
@@ -172,6 +257,7 @@ pub async fn build_impact_response(
     let local_impacted = downstream_impact_by_hop(graph, &target.id, request.depth)?;
     if local_impacted.is_empty() {
         lines.push("  No local downstream impact found.".to_string());
+        lines.extend(empty_impact_context(graph, target)?);
     } else {
         lines.push(format!(
             "  {} local entities impacted within {} hop{}:",
@@ -208,6 +294,113 @@ pub async fn build_impact_response(
         query,
         ranked,
     })
+}
+
+/// Move the identities that own incoming relations to the front, preserving the
+/// deterministic order within each group.
+///
+/// When one name covers several graph identities, only some of them are what
+/// impact analysis is about. A re-export, a forward declaration, or a test
+/// fixture sharing the name carries no dependents, and answering for it prints
+/// an empty result that is indistinguishable from a subject nothing depends on.
+/// The identity that owns incoming edges is the one the question was about.
+///
+/// A tie leaves the order untouched, so a set where nothing carries edges still
+/// resolves to the same deterministic first match it always did. That is what
+/// keeps this from being a reshuffle dressed as a preference.
+fn prefer_entities_owning_incoming_relations(
+    graph: &kin_db::InMemoryGraph,
+    matches: &mut [kin_model::Entity],
+) -> Result<()> {
+    if matches.len() < 2 {
+        return Ok(());
+    }
+    let mut owns_incoming = std::collections::HashSet::new();
+    for entity in matches.iter() {
+        if !graph
+            .get_all_relations_for_entity(&entity.id)?
+            .into_iter()
+            .any(|relation| {
+                relation.dst == GraphNodeId::Entity(entity.id)
+                    && relation.src != GraphNodeId::Entity(entity.id)
+            })
+        {
+            continue;
+        }
+        owns_incoming.insert(entity.id);
+    }
+    matches.sort_by_key(|entity| !owns_incoming.contains(&entity.id));
+    Ok(())
+}
+
+/// The relation kinds a member's dependent count is read over.
+///
+/// The same set `kin refs` answers on, so the count printed beside a suggested
+/// `kin impact <member>` is a number the reader can go and confirm. Containment
+/// is deliberately absent: a declaration contains its own members, and counting
+/// that edge would give every member a dependent it does not have.
+const IMPACT_MEMBER_RELATION_KINDS: &[kin_model::RelationKind] = &[
+    kin_model::RelationKind::Calls,
+    kin_model::RelationKind::Imports,
+    kin_model::RelationKind::References,
+];
+
+/// What the graph still says about a target with no downstream impact of its
+/// own.
+///
+/// A Rust type declaration owns one outgoing containment edge and nothing else,
+/// so "no local downstream impact" is true of the node and wrong about the
+/// repository: everything that depends on the type reaches it through a member.
+/// Naming those members, with the count a reader can verify, replaces an answer
+/// that looked like proof of no dependents with one that says where they are.
+///
+/// A target with no referenced members keeps the bare line. That is what keeps
+/// this from becoming a footer on every empty result.
+fn empty_impact_context(
+    graph: &kin_db::InMemoryGraph,
+    target: &kin_model::Entity,
+) -> Result<Vec<String>> {
+    let neighbors = crate::commands::declaration_neighbors::collect(
+        graph,
+        target,
+        IMPACT_MEMBER_RELATION_KINDS,
+    )?;
+    let referenced: Vec<_> = neighbors.referenced_members().collect();
+    let Some(first) = referenced.first() else {
+        return Ok(Vec::new());
+    };
+
+    let mut lines = vec![format!(
+        "  {} member{} of '{}' do have dependents:",
+        referenced.len(),
+        if referenced.len() == 1 { "" } else { "s" },
+        target.name
+    )];
+    for member in referenced
+        .iter()
+        .take(crate::commands::declaration_neighbors::MAX_LISTED)
+    {
+        lines.push(format!(
+            "    - {} ({}) @ {} [{} referencing {}]",
+            member.name,
+            member.kind,
+            member.location,
+            member.referencing_entities,
+            if member.referencing_entities == 1 {
+                "entity"
+            } else {
+                "entities"
+            },
+        ));
+    }
+    if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
+        crate::commands::declaration_neighbors::MAX_LISTED,
+        referenced.len(),
+    ) {
+        lines.push(format!("    {more}"));
+    }
+    lines.push(format!("    try: kin impact {}", first.name));
+    Ok(lines)
 }
 
 /// One breadth-first walk over inbound entity edges, pairing every reached
@@ -283,10 +476,23 @@ fn downstream_impact_by_hop<G: ImpactWalkGraph>(
     Ok(reached)
 }
 
+/// What a query resolved to, at both stages of resolution.
+///
+/// The two are kept apart so a qualifier that narrows the set to nothing can be
+/// reported as the filter miss it is. Collapsing them is what let
+/// `kin impact Error --file src/error.rs` answer "Entity 'Error' not found in
+/// this repo's graph" about an entity the unfiltered lookup had just found.
+struct ResolvedEntities {
+    /// After `--file`, `--kind`, and `--signature`.
+    matches: Vec<kin_model::Entity>,
+    /// Before them: what the name alone resolves to.
+    name_matches: Vec<kin_model::Entity>,
+}
+
 fn resolve_entities(
     graph: &kin_db::InMemoryGraph,
     request: &ImpactRequest,
-) -> Result<Vec<kin_model::Entity>> {
+) -> Result<ResolvedEntities> {
     let mut matches = if let Ok(uuid) = uuid::Uuid::parse_str(&request.entity) {
         graph.get_entity(&EntityId(uuid))?.into_iter().collect()
     } else {
@@ -325,6 +531,7 @@ fn resolve_entities(
         }
         matches
     };
+    let name_matches = matches.clone();
     if let Some(file) = request.file.as_deref() {
         matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).file == file);
     }
@@ -337,7 +544,89 @@ fn resolve_entities(
             kin_review::StableEntityIdentity::from_entity(entity).signature == normalized
         });
     }
-    Ok(matches)
+    Ok(ResolvedEntities {
+        matches,
+        name_matches,
+    })
+}
+
+/// The qualifiers a request carried, spelled the way the user passed them.
+fn active_qualifiers(request: &ImpactRequest) -> Vec<String> {
+    [
+        request.file.as_deref().map(|v| format!("--file {v}")),
+        request.kind.as_deref().map(|v| format!("--kind {v}")),
+        request
+            .signature
+            .as_deref()
+            .map(|v| format!("--signature {v}")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+/// The answer when a name resolves but the identity qualifiers exclude every
+/// match.
+///
+/// The entity is in the graph, so saying it is not is false, and it is the
+/// answer a user gets by following Kin's own advice to disambiguate by file.
+/// Report the miss as a miss and name what the name alone does resolve to, so
+/// the next command is a copy of one of these lines.
+fn qualifier_miss_guidance(
+    entity: &str,
+    qualifiers: &[String],
+    candidates: &[kin_model::Entity],
+    members_in_scope: &[String],
+) -> Vec<String> {
+    let mut lines = vec![format!(
+        "No entity named '{}' matches {}.",
+        entity,
+        qualifiers.join(" ")
+    )];
+    lines.push(format!(
+        "'{}' resolves in this repo's graph to {} entit{}:",
+        entity,
+        candidates.len(),
+        if candidates.len() == 1 { "y" } else { "ies" }
+    ));
+    for candidate in candidates
+        .iter()
+        .take(crate::commands::declaration_neighbors::MAX_LISTED)
+    {
+        lines.push(format!(
+            "  {} ({:?}) @ {}",
+            candidate.name,
+            candidate.kind,
+            entity_location(candidate).unwrap_or_else(|| "unknown".to_string())
+        ));
+    }
+    if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
+        crate::commands::declaration_neighbors::MAX_LISTED,
+        candidates.len(),
+    ) {
+        lines.push(format!("  {more}"));
+    }
+    if !members_in_scope.is_empty() {
+        lines.push(format!("Members of '{entity}' the graph does place there:"));
+        for member in members_in_scope
+            .iter()
+            .take(crate::commands::declaration_neighbors::MAX_LISTED)
+        {
+            lines.push(format!("  {member}"));
+        }
+        if let Some(more) = crate::commands::declaration_neighbors::and_more_suffix(
+            crate::commands::declaration_neighbors::MAX_LISTED,
+            members_in_scope.len(),
+        ) {
+            lines.push(format!("  {more}"));
+        }
+    }
+    lines.push(
+        "hint: qualify with one of the identities above, or drop the qualifier to analyze the \
+         first match."
+            .to_string(),
+    );
+    lines
 }
 
 /// `path:line` for an entity, or just the path when the graph carries no span.
@@ -345,11 +634,7 @@ fn resolve_entities(
 /// Location is projection metadata for the human reading the listing; the
 /// analysis itself is keyed on graph identity, never on paths.
 fn entity_location(entity: &kin_model::Entity) -> Option<String> {
-    let path = entity.file_origin.as_ref().map(|f| f.0.clone())?;
-    Some(match entity.span.as_ref().map(|s| s.start_line) {
-        Some(line) => format!("{path}:{line}"),
-        None => path,
-    })
+    crate::commands::declaration_neighbors::entity_location(entity)
 }
 
 /// Actionable guidance when `kin impact <symbol>` can't resolve the symbol in
@@ -660,6 +945,252 @@ mod tests {
             response.lines
         );
         assert!(response.lines[0].contains("'resolve_binary'"));
+    }
+
+    fn calls(graph: &kin_db::InMemoryGraph, src: &Entity, dst: &Entity) {
+        graph
+            .upsert_relation(&Relation {
+                id: RelationId::from_content(&src.id.to_string(), &dst.id.to_string(), "calls"),
+                kind: RelationKind::Calls,
+                src: GraphNodeId::Entity(src.id),
+                dst: GraphNodeId::Entity(dst.id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+    }
+
+    /// One name, two graph identities: a declaration nothing points at, sorting
+    /// first, and the definition every caller reaches. Answering for the first
+    /// prints an empty result about a subject that has dependents.
+    #[tokio::test]
+    async fn resolution_prefers_the_identity_that_owns_incoming_relations() {
+        let graph = kin_db::InMemoryGraph::new();
+        let declaration = entity_at("Thing", "src/a_declaration.rs", 3);
+        let definition = entity_at("Thing", "src/z_definition.rs", 40);
+        let caller = entity_at("caller", "src/caller.rs", 7);
+        for e in [&declaration, &definition, &caller] {
+            graph.upsert_entity(e).unwrap();
+        }
+        calls(&graph, &caller, &definition);
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Thing".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            response.lines[0].contains("src/z_definition.rs"),
+            "must answer for the identity that owns callers: {:?}",
+            response.lines
+        );
+        let joined = response.lines.join("\n");
+        assert!(
+            joined.contains("caller"),
+            "the dependents must actually be reported: {joined}"
+        );
+        assert!(
+            joined.contains("src/a_declaration.rs"),
+            "the identity passed over must still be named: {joined}"
+        );
+    }
+
+    /// The falsification for the preference above. When nothing carries incoming
+    /// relations there is no definition site to prefer, and the deterministic
+    /// first match must be exactly what it was before.
+    #[tokio::test]
+    async fn resolution_order_is_unchanged_when_no_identity_owns_relations() {
+        let graph = kin_db::InMemoryGraph::new();
+        for e in [
+            &entity_at("Thing", "src/a_declaration.rs", 3),
+            &entity_at("Thing", "src/z_definition.rs", 40),
+        ] {
+            graph.upsert_entity(e).unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Thing".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            response.lines[0].contains("src/a_declaration.rs"),
+            "a tie keeps the deterministic first match: {:?}",
+            response.lines
+        );
+    }
+
+    /// A self-recursive edge is the entity pointing at itself. It says nothing
+    /// about whether anything else depends on it, so it must not promote an
+    /// identity over one that real callers reach.
+    #[tokio::test]
+    async fn a_self_edge_does_not_count_as_owning_incoming_relations() {
+        let graph = kin_db::InMemoryGraph::new();
+        let recursive = entity_at("Thing", "src/a_declaration.rs", 3);
+        let definition = entity_at("Thing", "src/z_definition.rs", 40);
+        let caller = entity_at("caller", "src/caller.rs", 7);
+        for e in [&recursive, &definition, &caller] {
+            graph.upsert_entity(e).unwrap();
+        }
+        calls(&graph, &recursive, &recursive);
+        calls(&graph, &caller, &definition);
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Thing".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            response.lines[0].contains("src/z_definition.rs"),
+            "a self-edge must not outrank a real caller: {:?}",
+            response.lines
+        );
+    }
+
+    /// FIR-2032, at the unit boundary: the qualifier miss is reported as a miss,
+    /// the machine surface carries the identities the name does resolve to, and
+    /// the count of matches after qualification stays zero.
+    #[tokio::test]
+    async fn qualifier_miss_names_the_unfiltered_candidates_on_both_surfaces() {
+        let graph = kin_db::InMemoryGraph::new();
+        for e in [
+            &entity_at("Thing", "src/a.rs", 3),
+            &entity_at("Thing", "src/b.rs", 9),
+        ] {
+            graph.upsert_entity(e).unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Thing".to_string(),
+                depth: 3,
+                file: Some("src/nowhere.rs".to_string()),
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let joined = response.lines.join("\n");
+        assert!(
+            !joined.contains("not found in this repo's graph"),
+            "the entity is in the graph; the filter is what missed: {joined}"
+        );
+        assert!(joined.contains("--file src/nowhere.rs"), "{joined}");
+        assert!(
+            joined.contains("src/a.rs:3") && joined.contains("src/b.rs:9"),
+            "{joined}"
+        );
+        assert_eq!(response.query.match_count, 0);
+        assert_eq!(
+            response
+                .query
+                .name_candidates
+                .iter()
+                .map(|candidate| candidate.location.as_str())
+                .collect::<Vec<_>>(),
+            vec!["src/a.rs:3", "src/b.rs:9"],
+        );
+    }
+
+    /// A qualifier that does match must be unaffected by the miss path, and a
+    /// clean single resolution must not start carrying candidate noise.
+    #[tokio::test]
+    async fn a_matching_qualifier_still_resolves_and_carries_no_candidates() {
+        let graph = kin_db::InMemoryGraph::new();
+        for e in [
+            &entity_at("Thing", "src/a.rs", 3),
+            &entity_at("Thing", "src/b.rs", 9),
+        ] {
+            graph.upsert_entity(e).unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "Thing".to_string(),
+                depth: 3,
+                file: Some("src/b.rs".to_string()),
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.resolution, "resolved");
+        assert_eq!(response.query.match_count, 1);
+        assert!(
+            response.lines[0].contains("src/b.rs:9"),
+            "{:?}",
+            response.lines
+        );
+
+        let single = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "caller_only".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(single.resolution, "not_found");
+        assert!(single.query.name_candidates.is_empty());
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod context;
 pub mod contextbench_locate;
 pub mod daemon;
 pub mod dead_code;
+pub mod declaration_neighbors;
 pub mod deps;
 pub mod diff;
 pub mod drift;

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -226,10 +226,14 @@ pub fn build_refs_response(
 /// What the graph still says about a target whose incoming relations are empty.
 ///
 /// An empty answer on a type declaration is true of that entity and misleading
-/// about the repository: the references went to its members, and Kin knows
-/// exactly which ones. Naming them turns "no callers" into "these are the
-/// callers, one level down", and naming the same-name identities resolution
-/// passed over says which node was actually answered for.
+/// about the repository: the references went to entities the declaration's name
+/// qualifies, and Kin holds exactly which ones. Naming them turns "no callers"
+/// into "these are the callers, one level down", and naming the same-name
+/// identities resolution passed over says which node was actually answered for.
+///
+/// The listing is scoped by name and says so, because the graph ties a
+/// declaration only to its same-file members. Claiming ownership instead would
+/// tell a same-named declaration that another's members are its own.
 ///
 /// An entity with neither members nor same-name siblings adds nothing here, so
 /// it keeps the plain empty answer. That is what stops this note from becoming
@@ -243,10 +247,11 @@ fn empty_result_context(
     let referenced: Vec<_> = neighbors.referenced_members().collect();
     if let Some(first) = referenced.first() {
         lines.push(format!(
-            "{} member{} of '{}' do carry them:",
+            "{} entit{} named '{}::*' carr{} them:",
             referenced.len(),
-            if referenced.len() == 1 { "" } else { "s" },
-            target.name
+            if referenced.len() == 1 { "y" } else { "ies" },
+            target.name,
+            if referenced.len() == 1 { "ies" } else { "y" },
         ));
         for member in referenced.iter().take(declaration_neighbors::MAX_LISTED) {
             lines.push(format!(

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -7,6 +7,8 @@ use kin_ranking::entity_ranking;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::commands::declaration_neighbors;
+
 /// Resolve session id from KIN_SESSION_ID env var.
 ///
 /// Optional: returns None if unset/empty (commands behave as if no scope).
@@ -196,6 +198,8 @@ pub fn build_refs_response(
             "No incoming {} relations.",
             relation_kinds_label(&relation_kinds)
         ));
+        let neighbors = declaration_neighbors::collect(graph, target, &relation_kinds)?;
+        lines.extend(empty_result_context(target, &neighbors));
         return Ok(RefsResponse { lines });
     }
 
@@ -217,6 +221,101 @@ pub fn build_refs_response(
     }
 
     Ok(RefsResponse { lines })
+}
+
+/// What the graph still says about a target whose incoming relations are empty.
+///
+/// An empty answer on a type declaration is true of that entity and misleading
+/// about the repository: the references went to its members, and Kin knows
+/// exactly which ones. Naming them turns "no callers" into "these are the
+/// callers, one level down", and naming the same-name identities resolution
+/// passed over says which node was actually answered for.
+///
+/// An entity with neither members nor same-name siblings adds nothing here, so
+/// it keeps the plain empty answer. That is what stops this note from becoming
+/// noise that a reader learns to skip.
+fn empty_result_context(
+    target: &Entity,
+    neighbors: &declaration_neighbors::DeclarationNeighbors,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let referenced: Vec<_> = neighbors.referenced_members().collect();
+    if let Some(first) = referenced.first() {
+        lines.push(format!(
+            "{} member{} of '{}' do carry them:",
+            referenced.len(),
+            if referenced.len() == 1 { "" } else { "s" },
+            target.name
+        ));
+        for member in referenced.iter().take(declaration_neighbors::MAX_LISTED) {
+            lines.push(format!(
+                "  {} @ {} [{} referencing {}]",
+                member.name,
+                member.location,
+                member.referencing_entities,
+                if member.referencing_entities == 1 {
+                    "entity"
+                } else {
+                    "entities"
+                },
+            ));
+        }
+        if let Some(more) = declaration_neighbors::and_more_suffix(
+            declaration_neighbors::MAX_LISTED,
+            referenced.len(),
+        ) {
+            lines.push(format!("  {more}"));
+        }
+        lines.push(format!("  try: kin refs {}", first.name));
+    }
+
+    if !neighbors.siblings.is_empty() {
+        lines.push(format!(
+            "{} other graph identit{} the name '{}':",
+            neighbors.siblings.len(),
+            if neighbors.siblings.len() == 1 {
+                "y carries"
+            } else {
+                "ies carry"
+            },
+            target.name
+        ));
+        for sibling in neighbors
+            .siblings
+            .iter()
+            .take(declaration_neighbors::MAX_LISTED)
+        {
+            lines.push(format!(
+                "  {} ({}) @ {}",
+                sibling.name, sibling.kind, sibling.location
+            ));
+        }
+        if let Some(more) = declaration_neighbors::and_more_suffix(
+            declaration_neighbors::MAX_LISTED,
+            neighbors.siblings.len(),
+        ) {
+            lines.push(format!("  {more}"));
+        }
+    }
+
+    lines
+}
+
+/// Distinct entities that reference `entity_id` over the given relation kinds.
+///
+/// Counted through the same collector the listing is built from, so a count
+/// reported beside a suggested `kin refs <member>` is the number that command
+/// will print. A source id the graph carries an edge for but no entity record
+/// for is still a distinct referencing identity, so it counts here; the ordinary
+/// listing path fails loud on that same gap rather than reporting the row.
+pub(crate) fn distinct_referencing_entities(
+    graph: &impl GraphStore,
+    entity_id: &EntityId,
+    relation_kinds: &[RelationKind],
+) -> Result<usize> {
+    let collected = collect_graph_references(graph, entity_id, relation_kinds)?;
+    Ok(collected.references.len() + collected.missing_source_ids.len())
 }
 
 /// Actionable guidance when `kin refs <symbol>` misses in the current repo's

--- a/crates/kin-cli/tests/declaration_resolution_e2e.rs
+++ b/crates/kin-cli/tests/declaration_resolution_e2e.rs
@@ -210,6 +210,54 @@ fn fixture_premise_declaration_owns_no_incoming_edges_but_members_do() {
     }
 }
 
+/// Why the listing is gathered by name and not by the containment edge.
+///
+/// The Rust extractor emits a `Contains` for both `impl` blocks, but the linker
+/// keys containment against a declaration in the same file, and `src/error.rs`
+/// declares none. So the cross-file edge is dropped and the declaration is left
+/// owning exactly one outgoing `Contains`, to its same-file member. Collecting
+/// members from edges alone would therefore lose `Error::chain`, which is the
+/// member this whole answer exists to surface.
+///
+/// If this reddens because the declaration now owns an edge to `Error::chain`,
+/// the graph gap is closed and the collector should move to edges, where a
+/// declaration's members can be told from a same-named declaration's.
+#[test]
+fn fixture_premise_containment_reaches_only_the_same_file_member() {
+    let graph = anyhow_shaped_graph();
+    let declaration = graph
+        .query_entities(&kin_model::EntityFilter {
+            name_pattern: Some("Error".to_string()),
+            ..Default::default()
+        })
+        .unwrap()
+        .into_iter()
+        .find(|entity| {
+            entity.name == "Error"
+                && entity.file_origin.as_ref().map(|f| f.0.as_str()) == Some("src/lib.rs")
+        })
+        .expect("Error declared in src/lib.rs");
+
+    let contained: Vec<String> = graph
+        .get_all_relations_for_entity(&declaration.id)
+        .unwrap()
+        .into_iter()
+        .filter(|relation| {
+            relation.kind == kin_model::RelationKind::Contains
+                && relation.src == kin_model::GraphNodeId::Entity(declaration.id)
+        })
+        .filter_map(|relation| relation.dst.as_entity())
+        .filter_map(|id| graph.get_entity(&id).unwrap())
+        .map(|entity| entity.name)
+        .collect();
+
+    assert_eq!(
+        contained,
+        vec!["Error::msg".to_string()],
+        "containment must reach the same-file member and not the cross-file one"
+    );
+}
+
 #[test]
 fn refs_on_a_declaration_names_the_members_that_carry_references() {
     let graph = anyhow_shaped_graph();
@@ -351,5 +399,67 @@ async fn absent_name_still_reports_not_found() {
     assert!(
         joined.contains("not found in this repo's graph"),
         "a genuinely absent name keeps the not-found answer: {joined}"
+    );
+}
+
+/// The listing is gathered by name qualification, and the graph does not tie a
+/// declaration to members declared in another file, so the wording has to claim
+/// a shared name and not ownership.
+///
+/// `tests/ui/no-impl.rs` declares a unit `struct Error;` that owns nothing at
+/// all, and qualifying an ordinary command to it is reachable from the CLI.
+/// Telling that declaration it owns `Error::msg` and `Error::chain`, which
+/// belong to the `Error` in `src/lib.rs`, is the same answer that is true of
+/// nothing and wrong about the repository, pointed the other way.
+#[tokio::test]
+async fn a_memberless_declaration_is_not_told_it_owns_the_other_declarations_members() {
+    let graph = anyhow_shaped_graph();
+    let joined = impact_lines(&graph, "Error", Some("tests/ui/no-impl.rs")).await;
+
+    assert!(
+        joined.contains("Error::msg") || joined.contains("Error::chain"),
+        "the entities the name qualifies are still worth naming: {joined}"
+    );
+    assert!(
+        !joined.contains("member"),
+        "a declaration that owns no members must not be told it has them: {joined}"
+    );
+    assert!(
+        joined.contains("named 'Error::*'"),
+        "the listing must say it is scoped by name: {joined}"
+    );
+}
+
+/// The same claim on the `refs` surface. Resolution by name prefers the
+/// `src/lib.rs` identity, so the memberless one is reached by id, which is a
+/// spelling `kin refs` accepts.
+#[test]
+fn refs_scopes_the_listing_by_name_rather_than_claiming_ownership() {
+    let graph = anyhow_shaped_graph();
+    let memberless = graph
+        .query_entities(&kin_model::EntityFilter {
+            name_pattern: Some("Error".to_string()),
+            ..Default::default()
+        })
+        .unwrap()
+        .into_iter()
+        .find(|entity| {
+            entity.name == "Error"
+                && entity.file_origin.as_ref().map(|f| f.0.as_str()) == Some("tests/ui/no-impl.rs")
+        })
+        .expect("the unit struct Error in tests/ui/no-impl.rs");
+
+    let joined = refs_lines(&graph, &memberless.id.0.to_string());
+    assert!(
+        joined.contains("Error::msg") && joined.contains("Error::chain"),
+        "the entities the name qualifies are still worth naming: {joined}"
+    );
+    assert!(
+        !joined.contains("member"),
+        "a declaration that owns no members must not be told it has them: {joined}"
+    );
+    assert!(
+        joined.contains("named 'Error::*'"),
+        "the listing must say it is scoped by name: {joined}"
     );
 }

--- a/crates/kin-cli/tests/declaration_resolution_e2e.rs
+++ b/crates/kin-cli/tests/declaration_resolution_e2e.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end cover for the answers `kin refs` and `kin impact` give on a type
+//! declaration whose members live in other files.
+//!
+//! The fixture is the shape `anyhow` has: `pub struct Error` is declared in
+//! `src/lib.rs`, its `impl` blocks are split across `src/lib.rs` and
+//! `src/error.rs`, callers reach the members rather than the type, and a
+//! same-named private declaration sits in a `tests/ui` fixture. Run through the
+//! real Rust parser and the real cross-file linker, that produces a graph where
+//! the type declaration owns no incoming Calls/Imports/References edge at all,
+//! while its members own several.
+//!
+//! Both commands used to answer that with a bare empty line, which reads as
+//! "nothing depends on this type" when the graph plainly says otherwise. These
+//! tests pin the honest answer instead, and pin that a genuinely unreferenced
+//! entity still gets the plain empty one.
+
+use kin_cli::commands::impact::{build_impact_response, ImpactRequest};
+use kin_cli::commands::refs::{build_refs_response, RefsRequest};
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use kin_parser::{LanguageAdapter, RustAdapter};
+
+const LIB_RS: &str = r#"mod error;
+mod user;
+
+pub struct Error {
+    code: u32,
+}
+
+impl Error {
+    pub fn msg(code: u32) -> Self {
+        Error { code }
+    }
+}
+"#;
+
+const ERROR_RS: &str = r#"use crate::Error;
+
+impl Error {
+    pub fn chain(&self) -> u32 {
+        self.code
+    }
+}
+"#;
+
+const USER_RS: &str = r#"use crate::Error;
+
+pub fn build() -> Error {
+    Error::msg(1)
+}
+
+pub fn read(e: &Error) -> u32 {
+    e.chain()
+}
+"#;
+
+const UI_RS: &str = r#"struct Error;
+
+fn main() {
+    let _ = Error;
+}
+"#;
+
+fn parse_rs(file_path: &str, source: &str) -> FileParseData {
+    let adapter = RustAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse fixture");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|entity| entity.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+/// The fixture repository, ingested through the real parser and linker.
+pub fn anyhow_shaped_graph() -> InMemoryGraph {
+    let files = vec![
+        parse_rs("src/lib.rs", LIB_RS),
+        parse_rs("src/error.rs", ERROR_RS),
+        parse_rs("src/user.rs", USER_RS),
+        parse_rs("tests/ui/no-impl.rs", UI_RS),
+    ];
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
+
+    let graph = InMemoryGraph::new();
+    for entity in files.iter().flat_map(|file| file.entities.iter()) {
+        graph.upsert_entity(entity).expect("upsert entity");
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    graph
+}
+
+fn layout() -> (tempfile::TempDir, kin_core::KinLayout) {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+    (dir, layout)
+}
+
+fn refs_lines(graph: &InMemoryGraph, entity: &str) -> String {
+    let (_dir, layout) = layout();
+    build_refs_response(
+        &layout,
+        graph,
+        &RefsRequest {
+            entity: entity.to_string(),
+            kind: "all".to_string(),
+        },
+    )
+    .expect("refs response")
+    .lines
+    .join("\n")
+}
+
+async fn impact_lines(graph: &InMemoryGraph, entity: &str, file: Option<&str>) -> String {
+    let (_dir, layout) = layout();
+    build_impact_response(
+        &layout,
+        graph,
+        &ImpactRequest {
+            entity: entity.to_string(),
+            depth: 3,
+            file: file.map(ToOwned::to_owned),
+            kind: None,
+            signature: None,
+            require_unique: false,
+        },
+    )
+    .await
+    .expect("impact response")
+    .lines
+    .join("\n")
+}
+
+/// The premise every assertion below rests on: the linker really does leave the
+/// type declaration with no incoming reference edge, while its members carry
+/// them. Without this the tests could pass for the wrong reason.
+#[test]
+fn fixture_premise_declaration_owns_no_incoming_edges_but_members_do() {
+    let graph = anyhow_shaped_graph();
+    let declaration = graph
+        .query_entities(&kin_model::EntityFilter {
+            name_pattern: Some("Error".to_string()),
+            ..Default::default()
+        })
+        .unwrap()
+        .into_iter()
+        .find(|entity| {
+            entity.name == "Error"
+                && entity.file_origin.as_ref().map(|f| f.0.as_str()) == Some("src/lib.rs")
+        })
+        .expect("Error declared in src/lib.rs");
+
+    let incoming: Vec<_> = graph
+        .get_all_relations_for_entity(&declaration.id)
+        .unwrap()
+        .into_iter()
+        .filter(|relation| {
+            relation.dst == kin_model::GraphNodeId::Entity(declaration.id)
+                && matches!(
+                    relation.kind,
+                    kin_model::RelationKind::Calls
+                        | kin_model::RelationKind::Imports
+                        | kin_model::RelationKind::References
+                )
+        })
+        .collect();
+    assert!(
+        incoming.is_empty(),
+        "fixture premise: the declaration must own no incoming reference edge, got {incoming:?}"
+    );
+
+    for member in ["Error::msg", "Error::chain"] {
+        let entity = graph
+            .query_entities(&kin_model::EntityFilter {
+                name_pattern: Some(member.to_string()),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == member)
+            .unwrap_or_else(|| panic!("{member} in the fixture graph"));
+        let callers = graph
+            .get_all_relations_for_entity(&entity.id)
+            .unwrap()
+            .into_iter()
+            .filter(|relation| relation.dst == kin_model::GraphNodeId::Entity(entity.id))
+            .count();
+        assert!(
+            callers > 0,
+            "fixture premise: {member} must carry incoming edges"
+        );
+    }
+}
+
+#[test]
+fn refs_on_a_declaration_names_the_members_that_carry_references() {
+    let graph = anyhow_shaped_graph();
+    let joined = refs_lines(&graph, "Error");
+
+    assert!(
+        joined.contains("No incoming"),
+        "the empty signal itself must be preserved: {joined}"
+    );
+    assert!(
+        joined.contains("Error::msg") && joined.contains("src/lib.rs"),
+        "must name the member that carries references, with its file: {joined}"
+    );
+    assert!(
+        joined.contains("Error::chain") && joined.contains("src/error.rs"),
+        "must name a member declared in another file, with its file: {joined}"
+    );
+    assert!(
+        joined.contains("kin refs Error::"),
+        "must offer a runnable next command: {joined}"
+    );
+}
+
+/// The count in the note and the count the suggested command prints are read
+/// through one collector, so they cannot drift apart. A note advertising three
+/// referencing entities beside a command that then lists one is worse than no
+/// note at all.
+#[test]
+fn the_member_count_in_the_note_is_the_count_its_suggested_command_prints() {
+    let graph = anyhow_shaped_graph();
+    let note = refs_lines(&graph, "Error");
+    let advertised = note
+        .lines()
+        .find(|line| line.trim_start().starts_with("Error::msg @"))
+        .expect("the note lists Error::msg");
+    assert!(
+        advertised.contains("[1 referencing entity]"),
+        "note line: {advertised}"
+    );
+
+    let member = refs_lines(&graph, "Error::msg");
+    assert!(
+        member.contains("referenced by 1 entities:"),
+        "the suggested command must report the advertised count: {member}"
+    );
+}
+
+#[test]
+fn refs_on_a_declaration_names_the_other_identities_sharing_the_name() {
+    let graph = anyhow_shaped_graph();
+    let joined = refs_lines(&graph, "Error");
+    assert!(
+        joined.contains("tests/ui/no-impl.rs"),
+        "must name the same-named identity it did not choose: {joined}"
+    );
+}
+
+/// The falsification the ticket asks for: an entity that genuinely has no
+/// incoming references, no members, and no same-named sibling must still get the
+/// plain empty answer. If this reddens, the honest-empty note has become
+/// unconditional and stopped carrying information.
+#[test]
+fn genuinely_unreferenced_entity_still_gets_the_plain_empty_answer() {
+    let graph = anyhow_shaped_graph();
+    let joined = refs_lines(&graph, "read");
+    assert!(
+        joined.contains("No incoming"),
+        "must report the empty result: {joined}"
+    );
+    assert_eq!(
+        joined.lines().count(),
+        2,
+        "an entity with nothing further to report gets exactly the header and the empty line: {joined}"
+    );
+}
+
+#[tokio::test]
+async fn impact_on_a_declaration_names_the_members_that_carry_impact() {
+    let graph = anyhow_shaped_graph();
+    let joined = impact_lines(&graph, "Error", None).await;
+
+    assert!(
+        joined.contains("Error::msg") || joined.contains("Error::chain"),
+        "must name the members whose dependents exist: {joined}"
+    );
+    assert!(
+        joined.contains("kin impact Error::"),
+        "must offer a runnable next command: {joined}"
+    );
+    assert!(
+        joined.contains("tests/ui/no-impl.rs"),
+        "the ambiguity note must name the identity it did not choose: {joined}"
+    );
+}
+
+#[tokio::test]
+async fn impact_on_a_genuinely_isolated_entity_still_reports_plain_empty() {
+    let graph = anyhow_shaped_graph();
+    let joined = impact_lines(&graph, "read", None).await;
+    assert!(
+        joined.contains("No local downstream impact found"),
+        "must report the empty result: {joined}"
+    );
+    assert!(
+        !joined.contains("try:"),
+        "nothing further to offer means no next-step note: {joined}"
+    );
+}
+
+/// FIR-2032. `--file` narrows the candidates the ordinary lookup already found.
+/// When it narrows them to none, the answer must say the filter matched nothing
+/// and name what the name itself resolves to. Claiming the entity is absent from
+/// the graph is false: the unfiltered lookup just found it.
+#[tokio::test]
+async fn impact_file_qualifier_that_matches_nothing_reports_a_filter_miss() {
+    let graph = anyhow_shaped_graph();
+    let joined = impact_lines(&graph, "Error", Some("src/error.rs")).await;
+
+    assert!(
+        !joined.contains("not found in this repo's graph"),
+        "must not claim the entity is absent when the name resolves: {joined}"
+    );
+    assert!(
+        joined.contains("src/error.rs"),
+        "must name the qualifier that matched nothing: {joined}"
+    );
+    assert!(
+        joined.contains("src/lib.rs") && joined.contains("tests/ui/no-impl.rs"),
+        "must name the identities the unfiltered lookup does find: {joined}"
+    );
+}
+
+/// A name that really is absent must still get the not-found answer, so the
+/// filter-miss wording above cannot be reached by simply never reporting a miss.
+#[tokio::test]
+async fn absent_name_still_reports_not_found() {
+    let graph = anyhow_shaped_graph();
+    let joined = impact_lines(&graph, "NoSuchSymbol", Some("src/error.rs")).await;
+    assert!(
+        joined.contains("not found in this repo's graph"),
+        "a genuinely absent name keeps the not-found answer: {joined}"
+    );
+}


### PR DESCRIPTION
## Mechanism

Measured through the real Rust parser and the real cross-file linker, not inferred:

- `use crate::Error;` is recorded as a `FileImport`, and the linker turns it into an edge between
  two artifacts, so it produces no `Imports` edge on the entity.
- A type named in a signature (`fn build() -> Error`) produces no relation at all.
- The only edge a Rust type declaration owns is an outgoing `Contains` to its same-file members.

So `Error` carries zero incoming `Calls`/`Imports`/`References` edges, both commands resolved the
correct node, read its incoming relations, found none, and printed a bare empty answer. That answer
is true of the entity and wrong about the repository: everything that depends on the type reaches it
through `Error::msg`, `Error::from`, and the rest. `ErrorImpl::backtrace` worked because it is a
method and `Calls` edges to methods resolve. Python behaves differently only because its extractor
emits those edges.

The same-file qualifier above is load-bearing. The extractor does emit a `Contains` for a cross-file
`impl` block, and the linker drops it, because containment is keyed against a declaration in the
same file and a cross-file `impl` has none. `linker.rs` handles no `Contains` at all. So the graph
holds no edge tying a declaration to a member declared elsewhere, and collecting members from edges
would lose exactly the ones this answer exists to surface.
`fixture_premise_containment_reaches_only_the_same_file_member` pins that gap, so if the linker ever
closes it, the collector moves to edges rather than staying on names by inertia.

Members are therefore gathered by name qualification, and every line built from them says so. Two
declarations sharing a name cannot be told apart by a name, so these listings claim that entities
share a name prefix and never that a particular declaration owns them.

This corrects FIR-2031's stated cause. The ticket reads the resolved location `src/lib.rs:389` as a
re-export node, but in `anyhow` `pub struct Error` is declared at `src/lib.rs:390`, `pub struct Chain`
at `:415`, and `pub trait Context` at `:616`. None of the three is a re-export, and resolution was
never landing on the wrong node. Emitting `Imports`/`References` edges for Rust type usage is the
deeper fix and belongs in `kin-parser`/`kin-index`; it is written up on FIR-2031 and is not attempted
here. Attributing a member to the declaration the graph ties it to, rather than to every declaration
sharing its name, becomes possible once that gap closes and is likewise not attempted here.

Four changes, all reading graph truth only, no filesystem in the answer path:

1. When `refs` or `impact` returns empty, report the entities the name qualifies that do carry
   references and the same-name identities resolution passed over. A target with neither keeps the
   plain empty line.
2. `impact` distinguishes a qualifier miss from a genuine miss, and names what the unfiltered lookup
   found. The response also carries those identities in `query.name_candidates` for structured
   callers. `resolution` stays `not_found` so the machine contract is unchanged.
3. `impact`'s ambiguity note names the identities it did not choose, with `file:line`.
4. Where one name covers several identities, the human `impact` surface answers for one that owns
   incoming relations. A tie leaves the deterministic first match exactly where it was.

Member counts are read through the same collector `kin refs` lists from, so a count printed beside a
suggested command is the number that command prints.
`the_member_count_in_the_note_is_the_count_its_suggested_command_prints` pins it.

## Before and after, on the anyhow shape

The fixture in `crates/kin-cli/tests/declaration_resolution_e2e.rs` reproduces it exactly: `pub struct
Error` in `src/lib.rs`, `impl Error` split across `src/lib.rs` and `src/error.rs`, callers reaching the
members, plus a private same-named `struct Error` in `tests/ui/no-impl.rs`, which is why the real
corpus reports "2 matches".

Before:

```
$ kin refs Error
References to 'Error' -> Error (Class) @ src/lib.rs
No incoming Calls, Imports, References relations.

$ kin impact Error --depth 3
Impact analysis for 'Error' (Class) @ src/lib.rs:3:
  Note: 2 matches; showing the deterministic first match. Use --json with --file/--kind/--signature for fail-closed resolution.
  No local downstream impact found.

$ kin impact Error --file src/error.rs --depth 3
Entity 'Error' not found in this repo's graph.
hint: try `kin search Error` to find the symbol by name, or check the spelling.
      `kin impact` analyzes LOCAL downstream impact; for cross-repo dependents use `kin xref`.
```

After:

```
$ kin refs Error
References to 'Error' -> Error (Class) @ src/lib.rs
No incoming Calls, Imports, References relations.
2 entities named 'Error::*' carry them:
  Error::chain @ src/error.rs:3 [1 referencing entity]
  Error::msg @ src/lib.rs:8 [1 referencing entity]
  try: kin refs Error::chain
1 other graph identity carries the name 'Error':
  Error (Class) @ tests/ui/no-impl.rs:0

$ kin impact Error --depth 3
Impact analysis for 'Error' (Class) @ src/lib.rs:3:
  Note: 2 matches; showing the deterministic first match. Use --json with --file/--kind/--signature for fail-closed resolution.
  Other matches:
    - Error (Class) @ tests/ui/no-impl.rs:0
  No local downstream impact found.
  2 entities named 'Error::*' have dependents:
    - Error::chain (Method) @ src/error.rs:3 [1 referencing entity]
    - Error::msg (Method) @ src/lib.rs:8 [1 referencing entity]
    try: kin impact Error::chain

$ kin impact Error --file src/error.rs --depth 3
No entity named 'Error' matches --file src/error.rs.
'Error' resolves in this repo's graph to 2 entities:
  Error (Class) @ src/lib.rs:3
  Error (Class) @ tests/ui/no-impl.rs:0
Entities named 'Error::*' the graph does place there:
  Error::chain (Method) @ src/error.rs:3
hint: qualify with one of the identities above, or drop the qualifier to analyze the first match.
```

## Gates

Run in the lane worktree against this commit, `RUSTFLAGS=-D warnings` throughout.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | rc 0 |
| `cargo clippy --all-targets --all-features` under ci.yml's exact 45-lint allowlist | rc 0 |
| `cargo build --all-targets --locked` | rc 0 |
| `cargo test --workspace --no-fail-fast` | rc 0, 4996 passed, 0 failed, 11 ignored, 105 binaries |

Re-run against the follow-up commit that scopes the listing wording to the name it was gathered by:
`cargo fmt --all -- --check` rc 0, `cargo nextest run --workspace` plus `cargo test --doc` rc 0 across
4997 tests with 0 failures, and `cargo build --release -p kin-cli -p kin-daemon` rc 0. The fmt gate
was falsified before being trusted, since a lane-worktree `cargo fmt` without the dev `CARGO_HOME`
exits through usage and reads as clean.

## The flagship impact path is unchanged

`kin impact resolve_binary --depth 3` on `ripgrep` at `e89fff89ac9af12e8d4ce9d5fd07beb408ca730f`,
the pin the published demonstration names, cannot be reached by any behavior this changes.

Every occurrence of the name at that commit:

| Site | Role |
|---|---|
| `crates/cli/src/decompress.rs:420` | the one declaration, `pub fn resolve_binary` |
| `crates/core/search.rs:97` | call site |
| `crates/cli/src/decompress.rs:501` | call site |
| `crates/core/flags/hiargs.rs:1327` | call site |
| `crates/cli/src/lib.rs:137` | `pub use` re-export |
| `crates/cli/src/decompress.rs:137,426,448` | `try_resolve_binary`, a different name |

One declaration and three call sites, which is the published count of direct callers, and the
re-export is correctly not one of them for the reason this PR documents: a `use` produces an
artifact-level edge and no entity-level one.

`try_resolve_binary` is a real substring cousin of the query, and it is the case the exact-name
narrowing in `resolve_entities` exists for. After narrowing, the query resolves to a single entity, so
the definition-site preference returns at its `matches.len() < 2` guard without reordering anything.
The empty-result note is likewise unreachable on a target that has dependents, since it is built only
when the hop walk returns nothing.

`downstream_impact_by_hop`, which produces the count, and `impl ImpactWalkGraph for InMemoryGraph`,
which defines the edge set it follows, are byte-identical to `origin/main`.

Re-measured rather than argued. Against a fresh clone at that commit, from a scratch `HOME`, `kin init`
only, this branch's binary reports:

```
Impact analysis for 'resolve_binary' (Function) @ crates/cli/src/decompress.rs:419:
  13 local entities impacted within 3 hops:
  1 hop (direct callers):
    - default_decompression_commands (Function) @ crates/cli/src/decompress.rs:489
    - SearchWorkerBuilder::preprocessor (Method) @ crates/core/search.rs:91
    - hostname (Function) @ crates/core/flags/hiargs.rs:1324
```

13 within 3 hops and 3 direct, unchanged, and the three direct callers are the enclosing entities of
exactly the three call sites in the table above. The re-export contributes none, which is this PR's
own mechanism appearing in the flagship answer.

## Falsification

Each mechanism was reverted in turn against this commit, the tests re-run, and the tree
restored. Every revert was asserted to have actually changed the file, so a pattern that stopped
matching could not read as a fix that was not needed.

| Reverted | Reddens |
|---|---|
| `refs` empty-result context | `refs_on_a_declaration_names_the_members_that_carry_references`, `refs_on_a_declaration_names_the_other_identities_sharing_the_name`, `the_member_count_in_the_note_is_the_count_its_suggested_command_prints` |
| `impact` empty-result context | `impact_on_a_declaration_names_the_members_that_carry_impact` |
| filter miss collapsed back into not-found | `impact_file_qualifier_that_matches_nothing_reports_a_filter_miss`, `qualifier_miss_names_the_unfiltered_candidates_on_both_surfaces` |
| definition-site preference | `resolution_prefers_the_identity_that_owns_incoming_relations`, `a_self_edge_does_not_count_as_owning_incoming_relations` |
| `impact` other-matches listing | `impact_on_a_declaration_names_the_members_that_carry_impact` |
| name-scoped wording restored to an ownership claim on `refs` | `refs_scopes_the_listing_by_name_rather_than_claiming_ownership` |
| name-scoped wording restored to an ownership claim on `impact` | `a_memberless_declaration_is_not_told_it_owns_the_other_declarations_members` |

The first sweep reported all five clean and was wrong. `cargo test -p kin-cli --test <name> --lib <filter>`
applies the filter to both binaries, so the e2e binary matched no tests and reported success. The
suites are now run separately and unfiltered.

Six guards stay green throughout and are what stop the notes from becoming unconditional noise or
false claims: a genuinely unreferenced entity keeps the plain empty answer on both surfaces, an
absent name still reports not found, a matching qualifier still resolves and carries no candidate
list, a self-recursive edge does not promote an identity over one real callers reach, and a
declaration that owns no members is not told that a same-named declaration's members are its own.

## What FIR-2031 reports that this does not fix

FIR-2031 lists a third affected surface beside `refs` and `impact`: `kin context Error` returning a
pack built from the trybuild fixture `struct Error;` in `tests/ui/no-impl.rs` rather than from
`anyhow::Error`. This PR does not touch it. The definition-site preference has exactly one caller,
inside `build_impact_response`, and the change set is `declaration_neighbors.rs`, `impact.rs`,
`mod.rs`, `refs.rs`, and the e2e test. `context.rs` is not among them.

Stated precisely: this says the change cannot have altered `kin context`, not that `kin context` is
still wrong, which was not re-measured here. The context surface needs its own follow-up, and closing
FIR-2031 on this merge should not be read as having covered it.

Closes FIR-2031
Closes FIR-2032
