### PR TITLE
Refuse assistant-session traces in the pull request title and body

### DIFF
--- a/.github/workflows/pr-text-hygiene.yml
+++ b/.github/workflows/pr-text-hygiene.yml
@@ -20,6 +20,13 @@ name: PR Text Hygiene
 # to the shared workflow once a kin-actions release carries that input.
 on:
   pull_request:
+    # `edited` is the one that cannot be left out. The default trigger set is
+    # opened/synchronize/reopened, none of which fires when someone changes the
+    # title or body of an open pull request -- which is the text the queue
+    # mints, and the one edit that needs no push. Without `edited` the gate
+    # would inspect the text a pull request opened with and then let any later
+    # rewrite of it through unread.
+    types: [opened, reopened, synchronize, edited]
   # A required context must also report on the queue's speculative merge
   # commits, or the queue waits forever for a check that never runs.
   merge_group:

--- a/.github/workflows/pr-text-hygiene.yml
+++ b/.github/workflows/pr-text-hygiene.yml
@@ -1,0 +1,102 @@
+name: PR Text Hygiene
+
+# Refuses assistant-session traces in the pull request title and body.
+#
+# On a merge-queue repository GitHub mints the squash commit message verbatim
+# from the pull request title and body. That happens server-side, after every
+# local Git hook has already run, with nobody at the merge button, so a trace
+# placed in the body is authored directly into public history and no
+# commit-message hook can see it. A check on the pull request is the only
+# surface that can refuse it, and it must run on `pull_request` because the
+# queue snapshots the title and body when the entry is submitted.
+#
+# Internal tracker references (FIR-1234, linear.app links) are sanctioned in a
+# commit message and deliberately pass.
+#
+# This check is intentionally self-contained. The shared implementation lives in
+# firelock-ai/kin-actions (`public-history-hygiene.yml`, `scan-history: false`),
+# but every released kin-actions tag predates body scanning, so consuming it by
+# pin would install a check that reads green while inspecting nothing. Migrate
+# to the shared workflow once a kin-actions release carries that input.
+on:
+  pull_request:
+  # A required context must also report on the queue's speculative merge
+  # commits, or the queue waits forever for a check that never runs.
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  pr_text:
+    name: PR text hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan the pull request title and body
+        env:
+          # Read from the event payload and passed as quoted argv. Never
+          # interpolated into the shell, and never read from a checkout of the
+          # pull request's own code.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          python3 - "$EVENT_NAME" "$PR_TITLE" "$PR_BODY" <<'PY'
+          import re
+          import sys
+
+          # Assistant-session traces and attribution markers. Tracker references
+          # are absent on purpose: they are sanctioned in a commit message.
+          PATTERNS = [
+              ("assistant session trailer",
+               r"(?i)\b(?:Claude|Codex|OpenAI|ChatGPT|Gemini|Copilot|Cursor)-Session\s*:"),
+              ("assistant session URL",
+               r"(?i)https?://(?:claude\.ai|chat\.openai\.com|chatgpt\.com)/\S+"),
+              ("assistant session id", r"\bsession_[A-Za-z0-9]{16,}\b"),
+              ("assistant co-author trailer",
+               r"(?i)Co-Authored-By\s*:.*\b(?:Claude|Codex|ChatGPT|Copilot|Gemini|Cursor)\b"),
+              ("assistant generation notice",
+               r"(?i)Generated\s+with\b.*\b(?:Claude|Codex|ChatGPT|Copilot|Gemini|Cursor)\b"),
+              ("assistant vendor no-reply address",
+               r"(?i)\bnoreply@(?:anthropic|openai)\.com\b"),
+          ]
+          COMPILED = [(label, re.compile(pat)) for label, pat in PATTERNS]
+
+          event, title, body = sys.argv[1], sys.argv[2], sys.argv[3]
+
+          violations = []
+          for surface, text in (("PR title", title), ("PR body", body)):
+              for label, pat in COMPILED:
+                  if pat.search(text):
+                      violations.append(f"{surface} contains {label}")
+
+          # Report what was actually inspected. An input that never arrived and
+          # an input that scanned clean both produce zero violations, and a gate
+          # that prints the same thing for both cannot be audited.
+          def coverage(name, text):
+              return (f"  {name:<6}: {len(text)} chars scanned"
+                      if text else f"  {name:<6}: <none supplied, not scanned>")
+
+          print("Pull request text hygiene")
+          print(f"  event : {event}")
+          print(coverage("title", title))
+          print(coverage("body", body))
+          print("  tracker refs: FIR-... and linear.app links are sanctioned here")
+          if event != "pull_request":
+              print("  note  : no pull request payload on this event; the title and "
+                    "body were gated on the pull_request run that fed this queue entry")
+
+          if not violations:
+              print("OK: no assistant-session traces in the pull request text.")
+              raise SystemExit(0)
+
+          print(f"FAIL: {len(violations)} violation(s):")
+          for detail in violations:
+              print(f"    - {detail}")
+          print("")
+          print("The merge queue mints the squash commit message from this text, so "
+                "these bytes would become public history verbatim.")
+          print("Edit the pull request title/body to remove them, then re-run.")
+          raise SystemExit(1)
+          PY

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -495,6 +495,9 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/notify-approver.yml": {
         "notify": None,
     },
+    ".github/workflows/pr-text-hygiene.yml": {
+        "pr_text": "PR text hygiene",
+    },
     ".github/workflows/publish-release-installers.yml": {
         "dispatch": None,
     },


### PR DESCRIPTION
This repository merges through a hosted queue, which mints the squash commit
message verbatim from the pull request title and body. The mint happens
server-side after every local Git hook has already run, so a trace placed in
the body reaches public history with nobody at the merge button and no
commit-message hook able to see it. Commits on this default branch were
authored that way, and the vector is still open.

## Change

Adds a `PR text hygiene` check that reads the title and body from the event
payload and refuses assistant-session traces and attribution markers in them.

- Runs on `pull_request`, which is where the queue snapshots the text it will
  later mint, so a violation reports while it can still be edited.
- Includes the `edited` trigger. The default set is opened, synchronize, and
  reopened, none of which fires when someone rewrites the title or body of an
  open pull request, and that edit needs no push. Without it the gate would
  read the text a pull request opened with and let any later rewrite through
  unread.
- Also runs on `merge_group`, so the context still reports once it is added to
  the required set; a required context that never reports on the queue's
  speculative merge commits would hang the queue.
- The title and body are passed as quoted argv, never interpolated into the
  shell, and never read from a checkout of the pull request's own code.
- Internal tracker references are sanctioned in a commit message and pass.
- Reports what it actually inspected, so an input that never arrived cannot
  read the same as an input that scanned clean.

## Why this check is self-contained

The shared implementation lives in kin-actions. It is not consumed by pin here
because every released kin-actions tag predates body scanning: the newest tag
is from 2026-07-30 and the published Latest release is older still, while body
scanning landed 2026-08-05 and is contained in no tag. Consuming it today would
install a check that reads green while inspecting nothing, which is the exact
failure this change exists to end. Migrate to the shared workflow once a
release carries the `scan-history` input.

## Falsification

Eleven synthetic payloads run through the script extracted from this workflow
file, so the heredoc, the YAML dedent, and the argv quoting are proven as
shipped rather than in a paraphrase. Every planted pattern reds, every clean or
sanctioned body greens, and a payload of shell metacharacters produced no
side effects, confirming the text never reaches the shell.

## Still open

This check is not yet a required status context, so it reports without
blocking. Adding `PR text hygiene` to the branch ruleset is a repository
settings change and is what converts it from a warning into a gate.

Closes FIR-2049
