### PR TITLE
Stop a trace walk when the requester stops waiting for it

### DIFF
--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -49,23 +49,68 @@ const DEFAULT_TIME_BUDGET: Duration = Duration::from_secs(20);
 /// the same place every run and a trace stays reproducible.
 const DEFAULT_MAX_EDGES_SCANNED: usize = 250_000;
 
+/// A caller's standing answer to "does anyone still want this result?".
+///
+/// Set by whoever owns the request once nobody is waiting on it. The walk reads
+/// it at the same points it charges its budget, so abandonment costs at most one
+/// more relation rather than the rest of the traversal.
+#[derive(Debug, Clone, Default)]
+pub struct TraceCancel(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl TraceCancel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stop the walk at its next checkpoint.
+    pub fn cancel(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 /// Hard ceilings applied to one trace walk, independent of the request's own
 /// depth / fan-out parameters.
 ///
 /// Those parameters bound the SHAPE of the answer and are the caller's to
 /// choose. These bound the WORK, and are not: a caller cannot ask for an
 /// unbounded walk, because the daemon serving it has other callers.
-#[derive(Debug, Clone, Copy)]
+/// NOT `#[derive(Default)]`. A derived default is a zero budget, which reads as
+/// "no limits" and behaves as "stop before the first step", and every caller
+/// here reaches the default through struct-update syntax where that mistake
+/// would be invisible.
+#[derive(Debug, Clone)]
 pub struct TraceBudget {
     pub time_budget: Duration,
     pub max_edges_scanned: usize,
+    /// Absent for a walk nobody can abandon, such as the CLI's own in-process
+    /// call, where the process waiting for the answer is the one running it.
+    pub cancel: Option<TraceCancel>,
 }
 
 impl Default for TraceBudget {
     fn default() -> Self {
+        Self::bounded()
+    }
+}
+
+impl TraceBudget {
+    pub fn bounded() -> Self {
         Self {
             time_budget: DEFAULT_TIME_BUDGET,
             max_edges_scanned: DEFAULT_MAX_EDGES_SCANNED,
+            cancel: None,
+        }
+    }
+
+    /// The shipped budget, stopped early when `cancel` fires.
+    pub fn cancellable(cancel: TraceCancel) -> Self {
+        Self {
+            cancel: Some(cancel),
+            ..Self::bounded()
         }
     }
 }
@@ -80,6 +125,7 @@ enum TraceStop {
     Exhausted,
     TimeBudget,
     EdgeBudget,
+    Cancelled,
 }
 
 /// Running cost of one walk, checked at each frontier node and each relation.
@@ -104,10 +150,20 @@ impl TraceMeter {
         if self.edges_scanned >= self.budget.max_edges_scanned {
             return Some(TraceStop::EdgeBudget);
         }
-        self.exceeded_time()
+        self.should_stop()
     }
 
-    fn exceeded_time(&self) -> Option<TraceStop> {
+    /// Cancellation is checked first. A walk nobody is waiting for should stop
+    /// for that reason rather than be reported as having run out of time.
+    fn should_stop(&self) -> Option<TraceStop> {
+        if self
+            .budget
+            .cancel
+            .as_ref()
+            .is_some_and(TraceCancel::is_cancelled)
+        {
+            return Some(TraceStop::Cancelled);
+        }
         (self.started.elapsed() >= self.budget.time_budget).then_some(TraceStop::TimeBudget)
     }
 
@@ -149,6 +205,20 @@ fn record_trace_stop(
                 meter.budget.max_edges_scanned,
                 meter.elapsed().as_secs_f64(),
                 steps,
+            ),
+        ),
+        // Recorded even though the caller who would read it has, by definition,
+        // stopped listening. The walk still returns rather than being discarded
+        // silently, so anything that does observe the result — a log, a cache, a
+        // test — can tell an abandoned walk from a complete one.
+        TraceStop::Cancelled => (
+            "cancelled",
+            format!(
+                "trace walk was cancelled after {:.1}s with {} steps and {} relations examined; \
+                 the requester stopped waiting for this result",
+                meter.elapsed().as_secs_f64(),
+                steps,
+                meter.edges_scanned,
             ),
         ),
     };
@@ -434,7 +504,7 @@ pub fn build_trace_data_flow_response_within(
             // relation loop: reading one node's relations is itself unbounded
             // work on a high-fan-in entity, so a walk that has already spent
             // its budget must not start another one.
-            if let Some(reason) = meter.exceeded_time() {
+            if let Some(reason) = meter.should_stop() {
                 stop = reason;
                 break 'walk;
             }
@@ -1042,6 +1112,97 @@ mod tests {
                 .any(|d| d.component == "entity_bodies" && d.reason == "authority_unavailable"),
             "absent bodies must be explained: {:?}",
             response.degradations
+        );
+    }
+
+    #[test]
+    fn a_cancelled_walk_stops_and_says_why() {
+        let (graph, focal_id) = hub_graph(200);
+        let (_t, binding) = empty_binding();
+
+        let cancel = TraceCancel::new();
+        cancel.cancel();
+        let response = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &hub_request(focal_id),
+            TraceBudget::cancellable(cancel),
+        )
+        .unwrap();
+
+        assert_eq!(
+            response.total_steps, 0,
+            "a walk cancelled before it began expands nothing"
+        );
+        assert!(response.truncated);
+        let stop = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "trace_walk")
+            .expect("cancellation must be disclosed");
+        assert_eq!(stop.reason, "cancelled");
+        assert_ne!(
+            stop.reason, "time_budget_exceeded",
+            "an abandoned walk must not be reported as having run out of time"
+        );
+    }
+
+    /// The property FIR-1898 is actually about: the WORK stops, not just the
+    /// response. A cancelled walk must leave traversal undone that the same
+    /// walk uncancelled completes, measured against that walk rather than a
+    /// constant.
+    ///
+    /// Cancellation is set before the call rather than raced against a running
+    /// one. A walk over a test-sized graph finishes in microseconds, so a
+    /// cancel-from-another-thread test would be deciding a race, and a test that
+    /// sometimes cancels a walk that already ended proves nothing on the runs
+    /// where it loses. The checkpoint being exercised is the same one either
+    /// way.
+    #[test]
+    fn a_cancelled_walk_leaves_traversal_undone() {
+        let (graph, focal_id) = hub_graph(400);
+        let (_t, binding) = empty_binding();
+        let request = TraceDataFlowRequest {
+            focal: focal_id.to_string(),
+            depth: Some(2),
+            direction: Some(TraceDirection::Calls),
+            limit_per_step: Some(25),
+        };
+
+        let uncancelled = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &request,
+            TraceBudget::bounded(),
+        )
+        .unwrap();
+        assert!(
+            uncancelled.total_steps > 0,
+            "the control must actually walk something"
+        );
+        assert!(
+            !uncancelled
+                .degradations
+                .iter()
+                .any(|d| d.component == "trace_walk"),
+            "the control must run to completion inside every bound"
+        );
+
+        let cancel = TraceCancel::new();
+        cancel.cancel();
+        let cancelled = build_trace_data_flow_response_within(
+            &binding,
+            &graph,
+            &request,
+            TraceBudget::cancellable(cancel),
+        )
+        .unwrap();
+
+        assert!(
+            cancelled.total_steps < uncancelled.total_steps,
+            "cancelling must leave steps unwalked: {} vs {}",
+            cancelled.total_steps,
+            uncancelled.total_steps
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3038,15 +3038,38 @@ async fn run_trace_data_flow_off_runtime(
     graph: Arc<kin_db::InMemoryGraph>,
     request: kin_cli::commands::trace_data_flow::TraceDataFlowRequest,
 ) -> anyhow::Result<kin_cli::commands::trace_data_flow::TraceDataFlowResponse> {
+    let cancel = kin_cli::commands::trace_data_flow::TraceCancel::new();
+    // Dropping a `spawn_blocking` handle does not stop the thread, so the guard
+    // rather than the handle is what carries the client's departure across the
+    // seam. Axum drops this future when the connection goes away, which drops
+    // the guard, which the walk observes at its next checkpoint.
+    let _abandon = CancelOnDrop(cancel.clone());
+    let budget = kin_cli::commands::trace_data_flow::TraceBudget::cancellable(cancel);
     tokio::task::spawn_blocking(move || {
-        kin_cli::commands::trace_data_flow::build_trace_data_flow_response(
+        kin_cli::commands::trace_data_flow::build_trace_data_flow_response_within(
             &repository_authority,
             graph.as_ref(),
             &request,
+            budget,
         )
     })
     .await
     .map_err(|error| anyhow::anyhow!("trace-data-flow worker failed: {error}"))?
+}
+
+/// Cancels its token when dropped.
+///
+/// Held by a request future so that abandoning the request — a client
+/// disconnect, a timeout, a cancelled task — stops the server-side work rather
+/// than merely stopping anyone from reading its result. Without this, a query
+/// whose caller had gone kept burning CPU to completion, and a repository could
+/// be held out of service by work nobody was waiting for (FIR-1898).
+struct CancelOnDrop(kin_cli::commands::trace_data_flow::TraceCancel);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
 }
 
 /// POST /commands/refs — render incoming references from daemon-owned graph state.
@@ -20349,6 +20372,28 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Context pack for 'handler'")),
             "context response should identify the daemon graph entity"
+        );
+    }
+
+    /// The daemon half of the cancellation chain.
+    ///
+    /// The walk half — that a cancelled token stops the traversal — is asserted
+    /// in `kin_cli::commands::trace_data_flow`. This asserts the part that lives
+    /// here: abandoning the request sets that token. Two-sided, because a guard
+    /// that cancelled eagerly would stop every trace rather than the abandoned
+    /// ones, and that failure would be invisible in a one-sided test.
+    #[test]
+    fn abandoning_a_trace_request_cancels_its_walk() {
+        let cancel = kin_cli::commands::trace_data_flow::TraceCancel::new();
+        let guard = CancelOnDrop(cancel.clone());
+        assert!(
+            !cancel.is_cancelled(),
+            "a live request must not cancel its own walk"
+        );
+        drop(guard);
+        assert!(
+            cancel.is_cancelled(),
+            "dropping the request must stop the walk it started"
         );
     }
 


### PR DESCRIPTION
Stacked on #673, which this needs for its off-runtime seam. Review or land that
one first.

A query whose caller had gone kept running to completion. The report behind
FIR-1898 recorded a `semantic_locate` that hit its client's 180s timeout still
burning 100-200% CPU forty-four minutes later, with every client socket closed
and every client process exited. Nothing on the server side was listening for the
requester's departure, so the only thing a timeout stopped was the reading of the
result, not the producing of it. The knock-on is what makes it service
affecting, because a busy daemon reports itself unready and a longer-timeout
retry cannot start.

## What changes

`TraceCancel` is a shared flag the walk reads at the same checkpoints it already
charges its budget against, so abandonment costs at most one more relation rather
than the remainder of the traversal. `TraceBudget::cancellable` carries it. The
CLI's own in-process call passes none, since there the process waiting for the
answer is the one running it, and there is nobody to disappear.

On the daemon side the request future holds a `CancelOnDrop` guard. Axum drops
that future when the connection goes away, the guard drops, and the flag is set.
The guard rather than the `JoinHandle` is what carries the departure, because
dropping a `spawn_blocking` handle does not stop the thread. This repository
already documents that fact in
`cancelled_archive_request_cannot_release_a_running_worker_permit`, and the same
property is why cancellation could not have been added before #673 moved the walk
off the async runtime. A walk running inline in the handler future has no
checkpoint anyone can reach.

Cancellation reports its own reason rather than folding into the time budget, so
an abandoned walk is never mis-reported as a slow one.

## Tests

Proven in two halves, because the chain spans two crates, and each half is
two-sided.

In kin-cli, a cancelled walk stops, discloses `cancelled`, and leaves steps
unwalked that the same walk completes uncancelled, measured against that control
walk rather than against a constant. In kin-daemon, a live request does not
cancel its own walk and dropping it does. That second assertion matters as much
as the first, since a guard that cancelled eagerly would stop every trace and a
one-sided test would pass anyway.

Both were falsified by mutation rather than assumed. Making the walk ignore the
flag fails exactly the two kin-cli tests and nothing else. Making the drop
implementation a no-op fails exactly the daemon test.

Cancellation is set before the call rather than raced against a running one. A
walk over a test-sized graph finishes in microseconds, so cancelling from another
thread would be deciding a race, and the runs where it lost would prove nothing.
The checkpoint being exercised is the same either way.

## Not claiming

This covers `trace_data_flow`. The report's original subject was
`semantic_locate`, which runs a different path and is not cancelled by this
change. The mechanism here is the reusable half, since `TraceCancel` and
`CancelOnDrop` are not trace-specific, but wiring the locate path is separate
work and is not done here.

Closes FIR-1898
Refs FIR-1937
