### PR TITLE
Copy a captured Git repository under one source authority envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1130,7 +1130,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.12"
+version = "0.7.13"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "06913633eb8e8eba69ae2ab343e3992f5cd17e0a786dbc6b9882fdc313f4e025"
+checksum = "b7199f67903f9f2049ecbc73e67a363a76444011923bbe0c59829a7ae54d750f"
 dependencies = [
  "bincode",
  "bstr",
@@ -4123,7 +4123,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5045,7 +5045,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5114,7 +5114,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5558,7 +5558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5691,7 +5691,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6624,7 +6624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.12", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.13", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.3.0", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -634,34 +634,42 @@ fn copy_captured_authority(
 ) -> Result<()> {
     let total_objects = snapshot.objects.len();
     let report_every = progress_interval(total_objects);
-    for (copied, record) in snapshot.objects.iter().enumerate() {
-        if copied.is_multiple_of(report_every) {
-            progress.detail(format_args!("{copied}/{total_objects} objects"));
+    // One session for the whole copy. Every body here lands in a staging store
+    // that holds no authority yet, and a crash before
+    // `commit_repository_bootstrap` discards the store whole, so the batch
+    // boundary and the durability boundary this phase actually needs are the
+    // same boundary.
+    prepared.with_source_blob_batch(&mut |batch| {
+        for (copied, record) in snapshot.objects.iter().enumerate() {
+            if copied.is_multiple_of(report_every) {
+                progress.detail(format_args!("{copied}/{total_objects} objects"));
+            }
+            let capture_hash = kin_blobs::Hash256::from_bytes(*record.body_hash.as_bytes());
+            let body = capture_store.read(&capture_hash).map_err(|error| {
+                git_boundary_error(
+                    format!("read captured Git object {}", record.object.oid),
+                    error,
+                )
+            })?;
+            if staged_body_is_withheld(record.body_hash) {
+                continue;
+            }
+            batch.save(record.body_hash, &body)?;
         }
-        let capture_hash = kin_blobs::Hash256::from_bytes(*record.body_hash.as_bytes());
-        let body = capture_store.read(&capture_hash).map_err(|error| {
-            git_boundary_error(
-                format!("read captured Git object {}", record.object.oid),
-                error,
-            )
-        })?;
-        if staged_body_is_withheld(record.body_hash) {
-            continue;
+        for input in &proof.ignored_local.inputs {
+            let observed_len = u64::try_from(input.body.len()).map_err(|_| {
+                KinError::Other("local Git ignore input exceeds u64 byte length".to_string())
+            })?;
+            let observed_hash = Hash256::from_bytes(kin_blobs::digest_bytes(&input.body));
+            if observed_len != input.body_len || observed_hash != input.body_hash {
+                return Err(KinError::Other(
+                    "local Git ignore input no longer matches its preflight identity".to_string(),
+                ));
+            }
+            batch.save(input.body_hash, &input.body)?;
         }
-        prepared.save_source_blob(record.body_hash, &body)?;
-    }
-    for input in &proof.ignored_local.inputs {
-        let observed_len = u64::try_from(input.body.len()).map_err(|_| {
-            KinError::Other("local Git ignore input exceeds u64 byte length".to_string())
-        })?;
-        let observed_hash = Hash256::from_bytes(kin_blobs::digest_bytes(&input.body));
-        if observed_len != input.body_len || observed_hash != input.body_hash {
-            return Err(KinError::Other(
-                "local Git ignore input no longer matches its preflight identity".to_string(),
-            ));
-        }
-        prepared.save_source_blob(input.body_hash, &input.body)?;
-    }
+        Ok(())
+    })?;
     progress.detail(format_args!("{total_objects}/{total_objects} objects"));
     Ok(())
 }

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -147,6 +147,27 @@ impl PublishedRepository<'_> {
     }
 }
 
+/// One staging-store write session, scoped to the repository that opened it.
+///
+/// A save publishes the body under its content identity with the same
+/// validation and no-clobber rules a single
+/// [`PreparedRepositoryInit::save_source_blob`] applies. Durability arrives
+/// when the enclosing
+/// [`with_source_blob_batch`](PreparedRepositoryInit::with_source_blob_batch)
+/// returns, not per body.
+pub struct StagedSourceBlobBatch<'a> {
+    inner: &'a dyn kin_db::SourceBlobWriteBatch,
+}
+
+impl StagedSourceBlobBatch<'_> {
+    /// Stage exact bytes under their content identity.
+    pub fn save(&self, digest: Hash256, data: &[u8]) -> Result<()> {
+        self.inner
+            .save(*digest.as_bytes(), data)
+            .map_err(graph_error)
+    }
+}
+
 /// A complete `.kin` repository assembled outside the final namespace.
 ///
 /// The staging directory is private to this object and is removed on drop
@@ -223,6 +244,40 @@ impl PreparedRepositoryInit {
         self.authority()?
             .save_source_blob(digest, data)
             .map_err(graph_error)
+    }
+
+    /// Persist many immutable source bodies under one authority envelope.
+    ///
+    /// This is the bulk form of [`Self::save_source_blob`] and it stages
+    /// exactly the same bodies. It grants no authority either: a later
+    /// bootstrap transaction still has to reference every digest through
+    /// exact tree and history authority before publication. The bodies are
+    /// durable when this call returns, which is what lets a whole capture
+    /// copy run as one session and cross into bootstrap afterwards.
+    pub fn with_source_blob_batch(
+        &self,
+        operation: &mut dyn FnMut(&StagedSourceBlobBatch<'_>) -> Result<()>,
+    ) -> Result<()> {
+        let authority = self.authority()?;
+        // The batch boundary speaks kin-db's error type. Carry the caller's
+        // own failure out beside it so a Git or manifest boundary error is
+        // reported as itself rather than as a storage error.
+        let mut interrupted: Option<KinError> = None;
+        let outcome = authority.with_source_blob_write_batch(&mut |inner| match operation(
+            &StagedSourceBlobBatch { inner },
+        ) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                interrupted = Some(error);
+                Err(kin_db::KinDbError::StorageError(
+                    "staged source ingest stopped before its batch completed".to_string(),
+                ))
+            }
+        });
+        if let Some(error) = interrupted {
+            return Err(error);
+        }
+        outcome.map_err(graph_error)
     }
 
     /// Read immutable source bytes back out of the unpublished staging store.
@@ -3040,6 +3095,68 @@ mod tests {
             .to_string()
             .contains("repository and workspace manifest identities must be distinct"));
         assert!(!staging_root.exists());
+    }
+
+    #[test]
+    fn staged_source_batch_stages_the_same_bodies_as_repeated_single_writes() {
+        let batched_dir = tempfile::tempdir().unwrap();
+        let (batched, _) = prepare_unborn(batched_dir.path(), "batched");
+        let single_dir = tempfile::tempdir().unwrap();
+        let (single, _) = prepare_unborn(single_dir.path(), "single");
+
+        let bodies: Vec<Vec<u8>> = (0..16)
+            .map(|index| format!("staged body {index}\n\0\u{feff}").into_bytes())
+            .collect();
+        let digests: Vec<Hash256> = bodies
+            .iter()
+            .map(|body| Hash256::from_bytes(Sha256::digest(body).into()))
+            .collect();
+
+        batched
+            .with_source_blob_batch(&mut |batch| {
+                for (digest, body) in digests.iter().zip(&bodies) {
+                    batch.save(*digest, body)?;
+                }
+                Ok(())
+            })
+            .expect("one session stages every body");
+        for (digest, body) in digests.iter().zip(&bodies) {
+            single.save_source_blob(*digest, body).unwrap();
+        }
+
+        for (digest, body) in digests.iter().zip(&bodies) {
+            assert_eq!(
+                batched.load_source_blob(*digest).unwrap().as_ref(),
+                Some(body),
+                "a batched body must be readable at its content identity"
+            );
+            assert_eq!(
+                batched.load_source_blob(*digest).unwrap(),
+                single.load_source_blob(*digest).unwrap(),
+                "both paths must stage the same bytes at the same identity"
+            );
+        }
+    }
+
+    #[test]
+    fn staged_source_batch_reports_the_callers_own_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let (prepared, _) = prepare_unborn(directory.path(), "interrupted");
+        let body = b"a body staged before the caller stops";
+        let digest = Hash256::from_bytes(Sha256::digest(body).into());
+
+        let error = prepared
+            .with_source_blob_batch(&mut |batch| {
+                batch.save(digest, body)?;
+                Err(KinError::Other("git capture boundary failed".to_string()))
+            })
+            .expect_err("a session that stops must not report success");
+        // The caller's own error survives the kin-db batch boundary instead of
+        // arriving as a storage error about a batch the caller never saw.
+        assert!(
+            matches!(&error, KinError::Other(message) if message == "git capture boundary failed"),
+            "{error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`copy_captured_authority` runs the whole captured-Git copy as one source-body session instead of one repository authority envelope per object.

`PreparedRepositoryInit::with_source_blob_batch` is the bulk form of `save_source_blob`, and `StagedSourceBlobBatch` is the session handle the caller writes through. `save_source_blob` is unchanged and still used everywhere else.

## Why

A repository import staged one immutable body per captured Git object through `save_source_blob`. Each of those took kin-db's repository-wide exclusive lock and issued a full set of device-level durability barriers, so an import paid that envelope once per object. On APFS the barriers are where the phase spends its time; the lock itself measured at 2.3% of a single write.

kin-db PR firelock-ai/kin-db#167 has the barrier accounting and the invariant argument in full.

## The batching boundary

The batch boundary and the durability boundary this phase actually needs are the same boundary.

A body staged here lands in an unpublished staging store that holds no authority. The doc comment on `save_source_blob` already says so: saving a body does not grant it authority, and a later bootstrap transaction has to reference the digest through exact tree and history authority before publication. A crash before `commit_repository_bootstrap` discards that staging store whole, so a session that never flushed leaves nothing an import could mistake for staged truth.

Bodies are durable when the session returns, which is before the bootstrap commit reads them. Nothing in the import observes a body between the save and the flush.

Inside kin-db the deferred barriers are the directory and acknowledgement ones only. The body fsync that precedes the `linkat` naming it does not move, so a crash loses names rather than producing torn bodies, which is the failure class the per-object loop already had.

## Error fidelity

The kin-db batch boundary speaks `KinDbError`. `with_source_blob_batch` carries the caller's own failure back out beside it, so a Git capture read or an ignore-manifest identity mismatch is still reported as itself rather than as a storage error about a batch the caller never saw. There is a test for exactly that.

## Tests

- a batch stages the same bodies at the same content identities as repeated single writes, and both are readable at those identities
- a caller error raised inside a session comes back as the caller's own error
- `kin-core` is green, including the existing import tests that prove an admitted repository owns every historical body without the source Git repository, and that a body lost across publication is refused before the published seal reads it

## Dependency, now satisfied

This pins `kin-db =0.7.13`, which firelock-ai/kin-db#167 landed and the Registry Publish workflow published from `558126d2`.

`Cargo.lock` is resolved patch-off against the registry, so the entry keeps its sparse source and checksum:

```
name = "kin-db"
version = "0.7.13"
source = "sparse+https://kinlab.ai/registry/cargo/"
checksum = "b7199f67903f9f2049ecbc73e67a363a76444011923bbe0c59829a7ae54d750f"
```

The lock's other thirteen changed lines are dependency references converging on a `windows-sys` release the lock already carried. That normalization is not from this change: refreshing the lock against the current index with the previous `=0.7.12` pin still in place produces the same thirteen lines and no kin-db change. No package was added, removed, or re-versioned; the only package block that moved is kin-db.

Refs FIR-2017.
