### PR TITLE
Stop making doomed Git capture blobs durable during init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,14 +3046,14 @@ dependencies = [
 
 [[package]]
 name = "kin-blobs"
-version = "0.1.4"
+version = "0.1.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "83136143d2f8b72f835ca7d9e3d7793e415bd072445a648713d5d797e9e6bc9e"
+checksum = "bde2186360c16ff9fda080b4b9f6489e7aee8cb0cb30f803e8bd22b1ed4af609"
 dependencies = [
  "hex",
  "schemars",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.61.2",
@@ -6624,7 +6624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ serial_test = "3"
 
 # Internal crates
 kin-model = { version = "=0.7.5", registry = "kin" }
-kin-blobs = { version = "=0.1.4", registry = "kin" }
+kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
 kin-index = { path = "crates/kin-index" }

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -206,7 +206,16 @@ fn init_from_git_with_hooks(
         .prefix(".kin-git-capture-")
         .tempdir_in(source_parent)
         .map_err(|error| KinError::io(source_parent, error))?;
-    let capture_store = BlobStore::new(capture_dir.path().join("objects"))
+    // The capture store lives and dies inside this call, so its bodies are
+    // written without device barriers. Its root is the per-init `capture_dir`
+    // above, removed when that handle drops; every later init mints a fresh
+    // random name rather than reopening this one; and nothing durable ever
+    // records a path inside it. Every body that has to outlive init is copied
+    // into the repository's own source-blob store by `copy_captured_authority`,
+    // under that store's unchanged durability. A crash that could tear these
+    // bytes therefore destroys the only reader they ever had, and leaves no
+    // published `.kin` behind to reference them.
+    let capture_store = BlobStore::new_ephemeral(capture_dir.path().join("objects"))
         .map_err(|error| git_boundary_error("create capture CAS", error))?;
 
     let mut progress = PhaseProgress::new(GIT_ADMISSION_PHASES);


### PR DESCRIPTION
## What

`init_from_git_with_hooks` builds its Git capture store with
`BlobStore::new_ephemeral`, so the bodies written into the per-init tempdir
carry no device barriers. Nothing else about init changes, least of all the
durability of the store those bodies are copied into.

## Why

The capture store's root is a `tempfile::TempDir` created in the source's
parent and removed when init returns. Measured span counts are 26,887
`kin_blobs.write` calls for an anyhow init and 107,961 for click, into a
freshly minted directory where no prior content exists, so essentially every
one takes the miss path and pays its barrier. On APFS `File::sync_all` is
`F_FULLFSYNC`, a full device cache flush. All of it makes bytes durable in a
directory deleted before init returns.

## Why nothing needs these bytes to survive a crash

- The capture root is `capture_dir`, a `tempfile` directory carrying a fresh
  random suffix per init, referenced only where it is created.
- `BlobStore::root()` is called nowhere in kin, so no code can learn the
  capture path, let alone record it. Every phase that touches the store takes
  `&BlobStore` and addresses bodies by content hash.
- No later run reopens it: each init mints a new random name rather than
  looking for an existing one.
- Every body that has to outlive init is copied into the repository's own
  source-blob store by `copy_captured_authority`, through the unmodified
  `with_source_blob_batch` path, whose durability is untouched.
- A crashed init publishes no `.kin` at all — publication is a rename after
  the bootstrap commit — so no repository can reference these bytes.

The crash window this opens: a power loss mid-init may leave a
`.kin-git-capture-*` directory whose blobs are torn rather than absent.
Nothing reads it, and a crashed init already leaks that directory today,
barriers or not.

## Evidence

Store parity on a fixture: a clone of the kin-db working tree at 6bc2bdb
(470 commits, 4,881 reachable objects), byte-copied so both arms get identical
input. Both arms compile against the same kin-blobs build and the same kin
tree; only the constructor differs.

    source-blobs   ephemeral    files=4883
    source-blobs   barriered    files=4883
    source-blobs   IDENTICAL: same file set, same paths, same content hashes

Across the whole published `.kin`, 4,886 of 4,891 files are byte-identical.
The five that differ are `manifest.json` (fresh `repo_id`, `workspace_id`,
`created_at`), `authority.json` and the generation-1 snapshot it digests (both
carrying those uuids), `reconciliation/authority.key` (random key material),
and `reconciliation/projection.lock` (the writing process's pid and start
time). None of those can match between two inits of any code.

kin-blobs' own tests carry the barrier counts: zero for an ephemeral store
across write, sync, and drop, against one per body plus one per directory for
a barriered one.

## Sequencing

This consumes `BlobStore::new_ephemeral`, added in
firelock-ai/kin-blobs#27, and pins `kin-blobs = "=0.1.5"`, which is not
published yet. CI here is red on registry resolution until that release
exists, and `Cargo.lock` still carries the 0.1.4 entry because a patch-off
relock cannot resolve a version the registry does not have. The lock lands
with the release; nothing else in this change moves.

Refs FIR-2080
