### PR TITLE
Stop the agent-facing surface behaving worse than the human-facing one

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -19,6 +19,13 @@
 //! Override the auto-detected tier with the `KIN_LOCATE_PROFILE` environment
 //! variable, set to `minimal`, `standard`, or `performance` (case-insensitive);
 //! any other value falls through to auto-detection.
+//!
+//! Detection that cannot read the host says so. A probe failure used to be
+//! swallowed and replaced with a plausible number, which scored a large machine
+//! as `Minimal` and then advised its operator to obtain the hardware they were
+//! already running on. [`CapabilityDetection::misread_host`] carries that
+//! reason out to the caller so a tier chosen from a stand-in is never presented
+//! as a reading.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocateProfile {
@@ -32,25 +39,31 @@ pub enum LocateProfile {
 
 impl LocateProfile {
     pub fn detect() -> Self {
-        // Check env override first
-        if let Ok(val) = std::env::var("KIN_LOCATE_PROFILE") {
-            match val.to_lowercase().as_str() {
-                "minimal" => return Self::Minimal,
-                "standard" => return Self::Standard,
-                "performance" => return Self::Performance,
-                _ => {} // fall through to detection
-            }
-        }
+        CapabilityDetection::detect().profile
+    }
 
-        let cores = num_cpus();
-        let ram_gb = available_ram_gb();
-
+    /// Score a tier from an effective core count and RAM figure.
+    ///
+    /// Pure, so the thresholds are testable without a host to run on and
+    /// without the env override in the way.
+    fn score(cores: usize, ram_gb: f64) -> Self {
         if cores >= 8 && ram_gb >= 16.0 {
             Self::Performance
         } else if cores >= 4 && ram_gb >= 8.0 {
             Self::Standard
         } else {
             Self::Minimal
+        }
+    }
+
+    /// The tier named by `KIN_LOCATE_PROFILE`, or `None` when the value is
+    /// absent or is not one of the three tier tokens.
+    fn from_override(value: Option<&str>) -> Option<Self> {
+        match value?.trim().to_lowercase().as_str() {
+            "minimal" => Some(Self::Minimal),
+            "standard" => Some(Self::Standard),
+            "performance" => Some(Self::Performance),
+            _ => None,
         }
     }
 
@@ -139,57 +152,206 @@ fn num_cpus() -> usize {
     }
 }
 
+/// GiB assumed for a host whose memory could not be read.
+///
+/// Deliberately conservative, and deliberately never reported as a
+/// measurement: every path that scores a tier against it also carries
+/// [`HostMemory::Undetected`] so the caller can say the number was invented.
+const UNDETECTED_RAM_GB: f64 = 4.0;
+
+/// What a host-memory probe returned, or why it could not answer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HostMemory {
+    /// Physical RAM in GiB as read from the host.
+    Detected(f64),
+    /// The probe could not answer, with the reason it gave.
+    Undetected(String),
+}
+
+impl HostMemory {
+    /// GiB to score a tier against: the reading when there is one, otherwise
+    /// the conservative stand-in.
+    pub fn gb_or_stand_in(&self) -> f64 {
+        match self {
+            Self::Detected(gb) => *gb,
+            Self::Undetected(_) => UNDETECTED_RAM_GB,
+        }
+    }
+
+    /// Why the host could not be read, when it could not.
+    pub fn undetected_reason(&self) -> Option<&str> {
+        match self {
+            Self::Detected(_) => None,
+            Self::Undetected(reason) => Some(reason),
+        }
+    }
+}
+
+/// Physical RAM as reported by the `hw.memsize` sysctl, read through
+/// `sysctlbyname` rather than by running `/usr/sbin/sysctl`.
+///
+/// The subprocess form depended on the caller's `PATH`, and `/usr/sbin` is
+/// absent from the minimal environments that matter most here: an MCP client
+/// spawning `kin mcp start`, a launchd agent, a container entrypoint, a CI
+/// runner. There, command-not-found was swallowed and the host was scored as
+/// though it had 4 GB. The syscall cannot be defeated by the environment.
 #[cfg(target_os = "macos")]
-fn host_ram_gb() -> f64 {
-    use std::process::Command;
-    Command::new("sysctl")
-        .args(["-n", "hw.memsize"])
-        .output()
-        .ok()
-        .and_then(|out| {
-            String::from_utf8_lossy(&out.stdout)
-                .trim()
-                .parse::<u64>()
-                .ok()
-        })
-        .map(|bytes| bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-        .unwrap_or(4.0)
+fn probe_host_ram() -> HostMemory {
+    let mut bytes: u64 = 0;
+    let mut size = std::mem::size_of::<u64>() as libc::size_t;
+    let status = unsafe {
+        libc::sysctlbyname(
+            c"hw.memsize".as_ptr(),
+            std::ptr::addr_of_mut!(bytes).cast::<libc::c_void>(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if status != 0 {
+        return HostMemory::Undetected(format!(
+            "sysctlbyname(hw.memsize) failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if size != std::mem::size_of::<u64>() as libc::size_t || bytes == 0 {
+        return HostMemory::Undetected(format!(
+            "sysctlbyname(hw.memsize) returned {size} bytes holding {bytes}"
+        ));
+    }
+    HostMemory::Detected(bytes as f64 / (1024.0 * 1024.0 * 1024.0))
 }
 
 #[cfg(target_os = "linux")]
-fn host_ram_gb() -> f64 {
-    std::fs::read_to_string("/proc/meminfo")
-        .ok()
-        .and_then(|contents| {
-            for line in contents.lines() {
-                if line.starts_with("MemTotal:") {
-                    let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
-                    return Some(kb as f64 / (1024.0 * 1024.0));
-                }
-            }
-            None
-        })
-        .unwrap_or(4.0)
+fn probe_host_ram() -> HostMemory {
+    let contents = match std::fs::read_to_string("/proc/meminfo") {
+        Ok(contents) => contents,
+        Err(error) => return HostMemory::Undetected(format!("/proc/meminfo unreadable: {error}")),
+    };
+    match parse_meminfo_total_gb(&contents) {
+        Some(gb) => HostMemory::Detected(gb),
+        None => HostMemory::Undetected("/proc/meminfo carries no parsable MemTotal".to_string()),
+    }
+}
+
+/// `MemTotal` out of a `/proc/meminfo` body, in GiB.
+#[cfg(any(target_os = "linux", test))]
+fn parse_meminfo_total_gb(contents: &str) -> Option<f64> {
+    contents.lines().find_map(|line| {
+        let kb: u64 = line
+            .strip_prefix("MemTotal:")?
+            .split_whitespace()
+            .next()?
+            .parse()
+            .ok()?;
+        Some(kb as f64 / (1024.0 * 1024.0))
+    })
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn host_ram_gb() -> f64 {
-    // Conservative default for unsupported platforms
-    4.0
+fn probe_host_ram() -> HostMemory {
+    HostMemory::Undetected(format!(
+        "no host-memory probe for target_os {}",
+        std::env::consts::OS
+    ))
 }
 
-/// Effective available RAM in GiB: host physical RAM, capped by a container
-/// memory limit (cgroup v2 `memory.max` / v1 `memory.limit_in_bytes`) when one
-/// is set. Without a limit this is the host figure, so bare-metal detection is
-/// unchanged.
-fn available_ram_gb() -> f64 {
-    let host = host_ram_gb();
-    match cgroup_memory_limit_bytes() {
-        Some(limit) => {
-            let limit_gb = limit as f64 / (1024.0 * 1024.0 * 1024.0);
-            host.min(limit_gb)
+/// Probe the host once per process and warn the first time it cannot answer.
+///
+/// The warning is what stops a misread host from being silent for consumers
+/// that do not carry a structured degradation ledger of their own; `kin locate`
+/// additionally reports it in-band (see
+/// [`CapabilityDetection::misread_host`]).
+fn host_memory() -> HostMemory {
+    let memory = probe_host_ram();
+    if let Some(reason) = memory.undetected_reason() {
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| {
+            tracing::warn!(
+                reason,
+                stand_in_gb = UNDETECTED_RAM_GB,
+                "host memory could not be read; capability tiers on this process are scored \
+                 against a conservative stand-in, not a reading of this machine"
+            );
+        });
+    }
+    memory
+}
+
+fn host_ram_gb() -> f64 {
+    host_memory().gb_or_stand_in()
+}
+
+/// Effective available RAM: the host figure, capped by a container memory
+/// limit (cgroup v2 `memory.max` / v1 `memory.limit_in_bytes`) when one is set.
+/// Without a limit this is the host figure, so bare-metal detection is
+/// unchanged. A cap never turns an undetected host into a detected one.
+fn available_memory(host: HostMemory) -> HostMemory {
+    let Some(limit) = cgroup_memory_limit_bytes() else {
+        return host;
+    };
+    let limit_gb = limit as f64 / (1024.0 * 1024.0 * 1024.0);
+    match host {
+        HostMemory::Detected(gb) => HostMemory::Detected(gb.min(limit_gb)),
+        HostMemory::Undetected(reason) => HostMemory::Undetected(reason),
+    }
+}
+
+/// The tier this process will run at, and the evidence it was chosen from.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapabilityDetection {
+    pub profile: LocateProfile,
+    /// The operator named the tier through `KIN_LOCATE_PROFILE`; no probe was
+    /// consulted, so a probe that would have failed is not this tier's reason.
+    pub forced_by_env: bool,
+    /// Effective schedulable cores, or `None` under a forced tier.
+    pub cores: Option<usize>,
+    /// Effective memory, or `None` under a forced tier.
+    pub memory: Option<HostMemory>,
+}
+
+impl CapabilityDetection {
+    pub fn detect() -> Self {
+        Self::resolve(
+            std::env::var("KIN_LOCATE_PROFILE").ok().as_deref(),
+            num_cpus,
+            || available_memory(host_memory()),
+        )
+    }
+
+    /// Core of [`Self::detect`] with the override string and both probes as
+    /// explicit inputs, so every branch is testable on any host.
+    fn resolve(
+        override_value: Option<&str>,
+        cores: impl FnOnce() -> usize,
+        memory: impl FnOnce() -> HostMemory,
+    ) -> Self {
+        if let Some(profile) = LocateProfile::from_override(override_value) {
+            return Self {
+                profile,
+                forced_by_env: true,
+                cores: None,
+                memory: None,
+            };
         }
-        None => host,
+        let cores = cores();
+        let memory = memory();
+        Self {
+            profile: LocateProfile::score(cores, memory.gb_or_stand_in()),
+            forced_by_env: false,
+            cores: Some(cores),
+            memory: Some(memory),
+        }
+    }
+
+    /// Why this tier is not a reading of the host, when it is not.
+    ///
+    /// A tier derived from a failed probe must never be reported as though the
+    /// numbers behind it were measured: the remediation that follows from a
+    /// real reading ("run on a bigger host") is actively wrong advice when the
+    /// host was never read.
+    pub fn misread_host(&self) -> Option<&str> {
+        self.memory.as_ref()?.undetected_reason()
     }
 }
 
@@ -452,6 +614,102 @@ mod tests {
         assert_eq!(parse_oom_kill_count("low 0\nhigh 0\nmax 0\noom 0\n"), None);
         assert_eq!(parse_oom_kill_count("oom_kill 0\n"), Some(0));
         assert_eq!(parse_oom_kill_count("oom_kill notanumber\n"), None);
+    }
+
+    /// The FIR-2023 shape, both ways round. An 18-core host whose memory probe
+    /// fails must not be scored `Minimal` and reported as though 4 GB had been
+    /// measured; the same host with a reading must score `Performance`.
+    #[test]
+    fn a_failed_memory_probe_is_reported_rather_than_scored_as_four_gigabytes() {
+        let misread = CapabilityDetection::resolve(
+            None,
+            || 18,
+            || HostMemory::Undetected("sysctlbyname(hw.memsize) failed: no such file".to_string()),
+        );
+        assert_eq!(misread.profile, LocateProfile::Minimal);
+        assert_eq!(
+            misread.misread_host(),
+            Some("sysctlbyname(hw.memsize) failed: no such file"),
+            "a tier scored against the stand-in must carry the probe failure out to the caller"
+        );
+
+        let read = CapabilityDetection::resolve(None, || 18, || HostMemory::Detected(128.0));
+        assert_eq!(read.profile, LocateProfile::Performance);
+        assert_eq!(
+            read.misread_host(),
+            None,
+            "a successful probe must not be reported as a detection failure"
+        );
+    }
+
+    /// A genuinely small machine still reaches `Minimal`, and does so as a
+    /// reading rather than as a failure. Without this the fix could pass by
+    /// calling every low tier a misread.
+    #[test]
+    fn a_genuinely_constrained_host_still_scores_minimal_with_nothing_to_report() {
+        let constrained = CapabilityDetection::resolve(None, || 2, || HostMemory::Detected(2.0));
+        assert_eq!(constrained.profile, LocateProfile::Minimal);
+        assert_eq!(constrained.misread_host(), None);
+        assert!(!constrained.profile.disabled_signals().is_empty());
+    }
+
+    /// An operator who names the tier is not consulting a probe, so a probe
+    /// that would have failed is not this tier's reason and must not be
+    /// reported as one.
+    #[test]
+    fn a_forced_tier_reports_no_detection_failure() {
+        let forced = CapabilityDetection::resolve(
+            Some("performance"),
+            || unreachable!("a forced tier must not probe cores"),
+            || unreachable!("a forced tier must not probe memory"),
+        );
+        assert_eq!(forced.profile, LocateProfile::Performance);
+        assert!(forced.forced_by_env);
+        assert_eq!(forced.misread_host(), None);
+    }
+
+    #[test]
+    fn override_tokens_are_case_and_whitespace_tolerant_and_otherwise_ignored() {
+        assert_eq!(
+            LocateProfile::from_override(Some("  Performance ")),
+            Some(LocateProfile::Performance)
+        );
+        assert_eq!(LocateProfile::from_override(Some("turbo")), None);
+        assert_eq!(LocateProfile::from_override(None), None);
+    }
+
+    #[test]
+    fn tier_thresholds_need_both_cores_and_memory() {
+        assert_eq!(LocateProfile::score(8, 16.0), LocateProfile::Performance);
+        assert_eq!(LocateProfile::score(8, 15.9), LocateProfile::Standard);
+        assert_eq!(LocateProfile::score(4, 8.0), LocateProfile::Standard);
+        assert_eq!(LocateProfile::score(3, 64.0), LocateProfile::Minimal);
+    }
+
+    /// The probe on the host this test runs on. It is the only assertion here
+    /// that would have caught the original defect in situ: on a developer or CI
+    /// machine, memory is readable, and any environment-shaped failure to read
+    /// it shows up as `Undetected`.
+    #[test]
+    fn this_host_reports_its_memory() {
+        let memory = probe_host_ram();
+        match &memory {
+            HostMemory::Detected(gb) => assert!(*gb > 0.0, "a detected host must report real GiB"),
+            HostMemory::Undetected(reason) => {
+                panic!("host memory probe failed on the test host: {reason}")
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "linux", test))]
+    #[test]
+    fn meminfo_total_is_parsed_and_a_body_without_it_is_a_miss() {
+        assert_eq!(
+            parse_meminfo_total_gb("MemFree: 100 kB\nMemTotal:       16777216 kB\n"),
+            Some(16.0)
+        );
+        assert_eq!(parse_meminfo_total_gb("MemFree: 100 kB\n"), None);
+        assert_eq!(parse_meminfo_total_gb("MemTotal:       nope kB\n"), None);
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1223,23 +1223,34 @@ fn evaluate_mcp_client_against(
                 .get("env")
                 .and_then(|e| e.get("KIN_MCP_TOOL_PROFILE"))
                 .and_then(|p| p.as_str());
-            if profile == Some("agent-default") {
-                (
+            match profile {
+                Some("agent-default") => (
                     HealthStatus::Healthy,
                     format!(
                         "{servers_key}.kin present with agent-default profile ({})",
                         path.display()
                     ),
-                )
-            } else {
-                (
-                    HealthStatus::Misconfigured,
+                ),
+                // An entry that names no profile is served the curated
+                // agent-default surface by `kin mcp start` itself, so it is
+                // correctly wired even though `kin setup` would have stated it.
+                // Calling this misconfigured would report the supported default
+                // as a fault.
+                None => (
+                    HealthStatus::Healthy,
                     format!(
-                        "{servers_key}.kin present but KIN_MCP_TOOL_PROFILE is {} (expected agent-default) in {}",
-                        profile.unwrap_or("unset"),
+                        "{servers_key}.kin present, no KIN_MCP_TOOL_PROFILE set; the server \
+                         defaults to the agent-default profile ({})",
                         path.display()
                     ),
-                )
+                ),
+                Some(other) => (
+                    HealthStatus::Misconfigured,
+                    format!(
+                        "{servers_key}.kin present but KIN_MCP_TOOL_PROFILE is {other} (expected agent-default, or unset to take it as the default) in {}",
+                        path.display()
+                    ),
+                ),
             }
         }
     }
@@ -2545,8 +2556,12 @@ mod tests {
         );
     }
 
+    /// An entry that states no profile is served the curated agent-default
+    /// surface by `kin mcp start` itself, so it is correctly wired. Reporting
+    /// the supported default as a fault would send every hand-wired client to
+    /// fix something that is not broken.
     #[test]
-    fn mcp_config_without_agent_default_profile_is_misconfigured() {
+    fn mcp_config_with_no_profile_is_healthy_on_the_served_default() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("claude.json");
         std::fs::write(
@@ -2564,8 +2579,42 @@ mod tests {
         )
         .unwrap();
 
-        let (status, _detail) = evaluate_mcp_client_against(&path, "claude", "kin");
-        assert!(matches!(status, HealthStatus::Misconfigured));
+        let (status, detail) = evaluate_mcp_client_against(&path, "claude", "kin");
+        assert!(matches!(status, HealthStatus::Healthy), "detail: {detail}");
+        assert!(
+            detail.contains("defaults to the agent-default profile"),
+            "the reader must be told which surface an unset profile resolves to: {detail}"
+        );
+    }
+
+    /// A profile that names a different surface is still a deliberate departure
+    /// from what `kin setup` writes, and doctor still says so. Without this the
+    /// relaxation above would have turned the check into one that cannot fail.
+    #[test]
+    fn mcp_config_naming_another_profile_is_still_misconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claude.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "mcpServers": {
+                    "kin": {
+                        "command": "kin",
+                        "args": ["mcp", "start"],
+                        "env": { "KIN_MCP_TOOL_PROFILE": "full" }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let (status, detail) = evaluate_mcp_client_against(&path, "claude", "kin");
+        assert!(
+            matches!(status, HealthStatus::Misconfigured),
+            "detail: {detail}"
+        );
+        assert!(detail.contains("full"), "detail: {detail}");
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::BuildHasherDefault;
 
-use crate::capability::LocateProfile;
+use crate::capability::{CapabilityDetection, LocateProfile};
 
 /// Deterministic-iteration map for transient locate accumulators. Fixed-seed
 /// hashing keeps fusion/resolution iteration order stable across processes so
@@ -1365,12 +1365,36 @@ fn record_vector_index_degradation(
 /// / PRF / LTR off on smaller tiers); without this entry the same query returns
 /// different-quality results on different hardware with no in-band signal. On
 /// the `Performance` tier nothing is disabled and no entry is added.
+///
+/// A tier chosen after a failed host probe is reported as its own thing. The
+/// ordinary entry's remediation tells the reader to run on a bigger host, which
+/// is wrong advice when the host was never read: the machine that produced
+/// FIR-2023 had eight times the RAM the entry implied it lacked.
 fn record_capability_tier_degradation(
-    profile: LocateProfile,
+    detection: &CapabilityDetection,
     sink: &mut Vec<RetrievalDegradation>,
 ) {
-    let disabled = profile.disabled_signals();
-    if disabled.is_empty() {
+    let profile = detection.profile;
+    if let Some(reason) = detection.misread_host() {
+        record_degradation(
+            sink,
+            RetrievalDegradation {
+                component: "capability_tier".to_string(),
+                reason: "hardware_detection_failed".to_string(),
+                detail: format!(
+                    "host capability could not be read ({reason}); the tier was scored against a \
+                     conservative stand-in and resolved to '{}'{}",
+                    profile.name(),
+                    describe_disabled_signals(profile),
+                ),
+                remediation: "this tier was not derived from a reading of this host; set \
+                     KIN_LOCATE_PROFILE=performance|standard|minimal to state it explicitly"
+                    .to_string(),
+            },
+        );
+        return;
+    }
+    if profile.disabled_signals().is_empty() {
         return;
     }
     record_degradation(
@@ -1379,13 +1403,9 @@ fn record_capability_tier_degradation(
             component: "capability_tier".to_string(),
             reason: profile.name().to_string(),
             detail: format!(
-                "hardware capability tier '{}': {} disabled; multihop depth {}/{}, frontier {}/{}",
+                "hardware capability tier '{}'{}",
                 profile.name(),
-                disabled.join(", "),
-                profile.multihop_max_depth(),
-                LocateProfile::Performance.multihop_max_depth(),
-                profile.multihop_frontier_limit(),
-                LocateProfile::Performance.multihop_frontier_limit(),
+                describe_disabled_signals(profile),
             ),
             remediation:
                 "set KIN_LOCATE_PROFILE=performance to force the full pipeline, or run on a host \
@@ -1393,6 +1413,23 @@ fn record_capability_tier_degradation(
                     .to_string(),
         },
     );
+}
+
+/// The signals a tier turns off and the depths it narrows, as a clause both
+/// capability entries append to their own opening.
+fn describe_disabled_signals(profile: LocateProfile) -> String {
+    let disabled = profile.disabled_signals();
+    if disabled.is_empty() {
+        return ": full pipeline".to_string();
+    }
+    format!(
+        ": {} disabled; multihop depth {}/{}, frontier {}/{}",
+        disabled.join(", "),
+        profile.multihop_max_depth(),
+        LocateProfile::Performance.multihop_max_depth(),
+        profile.multihop_frontier_limit(),
+        LocateProfile::Performance.multihop_frontier_limit(),
+    )
 }
 
 fn file_path_from_retrieval_key(
@@ -1841,10 +1878,12 @@ fn run_with_graph_capture_budgeted(
     let mut prune_ledger: Vec<PruneEvent> = Vec::new();
 
     let pipeline_report = std::env::var("KIN_LOCATE_PIPELINE_REPORT").is_ok();
-    let profile = LocateProfile::detect();
+    let detection = CapabilityDetection::detect();
+    let profile = detection.profile;
     // Surface a hardware-driven quality downgrade in-band: on a sub-Performance
-    // tier some retrieval signals are off, and that must never be silent.
-    record_capability_tier_degradation(profile, &mut degradations);
+    // tier some retrieval signals are off, and that must never be silent — nor
+    // must a tier that a failed host probe, rather than the host, chose.
+    record_capability_tier_degradation(&detection, &mut degradations);
     let test_query = is_test_query(text);
     let text_lower = text.to_ascii_lowercase();
     let source_text_priority_query = test_query
@@ -16341,6 +16380,76 @@ mod tests {
             RepoPath::from_utf8(path).expect("valid test repository path"),
             TreeEntry::blob(hash, false),
         )
+    }
+
+    fn capability_entry(sink: &[RetrievalDegradation]) -> &RetrievalDegradation {
+        sink.iter()
+            .find(|entry| entry.component == "capability_tier")
+            .expect("a sub-Performance tier must record a capability_tier degradation")
+    }
+
+    /// FIR-2023 in the surface a caller actually reads. A tier the host chose
+    /// and a tier a failed probe chose must not produce the same entry: the
+    /// first's remediation is sound advice, the second's told an operator with
+    /// 128 GB to obtain more RAM.
+    #[test]
+    fn a_misread_host_is_a_distinct_capability_entry_from_a_small_one() {
+        let mut misread = Vec::new();
+        record_capability_tier_degradation(
+            &CapabilityDetection {
+                profile: LocateProfile::Minimal,
+                forced_by_env: false,
+                cores: Some(18),
+                memory: Some(crate::capability::HostMemory::Undetected(
+                    "sysctlbyname(hw.memsize) failed".to_string(),
+                )),
+            },
+            &mut misread,
+        );
+        let entry = capability_entry(&misread);
+        assert_eq!(entry.reason, "hardware_detection_failed");
+        assert!(
+            entry.detail.contains("sysctlbyname(hw.memsize) failed"),
+            "the entry must name what failed: {}",
+            entry.detail
+        );
+        assert!(
+            !entry.remediation.contains("run on a host"),
+            "a host that was never read must not be told to become a bigger host: {}",
+            entry.remediation
+        );
+
+        let mut small = Vec::new();
+        record_capability_tier_degradation(
+            &CapabilityDetection {
+                profile: LocateProfile::Minimal,
+                forced_by_env: false,
+                cores: Some(2),
+                memory: Some(crate::capability::HostMemory::Detected(2.0)),
+            },
+            &mut small,
+        );
+        let entry = capability_entry(&small);
+        assert_eq!(entry.reason, "minimal");
+        assert!(entry.detail.contains("reranker"));
+        assert!(entry.remediation.contains(">=8 cores"));
+    }
+
+    /// The full pipeline on a host that was actually read stays silent, which
+    /// is what keeps the two entries above meaningful.
+    #[test]
+    fn a_read_performance_host_records_no_capability_entry() {
+        let mut sink = Vec::new();
+        record_capability_tier_degradation(
+            &CapabilityDetection {
+                profile: LocateProfile::Performance,
+                forced_by_env: false,
+                cores: Some(18),
+                memory: Some(crate::capability::HostMemory::Detected(128.0)),
+            },
+            &mut sink,
+        );
+        assert!(sink.is_empty());
     }
 
     fn native_change(

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -20,7 +20,11 @@ use std::pin::Pin;
 /// server starts anyway and each `tools/call` fails loud with a structured,
 /// actionable error (see `kin_mcp::daemon_delegate::daemon_unavailable_tool_result`)
 /// instead of the process silently never having started at all.
-pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
+pub async fn start(
+    global: bool,
+    repo: Option<PathBuf>,
+    tool_profile: Option<String>,
+) -> Result<()> {
     let repo_override = resolve_repo_override(repo);
     if let Some(repo_dir) = &repo_override {
         if global {
@@ -85,17 +89,12 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
     }
 
     let mut config = build_mcp_start_config();
-    let profile_tools: Option<&'static [&'static str]> =
-        match std::env::var("KIN_MCP_TOOL_PROFILE").ok().as_deref() {
-            Some("agent-default") => Some(kin_mcp::agent_default_tool_names()),
-            Some("benchmark") => Some(kin_mcp::benchmark_tool_names()),
-            // Read-only graph-native ContextBench belt: no write-side session/
-            // transaction tools and no filesystem tools (none exist) — the
-            // purely graph-native arm.
-            Some("context-bench") => Some(kin_mcp::context_bench_tool_names()),
-            _ => None,
-        };
-    if let Some(names) = profile_tools {
+    let resolved_profile = resolve_tool_profile(
+        tool_profile.as_deref(),
+        std::env::var("KIN_MCP_TOOL_PROFILE").ok().as_deref(),
+    );
+    eprintln!("{}", resolved_profile.startup_notice());
+    if let Some(names) = resolved_profile.profile.allowed_tool_names() {
         config.allowed_tools = Some(
             names
                 .iter()
@@ -134,6 +133,174 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("MCP server error: {}", e))?;
 
     Ok(())
+}
+
+// ── Tool profile ────────────────────────────────────────────────────────
+
+/// Which tool surface this server exposes.
+///
+/// The curated agent belt is the default, and the whole surface is the opt-in.
+/// It used to be the other way round, which meant the safe surface was
+/// reachable only by going through `kin setup`: anything that wired MCP by hand
+/// — a hand-written `.mcp.json`, a container entrypoint, a CI harness, another
+/// tool spawning the server — silently received every tool the crate defines
+/// and paid roughly twelve thousand extra tokens of schemas in every session,
+/// with nothing saying a lighter profile existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum McpToolProfile {
+    /// The curated belt every configured agent gets. The default.
+    AgentDefault,
+    /// The retrieval belt the benchmark arm drives.
+    Benchmark,
+    /// Read-only graph-native ContextBench belt: no write-side session or
+    /// transaction tools, and no filesystem tools (there are none to expose).
+    ContextBench,
+    /// Every tool the crate defines. Explicit opt-in.
+    Full,
+}
+
+/// The canonical token for each profile: what `KIN_MCP_TOOL_PROFILE` and
+/// `--tool-profile` accept, in the order a help message should list them.
+const TOOL_PROFILE_TOKENS: &[(&str, McpToolProfile)] = &[
+    ("agent-default", McpToolProfile::AgentDefault),
+    ("full", McpToolProfile::Full),
+    ("benchmark", McpToolProfile::Benchmark),
+    ("context-bench", McpToolProfile::ContextBench),
+];
+
+impl McpToolProfile {
+    /// The tools this profile allows, or `None` for the unfiltered surface.
+    pub(crate) fn allowed_tool_names(self) -> Option<&'static [&'static str]> {
+        match self {
+            Self::AgentDefault => Some(kin_mcp::agent_default_tool_names()),
+            Self::Benchmark => Some(kin_mcp::benchmark_tool_names()),
+            Self::ContextBench => Some(kin_mcp::context_bench_tool_names()),
+            Self::Full => None,
+        }
+    }
+
+    pub(crate) fn token(self) -> &'static str {
+        TOOL_PROFILE_TOKENS
+            .iter()
+            .find(|(_, profile)| *profile == self)
+            .map(|(token, _)| *token)
+            .unwrap_or("agent-default")
+    }
+
+    /// How many tools this profile serves.
+    fn tool_count(self) -> usize {
+        match self.allowed_tool_names() {
+            Some(names) => names.len(),
+            None => kin_mcp::tool_definitions().tools.len(),
+        }
+    }
+}
+
+/// A resolved profile and how it was arrived at.
+///
+/// The source is carried rather than collapsed because an unconfigured server
+/// and a misconfigured one must not report the same thing: the first is the
+/// supported default, the second is a value nobody will otherwise notice was
+/// ignored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedToolProfile {
+    pub(crate) profile: McpToolProfile,
+    pub(crate) source: ToolProfileSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ToolProfileSource {
+    /// Nobody named a profile.
+    Default,
+    /// Named by `--tool-profile`.
+    Flag,
+    /// Named by `KIN_MCP_TOOL_PROFILE`.
+    Env,
+    /// A value was named and is not a profile. Carries what was asked for and
+    /// where it came from, so the notice can quote it back.
+    Unrecognized { origin: &'static str, value: String },
+}
+
+impl ResolvedToolProfile {
+    /// One line on stderr at startup naming the surface actually being served.
+    ///
+    /// MCP stdio reserves stdout for the protocol, so this is the only channel
+    /// available, and it is the whole point of the change: the previous default
+    /// was invisible.
+    pub(crate) fn startup_notice(&self) -> String {
+        let profile = self.profile;
+        let count = profile.tool_count();
+        let token = profile.token();
+        match &self.source {
+            ToolProfileSource::Unrecognized { origin, value } => format!(
+                "Kin MCP: {origin} requested tool profile '{value}', which is not a profile; \
+                 serving the default '{token}' profile ({count} tools). Accepted profiles: {}.",
+                accepted_tool_profiles()
+            ),
+            ToolProfileSource::Default => format!(
+                "Kin MCP: serving the default '{token}' tool profile ({count} tools). Set \
+                 KIN_MCP_TOOL_PROFILE=full (or --tool-profile full) for the complete {} tool \
+                 surface; accepted profiles: {}.",
+                McpToolProfile::Full.tool_count(),
+                accepted_tool_profiles()
+            ),
+            ToolProfileSource::Flag => {
+                format!("Kin MCP: serving the '{token}' tool profile ({count} tools) from --tool-profile.")
+            }
+            ToolProfileSource::Env => format!(
+                "Kin MCP: serving the '{token}' tool profile ({count} tools) from \
+                 KIN_MCP_TOOL_PROFILE."
+            ),
+        }
+    }
+}
+
+fn accepted_tool_profiles() -> String {
+    TOOL_PROFILE_TOKENS
+        .iter()
+        .map(|(token, _)| *token)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Resolve the tool surface from an explicit flag, then the environment, then
+/// the default.
+///
+/// A value nobody recognizes never silently becomes the full surface. That was
+/// the shape of the original defect in miniature: an unnamed profile meant
+/// "serve everything", so both an unconfigured server and a typo produced the
+/// heavy surface with no signal. Now both land on the curated default and say
+/// so.
+pub(crate) fn resolve_tool_profile(flag: Option<&str>, env: Option<&str>) -> ResolvedToolProfile {
+    for (origin, requested, source) in [
+        ("--tool-profile", flag, ToolProfileSource::Flag),
+        ("KIN_MCP_TOOL_PROFILE", env, ToolProfileSource::Env),
+    ] {
+        let Some(requested) = requested.map(str::trim).filter(|value| !value.is_empty()) else {
+            continue;
+        };
+        let lowered = requested.to_ascii_lowercase();
+        return match TOOL_PROFILE_TOKENS
+            .iter()
+            .find(|(token, _)| *token == lowered)
+        {
+            Some((_, profile)) => ResolvedToolProfile {
+                profile: *profile,
+                source,
+            },
+            None => ResolvedToolProfile {
+                profile: McpToolProfile::AgentDefault,
+                source: ToolProfileSource::Unrecognized {
+                    origin,
+                    value: requested.to_string(),
+                },
+            },
+        };
+    }
+    ResolvedToolProfile {
+        profile: McpToolProfile::AgentDefault,
+        source: ToolProfileSource::Default,
+    }
 }
 
 /// Whether registry mode should resolve a startup repository.
@@ -437,7 +604,8 @@ mod tests {
     use super::{
         bind_daemon_for_repo_dir, bind_first_kin_repo_against, build_mcp_start_config,
         registry_should_resolve, registry_startup_choice, resolve_repo_override,
-        session_authority_notice, RegistryStartupChoice,
+        resolve_tool_profile, session_authority_notice, McpToolProfile, RegistryStartupChoice,
+        ToolProfileSource,
     };
     use kin_core::registry::{KinRegistry, RegisteredRepo};
     use kin_core::test_env::EnvVarGuard;
@@ -465,6 +633,140 @@ mod tests {
         let message = session_authority_notice();
         assert!(message.contains("daemon-centered"));
         assert!(message.contains("disabled"));
+    }
+
+    /// FIR-2025(a), both sides. An unconfigured server serves the curated belt
+    /// and the whole surface is reachable only by asking for it.
+    ///
+    /// The counts are asserted against the profile lists themselves rather than
+    /// against literals, so this stays true as tools are added; what it pins is
+    /// the relationship, which is the thing that regressed: the default must be
+    /// the small surface and `full` must be strictly larger.
+    #[test]
+    fn an_unconfigured_server_serves_the_curated_belt_and_full_is_the_opt_in() {
+        let unconfigured = resolve_tool_profile(None, None);
+        assert_eq!(unconfigured.profile, McpToolProfile::AgentDefault);
+        assert_eq!(unconfigured.source, ToolProfileSource::Default);
+        let served = unconfigured
+            .profile
+            .allowed_tool_names()
+            .expect("the default profile must filter the surface");
+        assert_eq!(served.len(), kin_mcp::agent_default_tool_names().len());
+
+        let opted_in = resolve_tool_profile(None, Some("full"));
+        assert_eq!(opted_in.profile, McpToolProfile::Full);
+        assert_eq!(
+            opted_in.profile.allowed_tool_names(),
+            None,
+            "the full surface must apply no allowlist at all"
+        );
+        assert!(
+            kin_mcp::tool_definitions().tools.len() > served.len(),
+            "the opt-in surface must be strictly larger than the default, or the default \
+             is not saving anyone anything"
+        );
+    }
+
+    /// FIR-2025(b). "What breaks if I change this" is the product's flagship
+    /// question, and the tool whose name says exactly that must be in the
+    /// profile every agent receives.
+    #[test]
+    fn the_default_profile_carries_impact_analysis() {
+        let served = resolve_tool_profile(None, None)
+            .profile
+            .allowed_tool_names()
+            .expect("the default profile must filter the surface");
+        assert!(
+            served.contains(&"impact_analysis"),
+            "impact_analysis must be in the profile an unconfigured agent gets: {served:?}"
+        );
+        // The tool has to exist to be servable; a profile naming a tool the
+        // crate does not define would filter it away silently.
+        let definitions = kin_mcp::tool_definitions();
+        let defined: std::collections::HashSet<&str> = definitions
+            .tools
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect();
+        for name in served {
+            assert!(
+                defined.contains(name),
+                "profile names undefined tool {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_flag_outranks_the_environment() {
+        let resolved = resolve_tool_profile(Some("full"), Some("agent-default"));
+        assert_eq!(resolved.profile, McpToolProfile::Full);
+        assert_eq!(resolved.source, ToolProfileSource::Flag);
+    }
+
+    #[test]
+    fn every_named_profile_resolves_to_its_own_surface() {
+        for (token, expected) in [
+            ("agent-default", McpToolProfile::AgentDefault),
+            ("benchmark", McpToolProfile::Benchmark),
+            ("context-bench", McpToolProfile::ContextBench),
+            ("full", McpToolProfile::Full),
+        ] {
+            let resolved = resolve_tool_profile(None, Some(token));
+            assert_eq!(resolved.profile, expected, "for token {token}");
+            assert_eq!(resolved.source, ToolProfileSource::Env);
+            assert_eq!(resolved.profile.token(), token);
+        }
+        // Case and surrounding whitespace are a client config's business, not a
+        // reason to serve a different surface than the one named.
+        assert_eq!(
+            resolve_tool_profile(None, Some("  Full ")).profile,
+            McpToolProfile::Full
+        );
+        // An empty value is nobody naming anything, not a request.
+        assert_eq!(
+            resolve_tool_profile(None, Some("   ")).source,
+            ToolProfileSource::Default
+        );
+    }
+
+    /// A typo must not silently become the heavy surface — that was the old
+    /// default's failure shape. It falls back to the curated belt and the
+    /// notice quotes back what was asked for.
+    #[test]
+    fn an_unrecognized_profile_falls_back_loudly_rather_than_serving_everything() {
+        let resolved = resolve_tool_profile(None, Some("agent_default"));
+        assert_eq!(resolved.profile, McpToolProfile::AgentDefault);
+        assert_eq!(
+            resolved.source,
+            ToolProfileSource::Unrecognized {
+                origin: "KIN_MCP_TOOL_PROFILE",
+                value: "agent_default".to_string(),
+            }
+        );
+        let notice = resolved.startup_notice();
+        assert!(notice.contains("agent_default"), "notice: {notice}");
+        assert!(notice.contains("not a profile"), "notice: {notice}");
+        assert!(
+            notice.contains("full"),
+            "notice must name the opt-in: {notice}"
+        );
+    }
+
+    /// The startup line is the only channel this change has — stdout belongs to
+    /// the protocol — so an unconfigured server must announce both what it is
+    /// serving and how to ask for the rest.
+    #[test]
+    fn the_default_startup_notice_names_the_surface_and_the_opt_in() {
+        let notice = resolve_tool_profile(None, None).startup_notice();
+        assert!(notice.contains("agent-default"), "notice: {notice}");
+        assert!(
+            notice.contains("KIN_MCP_TOOL_PROFILE=full"),
+            "notice: {notice}"
+        );
+        assert!(
+            notice.contains(&kin_mcp::agent_default_tool_names().len().to_string()),
+            "notice must state the served count: {notice}"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4050,6 +4050,94 @@ fn resolve_idle_timeout_env(
     Some(caller_override.unwrap_or_else(default_idle_timeout_secs))
 }
 
+/// The idle window a caller must carry to a daemon it did not start, in
+/// seconds, or `None` when there is nothing to carry.
+///
+/// Injecting an idle timeout only works on the path that spawns the daemon.
+/// Every attach path — a supervisor route, a live repo-local endpoint — hands
+/// back a process whose window was fixed by whoever started it, which on a
+/// developer machine is almost always an ordinary CLI command taking the short
+/// CLI default. An MCP session that attached there inherited 60 seconds and had
+/// the daemon expire underneath it between tool calls (FIR-1886). A caller with
+/// a stated need has to say so to the daemon it actually got.
+///
+/// `None` means the caller stated no need of its own and is content with
+/// whatever the daemon is running, which is the pre-existing behavior for every
+/// ordinary CLI command. A user's explicit `KIN_DAEMON_IDLE_TIMEOUT_SECS` is
+/// their decision about this host and is never overridden from here.
+fn idle_timeout_to_carry(caller_override: Option<&str>, user_env_is_set: bool) -> Option<u64> {
+    if user_env_is_set {
+        return None;
+    }
+    caller_override?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|secs| *secs > 0)
+}
+
+/// Tell a daemon this process did not start what idle window its session needs.
+///
+/// Best-effort by construction: an older daemon has no such route, and a
+/// refusal here must never turn a working attach into a failed one. What it
+/// must not do is fail silently, so a daemon that declines to grow its window
+/// says so on stderr rather than leaving the caller believing its stated need
+/// was honoured.
+async fn carry_idle_timeout_to_existing_daemon(
+    base_url: &str,
+    caller_override: Option<&'static str>,
+) {
+    let user_timeout_set = std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_some();
+    let Some(at_least_secs) = idle_timeout_to_carry(caller_override, user_timeout_set) else {
+        return;
+    };
+    let mut request = daemon_health_client()
+        .post(format!("{}/idle-timeout", base_url.trim_end_matches('/')))
+        .json(&serde_json::json!({
+            "at_least_secs": at_least_secs,
+            "client": "kin mcp",
+        }));
+    if let Some(token) = resolve_daemon_auth_token() {
+        request = request.bearer_auth(token);
+    }
+    match request.send().await {
+        Ok(response) if response.status().is_success() => {
+            let effective = response
+                .json::<serde_json::Value>()
+                .await
+                .ok()
+                .and_then(|body| body.get("effective_secs")?.as_u64());
+            match effective {
+                Some(effective) if effective >= at_least_secs => {
+                    info!(
+                        requested_secs = at_least_secs,
+                        effective_secs = effective,
+                        "attached daemon idle window covers this session"
+                    );
+                }
+                Some(effective) => eprintln!(
+                    "Kin: this session needs the repo daemon to survive {at_least_secs}s idle, \
+                     but its window is {effective}s; it may exit mid-session. Set \
+                     KIN_DAEMON_IDLE_TIMEOUT_SECS={at_least_secs} and restart the daemon."
+                ),
+                None => eprintln!(
+                    "Kin: the repo daemon accepted a {at_least_secs}s idle window request but \
+                     reported no effective window; it may exit mid-session."
+                ),
+            }
+        }
+        Ok(response) => eprintln!(
+            "Kin: the repo daemon refused a {at_least_secs}s idle window request ({}); it may \
+             exit mid-session. Set KIN_DAEMON_IDLE_TIMEOUT_SECS={at_least_secs} and restart it.",
+            response.status()
+        ),
+        Err(error) => eprintln!(
+            "Kin: could not ask the repo daemon for a {at_least_secs}s idle window ({error}); it \
+             may exit mid-session."
+        ),
+    }
+}
+
 fn existing_daemon_ready_timeout_secs() -> u64 {
     std::env::var("KIN_DAEMON_EXISTING_READY_TIMEOUT_SECS")
         .ok()
@@ -6627,6 +6715,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
         .await
         .map_err(map_supervisor_auto_start_error)?;
     if let Some(base_url) = supervisor_route_for_repo(kin_root, &supervisor_url).await {
+        carry_idle_timeout_to_existing_daemon(&base_url, idle_timeout_override).await;
         return Ok(base_url);
     }
 
@@ -6635,6 +6724,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
             register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url)
                 .await
                 .map_err(AutoStartError::spawn)?;
+            carry_idle_timeout_to_existing_daemon(&base_url, idle_timeout_override).await;
             return Ok(base_url);
         }
         ExistingDaemon::Starting(message) | ExistingDaemon::LiveNotReady(message) => {
@@ -6647,6 +6737,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
         .await
         .map_err(AutoStartError::spawn)?;
     if let Some(base_url) = supervisor_route_for_repo(kin_root, &supervisor_url).await {
+        carry_idle_timeout_to_existing_daemon(&base_url, idle_timeout_override).await;
         return Ok(base_url);
     }
     match wait_for_existing_daemon(kin_root).await {
@@ -6654,6 +6745,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
             register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url)
                 .await
                 .map_err(AutoStartError::spawn)?;
+            carry_idle_timeout_to_existing_daemon(&base_url, idle_timeout_override).await;
             return Ok(base_url);
         }
         ExistingDaemon::Starting(message) | ExistingDaemon::LiveNotReady(message) => {
@@ -10543,5 +10635,47 @@ mod tests {
         // Regression guard: the MCP path must inject 1800s (30 min), not the
         // 60-second CLI default.
         assert_eq!(MCP_IDLE_TIMEOUT_SECS, "1800");
+    }
+
+    // ── idle-timeout carried to a daemon this process did not start ────────
+
+    /// FIR-1886, both sides. Injecting at spawn only helps the caller that
+    /// spawns, and an MCP session usually attaches to a daemon an ordinary CLI
+    /// command already started at the 60-second default. A caller with a stated
+    /// need must carry it; a caller with none must leave the daemon alone.
+    #[test]
+    fn an_mcp_session_carries_its_window_to_a_daemon_it_did_not_start() {
+        assert_eq!(
+            idle_timeout_to_carry(Some(MCP_IDLE_TIMEOUT_SECS), false),
+            Some(1800),
+            "an MCP attach must state its 1800s need to the daemon it got"
+        );
+        assert_eq!(
+            idle_timeout_to_carry(None, false),
+            None,
+            "an ordinary CLI attach states no need and must not touch the window"
+        );
+    }
+
+    /// A user who set `KIN_DAEMON_IDLE_TIMEOUT_SECS` decided this host's policy.
+    /// The attach path must respect that exactly as the spawn path does, or the
+    /// two would disagree about whose value wins.
+    #[test]
+    fn an_explicit_user_window_is_never_overridden_from_the_attach_path() {
+        assert_eq!(
+            idle_timeout_to_carry(Some(MCP_IDLE_TIMEOUT_SECS), true),
+            None
+        );
+        assert_eq!(idle_timeout_to_carry(None, true), None);
+    }
+
+    /// Nothing usable is carried rather than carried as a zero, which the
+    /// daemon would have to reject as "a floor of forever".
+    #[test]
+    fn an_unusable_window_value_is_not_carried_at_all() {
+        assert_eq!(idle_timeout_to_carry(Some("0"), false), None);
+        assert_eq!(idle_timeout_to_carry(Some(""), false), None);
+        assert_eq!(idle_timeout_to_carry(Some("later"), false), None);
+        assert_eq!(idle_timeout_to_carry(Some(" 900 "), false), Some(900));
     }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1600,6 +1600,12 @@ enum McpAction {
         /// any Kin repository (e.g. an umbrella workspace root).
         #[arg(long, value_name = "PATH")]
         repo: Option<PathBuf>,
+        /// Tool surface to serve: `agent-default` (the curated agent belt, and
+        /// the default), `full` (every tool, roughly 12k extra tokens of
+        /// schemas per session), `benchmark`, or `context-bench`. Overrides
+        /// KIN_MCP_TOOL_PROFILE.
+        #[arg(long = "tool-profile", value_name = "PROFILE")]
+        tool_profile: Option<String>,
     },
 }
 
@@ -2756,7 +2762,11 @@ fn main() -> Result<()> {
                     commands::blame::run(entity, reference).await
                 }
                 Command::Mcp { action } => match action {
-                    McpAction::Start { global, repo } => commands::mcp::start(global, repo).await,
+                    McpAction::Start {
+                        global,
+                        repo,
+                        tool_profile,
+                    } => commands::mcp::start(global, repo, tool_profile).await,
                 },
                 Command::Auth { action } => match action {
                     AuthAction::Login {

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -275,7 +275,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_ALLOW_PARENT_STORE", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "allow discovering a store in a parent directory" },
     EnvVarSpec { name: "KIN_BINARY_PATH", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "override the kin binary path for bench dispatch" },
     EnvVarSpec { name: "KIN_BUILD_GRAPH_TIMEOUT_SECS", kind: Kind::Secs, default: "60", sensitivity: Sensitivity::Operational, summary: "timeout for building a historical ref-view graph" },
-    EnvVarSpec { name: "KIN_MCP_TOOL_PROFILE", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "MCP tool exposure profile" },
+    EnvVarSpec { name: "KIN_MCP_TOOL_PROFILE", kind: Kind::Str, default: "agent-default", sensitivity: Sensitivity::Operational, summary: "MCP tool surface: agent-default (curated, the default), full (every tool), benchmark, context-bench" },
     EnvVarSpec { name: "KIN_MCP_REPO", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "bind `kin mcp start` to this repository instead of the launch directory" },
     EnvVarSpec { name: "KIN_MCP_CACHE_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "cache directory override for the npm MCP wrapper's managed Kin binary" },
     EnvVarSpec { name: "KIN_MCP_KIN_BINARY", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "explicit native Kin binary used by the @kinlab/kin-mcp wrapper" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1110,6 +1110,7 @@ fn auth_error(status: StatusCode, message: &str) -> Response {
 fn api_routes() -> Router<Arc<DaemonState>> {
     Router::new()
         .route("/health", get(health))
+        .route("/idle-timeout", get(idle_timeout).post(raise_idle_timeout))
         .route("/shutdown", post(request_daemon_shutdown))
         .route("/readiness", get(readiness))
         .route("/ready", get(readiness))
@@ -2033,6 +2034,78 @@ where
     Err(kin_mcp::McpError::Other(
         "graph authority changed repeatedly during bulk_check_references; retry".to_string(),
     ))
+}
+
+/// What an attached client asks this daemon to hold its idle window open for.
+#[derive(Debug, Deserialize)]
+struct RaiseIdleTimeoutRequest {
+    /// Seconds this client needs the daemon to survive without traffic.
+    at_least_secs: u64,
+    /// Who is asking, for the log line. Free-form and untrusted; it only ever
+    /// reaches a log field.
+    #[serde(default)]
+    client: Option<String>,
+}
+
+/// Report the idle window this daemon is running with.
+async fn idle_timeout(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    let effective_secs = state.idle_timeout().map_or(0, |window| window.as_secs());
+    Json(json!({
+        "effective_secs": effective_secs,
+        "idles_out": effective_secs > 0,
+        "max_attached_secs": crate::state::MAX_ATTACHED_IDLE_TIMEOUT_SECS,
+    }))
+}
+
+/// Grow this daemon's idle window to cover a client whose session outlasts it.
+///
+/// The window is fixed by whichever process spawns the daemon, and that is
+/// usually not the process that ends up depending on it: an ordinary CLI
+/// command spawns with the short CLI default, and an MCP agent session that
+/// attaches afterwards used to inherit it and be cut off mid-session. Stating
+/// the need here is how a client carries its own lifetime to the daemon it
+/// attached to instead of hoping it spawned the thing.
+///
+/// Growth only. This cannot shorten another client's window and cannot switch
+/// idle shutdown off; see [`crate::state::resolve_idle_timeout_floor`].
+async fn raise_idle_timeout(
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<RaiseIdleTimeoutRequest>,
+) -> Response {
+    if request.at_least_secs == 0 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "at_least_secs must be positive; a floor of forever is not a floor",
+            })),
+        )
+            .into_response();
+    }
+    let outcome = state.raise_idle_timeout(Duration::from_secs(request.at_least_secs));
+    let client = request.client.as_deref().unwrap_or("unnamed client");
+    let effective_secs = outcome.effective_secs();
+    match outcome.raised_from {
+        Some(previous) => info!(
+            client,
+            requested_secs = request.at_least_secs,
+            previous_secs = previous.as_secs(),
+            effective_secs,
+            "raised the daemon idle window for an attached client"
+        ),
+        None => tracing::debug!(
+            client,
+            requested_secs = request.at_least_secs,
+            effective_secs,
+            "idle window already covers an attached client's request"
+        ),
+    }
+    Json(json!({
+        "effective_secs": effective_secs,
+        "raised": outcome.raised(),
+        "previous_secs": outcome.raised_from.map(|window| window.as_secs()),
+        "idles_out": outcome.effective.is_some(),
+    }))
+    .into_response()
 }
 
 async fn health(
@@ -10449,6 +10522,79 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
+
+    /// The HTTP contract an attached client uses to state its idle need
+    /// (FIR-1886), driven through the real router.
+    ///
+    /// Both sides: a client whose session outlasts the daemon's window grows
+    /// it, and a request that is not a floor is refused rather than silently
+    /// interpreted as "live forever".
+    #[tokio::test]
+    async fn the_idle_timeout_route_grows_the_window_and_refuses_a_zero_floor() {
+        async fn post_floor(
+            app: Router,
+            body: serde_json::Value,
+        ) -> (StatusCode, serde_json::Value) {
+            let response = tower::ServiceExt::oneshot(
+                app,
+                Request::post("/idle-timeout")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+            let status = response.status();
+            let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+                .await
+                .unwrap();
+            (status, serde_json::from_slice(&bytes).unwrap())
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        state.install_idle_timeout(Some(Duration::from_secs(60)));
+        let app = api_routes().with_state(Arc::clone(&state));
+
+        let (status, body) = post_floor(
+            app.clone(),
+            json!({"at_least_secs": 1800, "client": "kin mcp"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["effective_secs"], 1800);
+        assert_eq!(body["raised"], true);
+        assert_eq!(body["previous_secs"], 60);
+        assert_eq!(state.idle_timeout(), Some(Duration::from_secs(1800)));
+
+        // Repeating it is a no-op, not a second raise.
+        let (status, body) = post_floor(app.clone(), json!({"at_least_secs": 1800})).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["raised"], false);
+        assert_eq!(body["effective_secs"], 1800);
+
+        // A zero floor is refused and leaves the window untouched, rather than
+        // being read as "this daemon should never exit".
+        let (status, _) = post_floor(app.clone(), json!({"at_least_secs": 0})).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(state.idle_timeout(), Some(Duration::from_secs(1800)));
+
+        // And reading it back reports what is in force.
+        let response = tower::ServiceExt::oneshot(
+            app,
+            Request::get("/idle-timeout").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["effective_secs"], 1800);
+        assert_eq!(body["idles_out"], true);
+    }
 
     #[test]
     fn bounded_archive_writer_rejects_before_crossing_limit() {

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -850,7 +850,6 @@ async fn run_idle_monitor(
             }
         }
     };
-    let check_interval = idle_check_interval(idle_timeout);
     // Start the idle window from when monitoring begins, not from process
     // construction. `last_activity_ms` is seeded to 0, so without this the
     // idle clock counts from `started_at` — which includes snapshot load and
@@ -863,6 +862,29 @@ async fn run_idle_monitor(
     );
 
     loop {
+        // Re-read the window every tick rather than closing over the startup
+        // value. An attached client whose session outlasts the window this
+        // daemon was spawned with can raise it (see
+        // `DaemonState::raise_idle_timeout`), and a monitor holding the old
+        // value would shut down underneath the client that just said so.
+        let Some(idle_timeout) = state.idle_timeout() else {
+            // Only reachable if the window were switched off mid-run, which
+            // raising cannot do. Treat it as "never idles out" rather than as
+            // "idle out now".
+            tokio::select! {
+                _ = tokio::time::sleep(CONTROL_PLANE_CHECK_INTERVAL) => {}
+                _ = cancel_rx.changed() => return,
+            }
+            if *cancel_rx.borrow() {
+                return;
+            }
+            if control_plane_demands_shutdown(&state, bound_port, *cancel_rx.borrow()) {
+                let _ = cancel_tx.send(true);
+                return;
+            }
+            continue;
+        };
+        let check_interval = idle_check_interval(idle_timeout);
         tokio::select! {
             _ = tokio::time::sleep(check_interval) => {}
             _ = cancel_rx.changed() => return,
@@ -875,6 +897,9 @@ async fn run_idle_monitor(
             let _ = cancel_tx.send(true);
             return;
         }
+        // Re-read once more before deciding: a raise that landed during the
+        // sleep above must be honoured by this tick, not the next one.
+        let idle_timeout = state.idle_timeout().unwrap_or(idle_timeout);
         let control_plane = classify_control_plane(&state);
         if ready_for_idle_shutdown(&state, idle_timeout, control_plane) {
             if state.is_dirty() {
@@ -1096,6 +1121,10 @@ pub async fn run_with_authority(
 
     info!(port = bound_port, "starting kin daemon");
 
+    // Publish the startup window into shared state before the monitor reads
+    // it, so an attached client can see and grow the window this daemon is
+    // actually running with rather than the one its spawner happened to choose.
+    state.install_idle_timeout(config.idle_timeout);
     let idle_state = Arc::clone(&state);
     let idle_timeout = config.idle_timeout;
     let idle_cancel_tx = cancel_tx.clone();
@@ -2803,6 +2832,136 @@ mod tests {
             super::ready_for_idle_shutdown(&state, expired, ControlPlane::Ours),
             "a genuinely idle initialized daemon must still idle out"
         );
+    }
+
+    /// FIR-1886 at the daemon: an attached client whose session outlasts the
+    /// window this daemon was spawned with grows it, and the grown window is
+    /// what the shutdown decision then reads.
+    ///
+    /// The two-sided part is the second half. Growing the window must not stop
+    /// the daemon idling out; it must only move when.
+    #[tokio::test]
+    async fn a_raised_idle_window_is_what_the_shutdown_decision_reads() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = DaemonState::open(initialized.layout).unwrap();
+        state.is_initialized.store(true, Ordering::Relaxed);
+
+        // Spawned the way a CLI autostart spawns one.
+        state.install_idle_timeout(Some(Duration::from_secs(60)));
+        assert_eq!(state.idle_timeout(), Some(Duration::from_secs(60)));
+
+        let raise = state.raise_idle_timeout(Duration::from_secs(1800));
+        assert_eq!(raise.effective, Some(Duration::from_secs(1800)));
+        assert_eq!(raise.raised_from, Some(Duration::from_secs(60)));
+        assert_eq!(
+            state.idle_timeout(),
+            Some(Duration::from_secs(1800)),
+            "the monitor reads the window through this accessor, so the raise must land here"
+        );
+
+        // The daemon is idle by every other measure, and the grown window is
+        // the only thing holding it open.
+        let window = state.idle_timeout().expect("a window is installed");
+        assert!(
+            !super::ready_for_idle_shutdown(&state, window, ControlPlane::Ours),
+            "a session that just stated a 1800s need must not be cut off immediately"
+        );
+        assert!(
+            super::ready_for_idle_shutdown(&state, Duration::ZERO, ControlPlane::Ours),
+            "growing the window must move when the daemon idles out, never whether"
+        );
+
+        // A second client that fits inside the window changes nothing.
+        let redundant = state.raise_idle_timeout(Duration::from_secs(300));
+        assert!(!redundant.raised());
+        assert_eq!(state.idle_timeout(), Some(Duration::from_secs(1800)));
+    }
+
+    /// The monitor reads the live window, not the one it was handed at start.
+    ///
+    /// This is the half of FIR-1886 that the state round-trip above cannot
+    /// reach: a monitor that closed over its startup value would keep counting
+    /// against 60 seconds however loudly an attached session said 1800, and the
+    /// state accessor would look perfectly correct while the daemon still died.
+    #[tokio::test]
+    async fn the_idle_monitor_counts_against_the_live_window_not_its_startup_one() {
+        async fn open_idle_state() -> (tempfile::TempDir, Arc<DaemonState>) {
+            let repo = tempfile::tempdir().unwrap();
+            let initialized = kin_core::init(repo.path()).unwrap();
+            let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+            state.is_initialized.store(true, Ordering::Relaxed);
+            (repo, state)
+        }
+        let short = Duration::from_millis(200);
+
+        // Control. Without it the second half could pass because the monitor
+        // never reaches a shutdown decision at all, which is exactly the shape
+        // of guard that cannot fail.
+        let (_expiring_repo, expiring) = open_idle_state().await;
+        expiring.install_idle_timeout(Some(short));
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let monitor = tokio::spawn(super::run_idle_monitor(
+            Arc::clone(&expiring),
+            Some(short),
+            4219,
+            cancel_tx.clone(),
+            cancel_rx,
+        ));
+        tokio::time::timeout(Duration::from_secs(30), monitor)
+            .await
+            .expect("an idle daemon on a 200ms window must reach idle shutdown")
+            .expect("the idle monitor must not panic");
+        assert!(
+            *cancel_tx.borrow(),
+            "the control monitor must have requested shutdown"
+        );
+
+        // The same startup window, raised by an attached client before the
+        // monitor's first decision. Counting against the startup value would
+        // shut this daemon down inside the wait below.
+        let (_raised_repo, raised) = open_idle_state().await;
+        raised.install_idle_timeout(Some(short));
+        raised.raise_idle_timeout(Duration::from_secs(3600));
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let monitor = tokio::spawn(super::run_idle_monitor(
+            Arc::clone(&raised),
+            Some(short),
+            4219,
+            cancel_tx.clone(),
+            cancel_rx,
+        ));
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert!(
+            !*cancel_tx.borrow(),
+            "a session that raised the window to 3600s must not be shut down after 1.5s"
+        );
+        assert!(
+            !monitor.is_finished(),
+            "the monitor must still be watching, not have exited"
+        );
+        cancel_tx
+            .send(true)
+            .expect("the monitor still holds a receiver");
+        monitor.await.expect("the idle monitor must not panic");
+    }
+
+    /// A daemon configured never to idle out stays that way. Nothing an
+    /// attached client says may give it a finite lifetime it did not have.
+    #[tokio::test]
+    async fn a_daemon_that_never_idles_out_cannot_be_given_a_window() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = DaemonState::open(initialized.layout).unwrap();
+
+        state.install_idle_timeout(None);
+        assert_eq!(state.idle_timeout(), None);
+
+        let raise = state.raise_idle_timeout(Duration::from_secs(1800));
+        assert_eq!(raise.effective, None);
+        assert_eq!(raise.effective_secs(), 0);
+        assert!(!raise.raised());
+        assert_eq!(state.idle_timeout(), None);
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -924,6 +924,64 @@ impl VectorCheckpointAuthorityMatch {
     }
 }
 
+/// The longest idle window an attached client may ask this daemon to hold.
+///
+/// A client stating what it needs is not a client deciding this daemon should
+/// live forever: an agent process that dies without withdrawing would otherwise
+/// pin the graph in memory indefinitely. Twenty-four hours is far beyond any
+/// real interactive session and still expires.
+pub const MAX_ATTACHED_IDLE_TIMEOUT_SECS: u64 = 86_400;
+
+/// What a request to grow the idle window did to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IdleTimeoutRaise {
+    /// The window now in force. `None` means the daemon never idles out.
+    pub effective: Option<Duration>,
+    /// The window this replaced, or `None` when nothing changed.
+    pub raised_from: Option<Duration>,
+}
+
+impl IdleTimeoutRaise {
+    /// The window now in force in whole seconds, with 0 meaning "never idles
+    /// out" — the shape the HTTP surface and the daemon's own env var speak in.
+    pub fn effective_secs(&self) -> u64 {
+        self.effective.map_or(0, |window| window.as_secs())
+    }
+
+    pub fn raised(&self) -> bool {
+        self.raised_from.is_some()
+    }
+}
+
+/// Resolve a requested idle floor against the window currently in force,
+/// returning the new window when one is warranted and `None` when the current
+/// window already covers the request.
+///
+/// This is the whole decision behind FIR-1886. The idle window is fixed by
+/// whichever process spawns the daemon, and on a developer machine that is
+/// almost always an ordinary CLI command taking the short CLI default. A
+/// later client with a much longer session — an MCP agent loop that goes quiet
+/// between tool calls — used to inherit that short window silently and have the
+/// daemon expire underneath it mid-session.
+///
+/// Three cases, each deliberate:
+/// - a daemon that never idles out already outlasts every finite request, so it
+///   is never given a finite window here;
+/// - a request for "never" (zero) is refused rather than honoured, because a
+///   floor of forever is not a floor;
+/// - anything above [`MAX_ATTACHED_IDLE_TIMEOUT_SECS`] is clamped to it.
+pub fn resolve_idle_timeout_floor(
+    current: Option<Duration>,
+    requested: Duration,
+) -> Option<Duration> {
+    let current = current?;
+    if requested.is_zero() {
+        return None;
+    }
+    let requested = requested.min(Duration::from_secs(MAX_ATTACHED_IDLE_TIMEOUT_SECS));
+    (requested > current).then_some(requested)
+}
+
 /// Shared daemon state. All mutable state is behind RwLock for
 /// concurrent access from the reconciliation loop and API handlers.
 pub struct DaemonState {
@@ -1104,6 +1162,19 @@ pub struct DaemonState {
     /// Last externally visible daemon activity, measured as milliseconds since
     /// `started_at`. Used by opt-in idle shutdown for CLI-autostarted daemons.
     pub last_activity_ms: AtomicU64,
+    /// The live idle window in milliseconds, or 0 when this daemon never idles
+    /// out.
+    ///
+    /// Seeded from startup configuration and readable by attached clients whose
+    /// session outlives it. It is here rather than captured by the idle monitor
+    /// because the window has to be able to grow after the process started: the
+    /// spawner fixes it at spawn time, and whoever spawns first is frequently
+    /// not who ends up depending on it.
+    ///
+    /// Milliseconds, not the seconds the env var and HTTP surface speak in, so
+    /// a sub-second window cannot round down into the sentinel and turn "expire
+    /// quickly" into "never expire".
+    idle_timeout_ms: AtomicU64,
     /// Number of API requests currently being handled.
     pub active_requests: AtomicU64,
     /// Channel for LSP enrichment messages (incremental or sweep).
@@ -1960,6 +2031,7 @@ impl DaemonState {
             active_embed_passes: AtomicU32::new(0),
             background_embed_paused: AtomicBool::new(false),
             last_activity_ms: AtomicU64::new(0),
+            idle_timeout_ms: AtomicU64::new(0),
             active_requests: AtomicU64::new(0),
             lsp_enrichment_tx: None,
             cached_repo_id,
@@ -2161,6 +2233,7 @@ impl DaemonState {
             active_embed_passes: AtomicU32::new(0),
             background_embed_paused: AtomicBool::new(false),
             last_activity_ms: AtomicU64::new(0),
+            idle_timeout_ms: AtomicU64::new(0),
             active_requests: AtomicU64::new(0),
             lsp_enrichment_tx: None,
             cached_repo_id: repo_id.to_string(),
@@ -4698,6 +4771,54 @@ impl DaemonState {
         Duration::from_millis(now_ms.saturating_sub(last_ms))
     }
 
+    /// The live idle window, or `None` when this daemon never idles out.
+    pub fn idle_timeout(&self) -> Option<Duration> {
+        Self::window_from_millis(self.idle_timeout_ms.load(Ordering::SeqCst))
+    }
+
+    fn window_from_millis(millis: u64) -> Option<Duration> {
+        (millis > 0).then(|| Duration::from_millis(millis))
+    }
+
+    /// Install the startup idle window. Called once by the daemon entrypoint
+    /// before the idle monitor starts.
+    pub fn install_idle_timeout(&self, timeout: Option<Duration>) {
+        let millis = timeout.map_or(0, |timeout| {
+            timeout.as_millis().min(u128::from(u64::MAX)) as u64
+        });
+        self.idle_timeout_ms.store(millis, Ordering::SeqCst);
+    }
+
+    /// Grow the idle window to cover an attached client that needs longer than
+    /// the window this daemon was started with, and report what happened.
+    ///
+    /// Only ever grows. A client stating what it needs must not be able to
+    /// shorten the window another client is relying on, and must not be able to
+    /// switch off idle shutdown for a daemon that was configured to have one.
+    pub fn raise_idle_timeout(&self, at_least: Duration) -> IdleTimeoutRaise {
+        loop {
+            let current_ms = self.idle_timeout_ms.load(Ordering::SeqCst);
+            let current = Self::window_from_millis(current_ms);
+            let Some(raised) = resolve_idle_timeout_floor(current, at_least) else {
+                return IdleTimeoutRaise {
+                    effective: current,
+                    raised_from: None,
+                };
+            };
+            let raised_ms = raised.as_millis().min(u128::from(u64::MAX)) as u64;
+            if self
+                .idle_timeout_ms
+                .compare_exchange(current_ms, raised_ms, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return IdleTimeoutRaise {
+                    effective: Some(raised),
+                    raised_from: current,
+                };
+            }
+        }
+    }
+
     /// Whether an agent/user session is currently active. The daemon's own
     /// reconcile-loop session is intentionally ignored.
     pub fn has_external_sessions(&self) -> bool {
@@ -4777,6 +4898,75 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         sync_directory_metadata(directory.path())
             .expect("directory metadata sync must not reject a valid host directory");
+    }
+
+    /// FIR-1886, both sides at the resolution layer. A client whose session
+    /// outlasts the window this daemon was spawned with grows it; a client that
+    /// already fits inside it changes nothing.
+    #[test]
+    fn an_idle_floor_grows_a_short_window_and_leaves_a_long_one_alone() {
+        let secs = Duration::from_secs;
+        // The exact case: a CLI-spawned daemon at 60s, an MCP session at 1800s.
+        assert_eq!(
+            resolve_idle_timeout_floor(Some(secs(60)), secs(1800)),
+            Some(secs(1800))
+        );
+        // The same session attaching to a daemon that already outlasts it.
+        assert_eq!(
+            resolve_idle_timeout_floor(Some(secs(3600)), secs(1800)),
+            None
+        );
+        assert_eq!(
+            resolve_idle_timeout_floor(Some(secs(1800)), secs(1800)),
+            None
+        );
+    }
+
+    /// Growth only, in both directions it could go wrong: a client must not be
+    /// able to shorten a window another client relies on, and must not be able
+    /// to switch idle shutdown off for a daemon configured to have one.
+    #[test]
+    fn an_idle_floor_can_neither_shorten_a_window_nor_abolish_one() {
+        let secs = Duration::from_secs;
+        assert_eq!(
+            resolve_idle_timeout_floor(Some(secs(1800)), secs(60)),
+            None,
+            "a shorter request must not shorten the window"
+        );
+        assert_eq!(
+            resolve_idle_timeout_floor(Some(secs(60)), Duration::ZERO),
+            None,
+            "a request for 'never' is not a floor and must be refused"
+        );
+        assert_eq!(
+            resolve_idle_timeout_floor(None, secs(1800)),
+            None,
+            "a daemon that never idles out already outlasts every finite request"
+        );
+    }
+
+    /// An attached client cannot pin the graph in memory indefinitely by asking
+    /// for an absurd window; the request is clamped and still expires.
+    #[test]
+    fn an_idle_floor_is_clamped_to_the_attached_maximum() {
+        let max = Duration::from_secs(MAX_ATTACHED_IDLE_TIMEOUT_SECS);
+        assert_eq!(
+            resolve_idle_timeout_floor(Some(Duration::from_secs(60)), Duration::MAX),
+            Some(max)
+        );
+        assert_eq!(resolve_idle_timeout_floor(Some(max), Duration::MAX), None);
+    }
+
+    /// A sub-second window is a real window, not "never idles out". Storing
+    /// whole seconds rounded one into the sentinel, which turned "expire
+    /// quickly" into "expire never" and left the monitor circling forever.
+    #[test]
+    fn a_sub_second_window_survives_the_round_trip_through_state() {
+        assert_eq!(
+            DaemonState::window_from_millis(200),
+            Some(Duration::from_millis(200))
+        );
+        assert_eq!(DaemonState::window_from_millis(0), None);
     }
 
     #[cfg(feature = "embeddings")]

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -39,7 +39,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_MCP_KIN_BINARY` | path | *(unset)* | operational | explicit native Kin binary used by the @kinlab/kin-mcp wrapper |
 | `KIN_MCP_RELEASE_BASE_URL` | url | GitHub Releases | operational | release mirror base URL used by the @kinlab/kin-mcp wrapper |
 | `KIN_MCP_REPO` | path | *(unset)* | operational | bind `kin mcp start` to this repository instead of the launch directory |
-| `KIN_MCP_TOOL_PROFILE` | string | *(unset)* | operational | MCP tool exposure profile |
+| `KIN_MCP_TOOL_PROFILE` | string | agent-default | operational | MCP tool surface: agent-default (curated, the default), full (every tool), benchmark, context-bench |
 | `KIN_NO_PROVISION` | bool | false | operational | forbid network provisioning by the @kinlab/kin launcher |
 | `KIN_NO_SETUP` | bool | false | operational | skip the installer's post-install setup wizard when set truthy |
 | `KIN_REGISTRY_REPAIR` | bool | false | operational | allow the POSIX installer to repair safe registry ownership modes |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -20,8 +20,7 @@ the **AI agents** intent. It writes Kin's MCP server entry into every detected c
 adds a Kin-first discovery reminder to your agent instruction files. `kin setup status`
 then verifies each client config.
 
-The wizard writes this entry (and `KIN_MCP_TOOL_PROFILE=agent-default` is what selects the
-small curated surface below instead of the full internal one):
+The wizard writes this entry, stating the profile explicitly:
 
 ```json
 {
@@ -43,6 +42,27 @@ see the quickstart's advanced configuration for its exact JSON and repository-bo
 To wire a client up by hand, or to use the canonical npm wrapper (`@kinlab/kin`, which
 can run `kin mcp start` with the same `agent-default` profile), see
 [Advanced configuration](quickstart.md#9-advanced-configuration) in the quickstart.
+
+### Tool profiles
+
+`kin mcp start` serves the curated `agent-default` profile whether or not anyone
+configures it, and prints the profile and its tool count on stderr at startup. A
+hand-written `.mcp.json`, a container entrypoint, or a CI harness therefore gets the same
+small surface the wizard writes, instead of every tool the server defines and roughly
+twelve thousand extra tokens of schemas in every session.
+
+Select a different surface with `KIN_MCP_TOOL_PROFILE`, or with `--tool-profile` on the
+command line (the flag wins):
+
+| profile | surface |
+| -- | -- |
+| `agent-default` | the curated agent belt — **the default** |
+| `full` | every tool this reference documents |
+| `benchmark` | the retrieval belt the benchmark arm drives |
+| `context-bench` | read-only graph-native retrieval, no write-side session or transaction tools |
+
+A value that is not one of these is not silently treated as "serve everything": the server
+falls back to `agent-default` and says on stderr what it was asked for and what it served.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -361,9 +361,11 @@ The wizard writes this entry to each client:
 }
 ```
 
-`KIN_MCP_TOOL_PROFILE=agent-default` exposes the small curated tool surface instead of the
-full internal one. (The wizard writes an absolute path to the installed `kin` binary as
-the `command`, so the entry works in agent processes that do not inherit your `PATH`.)
+`KIN_MCP_TOOL_PROFILE=agent-default` names the small curated tool surface. That is also
+what an unconfigured `kin mcp start` serves, so a hand-wired entry gets the same surface;
+set `full` (or pass `--tool-profile full`) when you want every tool. (The wizard writes an
+absolute path to the installed `kin` binary as the `command`, so the entry works in agent
+processes that do not inherit your `PATH`.)
 
 > Vector-backed MCP retrieval (`semantic_locate`) and the stateful session / transaction /
 > work / review tools operate against the repo's running Kin daemon. Daemon auto-start is


### PR DESCRIPTION
Three defects that all land on an MCP-spawned server and nowhere else. The diffs are disjoint (tool profile / daemon idle window / capability probe) and each is independently gated.

## FIR-2025 — the MCP tool profile inverted its default

`kin setup` writes `KIN_MCP_TOOL_PROFILE=agent-default` into every client config it touches, so the curated surface was reachable only by going through the wizard. Anything wired by hand — a `.mcp.json`, a container entrypoint, a CI harness, another tool spawning the server — got every tool the crate defines, with nothing saying a lighter profile existed.

The curated belt is now what an unconfigured server serves; the whole surface is an explicit `full` opt-in via the env var or a new `--tool-profile` flag; and the server prints which surface it is serving on stderr at startup. An unrecognized value falls back to the curated belt and quotes back what it was asked for, rather than becoming the heavy surface the way an unset value used to. `kin doctor` now reads an unset profile as healthy (the server defaults it); an explicitly different profile is still reported.

Measured over real stdio JSON-RPC against this build, no repository bound and no daemon:

| how the server is started | tools | `tools/list` payload |
| -- | -- | -- |
| `kin mcp start`, no env | **19** | 35,088 B (~8.8k tokens) |
| `KIN_MCP_TOOL_PROFILE=full` | 64 | 79,617 B (~19.9k tokens) |
| `--tool-profile full` | 64 | 79,617 B |
| `KIN_MCP_TOOL_PROFILE=agent_default` (typo) | 19, with the fallback named on stderr | 35,088 B |

The ticket says eighteen; it is nineteen because #647 added `impact_analysis`, which the served set is asserted to contain.

## FIR-1886 — MCP sessions inherited the CLI daemon's idle window

The idle window is fixed by whoever spawns the daemon, and that is usually not who ends up depending on it. Injecting 1800s only ever worked on the path that spawns: both existing-daemon early returns in `ensure_daemon_running_with_idle_timeout` (supervisor route, live repo-local endpoint) handed back a process already running on the short CLI default and dropped the override. An agent loop that goes quiet between tool calls then had the daemon expire underneath it.

The window now lives in `DaemonState` where the idle monitor re-reads it each tick, and an attached client states the lifetime it needs through `POST /idle-timeout`. Growth only: it cannot shorten a window another client relies on, cannot switch idle shutdown off, and is clamped to 24h so a client that dies without withdrawing cannot pin the graph in memory forever. Rebased on #664, which is about in-flight work rather than the idle session lifetime.

Storing the window in whole seconds rounded a sub-second window into the "never idles out" sentinel, so it is stored in milliseconds.

## FIR-2023 — capability detection invented 4 GB on a restricted PATH

`host_ram_gb()` ran `sysctl` as a subprocess, so it depended on the caller's `PATH`. `/usr/sbin` is absent from exactly the environments that spawn MCP servers, launchd agents, container entrypoints, and CI runners; command-not-found was swallowed by `.ok()` and `unwrap_or(4.0)` invented a plausible number. An eighteen-core, 128 GB machine was classified `Minimal` and told to run on bigger hardware.

Memory now comes from `sysctlbyname`, which the caller's environment cannot defeat. A probe that fails is no longer silent: it is reported as `capability_tier` / `hardware_detection_failed` carrying the probe's own reason, with remediation that does not presume the number was real, plus a one-shot warning for consumers that carry no degradation ledger.

Verified on the exact PATH from the report — `command -v sysctl` returns not-found there and the old subprocess exits 127, while the probe reports this host's real memory.

## Gates

- `cargo fmt --all --check` clean (it failed on real diffs before formatting, so the check is live rather than exiting through usage)
- `bin/kin-dev local-check kin` green
- `bin/kin-dev local-test kin` green: 5034 tests run, 5034 passed, 10 skipped

Each fix's tests were falsified by reverting the fix under them: restoring the `full` default fails the three profile tests; making the idle monitor close over its startup value fails the live-window test; the capability probe test panics on an undetected host.

Closes FIR-2025
Closes FIR-1886
Closes FIR-2023

The third FIR-2025 sub-item (trace_data_flow direction enum) moves to its own ticket with a corrected mechanism: the advertised schema enum rejects valid vocabulary client-side while the handler is already tolerant. Refs FIR-2067.