### PR TITLE
Announce the background embedding pass, and let an operator decline it

### DIFF
--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -205,6 +205,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_DAEMON_REQUIRE_TOKEN", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "require a bearer token for all daemon requests; set falsy to opt out" },
     EnvVarSpec { name: "KIN_DAEMON_WATCH_PID", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "pid the daemon watches; it exits when that process dies" },
     EnvVarSpec { name: "KIN_DAEMON_EMBED_BATCH_SIZE", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "embedding batch size for daemon-side embed passes" },
+    EnvVarSpec { name: "KIN_DAEMON_AUTO_EMBED", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "let the daemon start background embedding on its own; set falsy to defer until an explicit embed request" },
     EnvVarSpec { name: "KIN_DAEMON_BOOTSTRAP_EXPORT_CONCURRENCY", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "concurrency for the daemon bootstrap export" },
     EnvVarSpec { name: "KIN_DAEMON_IDLE_TIMEOUT_SECS", kind: Kind::Secs, default: "3600", sensitivity: Sensitivity::Operational, summary: "auto-shutdown after this idle period; 0 disables idle shutdown" },
     EnvVarSpec { name: "KIN_DAEMON_READY_TIMEOUT_SECS", kind: Kind::Secs, default: "300", sensitivity: Sensitivity::Operational, summary: "how long to wait for a starting daemon to become ready" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -451,6 +451,14 @@ pub struct HealthResponse {
     /// merely whether the opt-in environment variable was present.
     #[serde(default)]
     pub filesystem_reconcile_disabled: bool,
+    /// Whether an operator turned the automatic background embedding pass off
+    /// (`KIN_DAEMON_AUTO_EMBED` falsy). Distinct from
+    /// `embed_persistence_unavailable`, which is the daemon refusing because it
+    /// cannot durably persist a sidecar. Deferred, not disabled: an explicit
+    /// embed request still runs. Does not drive `status: "attention"`, because
+    /// it is a chosen configuration rather than a fault.
+    #[serde(default)]
+    pub background_embed_deferred: bool,
     /// Monotonic authority-head marker (`.kin/kindb/head-generation`), bumped
     /// when the daemon commits a newer graph snapshot. A freshness token that
     /// lets clients and the MCP envelope express `graph_as_of` and detect stale
@@ -2119,6 +2127,7 @@ async fn health(
         embed_worker_failed,
         embed_persistence_unavailable,
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
+        background_embed_deferred: !crate::daemon::auto_embed_enabled(),
         graph_generation: DaemonState::read_generation_marker(&state.layout),
         behavior_env: kin_core::behavior_env::snapshot_from_process(),
         coordination: Some(
@@ -24352,6 +24361,48 @@ mod tests {
         let json: HealthResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(json.status, "attention");
         assert!(json.embed_worker_failed);
+    }
+
+    #[tokio::test]
+    async fn health_surfaces_a_deferred_background_embed_without_calling_it_a_fault() {
+        // An operator who turned auto-embed off must be able to read that back
+        // off the daemon rather than infer it from a pass that never ran. It is
+        // a chosen configuration, so unlike the embed faults beside it, it does
+        // not move `status` off "ok".
+        async fn deferred_flag(state: Arc<DaemonState>) -> HealthResponse {
+            let response = router(state)
+                .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            serde_json::from_slice(&body).unwrap()
+        }
+
+        let default = {
+            let _env = kin_core::test_env::EnvVarGuard::unset(crate::daemon::AUTO_EMBED_ENV);
+            deferred_flag(test_state()).await
+        };
+        assert!(
+            !default.background_embed_deferred,
+            "the shipped default embeds in the background and must not report deferred"
+        );
+        assert_eq!(default.status, "ok");
+
+        let opted_out = {
+            let _env = kin_core::test_env::EnvVarGuard::set(crate::daemon::AUTO_EMBED_ENV, "0");
+            deferred_flag(test_state()).await
+        };
+        assert!(
+            opted_out.background_embed_deferred,
+            "an opt-out must be readable off /health"
+        );
+        assert_eq!(
+            opted_out.status, "ok",
+            "a chosen configuration is not a fault and must not raise attention"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -410,6 +410,68 @@ fn should_flush_now(
     since_save >= periodic_flush || since_mutation >= idle_flush
 }
 
+/// Operator opt-out for the background embedding pass the daemon starts on its
+/// own after the first reconciliation cycle.
+pub(crate) const AUTO_EMBED_ENV: &str = "KIN_DAEMON_AUTO_EMBED";
+
+/// Whether the daemon may queue and drain the embedding backlog without being
+/// asked. Default ON: unset, or any value other than the documented falsy set,
+/// keeps today's behavior exactly. A falsy value defers the pass until an
+/// explicit embed request, which is the opt-out for an operator who does not
+/// want a bulk accelerator pass starting because a store was opened.
+///
+/// The falsy set matches `KIN_DAEMON_REQUIRE_TOKEN`, the sibling boolean knob,
+/// so one spelling works across the daemon's env surface.
+pub(crate) fn auto_embed_enabled() -> bool {
+    std::env::var(AUTO_EMBED_ENV)
+        .map(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off"
+            )
+        })
+        .unwrap_or(true)
+}
+
+/// Build the background embedding backlog and announce it, or defer the whole
+/// pass because an operator opted out. Returns whether the backlog was queued.
+///
+/// Announcing matters because nothing the user ran asks for this work. Opening
+/// a store whose index has not caught up is enough to start it, so the pass is
+/// a property of the store's state rather than of the command issued, and on an
+/// accelerator it is a bulk run writing a sidecar nobody requested. A worker
+/// that starts silently leaves an operator inferring it from machine load.
+///
+/// Deferring pauses rather than disables. The queue is left unbuilt and the
+/// worker stood down, so an explicit embed request still runs the pass on
+/// demand (`/embed` resumes the worker). Pausing is also what keeps a deferred
+/// daemon eligible for idle shutdown: a backlog no worker will drain must not
+/// read as work in flight.
+fn start_or_defer_background_embed(state: &DaemonState) -> bool {
+    if !auto_embed_enabled() {
+        state.pause_background_embed();
+        warn!(
+            trigger = AUTO_EMBED_ENV,
+            "background embedding deferred by operator opt-out: no vectors will be generated, and semantic coverage stays as it is until an explicit embed request runs"
+        );
+        return false;
+    }
+    // Re-queue every object the persisted index still lacks a vector for, so the
+    // worker resumes after a restart drained the in-memory queue (the queue is
+    // not persisted; coverage is, via graph-vs-index truth). Idempotent (HashSet
+    // queues) — a fresh start that already enqueued via reconcile is unaffected.
+    #[cfg(feature = "embeddings")]
+    state.graph.queue_missing_for_embedding();
+    state.graph.queue_missing_artifacts_for_embedding();
+    info!(
+        queued_entities = state.graph.pending_embeddings(),
+        queued_artifacts = state.graph.pending_artifact_embeddings(),
+        opt_out = AUTO_EMBED_ENV,
+        "background embedding started: generating vectors for everything the index is missing"
+    );
+    true
+}
+
 /// Grace period the escalation watchdog waits after shutdown is signalled before
 /// force-exiting. Configurable via `KIN_DAEMON_SHUTDOWN_GRACE_SECS` (0 escalates
 /// immediately once the signal fires — used by tests).
@@ -1508,14 +1570,7 @@ pub async fn run_with_authority(
             }
         }
         info!("embedding worker started");
-        // Re-queue every object the persisted index still lacks a vector
-        // for, so the worker resumes after a restart drained the in-memory queue
-        // (the queue is not persisted; coverage is, via graph-vs-index truth).
-        // Idempotent (HashSet queues) — a fresh start that already enqueued via
-        // reconcile is unaffected.
-        #[cfg(feature = "embeddings")]
-        embed_state.graph.queue_missing_for_embedding();
-        embed_state.graph.queue_missing_artifacts_for_embedding();
+        start_or_defer_background_embed(&embed_state);
         let mut consecutive_panics: u32 = 0;
         const MAX_CONSECUTIVE_PANICS: u32 = 3;
         // Recovery + backoff state for vector-index errors (e.g. a stale on-disk
@@ -2836,6 +2891,75 @@ mod tests {
         assert!(
             super::ready_for_idle_shutdown(&state, expired, ControlPlane::EndpointLost),
             "an unreachable daemon with no work left must still idle out"
+        );
+    }
+
+    // ── Background auto-embed: announced, and opt-out-able ────────────────
+    //
+    // The pass starts because a store was opened, not because anyone asked for
+    // it, so it needs both a line that says it started and a way to say no.
+    // The default is unchanged: auto-embed stays on.
+
+    /// Read `auto_embed_enabled` with `KIN_DAEMON_AUTO_EMBED` held at `value`
+    /// (`None` removes it) for the duration of the read. The guard restores what
+    /// the process had and serializes against every other env-mutating test.
+    fn auto_embed_enabled_with(value: Option<&str>) -> bool {
+        let _env = match value {
+            Some(value) => kin_core::test_env::EnvVarGuard::set(super::AUTO_EMBED_ENV, value),
+            None => kin_core::test_env::EnvVarGuard::unset(super::AUTO_EMBED_ENV),
+        };
+        super::auto_embed_enabled()
+    }
+
+    #[test]
+    fn auto_embed_is_on_unless_an_operator_spells_out_otherwise() {
+        // Absent is the shipped default and stays on.
+        assert!(auto_embed_enabled_with(None));
+        assert!(auto_embed_enabled_with(Some("1")));
+        assert!(auto_embed_enabled_with(Some("true")));
+        // The falsy set matches KIN_DAEMON_REQUIRE_TOKEN, whitespace and case
+        // included, so one spelling works across the daemon's env surface.
+        assert!(!auto_embed_enabled_with(Some("0")));
+        assert!(!auto_embed_enabled_with(Some("false")));
+        assert!(!auto_embed_enabled_with(Some("no")));
+        assert!(!auto_embed_enabled_with(Some("off")));
+        assert!(!auto_embed_enabled_with(Some("  OFF  ")));
+        // An unparseable value is not silently read as an opt-out: the default
+        // is on, and a typo must not disable embedding behind the operator.
+        assert!(auto_embed_enabled_with(Some("maybe")));
+        assert!(auto_embed_enabled_with(Some("")));
+    }
+
+    #[tokio::test]
+    async fn background_embed_queues_by_default_and_defers_on_opt_out() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = DaemonState::open(initialized.layout).unwrap();
+
+        {
+            let _env = kin_core::test_env::EnvVarGuard::unset(super::AUTO_EMBED_ENV);
+            assert!(
+                super::start_or_defer_background_embed(&state),
+                "the default must still build the backlog and start the pass"
+            );
+        }
+        assert!(
+            !state.background_embed_paused(),
+            "the default must leave the worker running"
+        );
+
+        state.resume_background_embed();
+        {
+            let _env = kin_core::test_env::EnvVarGuard::set(super::AUTO_EMBED_ENV, "0");
+            assert!(
+                !super::start_or_defer_background_embed(&state),
+                "an opt-out must defer the pass rather than queue it"
+            );
+        }
+        assert!(
+            state.background_embed_paused(),
+            "a deferred pass must stand the worker down, so a daemon holding no \
+             drainable backlog can still idle out"
         );
     }
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (421 total, 310 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (422 total, 310 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -90,6 +90,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | Variable | Kind | Default | Sensitivity | Description |
 | --- | --- | --- | --- | --- |
 | `KIN_DAEMON_AUTH_TOKEN` | secret | *(unset)* | secret | bearer token for authenticated daemon requests |
+| `KIN_DAEMON_AUTO_EMBED` | bool | true | operational | let the daemon start background embedding on its own; set falsy to defer until an explicit embed request |
 | `KIN_DAEMON_BIN` | path | *(unset)* | operational | override path to the kin-daemon binary |
 | `KIN_DAEMON_BIND_HOST` | string | *(unset)* | operational | host/interface the daemon binds its HTTP endpoint to |
 | `KIN_DAEMON_BOOTSTRAP_EXPORT_CONCURRENCY` | usize | *(unset)* | operational | concurrency for the daemon bootstrap export |


### PR DESCRIPTION
Once the first reconciliation cycle completes, the daemon queues every entity
and artifact the index is missing and drains that backlog continuously. Nothing
the user ran asks for it. Opening a store the index has not caught up with is
enough to start it, so the pass is a property of the store's state rather than
of the command issued, and on a machine with an accelerator it is a bulk run
writing a vector sidecar nobody requested.

The only existing opt-out is a storage-backend graph, and that one opts out
because it cannot durably persist a sidecar, not because anyone chose.

Two gaps, both closed here, and the default is unchanged: auto-embed stays on.

## It announces itself

`embedding worker started` was logged before anything was queued and carried no
count, so neither the log nor any status surface said that a bulk pass had just
begun or how much work it represented. The worker now logs the pass with the
entity and artifact counts it queued, and names the variable that turns it off.

`/health` gains `background_embed_deferred`, so an operator who declined can
read that back off the daemon instead of inferring it from a pass that never
ran. It is deliberately kept out of the `status: "attention"` set beside it: a
chosen configuration is not a fault, unlike `embed_worker_failed` and
`embed_persistence_unavailable`, which both mean something that should work does
not.

## It can be declined

`KIN_DAEMON_AUTO_EMBED` is registered in the env registry beside its siblings.
Unset, or any value outside the falsy set, keeps today's behavior exactly. A
falsy value (`0`/`false`/`no`/`off`, matching `KIN_DAEMON_REQUIRE_TOKEN` so one
spelling works across the daemon's env surface) defers the pass, with a warning
saying it deferred and what that costs.

Deferred, not disabled. The queue is left unbuilt and the worker stood down
through the existing pause latch, so an explicit embed request still runs the
pass on demand: `/embed` resumes the worker on the unbounded path it already
takes today. Pausing rather than inventing a third state is also what keeps a
deferred daemon eligible for idle shutdown, since a backlog no worker will drain
must not read as work in flight.

A typo is not read as an opt-out. Only the documented falsy spellings defer, so
a mistyped value leaves embedding on rather than silently turning it off behind
the operator.

## Tests

Three tests, each asserting both directions, and each falsified by mutation
rather than assumed.

- `auto_embed_is_on_unless_an_operator_spells_out_otherwise`: absent, `1`, and
  `true` are on; the four falsy spellings, with surrounding whitespace and mixed
  case, are off; an unparseable value and an empty value stay on.
- `background_embed_queues_by_default_and_defers_on_opt_out`: the default builds
  the backlog and leaves the worker running, and the opt-out defers and stands
  the worker down.
- `health_surfaces_a_deferred_background_embed_without_calling_it_a_fault`: the
  flag is false by default and true under the opt-out, and `status` stays `ok`
  in both.

Forcing `auto_embed_enabled` to true fails the first two and nothing else.
Dropping the `pause_background_embed` call from the defer path fails only the
second, at the stand-down assertion. Hardcoding the `/health` field fails only
the third.

## Verification

- `kin-dev local-check kin`: green, no tracked lock contamination.
- `kin-dev local-test kin`: green.
- `cargo fmt --all --check`: clean.
- `cargo clippy --all-targets --all-features` under the ci.yml allowlist with
  `RUSTFLAGS=-Dwarnings`: clean.
- `docs/env-vars.md` regenerated from the registry, so the doc-drift test passes.

Closes FIR-2045
Refs FIR-2044, FIR-1945
