### PR TITLE
Hold one repository authority for a whole trace instead of one per step

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -862,7 +862,24 @@ fn resolve_source_entity(
 
 fn graph_source_record(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
-    graph: &kin_db::InMemoryGraph,
+    _graph: &kin_db::InMemoryGraph,
+    entity: &Entity,
+) -> Result<GraphSourceRecord> {
+    let authority = super::repository_authority::ActiveRepositoryAuthority::open(binding)?;
+    let workspace = authority.workspace()?;
+    graph_source_record_from(&authority, &workspace, entity)
+}
+
+/// Build an entity's source record through an authority the caller already
+/// holds open.
+///
+/// Opening authority verifies every stored body once, linear in store size, so
+/// a caller that needs records for many entities must pay that once for the set
+/// rather than once per entity. `graph_source_record` above is the single-record
+/// convenience wrapper; batch callers own the open and pass it here.
+pub(crate) fn graph_source_record_from(
+    authority: &super::repository_authority::ActiveRepositoryAuthority,
+    workspace: &kin_model::WorkspaceState,
     entity: &Entity,
 ) -> Result<GraphSourceRecord> {
     let file_origin = entity
@@ -873,7 +890,7 @@ fn graph_source_record(
         .span
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("entity '{}' has no source span", entity.name))?;
-    let (bytes, blob) = read_entity_file_bytes_with_digest(binding, graph, entity)?;
+    let (bytes, blob) = read_entity_file_bytes_with_digest_from(authority, workspace, entity)?;
     // Bind the span to the bytes it is about to cut, through the SAME rule the MCP
     // resolver uses.
     //
@@ -949,6 +966,24 @@ pub(crate) fn read_entity_file_bytes_with_digest(
     _graph: &impl GraphStore,
     entity: &Entity,
 ) -> Result<(Vec<u8>, kin_model::Hash256)> {
+    let authority = super::repository_authority::ActiveRepositoryAuthority::open(binding)?;
+    let workspace = authority.workspace()?;
+    read_entity_file_bytes_with_digest_from(&authority, &workspace, entity)
+}
+
+/// The same read against an authority and workspace the caller already holds.
+///
+/// Split from [`read_entity_file_bytes_with_digest`] so a caller reading many
+/// entities pays one authority open for the whole set. The workspace is passed
+/// alongside rather than re-derived per entity so every read in a set resolves
+/// against one coherent generation: re-deriving it per entity would let a
+/// publication landing mid-walk serve some entities from the tree that replaced
+/// the one the others came from.
+pub(crate) fn read_entity_file_bytes_with_digest_from(
+    authority: &super::repository_authority::ActiveRepositoryAuthority,
+    workspace: &kin_model::WorkspaceState,
+    entity: &Entity,
+) -> Result<(Vec<u8>, kin_model::Hash256)> {
     let file_id = entity
         .file_origin
         .as_ref()
@@ -959,8 +994,6 @@ pub(crate) fn read_entity_file_bytes_with_digest(
             file_id.0
         )
     })?;
-    let authority = super::repository_authority::ActiveRepositoryAuthority::open(binding)?;
-    let workspace = authority.workspace()?;
     let artifact = workspace.tree.artifact_at_path(&path).ok_or_else(|| {
         anyhow::anyhow!(
             "entity source '{}' is absent from repository-v6 workspace {} at generation {}",

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -19,14 +19,151 @@ use anyhow::{Context, Result};
 use kin_model::{Entity, EntityId, EntityStore, GraphNodeId, RelationKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::time::{Duration, Instant};
 
-use crate::commands::graph::{build_graph_source_response, GraphSourceRecord};
+use crate::commands::graph::{graph_source_record_from, GraphSourceRecord};
+use crate::commands::locate::{record_degradation, RetrievalDegradation};
+use crate::commands::repository_authority::ActiveRepositoryAuthority;
 
 const DEFAULT_DEPTH: usize = 3;
 const MAX_DEPTH: usize = 8;
 const DEFAULT_LIMIT_PER_STEP: usize = 5;
 const MAX_LIMIT_PER_STEP: usize = 25;
 const MAX_TOTAL_STEPS: usize = 200;
+
+/// Wall-clock ceiling for one trace walk.
+///
+/// Every bound above this one is structural — depth, per-step fan-out, total
+/// steps — and structural bounds say nothing about elapsed time. A walk of 200
+/// steps is small by every one of them while still running for minutes, because
+/// what each step costs depends on the store rather than on the shape of the
+/// chain. This is the only bound that holds when a step turns out to be
+/// expensive, so it is the one that keeps a trace answerable.
+const DEFAULT_TIME_BUDGET: Duration = Duration::from_secs(20);
+
+/// Relations examined before the walk stops regardless of the clock.
+///
+/// A time budget alone leaves the response time-dependent: the same query
+/// against the same store returns a different chain on a loaded machine than on
+/// an idle one. This bound is deterministic, so a pathological fan-in is cut at
+/// the same place every run and a trace stays reproducible.
+const DEFAULT_MAX_EDGES_SCANNED: usize = 250_000;
+
+/// Hard ceilings applied to one trace walk, independent of the request's own
+/// depth / fan-out parameters.
+///
+/// Those parameters bound the SHAPE of the answer and are the caller's to
+/// choose. These bound the WORK, and are not: a caller cannot ask for an
+/// unbounded walk, because the daemon serving it has other callers.
+#[derive(Debug, Clone, Copy)]
+pub struct TraceBudget {
+    pub time_budget: Duration,
+    pub max_edges_scanned: usize,
+}
+
+impl Default for TraceBudget {
+    fn default() -> Self {
+        Self {
+            time_budget: DEFAULT_TIME_BUDGET,
+            max_edges_scanned: DEFAULT_MAX_EDGES_SCANNED,
+        }
+    }
+}
+
+/// Why a walk stopped expanding.
+///
+/// `Exhausted` is the healthy end: the frontier ran out within every bound.
+/// The rest are refusals to keep working, and each one is reported to the
+/// caller as a degradation rather than silently shortening the chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraceStop {
+    Exhausted,
+    TimeBudget,
+    EdgeBudget,
+}
+
+/// Running cost of one walk, checked at each frontier node and each relation.
+struct TraceMeter {
+    budget: TraceBudget,
+    started: Instant,
+    edges_scanned: usize,
+}
+
+impl TraceMeter {
+    fn new(budget: TraceBudget) -> Self {
+        Self {
+            budget,
+            started: Instant::now(),
+            edges_scanned: 0,
+        }
+    }
+
+    /// Charge one examined relation and report whether the walk may continue.
+    fn charge_edge(&mut self) -> Option<TraceStop> {
+        self.edges_scanned = self.edges_scanned.saturating_add(1);
+        if self.edges_scanned >= self.budget.max_edges_scanned {
+            return Some(TraceStop::EdgeBudget);
+        }
+        self.exceeded_time()
+    }
+
+    fn exceeded_time(&self) -> Option<TraceStop> {
+        (self.started.elapsed() >= self.budget.time_budget).then_some(TraceStop::TimeBudget)
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+}
+
+/// Translate a stop reason into the caller-facing degradation record.
+///
+/// `Exhausted` produces nothing: a walk that finished inside every bound has
+/// nothing to disclose, which is what keeps an unaffected trace byte-identical
+/// to the one this bound was added to.
+fn record_trace_stop(
+    sink: &mut Vec<RetrievalDegradation>,
+    stop: TraceStop,
+    meter: &TraceMeter,
+    steps: usize,
+) {
+    let (reason, detail) = match stop {
+        TraceStop::Exhausted => return,
+        TraceStop::TimeBudget => (
+            "time_budget_exceeded",
+            format!(
+                "trace walk stopped after {:.1}s (budget {:.0}s) with {} steps and {} relations \
+                 examined; the chain below is the part that was reached",
+                meter.elapsed().as_secs_f64(),
+                meter.budget.time_budget.as_secs_f64(),
+                steps,
+                meter.edges_scanned,
+            ),
+        ),
+        TraceStop::EdgeBudget => (
+            "edge_budget_exceeded",
+            format!(
+                "trace walk examined {} relations (budget {}) in {:.1}s and stopped with {} \
+                 steps; the chain below is the part that was reached",
+                meter.edges_scanned,
+                meter.budget.max_edges_scanned,
+                meter.elapsed().as_secs_f64(),
+                steps,
+            ),
+        ),
+    };
+    record_degradation(
+        sink,
+        RetrievalDegradation {
+            component: "trace_walk".to_string(),
+            reason: reason.to_string(),
+            detail,
+            remediation: "narrow the trace with a smaller --depth or --limit-per-step, or start \
+                          from a more specific focal entity"
+                .to_string(),
+        },
+    );
+}
 
 /// Direction of traversal from the focal entity.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -135,6 +272,12 @@ pub struct TraceDataFlowResponse {
     /// True when the traversal was cut off because per-step or total caps
     /// were hit. Lets callers detect when they need to widen the limit.
     pub truncated: bool,
+    /// Every work bound that cut this walk short, in the same machine-readable
+    /// shape `semantic_locate` reports retrieval degradation in. Empty — and
+    /// omitted from the payload — for a walk that finished inside every bound,
+    /// so a trace unaffected by these ceilings is unchanged by them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degradations: Vec<RetrievalDegradation>,
 }
 
 /// CLI entry: `kin trace-data-flow --focal <e> [--depth N] [--direction D]
@@ -191,6 +334,20 @@ pub fn build_trace_data_flow_response(
     graph: &kin_db::InMemoryGraph,
     request: &TraceDataFlowRequest,
 ) -> Result<TraceDataFlowResponse> {
+    build_trace_data_flow_response_within(binding, graph, request, TraceBudget::default())
+}
+
+/// The same walk under caller-supplied work ceilings.
+///
+/// Split out so the bounds are testable at a scale a test can actually reach:
+/// the shipped budget is measured in seconds and hundreds of thousands of
+/// edges, and a test that had to exhaust it would be as slow as the defect.
+pub fn build_trace_data_flow_response_within(
+    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    graph: &kin_db::InMemoryGraph,
+    request: &TraceDataFlowRequest,
+    budget: TraceBudget,
+) -> Result<TraceDataFlowResponse> {
     let trimmed = request.focal.trim();
     if trimmed.is_empty() {
         anyhow::bail!("trace_data_flow requires a non-empty focal");
@@ -207,9 +364,46 @@ pub fn build_trace_data_flow_response(
         None => anyhow::bail!("no entity found matching '{}'", trimmed),
     };
 
+    let mut meter = TraceMeter::new(budget);
+    let mut degradations: Vec<RetrievalDegradation> = Vec::new();
+
+    // One authority open for the whole chain, not one per step.
+    //
+    // Opening authority verifies every stored body, linear in store size. The
+    // per-step body projection used to open its own, so a chain of N steps paid
+    // N+1 full-store verifications and a structurally tiny trace ran for
+    // minutes on a large store (FIR-1937, FIR-1909). Holding one open also
+    // makes the chain coherent: every step is now read from the same
+    // generation, where per-step opens could straddle a publication.
+    //
+    // A store with no readable authority still gets its chain. Bodies were
+    // always optional per step, and hoisting the open must not turn a payload
+    // that used to arrive body-less into a failed call — so the failure is
+    // disclosed and the walk continues on identity alone.
+    let projection = match open_body_projection(binding) {
+        Ok(projection) => Some(projection),
+        Err(error) => {
+            record_degradation(
+                &mut degradations,
+                RetrievalDegradation {
+                    component: "entity_bodies".to_string(),
+                    reason: "authority_unavailable".to_string(),
+                    detail: format!(
+                        "repository authority could not be opened, so no step carries an inlined \
+                         body: {error:#}"
+                    ),
+                    remediation: "run 'kin status' to check the repository store, and 'kin init' \
+                                  if it has not been initialized"
+                        .to_string(),
+                },
+            );
+            None
+        }
+    };
+
     // Try to load the focal source record. Failures (missing span, OOB blob)
     // degrade gracefully to the identity-only payload — the chain still works.
-    let focal_record = source_record_or_none(binding, graph, &focal_entity);
+    let focal_record = source_record_or_none(projection.as_ref(), &focal_entity);
 
     let reference_kinds = [
         RelationKind::Calls,
@@ -222,17 +416,27 @@ pub fn build_trace_data_flow_response(
     let mut visited: HashSet<EntityId> = HashSet::new();
     visited.insert(focal_entity.id);
     let mut truncated = false;
+    let mut stop = TraceStop::Exhausted;
 
     // Frontier: (parent_step, parent_entity, parent_depth).
     let mut frontier: Vec<(usize, EntityId, usize)> = vec![(0, focal_entity.id, 0)];
     let mut next_frontier: Vec<(usize, EntityId, usize)>;
 
-    while !frontier.is_empty() {
+    'walk: while !frontier.is_empty() {
         next_frontier = Vec::new();
 
         for (parent_step, parent_id, parent_depth) in frontier.drain(..) {
             if parent_depth >= depth {
                 continue;
+            }
+
+            // Checked before the relation read rather than only inside the
+            // relation loop: reading one node's relations is itself unbounded
+            // work on a high-fan-in entity, so a walk that has already spent
+            // its budget must not start another one.
+            if let Some(reason) = meter.exceeded_time() {
+                stop = reason;
+                break 'walk;
             }
 
             let relations = graph
@@ -249,6 +453,10 @@ pub fn build_trace_data_flow_response(
             let mut callee_count = 0usize;
             let mut caller_count = 0usize;
             for rel in &relations {
+                if let Some(reason) = meter.charge_edge() {
+                    stop = reason;
+                    break 'walk;
+                }
                 if !allowed.contains(&rel.kind) {
                     continue;
                 }
@@ -311,7 +519,7 @@ pub fn build_trace_data_flow_response(
                     Some(entity) => entity,
                     None => continue,
                 };
-                let next_record = source_record_or_none(binding, graph, &next_entity);
+                let next_record = source_record_or_none(projection.as_ref(), &next_entity);
                 let next_depth = parent_depth + 1;
                 let step_index = chain.len() + 1;
 
@@ -347,6 +555,14 @@ pub fn build_trace_data_flow_response(
         frontier = next_frontier;
     }
 
+    // A walk stopped by a work ceiling is truncated in exactly the sense the
+    // existing flag already means, so it sets that flag too; the degradation
+    // adds which ceiling and what it cost, which the flag alone cannot say.
+    if stop != TraceStop::Exhausted {
+        truncated = true;
+        record_trace_stop(&mut degradations, stop, &meter, chain.len());
+    }
+
     Ok(TraceDataFlowResponse {
         focal: focal_record,
         focal_id: focal_entity.id.to_string(),
@@ -358,6 +574,7 @@ pub fn build_trace_data_flow_response(
         total_steps: chain.len(),
         chain,
         truncated,
+        degradations,
     })
 }
 
@@ -377,15 +594,43 @@ fn resolve_trace_focal(graph: &kin_db::InMemoryGraph, query: &str) -> Result<Opt
     Ok(matches.into_iter().next())
 }
 
+/// The open authority a walk reads every step's body through.
+///
+/// Held for the whole walk so the repeated per-step open is structurally
+/// impossible rather than merely avoided at the current call sites.
+struct BodyProjection {
+    authority: ActiveRepositoryAuthority,
+    workspace: kin_model::WorkspaceState,
+}
+
+fn open_body_projection(
+    binding: &kin_core::LocalRepositoryAuthorityBinding,
+) -> Result<BodyProjection> {
+    let authority = ActiveRepositoryAuthority::open(binding)
+        .context("open repository authority for trace-data-flow")?;
+    let workspace = authority
+        .workspace()
+        .context("resolve workspace for trace-data-flow")?;
+    Ok(BodyProjection {
+        authority,
+        workspace,
+    })
+}
+
 /// Try to read an entity's source record; fall back to None for entities
 /// without a readable span / blob so the chain still includes their identity.
+///
+/// Takes the already-open projection rather than the binding. The entity is
+/// also passed directly instead of being re-resolved from its own id string,
+/// which is what the previous route through `build_graph_source_response` did:
+/// that wrapper exists to answer a text query, and the walk already holds the
+/// entity the query would resolve back to.
 fn source_record_or_none(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
-    graph: &kin_db::InMemoryGraph,
+    projection: Option<&BodyProjection>,
     entity: &Entity,
 ) -> Option<GraphSourceRecord> {
-    let response = build_graph_source_response(binding, graph, &entity.id.to_string()).ok()?;
-    response.source
+    let projection = projection?;
+    graph_source_record_from(&projection.authority, &projection.workspace, entity).ok()
 }
 
 #[cfg(test)]
@@ -641,6 +886,163 @@ mod tests {
 
         assert_eq!(response.total_steps, 3, "limit_per_step caps the fan-out");
         assert!(response.truncated, "truncated flag must be set when capped");
+    }
+
+    /// A hub whose fan-out is far wider than any per-step limit, so a walk over
+    /// it examines many more relations than it can ever turn into steps.
+    fn hub_graph(fan_out: usize) -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("hub", "src/hub.rs");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+        for i in 0..fan_out {
+            let callee = make_entity(&format!("callee_{i}"), &format!("src/c_{i}.rs"));
+            let callee_id = callee.id;
+            graph.upsert_entity(&callee).unwrap();
+            graph
+                .upsert_relation(&make_relation(focal_id, callee_id, RelationKind::Calls))
+                .unwrap();
+        }
+        (graph, focal_id)
+    }
+
+    fn hub_request(focal_id: EntityId) -> TraceDataFlowRequest {
+        TraceDataFlowRequest {
+            focal: focal_id.to_string(),
+            depth: Some(2),
+            direction: Some(TraceDirection::Calls),
+            limit_per_step: Some(5),
+        }
+    }
+
+    #[test]
+    fn edge_budget_bounds_the_walk_and_says_so() {
+        let (graph, focal_id) = hub_graph(200);
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &hub_request(focal_id),
+            TraceBudget {
+                max_edges_scanned: 10,
+                ..TraceBudget::default()
+            },
+        )
+        .unwrap();
+
+        assert!(
+            response.truncated,
+            "a walk stopped by the edge budget is truncated"
+        );
+        let stop = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "trace_walk")
+            .expect("the edge budget must be disclosed, not silently applied");
+        assert_eq!(stop.reason, "edge_budget_exceeded");
+        assert!(
+            !stop.remediation.is_empty(),
+            "a degradation must say what restores full capability"
+        );
+        // The bound is what stopped it: fewer steps than the per-step limit
+        // would otherwise have produced from a 200-wide hub.
+        assert!(
+            response.total_steps < 10,
+            "edge budget must cut the chain short, got {} steps",
+            response.total_steps
+        );
+    }
+
+    #[test]
+    fn time_budget_bounds_the_walk_and_says_so() {
+        let (graph, focal_id) = hub_graph(200);
+        let (_t, binding) = empty_binding();
+
+        // A zero budget is already spent at the first check, so this asserts
+        // the bound without making the test wait for a real one to elapse.
+        let response = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &hub_request(focal_id),
+            TraceBudget {
+                time_budget: Duration::ZERO,
+                ..TraceBudget::default()
+            },
+        )
+        .unwrap();
+
+        assert!(response.truncated, "a timed-out walk is truncated");
+        let stop = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "trace_walk")
+            .expect("the time budget must be disclosed");
+        assert_eq!(stop.reason, "time_budget_exceeded");
+        assert_eq!(
+            response.total_steps, 0,
+            "a budget spent before the first expansion yields no steps"
+        );
+        // Still a well-formed answer about the right entity rather than an
+        // error: the caller learns what was asked and why it stopped.
+        assert_eq!(response.focal_id, focal_id.to_string());
+    }
+
+    #[test]
+    fn a_walk_inside_every_bound_reports_no_work_degradation() {
+        let (graph, focal_id) = hub_graph(3);
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &hub_request(focal_id),
+            TraceBudget::default(),
+        )
+        .unwrap();
+
+        assert_eq!(response.total_steps, 3, "the whole hub fits inside limits");
+        assert!(!response.truncated, "nothing was cut off");
+        assert!(
+            !response
+                .degradations
+                .iter()
+                .any(|d| d.component == "trace_walk"),
+            "an unaffected walk must carry no work degradation: {:?}",
+            response.degradations
+        );
+    }
+
+    #[test]
+    fn an_unopenable_authority_still_returns_the_chain() {
+        // The walk holds one authority open for every step's body. This asserts
+        // that hoisting the open did not turn a store whose bodies were already
+        // unreadable into a failed call: the chain still arrives, identity
+        // only, and the missing bodies are disclosed rather than unexplained.
+        let (graph, focal_id) = hub_graph(3);
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &hub_request(focal_id),
+            TraceBudget::default(),
+        )
+        .unwrap();
+
+        assert_eq!(response.total_steps, 3);
+        assert!(
+            response.chain.iter().all(|step| step.entity.is_none()),
+            "no body is readable through an absent authority"
+        );
+        assert!(
+            response
+                .degradations
+                .iter()
+                .any(|d| d.component == "entity_bodies" && d.reason == "authority_unavailable"),
+            "absent bodies must be explained: {:?}",
+            response.degradations
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2900,13 +2900,50 @@ async fn command_trace_data_flow(
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
-    let response = kin_cli::commands::trace_data_flow::build_trace_data_flow_response(
-        &repository_authority,
-        graph.as_ref(),
-        &request,
-    )
-    .map_err(internal_error)?;
+    let response = run_trace_data_flow_off_runtime(repository_authority, graph, request)
+        .await
+        .map_err(internal_error)?;
     Ok(Json(response))
+}
+
+/// Run one trace walk on the blocking pool instead of on a Tokio worker.
+///
+/// The walk is entirely synchronous and, on a large store, long. Called
+/// directly from the async handler it held a worker thread for its whole
+/// duration.
+///
+/// Being precise about what that did and did not cause, because the reported
+/// symptom is a dead daemon and this is not what killed it. Probing a daemon
+/// every two seconds through a 180s trace, it answered 26 of 26 probes and
+/// survived: the runtime carries roughly eighteen workers, so one blocked worker
+/// leaves seventeen and a single trace does not wedge it. The "daemon exited;
+/// restart required" the user saw comes from the client, which times out at 60s,
+/// reads a timeout as a possible exit, retries into the same timeout because
+/// server-side work is not cancelled, then revives and loses the race for a repo
+/// lock the live daemon still holds. What actually made the call slow enough to
+/// trip that ladder was one repository-authority open per step, fixed alongside
+/// this (FIR-1937).
+///
+/// So this is defence in depth for the concurrent case rather than the fix, and
+/// it is what makes cancellation reachable at all: a walk inline in the handler
+/// future cannot be told to stop.
+///
+/// The walk carries its own time and edge ceilings, so this seam does not need
+/// a timeout of its own: it moves the work, and the budget bounds it.
+async fn run_trace_data_flow_off_runtime(
+    repository_authority: kin_core::LocalRepositoryAuthorityBinding,
+    graph: Arc<kin_db::InMemoryGraph>,
+    request: kin_cli::commands::trace_data_flow::TraceDataFlowRequest,
+) -> anyhow::Result<kin_cli::commands::trace_data_flow::TraceDataFlowResponse> {
+    tokio::task::spawn_blocking(move || {
+        kin_cli::commands::trace_data_flow::build_trace_data_flow_response(
+            &repository_authority,
+            graph.as_ref(),
+            &request,
+        )
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("trace-data-flow worker failed: {error}"))?
 }
 
 /// POST /commands/refs — render incoming references from daemon-owned graph state.
@@ -6801,17 +6838,19 @@ async fn mcp_tools_call(
             Ok(binding) => binding,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
-        let result = match kin_cli::commands::trace_data_flow::build_trace_data_flow_response(
-            &repository_authority,
-            graph.as_ref(),
-            &req,
-        ) {
-            Ok(response) => match serde_json::to_string_pretty(&response) {
-                Ok(json) => kin_mcp::ToolCallResult::text(json),
+        // Same off-runtime seam as the CLI route. This is the arm the reported
+        // failure came through: the MCP client is the one whose request timeout
+        // turns a slow call into a dead-daemon verdict.
+        let result =
+            match run_trace_data_flow_off_runtime(repository_authority, Arc::clone(&graph), req)
+                .await
+            {
+                Ok(response) => match serde_json::to_string_pretty(&response) {
+                    Ok(json) => kin_mcp::ToolCallResult::text(json),
+                    Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+                },
                 Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
-            },
-            Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
-        };
+            };
         return Ok(Json(result));
     }
 
@@ -20085,6 +20124,72 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Context pack for 'handler'")),
             "context response should identify the daemon graph entity"
+        );
+    }
+
+    /// A trace request must not be the only thing this daemon can be doing.
+    ///
+    /// The walk now runs on the blocking pool, so the runtime stays free to
+    /// serve other routes while it runs. This asserts the seam is wired and
+    /// that both routes answer when they overlap. It does NOT prove the
+    /// occupancy property on its own: a walk over a test-sized store is fast
+    /// enough that an inline one would also let `/health` through. What it
+    /// guards is the wiring — a regression that put the walk back on the async
+    /// worker would still answer here, so the occupancy claim rests on the
+    /// live-daemon measurement, not on this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn a_trace_in_flight_leaves_the_daemon_answering() {
+        let state = test_state();
+        let source = "def handler():\n    return 1\n";
+        install_repository_file(&state, "src/lib.py", source.as_bytes());
+        let mut focal = test_entity("handler", "src/lib.py");
+        focal.span.as_mut().unwrap().end_byte = source.len();
+        focal.span.as_mut().unwrap().end_line = 2;
+        let focal_id = focal.id;
+        state.graph.upsert_entity(&focal).unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+
+        let tracing_app = app.clone();
+        let trace = tokio::spawn(async move {
+            tracing_app
+                .oneshot(
+                    Request::post("/commands/trace-data-flow")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::json!({ "focal": focal_id.to_string() }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        });
+
+        let health = app
+            .clone()
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            health.status(),
+            StatusCode::OK,
+            "the daemon must keep answering while a trace runs"
+        );
+
+        let response = trace.await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::trace_data_flow::TraceDataFlowResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(result.focal_id, focal_id.to_string());
+        assert!(
+            result.degradations.is_empty(),
+            "a healthy store's trace discloses no degradation: {:?}",
+            result.degradations
         );
     }
 


### PR DESCRIPTION
A `trace_data_flow` call opened the repository authority once per step in the
chain, and every open verifies every stored body in the repository. The walk is
capped at 200 steps, so one trace could pay 201 full-store verifications. Cost
never depended on the graph, only on how many steps the chain reached and how
large the store was, which is why the reported failure came from a store the
same report describes as small.

## Measured on a real store

Fixture is gin-gonic/gin at 3e44fdc, initialized from scratch into an isolated
HOME. The resulting store is 246M with 1700 entities and 7825 entity-to-entity
relations, close to the 1967 entities the report recorded.

`kin graph source` is exactly one authority open plus one body read. Three runs
on that store took 4.32s, 4.40s, and 4.31s. A `Context.Next --direction callers`
trace returns 12 steps, so it performs 13 body projections, and 13 times 4.35s
predicts 56.6s against 57.5s measured. The arithmetic accounts for the latency
to within two percent, and a `sample` of the daemon mid-call agrees from the
other side, with `sha2::sha256::compress256` and `__openat` at the top of the
in-process frames.

Warm to warm on that trace, this change takes 70.9s to 4.8s. The remaining 4.8s
is approximately the one authority open plus the walk, which is the floor the
change was aiming at. On a deliberately pathological trace, `Context` with
direction both, depth 8 and limit-per-step 25, the walk reaches the 200-step cap.
Before, it did not finish inside a 180s ceiling and was killed with empty output.
After, it returns in 23.5s.

The healthy answer is unchanged, and that is checked rather than asserted. The
before and after payloads for the 12-step trace compare byte for byte identical,
same chain, same bodies, and no new key.

## What changes

The authority open moves out of the per-entity read.
`read_entity_file_bytes_with_digest_from` and `graph_source_record_from` take an
authority the caller already holds, while the existing entry points keep their
signatures and open once, so no other call site changes. The walk opens one
projection up front and reads every step through it. Passing the workspace
alongside also makes the chain coherent, since every step now resolves against
one generation where per-step opens could straddle a publication.

A store whose authority cannot be opened still returns its chain, identity only,
with a stated degradation. Without that, hoisting the open would have turned a
payload that used to arrive body-less into a failed call. It also closes a real
gap, because those bodies were previously absent with nothing saying why.

Every pre-existing bound on the walk is structural, being depth, per-step
fan-out, and total steps, and structural bounds say nothing about elapsed time.
That is exactly how a 200-step walk ran for minutes. `TraceBudget` adds a 20s
wall clock and a 250k examined-relation ceiling, checked at each frontier node
and each relation. When one fires the walk returns what it reached, sets the
existing `truncated` flag, and appends a `RetrievalDegradation` in the same shape
`semantic_locate` already reports. The field is skipped when empty, so a walk
inside every bound emits nothing new.

The walk also moves off the async runtime onto a blocking seam. See the
correction below for why that is defence in depth rather than the fix.

## A correction to FIR-1909

FIR-1909 concluded from source that the trace path "never performed a
per-candidate authority open or history replay", reading
`kin_mcp::handlers::entities::handle_trace_data_flow`. The daemon never reaches
that handler for this tool. `mcp_tools_call` special-cases `trace_data_flow` and
returns from its own branch, routing to the kin-cli builder, which does take a
repository authority and does project a body per step. The branch comment says
why it exists, which is to inline a source body for each step. So this cost is
the FIR-1897 authority defect applied per step, and #608 did not reach it because
#608 fixed the `semantic_locate` path.

## A correction to my own first reading

I also expected the synchronous walk to starve the daemon's runtime, and the
measurement disagreed. Probing the daemon every two seconds while a 180s
pathological trace was in flight, it answered 26 of 26 probes and survived. The
daemon runs about eighteen worker threads, so one blocked worker leaves
seventeen. A single trace does not wedge it.

The user-visible "daemon exited; restart required" is produced by the client
rather than by a dead daemon. The MCP delegate times out at 60s, maps a timeout
to a possible exit, retries into the same timeout because server-side work is not
cancelled, and then revives, at which point the spawn loses the race for a repo
lock the live daemon still holds and exits 1. That is the reported text verbatim.
The report itself noted it never confirmed by `ps` that the daemon exited, and on
this evidence it very likely did not.

So the fix that matters here is the hoist. The move off the runtime is retained
for the concurrent case and the code comment labels it that way.

## Tests

Four new tests in the trace module, ten total, all green, each falsified by
mutation rather than assumed. Making the two bounds never fire fails exactly the
two budget tests. Setting the edge ceiling to 1 fails the test asserting an
unaffected walk carries no degradation, and takes four pre-existing tests with
it, which confirms the bound really changes chain content when it fires. Making
the authority-open failure fatal fails the test asserting a chain still returns
without one, and takes every other test using that fixture with it.

The daemon test asserts both routes answer when they overlap, and its comment
states plainly that it does not prove the occupancy property on its own, because
a test-sized store is fast enough that an inline walk would also let health
through.

## A limit worth stating

The time budget starts before the authority open, so the open counts against it.
That is deliberate, since a caller cares about total latency rather than about
which phase spent it, and it means the whole call is bounded rather than only its
walk. It does have a consequence on a very large store. Extrapolating the
measured 4.3s open at 246M, a store somewhere past a gigabyte can spend the whole
20s budget on the open alone and return a correct, bounded, honestly-labelled
response with zero steps in it. The degradation detail shows that, reporting zero
relations examined, but its remediation suggests narrowing the trace, which would
not help in that case.

That is why this refs FIR-1909 rather than closing it. FIR-1909's store is 3.5G.
This turns its symptom from an unbounded hang into a bounded answer with a stated
reason, which is the part that made the tool unusable, but on a store that large
the answer may still be empty. The fix that finishes it is extending the daemon's
`ProjectionAuthorityCache`, which already holds one authority per publication for
the `semantic_locate` snippet path, to the `ActiveRepositoryAuthority::open`
callers in kin-cli that `kin graph source` and this walk still use. That is
separate work and is not done here.

Closes FIR-1937
Refs FIR-1909
Refs FIR-1897
Refs FIR-1898
