### PR TITLE
Name the fix in the shallow-clone and submodule init refusals

### DIFF
--- a/crates/kin-git/src/error.rs
+++ b/crates/kin-git/src/error.rs
@@ -123,7 +123,12 @@ pub enum GitError {
     #[error("no commits in repository")]
     EmptyRepository,
 
-    #[error("shallow Git repositories cannot be imported losslessly")]
+    /// The refusal is correct: Kin's ingest contract is lossless capture of
+    /// everything reachable, and a shallow clone is genuinely un-capturable
+    /// under it. What the message has to add is the way out, because
+    /// `actions/checkout` clones at depth 1 by default and this is therefore the
+    /// first thing Kin says to anyone trying it inside CI.
+    #[error("shallow Git repositories cannot be imported losslessly; run 'git fetch --unshallow' first (in CI, actions/checkout needs fetch-depth: 0)")]
     ShallowRepository,
 
     #[error("Git object {oid} is missing while traversing {context}")]

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -2213,6 +2213,27 @@ mod tests {
         ));
     }
 
+    /// `actions/checkout` clones at depth 1 by default, so this refusal is the
+    /// first thing Kin says to anyone trying it inside GitHub Actions. Stating
+    /// the property that was violated without stating the one command that fixes
+    /// it leaves that user with nothing to do.
+    #[test]
+    fn the_shallow_refusal_names_its_recovery_command() {
+        let message = GitError::ShallowRepository.to_string();
+        assert!(
+            message.contains("shallow Git repositories cannot be imported losslessly"),
+            "the reason for the refusal is unchanged: {message}"
+        );
+        assert!(
+            message.contains("git fetch --unshallow"),
+            "must name the recovery command: {message}"
+        );
+        assert!(
+            message.contains("fetch-depth: 0"),
+            "must name the CI form of the same fix: {message}"
+        );
+    }
+
     #[test]
     fn sha256_capture_is_exact_but_rehydration_fails_before_creating_output() {
         let root = tempdir().unwrap();

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -1408,9 +1408,28 @@ fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts>
                 })?;
             }
             "core" => reject_transfer_core_keys(section)?,
+            // Split out of the arm below because it is the one section here a
+            // user reaches without ever configuring transport: `git submodule
+            // add` writes it for them.
+            "submodule" => {
+                return Err(unsafe_submodule_config(
+                    section
+                        .header()
+                        .subsection_name()
+                        .and_then(|name| name.to_str().ok()),
+                ));
+            }
             "credential" | "http" | "https" | "url" | "protocol" | "transport" | "transfer"
-            | "fetch" | "receive" | "uploadpack" | "ssh" | "submodule" | "lfs" => {
-                return Err(unsafe_git_config("unsupported transfer-affecting section"));
+            | "fetch" | "receive" | "uploadpack" | "ssh" | "lfs" => {
+                // Twelve sections share this refusal, so naming the one that
+                // matched is the difference between a reader knowing what to
+                // look for and reading a category. The section name is one of
+                // these literals and is always safe to print; the subsection
+                // name is not, because for `url`, `http`, and `credential` it is
+                // itself a URL that can carry `user:password@`.
+                return Err(unsafe_git_config(format!(
+                    "unsupported transfer-affecting section [{section_name}]"
+                )));
             }
             _ => {}
         }
@@ -1670,6 +1689,30 @@ fn validate_remote_relationships(
         }
     }
     Ok(())
+}
+
+/// The refusal a repository carrying a submodule gets.
+///
+/// Kin does not model submodules yet, so refusing is correct. What the generic
+/// transport wording could not do is get the reader from the failure to an
+/// action: it named neither the submodule, nor the file the entry lives in, nor
+/// whether anything could be done about it.
+///
+/// The subsection name is the submodule's path. Its URL lives in a key inside
+/// the section and never in the header, so naming the path cannot disclose a
+/// credential the way naming a `url` subsection would. A path that is not valid
+/// UTF-8 has no spelling worth printing and is left out rather than turning a
+/// refusal about submodules into one about encoding.
+fn unsafe_submodule_config(path: Option<&str>) -> GitError {
+    let subject = match path {
+        Some(path) => format!("unsupported submodule section for '{path}'"),
+        None => "unsupported submodule section".to_string(),
+    };
+    unsafe_git_config(format!(
+        "{subject}; Kin cannot yet import a repository that carries submodules. Remove them with \
+         'git submodule deinit --all' and drop the matching .gitmodules entries, or run kin init \
+         inside the submodule's own repository"
+    ))
 }
 
 fn unsafe_git_config(reason: impl Into<String>) -> GitError {
@@ -3538,6 +3581,138 @@ mod tests {
         let error = remote_mapping_facts(&open_repo(&repo).expect("open include fixture"))
             .expect_err("local include must reject");
         assert!(error.to_string().contains("safe exact subset"));
+    }
+
+    /// A submodule is the one transfer-affecting section a user reaches without
+    /// ever configuring transport: `git submodule add` writes it for them. The
+    /// refusal is correct until submodule modeling lands, so the message is what
+    /// has to carry the user from the failure to an action.
+    #[test]
+    fn submodule_rejection_names_the_submodule_its_path_and_the_workaround() {
+        let (_temp, repo) = config_only_repository();
+        git(
+            &repo,
+            &[
+                "config",
+                "submodule.vendor/anyhow.url",
+                "https://example.invalid/anyhow.git",
+            ],
+        );
+        let error = remote_mapping_facts(&open_repo(&repo).expect("open submodule fixture"))
+            .expect_err("submodule config must reject");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("safe exact subset"),
+            "the refusal itself is unchanged: {message}"
+        );
+        assert!(
+            message.contains("submodule"),
+            "must name the cause the user can recognize: {message}"
+        );
+        assert!(
+            message.contains("vendor/anyhow"),
+            "must name which submodule: {message}"
+        );
+        assert!(
+            message.contains(".gitmodules"),
+            "must name the file the entry lives in: {message}"
+        );
+        assert!(
+            message.contains("git submodule deinit"),
+            "must state the workaround: {message}"
+        );
+    }
+
+    /// Every transfer-affecting section shares one message, so naming the cause
+    /// means naming the section that actually matched rather than guessing.
+    #[test]
+    fn transfer_affecting_sections_name_the_section_that_matched() {
+        for (key, value, expected) in [
+            ("http.postBuffer", "1048576", "http"),
+            ("credential.helper", "cache", "credential"),
+            ("lfs.url", "https://example.invalid/lfs", "lfs"),
+        ] {
+            let (temp, repo) = config_only_repository();
+            git(&repo, &["config", key, value]);
+            let error = remote_mapping_facts(&open_repo(&repo).expect("open section fixture"))
+                .expect_err("transfer-affecting section must reject");
+            let message = error.to_string();
+            assert!(message.contains("safe exact subset"), "{message}");
+            assert!(
+                message.contains(expected),
+                "must name the [{expected}] section: {message}"
+            );
+            drop(temp);
+        }
+    }
+
+    /// The falsification for naming things. A section name is one of a fixed set
+    /// of literals and is always safe to print; a subsection name is arbitrary
+    /// user bytes, and for `url`, `http`, and `credential` it IS a URL that can
+    /// carry `user:password@`. Naming the cause must never turn an error message
+    /// into a credential disclosure.
+    #[test]
+    fn naming_the_section_never_echoes_a_credential_bearing_subsection() {
+        let (temp, repo) = config_only_repository();
+        git(
+            &repo,
+            &[
+                "config",
+                "url.https://kin:hunter2@example.invalid/.insteadOf",
+                "https://example.invalid/",
+            ],
+        );
+        let error = remote_mapping_facts(&open_repo(&repo).expect("open rewrite fixture"))
+            .expect_err("URL rewrite must reject");
+        let message = error.to_string();
+        assert!(
+            message.contains("url"),
+            "must still name the section: {message}"
+        );
+        assert!(
+            !message.contains("hunter2"),
+            "credential leaked into the refusal: {message}"
+        );
+        drop(temp);
+
+        // A submodule's own URL lives in a key inside the section, never in the
+        // subsection name, so naming the path cannot disclose it.
+        let (_temp, repo) = config_only_repository();
+        git(
+            &repo,
+            &[
+                "config",
+                "submodule.vendor/dep.url",
+                "https://kin:hunter2@example.invalid/dep.git",
+            ],
+        );
+        let error = remote_mapping_facts(&open_repo(&repo).expect("open submodule url fixture"))
+            .expect_err("submodule config must reject");
+        let message = error.to_string();
+        assert!(message.contains("vendor/dep"), "{message}");
+        assert!(
+            !message.contains("hunter2"),
+            "credential leaked into the refusal: {message}"
+        );
+    }
+
+    /// A submodule path that is not valid UTF-8 has no spelling the message can
+    /// safely carry, so the section is still named and the path is simply
+    /// omitted. The refusal must not become an error about printing.
+    #[test]
+    fn a_non_utf8_submodule_path_still_refuses_and_still_names_the_section() {
+        let (_temp, repo) = config_only_repository();
+        let config = repo.join(".git/config");
+        let mut bytes = fs::read(&config).expect("read config");
+        bytes.extend_from_slice(b"[submodule \"vendor/\xff\"]\n\turl = https://example.invalid/\n");
+        fs::write(&config, bytes).expect("write config");
+
+        let error = remote_mapping_facts(&open_repo(&repo).expect("open non-utf8 fixture"))
+            .expect_err("submodule config must reject");
+        let message = error.to_string();
+        assert!(message.contains("safe exact subset"), "{message}");
+        assert!(message.contains("submodule"), "{message}");
     }
 
     #[test]


### PR DESCRIPTION
Both refusals are correct and neither changes here. Kin's ingest contract is lossless capture of
everything reachable, a shallow clone is genuinely un-capturable under it, and submodules are not
modeled yet (FIR-1549). Only the messages change, so that each one gets the reader from the failure
to an action.

Both were measured tonight by the edge-prove lane against published v0.5.5, binary `1c239a84`
(`.kin-coord/reports/edge-prove-20260806.md`, sections 8 and 9).

## Shallow clone

`actions/checkout` clones at depth 1 by default, so this is the first thing Kin says to anyone
trying it inside GitHub Actions. The message named the property that was violated and not the one
command that fixes it.

Before, then after:

```
shallow Git repositories cannot be imported losslessly
shallow Git repositories cannot be imported losslessly; run 'git fetch --unshallow' first (in CI, actions/checkout needs fetch-depth: 0)
```

## Submodule

Twelve config sections shared one sentence, `unsupported transfer-affecting section`, so the message
could not name a cause even in principle. The section that matched is now named, and the submodule
case is split out of that arm because it is the only one a user reaches without ever configuring
transport: `git submodule add` writes it for them.

Before, then after:

```
repository-local Git transport configuration is outside Kin's safe exact subset (unsupported transfer-affecting section)

repository-local Git transport configuration is outside Kin's safe exact subset (unsupported submodule section for 'vendor/anyhow'; Kin cannot yet import a repository that carries submodules. Remove them with 'git submodule deinit --all' and drop the matching .gitmodules entries, or run kin init inside the submodule's own repository)
```

The other eleven sections gain the section name alone, for example
`unsupported transfer-affecting section [http]`.

These are the error strings the new tests assert. The outer frames a user sees around them
(`Error: admit exact reachable Git repository authority` / `Caused by: capture exact Git repository:`
and `prove mutable Git workspace: Git migration preflight failed:`) are unchanged and are quoted from
edge-prove's measured v0.5.5 output rather than from a run of my own.

## Naming a cause without disclosing a secret

A section name is one of a fixed set of literals and is always safe to print. A subsection name is
not: for `url`, `http`, and `credential` the subsection **is** a URL and can carry `user:password@`.
It is therefore never echoed. A submodule is the exception that is provably safe, because its URL
lives in a key inside the section and never in the header, so the path can be named while the
credential cannot leak. A submodule path that is not valid UTF-8 is omitted rather than turning a
refusal about submodules into one about encoding.

`naming_the_section_never_echoes_a_credential_bearing_subsection` pins both halves, and the
falsification below includes a deliberate leak to prove that guard is not vacuous.

## Discrimination control for FIR-2040

The ticket was filed with its control still queued, and the control never ran: edge-prove's phase 2
is blocked on the gpu lock and their report still lists those rows as pending. Rather than wait or
guess, causation was settled from source, which is stronger than the black-box control would have
been because it gives the exact predicate.

`crates/kin-git/src/preflight.rs` matched `"submodule"` as a literal arm alongside eleven transport
sections, and `git submodule add` writes `[submodule "<path>"]` into `.git/config`. So the refusal
**is** submodule-caused and FIR-2040 stands as filed. `submodule_rejection_names_the_submodule_its_path_and_the_workaround`
is that control, now running in-process on every CI run instead of once by hand.

## Gates

Run in the lane worktree against this commit, `RUSTFLAGS=-D warnings` throughout.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | rc 0 |
| `cargo clippy --all-targets --all-features` under ci.yml's exact 45-lint allowlist | rc 0 |
| `cargo build --all-targets --locked` | rc 0 |
| `cargo test --workspace --no-fail-fast` | rc 0, 4987 passed, 0 failed, 11 ignored |

All five new tests were confirmed red on the parent commit first, each reproducing the exact string
edge-prove measured on v0.5.5.

## Falsification

Each change was reverted in turn against this commit, the tests re-run, and the tree restored. Every
edit was asserted to have actually changed the file, so a pattern that stopped matching could not
read as a fix that was not needed.

| Reverted | Reddens |
|---|---|
| shallow recovery hint | `the_shallow_refusal_names_its_recovery_command` |
| section naming, back to the shared literal | `transfer_affecting_sections_name_the_section_that_matched`, `naming_the_section_never_echoes_a_credential_bearing_subsection` |
| submodule arm, folded back into the generic one | `submodule_rejection_names_the_submodule_its_path_and_the_workaround`, `a_non_utf8_submodule_path_still_refuses_and_still_names_the_section`, `naming_the_section_never_echoes_a_credential_bearing_subsection` |
| not a revert: deliberately echoing the subsection name | `naming_the_section_never_echoes_a_credential_bearing_subsection` |

The last row is the one that matters most. A guard against leaking credentials is worthless if it
cannot fail, so a leak was introduced on purpose and the test caught it.

This is deliberately separate from #658 (FIR-2031 / FIR-2032) so a revert of one never drags the
other.

Refs FIR-1906 (fixes the init message, the first of the ticket's three defects; docs and the setup preflight surfaces stay open)
Closes FIR-2040