### PR TITLE
Keep the vector index across upgrades, and say so when one is discarded

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1656,21 +1656,41 @@ fn semantic_query_health_from_runtime(
     }
 
     if total == 0 || (indexed == total && pending == 0) {
-        HealthCheck::new(
+        // Coverage is whole. A discard earlier in this daemon's life has been
+        // paid off and leaves nothing to act on, and a check that stays yellow
+        // after its cause is gone is a check nobody reads.
+        return HealthCheck::new(
             "semantic_query_readiness",
             "Semantic query readiness",
             HealthStatus::Healthy,
             detail,
-        )
-    } else {
-        HealthCheck::new(
+        );
+    }
+
+    // Incomplete coverage reads identically whether this is a first run or a
+    // repository whose finished index was thrown away at open. Only one of them
+    // means work already paid for is being paid for again, so when the daemon
+    // knows which it is, say so instead of leaving it to be inferred.
+    let Some(reason) = &runtime.vector_index_discarded else {
+        return HealthCheck::new(
             "semantic_query_readiness",
             "Semantic query readiness",
             HealthStatus::Stale,
             detail,
         )
-        .with_manual_fix("allow daemon embedding to finish or run `kin embed`")
-    }
+        .with_manual_fix("allow daemon embedding to finish or run `kin embed`");
+    };
+
+    HealthCheck::new(
+        "semantic_query_readiness",
+        "Semantic query readiness",
+        HealthStatus::Stale,
+        format!("{detail}; {reason}, so it is being rebuilt from scratch"),
+    )
+    .with_manual_fix(
+        "allow daemon embedding to finish or run `kin embed`; the rebuild is not lost work \
+         repeating itself once it completes",
+    )
 }
 
 #[cfg(feature = "vector")]
@@ -2519,6 +2539,50 @@ mod tests {
         assert!(matches!(missing.status, HealthStatus::Missing));
         assert!(missing.detail.contains("embedding worker failed"));
         assert!(missing.manual_fix.is_some());
+    }
+
+    /// A repository whose finished index was thrown away at open looks exactly
+    /// like a first run if only the coverage counters are reported: partial
+    /// coverage, work in progress, nothing wrong. Naming the discard is the
+    /// difference between "Kin is indexing" and "Kin is indexing this again".
+    #[cfg(feature = "vector")]
+    #[test]
+    fn semantic_query_readiness_names_a_discarded_vector_index() {
+        let discarded = crate::commands::resources::EmbedRuntimeState {
+            embeddings_indexed: 0,
+            embeddings_total: 41,
+            embeddings_pending: 41,
+            vector_index_discarded: Some(
+                "the persisted vector index at .kin/kindb/graph.kvec could not be read".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let semantic = semantic_query_health_from_runtime("http://daemon", &discarded);
+
+        assert!(matches!(semantic.status, HealthStatus::Stale));
+        assert!(
+            semantic.detail.contains("graph.kvec")
+                && semantic.detail.contains("rebuilt from scratch"),
+            "a discarded index must be named, not left to be inferred from coverage: {}",
+            semantic.detail
+        );
+        assert!(semantic.manual_fix.is_some());
+
+        // Once the rebuild lands there is nothing left to act on, and a check
+        // that stays yellow after its cause is gone is a check nobody reads.
+        let rebuilt = crate::commands::resources::EmbedRuntimeState {
+            embeddings_indexed: 41,
+            embeddings_pending: 0,
+            ..discarded
+        };
+        let settled = semantic_query_health_from_runtime("http://daemon", &rebuilt);
+        assert!(
+            matches!(settled.status, HealthStatus::Healthy),
+            "a paid-off discard must not hold the check yellow forever: {:?}",
+            settled.status
+        );
+        assert!(!settled.detail.contains("graph.kvec"));
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -29,6 +29,12 @@ pub struct EmbedRuntimeState {
     pub hybrid_metrics: HybridMetricsRuntime,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metal_profile: Option<MetalProfileRuntime>,
+    /// Why the daemon did not install the vector index it found on disk when it
+    /// opened, when it found one and did not. Without it, a repository that had
+    /// full coverage yesterday reports partial coverage today with nothing to
+    /// distinguish that from a first run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector_index_discarded: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -3063,12 +3063,14 @@ fn terminate_spawned_process(
     }
 }
 
-/// The build identity this test binary carries, in the exact form the daemon
-/// stamps persisted vector sidecars with.
+/// The build identity this test binary carries, joined the way
+/// `kin_buildinfo::sha_with_dirty` joins it.
 ///
-/// A test that seeds prepared state writes this stamp; the daemon that later
-/// reopens the repository demands its own. The two only agree when both
-/// binaries came out of one build of `kin-buildinfo`.
+/// This is a harness-local identity for pairing a test binary with a daemon
+/// built beside it. It is deliberately NOT what the daemon stamps persisted
+/// vector sidecars with: keying index reuse on a build SHA is what made every
+/// Kin upgrade discard the user's whole index, and the sidecar now carries the
+/// embedding runtime's own identity instead.
 pub fn expected_build_stamp() -> String {
     kin_buildinfo::sha_with_dirty(kin_buildinfo::get())
 }
@@ -3077,10 +3079,9 @@ pub fn expected_build_stamp() -> String {
 /// `kin_buildinfo::sha_with_dirty` would produce for the same build.
 ///
 /// The daemon reports the two fields separately, so the harness has to join
-/// them the way the authority does rather than comparing the pair directly:
-/// when the commit is unknown the dirty flag is not part of the identity, and
-/// a raw pair comparison would reject a daemon whose embedder identity
-/// actually matches.
+/// them the same way rather than comparing the pair directly: when the commit
+/// is unknown the dirty flag is not part of the identity, and a raw pair
+/// comparison would reject a daemon that actually matches.
 fn build_stamp(sha: &str, dirty: bool) -> String {
     if dirty && sha != "unknown" {
         format!("{sha}-dirty")
@@ -3092,14 +3093,19 @@ fn build_stamp(sha: &str, dirty: bool) -> String {
 /// Why a candidate `kin-daemon` may not be reused by this test binary, or
 /// `None` when it may be.
 ///
-/// Two independent reasons, and the second is the one that used to be missed.
-/// A daemon whose graph snapshot version differs cannot read the repository at
-/// all. A daemon that is merely built from a *different commit or working
-/// tree* reads it fine, but stamps and demands a different embedder identity —
-/// so a sidecar seeded by this test binary is rejected on load,
-/// `indexed_embedding_count` reads 0, and the suite reports a product defect
-/// that only exists because two binaries in one target directory were built at
-/// different times.
+/// Two independent reasons. A daemon whose graph snapshot version differs
+/// cannot read the repository at all. A daemon built from a *different commit
+/// or working tree* reads it fine, but the CLI/daemon HTTP surface between them
+/// is versioned by nothing except being built together, so a mixed pair out of
+/// one target directory is not a configuration any release ships and not one a
+/// failure should be attributed to.
+///
+/// It is no longer true that such a pair disagrees about persisted vector
+/// sidecars. That WAS this gate's second reason, and it was the product defect
+/// showing through the harness: a differently-built daemon rejected a seeded
+/// sidecar, `indexed_embedding_count` read 0, and the suite reported a defect
+/// the harness then worked around. Index reuse no longer keys on a build SHA,
+/// so a mixed pair reuses the index just as a user's upgrade now does.
 pub fn daemon_compat_mismatch(
     payload: &Value,
     expected_snapshot_version: u64,
@@ -3253,11 +3259,10 @@ fn fresh_daemon_bin(runtime: &IsolatedDaemonRuntime) -> PathBuf {
         panic!(
             "kin-daemon at {} is unusable after rebuild: {reason}.\n\
              This test binary carries build identity {}. A daemon built from a \
-             different commit or working tree stamps persisted vector sidecars \
-             with a different embedder identity, so state this suite seeds is \
-             rejected on reopen and indexed_embedding_count reads 0 — a harness \
-             fault that reads as a product defect. Build both from one tree: \
-             cargo build --all-targets",
+             different commit or working tree pairs with this binary over an \
+             HTTP surface that nothing versions except having been built \
+             together, so failures under a mixed pair are not attributable to \
+             either side. Build both from one tree: cargo build --all-targets",
             daemon_bin.display(),
             expected_build_stamp()
         );

--- a/crates/kin-cli/tests/daemon_compat_gate.rs
+++ b/crates/kin-cli/tests/daemon_compat_gate.rs
@@ -90,9 +90,9 @@ fn a_compat_payload_without_build_identity_is_not_reusable() {
 }
 
 /// Pins the harness's `build.sha` + `build.dirty` join against
-/// `kin_buildinfo::sha_with_dirty`, which is what the daemon actually stamps
-/// sidecars with. If that rule changes and this join does not, every daemon
-/// would look skewed and no rebuild would clear it.
+/// `kin_buildinfo::sha_with_dirty`, the joining rule it borrows. If that rule
+/// changes and this join does not, every daemon would look skewed and no
+/// rebuild would clear it.
 #[test]
 fn the_joined_stamp_agrees_with_kin_buildinfo() {
     let info = kin_buildinfo::get();

--- a/crates/kin-cli/tests/prepared_state_json.rs
+++ b/crates/kin-cli/tests/prepared_state_json.rs
@@ -165,14 +165,14 @@ fn seed_local_vectors(kin_dir: &Path) {
         graph.load_vector_index_compatible(&vector_path, &descriptor),
         kin_db::VectorIndexLoad::Loaded(_)
     ));
-    // Stamp the same embedder identity the daemon writes and demands on load,
-    // so a reopened repo accepts this sidecar instead of treating it as one
-    // produced by a different build.
-    let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
+    // Stamped and validated with no producer pin, exactly as the daemon writes
+    // and reads it. Pinning a build SHA here would make the fixture describe a
+    // rule the product no longer has, and would hide the case this seeds for:
+    // a sidecar written by one build being reopened by another.
     kin_db::SnapshotManager::save_vector_index_for_graph(
         layout.kindb_snapshot_path(),
         &graph,
-        Some(embedder_identity.as_str()),
+        None,
     )
     .expect("persist seeded vector sidecar");
     fs::remove_file(vector_path).expect("remove temp vector file");
@@ -180,7 +180,7 @@ fn seed_local_vectors(kin_dir: &Path) {
         kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
             &graph,
             &layout.kindb_snapshot_path(),
-            Some(embedder_identity.as_str()),
+            None,
         )
         .expect("validate seeded vector sidecar"),
         "seeded sidecar must validate against the repository graph it was built from"

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -446,6 +446,18 @@ pub struct HealthResponse {
     /// A true value drives `status: "attention"`.
     #[serde(default)]
     pub embed_persistence_unavailable: bool,
+    /// Why the persisted vector index was not installed when this daemon
+    /// opened, when one was on disk and was not. The graph is intact and every
+    /// query is still served; the index is being re-derived from zero, which is
+    /// worth stating because the only other evidence is a coverage counter that
+    /// restarted without explanation. A value drives `status: "attention"`.
+    ///
+    /// This describes one daemon's open and so holds for that process's life,
+    /// the same way `embed_worker_failed` does, rather than clearing when the
+    /// rebuild catches up. `kin health` is the surface that tracks the rebuild
+    /// and goes quiet once coverage is whole.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vector_index_discarded: Option<String>,
     /// Effective filesystem-to-graph admission policy. This reports the frozen
     /// daemon state, including intrinsic storage-backend graph authority, not
     /// merely whether the opt-in environment variable was present.
@@ -2072,6 +2084,7 @@ async fn health(
         .embed_worker_failed
         .load(std::sync::atomic::Ordering::Relaxed);
     let embed_persistence_unavailable = !state.can_persist_embed_progress_locally();
+    let vector_index_discarded = state.vector_index_discarded().map(str::to_string);
     let coordination_event_persist_failures = state
         .coordination_event_persist_failures
         .load(std::sync::atomic::Ordering::Relaxed);
@@ -2079,11 +2092,13 @@ async fn health(
     // operator or client polling /health sees a non-"ok" signal when the daemon
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
     // permanently stopped (embed-degraded), OR the configured storage backend
-    // cannot durably persist vector progress, OR coordination evidence could not
-    // be persisted. The graph itself stays intact and served in all cases.
+    // cannot durably persist vector progress, OR the persisted vector index was
+    // discarded at open and is being re-derived, OR coordination evidence could
+    // not be persisted. The graph itself stays intact and served in all cases.
     let status = if mass_deletion_blocked
         || embed_worker_failed
         || embed_persistence_unavailable
+        || vector_index_discarded.is_some()
         || coordination_event_persist_failures > 0
     {
         "attention"
@@ -2118,6 +2133,7 @@ async fn health(
         mass_deletion_blocked,
         embed_worker_failed,
         embed_persistence_unavailable,
+        vector_index_discarded,
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
         graph_generation: DaemonState::read_generation_marker(&state.layout),
         behavior_env: kin_core::behavior_env::snapshot_from_process(),
@@ -2691,6 +2707,7 @@ async fn command_resources(
         embeddings_total: embed_status.total,
         hybrid_metrics: hybrid_metrics_runtime(),
         metal_profile: metal_profile_runtime(),
+        vector_index_discarded: state.vector_index_discarded().map(str::to_string),
     };
 
     let actual = kin_cli::commands::resources::ActualResources::capture();
@@ -15922,6 +15939,11 @@ mod tests {
             "local repository authority must allow derived vector persistence"
         );
         assert!(
+            json.vector_index_discarded.is_none(),
+            "a repository with no index to discard must not report one: {:?}",
+            json.vector_index_discarded
+        );
+        assert!(
             !json.filesystem_reconcile_disabled,
             "local authority remains file-compatible unless explicitly disabled"
         );
@@ -16672,6 +16694,50 @@ mod tests {
         assert!(
             message.contains(BACKEND_FAULT_TEXT),
             "the fault must carry the backend error rather than discard it: {message}"
+        );
+    }
+
+    /// Discarding the user's whole vector index is a degradation, and a
+    /// degradation nobody can read is indistinguishable from silence. The graph
+    /// still serves every query, so this is not a fault; it is minutes to hours
+    /// of embedding about to be paid for twice, and `/health` says so.
+    #[cfg(feature = "vector")]
+    #[tokio::test]
+    async fn health_surfaces_a_discarded_vector_index_as_attention() {
+        install_test_registry_override();
+        let dir = std::env::temp_dir().join(format!("kin-daemon-kvec-discard-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let layout = kin_core::init(&dir).unwrap().layout;
+        // An index on disk that this build cannot bind to graph truth: the
+        // shape every rejected sidecar arrives in, whatever rejected it.
+        std::fs::create_dir_all(layout.kindb_dir()).unwrap();
+        std::fs::write(layout.kindb_vector_index_path(), b"unbindable index").unwrap();
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+
+        let response = router(state)
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: HealthResponse = serde_json::from_slice(&body).unwrap();
+
+        let reason = json
+            .vector_index_discarded
+            .expect("a discarded index must be reported, not left to a coverage counter");
+        assert!(
+            reason.contains("graph.kvec"),
+            "the report must name what was discarded: {reason}"
+        );
+        assert_eq!(
+            json.status, "attention",
+            "re-deriving the whole index is not an `ok` steady state"
+        );
+        assert!(
+            !json.embed_worker_failed,
+            "a discarded index is not a worker crash"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -937,6 +937,15 @@ pub struct DaemonState {
     /// error, so an un-hydrated store is reported as the authority gap it is
     /// rather than as a mysteriously absent object.
     ingest_cas_hydration_gap: Option<String>,
+    /// Why the persisted vector index on disk was not installed when this state
+    /// was opened, when one was there and was not.
+    ///
+    /// A discarded index is re-derived from scratch, which is minutes to hours
+    /// of embedding on a real repository, so it is stated rather than left to
+    /// be inferred from a coverage counter that silently restarted at zero.
+    /// `None` means either that the index loaded or that there was none to
+    /// load, which are the two states that need no explanation.
+    vector_index_discarded: Option<String>,
     pub reconciler: RwLock<Reconciler>,
     /// Cached FileLayouts for all tracked files.
     /// Populated on init, updated on commits.
@@ -1411,26 +1420,73 @@ impl DaemonState {
     ///
     /// The `SnapshotManager::open` / `open_read_only_for_locate` path already
     /// performs this validated load during construction, so it does not call this.
-    fn load_validated_vector_index(layout: &KinLayout, graph: &kin_db::InMemoryGraph) {
+    ///
+    /// # Reuse is keyed on format, not on the product version
+    ///
+    /// No build identity is pinned here. Whether previously derived vectors are
+    /// reusable is decided entirely by keys that describe the vectors and the
+    /// graph, all of which kin-db compares on its own: the sidecar envelope
+    /// version, the on-disk index format version, the embedding
+    /// provider/model/revision/pipeline-epoch/dimensions, the index's own
+    /// self-described model, and the retrieval-authority hash binding it to
+    /// graph truth. None of those move when Kin's version does.
+    ///
+    /// Passing the daemon's build SHA as the expected producer identity made
+    /// every upgrade reject the whole index and re-embed the repository from
+    /// zero, because that SHA changes on every commit whether or not anything
+    /// about embedding did. It is deliberately absent, and the same call in
+    /// `require_complete_prepared_embeddings` pins nothing either. Invalidating
+    /// deliberately is still available and belongs on the key that describes
+    /// the pipeline (kin-db's embedding pipeline epoch), which every persisted
+    /// sidecar already carries and every load already checks.
+    ///
+    /// Returns `Some(reason)` when an index was on disk and was not installed,
+    /// so the caller can record and announce what was discarded. `None` means
+    /// the index loaded, or there was none to load.
+    fn load_validated_vector_index(
+        layout: &KinLayout,
+        graph: &kin_db::InMemoryGraph,
+    ) -> Option<String> {
         let snapshot_path = layout.kindb_snapshot_path();
-        let expected_embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
-        match kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
+        let vector_path = layout.kindb_vector_index_path();
+        // Sampled BEFORE the load so a discard can be told apart from a repo
+        // that simply has no index yet. kin-db reports both as `Ok(false)`, and
+        // announcing the second would fire this on every fresh repository.
+        let had_persisted_index = vector_path.exists();
+        let outcome = kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
             graph,
             &snapshot_path,
-            Some(expected_embedder_identity.as_str()),
-        ) {
+            None,
+        );
+        let discarded = match outcome {
             Ok(true) => {
                 debug!(path = %snapshot_path.display(), "loaded validated persisted vector index");
+                return None;
             }
-            Ok(false) => {}
-            Err(error) => {
-                debug!(
-                    error = %error,
-                    path = %snapshot_path.display(),
-                    "failed to load persisted vector index"
-                );
-            }
-        }
+            Ok(false) if !had_persisted_index => return None,
+            Ok(false) => format!(
+                "the persisted vector index at {} no longer matches this repository's graph or \
+                 embedding model, so it was not loaded",
+                vector_path.display()
+            ),
+            Err(error) => format!(
+                "the persisted vector index at {} could not be read ({error}), so it was not loaded",
+                vector_path.display()
+            ),
+        };
+        warn!(
+            path = %vector_path.display(),
+            "{discarded}; every entity will be embedded again from scratch. \
+             Run `kin embed` to rebuild it now, or `kin health` to watch coverage recover."
+        );
+        Some(discarded)
+    }
+
+    /// Why the persisted vector index was not installed at open, when it was
+    /// there and was not. Reported by `/health` and by semantic-query readiness
+    /// so a coverage counter that restarted at zero comes with its reason.
+    pub fn vector_index_discarded(&self) -> Option<&str> {
+        self.vector_index_discarded.as_deref()
     }
 
     fn spine_disabled() -> bool {
@@ -1872,7 +1928,7 @@ impl DaemonState {
         // `from_snapshot_with_text_index` restores the text index but not the
         // vector sidecar, so without this the reopened repository reports every
         // entity as unembedded and re-derives an index it already has on disk.
-        Self::load_validated_vector_index(&layout, graph.as_ref());
+        let vector_index_discarded = Self::load_validated_vector_index(&layout, graph.as_ref());
 
         let mut reconciler = Reconciler::new(layout.working_dir().to_path_buf());
         // Seed LKG from persisted graph so the first reconcile after daemon
@@ -1903,6 +1959,7 @@ impl DaemonState {
             graph,
             blobs: Arc::new(blobs),
             ingest_cas_hydration_gap: None,
+            vector_index_discarded,
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
@@ -2081,7 +2138,7 @@ impl DaemonState {
         // The backend path builds the graph via `from_snapshot_with_text_index`,
         // which does NOT load the vector-index sidecar — do the validated load
         // here (no-ops if no/stale sidecar).
-        Self::load_validated_vector_index(&layout, graph.as_ref());
+        let vector_index_discarded = Self::load_validated_vector_index(&layout, graph.as_ref());
         let mut reconciler = Reconciler::new(layout.working_dir().to_path_buf());
         reconciler.seed_lkg_entities_from_graph(graph.as_ref());
 
@@ -2104,6 +2161,7 @@ impl DaemonState {
             graph: Arc::clone(&graph),
             blobs: Arc::new(blobs),
             ingest_cas_hydration_gap,
+            vector_index_discarded,
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
@@ -4150,11 +4208,14 @@ impl DaemonState {
             self.vector_checkpoint_authority_match
                 .record(generation, live_tree);
         }
-        let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
+        // No producer identity: kin-db stamps the embedding runtime's own
+        // provider/model/revision/epoch, which is what decides on reload
+        // whether these vectors are still usable. Stamping this binary's build
+        // SHA instead made the sidecar unloadable by the next release.
         kin_db::SnapshotManager::checkpoint_vector_index_for_graph(
             self.layout.kindb_snapshot_path(),
             self.graph.as_ref(),
-            Some(embedder_identity.as_str()),
+            None,
         )
         .map_err(DaemonError::from)?;
         if self.post_commit_finalization_pending.load(Ordering::SeqCst) {
@@ -4189,11 +4250,12 @@ impl DaemonState {
             .persist_lock
             .lock()
             .map_err(|_| DaemonError::Io(std::io::Error::other("persist lock poisoned")))?;
-        let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
+        // See `flush_embed_progress`: the sidecar carries the embedding
+        // runtime's identity, never this binary's build SHA.
         kin_db::SnapshotManager::save_vector_index_for_graph(
             self.layout.kindb_snapshot_path(),
             self.graph.as_ref(),
-            Some(embedder_identity.as_str()),
+            None,
         )
         .map_err(DaemonError::from)
     }
@@ -7773,6 +7835,181 @@ mod tests {
             reported.contains("never hydrated on this open path")
                 && reported.contains("hosted backend carries no authority"),
             "the error must name the hydration gap: {reported}"
+        );
+    }
+
+    /// Build a store carrying one entity and a persisted vector index, and
+    /// stamp the sidecar with `producer` as its producing-artifact identity.
+    ///
+    /// The index is four synthetic dimensions written straight into a
+    /// `VectorIndex`, so no embedding model is loaded and no inference runs.
+    /// That is enough to exercise every gate a real index passes through on
+    /// reopen, because those gates read the sidecar's metadata and the graph's
+    /// authority hash, never the vectors themselves.
+    #[cfg(feature = "vector")]
+    fn store_with_persisted_vector_index(
+        layout: &KinLayout,
+        producer: Option<&str>,
+    ) -> Arc<kin_db::InMemoryGraph> {
+        std::fs::create_dir_all(layout.kindb_dir()).unwrap();
+        let snapshot_path = layout.kindb_snapshot_path();
+        let manager = kin_db::SnapshotManager::new(&snapshot_path);
+        let graph = manager.graph();
+        let entity = test_entity("semantic_query_target", "src/lib.rs");
+        graph.upsert_entity(&entity).unwrap();
+
+        // The placeholder binding only has to let the index install; the
+        // `save_vector_index_for_graph` below re-stamps it with the exact model
+        // identity and authority hash, which is what a reopen checks.
+        let placeholder = kin_db::IndexDescriptor {
+            model_id: Some("fixture-model".to_string()),
+            graph_root: Some("fixture-root".to_string()),
+        };
+        let index = kin_db::VectorIndex::new(4).unwrap();
+        index.upsert(entity.id, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+        index.set_descriptor(placeholder.clone());
+        index.save(&layout.kindb_vector_index_path()).unwrap();
+        assert!(
+            matches!(
+                graph.load_vector_index_compatible(&layout.kindb_vector_index_path(), &placeholder),
+                kin_db::VectorIndexLoad::Loaded(_)
+            ),
+            "fixture index must install before the store is persisted"
+        );
+
+        manager.save().unwrap();
+        kin_db::SnapshotManager::save_vector_index_for_graph(
+            &snapshot_path,
+            graph.as_ref(),
+            producer,
+        )
+        .unwrap();
+        graph
+    }
+
+    /// The daemon's real open path builds its graph with
+    /// `from_snapshot_with_text_index`, which restores no vector index. Clear
+    /// the fixture's index to reproduce that state exactly.
+    #[cfg(feature = "vector")]
+    fn as_reopened_by_the_daemon(graph: &kin_db::InMemoryGraph) {
+        graph.reset_vector_index();
+        assert_eq!(
+            graph.embedding_status().indexed,
+            0,
+            "a daemon reopen starts with no vector index installed"
+        );
+    }
+
+    /// A Kin upgrade must not throw the user's embeddings away.
+    ///
+    /// Releases before this one pinned index reuse to the daemon's own build
+    /// SHA, which changes on every commit, so moving between any two versions
+    /// rejected the whole index and re-embedded the repository from zero. The
+    /// sidecar here is stamped with a foreign build SHA exactly as an older
+    /// release would have left it, and it must still load: nothing about the
+    /// format, the model, or the graph moved.
+    #[test]
+    #[cfg(feature = "vector")]
+    fn an_index_written_by_a_different_build_survives_the_upgrade() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo_dir.path().join(".kin"));
+        let graph = store_with_persisted_vector_index(
+            &layout,
+            Some("6c1f0a9d3b74e25a8f0c1d6e4b93a27f5d8e0c14"),
+        );
+        as_reopened_by_the_daemon(graph.as_ref());
+
+        let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
+
+        assert_eq!(
+            discarded, None,
+            "an index from another build is not a discard: {discarded:?}"
+        );
+        assert_eq!(
+            graph.embedding_status().indexed,
+            1,
+            "the persisted index must survive a version change, not be re-derived"
+        );
+    }
+
+    /// The other side of the same contract: a sidecar this build genuinely
+    /// cannot use is still refused, and now says so.
+    ///
+    /// A metadata envelope version this build does not know is the real format
+    /// change the old build-SHA pin was standing in for. It must reject, and
+    /// the rejection must name what was discarded rather than land in a debug
+    /// log nobody reads.
+    #[test]
+    #[cfg(feature = "vector")]
+    fn a_sidecar_in_an_unknown_format_is_refused_and_announced() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo_dir.path().join(".kin"));
+        let graph = store_with_persisted_vector_index(&layout, None);
+        as_reopened_by_the_daemon(graph.as_ref());
+
+        let metadata_path = layout.kindb_dir().join("graph.kvec.meta.json");
+        let mut metadata: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&metadata_path).unwrap()).unwrap();
+        metadata["version"] = json!(u32::MAX);
+        std::fs::write(&metadata_path, serde_json::to_vec(&metadata).unwrap()).unwrap();
+
+        let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
+
+        let reason = discarded.expect("a refused sidecar must be announced, not dropped silently");
+        assert!(
+            reason.contains("graph.kvec") && reason.contains("could not be read"),
+            "the announcement must name what was discarded and why: {reason}"
+        );
+        assert_eq!(
+            graph.embedding_status().indexed,
+            0,
+            "an unreadable sidecar must not be installed"
+        );
+    }
+
+    /// A sidecar bound to a graph that has since moved on describes entities
+    /// this store no longer has, so it is refused and announced too.
+    #[test]
+    #[cfg(feature = "vector")]
+    fn an_index_bound_to_stale_graph_truth_is_refused_and_announced() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo_dir.path().join(".kin"));
+        let graph = store_with_persisted_vector_index(&layout, None);
+        as_reopened_by_the_daemon(graph.as_ref());
+        graph
+            .upsert_entity(&test_entity("added_after_the_index", "src/added.rs"))
+            .unwrap();
+
+        let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
+
+        let reason = discarded.expect("a refused sidecar must be announced, not dropped silently");
+        assert!(
+            reason.contains("graph.kvec") && reason.contains("no longer matches"),
+            "the announcement must name what was discarded and why: {reason}"
+        );
+        assert_eq!(
+            graph.embedding_status().indexed,
+            0,
+            "an index bound to stale graph truth must not be installed"
+        );
+    }
+
+    /// The announcement must distinguish "your index was thrown away" from
+    /// "you have not built one yet". Every repository is in the second state
+    /// until its first embed, and an announcement that fires there is noise
+    /// that trains people to ignore the one that matters.
+    #[test]
+    #[cfg(feature = "vector")]
+    fn a_repository_with_no_persisted_index_announces_nothing() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(repo_dir.path().join(".kin"));
+        std::fs::create_dir_all(layout.kindb_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        assert_eq!(
+            DaemonState::load_validated_vector_index(&layout, &graph),
+            None,
+            "a repository that never had an index has had nothing discarded"
         );
     }
 

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -295,7 +295,7 @@
     },
     {
       "file": "crates/kin-daemon/src/state.rs",
-      "reason": "Daemon state persistence boundary. The excused bodies write and read back state the daemon owns about itself, never repository content. Snapshot and marker persistence: the generation marker, the vfs version record, the mcp transaction log, and the coordination event log, each written through a temp-and-rename with an explicit directory fsync so a crash cannot leave a torn record, which is what the two cfg-gated sync_directory_metadata bodies and the two `open` bodies are. Failure accounting: the persisted failure count and its marker file. Graph-to-disk projection: staging and finalizing the canonical read index from graph truth, and invalidating it. Authority pinning: resolving the registered local repository authority roots. The one expression pin is a lease metadata accessor, which returns graph-owned workspace state and only shares a name with the filesystem probe. Function-scoped rather than whole-file: this module is large and holds far more than its persistence paths, and all of that stays scanned.",
+      "reason": "Daemon state persistence boundary. The excused bodies write and read back state the daemon owns about itself, never repository content. Snapshot and marker persistence: the generation marker, the vfs version record, the mcp transaction log, and the coordination event log, each written through a temp-and-rename with an explicit directory fsync so a crash cannot leave a torn record, which is what the two cfg-gated sync_directory_metadata bodies and the two `open` bodies are. Failure accounting: the persisted failure count and its marker file. Graph-to-disk projection: staging and finalizing the canonical read index from graph truth, and invalidating it. Authority pinning: resolving the registered local repository authority roots. The one expression pin is a lease metadata accessor, which returns graph-owned workspace state and only shares a name with the filesystem probe. Derived-sidecar disclosure: load_validated_vector_index asks kin-db to install the persisted vector index and probes for that same sidecar's presence beforehand. The probe decides nothing about the answer to any query and cannot change what the graph returns; the sidecar either installed or it did not, and kin-db reports both a missing sidecar and a rejected one as the same negative. It separates those two so a rejected index is announced as the discarded work it is instead of reading as a repository that never had one, which is the whole of FIR-1959. Nothing is read from the file, no content is recovered from it, and a probe that lied in either direction would change only the wording of a health report. Function-scoped rather than whole-file: this module is large and holds far more than its persistence paths, and all of that stays scanned.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_fn": [
@@ -319,7 +319,8 @@
         "invalidate_canonical_read_index",
         "stage_read_index_from_graph",
         "write_generation_marker",
-        "read_generation_marker"
+        "read_generation_marker",
+        "load_validated_vector_index"
       ],
       "allow_match": [
         "lease.metadata()"


### PR DESCRIPTION
Kin keyed persisted vector-index reuse on the daemon's own build SHA, which changes on
every commit and therefore on every release. Moving between any two versions rejected the
whole index and re-embedded the repository from zero, and the only trace was a
`tracing::warn!` inside a background daemon.

```rust
let expected_embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
kin_db::SnapshotManager::load_vector_index_into_graph_if_valid(
    graph, &snapshot_path, Some(expected_embedder_identity.as_str()))
```

`sha_with_dirty` is `env!("KIN_BUILD_GIT_SHA")` plus a dirty marker. kin's own comment two
lines above that call already named the consequence of an unloaded sidecar: the reopened
repository "reports every entity as unembedded and re-derives an index it already has on
disk."

## The build SHA was never a format key

Whether previously derived vectors are reusable is already decided, on every load, by keys
that describe the vectors and the graph: the sidecar envelope version
(`VECTOR_INDEX_METADATA_VERSION`), the on-disk index format version
(`HNSW_FORMAT_VERSION`), the embedding provider, model id, revision, pipeline epoch and
dimensions, the index's own self-described model, and the retrieval-authority hash binding
it to graph truth. None of those move when the product version does, and all of them are
compared independently of the producer identity.

The pin was an outlier rather than a policy. kin-db's own open paths pass no producer
identity. So did kin's prepared-state validator and its backend loader. Only the daemon
pinned a build, and kin-db documents the omitted case as the supported one: "If omitted,
KinDB writes a required identity derived from the exact provider/model/revision/pipeline
descriptor."

The integration harness had already met this defect and attributed it to itself. Its
daemon-reuse gate documented that a daemon built from a different commit "stamps and
demands a different embedder identity, so a sidecar seeded by this test binary is rejected
on load, indexed_embedding_count reads 0, and the suite reports a product defect that only
exists because two binaries in one target directory were built at different times." The
defect was real; only the attribution was wrong. That comment is corrected here.

## What changes

The daemon pins no build identity on read and stamps none on write, so a sidecar carries
the embedding runtime's identity as kin-db derives it rather than a value meaning "this
exact binary". Deliberate invalidation stays available on the key that describes the
pipeline, which every sidecar already carries and every load already checks.

A named constant would have been worse than omitting the pin: sidecars already on disk
carry a build SHA, so any new constant mismatches them once and the very upgrade shipping
the fix would still discard every current user's index.

Silence was the other half of the defect, and the `Err` path was quieter still at `debug!`.
`load_validated_vector_index` now samples whether an index was on disk before attempting
the load, so a discard is distinguishable from a repository that never had one, and
returns the reason. That reason is logged at `warn!` with the remedy, recorded on daemon
state the way the ingest-CAS hydration gap is, published on `GET /health` as
`vector_index_discarded` driving `status: "attention"`, and reported by `kin health`'s
semantic query readiness check.

The two surfaces keep deliberately different lifetimes. `/health` describes one daemon's
open and holds for that process, matching `embed_worker_failed` beside it. `kin health`
reports the discard only while coverage is still incomplete, because once the rebuild
lands there is nothing to act on and a check that cannot go green is a check nobody reads.

## Tests

Two-sided, using a synthetic four-dimension index written straight to disk, so no
embedding model is loaded and no inference runs. That is sufficient because every gate on
the reopen path reads sidecar metadata and the graph's authority hash, never the vectors.

- `an_index_written_by_a_different_build_survives_the_upgrade`: a sidecar stamped with a
  foreign 40-hex build SHA, exactly as an older release leaves it, loads and answers with
  its vectors intact.
- `a_sidecar_in_an_unknown_format_is_refused_and_announced`: an envelope version this
  build does not know, which is the real format change the build-SHA pin was standing in
  for, is refused and named.
- `an_index_bound_to_stale_graph_truth_is_refused_and_announced`: a sidecar whose graph
  has moved on is refused and named.
- `a_repository_with_no_persisted_index_announces_nothing`: the announcement does not fire
  on a first run, which would make it noise nobody reads.
- `health_surfaces_a_discarded_vector_index_as_attention`, and
  `health_returns_ok_with_extended_fields` extended to assert a healthy daemon reports no
  discard.
- `semantic_query_readiness_names_a_discarded_vector_index`, including that a rebuild
  which has caught up returns the check to healthy.

Restoring `Some(kin_buildinfo::sha_with_dirty(..))` at the one call site fails the first
test and nothing else:

```
assertion `left == right` failed: an index from another build is not a discard:
Some("the persisted vector index at .../graph.kvec no longer matches this repository's
      graph or embedding model, so it was not loaded")
```

The three refusal tests pass under both the old and the new policy, which is the correct
result: genuine incompatibility must still reject either way, so the surviving test
measures the policy change and nothing else.

## Not claiming

No end-to-end upgrade was run. Nothing installed an older release, embedded a real
repository, upgraded, and observed the index survive, because that needs an embedded store
and the GPU. What is proven is the storage-layer contract the daemon's open path calls,
exercised through the daemon's own function, with the "different build" simulated by the
identity string rather than by two separately compiled binaries.

Closes FIR-1959
