### PR TITLE
Install as the user who ran the installer, and configure a shell the host has

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -141,11 +141,26 @@ fn require_empty_native_boundary(dir: &Path) -> Result<()> {
         anyhow::bail!(
             "non-Git repository admission currently requires an empty directory: {}; Kin will \
              not silently ignore or derive authority from existing filesystem contents. Commit \
-             the exact files to Git and retry, or initialize an empty Kin-native repository.",
-            dir.display()
+             the exact files to Git and retry, or initialize an empty Kin-native repository.{}",
+            dir.display(),
+            git_prerequisite_note(which::which("git").is_ok())
         );
     }
     Ok(())
+}
+
+/// The suffix naming Git as a prerequisite of the remedy above.
+///
+/// Kin reads a repository's history through `gix` and never needs the host
+/// binary to admit one, so this error is reachable on a host with no Git at
+/// all — and the first remedy it offers is a `git commit`. Say that the tool
+/// is missing rather than sending the reader to a command they do not have.
+fn git_prerequisite_note(git_on_path: bool) -> &'static str {
+    if git_on_path {
+        ""
+    } else {
+        " Git is not installed on this host, so committing to Git needs `git` installed first."
+    }
 }
 
 fn path_exists(path: &Path) -> Result<bool> {
@@ -319,6 +334,25 @@ mod tests {
             semantic_change_count: 0,
             completion_attested: false,
         }
+    }
+
+    /// The non-empty-directory refusal offers "commit the exact files to Git"
+    /// as its first remedy. Measured on a fresh ubuntu:24.04 curl install, that
+    /// host has no git at all, so the remedy names a command the reader does
+    /// not have and the error dead-ends.
+    #[test]
+    fn the_non_git_refusal_names_git_as_a_prerequisite_only_when_it_is_absent() {
+        assert_eq!(
+            git_prerequisite_note(true),
+            "",
+            "a host that has git needs no extra instruction"
+        );
+
+        let absent = git_prerequisite_note(false);
+        assert!(
+            absent.contains("not installed") && absent.contains("git"),
+            "a host without git must be told before being sent to a git commit: {absent}"
+        );
     }
 
     /// A repository Kin could not extract anything from must SAY so and name the

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1223,7 +1223,34 @@ pub(crate) fn detect_shell() -> &'static str {
         return "powershell";
     }
 
-    "zsh"
+    fallback_shell()
+}
+
+/// The shell to configure when nothing in the environment names one.
+///
+/// `SHELL` is unset in containers, cron, and most non-login invocations, which
+/// is exactly where first-run happens. A flat default of zsh then wrote the hook
+/// and the PATH line into a `.zshrc` on hosts with no zsh installed, reported
+/// that as shell integration installed, and disagreed with the installer, which
+/// had already chosen `.bashrc` for the same install. Choose a shell the host
+/// actually has, in the platform's own order of preference, so the two agree.
+fn fallback_shell() -> &'static str {
+    // On Windows the PowerShell markers above are the signal Kin acts on, and a
+    // Git-for-Windows PATH routinely carries a bash that is not the shell anyone
+    // configures Kin for. Leave that platform on its historical default.
+    if cfg!(target_os = "windows") {
+        return "zsh";
+    }
+
+    let ordered: [&'static str; 3] = if cfg!(target_os = "macos") {
+        ["zsh", "bash", "fish"]
+    } else {
+        ["bash", "zsh", "fish"]
+    };
+    ordered
+        .into_iter()
+        .find(|shell| check_binary_in_path(shell).is_some())
+        .unwrap_or(ordered[0])
 }
 
 pub(crate) fn shell_rc(shell: &str) -> Result<PathBuf> {
@@ -2060,6 +2087,40 @@ fn rc_declares_kin_bin(content: &str, bin_dir: &Path) -> bool {
     content.contains(bin.as_ref()) || content.contains(".kin/bin") || content.contains("kin/bin")
 }
 
+/// Whether this `kin` is the binary the published installer placed in
+/// `~/.kin/bin`, rather than one built from a source checkout.
+fn is_managed_install(exe: Option<&Path>, kin_home: &Path) -> bool {
+    let Some(exe_dir) = exe.and_then(Path::parent) else {
+        return false;
+    };
+    let managed_bin = kin_home.join("bin");
+    match (exe_dir.canonicalize(), managed_bin.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => exe_dir == managed_bin,
+    }
+}
+
+/// Headline and command to print when the projection shim is missing.
+///
+/// A cargo target is the right remedy only for someone running a `kin` they
+/// built from this source tree. A user who installed through the published
+/// one-liner has neither a checkout nor cargo, so naming a cargo build sends
+/// them to a command they cannot run; the installer that ships the shim is
+/// their route back, and it is the same remedy `kin doctor` already gives.
+fn missing_shim_guidance(exe: Option<&Path>, kin_home: &Path) -> (&'static str, &'static str) {
+    if is_managed_install(exe, kin_home) {
+        (
+            "VFS shim not found. Reinstall Kin to restore it:",
+            crate::daemon_client::KIN_INSTALL_COMMAND,
+        )
+    } else {
+        (
+            "VFS shim not found. Build it with:",
+            "cargo build --release -p kin-vfs-shim",
+        )
+    }
+}
+
 fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
     let kin_home = kin_dir()?;
     let bin_dir = kin_home.join("bin");
@@ -2093,57 +2154,99 @@ fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
             }
         }
     } else {
-        println!("  VFS shim not found. Build it with:");
-        println!("    cargo build --release -p kin-vfs-shim");
+        let (headline, command) =
+            missing_shim_guidance(env::current_exe().ok().as_deref(), &kin_home);
+        println!("  {headline}");
+        println!("    {command}");
     }
 
     let source_line = rc_source_line(shell_name, &hook_file);
 
     let rc_path = shell_rc(shell_name)?;
-    let mut rc_content = if rc_path.exists() {
+    let rc_content = if rc_path.exists() {
         fs::read_to_string(&rc_path)?
     } else {
         String::new()
     };
-    let hook_installed = rc_content.contains("kin-vfs");
-    let path_installed = rc_declares_kin_bin(&rc_content, &bin_dir);
 
-    if hook_installed {
-        println!(
-            "  Shell rc already sources kin-vfs hook: {}",
-            rc_path.display()
-        );
-    } else {
-        if !rc_content.ends_with('\n') && !rc_content.is_empty() {
-            rc_content.push('\n');
-        }
-        rc_content.push_str(&rc_integration_block(&source_line));
-        println!("  Appended to {}", rc_path.display());
+    let update = plan_rc_update(&rc_content, shell_name, &source_line, &rc_path, &bin_dir);
+    for line in &update.already_present {
+        println!("{line}");
     }
-
-    if path_installed {
-        println!("  Shell rc already adds {} to PATH", bin_dir.display());
-    } else {
-        if !rc_content.ends_with('\n') && !rc_content.is_empty() {
-            rc_content.push('\n');
-        }
-        rc_content.push_str(&rc_path_block(shell_name, &bin_dir));
-        println!(
-            "  Added {} to PATH for new shell sessions",
-            bin_dir.display()
-        );
-    }
-
-    if !hook_installed || !path_installed {
+    if !update.applied.is_empty() {
         if let Some(parent) = rc_path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("failed to create {}", parent.display()))?;
         }
-        fs::write(&rc_path, &rc_content)
+        fs::write(&rc_path, &update.content)
             .with_context(|| format!("failed to update {}", rc_path.display()))?;
+        for line in &update.applied {
+            println!("{line}");
+        }
     }
 
     Ok((hook_file, source_line))
+}
+
+/// The rc file Kin wants on disk, split from what it may say about it.
+///
+/// `applied` is non-empty exactly when a write is needed, and every line in it
+/// describes rc state that exists only once that write lands. Keeping the two
+/// apart is what stops setup announcing "Appended to ~/.zshrc" and then failing
+/// the run out from under the claim.
+#[derive(Debug)]
+struct RcUpdate {
+    content: String,
+    applied: Vec<String>,
+    already_present: Vec<String>,
+}
+
+fn plan_rc_update(
+    existing: &str,
+    shell_name: &str,
+    source_line: &str,
+    rc_path: &Path,
+    bin_dir: &Path,
+) -> RcUpdate {
+    let mut content = existing.to_string();
+    let mut applied = Vec::new();
+    let mut already_present = Vec::new();
+
+    let append = |content: &mut String, block: &str| {
+        if !content.ends_with('\n') && !content.is_empty() {
+            content.push('\n');
+        }
+        content.push_str(block);
+    };
+
+    if existing.contains("kin-vfs") {
+        already_present.push(format!(
+            "  Shell rc already sources kin-vfs hook: {}",
+            rc_path.display()
+        ));
+    } else {
+        append(&mut content, &rc_integration_block(source_line));
+        applied.push(format!("  Appended to {}", rc_path.display()));
+    }
+
+    if rc_declares_kin_bin(existing, bin_dir) {
+        already_present.push(format!(
+            "  Shell rc already adds {} to PATH",
+            bin_dir.display()
+        ));
+    } else {
+        append(&mut content, &rc_path_block(shell_name, bin_dir));
+        applied.push(format!(
+            "  Added {} to PATH for new shell sessions",
+            bin_dir.display()
+        ));
+    }
+
+    RcUpdate {
+        content,
+        applied,
+        already_present,
+    }
 }
 
 /// Reinstall the shell hook + rc source line for the detected shell.
@@ -14664,6 +14767,13 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     #[test]
     #[serial]
     fn detect_shell_uses_powershell_markers_when_no_posix_shell_names_itself() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        // Pin the host evidence the nothing-named-itself fallback reads, so this
+        // test stays about the markers on every platform.
+        write_stub_shell(&bin, "zsh");
+        let _path = EnvVarGuard::set("PATH", &bin);
+
         let mut shell_env = EnvVarGuard::unset("SHELL")
             .without("PSModulePath")
             .without("PSVersionTable");
@@ -14677,6 +14787,153 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         // still decide.
         shell_env.apply("SHELL", Some("/usr/bin/false"));
         assert_eq!(detect_shell(), "powershell");
+    }
+
+    fn write_stub_shell(bin: &Path, name: &str) {
+        fs::create_dir_all(bin).unwrap();
+        let shell = bin.join(name);
+        fs::write(&shell, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let mut permissions = fs::metadata(&shell).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&shell, permissions).unwrap();
+        }
+    }
+
+    /// `SHELL` is unset in containers, cron, and most non-login invocations —
+    /// exactly where first-run happens. Measured on ubuntu:24.04, a flat zsh
+    /// default wrote the hook into a `.zshrc` on a host with no zsh, while the
+    /// installer had already chosen `.bashrc` for the same install.
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn detect_shell_falls_back_to_a_shell_the_host_actually_has() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+
+        let _shell_env = EnvVarGuard::unset("SHELL")
+            .without("PSModulePath")
+            .without("PSVersionTable");
+        let _path = EnvVarGuard::set("PATH", &bin);
+
+        write_stub_shell(&bin, "bash");
+        assert_eq!(
+            detect_shell(),
+            "bash",
+            "a host carrying only bash must be configured as bash"
+        );
+
+        fs::remove_file(bin.join("bash")).unwrap();
+        write_stub_shell(&bin, "zsh");
+        assert_eq!(
+            detect_shell(),
+            "zsh",
+            "a host carrying only zsh must be configured as zsh"
+        );
+
+        // Both present: the platform's own preference decides, and it is the
+        // same one the installer applies when it picks an rc file.
+        write_stub_shell(&bin, "bash");
+        let expected = if cfg!(target_os = "macos") {
+            "zsh"
+        } else {
+            "bash"
+        };
+        assert_eq!(detect_shell(), expected);
+
+        // No shell resolvable at all still yields the platform default rather
+        // than failing setup.
+        fs::remove_file(bin.join("bash")).unwrap();
+        fs::remove_file(bin.join("zsh")).unwrap();
+        assert_eq!(
+            detect_shell(),
+            if cfg!(target_os = "macos") {
+                "zsh"
+            } else {
+                "bash"
+            }
+        );
+    }
+
+    /// A curl-installed user has neither a checkout nor cargo, so naming a cargo
+    /// target as the remedy sends them to a command they cannot run.
+    #[test]
+    fn missing_shim_guidance_routes_managed_installs_to_the_installer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kin_home = tmp.path().join("kin-home");
+        let managed_bin = kin_home.join("bin");
+        fs::create_dir_all(&managed_bin).unwrap();
+
+        let (headline, command) = missing_shim_guidance(Some(&managed_bin.join("kin")), &kin_home);
+        assert_eq!(command, crate::daemon_client::KIN_INSTALL_COMMAND);
+        assert!(
+            !headline.contains("cargo") && !command.contains("cargo"),
+            "a managed install must never be told to build the shim: {headline} / {command}"
+        );
+    }
+
+    #[test]
+    fn missing_shim_guidance_keeps_the_cargo_build_for_source_checkouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kin_home = tmp.path().join("kin-home");
+        fs::create_dir_all(kin_home.join("bin")).unwrap();
+        let checkout_bin = tmp.path().join("checkout").join("target").join("release");
+        fs::create_dir_all(&checkout_bin).unwrap();
+
+        let (_headline, command) =
+            missing_shim_guidance(Some(&checkout_bin.join("kin")), &kin_home);
+        assert_eq!(command, "cargo build --release -p kin-vfs-shim");
+    }
+
+    #[test]
+    fn missing_shim_guidance_without_a_resolvable_exe_does_not_claim_a_managed_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kin_home = tmp.path().join("kin-home");
+        let (_headline, command) = missing_shim_guidance(None, &kin_home);
+        assert_eq!(command, "cargo build --release -p kin-vfs-shim");
+    }
+
+    /// `applied` is the exact set of claims that become true only when the rc
+    /// write lands, so an rc that already carries both blocks must produce none
+    /// — there is no write, and nothing to announce.
+    #[test]
+    fn plan_rc_update_announces_only_what_a_write_would_change() {
+        let rc_path = Path::new("/home/u/.zshrc");
+        let bin_dir = Path::new("/home/u/.kin/bin");
+        let source_line = "source /home/u/.kin/shell/kin-vfs.zsh";
+
+        let fresh = plan_rc_update("", "zsh", source_line, rc_path, bin_dir);
+        assert_eq!(fresh.applied.len(), 2, "{:?}", fresh.applied);
+        assert!(fresh.already_present.is_empty());
+        assert!(fresh.content.contains(source_line));
+        assert!(fresh.content.contains(&rc_path_line("zsh", bin_dir)));
+
+        let settled = plan_rc_update(&fresh.content, "zsh", source_line, rc_path, bin_dir);
+        assert!(
+            settled.applied.is_empty(),
+            "nothing is written on a second run, so nothing may be claimed: {:?}",
+            settled.applied
+        );
+        assert_eq!(settled.already_present.len(), 2);
+        assert_eq!(settled.content, fresh.content);
+    }
+
+    #[test]
+    fn plan_rc_update_claims_only_the_half_that_is_missing() {
+        let rc_path = Path::new("/home/u/.bashrc");
+        let bin_dir = Path::new("/home/u/.kin/bin");
+        let source_line = "source /home/u/.kin/shell/kin-vfs.bash";
+
+        let hook_only = format!("{}\n", rc_integration_block(source_line));
+        let update = plan_rc_update(&hook_only, "bash", source_line, rc_path, bin_dir);
+        assert_eq!(update.applied.len(), 1, "{:?}", update.applied);
+        assert!(update.applied[0].contains("PATH"));
+        assert_eq!(update.already_present.len(), 1);
+        assert!(update.already_present[0].contains("already sources"));
     }
 
     #[test]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,6 +75,18 @@ printf '\n'
 
 info "Platform: $OS ($ARCH)"
 
+# ── Declare the one host tool Kin needs but does not install ──────────
+
+# Installing Kin needs no git, and Kin reads a repository's Git history itself
+# rather than shelling out for it. The host binary is still required in two
+# places a first-run user reaches immediately: `kin setup` validates workspace
+# MCP authority through git when it runs inside a Git repository, and adopting
+# an existing project means committing it to Git first, which `kin init` asks
+# for. Declaring that here beats letting the first real command fail on it.
+if ! has_cmd git; then
+    info 'git not found. Kin installs and runs without it, but `kin setup` inside a Git repository and adopting an existing project both require it.'
+fi
+
 # ── Detect an existing install (reinstall / upgrade) ──────────────────
 
 PREVIOUS_VERSION=""
@@ -190,12 +202,32 @@ info "Installing to $KIN_DIR..."
 
 mkdir -p "$KIN_BIN" "$KIN_LIB"
 
-tar xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
+# Everything under $KIN_DIR must end owned by the user doing the install. GNU
+# tar restores the uid/gid recorded in the archive when it runs as root, and
+# release archives are built by CI under an unrelated uid, so a root install
+# otherwise lands foreign-owned binaries and a foreign-owned projection shim in
+# the user's own home. Kin then refuses to verify the shim it just installed
+# ("managed config is not owned by the current user") and `kin doctor` reports
+# the install ledger STALE on a perfectly good install.
+#
+# --no-same-owner is the fix, but it is not universal: busybox tar spells it -o
+# and rejects the long option. Fall back to a plain extraction and repair the
+# ownership directly, which is the only case where the chown has anything to do.
+if ! tar --no-same-owner -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" 2>/dev/null; then
+    tar xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
+fi
 
 # Find the extracted directory (archive contains a subdirectory)
 EXTRACT_DIR=$(find "$TMPDIR" -maxdepth 1 -type d -name "kin-*" | head -1)
 if [ -z "$EXTRACT_DIR" ]; then
     EXTRACT_DIR="$TMPDIR"
+fi
+
+# Only root can be handed foreign ownership by tar, and only root can repair it.
+# Every file below is moved, not copied, so fixing the extracted tree here is
+# what makes the installed tree caller-owned.
+if [ "$(id -u)" = "0" ]; then
+    chown -R "$(id -u):$(id -g)" "$EXTRACT_DIR" 2>/dev/null || true
 fi
 
 # kin-daemon is mandatory — `kin status`/`kin search` and the MCP server all

--- a/scripts/test_install_optional_vfs.py
+++ b/scripts/test_install_optional_vfs.py
@@ -11,6 +11,7 @@ import hashlib
 import os
 import platform
 import pty
+import shutil
 import stat
 import subprocess
 import tarfile
@@ -43,6 +44,8 @@ def executable(path: Path, body: str) -> None:
 
 
 class OptionalVfsInstallerTests(unittest.TestCase):
+    tar_argv_log: Path | None = None
+
     def run_installer(
         self,
         *,
@@ -54,6 +57,8 @@ class OptionalVfsInstallerTests(unittest.TestCase):
         existing_notifier: bool = False,
         seed_current_install: bool = False,
         seed_launcher_stamp: bool = False,
+        archive_owner: tuple[int, int] | None = None,
+        tar_stub: str | None = None,
     ) -> tuple[subprocess.CompletedProcess[str], Path]:
         temp = tempfile.TemporaryDirectory()
         self.addCleanup(temp.cleanup)
@@ -95,9 +100,20 @@ class OptionalVfsInstallerTests(unittest.TestCase):
         release_dir = root / "download" / f"v{VERSION}"
         release_dir.mkdir(parents=True)
         archive = release_dir / f"kin-{target}.tar.gz"
+        def stamp_archive_owner(info: tarfile.TarInfo) -> tarfile.TarInfo:
+            if archive_owner is not None:
+                info.uid, info.gid = archive_owner
+                # Empty names force tar to honour the numeric ids, which is what
+                # a release archive built on a CI runner effectively carries.
+                info.uname = ""
+                info.gname = ""
+            return info
+
         with tarfile.open(archive, "w:gz") as bundle:
             bundle.dereference = False
-            bundle.add(archive_root, arcname=archive_root.name)
+            bundle.add(
+                archive_root, arcname=archive_root.name, filter=stamp_archive_owner
+            )
         digest = hashlib.sha256(archive.read_bytes()).hexdigest()
         archive.with_suffix(archive.suffix + ".sha256").write_text(
             f"{digest}  {archive.name}\n", encoding="utf-8"
@@ -137,9 +153,11 @@ class OptionalVfsInstallerTests(unittest.TestCase):
                 "SHELL": "/bin/sh",
             }
         )
+        fake_bin = root / "fake-bin"
+        if pretend_macos or tar_stub is not None:
+            fake_bin.mkdir(exist_ok=True)
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
         if pretend_macos:
-            fake_bin = root / "fake-bin"
-            fake_bin.mkdir()
             executable(
                 fake_bin / "uname",
                 "#!/bin/sh\n"
@@ -149,7 +167,30 @@ class OptionalVfsInstallerTests(unittest.TestCase):
                 "  *) exit 2 ;;\n"
                 "esac\n",
             )
-            env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+        if tar_stub is not None:
+            real_tar = shutil.which("tar", path=os.defpath)
+            assert real_tar is not None, "no system tar to delegate to"
+            self.tar_argv_log = root / "tar-argv.log"
+            # "reject" stands in for busybox tar, which spells no-same-owner `-o`
+            # and refuses the long option outright, so the installer's fallback
+            # is exercised rather than assumed.
+            refusal = (
+                'for arg in "$@"; do\n'
+                '  if [ "$arg" = "--no-same-owner" ]; then\n'
+                '    echo "tar: unrecognized option: no-same-owner" >&2\n'
+                "    exit 1\n"
+                "  fi\n"
+                "done\n"
+                if tar_stub == "reject"
+                else ""
+            )
+            executable(
+                fake_bin / "tar",
+                "#!/bin/sh\n"
+                f'printf \'%s\\n\' "$*" >> "{self.tar_argv_log}"\n'
+                f"{refusal}"
+                f'exec "{real_tar}" "$@"\n',
+            )
         args = ["sh", str(INSTALLER)]
         if progress_tty:
             master, slave = pty.openpty()
@@ -211,6 +252,62 @@ class OptionalVfsInstallerTests(unittest.TestCase):
         self.assertIn("Filesystem projection is unavailable", result.stdout)
         self.assertFalse((kin_home / "bin" / "kin-vfs").exists())
         self.assertFalse(any((kin_home / "lib").glob("libkin_vfs_shim.*")))
+
+    def test_extraction_refuses_the_archives_recorded_ownership(self) -> None:
+        # tar running as root restores the uid/gid the archive records, and
+        # release archives are built by CI under an unrelated uid. Left alone,
+        # a root install lands a foreign-owned projection shim in the user's own
+        # ~/.kin, Kin refuses to verify the shim it just installed, and doctor
+        # reports the install ledger STALE on a clean install.
+        result, _ = self.run_installer(vfs_exit=0, tar_stub="record")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        assert self.tar_argv_log is not None
+        invocations = self.tar_argv_log.read_text(encoding="utf-8")
+        self.assertIn(
+            "--no-same-owner",
+            invocations,
+            f"the installer must not let tar restore archived ownership: {invocations!r}",
+        )
+
+    def test_extraction_falls_back_when_tar_rejects_no_same_owner(self) -> None:
+        result, kin_home = self.run_installer(vfs_exit=0, tar_stub="reject")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        assert self.tar_argv_log is not None
+        invocations = self.tar_argv_log.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(
+            any("--no-same-owner" in line for line in invocations),
+            f"the long option is still tried first: {invocations!r}",
+        )
+        self.assertTrue(
+            any("--no-same-owner" not in line for line in invocations),
+            f"a tar that refuses the option must still extract: {invocations!r}",
+        )
+        self.assertTrue((kin_home / "bin" / "kin").exists())
+        self.assertTrue((kin_home / "bin" / "kin-daemon").exists())
+
+    @unittest.skipUnless(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        "only root is handed the archive's recorded ownership by tar",
+    )
+    def test_root_install_lands_every_file_owned_by_the_installing_user(self) -> None:
+        result, kin_home = self.run_installer(vfs_exit=0, archive_owner=(1001, 1001))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        installed = [
+            kin_home / "bin" / "kin",
+            kin_home / "bin" / "kin-daemon",
+            kin_home / "bin" / "kin-vfs",
+            *(kin_home / "lib").glob("libkin_vfs_shim.*"),
+        ]
+        self.assertGreaterEqual(len(installed), 4)
+        for path in installed:
+            self.assertEqual(
+                path.stat().st_uid,
+                os.geteuid(),
+                f"{path} kept the archive's uid instead of the installing user's",
+            )
 
     def test_interactive_archive_download_exposes_live_byte_percent_meter(self) -> None:
         result, _ = self.run_installer(vfs_exit=0, progress_tty=True)


### PR DESCRIPTION
Three first-run defects, all measured on a fresh `ubuntu:24.04` curl install in Docker on arm64.

## A clean install ends on a red install ledger

A completely successful install closes red:

```
  ! Install ledger             STALE          5 tracked: 0 removed, 1 modified since install
Summary: 8 passed, 2 need attention, 6 not applicable.
```

`kin setup ledger` names the single offender:

```
  ! shim   VFS shim at /root/.kin/lib/libkin_vfs_shim.so could not be safely verified —
           Kin will not trust or touch it: managed config is not owned by the current user
```

`tar` running as root defaults to `--same-owner`, so it restores the uid recorded in the archive rather than the installing user's. The release archive records the build machine's identity (`runner/runner`), so a root install lands every extracted file, the projection shim included, owned by uid 1001 while the installing user is uid 0. `validate_regular_config_file` then refuses a managed file it does not own, `verify_entry` maps that refusal to `Modified` (deliberately, so no uninstall path mistakes it for verified or absent), and `check_setup_ledger` reports `Stale`.

The tell that this is an installer bug and not a verifier bug: every artifact Kin itself wrote (`setup.toml`, `kin-vfs.zsh`, both rc lines) verifies clean at uid 0. Only the artifact that came out of the tarball is foreign-owned.

This is the same family as #648 but a different mechanism, and #648 does not cover it. `setup_ledger.rs` and `setup.rs` are byte-identical between v0.5.5 and `main` (sha256 `f58cd7cb…` and `6c9b69df…`), and the `health.rs` diff between them never mentions `check_setup_ledger`. Given identical on-disk state, `main` produces the identical verdict.

The installer now extracts with `--no-same-owner`, falls back to a plain extraction where tar rejects the long option (busybox spells it `-o`), and repairs ownership with `chown` when running as root. Files are moved rather than copied, so fixing the extracted tree is what makes the installed tree caller-owned.

A/B in `ubuntu:24.04` arm64 as root, same image, same pinned `KIN_VERSION=0.5.5`, same archive, only the script differs:

| | before | after |
|---|---|---|
| `~/.kin/bin/*`, `~/.kin/lib/*` owner | `1001 1001` | `0 0` |
| `kin setup ledger` | 4 verified, 1 modified | 5 verified, 0 modified |
| doctor | `! Install ledger STALE` | `✓ Install ledger ok  5 artifact(s) tracked, all present and unmodified` |
| summary | 8 passed, 2 need attention | 9 passed, 1 need attention |

The one remaining needs-attention in the after arm is `Repository MISSING`, which is correct outside a Kin repo.

## Setup configures a shell the host does not have

Same container, `SHELL` unset, no zsh, bash present. The install flow disagreed with itself:

```
  ✓ Added /root/.kin/bin to PATH in /root/.bashrc              <- installer picked bash
Shell integration: adding one `source` line to /root/.zshrc.   <- kin setup picked zsh
  ✓ Shell integration  ok  zsh hook installed and sourced from /root/.zshrc
```

`detect_shell` ended in a bare `"zsh"` whenever `SHELL` named nothing, which is the normal state in containers, cron, and non-login invocations, i.e. exactly where first-run happens. The fallback now picks the first shell the host actually has, in the platform's own order (`zsh, bash, fish` on macOS; `bash, zsh, fish` elsewhere), matching the preference `install.sh` already applies when choosing an rc file. Windows keeps its historical default verbatim and deliberately: the PowerShell markers are the signal there, and a Git-for-Windows `bash` on PATH is not the shell anyone configures Kin for.

`install_shell_hook` also printed "Appended to \<rc\>" and "Added \<bin\> to PATH" before the `fs::write` that made either true, so a failing write announced success and then errored out from under the claim. The rc mutation is now the pure `plan_rc_update`, returning `RcUpdate { content, applied, already_present }`; `applied` is non-empty exactly when a write is needed and is printed only after that write lands.

## Setup names commands the host does not have

Setup told every user with a missing shim to run `cargo build --release -p kin-vfs-shim`. A curl-installed user has neither a checkout nor cargo, and `kin doctor` already routes them to the installer, so setup was the one surface out of step. `missing_shim_guidance` now branches on whether the running `kin` is the binary the installer placed in `~/.kin/bin`.

`kin init` in a non-empty non-Git directory offers "Commit the exact files to Git and retry" as its first remedy, and that error is reachable on a host with no git at all, since `kin_core::init_from_git` reads history through `gix` and never shells out. It now says so when git is off PATH. `install.sh` declares git at install time, naming where it is genuinely required: `setup.rs::git_authority_output_with_resolution_policy_from` does `which::which_in("git", …)` with the context "host Git is required to validate workspace MCP authority", so `kin setup` inside a Git repository needs the host binary.

## Tests

Every new test was falsified once by reverting the behavior it covers, and each failed as intended while its two-sided counterpart stayed green.

| test | falsified by |
|---|---|
| `test_extraction_refuses_the_archives_recorded_ownership` | removing `--no-same-owner` |
| `test_extraction_falls_back_when_tar_rejects_no_same_owner` | removing the fallback branch |
| `test_root_install_lands_every_file_owned_by_the_installing_user` | root-only; skips off-root, runs for real in a root container |
| `detect_shell_falls_back_to_a_shell_the_host_actually_has` | reverting the fallback to `"zsh"` |
| `plan_rc_update_announces_only_what_a_write_would_change` | pushing an `applied` line with no write |
| `plan_rc_update_claims_only_the_half_that_is_missing` | same |
| `missing_shim_guidance_routes_managed_installs_to_the_installer` | forcing the cargo branch |
| `the_non_git_refusal_names_git_as_a_prerequisite_only_when_it_is_absent` | returning `""` always |

`detect_shell_uses_powershell_markers_when_no_posix_shell_names_itself` previously asserted a bare `"zsh"` with `SHELL` unset, which this change would have broken on Linux. It now pins PATH to a stub `zsh`, so it stays a test about the markers on every platform. The `cfg!(target_os = "macos")` branch of the fallback is exercised both ways: macOS locally, the bash-first branch by CI's ubuntu runner.

## Not fixed here

- Existing installs stay stale until the user re-runs the installer; nothing heals foreign ownership in place.
- The release archives still record `runner/runner`. Building them with `--owner=0 --group=0 --numeric-owner` would make every archive own-neutral, but that touches the release train and only helps future releases, whereas the installer fix protects every install including old archives.
- The doctor aggregate says "1 modified since install" for an entry that was never inspected. The per-entry line is honest; the roll-up is not.

Closes FIR-2029
Closes FIR-1414
Closes FIR-2060
