### PR TITLE
Stop background passes that spend a machine without advancing

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1623,21 +1623,16 @@ async fn check_semantic_query_readiness() -> HealthCheck {
     .with_platform_note("this platform ships the supported vector-free Kin runtime")
 }
 
-/// Semantic readiness when no daemon is running to ask.
-///
-/// This is where every repository sits until its first command needs a daemon,
-/// so it is an unread state rather than a failed one, and reporting it as a
-/// failure is what makes an install that did everything right end on a red
-/// summary. The authority gate is unchanged for every state that *can* be read:
-/// a reachable daemon whose graph coverage is incomplete or unreadable is still
-/// Stale, and Stale on this check still blocks readiness.
-#[cfg(feature = "vector")]
 /// Render the daemon's background-work disclosure as a health check.
 ///
 /// Split from its fetch so the reporting rule is testable without a daemon.
 /// Healthy is the answer whenever nothing was stopped, including while passes
 /// are working hard: this check reports faults, and the ordinary account of what
 /// the daemon is spending lives in `kin resources`.
+///
+/// Deliberately not gated on `vector`: background work is every pass the daemon
+/// runs, and a build without the vector feature still runs a reconcile loop that
+/// can wedge.
 pub fn background_work_health_from_state(
     work: &crate::commands::resources::DaemonWorkState,
 ) -> HealthCheck {
@@ -1736,6 +1731,15 @@ async fn check_background_work() -> HealthCheck {
     }
 }
 
+/// Semantic readiness when no daemon is running to ask.
+///
+/// This is where every repository sits until its first command needs a daemon,
+/// so it is an unread state rather than a failed one, and reporting it as a
+/// failure is what makes an install that did everything right end on a red
+/// summary. The authority gate is unchanged for every state that *can* be read:
+/// a reachable daemon whose graph coverage is incomplete or unreadable is still
+/// Stale, and Stale on this check still blocks readiness.
+#[cfg(feature = "vector")]
 fn semantic_query_readiness_without_a_daemon() -> HealthCheck {
     HealthCheck::new(
         "semantic_query_readiness",

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -158,6 +158,7 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_editor());
     checks.push(check_kinlab_connect());
     checks.push(check_semantic_query_readiness().await);
+    checks.push(check_background_work().await);
     checks.push(check_retrieval_profile());
     checks.push(check_binary_assessment_load());
 
@@ -1631,6 +1632,110 @@ async fn check_semantic_query_readiness() -> HealthCheck {
 /// a reachable daemon whose graph coverage is incomplete or unreadable is still
 /// Stale, and Stale on this check still blocks readiness.
 #[cfg(feature = "vector")]
+/// Render the daemon's background-work disclosure as a health check.
+///
+/// Split from its fetch so the reporting rule is testable without a daemon.
+/// Healthy is the answer whenever nothing was stopped, including while passes
+/// are working hard: this check reports faults, and the ordinary account of what
+/// the daemon is spending lives in `kin resources`.
+pub fn background_work_health_from_state(
+    work: &crate::commands::resources::DaemonWorkState,
+) -> HealthCheck {
+    let stopped: Vec<&crate::commands::resources::BackgroundPassReport> = work
+        .passes
+        .iter()
+        .filter(|pass| pass.stopped_reason.is_some())
+        .collect();
+    let cpu = match work.daemon_cpu_seconds {
+        Some(seconds) => format!("daemon has used {seconds:.0}s of CPU"),
+        None => "daemon CPU not sampled yet".to_string(),
+    };
+    if stopped.is_empty() {
+        let working = work
+            .passes
+            .iter()
+            .filter(|pass| pass.state == "working")
+            .count();
+        return HealthCheck::new(
+            "background_work",
+            "Background work",
+            HealthStatus::Healthy,
+            format!(
+                "{cpu}; {} background pass(es), {working} working, none stopped",
+                work.passes.len()
+            ),
+        );
+    }
+    let reasons = stopped
+        .iter()
+        .filter_map(|pass| pass.stopped_reason.as_deref())
+        .collect::<Vec<_>>()
+        .join("; ");
+    HealthCheck::new(
+        "background_work",
+        "Background work",
+        HealthStatus::Stale,
+        format!("{cpu}; {reasons}"),
+    )
+    .with_manual_fix(
+        "restart the daemon (`kin daemon restart`) to retry the stopped pass, and report the \
+         reason above if it stops again",
+    )
+}
+
+async fn check_background_work() -> HealthCheck {
+    let cwd = env::current_dir().unwrap_or_default();
+    let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
+        return HealthCheck::new(
+            "background_work",
+            "Background work",
+            HealthStatus::Unsupported,
+            "n/a — not in a Kin repository",
+        );
+    };
+    let Some(daemon_url) = crate::daemon_client::resolve_daemon_url_if_running_async(&layout).await
+    else {
+        return HealthCheck::new(
+            "background_work",
+            "Background work",
+            HealthStatus::Unsupported,
+            "n/a — no daemon running for this repository, so there is no background work to \
+             account for; a daemon starts on first use",
+        );
+    };
+    let client = match crate::daemon_client::DaemonClient::from_base_url_for_layout(
+        daemon_url.clone(),
+        &layout,
+    ) {
+        Ok(client) => client,
+        Err(error) => {
+            return HealthCheck::new(
+                "background_work",
+                "Background work",
+                HealthStatus::Stale,
+                format!("daemon reachable ({daemon_url}), but its URL is invalid: {error}"),
+            )
+            .with_manual_fix("run `kin status --json` and resolve the reported daemon error");
+        }
+    };
+    match client
+        .command_resources(&crate::commands::resources::CommandResourcesRequest::default())
+        .await
+    {
+        Ok(response) => background_work_health_from_state(&response.daemon_work),
+        Err(error) => HealthCheck::new(
+            "background_work",
+            "Background work",
+            HealthStatus::Stale,
+            format!(
+                "daemon reachable ({daemon_url}), but its background-work state is unavailable: \
+                 {error}"
+            ),
+        )
+        .with_manual_fix("run `kin status --json` and resolve the reported daemon error"),
+    }
+}
+
 fn semantic_query_readiness_without_a_daemon() -> HealthCheck {
     HealthCheck::new(
         "semantic_query_readiness",
@@ -1870,6 +1975,81 @@ mod tests {
             .unwrap()
             .write_all(bytes)
             .unwrap();
+    }
+
+    fn pass_report(
+        name: &str,
+        state: &str,
+        stopped_reason: Option<&str>,
+    ) -> crate::commands::resources::BackgroundPassReport {
+        crate::commands::resources::BackgroundPassReport {
+            name: name.to_string(),
+            state: state.to_string(),
+            progress: 128,
+            progress_age_seconds: Some(4),
+            working_seconds: Some(9),
+            stopped_reason: stopped_reason.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn background_work_is_healthy_while_passes_are_merely_busy() {
+        let check =
+            background_work_health_from_state(&crate::commands::resources::DaemonWorkState {
+                daemon_cpu_seconds: Some(41.6),
+                passes: vec![
+                    pass_report("embed", "working", None),
+                    pass_report("reconcile", "idle", None),
+                ],
+            });
+        assert!(matches!(check.status, HealthStatus::Healthy));
+        assert!(
+            check.detail.contains("42s of CPU"),
+            "the check must disclose cumulative CPU: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("none stopped"),
+            "a busy daemon is not a faulty one: {}",
+            check.detail
+        );
+    }
+
+    /// The falsification: the same shape with a stopped pass must NOT read
+    /// healthy, and must carry the daemon's own reason rather than a summary
+    /// invented here.
+    #[test]
+    fn background_work_reports_a_stopped_pass_and_repeats_its_reason() {
+        let check =
+            background_work_health_from_state(&crate::commands::resources::DaemonWorkState {
+                daemon_cpu_seconds: Some(48_180.0),
+                passes: vec![
+                    pass_report(
+                        "embed",
+                        "stopped",
+                        Some("the embed pass held the CPU for 601s"),
+                    ),
+                    pass_report("reconcile", "idle", None),
+                ],
+            });
+        assert!(matches!(check.status, HealthStatus::Stale));
+        assert!(check
+            .detail
+            .contains("the embed pass held the CPU for 601s"));
+        assert!(check.manual_fix.is_some());
+    }
+
+    #[test]
+    fn background_work_says_so_when_cpu_has_not_been_sampled() {
+        let check = background_work_health_from_state(
+            &crate::commands::resources::DaemonWorkState::default(),
+        );
+        assert!(matches!(check.status, HealthStatus::Healthy));
+        assert!(
+            check.detail.contains("not sampled yet"),
+            "an unsampled total must not be reported as zero CPU: {}",
+            check.detail
+        );
     }
 
     /// The magic bytes a valid shim carries on the current platform.

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -124,12 +124,56 @@ fn non_empty_env(key: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// What one background pass the daemon runs on its own initiative is doing.
+///
+/// A user asking why the fan is on gets the answer from the product rather than
+/// from Activity Monitor: which pass is working, how long it has been working,
+/// and how long since it last recorded anything durable. Sourced entirely from
+/// daemon-owned state and never recomputed here.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackgroundPassReport {
+    /// Stable pass name, e.g. `embed` or `reconcile`.
+    pub name: String,
+    /// `idle`, `working`, or `stopped`.
+    pub state: String,
+    /// Units of work this pass has durably recorded since the daemon started.
+    /// Monotonic, so a delta across two reads is meaningful.
+    pub progress: u64,
+    /// Seconds since `progress` last advanced; absent when it never has. A
+    /// working pass whose progress age keeps climbing is the shape the daemon
+    /// stops on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress_age_seconds: Option<u64>,
+    /// Seconds this pass has been working without an idle stretch in between;
+    /// absent while idle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_seconds: Option<u64>,
+    /// Why this pass was stopped, once it has been. A value drives
+    /// `status: "attention"` on `/health`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopped_reason: Option<String>,
+}
+
+/// What the daemon is spending on work nobody asked for interactively.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DaemonWorkState {
+    /// Cumulative CPU seconds this daemon process has consumed. Absent before
+    /// the supervisor's first sample, which is not the same as zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_cpu_seconds: Option<f64>,
+    /// Every background pass this daemon has actually started.
+    #[serde(default)]
+    pub passes: Vec<BackgroundPassReport>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandResourcesResponse {
     pub plan: ResourcePlan,
     pub embed_runtime: EmbedRuntimeState,
     #[serde(default)]
     pub actual: ActualResources,
+    #[serde(default)]
+    pub daemon_work: DaemonWorkState,
     #[serde(default)]
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -145,6 +189,7 @@ struct ResourcesJson<'a> {
     plan: &'a ResourcePlan,
     embed_runtime: &'a EmbedRuntimeState,
     actual: &'a ActualResources,
+    daemon_work: &'a DaemonWorkState,
 }
 
 /// Parse a CLI/request profile name. Absent input defaults to `Interactive`;
@@ -173,10 +218,46 @@ fn profile_label(profile: Profile) -> &'static str {
     }
 }
 
+/// One line per background pass, plus the daemon's cumulative CPU.
+///
+/// Rendered even when every pass is healthy. The question this answers — what is
+/// this process spending my machine on — is one a user asks while nothing is
+/// visibly wrong, so a surface that only appears on a fault does not answer it.
+fn render_daemon_work_lines(work: &DaemonWorkState) -> Vec<String> {
+    let mut lines = vec![format!(
+        "Daemon CPU: {}",
+        match work.daemon_cpu_seconds {
+            Some(seconds) => format!("{seconds:.1}s cumulative"),
+            None => "not sampled yet".to_string(),
+        }
+    )];
+    if work.passes.is_empty() {
+        lines.push("Background passes: none started".to_string());
+        return lines;
+    }
+    for pass in &work.passes {
+        let detail = match (&pass.stopped_reason, pass.working_seconds) {
+            (Some(reason), _) => format!("stopped — {reason}"),
+            (None, Some(working)) => format!("working {working}s"),
+            (None, None) => "idle".to_string(),
+        };
+        let progress_age = match pass.progress_age_seconds {
+            Some(age) => format!("last advanced {age}s ago"),
+            None => "no progress yet".to_string(),
+        };
+        lines.push(format!(
+            "Background pass {}: {detail}, {} units, {progress_age}",
+            pass.name, pass.progress
+        ));
+    }
+    lines
+}
+
 fn render_lines(
     plan: &ResourcePlan,
     embed: &EmbedRuntimeState,
     actual: &ActualResources,
+    daemon_work: &DaemonWorkState,
 ) -> Vec<String> {
     let accel = format!("{:?}", plan.accelerator.backend).to_ascii_lowercase();
     let mut lines = vec![
@@ -219,6 +300,7 @@ fn render_lines(
     ];
 
     lines.push(profile_selector_line(actual));
+    lines.extend(render_daemon_work_lines(daemon_work));
 
     // The profile selector is reported on its own line above, with who chose it.
     // Listing it here too would read as an operator override even when the
@@ -265,9 +347,10 @@ pub fn build_command_resources_response(
     plan: ResourcePlan,
     embed_runtime: EmbedRuntimeState,
     actual: ActualResources,
+    daemon_work: DaemonWorkState,
     json: bool,
 ) -> Result<CommandResourcesResponse> {
-    let text = render_lines(&plan, &embed_runtime, &actual)
+    let text = render_lines(&plan, &embed_runtime, &actual, &daemon_work)
         .into_iter()
         .map(|line| format!("{line}\n"))
         .collect::<String>();
@@ -276,6 +359,7 @@ pub fn build_command_resources_response(
             plan: &plan,
             embed_runtime: &embed_runtime,
             actual: &actual,
+            daemon_work: &daemon_work,
         })?)
     } else {
         None
@@ -284,6 +368,7 @@ pub fn build_command_resources_response(
         plan,
         embed_runtime,
         actual,
+        daemon_work,
         text,
         json,
     })
@@ -419,6 +504,7 @@ mod tests {
             sample_plan(Profile::Interactive),
             embed,
             actual,
+            DaemonWorkState::default(),
             true,
         )
         .unwrap();
@@ -460,6 +546,7 @@ mod tests {
             sample_plan(Profile::Throughput),
             embed,
             ActualResources::default(),
+            DaemonWorkState::default(),
             true,
         )
         .unwrap();
@@ -498,6 +585,7 @@ mod tests {
             sample_plan(Profile::Throughput),
             embed,
             ActualResources::default(),
+            DaemonWorkState::default(),
             true,
         )
         .unwrap();
@@ -521,6 +609,7 @@ mod tests {
             sample_plan(Profile::Proof),
             EmbedRuntimeState::default(),
             ActualResources::default(),
+            DaemonWorkState::default(),
             false,
         )
         .unwrap();
@@ -542,6 +631,7 @@ mod tests {
             sample_plan(Profile::Interactive),
             EmbedRuntimeState::default(),
             actual,
+            DaemonWorkState::default(),
             false,
         )
         .unwrap();
@@ -564,6 +654,7 @@ mod tests {
             sample_plan(Profile::Interactive),
             EmbedRuntimeState::default(),
             ActualResources::default(),
+            DaemonWorkState::default(),
             false,
         )
         .unwrap();

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -706,6 +706,7 @@ mod tests {
             sample_plan(Profile::Interactive),
             EmbedRuntimeState::default(),
             actual,
+            DaemonWorkState::default(),
             false,
         )
         .unwrap();

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -619,6 +619,18 @@ pub struct HealthResponse {
     /// the signal that distinguishes "busy" from "dead".
     #[serde(default)]
     pub spine_warming: bool,
+    /// Cumulative CPU seconds this daemon process has consumed. The answer to
+    /// "why is my fan on" belongs in the product rather than in Activity
+    /// Monitor. Absent before the background-work supervisor's first sample,
+    /// which is not the same as zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_cpu_seconds: Option<f64>,
+    /// Every background pass this daemon has actually started, with how long
+    /// each has been working and how long since it last recorded persisted
+    /// progress. A pass carrying a `stopped_reason` was stopped for spending the
+    /// machine without advancing, and drives `status: "attention"`.
+    #[serde(default)]
+    pub background_passes: Vec<kin_cli::commands::resources::BackgroundPassReport>,
     pub build: BuildResponse,
 }
 
@@ -2347,18 +2359,23 @@ async fn health(
     let coordination_event_persist_failures = state
         .coordination_event_persist_failures
         .load(std::sync::atomic::Ordering::Relaxed);
+    let background_passes = state.background_work.reports(std::time::Instant::now());
+    let background_pass_stopped = state.background_work.any_stopped();
     // Surface graph-safety + derived-index health in the top-level status so an
     // operator or client polling /health sees a non-"ok" signal when the daemon
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
     // permanently stopped (embed-degraded), OR the configured storage backend
     // cannot durably persist vector progress, OR the persisted vector index was
     // discarded at open and is being re-derived, OR coordination evidence could
-    // not be persisted. The graph itself stays intact and served in all cases.
+    // not be persisted, OR a background pass was stopped for spending the
+    // machine without advancing. The graph itself stays intact and served in all
+    // cases.
     let status = if mass_deletion_blocked
         || embed_worker_failed
         || embed_persistence_unavailable
         || vector_index_discarded.is_some()
         || coordination_event_persist_failures > 0
+        || background_pass_stopped
     {
         "attention"
     } else {
@@ -2404,6 +2421,8 @@ async fn health(
         ),
         coordination_event_persist_failures: Some(coordination_event_persist_failures),
         spine_warming: state.spine_warming(),
+        daemon_cpu_seconds: state.background_work.daemon_cpu_seconds(),
+        background_passes,
         build: current_build_response(),
     }))
 }
@@ -2975,10 +2994,12 @@ async fn command_resources(
     };
 
     let actual = kin_cli::commands::resources::ActualResources::capture();
+    let daemon_work = state.background_work.work_state(std::time::Instant::now());
     let response = kin_cli::commands::resources::build_command_resources_response(
         plan,
         embed_runtime,
         actual,
+        daemon_work,
         request.json,
     )
     .map_err(internal_error)?;
@@ -16371,6 +16392,150 @@ mod tests {
         let legacy: HealthResponse = serde_json::from_value(legacy).unwrap();
         assert!(legacy.coordination.is_none());
         assert!(legacy.coordination_event_persist_failures.is_none());
+    }
+
+    async fn health_json(state: Arc<DaemonState>) -> HealthResponse {
+        let response = router(state)
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    /// The whole point of the supervisor, end to end on the surface a user or
+    /// agent actually reads.
+    ///
+    /// A pass that declares itself working and never records anything is exactly
+    /// the shape of a daemon spending a machine with no signal, and the daemon
+    /// must stop it and say so. Time is supplied rather than slept: the sweep
+    /// takes the instant it judges against, so the real production threshold is
+    /// exercised without the test waiting ten minutes for it.
+    #[tokio::test]
+    async fn a_wedged_background_pass_is_stopped_and_its_reason_reaches_health() {
+        let state = test_state();
+        let pass = state
+            .background_work
+            .pass(crate::background_work::PASS_EMBED);
+        let base = std::time::Instant::now();
+        pass.working(base);
+
+        assert!(
+            health_json(Arc::clone(&state)).await.status == "ok",
+            "a pass that has only just started working is not yet a fault"
+        );
+
+        let past_threshold =
+            base + crate::background_work::DEFAULT_STALL_THRESHOLD + Duration::from_secs(1);
+        assert_eq!(state.background_work.sweep(past_threshold).len(), 1);
+
+        let json = health_json(state).await;
+        assert_eq!(
+            json.status, "attention",
+            "a stopped background pass must not leave health reporting ok"
+        );
+        let report = json
+            .background_passes
+            .iter()
+            .find(|report| report.name == crate::background_work::PASS_EMBED)
+            .expect("the stopped pass must appear in health");
+        assert_eq!(report.state, "stopped");
+        let reason = report
+            .stopped_reason
+            .as_deref()
+            .expect("a stopped pass must carry a reason");
+        assert!(
+            reason.contains("without recording any progress"),
+            "the reason must say why the pass was stopped: {reason}"
+        );
+        assert!(
+            reason.contains("the daemon keeps serving"),
+            "the reason must say what still works: {reason}"
+        );
+    }
+
+    /// The falsification for the test above, and the property that makes the
+    /// mechanism safe to ship.
+    ///
+    /// Same pass, same working stretch, same sweep instant — the ONLY difference
+    /// is that this one reports progress. A supervisor that stopped long-running
+    /// work rather than stalled work would pass the test above and fail here.
+    #[tokio::test]
+    async fn a_long_pass_that_reports_progress_is_never_stopped() {
+        let state = test_state();
+        let pass = state
+            .background_work
+            .pass(crate::background_work::PASS_EMBED);
+        let base = std::time::Instant::now();
+        pass.working(base);
+
+        let threshold = crate::background_work::DEFAULT_STALL_THRESHOLD;
+        // Work for ten times the threshold, recording progress throughout.
+        for step in 1..=20u32 {
+            let now = base + threshold.mul_f64(f64::from(step) / 2.0);
+            pass.advanced(32, now);
+            assert!(
+                state.background_work.sweep(now).is_empty(),
+                "a pass recording progress must never be stopped"
+            );
+        }
+
+        let json = health_json(state).await;
+        assert_eq!(json.status, "ok");
+        let report = json
+            .background_passes
+            .iter()
+            .find(|report| report.name == crate::background_work::PASS_EMBED)
+            .expect("a healthy pass is still disclosed");
+        assert_eq!(report.state, "working");
+        assert_eq!(report.progress, 32 * 20);
+        assert!(report.stopped_reason.is_none());
+    }
+
+    /// Exhausting a retry ladder's cumulative budget parks the work with a
+    /// reason on the same surface, rather than retrying at the backoff ceiling
+    /// for as long as the process lives.
+    #[tokio::test]
+    async fn retry_budget_exhaustion_parks_the_pass_with_a_reason_in_health() {
+        let state = test_state();
+        let pass = state
+            .background_work
+            .pass(crate::background_work::PASS_EMBED);
+        let budget = Duration::from_secs(120);
+
+        assert!(pass.charge_retry(Duration::from_secs(60), budget, "the embedding worker"));
+        assert_eq!(health_json(Arc::clone(&state)).await.status, "ok");
+
+        assert!(!pass.charge_retry(Duration::from_secs(60), budget, "the embedding worker"));
+
+        let json = health_json(state).await;
+        assert_eq!(json.status, "attention");
+        let reason = json
+            .background_passes
+            .iter()
+            .find(|report| report.name == crate::background_work::PASS_EMBED)
+            .and_then(|report| report.stopped_reason.clone())
+            .expect("a parked pass must carry a reason");
+        assert!(
+            reason.contains("cumulative retry backoff"),
+            "the reason must name the budget that was spent: {reason}"
+        );
+    }
+
+    /// A daemon that has started no background pass discloses that honestly,
+    /// and does not invent a cumulative CPU figure it has not measured.
+    #[tokio::test]
+    async fn health_discloses_no_passes_and_no_cpu_before_anything_runs() {
+        let json = health_json(test_state()).await;
+        assert_eq!(json.status, "ok");
+        assert!(json.background_passes.is_empty());
+        assert!(
+            json.daemon_cpu_seconds.is_none(),
+            "an unsampled CPU total must be absent rather than reported as zero"
+        );
     }
 
     async fn advertised_repo_id(state: Arc<DaemonState>) -> String {

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -402,8 +402,17 @@ impl BackgroundWorkSupervisor {
     /// Sampled on the sweep rather than on each `/health` read: the answer moves
     /// slowly, a process refresh is not free, and a health endpoint that got
     /// more expensive the more it was polled would be its own runaway.
+    ///
+    /// The PID comes from `sysinfo::get_current_pid` rather than from the
+    /// standard library. Both name this process, but the zero-file-search guard
+    /// reads any `process::` path as a subprocess launch in an answer path, and
+    /// the crate's own accessor states the intent without arguing with a guard
+    /// that is right to be blunt. A platform that cannot report its own PID
+    /// leaves the total unsampled, which reads as absent rather than as zero.
     pub fn sample_process_cpu(&self) {
-        let pid = sysinfo::Pid::from_u32(std::process::id());
+        let Ok(pid) = sysinfo::get_current_pid() else {
+            return;
+        };
         let mut system = sysinfo::System::new();
         system.refresh_processes_specifics(
             sysinfo::ProcessesToUpdate::Some(&[pid]),

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -1,0 +1,749 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Self-limiting background work.
+//!
+//! The only Kin process on an end user's machine is the daemon, and the work it
+//! starts on its own initiative — embedding, reconciling, rebuilding derived
+//! indexes — runs with nobody watching. A pass that wedges therefore spends that
+//! machine indefinitely and the sole evidence is a warm fan. This module is the
+//! product-side answer: every background pass reports persisted progress to a
+//! supervisor, and a pass that holds the CPU without advancing that count is
+//! stopped and said out loud.
+//!
+//! Liveness keys on the persisted-progress delta and never on CPU utilization. A
+//! busy-spin pegs a core while achieving nothing, so utilization cannot tell a
+//! working pass from a wedged one, and a counter that moves only when work is
+//! durably recorded can.
+//!
+//! Three properties are load-bearing and each exists because its absence makes
+//! the mechanism silently useless:
+//!
+//! - **Idle is never stalled.** A pass with nothing to do reports no progress by
+//!   definition. Only a pass that has declared itself working is a candidate, so
+//!   a quiet daemon is never stopped for being quiet.
+//! - **The working mark latches.** [`BackgroundPass::working`] sets the start of
+//!   a working stretch only when the pass was not already working. A per-iteration
+//!   reset would restart the clock on every turn of the very loop that is wedged,
+//!   and the stall could never be observed.
+//! - **Stopping is cooperative.** The supervisor raises a flag the pass reads at
+//!   its own checkpoint, exactly as trace cancellation does. Nothing is killed
+//!   mid-write, and a pass holding a lock releases it on its own terms.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
+use std::time::{Duration, Instant};
+
+use kin_cli::commands::resources::{BackgroundPassReport, DaemonWorkState};
+
+/// The background embedding worker.
+pub const PASS_EMBED: &str = "embed";
+/// The filesystem reconciliation loop.
+pub const PASS_RECONCILE: &str = "reconcile";
+
+/// How long a pass may hold the CPU with no persisted progress before the daemon
+/// stops it.
+///
+/// Generous on purpose. The cost of stopping a healthy pass is lost work a user
+/// asked for; the cost of waiting is ten more minutes of a fan. A pass that has
+/// been working continuously for this long and has recorded nothing durable in
+/// that whole stretch is not slow, it is stuck.
+pub const DEFAULT_STALL_THRESHOLD: Duration = Duration::from_secs(600);
+
+/// How much cumulative delay a retry ladder may spend before the work it is
+/// retrying is parked with an announced reason.
+///
+/// Backoff alone bounds the rate of a retry loop and not its lifetime, so a
+/// failure that never clears retries forever at the backoff ceiling. This is the
+/// lifetime bound.
+pub const DEFAULT_RETRY_BUDGET: Duration = Duration::from_secs(1800);
+
+/// How often the supervisor evaluates every registered pass.
+pub const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Read a duration from the environment in seconds, falling back to `default`.
+///
+/// An explicit `0` disables the limit rather than meaning "immediately", because
+/// a limit whose off-switch is also its most aggressive setting is a trap.
+fn duration_from_env_secs(key: &str, default: Duration) -> Duration {
+    match std::env::var(key) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => default,
+        },
+        Err(_) => default,
+    }
+}
+
+/// The configured stall threshold; `KIN_DAEMON_PASS_STALL_SECS` overrides it and
+/// `0` disables stopping entirely.
+pub fn configured_stall_threshold() -> Duration {
+    duration_from_env_secs("KIN_DAEMON_PASS_STALL_SECS", DEFAULT_STALL_THRESHOLD)
+}
+
+/// The configured cumulative retry budget; `KIN_DAEMON_PASS_RETRY_BUDGET_SECS`
+/// overrides it and `0` disables parking entirely.
+pub fn configured_retry_budget() -> Duration {
+    duration_from_env_secs("KIN_DAEMON_PASS_RETRY_BUDGET_SECS", DEFAULT_RETRY_BUDGET)
+}
+
+/// One background pass, and everything the supervisor knows about it.
+#[derive(Debug)]
+pub struct BackgroundPass {
+    name: &'static str,
+    /// Mirrors `inner.halt.is_some()` so a pass can poll its own checkpoint
+    /// without taking the lock. Published after the reason, so a reader that
+    /// observes `true` always finds a reason behind it.
+    halted: AtomicBool,
+    inner: Mutex<PassInner>,
+}
+
+#[derive(Debug)]
+struct PassInner {
+    /// Units of work this pass has durably recorded. Monotonic for the life of
+    /// the process, so a delta over any window is meaningful.
+    progress: u64,
+    /// When `progress` last advanced; `None` until it first does.
+    progress_at: Option<Instant>,
+    /// Start of the current uninterrupted working stretch; `None` while idle.
+    working_since: Option<Instant>,
+    /// Why this pass stopped, once it has.
+    halt: Option<String>,
+    /// Cumulative delay charged to the retry ladder since the last success.
+    retry_spent: Duration,
+}
+
+impl BackgroundPass {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            halted: AtomicBool::new(false),
+            inner: Mutex::new(PassInner {
+                progress: 0,
+                progress_at: None,
+                working_since: None,
+                halt: None,
+                retry_spent: Duration::ZERO,
+            }),
+        }
+    }
+
+    /// A poisoned lock must not disarm the watchdog. A panic elsewhere in the
+    /// daemon is precisely when unattended work is most likely to be wedged, so
+    /// the guard is recovered rather than propagated.
+    fn lock(&self) -> std::sync::MutexGuard<'_, PassInner> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Declare that this pass is consuming CPU.
+    ///
+    /// Idempotent while already working: the start of the stretch is latched on
+    /// the first call and left alone afterwards. Calling this once per loop turn
+    /// is the intended usage, and it is correct precisely because repeat calls do
+    /// not restart the clock.
+    pub fn working(&self, now: Instant) {
+        let mut inner = self.lock();
+        if inner.working_since.is_none() {
+            inner.working_since = Some(now);
+        }
+    }
+
+    /// Declare that this pass has nothing to do.
+    ///
+    /// Ends the working stretch, so the next [`working`](Self::working) starts a
+    /// fresh one. Call it wherever the pass genuinely has no work — a drained
+    /// queue, an empty event batch — and nowhere else: an `idle` on a path the
+    /// wedged loop still reaches would clear the very stretch being measured.
+    pub fn idle(&self) {
+        self.lock().working_since = None;
+    }
+
+    /// Record `units` of newly persisted work.
+    ///
+    /// Advancing by zero is not progress and is ignored, so a pass that reports
+    /// every completed batch — including empty ones — cannot keep itself alive
+    /// with them.
+    pub fn advanced(&self, units: u64, now: Instant) {
+        if units == 0 {
+            return;
+        }
+        let mut inner = self.lock();
+        inner.progress = inner.progress.saturating_add(units);
+        inner.progress_at = Some(now);
+    }
+
+    /// Whether this pass has been stopped and should wind itself down.
+    ///
+    /// Polled by the pass at its own checkpoint. Nothing else enforces the stop:
+    /// a pass that never checks keeps running, which is why every instrumented
+    /// loop checks alongside its shutdown signal.
+    pub fn halted(&self) -> bool {
+        self.halted.load(Ordering::Relaxed)
+    }
+
+    /// Why this pass stopped, if it has.
+    pub fn halt_reason(&self) -> Option<String> {
+        self.lock().halt.clone()
+    }
+
+    /// Stop this pass with an announced reason. The first reason wins, so a pass
+    /// that notices the supervisor's verdict and parks itself does not overwrite
+    /// the account of why it was stopped.
+    pub fn halt(&self, reason: impl Into<String>) {
+        let mut inner = self.lock();
+        if inner.halt.is_some() {
+            return;
+        }
+        inner.halt = Some(reason.into());
+        inner.working_since = None;
+        drop(inner);
+        self.halted.store(true, Ordering::Relaxed);
+    }
+
+    /// Charge `delay` against this pass's cumulative retry budget.
+    ///
+    /// Returns `true` while the ladder may keep retrying. On exhaustion the pass
+    /// is parked with a reason naming what was being retried, so the work stops
+    /// visibly instead of retrying until the process is killed. A zero budget
+    /// disables the limit.
+    pub fn charge_retry(&self, delay: Duration, budget: Duration, retrying: &str) -> bool {
+        let spent = {
+            let mut inner = self.lock();
+            inner.retry_spent = inner.retry_spent.saturating_add(delay);
+            inner.retry_spent
+        };
+        if budget.is_zero() || spent < budget {
+            return true;
+        }
+        self.halt(format!(
+            "{retrying} kept failing for {}s of cumulative retry backoff and was parked; \
+             the daemon keeps serving and a restart retries it",
+            spent.as_secs()
+        ));
+        false
+    }
+
+    /// Clear the retry ladder after a success, so an intermittent failure never
+    /// accumulates across healthy stretches into a park.
+    pub fn reset_retries(&self) {
+        self.lock().retry_spent = Duration::ZERO;
+    }
+
+    /// Cumulative retry delay charged since the last success.
+    pub fn retry_spent(&self) -> Duration {
+        self.lock().retry_spent
+    }
+
+    /// Units of work durably recorded so far.
+    pub fn progress(&self) -> u64 {
+        self.lock().progress
+    }
+
+    fn report(&self, now: Instant) -> BackgroundPassReport {
+        let inner = self.lock();
+        let state = if inner.halt.is_some() {
+            "stopped"
+        } else if inner.working_since.is_some() {
+            "working"
+        } else {
+            "idle"
+        };
+        BackgroundPassReport {
+            name: self.name.to_string(),
+            state: state.to_string(),
+            progress: inner.progress,
+            progress_age_seconds: inner
+                .progress_at
+                .map(|at| now.saturating_duration_since(at).as_secs()),
+            working_seconds: inner
+                .working_since
+                .map(|since| now.saturating_duration_since(since).as_secs()),
+            stopped_reason: inner.halt.clone(),
+        }
+    }
+}
+
+/// Whether a pass should be stopped at this sweep.
+///
+/// Total and pure so both directions can be tested against each other with every
+/// other input held equal: a wedged pass must be stopped, and a pass reporting
+/// progress must not be. A one-sided test would pass for a predicate that stops
+/// everything.
+///
+/// Both conditions are required. Working long enough alone would stop a pass that
+/// is advancing steadily through a large backlog, and a stale progress timestamp
+/// alone would stop a pass that has just started working after an idle stretch.
+fn is_stalled(
+    working_for: Option<Duration>,
+    since_progress: Option<Duration>,
+    threshold: Duration,
+) -> bool {
+    if threshold.is_zero() {
+        return false;
+    }
+    let Some(working_for) = working_for else {
+        return false;
+    };
+    if working_for < threshold {
+        return false;
+    }
+    // A pass that has never recorded progress is judged from when it started
+    // working, not from process start: it has had exactly this stretch to
+    // produce something.
+    since_progress.unwrap_or(working_for) >= threshold
+}
+
+/// Watches every background pass the daemon runs and stops the ones that are
+/// spending the machine without advancing.
+#[derive(Debug)]
+pub struct BackgroundWorkSupervisor {
+    stall_threshold: Duration,
+    passes: RwLock<BTreeMap<&'static str, Arc<BackgroundPass>>>,
+    /// Cumulative process CPU time in milliseconds, sampled by the sweep. Read
+    /// by `/health`, which must stay cheap enough to poll.
+    cpu_millis: AtomicU64,
+    cpu_sampled: AtomicBool,
+}
+
+impl Default for BackgroundWorkSupervisor {
+    fn default() -> Self {
+        Self::new(configured_stall_threshold())
+    }
+}
+
+impl BackgroundWorkSupervisor {
+    pub fn new(stall_threshold: Duration) -> Self {
+        Self {
+            stall_threshold,
+            passes: RwLock::new(BTreeMap::new()),
+            cpu_millis: AtomicU64::new(0),
+            cpu_sampled: AtomicBool::new(false),
+        }
+    }
+
+    fn passes(
+        &self,
+    ) -> std::sync::RwLockReadGuard<'_, BTreeMap<&'static str, Arc<BackgroundPass>>> {
+        self.passes.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// The handle for `name`, registering it on first use.
+    ///
+    /// Registration is lazy so a pass that a build never spawns — the embedding
+    /// worker without its feature, the reconcile loop on a bare repository —
+    /// never appears in the report claiming to be idle when it does not exist.
+    pub fn pass(&self, name: &'static str) -> Arc<BackgroundPass> {
+        if let Some(pass) = self.passes().get(name) {
+            return Arc::clone(pass);
+        }
+        let mut passes = self.passes.write().unwrap_or_else(PoisonError::into_inner);
+        Arc::clone(
+            passes
+                .entry(name)
+                .or_insert_with(|| Arc::new(BackgroundPass::new(name))),
+        )
+    }
+
+    /// An already-registered pass, without registering one.
+    pub fn registered(&self, name: &str) -> Option<Arc<BackgroundPass>> {
+        self.passes().get(name).map(Arc::clone)
+    }
+
+    pub fn stall_threshold(&self) -> Duration {
+        self.stall_threshold
+    }
+
+    /// Evaluate every pass and stop the stalled ones. Returns the halt reason of
+    /// each pass stopped by this sweep, for logging.
+    pub fn sweep(&self, now: Instant) -> Vec<String> {
+        let passes: Vec<Arc<BackgroundPass>> = self.passes().values().map(Arc::clone).collect();
+        let mut stopped = Vec::new();
+        for pass in passes {
+            let (working_for, since_progress, progress, already_halted) = {
+                let inner = pass.lock();
+                (
+                    inner
+                        .working_since
+                        .map(|since| now.saturating_duration_since(since)),
+                    inner
+                        .progress_at
+                        .map(|at| now.saturating_duration_since(at)),
+                    inner.progress,
+                    inner.halt.is_some(),
+                )
+            };
+            if already_halted {
+                continue;
+            }
+            if !is_stalled(working_for, since_progress, self.stall_threshold) {
+                continue;
+            }
+            let working_for = working_for.unwrap_or_default();
+            let reason = format!(
+                "the {} pass held the CPU for {}s without recording any progress \
+                 (still at {progress} units) and was stopped; the daemon keeps serving and a \
+                 restart retries it",
+                pass.name(),
+                working_for.as_secs(),
+            );
+            pass.halt(reason.clone());
+            stopped.push(reason);
+        }
+        stopped
+    }
+
+    /// Sample this process's cumulative CPU time.
+    ///
+    /// Sampled on the sweep rather than on each `/health` read: the answer moves
+    /// slowly, a process refresh is not free, and a health endpoint that got
+    /// more expensive the more it was polled would be its own runaway.
+    pub fn sample_process_cpu(&self) {
+        let pid = sysinfo::Pid::from_u32(std::process::id());
+        let mut system = sysinfo::System::new();
+        system.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[pid]),
+            true,
+            sysinfo::ProcessRefreshKind::nothing().with_cpu(),
+        );
+        if let Some(process) = system.process(pid) {
+            self.cpu_millis
+                .store(process.accumulated_cpu_time(), Ordering::Relaxed);
+            self.cpu_sampled.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Cumulative CPU seconds this daemon has spent, or `None` before the first
+    /// sample. Reported rather than inferred: an absent value says the daemon
+    /// does not know, which is not the same as zero.
+    pub fn daemon_cpu_seconds(&self) -> Option<f64> {
+        if !self.cpu_sampled.load(Ordering::Relaxed) {
+            return None;
+        }
+        Some(self.cpu_millis.load(Ordering::Relaxed) as f64 / 1000.0)
+    }
+
+    /// Per-pass state for the disclosure surfaces.
+    pub fn reports(&self, now: Instant) -> Vec<BackgroundPassReport> {
+        self.passes()
+            .values()
+            .map(|pass| pass.report(now))
+            .collect()
+    }
+
+    /// Whether any pass has been stopped. Drives the `attention` health status.
+    pub fn any_stopped(&self) -> bool {
+        self.passes().values().any(|pass| pass.halted())
+    }
+
+    /// The complete disclosure: cumulative CPU and every pass's progress age.
+    pub fn work_state(&self, now: Instant) -> DaemonWorkState {
+        DaemonWorkState {
+            daemon_cpu_seconds: self.daemon_cpu_seconds(),
+            passes: self.reports(now),
+        }
+    }
+}
+
+/// Run the supervisor until shutdown.
+///
+/// Deliberately does nothing but observe and announce. It starts no work, takes
+/// no graph lock, and touches no store, so it can keep answering for a daemon
+/// whose real work has wedged — which is the only condition under which it
+/// matters at all.
+pub async fn run_background_work_supervisor(
+    supervisor: Arc<BackgroundWorkSupervisor>,
+    mut cancel: tokio::sync::watch::Receiver<bool>,
+) {
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(SWEEP_INTERVAL) => {}
+            _ = cancel.changed() => return,
+        }
+        if *cancel.borrow() {
+            return;
+        }
+        supervisor.sample_process_cpu();
+        for reason in supervisor.sweep(Instant::now()) {
+            tracing::error!("{reason}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn an_idle_pass_is_never_stalled_however_long_it_has_been_quiet() {
+        assert!(!is_stalled(
+            None,
+            Some(Duration::from_secs(86_400)),
+            Duration::from_secs(60)
+        ));
+    }
+
+    #[test]
+    fn a_working_pass_with_no_progress_stalls_at_the_threshold() {
+        let threshold = Duration::from_secs(60);
+        assert!(!is_stalled(Some(Duration::from_secs(59)), None, threshold));
+        assert!(is_stalled(Some(Duration::from_secs(60)), None, threshold));
+    }
+
+    /// The falsification for the stop rule: the SAME pass, working for the same
+    /// stretch, is left alone once it reports progress. Without this the rule
+    /// could be "stop everything that works long enough" and the stop test would
+    /// still pass.
+    #[test]
+    fn recent_progress_protects_a_pass_that_has_worked_far_past_the_threshold() {
+        let threshold = Duration::from_secs(60);
+        let working_for = Duration::from_secs(3_600);
+        assert!(is_stalled(Some(working_for), None, threshold));
+        assert!(!is_stalled(
+            Some(working_for),
+            Some(Duration::from_secs(5)),
+            threshold
+        ));
+    }
+
+    /// Progress recorded during an earlier working stretch must not vouch for
+    /// this one, and does not: the conjunction requires the current stretch to
+    /// be long as well.
+    #[test]
+    fn a_freshly_started_pass_is_not_stalled_by_an_old_progress_timestamp() {
+        assert!(!is_stalled(
+            Some(Duration::from_secs(2)),
+            Some(Duration::from_secs(9_000)),
+            Duration::from_secs(60)
+        ));
+    }
+
+    #[test]
+    fn a_zero_threshold_disables_stopping() {
+        assert!(!is_stalled(
+            Some(Duration::from_secs(9_000)),
+            Some(Duration::from_secs(9_000)),
+            Duration::ZERO
+        ));
+    }
+
+    #[test]
+    fn the_working_mark_latches_so_a_wedged_loop_cannot_restart_its_own_clock() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        let base = Instant::now();
+
+        // A wedged loop calls `working` on every turn. The stretch must still be
+        // measured from the first one.
+        for turn in 0..10 {
+            pass.working(at(base, turn));
+        }
+        assert!(supervisor.sweep(at(base, 59)).is_empty());
+
+        let stopped = supervisor.sweep(at(base, 61));
+        assert_eq!(stopped.len(), 1, "the wedged pass must be stopped");
+        assert!(pass.halted());
+        assert!(pass
+            .halt_reason()
+            .expect("a stopped pass carries a reason")
+            .contains("without recording any progress"));
+    }
+
+    /// The other half of the same scenario. Only the progress feed differs, so a
+    /// guard that stopped every long pass would fail here.
+    #[test]
+    fn the_same_long_pass_is_untouched_while_it_reports_progress() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        let base = Instant::now();
+
+        pass.working(base);
+        for minute in 1..30 {
+            pass.advanced(64, at(base, minute * 30));
+            assert!(
+                supervisor.sweep(at(base, minute * 30 + 1)).is_empty(),
+                "a pass recording progress must never be stopped"
+            );
+        }
+        assert!(!pass.halted());
+        assert_eq!(pass.progress(), 64 * 29);
+    }
+
+    #[test]
+    fn going_idle_ends_the_working_stretch() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_RECONCILE);
+        let base = Instant::now();
+
+        pass.working(base);
+        pass.idle();
+        assert!(supervisor.sweep(at(base, 3_600)).is_empty());
+
+        pass.working(at(base, 3_600));
+        assert!(supervisor.sweep(at(base, 3_640)).is_empty());
+        assert_eq!(supervisor.sweep(at(base, 3_661)).len(), 1);
+    }
+
+    #[test]
+    fn an_empty_batch_is_not_progress() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        let base = Instant::now();
+
+        pass.working(base);
+        for turn in 0..10 {
+            pass.advanced(0, at(base, turn));
+        }
+        assert_eq!(supervisor.sweep(at(base, 61)).len(), 1);
+    }
+
+    #[test]
+    fn a_stopped_pass_is_stopped_once_and_keeps_its_first_reason() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        let base = Instant::now();
+
+        pass.working(base);
+        assert_eq!(supervisor.sweep(at(base, 61)).len(), 1);
+        let first = pass.halt_reason().expect("a reason");
+        assert!(supervisor.sweep(at(base, 600)).is_empty());
+        pass.halt("a later reason");
+        assert_eq!(pass.halt_reason().as_deref(), Some(first.as_str()));
+    }
+
+    #[test]
+    fn the_retry_ladder_parks_once_its_cumulative_budget_is_spent() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        let budget = Duration::from_secs(100);
+
+        assert!(pass.charge_retry(Duration::from_secs(60), budget, "embedding"));
+        assert!(!pass.halted());
+        assert!(!pass.charge_retry(Duration::from_secs(60), budget, "embedding"));
+        assert!(pass.halted());
+        assert!(pass
+            .halt_reason()
+            .expect("a parked pass carries a reason")
+            .contains("cumulative retry backoff"));
+    }
+
+    /// The falsification for the budget: a ladder that recovers must not carry
+    /// its spent delay into the next failure and park a healthy pass.
+    #[test]
+    fn a_recovered_retry_ladder_starts_its_budget_over() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        let budget = Duration::from_secs(100);
+
+        for _ in 0..10 {
+            assert!(pass.charge_retry(Duration::from_secs(60), budget, "embedding"));
+            pass.reset_retries();
+        }
+        assert!(!pass.halted());
+        assert_eq!(pass.retry_spent(), Duration::ZERO);
+    }
+
+    #[test]
+    fn a_zero_budget_disables_parking() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_EMBED);
+        for _ in 0..100 {
+            assert!(pass.charge_retry(Duration::from_secs(60), Duration::ZERO, "embedding"));
+        }
+        assert!(!pass.halted());
+    }
+
+    #[test]
+    fn the_report_discloses_state_progress_and_ages() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(600));
+        let base = Instant::now();
+
+        let embed = supervisor.pass(PASS_EMBED);
+        embed.working(base);
+        embed.advanced(128, at(base, 10));
+        supervisor.pass(PASS_RECONCILE);
+
+        let reports = supervisor.reports(at(base, 40));
+        assert_eq!(reports.len(), 2);
+
+        let embed_report = reports
+            .iter()
+            .find(|report| report.name == PASS_EMBED)
+            .expect("the embed pass is reported");
+        assert_eq!(embed_report.state, "working");
+        assert_eq!(embed_report.progress, 128);
+        assert_eq!(embed_report.progress_age_seconds, Some(30));
+        assert_eq!(embed_report.working_seconds, Some(40));
+        assert!(embed_report.stopped_reason.is_none());
+
+        let reconcile_report = reports
+            .iter()
+            .find(|report| report.name == PASS_RECONCILE)
+            .expect("the reconcile pass is reported");
+        assert_eq!(reconcile_report.state, "idle");
+        assert_eq!(reconcile_report.progress_age_seconds, None);
+        assert_eq!(reconcile_report.working_seconds, None);
+    }
+
+    #[test]
+    fn a_stopped_pass_reports_its_reason_and_raises_attention() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let base = Instant::now();
+        let pass = supervisor.pass(PASS_EMBED);
+
+        assert!(!supervisor.any_stopped());
+        pass.working(base);
+        supervisor.sweep(at(base, 61));
+
+        assert!(supervisor.any_stopped());
+        let report = supervisor
+            .reports(at(base, 61))
+            .into_iter()
+            .find(|report| report.name == PASS_EMBED)
+            .expect("the embed pass is reported");
+        assert_eq!(report.state, "stopped");
+        assert!(report.stopped_reason.is_some());
+    }
+
+    #[test]
+    fn cumulative_cpu_is_absent_until_it_is_sampled_and_present_after() {
+        let supervisor = BackgroundWorkSupervisor::new(DEFAULT_STALL_THRESHOLD);
+        assert_eq!(supervisor.daemon_cpu_seconds(), None);
+        supervisor.sample_process_cpu();
+        let sampled = supervisor
+            .daemon_cpu_seconds()
+            .expect("this process has accumulated CPU time");
+        assert!(
+            sampled >= 0.0,
+            "cumulative CPU must be a real measurement: {sampled}"
+        );
+    }
+
+    #[test]
+    fn registration_is_lazy_so_an_unspawned_pass_never_claims_to_be_idle() {
+        let supervisor = BackgroundWorkSupervisor::new(DEFAULT_STALL_THRESHOLD);
+        assert!(supervisor.reports(Instant::now()).is_empty());
+        assert!(supervisor.registered(PASS_EMBED).is_none());
+        supervisor.pass(PASS_EMBED);
+        assert!(supervisor.registered(PASS_EMBED).is_some());
+        assert_eq!(supervisor.reports(Instant::now()).len(), 1);
+    }
+
+    #[test]
+    fn repeated_registration_returns_one_shared_pass() {
+        let supervisor = BackgroundWorkSupervisor::new(DEFAULT_STALL_THRESHOLD);
+        let first = supervisor.pass(PASS_EMBED);
+        first.advanced(7, Instant::now());
+        let second = supervisor.pass(PASS_EMBED);
+        assert_eq!(second.progress(), 7);
+        assert_eq!(supervisor.reports(Instant::now()).len(), 1);
+    }
+}

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -305,17 +305,43 @@ async fn wait_for_lsp_index(server: &kin_lsp::lifecycle::LspServer, max: Duratio
 /// never interleave and the persisted generation cursor advances monotonically.
 /// Returns once the handle is cleared so callers can use this both to overlap a
 /// flush with the next batch's prep and to drain the tail at every loop exit.
-async fn drain_pending_flush(pending: &mut Option<tokio::task::JoinHandle<Result<usize>>>) {
-    if let Some(handle) = pending.take() {
-        match handle.await {
-            Ok(Ok(_pending)) => {}
-            Ok(Err(e)) => {
-                error!(error = %e, "failed to flush embed progress");
-            }
-            Err(e) => {
-                error!(error = %e, "embed progress flush task panicked");
-            }
+///
+/// The returned flag says whether a flush actually reached disk, which is what
+/// lets a caller credit persisted progress without crediting a failed persist.
+/// Nothing in flight is reported as nothing persisted.
+async fn drain_pending_flush(pending: &mut Option<tokio::task::JoinHandle<Result<usize>>>) -> bool {
+    let Some(handle) = pending.take() else {
+        return false;
+    };
+    match handle.await {
+        Ok(Ok(_pending)) => true,
+        Ok(Err(e)) => {
+            error!(error = %e, "failed to flush embed progress");
+            false
         }
+        Err(e) => {
+            error!(error = %e, "embed progress flush task panicked");
+            false
+        }
+    }
+}
+
+/// Drain the in-flight flush and credit what it persisted to the embedding pass.
+///
+/// Progress is credited here rather than when a batch finishes embedding,
+/// because the counter the supervisor judges liveness on has to mean work that
+/// survived to disk. A batch whose flush failed produced nothing durable, and
+/// crediting it anyway would let a worker that can never persist keep vouching
+/// for itself indefinitely — the exact silence this supervisor exists to end.
+async fn drain_embed_flush(
+    pending: &mut Option<tokio::task::JoinHandle<Result<usize>>>,
+    embedded: &mut u64,
+    pass: &crate::background_work::BackgroundPass,
+) {
+    let persisted = drain_pending_flush(pending).await;
+    let credited = std::mem::take(embedded);
+    if persisted {
+        pass.advanced(credited, Instant::now());
     }
 }
 
@@ -1600,6 +1626,14 @@ pub async fn run_with_authority(
         }
         info!("embedding worker started");
         start_or_defer_background_embed(&embed_state);
+        // Register with the self-limit supervisor. Registration is what makes
+        // this worker's CPU accountable: from here it declares when it is
+        // working, credits what it persists, and is stopped and announced if
+        // those two ever come apart.
+        let embed_pass = embed_state
+            .background_work
+            .pass(crate::background_work::PASS_EMBED);
+        let embed_retry_budget = crate::background_work::configured_retry_budget();
         let mut consecutive_panics: u32 = 0;
         const MAX_CONSECUTIVE_PANICS: u32 = 3;
         // Recovery + backoff state for vector-index errors (e.g. a stale on-disk
@@ -1611,6 +1645,11 @@ pub async fn run_with_authority(
         let mut error_backoff: Option<Duration> = None;
         const EMBED_ERROR_BACKOFF_MAX: Duration = Duration::from_secs(60);
         'wake: loop {
+            // Between wakes this worker is genuinely doing nothing, so the
+            // working stretch ends here. A wedged drain never reaches this
+            // point, which is precisely why the stretch it started keeps
+            // accumulating and becomes observable.
+            embed_pass.idle();
             // While an embed/index error is being retried, sleep for the current
             // backoff instead of the normal idle interval (no tight-spin).
             let idle = error_backoff.unwrap_or(embed_interval);
@@ -1622,6 +1661,9 @@ pub async fn run_with_authority(
                 }
             }
             if *embed_cancel.borrow() {
+                break;
+            }
+            if embed_pass.halted() {
                 break;
             }
 
@@ -1641,9 +1683,21 @@ pub async fn run_with_authority(
             // every loop exit so two flushes never interleave and the tail is
             // always awaited.
             let mut pending_flush: Option<tokio::task::JoinHandle<Result<usize>>> = None;
+            // Entities embedded by batches whose flush has not been awaited yet.
+            // Credited to the pass only once that flush reports it reached disk.
+            let mut embedded_since_flush: u64 = 0;
             loop {
                 if *embed_cancel.borrow() {
-                    drain_pending_flush(&mut pending_flush).await;
+                    drain_embed_flush(&mut pending_flush, &mut embedded_since_flush, &embed_pass)
+                        .await;
+                    break 'wake;
+                }
+                // The supervisor's verdict is enforced here, at the worker's own
+                // checkpoint, so an in-flight batch and its flush finish rather
+                // than being torn out from under the vector sidecar.
+                if embed_pass.halted() {
+                    drain_embed_flush(&mut pending_flush, &mut embedded_since_flush, &embed_pass)
+                        .await;
                     break 'wake;
                 }
                 if embed_state.background_embed_paused() {
@@ -1659,6 +1713,10 @@ pub async fn run_with_authority(
                 if pending == 0 && pending_artifacts == 0 {
                     break;
                 }
+                // From here to the next `idle` this worker is spending the
+                // machine. Latched, so a drain that never finishes keeps one
+                // stretch rather than restarting it every batch.
+                embed_pass.working(Instant::now());
                 let batch = embed_batch_size;
                 let state_for_embed = Arc::clone(&embed_state);
                 let is_artifact = pending == 0;
@@ -1696,6 +1754,7 @@ pub async fn run_with_authority(
                         // embedder — clear any error backoff / reset latch.
                         index_reset_triggered = false;
                         error_backoff = None;
+                        embed_pass.reset_retries();
                         info!(count, remaining = remaining.saturating_sub(count), label);
                         // Serialize successive flushes: the previous batch's
                         // flush — which may still be running concurrently with
@@ -1704,7 +1763,13 @@ pub async fn run_with_authority(
                         // This guarantees at most one persist runs at a time, so
                         // two flushes never interleave and the persisted
                         // generation cursor advances monotonically.
-                        drain_pending_flush(&mut pending_flush).await;
+                        drain_embed_flush(
+                            &mut pending_flush,
+                            &mut embedded_since_flush,
+                            &embed_pass,
+                        )
+                        .await;
+                        embedded_since_flush = count as u64;
                         // Persist the vector index under the shared persist lock so
                         // this kvec write can never interleave with a snapshot save
                         // running in the persistence loop or idle-shutdown flush.
@@ -1726,7 +1791,12 @@ pub async fn run_with_authority(
                         // runs; proof/serial blocks on it now so the persisted
                         // order is fully deterministic.
                         if !embed_pipeline_overlap {
-                            drain_pending_flush(&mut pending_flush).await;
+                            drain_embed_flush(
+                                &mut pending_flush,
+                                &mut embedded_since_flush,
+                                &embed_pass,
+                            )
+                            .await;
                         }
                     }
                     Ok(BackgroundEmbeddingBatchOutcome::Completed(_)) => {
@@ -1736,6 +1806,7 @@ pub async fn run_with_authority(
                         consecutive_panics = 0;
                         index_reset_triggered = false;
                         error_backoff = None;
+                        embed_pass.reset_retries();
                         break;
                     }
                     Ok(BackgroundEmbeddingBatchOutcome::ResetAfterIndexError(e)) => {
@@ -1774,6 +1845,22 @@ pub async fn run_with_authority(
                             backoff_s = next.as_secs(),
                             "embedding worker error — backing off"
                         );
+                        // Backoff bounds how fast this ladder retries and not how
+                        // long it retries for, so a failure that never clears
+                        // retries at the ceiling until the process dies. Charging
+                        // each delay against a cumulative budget puts an end on
+                        // it: the work parks with a reason a user can read
+                        // instead of retrying out of sight forever.
+                        if !embed_pass.charge_retry(
+                            next,
+                            embed_retry_budget,
+                            "the background embedding worker",
+                        ) {
+                            error!(
+                                budget_s = embed_retry_budget.as_secs(),
+                                "embedding worker parked — cumulative retry budget exhausted (see /health background_passes)"
+                            );
+                        }
                         break;
                     }
                     Err(e) => {
@@ -1787,12 +1874,25 @@ pub async fn run_with_authority(
                             embed_state
                                 .embed_worker_failed
                                 .store(true, std::sync::atomic::Ordering::Relaxed);
+                            // Say it on the pass surface too. A reader looking at
+                            // background passes must not see this worker sitting
+                            // at `idle` when it is never coming back.
+                            embed_pass.halt(format!(
+                                "the embedding worker panicked {consecutive_panics} times in a row \
+                                 and stopped; the vector index will not advance until the daemon \
+                                 restarts and the daemon keeps serving graph, locate and reconcile"
+                            ));
                             error!(
                                 error = %e,
                                 consecutive_panics,
                                 "embedding worker permanently failed — vector index will not update until daemon restart; daemon continues in embed-degraded mode (see /health embed_worker_failed)"
                             );
-                            drain_pending_flush(&mut pending_flush).await;
+                            drain_embed_flush(
+                                &mut pending_flush,
+                                &mut embedded_since_flush,
+                                &embed_pass,
+                            )
+                            .await;
                             break 'wake;
                         }
                         error!(
@@ -1812,7 +1912,8 @@ pub async fn run_with_authority(
                 // signal) is left for the bounded teardown to handle.
                 if *embed_cancel.borrow() {
                     info!("embedding worker stopping mid-drain on shutdown");
-                    drain_pending_flush(&mut pending_flush).await;
+                    drain_embed_flush(&mut pending_flush, &mut embedded_since_flush, &embed_pass)
+                        .await;
                     break 'wake;
                 }
 
@@ -1827,9 +1928,26 @@ pub async fn run_with_authority(
             // transient error, or panic respawn) so a persist started under the
             // throughput profile is always awaited before the worker idles or
             // re-enters the next wake — no flush outlives the loop unobserved.
-            drain_pending_flush(&mut pending_flush).await;
+            drain_embed_flush(&mut pending_flush, &mut embedded_since_flush, &embed_pass).await;
         }
+        embed_pass.idle();
     });
+
+    // Spawn the background-work supervisor.
+    //
+    // The daemon is the only Kin process on a user's machine, so no watchdog
+    // outside it will ever notice a pass that has wedged. This one keys on the
+    // persisted-progress delta rather than on CPU utilization — a busy-spin pegs
+    // a core while achieving nothing, so utilization cannot tell working from
+    // stuck — and stops a pass that spends the machine without advancing,
+    // announcing the stop through `/health` and `kin resources` rather than
+    // leaving a warm fan as the only evidence.
+    let supervisor_work = Arc::clone(&state.background_work);
+    let supervisor_work_cancel = cancel_rx.clone();
+    tokio::spawn(crate::background_work::run_background_work_supervisor(
+        supervisor_work,
+        supervisor_work_cancel,
+    ));
 
     // Spawn the LSP enrichment worker (channel was set up before Arc::new).
     if let Some(mut lsp_rx) = lsp_rx {

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -115,6 +115,7 @@
 //!   stream ineligible rather than reporting a misleading success.
 
 pub mod api;
+pub mod background_work;
 pub mod commit_deltas;
 pub mod daemon;
 pub mod error;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use kin_index::{
     FileClassification, FileClassifier, FileEvent, FileWatcher, IndexPipeline, IndexedAny,
@@ -869,13 +869,38 @@ pub async fn run_loop(
     let mut pending_events: VecDeque<FileEvent> = VecDeque::new();
     let mut backlog_warning_active = false;
 
+    // Register with the self-limit supervisor. Registered here rather than at
+    // daemon start so a repository that never runs this loop — filesystem
+    // reconcile disabled, a bare checkout — reports no reconcile pass instead of
+    // one that claims to be idle forever.
+    let pass = state
+        .background_work
+        .pass(crate::background_work::PASS_RECONCILE);
+
     loop {
         // Check for shutdown signal.
         if *cancel.borrow() {
             state
                 .reconciliation_status
                 .store(RECON_IDLE, Ordering::Relaxed);
+            pass.idle();
             info!("reconciliation loop shutting down");
+            break;
+        }
+
+        // The supervisor stopped this loop for spending the machine without
+        // admitting anything. Enforced at this checkpoint, before any lock is
+        // taken, so nothing is abandoned mid-transaction. Graph truth is
+        // untouched and the daemon keeps serving it; what stops is the automatic
+        // tracking of working-copy edits, which the announced reason says.
+        if pass.halted() {
+            state
+                .reconciliation_status
+                .store(RECON_IDLE, Ordering::Relaxed);
+            error!(
+                reason = pass.halt_reason().unwrap_or_default(),
+                "reconciliation loop stopped by the background-work supervisor"
+            );
             break;
         }
 
@@ -954,6 +979,11 @@ pub async fn run_loop(
         enqueue_file_events(&mut pending_events, incoming_events);
 
         if pending_events.is_empty() {
+            // Nothing observed, so this loop is genuinely doing nothing and its
+            // working stretch ends. This is the only path that clears it: a tick
+            // that keeps retrying the same unadmittable paths never arrives
+            // here, which is what makes that spin observable.
+            pass.idle();
             // No events — sleep briefly then check again.
             tokio::select! {
                 _ = tokio::time::sleep(interval) => {}
@@ -969,6 +999,7 @@ pub async fn run_loop(
         state
             .reconciliation_status
             .store(RECON_PROCESSING, Ordering::Relaxed);
+        pass.working(Instant::now());
 
         // Backpressure stays bounded. A large burst remains in `pending_events` and is
         // consumed over multiple iterations; processing the entire queue under the write
@@ -1006,6 +1037,12 @@ pub async fn run_loop(
         // staging view; there is no second mutable overlay authority.
         let mut reconciler = state.reconciler.write().await;
         let mut graph_changed = false;
+        // Events this tick admitted without deferring them back to the retry
+        // queue. This is the reconcile pass's persisted-progress counter: a tick
+        // that re-observes the same paths and defers every one of them scores
+        // zero however much work it did, which is the honest account of a loop
+        // that is spending the machine and moving nothing.
+        let mut admitted_events: u64 = 0;
         let mut projection_changed = ProjectionChangedSet::default();
 
         let mut lsp_changed: Vec<(kin_model::FilePathId, Vec<kin_model::EntityId>)> = Vec::new();
@@ -1109,6 +1146,7 @@ pub async fn run_loop(
                     continue;
                 }
             }
+            admitted_events += 1;
 
             let (semantic_event, semantic_repo_path) = match admitted {
                 AdmittedFileEvent::Regular {
@@ -1471,6 +1509,8 @@ pub async fn run_loop(
                 error!(error = %e, "failed to refresh projection after reconciliation");
             }
         }
+
+        pass.advanced(admitted_events, Instant::now());
 
         let backlog_remains = !pending_events.is_empty() || !retry_queue.is_empty();
         if !backlog_remains {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1275,6 +1275,11 @@ pub struct DaemonState {
     /// daemon-health signal so this degraded state is LOUD, never silent (the
     /// worker dying must NOT take the whole daemon down).
     pub embed_worker_failed: AtomicBool,
+    /// Watches every pass this daemon runs on its own initiative and stops the
+    /// ones spending the machine without advancing. The daemon is the only Kin
+    /// process on a user's box, so nothing outside it can notice a wedged pass;
+    /// this is where that noticing lives.
+    pub background_work: Arc<crate::background_work::BackgroundWorkSupervisor>,
     /// Why the views this daemon derives from repository authority stopped
     /// matching it, or `None` when they match.
     ///
@@ -2138,6 +2143,7 @@ impl DaemonState {
             spine: std::sync::OnceLock::new(),
             spine_initialization: Mutex::new(()),
             spine_warming: AtomicBool::new(false),
+            background_work: Arc::new(crate::background_work::BackgroundWorkSupervisor::default()),
             #[cfg(test)]
             spine_initialization_test_hook: Mutex::new(None),
             #[cfg(all(test, feature = "embeddings"))]
@@ -2354,6 +2360,7 @@ impl DaemonState {
             spine: std::sync::OnceLock::new(),
             spine_initialization: Mutex::new(()),
             spine_warming: AtomicBool::new(false),
+            background_work: Arc::new(crate::background_work::BackgroundWorkSupervisor::default()),
             #[cfg(test)]
             spine_initialization_test_hook: Mutex::new(None),
             #[cfg(all(test, feature = "embeddings"))]


### PR DESCRIPTION
The daemon is the only Kin process on an end user's machine, so nothing
outside it can notice a background pass that has wedged. One burned 803
CPU-minutes over sixteen hours on the dev box with no user-visible
signal, and the only evidence was a warm fan. The fleet has a watchdog
for that; a user has nothing.

## The mechanism

Every background pass reports to a daemon-level supervisor. A pass
declares when it is working and credits the units it has durably
persisted. A pass that holds the CPU past the stall threshold without
advancing that count is stopped, and the stop carries a reason through
`/health`, `/commands/resources` and `kin health` instead of happening
quietly.

Liveness keys on the persisted-progress delta and never on CPU
utilization. A busy-spin pegs a core while achieving nothing, so
utilization cannot tell a working pass from a stuck one, and a counter
that moves only when work is durably recorded can.

## Three details that carry it

Idle passes are never candidates, so a quiet daemon is never stopped for
being quiet.

The working mark latches rather than resetting per iteration. A per-turn
reset would restart the clock on every turn of the very loop that is
wedged, and the stall could never be observed at all.

Stopping is cooperative. The supervisor raises a flag the pass reads at
its own checkpoint, the same shape trace cancellation already uses, so
nothing is torn out mid-write and a pass holding a lock releases it on
its own terms.

## What reports

The embedding worker and the reconciliation loop. Embedding progress is
credited when a flush reports it reached disk, so a worker that can never
persist cannot vouch for itself with batches nobody kept. Reconciliation
credits events it admitted without deferring, so a tick that re-observes
the same unadmittable paths scores zero however hard it worked.

The embedding retry ladder now charges each backoff against a cumulative
budget and parks with an announced reason once that budget is spent.
Backoff bounded how fast that ladder retried and not how long, so a
failure that never cleared retried at the ceiling for as long as the
process lived.

Health and resources disclose cumulative daemon CPU seconds and every
pass's progress age, so a user asking why the fan is on gets the answer
from the product rather than from Activity Monitor. An unsampled CPU
total is reported as absent rather than as zero.

## Configuration

Ten minutes of stalled work and thirty minutes of cumulative retry by
default, overridable through `KIN_DAEMON_PASS_STALL_SECS` and
`KIN_DAEMON_PASS_RETRY_BUDGET_SECS`. Zero disables a limit rather than
meaning immediately, because a limit whose off-switch is also its most
aggressive setting is a trap.

## Not covered

The projection rebuild and LSP enrichment workers still run unaccounted.
The supervisor is general and registration is one call, so wiring them is
mechanical, but it is not done here.

Refs FIR-2101
