### PR TITLE
Record v0.5.6 as abandoned so the release rail stops holding on it

### DIFF
--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -42,6 +42,13 @@
       "reason": "The public install proof frozen at this tag fails on three of its five legs, and the tag can receive none of the repairs. The macos-15-intel and ubuntu-24.04-arm legs fail the installed-capability proof: the tagged binary reports embedding coverage as unobserved with reason graph_mutation_in_flight, so the proof reads a transient window in which the graph is still being mutated as a failure to prove complete coverage rather than waiting for it to settle. The failure is a race and not a fixed property of the platform, which is why the same two legs pass on some attempts and a third Unix leg failed on the first attempt. The windows-latest leg fails separately at the graph and MCP tool-call proof, where the daemon port file the step reads never appears. Both the proof workflow and the binary resolve from the tag, and the repairs landed on main only after it, so no later change to main can reach the failing steps. All three attempts of the cited run failed and automatic release recovery exhausted its bounded retries. The only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, so the tag never became the finalized Latest release and nothing downstream of the proof ever ran.",
       "superseded_by": "v0.5.0",
       "failed_release_run_id": "30947137583"
+    },
+    {
+      "tag": "v0.5.6",
+      "sha": "e01955f4b8f0174536885ccffaa0fbbfaffd96e7",
+      "reason": "The provenance aggregator frozen at this tag requires every per-artifact manifest to carry the same run_attempt as the publishing job. The five platform builds succeeded on the first attempt and were never re-run, so their manifests record attempt 1, while a runner outage failed the daemon-image job on that same attempt and pushed the aggregator to attempt 3, where Publish Release is refused with 'kin-linux-x86_64.provenance.json run attempt does not match this run'. Automatic release recovery cannot remedy this and made it worse on each pass, because rerunning failed jobs is its only remedy and every retry moves the publishing attempt further from the attempt the manifests record. The repair for FIR-1571 landed on main only after the tag, and the release workflow resolves from the tag, so no later change to main can reach the failing step. All three attempts of the cited run failed, no GitHub Release object was ever created for this tag, and no channel published it.",
+      "superseded_by": "v0.5.7",
+      "failed_release_run_id": "31114407438"
     }
   ]
 }


### PR DESCRIPTION
The aggregator frozen at `v0.5.6` requires every per-artifact provenance manifest to carry the publishing job's `run_attempt`. Its five platform builds succeeded on attempt 1 and never re-ran, a runner outage failed the daemon-image job on that same attempt, and the aggregator therefore reached attempt 3 and refused publication with `kin-linux-x86_64.provenance.json run attempt does not match this run`. Rerunning failed jobs is automatic recovery's only remedy and moves the publishing attempt further from the one the manifests record, so the rail cannot retry its way out. The release workflow resolves from the tag, so the repair cannot reach this run no matter what lands on `main`.

Nothing was published under the tag. `repos/firelock-ai/kin/releases/tags/v0.5.6` returns 404, no release object exists, and no channel moved, so retiring it costs nothing downstream and `releases/latest` stays `v0.5.5` untouched.

This entry is the reviewed record the release rail already reads through `select-admissible-release-tag.py`. It is the designed way to stand the Release Recovery alarm down from a tag it cannot fix: that controller is currently firing roughly every fifteen minutes against `v0.5.6`, and its alert step ends in a deliberate `exit 1`, so the alarm repeats until the tag either succeeds, is superseded, or is recorded here. Recording it also lets the mint select `v0.5.7`.

## Sequencing

Land this **after or together with #661**. #661 repairs the assertion for every future release; this entry retires the one tag that can no longer benefit from it. The post-wave release-reconcile dispatch then produces `v0.5.7`, whose commit contains #661 and is therefore immune to the trap.

The two changes touch disjoint files and do not conflict.

## Verification

The recorded sha was read back from the live tag (`repos/firelock-ai/kin/git/ref/tags/v0.5.6` resolves to `e01955f4b8f0174536885ccffaa0fbbfaffd96e7`) rather than copied from a report, and the entry's field names, field order, and run-id-as-string match the existing `v0.4.x` entries exactly.

`scripts/test-release-workflow-authority.py`, which `ci.yml` runs and which exercises every shipped entry through the selector, passes with the new entry.

The runtime behaviour was then checked two-sided by calling the selector the way `release-recovery.yml` calls it, with the candidate listing carrying the tag's real commit:

- tracked record: `skipping abandoned release tag v0.5.6`, empty ranking, so recovery stands down.
- same record with one hex digit changed in the sha: `abandonment of v0.5.6 waives ...96e0 but the tag now names ...96e7; correct the reviewed record before releasing`, rc=1, so recovery stays armed.

Worth recording from that second case: the authority suite passes a record whose sha does not match its tag, because it builds its candidate listing out of the record itself and so never confronts the record with the real commit. The mismatch is caught loudly at runtime by the selector instead, which refuses the release rail rather than silently waiving nothing, so this is a CI blind spot rather than a runtime hole. It is filed separately and is not a defect in this entry.

Refs FIR-1571
Refs FIR-1839
