### PR TITLE
Share one validated repository authority per publication

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1780,7 +1780,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     extra_priority_files: Vec<(String, f32)>,
     vector_source: Option<&kin_db::InMemoryGraph>,
     snippet_opts: SnippetOptions,
-    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&kin_mcp::handlers::RequestRepositoryAuthority>,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
 ) -> Result<LocateResult> {
     run_with_graph_capture_budgeted(
@@ -1848,7 +1848,7 @@ fn run_with_graph_capture_budgeted(
     extra_priority_files: Vec<(String, f32)>,
     vector_source: Option<&kin_db::InMemoryGraph>,
     snippet_opts: SnippetOptions,
-    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&kin_mcp::handlers::RequestRepositoryAuthority>,
     source_scope: kin_mcp::handlers::common::EntitySourceScope,
     mut budget: LocateBudget,
 ) -> Result<LocateResult> {
@@ -3978,8 +3978,11 @@ pub fn run_with_graph_capture_at_ref(
 ) -> Result<LocateResult> {
     let authority =
         crate::commands::repository_authority::ActiveRepositoryAuthority::open(binding)?;
+    // A one-shot CLI process has no earlier request to share an open with, so
+    // the source session holds the pinned arm and opens for itself.
+    let source_authority = kin_mcp::handlers::RequestRepositoryAuthority::pinned(binding.clone());
     run_with_repository_authority_capture_at_ref(
-        Some(binding),
+        Some(&source_authority),
         authority.manager(),
         vector_source,
         head,
@@ -3994,7 +3997,7 @@ pub fn run_with_graph_capture_at_ref(
 }
 
 fn run_with_repository_authority_capture_at_ref<B>(
-    repository_authority: Option<&kin_core::LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&kin_mcp::handlers::RequestRepositoryAuthority>,
     authority: &kin_db::RepositoryAuthorityManager<B>,
     vector_source: &kin_db::InMemoryGraph,
     head: &SemanticChangeId,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -68,10 +68,7 @@ impl ActiveApiRepositoryAuthority {
             .local_repository_authority_binding()
             .map_err(repository_authority_error)?;
         let manager = binding.open_manager().map_err(repository_authority_error)?;
-        state
-            .projection_authority
-            .loads
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        state.projection_authority.record_load();
         Ok(Self {
             manager: Arc::new(manager),
             repository_id: binding.repository_id().clone(),
@@ -195,16 +192,28 @@ fn read_local_publication_identity(
     ))
 }
 
-/// One repository-v6 authority shared across the daemon's projection routes.
+/// One repository-v6 authority per durable publication, shared across the
+/// daemon's readers.
 ///
 /// Opening authority is a full snapshot read, SHA-256, and deserialize under an
-/// exclusive repository lock. Paying that per projected read makes every VFS
-/// request proportional to whole-repository size. Holding one open authority
-/// and revalidating it against the durable publication record keeps the answer
+/// exclusive repository lock, and it re-verifies every persisted body against
+/// its content address. Paying that per request makes every request
+/// proportional to whole-repository size. Holding one open authority and
+/// revalidating it against the durable publication record keeps the answer
 /// exactly as fresh while making the common request a small metadata read.
+///
+/// Two readers hold slots here, because they read through different crates'
+/// authority wrappers: the projection routes (`ActiveApiRepositoryAuthority`,
+/// for workspace tree state) and the MCP query tools (kin-mcp's
+/// `ActiveRepositoryAuthority`, for source projection). Both slots key on the
+/// same [`LocalPublicationIdentity`] under the same load gate and count into
+/// the same [`Self::loads`], so the contract is one contract; only the wrapper
+/// differs. The name predates the second reader and is kept because the field
+/// it fills is declared elsewhere.
 #[derive(Default)]
 pub(crate) struct ProjectionAuthorityCache {
     held: std::sync::Mutex<Option<HeldProjectionAuthority>>,
+    query: std::sync::Mutex<Option<HeldQueryAuthority>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
     load_gate: std::sync::Mutex<()>,
@@ -223,14 +232,30 @@ struct HeldProjectionAuthority {
     authority: ActiveApiRepositoryAuthority,
 }
 
+#[derive(Clone)]
+struct HeldQueryAuthority {
+    /// Read strictly before the authority it labels was loaded, exactly as for
+    /// [`HeldProjectionAuthority::published`] and for the same reason.
+    published: LocalPublicationIdentity,
+    authority: Arc<kin_mcp::handlers::ActiveRepositoryAuthority>,
+}
+
 impl ProjectionAuthorityCache {
     /// Complete durable-authority loads this daemon state has paid for.
     ///
-    /// Every [`ActiveApiRepositoryAuthority::open`] counts, whichever route
-    /// asked for it. One load per publication rather than one per request is
-    /// the property this cache exists to make true.
+    /// Every full open counts, whichever route asked for it and whichever
+    /// wrapper it produced. One load per publication rather than one per
+    /// request is the property this cache exists to make true, and this counter
+    /// is how a test states it: it climbs with publications, never with request
+    /// volume, and a path that reverted to opening per request climbs with
+    /// volume again.
     pub(crate) fn loads(&self) -> u64 {
         self.loads.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn record_load(&self) {
+        self.loads
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn reuse(&self, published: &LocalPublicationIdentity) -> Option<ActiveApiRepositoryAuthority> {
@@ -251,8 +276,30 @@ impl ProjectionAuthorityCache {
         });
     }
 
+    fn reuse_query(
+        &self,
+        published: &LocalPublicationIdentity,
+    ) -> Option<Arc<kin_mcp::handlers::ActiveRepositoryAuthority>> {
+        lock_recover(&self.query)
+            .as_ref()
+            .filter(|held| &held.published == published)
+            .map(|held| Arc::clone(&held.authority))
+    }
+
+    fn install_query(
+        &self,
+        published: LocalPublicationIdentity,
+        authority: Arc<kin_mcp::handlers::ActiveRepositoryAuthority>,
+    ) {
+        *lock_recover(&self.query) = Some(HeldQueryAuthority {
+            published,
+            authority,
+        });
+    }
+
     fn invalidate(&self) {
         *lock_recover(&self.held) = None;
+        *lock_recover(&self.query) = None;
     }
 }
 
@@ -321,6 +368,80 @@ fn projection_repository_authority(
         repository = %authority.repository_id,
         loads = state.projection_authority.loads(),
         "projection repository authority loaded"
+    );
+    Ok(authority)
+}
+
+/// Resolve the repository-v6 authority the MCP query tools read source from.
+///
+/// The same contract as [`projection_repository_authority`], for the other
+/// wrapper: probe the pinned namespace, read which publication local storage
+/// holds, reuse the authority already loaded at that publication, and otherwise
+/// perform one full validating open behind the shared load gate.
+///
+/// STALENESS, EXACTLY. A query served from a reused authority answers from the
+/// durable publication whose record this function read just before handing the
+/// authority over. That is the publication a fresh open at that same instant
+/// would have loaded, and both would decode the same content-addressed bytes
+/// under the same validation, so the reused answer IS the fresh answer -- a
+/// reused open is not an approximation of one. What such a query cannot observe
+/// is a commit that lands after its publication read; neither can a fresh open,
+/// which also samples storage once and then answers from what it sampled. Every
+/// call reads the record again, so a publication that lands between two calls
+/// is observed by the second, including one committed by a separate process
+/// such as a CLI ingest running beside the daemon. The record digest errs in
+/// the safe direction: identical record bytes mean identical durable state, and
+/// a rewrite that is not a new publication costs one extra full load rather
+/// than a stale serve.
+///
+/// Reuse never weakens what an open proves. KinDB re-verifies every persisted
+/// body against its content address on every open, and this function cannot
+/// reach past that: it either hands back the result of one that already ran for
+/// these exact durable bytes, or it performs one.
+///
+/// Blocking: reads storage metadata and, on a publication change, loads the
+/// complete durable authority.
+fn query_repository_authority(
+    state: &DaemonState,
+) -> Result<Arc<kin_mcp::handlers::ActiveRepositoryAuthority>, (StatusCode, String)> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let repository_id = binding.repository_id().clone();
+
+    if let Err(error) = confirm_pinned_projection_namespace(&backend, &repository_id) {
+        state.projection_authority.invalidate();
+        return Err(error);
+    }
+
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(authority) = state.projection_authority.reuse_query(&published) {
+        return Ok(authority);
+    }
+
+    let _load = lock_recover(&state.projection_authority.load_gate);
+    // Re-read under the gate: the publication may have moved while this request
+    // waited, and the label installed below must be the one taken before the
+    // load it describes.
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(authority) = state.projection_authority.reuse_query(&published) {
+        return Ok(authority);
+    }
+    let authority = Arc::new(
+        kin_mcp::handlers::ActiveRepositoryAuthority::open(&binding)
+            .map_err(repository_authority_error)?,
+    );
+    state.projection_authority.record_load();
+    state
+        .projection_authority
+        .install_query(published, Arc::clone(&authority));
+    tracing::debug!(
+        repository = %repository_id,
+        loads = state.projection_authority.loads(),
+        "query repository authority loaded"
     );
     Ok(authority)
 }
@@ -1944,7 +2065,7 @@ where
 }
 
 async fn mcp_find_references_with_stable_authority<F>(
-    state: &DaemonState,
+    state: &Arc<DaemonState>,
     session_id: Option<&SessionId>,
     selected_graph: Arc<kin_db::InMemoryGraph>,
     authority: RequestGraphAuthority,
@@ -1955,7 +2076,7 @@ where
     F: FnMut(usize),
 {
     let spine = state.ensure_spine();
-    let repository_authority = mcp_repository_authority_binding(state)?;
+    let repository_authority = mcp_repository_authority_source(state)?;
     for attempt_number in 0..XREF_STABLE_READ_ATTEMPTS {
         let Some(attempt) = prepare_xref_graph_read(state, &selected_graph, authority) else {
             continue;
@@ -1987,7 +2108,7 @@ where
     ))
 }
 
-fn mcp_repository_authority_binding(
+fn mcp_local_repository_binding(
     state: &DaemonState,
 ) -> kin_mcp::Result<Option<kin_core::LocalRepositoryAuthorityBinding>> {
     if state.storage_backend.is_some() {
@@ -2003,10 +2124,67 @@ fn mcp_repository_authority_binding(
         })
 }
 
+fn mcp_authority_gap(message: impl std::fmt::Display) -> kin_mcp::McpError {
+    kin_mcp::McpError::Context(format!("graph authority gap: {message}"))
+}
+
+/// The authority source the daemon's MCP dispatch hands one tool call.
+///
+/// Resolution is deferred to the first source read rather than performed here.
+/// Most of what reaches this dispatch never reads a body -- session,
+/// transaction, and pure-graph tools -- and resolving up front would charge the
+/// first such call for a full open of a publication it does not touch. The
+/// resolver runs at most once per request, when a handler actually needs
+/// authority, and answers from the shared per-publication load.
+fn mcp_repository_authority_source(
+    state: &Arc<DaemonState>,
+) -> kin_mcp::Result<Option<kin_mcp::handlers::RequestRepositoryAuthority>> {
+    Ok(mcp_local_repository_binding(state)?.map(|binding| shared_authority_source(state, binding)))
+}
+
+/// Bind a request's authority to this daemon's shared per-publication load.
+///
+/// The resolver runs at most once per request, and only if a handler reaches a
+/// read that needs authority.
+fn shared_authority_source(
+    state: &Arc<DaemonState>,
+    binding: kin_core::LocalRepositoryAuthorityBinding,
+) -> kin_mcp::handlers::RequestRepositoryAuthority {
+    let resolver_state = Arc::clone(state);
+    kin_mcp::handlers::RequestRepositoryAuthority::shared(
+        binding,
+        Arc::new(move || {
+            query_repository_authority(&resolver_state)
+                .map_err(|(_, message)| mcp_authority_gap(message))
+        }),
+    )
+}
+
+/// The authority source for a route that has already decided it reads source.
+///
+/// Resolves through the shared per-publication load immediately, because the
+/// caller only reaches this after establishing that the request projects
+/// bodies.
 fn require_mcp_local_repository_authority(
     state: &DaemonState,
+) -> kin_mcp::Result<kin_mcp::handlers::RequestRepositoryAuthority> {
+    let binding = require_mcp_local_repository_binding(state)?;
+    let authority =
+        query_repository_authority(state).map_err(|(_, message)| mcp_authority_gap(message))?;
+    Ok(kin_mcp::handlers::RequestRepositoryAuthority::already_open(
+        binding, authority,
+    ))
+}
+
+/// The startup-pinned binding alone, for routes that hand it to a command
+/// helper which opens authority through its own crate's wrapper.
+///
+/// These do not read through this daemon's shared open, so resolving one here
+/// would load a publication the route never consults.
+fn require_mcp_local_repository_binding(
+    state: &DaemonState,
 ) -> kin_mcp::Result<kin_core::LocalRepositoryAuthorityBinding> {
-    mcp_repository_authority_binding(state)?.ok_or_else(|| {
+    mcp_local_repository_binding(state)?.ok_or_else(|| {
         kin_mcp::McpError::Context(
             "graph authority gap: this MCP operation requires startup-pinned local repository \
              authority, but the daemon is serving hosted snapshot authority"
@@ -4740,9 +4918,15 @@ async fn run_fused_locate_for_state(
     max_files_explicit: bool,
     snippet_opts: kin_cli::commands::locate::SnippetOptions,
 ) -> Result<kin_cli::commands::locate::LocateResult, String> {
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(|error| error.to_string())?;
+    // Bound to this daemon's shared per-publication load, and resolved only if
+    // the page actually projects a body: a locate that returns no snippets
+    // never opens authority at all.
+    let repository_authority = shared_authority_source(
+        state,
+        state
+            .local_repository_authority_binding()
+            .map_err(|error| error.to_string())?,
+    );
     // When a session scope is active, discover historical test artifact
     // priority files to match the ref-scoped path's behavior.
     let session_scope = if let Some(sid) = session_id {
@@ -6870,7 +7054,7 @@ async fn mcp_tools_call(
                 "missing required parameter: entity_id".to_string(),
             )));
         };
-        let repository_authority = match require_mcp_local_repository_authority(&state) {
+        let repository_authority = match require_mcp_local_repository_binding(&state) {
             Ok(binding) => binding,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
@@ -6893,7 +7077,7 @@ async fn mcp_tools_call(
             Ok(parsed) => parsed,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
-        let repository_authority = match require_mcp_local_repository_authority(&state) {
+        let repository_authority = match require_mcp_local_repository_binding(&state) {
             Ok(binding) => binding,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
@@ -6960,7 +7144,7 @@ async fn mcp_tools_call(
             direction: parsed_direction,
             limit_per_step,
         };
-        let repository_authority = match require_mcp_local_repository_authority(&state) {
+        let repository_authority = match require_mcp_local_repository_binding(&state) {
             Ok(binding) => binding,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
@@ -7236,7 +7420,7 @@ async fn mcp_tools_call(
             "coordination enforcement rejected transaction before repository publication: {evidence}"
         ))
     } else {
-        let repository_authority = mcp_repository_authority_binding(&state);
+        let repository_authority = mcp_repository_authority_source(&state);
         let handled = if request.name == "find_references" {
             mcp_find_references_with_stable_authority(
                 &state,
@@ -25015,12 +25199,21 @@ mod tests {
     /// Call `semantic_locate` over the MCP dispatch route and return the
     /// parsed JSON payload (must not be a tool error).
     async fn call_semantic_locate(app: Router, arguments: serde_json::Value) -> serde_json::Value {
+        call_mcp_tool(app, "semantic_locate", arguments).await
+    }
+
+    /// Run one MCP tool through the real dispatch route and parse its JSON.
+    async fn call_mcp_tool(
+        app: Router,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> serde_json::Value {
         let response = app
             .oneshot(
                 Request::post("/mcp/tools/call")
                     .header("content-type", "application/json")
                     .body(Body::from(
-                        json!({ "name": "semantic_locate", "arguments": arguments }).to_string(),
+                        json!({ "name": name, "arguments": arguments }).to_string(),
                     ))
                     .unwrap(),
             )
@@ -25031,7 +25224,7 @@ mod tests {
             .await
             .unwrap();
         let result: kin_mcp::ToolCallResult = serde_json::from_slice(&body).unwrap();
-        assert_ne!(result.is_error, Some(true), "tool call errored: {result:?}");
+        assert_ne!(result.is_error, Some(true), "{name} errored: {result:?}");
         let text = match result.content.first().unwrap() {
             kin_mcp::ContentBlock::Text { text } => text,
         };
@@ -25271,36 +25464,209 @@ mod tests {
     /// `install_repository_file` is its own change, so the entities are
     /// introduced by different changes. That is the shape a real retrieval page
     /// has, and it is the one where a per-result authority open multiplies.
-    fn install_locate_page(state: &Arc<DaemonState>, page: usize) {
-        for index in 0..page {
-            let path = format!("src/config{index}.py");
-            let source =
-                format!("def parse_config{index}(path):\n    return {{\"which\": {index}}}\n");
-            install_repository_file(state, &path, source.as_bytes());
-            install_working_copy_file(state, &path, source.as_bytes(), false);
-            let mut entity = test_entity(&format!("parse_config{index}"), &path);
-            entity.span = Some(SourceSpan {
-                file: kin_model::FilePathId::new(&path),
-                start_byte: 0,
-                end_byte: source.len(),
-                start_line: 0,
-                start_col: 0,
-                end_line: 1,
-                end_col: 24,
-            });
-            // The fused ranker reads this preview to decide an entity is a
-            // definition rather than a bare reference, and only definitions get
-            // bodies. Without it this fixture would exercise the reference path,
-            // which projects nothing and would make the bound below vacuous.
-            entity.metadata.extra.insert(
-                "embedding_body_preview".to_string(),
-                json!(source.lines().next().unwrap()),
-            );
-            state.graph.upsert_entity(&entity).unwrap();
-        }
+    /// Distinct query tools at ONE publication share ONE authority load.
+    ///
+    /// FIR-2079. Every MCP query request used to open repository authority for
+    /// itself, and an open decodes the whole persisted snapshot and re-verifies
+    /// every persisted body against its content address, so the query floor was
+    /// whole-repository work per REQUEST rather than per publication.
+    ///
+    /// The bound is a COUNT, never elapsed time. What an open costs is a
+    /// property of the store, so a timing assertion on a four-file fixture
+    /// would pass just as readily with the defect present; a count does not
+    /// move with the host and does not move with store size either.
+    ///
+    /// It reads this daemon state's own counter rather than the process-wide
+    /// open count, so a sibling test opening authority in parallel cannot enter
+    /// it. The only path that increments it is one that performed a full
+    /// validating open, which is why the same counter is also the evidence
+    /// below that a publication boundary re-validated.
+    #[tokio::test]
+    async fn distinct_query_tools_share_one_authority_load_per_publication() {
+        const PAGE: usize = 3;
+        // Same reason as the FIR-1897 test above: a phase budget exhausted by a
+        // stalled host makes locate return early with nothing projected, which
+        // reads at these assertions exactly like the regression they catch.
+        let _budget = kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_TOTAL_TIMEOUT_SECS", "0")
+            .with("KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS", "0")
+            .with("KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS", "0")
+            .with("KIN_LOCATE_PHASE_MULTIHOP_SECS", "0")
+            .with("KIN_LOCATE_PHASE_TEXT_SEARCH_SECS", "0")
+            .with("KIN_LOCATE_PHASE_SOURCE_TEXT_SECS", "0")
+            .with("KIN_LOCATE_PHASE_SCORING_SECS", "0");
+        let state = test_state();
+        let entities = install_locate_page(&state, PAGE);
+        let app = router(Arc::clone(&state));
+
+        let before = state.projection_authority.loads();
+        let located = call_semantic_locate(
+            app.clone(),
+            json!({
+                "query": "parse config",
+                "limit": 5,
+                "pipeline": "fused",
+                "include_snippet": true
+            }),
+        )
+        .await;
+        let entity = call_mcp_tool(
+            app.clone(),
+            "get_entity",
+            json!({ "entity_id": entities[0].to_string() }),
+        )
+        .await;
+        let pack = call_mcp_tool(
+            app.clone(),
+            "get_context_pack",
+            json!({ "entity_id": entities[1].to_string() }),
+        )
+        .await;
+
+        // Non-vacuity: each call must actually have projected graph-owned
+        // source. A tool that returned without reading a body needs no
+        // authority at all, and three such calls would hold the count at one
+        // while proving nothing about sharing.
+        assert!(
+            bodies_projected(&located) >= 2,
+            "the located page must project bodies for the bound to mean anything: {located}"
+        );
+        assert!(
+            entity["source_excerpt"]
+                .as_str()
+                .is_some_and(|body| body.contains("parse_config0")),
+            "get_entity must serve its graph-owned body: {entity}"
+        );
+        assert!(
+            pack["focal_entity"]["body"]
+                .as_str()
+                .is_some_and(|body| body.contains("parse_config1")),
+            "get_context_pack must serve its focal body: {pack}"
+        );
+
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            1,
+            "three distinct query tools reading source at one publication must load repository \
+             authority exactly once; a count that climbs with request volume is the per-request \
+             open this shares"
+        );
+    }
+
+    /// A publication boundary forces a fresh, fully validating load.
+    ///
+    /// The other half of the bound above, and the one that keeps it honest: a
+    /// count held at one by never reloading would be a cache that serves
+    /// authority the store has moved past. The commit here goes through the
+    /// ordinary repository write path, exactly as a CLI ingest running beside
+    /// the daemon does.
+    ///
+    /// Freshness is asserted on the ANSWER, not only on the counter. The entity
+    /// installed after the boundary lives on a path the previous publication's
+    /// workspace tree does not carry, so an authority reused across the
+    /// boundary could not serve its body at all.
+    #[tokio::test]
+    async fn a_publication_boundary_costs_exactly_one_more_authority_load() {
+        const AFTER: &str = "def parse_after(path):\n    return {\"which\": \"after\"}\n";
+        let state = test_state();
+        let entities = install_locate_page(&state, 1);
+        let app = router(Arc::clone(&state));
+
+        let before = state.projection_authority.loads();
+        let first = call_mcp_tool(
+            app.clone(),
+            "get_entity",
+            json!({ "entity_id": entities[0].to_string() }),
+        )
+        .await;
+        assert!(
+            first["source_excerpt"].as_str().is_some(),
+            "the first read must project a body, or it loaded no authority: {first}"
+        );
+        let at_first_publication = state.projection_authority.loads() - before;
+        assert_eq!(at_first_publication, 1, "the first read must load once");
+
+        let after = install_source_entity(&state, "parse_after", "src/after.py", AFTER);
+
+        let served = call_mcp_tool(
+            app.clone(),
+            "get_entity",
+            json!({ "entity_id": after.to_string() }),
+        )
+        .await;
+        assert!(
+            served["source_excerpt"]
+                .as_str()
+                .is_some_and(|body| body.contains("parse_after")),
+            "a read after the boundary must serve the publication that replaced the one the \
+             previous read loaded: {served}"
+        );
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            2,
+            "crossing one publication boundary must cost exactly one more full validating load: \
+             fewer means authority was reused past the commit that replaced it, more means the \
+             reuse stopped holding within a publication"
+        );
+
+        // And the new publication is then shared in turn, rather than reloaded
+        // per request from here on.
+        let repeat =
+            call_mcp_tool(app, "get_entity", json!({ "entity_id": after.to_string() })).await;
+        assert!(repeat["source_excerpt"].as_str().is_some());
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            2,
+            "a second read at the new publication must reuse the load the first one paid for"
+        );
+    }
+
+    /// Publish one source file and the graph entity whose span covers it.
+    ///
+    /// Returns the entity id, so a test can aim a tool at a known entity by ID
+    /// rather than at whatever a ranker happens to surface.
+    fn install_source_entity(
+        state: &Arc<DaemonState>,
+        name: &str,
+        path: &str,
+        source: &str,
+    ) -> EntityId {
+        install_repository_file(state, path, source.as_bytes());
+        install_working_copy_file(state, path, source.as_bytes(), false);
+        let mut entity = test_entity(name, path);
+        entity.span = Some(SourceSpan {
+            file: kin_model::FilePathId::new(path),
+            start_byte: 0,
+            end_byte: source.len(),
+            start_line: 0,
+            start_col: 0,
+            end_line: 1,
+            end_col: 24,
+        });
+        // The fused ranker reads this preview to decide an entity is a
+        // definition rather than a bare reference, and only definitions get
+        // bodies. Without it this fixture would exercise the reference path,
+        // which projects nothing and would make the bound below vacuous.
+        entity.metadata.extra.insert(
+            "embedding_body_preview".to_string(),
+            json!(source.lines().next().unwrap()),
+        );
+        state.graph.upsert_entity(&entity).unwrap();
+        entity.id
+    }
+
+    fn install_locate_page(state: &Arc<DaemonState>, page: usize) -> Vec<EntityId> {
+        let ids = (0..page)
+            .map(|index| {
+                let path = format!("src/config{index}.py");
+                let source =
+                    format!("def parse_config{index}(path):\n    return {{\"which\": {index}}}\n");
+                install_source_entity(state, &format!("parse_config{index}"), &path, &source)
+            })
+            .collect();
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        ids
     }
 
     /// Bodies projected on a `semantic_locate` page, by whichever key the arm

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2463,7 +2463,9 @@ mod tests {
 
         // The exact bytes `get_entity` returns, then straight back in as the
         // payload, which is the round trip nothing else in the workspace walks.
-        let binding = state.local_repository_authority_binding().unwrap();
+        let binding = kin_mcp::handlers::RequestRepositoryAuthority::pinned(
+            state.local_repository_authority_binding().unwrap(),
+        );
         let response = kin_mcp::handlers::common::entity_response_json(
             state.graph.as_ref(),
             &entity,

--- a/crates/kin-mcp/src/handlers/artifacts.rs
+++ b/crates/kin-mcp/src/handlers/artifacts.rs
@@ -66,15 +66,17 @@ pub(crate) struct ExactTreeSelection {
 }
 
 fn require_repository_authority(
-    binding: Option<&super::repository_authority::LocalRepositoryAuthorityBinding>,
-) -> Result<super::repository_authority::ActiveRepositoryAuthority> {
-    super::repository_authority::ActiveRepositoryAuthority::open(binding.ok_or_else(|| {
-        McpError::Context(
-            "graph authority gap: this MCP runtime has no startup-pinned local repository \
-             authority binding"
-                .to_string(),
-        )
-    })?)
+    binding: Option<&super::repository_authority::RequestRepositoryAuthority>,
+) -> Result<std::sync::Arc<super::repository_authority::ActiveRepositoryAuthority>> {
+    binding
+        .ok_or_else(|| {
+            McpError::Context(
+                "graph authority gap: this MCP runtime has no startup-pinned local repository \
+                 authority binding"
+                    .to_string(),
+            )
+        })?
+        .open()
 }
 
 fn explicit_source_change_id(
@@ -93,7 +95,7 @@ fn explicit_source_change_id(
 pub(crate) fn resolve_tree_selection<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&super::repository_authority::LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&super::repository_authority::RequestRepositoryAuthority>,
 ) -> Result<ExactTreeSelection> {
     let explicit = explicit_source_change_id(args)?;
     let (source_change_id, tree) = match explicit {
@@ -176,7 +178,7 @@ fn select_artifact<'a>(
 pub fn handle_artifact_list<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&super::repository_authority::LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&super::repository_authority::RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let selection = resolve_tree_selection(args, store, repository_authority)?;
     let offset = args
@@ -213,7 +215,7 @@ pub fn handle_artifact_list<G: GraphStore>(
 pub fn handle_artifact_read<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&super::repository_authority::LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&super::repository_authority::RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let selection = resolve_tree_selection(args, store, repository_authority)?;
     let artifact = select_artifact(args, &selection.tree)?;

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -22,9 +22,10 @@ thread_local! {
     pub static LAST_READ_SOURCE: std::cell::Cell<&'static str> = std::cell::Cell::new("unknown");
 }
 
-use super::repository_authority::{ActiveRepositoryAuthority, WorkspaceReadSample};
+use super::repository_authority::{
+    ActiveRepositoryAuthority, RequestRepositoryAuthority, WorkspaceReadSample,
+};
 use crate::error::{McpError, Result};
-use kin_core::LocalRepositoryAuthorityBinding;
 
 pub use super::repository_authority::{
     repository_authority_opens_on_this_thread, REPOSITORY_AUTHORITY_OPEN_COUNT,
@@ -453,7 +454,7 @@ pub fn collect_primary_trace_chain<G: GraphStore>(
 pub fn trace_body<G: GraphStore>(
     store: &G,
     entity: &Entity,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<String> {
     trace_body_held(
         &HeldSourceAuthority::new(store, repository_authority),
@@ -852,7 +853,7 @@ pub fn evaluate_trace_chain<G: GraphStore>(
     store: &G,
     chain: &[Entity],
     input_literal: i64,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<Option<Vec<TraceEvaluationStep>>> {
     evaluate_trace_chain_held(
         &HeldSourceAuthority::new(store, repository_authority),
@@ -1016,7 +1017,7 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     store: &G,
     entity_id: &EntityId,
     relation_kinds: &[RelationKind],
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<Vec<ReferenceRow>> {
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
     let mut grouped: HashMap<String, ReferenceRow> = HashMap::new();
@@ -1527,13 +1528,21 @@ pub fn span_source_coherence(
 /// a 40-candidate `semantic_locate` perform 40 authority opens and 40 whole-
 /// history replays and put a real repository out of service.
 ///
-/// The reuse is sound because it is scoped, not cached. The session borrows ONE
-/// store snapshot for its whole life, so a memoized replay is byte-identical to
-/// the replay it replaces -- `resolve_graph_at` is deterministic in (store,
-/// change). Nothing survives the request: a later request opens authority again
-/// and sees whatever the store holds then. There is deliberately no process-wide
-/// cache here, because that is the shape that can serve authority the store has
-/// already moved past.
+/// The replay reuse is sound because it is scoped, not cached. The session
+/// borrows ONE store snapshot for its whole life, so a memoized replay is
+/// byte-identical to the replay it replaces -- `resolve_graph_at` is
+/// deterministic in (store, change). Nothing derived here survives the request.
+///
+/// The authority itself may outlive the request, and only under a condition the
+/// caller has to have met. This type never caches an open and never decides
+/// that one is still good: it opens from its binding, or it reads through an
+/// authority a caller opened and labelled with the durable publication it was
+/// loaded at. The shape this deliberately does not have is a process-wide cache
+/// that keeps an open on nothing but its own say-so, because that is the one
+/// that serves authority the store has already moved past. See
+/// [`RequestRepositoryAuthority::shared`] for the obligation a caller takes on,
+/// and note that a caller that meets it hands over exactly the bytes a fresh
+/// open would have produced at the instant it sampled the publication.
 ///
 /// Reusing one sample is also strictly MORE coherent than re-sampling per
 /// entity. [`WorkspaceReadSample`] exists because pairing a tree from one
@@ -1549,11 +1558,11 @@ pub fn span_source_coherence(
 /// [`WorkspaceReadSample`]: super::repository_authority::WorkspaceReadSample
 pub struct HeldSourceAuthority<'store, G: GraphStore> {
     store: &'store G,
-    binding: Option<LocalRepositoryAuthorityBinding>,
+    source: Option<RequestRepositoryAuthority>,
     /// One open attempt for the session. The error is retained as its message so
     /// every entity that needs authority reports the same gap this session hit,
     /// instead of re-attempting a recovery that already failed.
-    authority: std::sync::OnceLock<std::result::Result<ActiveRepositoryAuthority, String>>,
+    authority: std::sync::OnceLock<std::result::Result<Arc<ActiveRepositoryAuthority>, String>>,
     head_sample: std::sync::OnceLock<std::result::Result<Arc<WorkspaceReadSample>, String>>,
     graph_at: Mutex<HashMap<SemanticChangeId, Arc<kin_model::graph::ResolvedGraphState>>>,
     tree_at: Mutex<HashMap<SemanticChangeId, Arc<kin_model::ResolvedTree>>>,
@@ -1566,17 +1575,19 @@ pub struct HeldSourceAuthority<'store, G: GraphStore> {
 impl<'store, G: GraphStore> HeldSourceAuthority<'store, G> {
     /// Hold authority for one request against one store snapshot.
     ///
-    /// `repository_authority` is the startup-pinned binding, not an open: this
-    /// constructor performs no IO. A `None` binding is an ordinary state (a
-    /// daemon serving hosted snapshot authority), and only a read that actually
-    /// needs local authority turns it into a gap.
+    /// `repository_authority` names where this request's authority comes from,
+    /// and is not itself an open: this constructor performs no IO whether the
+    /// caller passed a startup-pinned binding or an authority it already
+    /// opened. A `None` source is an ordinary state (a daemon serving hosted
+    /// snapshot authority), and only a read that actually needs local authority
+    /// turns it into a gap.
     pub fn new(
         store: &'store G,
-        repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+        repository_authority: Option<&RequestRepositoryAuthority>,
     ) -> Self {
         Self {
             store,
-            binding: repository_authority.cloned(),
+            source: repository_authority.cloned(),
             authority: std::sync::OnceLock::new(),
             head_sample: std::sync::OnceLock::new(),
             graph_at: Mutex::new(HashMap::new()),
@@ -1600,14 +1611,14 @@ impl<'store, G: GraphStore> HeldSourceAuthority<'store, G> {
 
     fn authority(&self) -> Result<&ActiveRepositoryAuthority> {
         match self.authority.get_or_init(|| {
-            let binding = self.binding.as_ref().ok_or_else(|| {
+            let source = self.source.as_ref().ok_or_else(|| {
                 "graph authority gap: this MCP runtime has no startup-pinned local repository \
                  authority binding"
                     .to_string()
             })?;
-            ActiveRepositoryAuthority::open(binding).map_err(retained_gap_message)
+            source.open().map_err(retained_gap_message)
         }) {
-            Ok(authority) => Ok(authority),
+            Ok(authority) => Ok(authority.as_ref()),
             Err(message) => Err(record_graph_source_gap(McpError::Context(message.clone()))),
         }
     }
@@ -1976,7 +1987,7 @@ pub fn read_entity_source_excerpt_detailed<G: GraphStore>(
     entity: &Entity,
     max_lines: usize,
     max_chars: usize,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
     scope: EntitySourceScope,
 ) -> Result<Option<ExactEntitySource>> {
     read_entity_source_excerpt_detailed_held(
@@ -2067,7 +2078,7 @@ pub const RETRIEVAL_SNIPPET_MAX_CHARS: usize = 800;
 pub fn read_bounded_entity_snippet<G: GraphStore>(
     store: &G,
     entity: &Entity,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
     scope: EntitySourceScope,
 ) -> Result<Option<String>> {
     read_bounded_entity_snippet_held(
@@ -2368,7 +2379,7 @@ pub fn clip_rendered_text_with_cap(text: &str, max_lines: usize, max_chars: usiz
 pub fn entity_response_json<G: GraphStore>(
     store: &G,
     entity: &Entity,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<serde_json::Value> {
     let mut value = serde_json::to_value(entity).map_err(McpError::Json)?;
     let Some(obj) = value.as_object_mut() else {
@@ -2421,7 +2432,7 @@ pub fn focal_context_json<G: GraphStore>(
     store: &G,
     entity: &Entity,
     compact: bool,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<serde_json::Value> {
     focal_context_json_held(
         &HeldSourceAuthority::new(store, repository_authority),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use kin_core::LocalRepositoryAuthorityBinding;
+use super::repository_authority::RequestRepositoryAuthority;
 use kin_model::entity::EntityKind;
 use kin_model::graph::{EntityFilter, GraphStore};
 use kin_model::relation::RelationKind;
@@ -158,7 +158,7 @@ get_entity_source when you actually need to read the code.";
 pub fn handle_get_entity<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let id_str = get_string_param(args, "entity_id")?;
     let entity_id = parse_entity_id(&id_str)?;
@@ -195,7 +195,7 @@ trace_data_flow when you also need the entity's neighborhood rather than just it
 pub fn handle_get_entity_source<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let id_str = get_string_param(args, "entity_id")?;
     let entity_id = parse_entity_id(&id_str)?;
@@ -558,7 +558,7 @@ fn resolve_entity_source_generic<G: GraphStore>(
 pub fn handle_get_entity_sources<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let (entity_ids, opts) = parse_batch_source_args(args)?;
     // A batch is one request: it holds authority once for every id it resolves.
@@ -590,7 +590,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
     sessions: &SessionRegistry,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     use kin_context::{build_context_pack_with_traffic, ContextOptions};
     use kin_model::context::TokenBudget;
@@ -788,7 +788,7 @@ pub fn handle_trace_computation<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
     sessions: &SessionRegistry,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let mut merged: HashMap<String, serde_json::Value> = args.clone();
 
@@ -1009,7 +1009,7 @@ fn daemon_spine_xref(
 pub async fn handle_find_references<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     handle_find_references_with_authority_source(
         args,
@@ -1031,7 +1031,7 @@ pub async fn handle_find_references_with_ambient_binding<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
     binding: AmbientCrossRepoBinding,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     handle_find_references_with_authority_source(
         args,
@@ -1051,7 +1051,7 @@ pub async fn handle_find_references_with_authority<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
     authority: FindReferencesAuthority<'_>,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     handle_find_references_with_authority_source(
         args,
@@ -1066,7 +1066,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
     authority_source: FindReferencesAuthoritySource<'_>,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let relation_kinds = if let Some(raw_kinds) = get_optional_string_array(args, "relation_kinds")
     {
@@ -1620,7 +1620,7 @@ get_context_pack, find_references, trace_data_flow) let you go deeper precisely.
 pub fn handle_explore_codebase<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     use kin_context::{build_context_pack, estimate_tokens, ContextOptions};
     use kin_model::context::TokenBudget;

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -17,7 +17,9 @@ pub mod sessions;
 pub mod verification;
 pub mod work;
 
-pub use repository_authority::LocalRepositoryAuthorityBinding;
+pub use repository_authority::{
+    ActiveRepositoryAuthority, LocalRepositoryAuthorityBinding, RequestRepositoryAuthority,
+};
 
 use std::collections::HashMap;
 
@@ -35,7 +37,7 @@ pub async fn handle_tool_call<G: GraphStore>(
     store: &G,
     sessions: &SessionRegistry,
     session_authority_mode: SessionAuthorityMode,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     match tool_name {
         // Exact repository membership and bytes
@@ -815,7 +817,15 @@ mod tests {
         initialize_test_repository(root, &change);
     }
 
-    fn test_repository_authority(
+    /// The default arm: a request that opens authority for itself. Tests that
+    /// bound the open COUNT depend on this staying the pinned arm, because a
+    /// shared open would hold that count flat whether or not the path under
+    /// test still holds authority once per request.
+    fn test_repository_authority(root: &std::path::Path) -> RequestRepositoryAuthority {
+        RequestRepositoryAuthority::pinned(test_repository_binding(root))
+    }
+
+    fn test_repository_binding(
         root: &std::path::Path,
     ) -> kin_core::LocalRepositoryAuthorityBinding {
         let layout = kin_core::KinLayout::discover(root)
@@ -2682,7 +2692,8 @@ mod tests {
 
         // The bootstrap mints its own artifact ids, so the update has to name the
         // identity that actually occupies the path rather than the fixture's.
-        let admitted = super::repository_authority::ActiveRepositoryAuthority::open(&authority)
+        let admitted = authority
+            .open_fresh()
             .unwrap()
             .workspace()
             .unwrap()
@@ -4891,12 +4902,7 @@ mod tests {
         before: &str,
         after: &str,
         stamp: SpanStamp,
-    ) -> (
-        Entity,
-        EmptyStore,
-        kin_core::LocalRepositoryAuthorityBinding,
-        Hash256,
-    ) {
+    ) -> (Entity, EmptyStore, RequestRepositoryAuthority, Hash256) {
         let kin_dir = dir.join(".kin");
         fs::create_dir_all(&kin_dir).unwrap();
         let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
@@ -6029,12 +6035,14 @@ mod tests {
         initialize_release_test_repository(dir.path(), store);
         let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
         let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
-        let authority = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap();
+        let authority = RequestRepositoryAuthority::pinned(
+            kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap(),
+        );
         verification::handle_release_check(args, store, Some(&authority))
     }
 
     pub(super) fn with_empty_test_repository<T>(
-        call: impl FnOnce(&kin_core::LocalRepositoryAuthorityBinding) -> T,
+        call: impl FnOnce(&RequestRepositoryAuthority) -> T,
     ) -> T {
         let _lock = ENV_MUTEX
             .get_or_init(|| Mutex::new(()))
@@ -6043,8 +6051,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let init = kin_core::init(dir.path()).unwrap();
         let _guard = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
-        let authority =
-            kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap();
+        let authority = RequestRepositoryAuthority::pinned(
+            kin_core::LocalRepositoryAuthorityBinding::from_layout(&init.layout).unwrap(),
+        );
         call(&authority)
     }
 

--- a/crates/kin-mcp/src/handlers/repository_authority.rs
+++ b/crates/kin-mcp/src/handlers/repository_authority.rs
@@ -11,7 +11,9 @@
 //! and let one daemon silently change which repository it serves.
 
 use std::collections::BTreeSet;
+use std::fmt;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use kin_db::{
     LocalFileBackend, PersistedRepositoryAuthority, RepositoryAuthorityManager,
@@ -52,7 +54,7 @@ impl RepositoryAuthorityMetadata for RepositoryAuthorityState {
 /// A process launched outside a Kin repository has no binding; handlers that
 /// require exact repository authority will then fail loudly. An invalid
 /// repository that *is* discovered remains a startup error.
-pub(crate) fn discover_for_process() -> Result<Option<LocalRepositoryAuthorityBinding>> {
+pub(crate) fn discover_for_process() -> Result<Option<RequestRepositoryAuthority>> {
     let start = std::env::var_os("KIN_SOURCE_ROOT")
         .map(PathBuf::from)
         .map(Ok)
@@ -61,14 +63,128 @@ pub(crate) fn discover_for_process() -> Result<Option<LocalRepositoryAuthorityBi
         return Ok(None);
     };
     LocalRepositoryAuthorityBinding::from_layout(&layout)
+        .map(RequestRepositoryAuthority::pinned)
         .map(Some)
         .map_err(|error| McpError::Context(format!("graph authority gap: {error}")))
 }
 
-pub(crate) struct ActiveRepositoryAuthority {
+pub struct ActiveRepositoryAuthority {
     manager: RepositoryAuthorityManager<LocalFileBackend>,
     pub repository_id: RepositoryId,
     pub workspace_id: WorkspaceId,
+}
+
+/// The repository authority one request reads at, and when it was opened.
+///
+/// Opening authority re-verifies every persisted body against its content
+/// address, so it costs whatever the whole store is worth rather than whatever
+/// the request asked for. A one-shot process has no one to share that with and
+/// opens for itself, which is what every handler did before this type existed.
+/// A long-lived server does: it resolves one open per durable publication and
+/// hands the same authority to every request that reads at that publication.
+///
+/// Both arms answer from an open that passed KinDB's complete open-time
+/// validation. There is no third arm, no flag, and no path through this type
+/// that produces authority which skipped validation -- reuse can only hand back
+/// the result of a full validation that already ran over these exact durable
+/// bytes. What a server has to get right is not WHETHER the authority it shares
+/// was validated but WHICH publication it was validated at; see
+/// [`Self::shared`].
+#[derive(Clone)]
+pub struct RequestRepositoryAuthority {
+    binding: LocalRepositoryAuthorityBinding,
+    shared: Option<SharedAuthorityResolver>,
+}
+
+/// A server's promise to produce authority for the publication a request reads
+/// at, run only if the request turns out to need source at all.
+///
+/// Deferred rather than resolved up front because most of what an MCP dispatch
+/// carries never reads a body: resolving eagerly would charge a session or
+/// transaction call for the first full open of a publication it does not touch.
+pub type SharedAuthorityResolver =
+    Arc<dyn Fn() -> Result<Arc<ActiveRepositoryAuthority>> + Send + Sync>;
+
+impl RequestRepositoryAuthority {
+    /// Authority this request opens for itself, once, on first use.
+    pub fn pinned(binding: LocalRepositoryAuthorityBinding) -> Self {
+        Self {
+            binding,
+            shared: None,
+        }
+    }
+
+    /// Authority a server resolves for the publication this request reads at.
+    ///
+    /// The server owns the freshness argument, and it is the whole of what this
+    /// type cannot check for itself. Each call to `resolve` must return an
+    /// authority opened at a durable publication the server confirmed is still
+    /// the one local storage holds, with that confirmation read BEFORE the open
+    /// it labels rather than after. A label taken afterwards can name a
+    /// publication that landed during the load, which marks older bytes as
+    /// current and serves them past the commit that replaced them.
+    pub fn shared(
+        binding: LocalRepositoryAuthorityBinding,
+        resolve: SharedAuthorityResolver,
+    ) -> Self {
+        Self {
+            binding,
+            shared: Some(resolve),
+        }
+    }
+
+    /// Authority a server already resolved for the publication this request
+    /// reads at.
+    ///
+    /// The eager form of [`Self::shared`], for a caller that decided the
+    /// request reads source before starting it. The same freshness obligation
+    /// applies, at the instant the caller resolved.
+    pub fn already_open(
+        binding: LocalRepositoryAuthorityBinding,
+        authority: Arc<ActiveRepositoryAuthority>,
+    ) -> Self {
+        Self::shared(binding, Arc::new(move || Ok(Arc::clone(&authority))))
+    }
+
+    /// The startup-pinned identity and storage capability behind this
+    /// authority, for the surfaces that still take a binding.
+    pub fn binding(&self) -> &LocalRepositoryAuthorityBinding {
+        &self.binding
+    }
+
+    /// The open authority to read this request from.
+    ///
+    /// Reuses the caller's open when there is one, and otherwise performs the
+    /// full validating open. Handlers call this rather than
+    /// [`ActiveRepositoryAuthority::open`] so a server's shared open is not
+    /// silently bypassed by one read path.
+    pub(crate) fn open(&self) -> Result<Arc<ActiveRepositoryAuthority>> {
+        match &self.shared {
+            Some(resolve) => resolve(),
+            None => self.open_fresh(),
+        }
+    }
+
+    /// Open authority from durable storage, ignoring any open handed in.
+    ///
+    /// For the paths whose answer is "has this moved?". A shared open describes
+    /// the publication its owner sampled, so re-reading it can only ever return
+    /// what the caller already saw -- correct for a read, useless for a
+    /// re-check. Loading again is the only way to observe a commit that landed
+    /// under a separate process since.
+    pub(crate) fn open_fresh(&self) -> Result<Arc<ActiveRepositoryAuthority>> {
+        ActiveRepositoryAuthority::open(&self.binding).map(Arc::new)
+    }
+}
+
+impl fmt::Debug for RequestRepositoryAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RequestRepositoryAuthority")
+            .field("binding", &self.binding)
+            .field("shared", &self.shared.is_some())
+            .finish()
+    }
 }
 
 /// One instant of workspace authority: the exact graph-owned tree, its identity
@@ -98,6 +214,13 @@ pub(crate) struct WorkspaceReadSample {
 /// once per request stays O(1) here no matter how large the store gets, and one
 /// that opens per candidate does not. Public because the surfaces that must hold
 /// that bound (`semantic_locate`, `kin locate --snippets`) live in other crates.
+///
+/// It counts LOADS, not requests: serving a request from an authority a server
+/// already opened for the same durable publication performs no recovery and is
+/// not counted. That is what makes this counter the acceptance instrument for
+/// sharing one open across a publication -- it climbs with publications rather
+/// than with request volume, and a path that quietly reverted to opening per
+/// request would climb with volume again.
 pub static REPOSITORY_AUTHORITY_OPEN_COUNT: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
@@ -126,7 +249,13 @@ pub fn repository_authority_opens_on_this_thread() -> u64 {
 }
 
 impl ActiveRepositoryAuthority {
-    pub(crate) fn open(binding: &LocalRepositoryAuthorityBinding) -> Result<Self> {
+    /// Perform one full validating open.
+    ///
+    /// Public so a server can pay for one open per durable publication and hand
+    /// the result to [`RequestRepositoryAuthority::already_open`]. Read paths
+    /// inside a request go through [`RequestRepositoryAuthority::open`]
+    /// instead, so a shared open is never bypassed by one of them.
+    pub fn open(binding: &LocalRepositoryAuthorityBinding) -> Result<Self> {
         REPOSITORY_AUTHORITY_OPEN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         REPOSITORY_AUTHORITY_OPENS_ON_THREAD.with(|opens| opens.set(opens.get() + 1));
         let manager = binding.open_manager().map_err(|error| {

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use kin_core::LocalRepositoryAuthorityBinding;
+use super::repository_authority::RequestRepositoryAuthority;
 use kin_model::graph::GraphStore;
 use kin_model::ids::SemanticChangeId;
 use kin_review::{format_review, SemanticReview};
@@ -276,7 +276,7 @@ change before merge, or to feed a merge-gate dashboard.";
 fn resolve_shadow_ref<G: GraphStore>(
     store: &G,
     reference: &str,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<SemanticChangeId> {
     if let Some(branch_name) = reference.strip_prefix("branch:") {
         return resolve_shadow_branch(store, branch_name, repository_authority);
@@ -307,17 +307,17 @@ fn resolve_shadow_ref<G: GraphStore>(
 fn resolve_shadow_branch<G: GraphStore>(
     store: &G,
     branch_name: &str,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<SemanticChangeId> {
-    let authority = super::repository_authority::ActiveRepositoryAuthority::open(
-        repository_authority.ok_or_else(|| {
+    let authority = repository_authority
+        .ok_or_else(|| {
             McpError::Context(
                 "graph authority gap: shadow ref resolution requires a startup-pinned local \
                  repository authority binding"
                     .to_string(),
             )
-        })?,
-    )?;
+        })?
+        .open()?;
     let ref_name = super::repository_authority::parse_branch_ref(branch_name)?;
     let change_id = authority.resolve_named_ref(&ref_name)?;
     ensure_shadow_change(store, change_id, branch_name)
@@ -345,18 +345,18 @@ fn ensure_shadow_change<G: GraphStore>(
 fn resolve_shadow_git<G: GraphStore>(
     store: &G,
     git_oid: &str,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<SemanticChangeId> {
     let oid = super::repository_authority::parse_git_object_id(git_oid)?;
-    let authority = super::repository_authority::ActiveRepositoryAuthority::open(
-        repository_authority.ok_or_else(|| {
+    let authority = repository_authority
+        .ok_or_else(|| {
             McpError::Context(
                 "graph authority gap: Git alias resolution requires a startup-pinned local \
                  repository authority binding"
                     .to_string(),
             )
-        })?,
-    )?;
+        })?
+        .open()?;
     let change_id = authority.resolve_git_oid(oid)?;
     ensure_shadow_change(store, change_id, git_oid)
 }
@@ -364,7 +364,7 @@ fn resolve_shadow_git<G: GraphStore>(
 pub fn handle_shadow_gate_report<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let base_ref = get_string_param(args, "base")?;
     let head_ref = get_string_param(args, "head")?;

--- a/crates/kin-mcp/src/handlers/verification.rs
+++ b/crates/kin-mcp/src/handlers/verification.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use kin_core::LocalRepositoryAuthorityBinding;
+use super::repository_authority::RequestRepositoryAuthority;
 use kin_model::graph::GraphStore;
 
 use crate::error::{McpError, Result};
@@ -213,7 +213,7 @@ fn release_optional_entity_count(
 pub fn handle_release_check<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
-    repository_authority: Option<&LocalRepositoryAuthorityBinding>,
+    repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
     let require_proof = release_optional_bool(args, "require_proof", false)?;
     let require_approval = release_optional_bool(args, "require_approval", false)?;
@@ -231,8 +231,12 @@ pub fn handle_release_check<G: GraphStore>(
                 .to_string(),
         )
     })?;
-    let authority =
-        super::repository_authority::ActiveRepositoryAuthority::open(repository_authority)?;
+    // Both opens on this path load from storage rather than reading through an
+    // authority a server already holds. The pair exists to compare the branch
+    // head before the source checks against the head after them, and two reads
+    // of one shared open are the same read: it describes the publication its
+    // owner sampled, so a move that landed since could not appear in either.
+    let authority = repository_authority.open_fresh()?;
     let mut branches = authority
         .repository_refs()
         .into_iter()
@@ -347,8 +351,7 @@ pub fn handle_release_check<G: GraphStore>(
     // This tool is advisory and cannot hold the daemon's mutation gate, but it
     // must at least detect a branch move that happened while the source checks
     // above were running. Publication still performs the authoritative CAS.
-    let final_authority =
-        super::repository_authority::ActiveRepositoryAuthority::open(repository_authority)?;
+    let final_authority = repository_authority.open_fresh()?;
     let final_branch = final_authority.repository_ref(&branch.name);
     let final_branch_head = final_branch
         .as_ref()

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use crate::daemon_delegate;
 use crate::envelope::{self, Envelope};
 use crate::error::{McpError, Result};
-use crate::handlers::{handle_tool_call, LocalRepositoryAuthorityBinding};
+use crate::handlers::{handle_tool_call, RequestRepositoryAuthority};
 use crate::session::SessionRegistry;
 use crate::tools::tool_definitions;
 use crate::types::*;
@@ -32,7 +32,7 @@ pub struct McpServerConfig {
     ///
     /// Product daemon mode dispatches inside the daemon and supplies its own
     /// retained binding; it never populates this stdio-side field.
-    pub repository_authority: Option<LocalRepositoryAuthorityBinding>,
+    pub repository_authority: Option<RequestRepositoryAuthority>,
 }
 
 /// How the stdio server should present session authority.


### PR DESCRIPTION
Every MCP query request opened repository authority for itself. An open decodes the whole persisted snapshot and re-verifies every persisted body against its content address, so the cost of answering a query was a property of the store rather than of the request, and it was paid again on every call.

This resolves one open per durable publication instead, through the contract the daemon already used for its two projection routes: probe the pinned namespace, read which publication local storage holds, reuse the authority loaded at that publication, and otherwise perform one full validating open behind the shared load gate. Both readers — the projection routes and the MCP query tools — now key on the same publication identity under the same gate and count into the same `loads()` counter.

## No validation was weakened

There is no arm that skips validation, no flag that disables it, and no path through the new `RequestRepositoryAuthority` type that yields authority which was not fully validated. KinDB's unconditional `validate_all_authority_bodies` is untouched; reuse can only hand back the result of a validation that already ran over these exact durable bytes. The tamper-refusal property holds exactly as before, because any publication change forces a fresh, fully validating open.

`release_check` keeps loading from storage on both of its opens. That pair exists to detect a branch move across the source checks between them, and two reads of one shared open are the same read, so it uses an explicit re-open rather than the shared one.

## Staleness contract

A query served from a reused authority answers from the durable publication whose record was read just before the authority was handed over. That is the publication a fresh open at that same instant would have loaded, and both decode the same content-addressed bytes under the same validation, so the reused answer is the fresh answer rather than an approximation of one. What such a query cannot observe is a commit that lands after its publication read — neither can a fresh open, which also samples storage once and then answers from what it sampled. Every call reads the record again, so a publication that lands between two calls is observed by the second, including one committed by a separate process such as a CLI ingest running beside the daemon. The record digest errs in the safe direction: a rewrite that is not a new publication costs one extra full load rather than a stale serve.

Resolution is deferred to a request's first source read, so session, transaction, and pure-graph tools do not pay for a publication they never consult.

## Acceptance

Two load-independent tests, both counting `ProjectionAuthorityCache::loads()` rather than elapsed time — an open costs whatever the store is worth, so a timing assertion on a small fixture would pass with the defect present.

- `distinct_query_tools_share_one_authority_load_per_publication`: three distinct query tools (`semantic_locate` with snippets, `get_entity`, `get_context_pack`) at one publication, each asserted to have actually projected graph-owned source, hold `loads() == 1`. With reuse disabled the same test reads 3.
- `a_publication_boundary_costs_exactly_one_more_authority_load`: crossing a publication boundary costs exactly +1, the entity published after the boundary is served, and a second read at the new publication reuses it. With the generation check removed, the reused authority refuses the new entity as absent at the old generation and the test fails loudly.

The existing bounds are unchanged and still pass: `semantic_locate_fused_page_opens_repository_authority_once`, `concurrent_projected_reads_share_one_authority_load`, and `projected_reads_serve_a_publication_committed_while_serving`. The two projection routes behave exactly as before.

Gates from the lane worktree: `cargo fmt --all --check` rc=0 (falsified once at rc=1 before formatting), `kin-dev local-check kin` rc=0, `kin-dev local-test kin` rc=0.

No wall-clock claim is made here; the counter is the claim.

Refs FIR-2079