### PR TITLE
Let a recovered release publish, and stop one unreadable attempt vetoing a repeat

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -341,8 +341,17 @@ jobs:
           # they are kept apart so the alert can state which one it observed
           # instead of asserting the stronger claim on both.
           distinct="$(sort -u "$signatures" | wc -l | tr -d '[:space:]')"
+          # Readability is judged on the two signatures the stop rule actually
+          # compares, not on the whole run. A whole-run unknown count vetoed the
+          # repeat stop for every later attempt as well, so one unreadable early
+          # attempt spent the entire remaining budget on attempts whose
+          # signatures were readable and identical. A job cancelled mid-outage
+          # is the shape that reads as unreadable, because it records neither a
+          # failing step nor a failing job conclusion. An
+          # `unrecorded` latest can never establish a repeat on its own, and it
+          # cannot equal a readable previous, so testing it is enough.
           repeated=false
-          if [ "$ATTEMPTS" -ge 2 ] && [ "$unknown" -eq 0 ] &&
+          if [ "$ATTEMPTS" -ge 2 ] && [ "$latest" != unrecorded ] &&
              [ "$latest" = "$previous" ]; then
             repeated=true
           fi
@@ -420,10 +429,12 @@ jobs:
             printf 'unrecorded\n' > "$signatures"
           fi
           failing_steps="$(tail -1 "$signatures")"
-          if [ "${UNKNOWN:-1}" -ne 0 ]; then
-            verdict="indeterminate"
-            advice="At least one attempt could not be read or carried no concrete failed step, so neither a deterministic nor a transient cause is established. Inspect the unrecorded attempts before choosing a same-release rerun or a source-fixed recut."
-          elif [ "${REPEATED:-false}" = true ]; then
+          # An established repeat is the stronger reading and is tested first. An
+          # unreadable attempt elsewhere in the run does not weaken two readable
+          # adjacent attempts that failed identically, and reporting that state
+          # as indeterminate sent the operator to inspect the unrecorded attempt
+          # while the actual repeated failure went unnamed.
+          if [ "${REPEATED:-false}" = true ]; then
             verdict="repeated failure signature"
             # The stop rule is last-two equality, so a run that reached the end
             # of its budget is one whose earlier attempts differed: an identical
@@ -436,8 +447,11 @@ jobs:
             if [ "${DISTINCT:-0}" = 1 ]; then
               advice="Every observed attempt failed in the same job and step set, so another immediate rerun is unlikely to help. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
             else
-              advice="The two most recent attempts failed in the same job and step set, so another immediate rerun is unlikely to help. Earlier attempts failed differently, which is evidence in its own right that the cause is not purely deterministic, so read the whole per-attempt list below before choosing a remedy. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
+              advice="The two most recent attempts failed in the same job and step set, so another immediate rerun is unlikely to help. Earlier attempts failed differently or could not be read, which is evidence in its own right that the cause is not purely deterministic, so read the whole per-attempt list below before choosing a remedy. Step identity does not prove the root cause: inspect the logs, recut only after confirming a source-bound defect, and preserve this tag for a same-release rerun if the cause is external."
             fi
+          elif [ "${UNKNOWN:-1}" -ne 0 ]; then
+            verdict="indeterminate"
+            advice="At least one attempt could not be read or carried no concrete failed step, and no two adjacent readable attempts failed identically, so neither a deterministic nor a transient cause is established. Inspect the unrecorded attempts before choosing a same-release rerun or a source-fixed recut."
           else
             verdict="varying failure signatures"
             advice="The observed failing job and step sets differed, which is consistent with the transient shape this controller exists for. Diagnose and rerun the same release rather than cutting a newer version unless the logs identify a source-bound defect."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1376,8 +1376,27 @@ jobs:
               `${manifestPath} repository identity does not match this run`);
             fail(manifest.workflow?.run_id === process.env.GITHUB_RUN_ID,
               `${manifestPath} run ID does not match this run`);
-            fail(manifest.workflow?.run_attempt === process.env.GITHUB_RUN_ATTEMPT,
-              `${manifestPath} run attempt does not match this run`);
+            // Binding the artifact set to this run is what run_id proves, and it
+            // is the whole integrity claim available here: artifacts are scoped
+            // to a run, so a manifest carrying this run's id was produced by a
+            // job of this run. Requiring the ATTEMPT to match as well proved
+            // something else entirely, that no partial re-run had happened,
+            // which is a liveness condition rather than an integrity one.
+            // Re-running failed jobs re-executes only what failed: a build that
+            // already succeeded keeps the artifact and manifest it uploaded on
+            // its original attempt while this job runs under a later number, so
+            // attempt equality refused every release that reached publication
+            // through a recovery, and refused it harder on each further retry.
+            // A manifest must still name a real attempt of this run, so an
+            // artifact cannot claim one that has not happened yet.
+            const manifestAttempt = Number(manifest.workflow?.run_attempt);
+            const currentAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+            fail(
+              Number.isInteger(manifestAttempt) &&
+                Number.isInteger(currentAttempt) &&
+                manifestAttempt >= 1 &&
+                manifestAttempt <= currentAttempt,
+              `${manifestPath} run attempt ${manifest.workflow?.run_attempt} is not an attempt of this run (current attempt ${process.env.GITHUB_RUN_ATTEMPT})`);
 
             // Judge the archive's declared member paths before extracting it. A
             // member that escapes the extraction root has already been written


### PR DESCRIPTION
Publishing asserted that every per-artifact provenance manifest carried the same `run_attempt` as the publishing job. Re-running failed jobs re-executes only what failed, so builds that already succeeded keep the artifacts and manifests they uploaded on their original attempt while the aggregator runs under a later number. Every release that reached publication through a recovery was therefore refused, and refused further on each retry.

The integrity claim available at that point is `run_id`, which artifacts are scoped to, and it stays strict. Attempt equality asserted only that no partial re-run had happened, which is a liveness condition rather than an integrity one, and the manifest independently binds the kin commit, both `Cargo.lock` hashes, the pinned kin-vfs commit, the archive digest and size, every member digest, and the static build identity. The attempt is now required to be a real attempt of this run rather than the current one, so an artifact still cannot claim an attempt that has not happened, and the failure message names both values instead of only asserting a mismatch.

This is what left v0.5.6 unpublished. Its five platform builds succeeded on attempt 1 at 15:08Z and never re-ran, so their manifests still read `run_attempt: 1` while the outage forced the aggregator to attempt 3 at 23:26Z, where it failed with `kin-linux-x86_64.provenance.json run attempt does not match this run`. The same assertion also made the recovery controller structurally unable to recover any release, because `rerun-failed-jobs` is its only remedy and is the exact gesture the assertion refused.

Release Recovery separately judged signature readability across the whole run while its stop rule compares only the last two attempts, so one unreadable attempt vetoed the repeat stop for every later one and drove the reported verdict to `indeterminate` over an established repeat. A job cancelled mid-outage reads as unreadable, recording neither a failing step nor a failing job conclusion, which is the normal shape when this controller runs. Readability is now judged on the two signatures the rule actually compares, and an established repeat is reported ahead of an unknown count.

## Verification

The attempt assertion was exercised against the real v0.5.6 values, old rule versus new, with controls in both directions. The old rule refuses the recovered release and the new rule admits it; a clean first-attempt release and a partial recovery pass under both; and a manifest naming a future attempt, carrying no attempt, carrying a non-numeric attempt, or carrying zero is refused under both.

The classifier was exercised the same way against captured signature sets. The targeted shape, an unreadable attempt followed by two identical readable ones, moves from `repeated=false` / `indeterminate` to `repeated=true` / `repeated failure signature`. Five controls are unchanged, including the v0.5.6 and v0.4.6 real shapes, the ordinary two-attempt repeat stop, two differing attempts that must keep retrying, and an unreadable latest that must never establish a repeat.

`actionlint`, which runs shellcheck over every `run:` step, is clean on both files and byte-identical to its output on the unmodified versions. All four embedded Node blocks in `release.yml` pass `node --check` after extraction, verified against a deliberately poisoned copy so the check is known to fail when it should.

No behaviour changes for a release that publishes on its first attempt.

Closes FIR-1571
Closes FIR-2048
Refs FIR-1981
Refs FIR-1839
