### PR TITLE
Drop the buzzword from the README hero and say what impact actually returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ critical workflow.
 
 ## See it on a real repository
 
-A one-line signature change in ripgrep looks harmless in the diff. Asked
-before any compiler runs, on a graph that was already built, `kin impact`
-names the entities the edit affects, from the direct callers of the changed
-signature out through the wider blast radius.
+A one-line signature change in ripgrep looks harmless in the diff. Ask
+`kin impact` about it, before any compiler runs, and it names what the edit
+reaches. The callers of the changed signature come first, then everything
+those callers pull in behind them.
 
 <p align="center">
   <img src="docs/assets/kin-impact-ripgrep.png" alt="kin impact on ripgrep listing 13 impacted entities within 3 hops of a one-line signature change" width="100%" />
@@ -291,10 +291,11 @@ the graph, then pass explicit commit SHAs to the report-only shadow gate:
 kin review shadow "$(git rev-parse main)..$(git rev-parse HEAD)"
 ```
 
-The result is `PASS`, `NEEDS ATTENTION`, or `WOULD BLOCK`, with graph-derived
-blast radius, repair context, and recorded evidence. Authorship is declared,
-not verified. The command does not block a merge or mutate graph state. It
-produces evidence for a human or CI policy to act on.
+The result is `PASS`, `NEEDS ATTENTION`, or `WOULD BLOCK`, and it comes with the
+impact Kin derived from the graph, the context needed to repair it, and the
+evidence behind both. Authorship is declared, not verified. The command will not
+block your merge or change graph state. It hands evidence to a human or a CI
+policy and stops there.
 
 ## How Kin relates to Git
 


### PR DESCRIPTION
Prompted by public criticism during the launch that the project's writing reads as machine-generated. The `/proof` page got the same treatment in kinlab#191; this is the repository front page, which is where anyone arriving from a link actually lands.

## What was wrong

Two uses of "blast radius", one of them in the hero paragraph.

KinLab's own public-copy gate (`check-launch-copy.mjs`) already lists that phrase as banned marketing filler. So the repository front page was using language the marketing site is not permitted to publish. That inconsistency is the clearest possible signal it does not belong.

In the hero it was also doing no work:

> "`kin impact` names the entities the edit affects, from the direct callers of the changed signature out through the wider blast radius."

"Names the entities the edit affects" already said it. The trailing clause restated the same idea in a more impressive register, which is exactly the "a lot of words with very little content" problem that was called out publicly.

## What changed

The hero now describes the actual shape of the answer rather than gesturing at its size, so a reader learns something concrete about what the tool returns:

> "Ask `kin impact` about it, before any compiler runs, and it names what the edit reaches. The callers of the changed signature come first, then everything those callers pull in behind them."

The review paragraph had a three-item parallel list ("graph-derived blast radius, repair context, and recorded evidence"). It now names the same three things without the drumbeat, and addresses the reader about their own merge rather than about merges in the abstract.

## What deliberately did not change

`substrate` and `control plane` both appear in the README and both are on that same banned list. They stay. Each is used as an architectural descriptor of a specific component (`kin-vector`, `kin-infer`, KinLab), they match the vocabulary the ecosystem docs already use, and neither is decorative. The ban exists to catch marketing filler, and applying it mechanically to genuine technical vocabulary would make the writing worse, not better.

## No claim moved

Verified byte-exact after the edit: the ripgrep commit sha, 13 impacted entities within 3 hops, 3 direct callers, the `PASS` / `NEEDS ATTENTION` / `WOULD BLOCK` verdicts, and the "Authorship is declared, not verified" boundary.

Measured before and after: "blast radius" 2 to 0, em dashes 0 to 0, and no inline colon introduced. An earlier draft of the hero sentence did introduce one, which is why the diff was checked for it specifically rather than assumed clean.