### PR TITLE
Stop scoring an unconfigured install as a degraded retrieval profile

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -599,12 +599,17 @@ jobs:
             }
             return checks;
           };
-          // The repo-free Windows posture, pinned by name. `repo_init` is
-          // missing because there is no repository here, and `daemon_running`
-          // is unsupported because the daemon is repo-scoped. Both are the
-          // product's own documented no-repository answers, so both are
-          // required rather than tolerated: a change that turns either into
-          // something else has to come here and say so.
+          // The repo-free Windows posture, pinned by name. `repo_init` and
+          // `daemon_running` are both unsupported here: there is no repository,
+          // and the daemon is repo-scoped. Those are the product's own
+          // documented no-repository answers, so both are required rather than
+          // tolerated: a change that turns either into something else has to
+          // come here and say so. `repo_init` says so now. It was pinned to
+          // `missing`, and "not inside a Kin repository yet" became an expected
+          // first-run state rather than a failure when the four checks beside
+          // it were reclassified. The `hardFailures` sweep below still exempts
+          // it, so this pin is the only thing that was left describing the old
+          // answer.
           const required = new Map([
             ["kin_binary", "healthy"],
             ["kin_daemon_binary", "healthy"],
@@ -614,7 +619,7 @@ jobs:
             ["vfs_projection", "unsupported"],
             ["semantic_query_readiness", "unsupported"],
             ["daemon_running", "unsupported"],
-            ["repo_init", "missing"],
+            ["repo_init", "unsupported"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],
             ["mcp_client_gemini", "healthy"],

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1768,6 +1768,15 @@ fn check_retrieval_profile() -> HealthCheck {
     let ce_model = env::var("KIN_LOCATE_CROSS_ENCODER_MODEL")
         .unwrap_or_else(|_| "BAAI/bge-reranker-base".to_string());
     let ce_cached = crate::retrieval_profile::cross_encoder_model_cached(&ce_model);
+    // Has anyone configured retrieval on this install yet? Three independent
+    // signals, any one of them sufficient: a profile was selected, the reranker
+    // was overridden either way, or a reranker model was fetched into this
+    // install's cache at some point, whether or not a usable snapshot survives
+    // there now. An empty value is not a selection.
+    let selected = |key: &str| env::var(key).is_ok_and(|value| !value.trim().is_empty());
+    let ever_configured = selected("KIN_PROFILE")
+        || selected("KIN_LOCATE_CROSS_ENCODER_ENABLED")
+        || crate::retrieval_profile::cross_encoder_model_ever_fetched(&ce_model);
     // Report the daemon-serving default (the state queries actually run
     // under), not this one-shot CLI process's own gate.
     let ce_active = env::var("KIN_LOCATE_CROSS_ENCODER_ENABLED")
@@ -1800,11 +1809,15 @@ fn check_retrieval_profile() -> HealthCheck {
     .into_iter()
     .flatten()
     .collect();
-    let detail =
+    let mut detail =
         format!(
         "{}profile {} — semantic_locate routing: {}; entity fusion: {}; lexical parity floor: {}; \
          cross-encoder rerank: {} (model {} {})",
-        if levers_off.is_empty() { "" } else { "degraded: " },
+        match (levers_off.is_empty(), ever_configured) {
+            (true, _) => "",
+            (false, true) => "degraded: ",
+            (false, false) => "stock defaults: ",
+        },
         profile.name(),
         if profile.semantic_locate_fused() {
             "fused locate pipeline"
@@ -1818,16 +1831,33 @@ fn check_retrieval_profile() -> HealthCheck {
         if ce_cached { "cached" } else { "not cached" },
     );
     // A profile serving with levers off is answering worse than this build can,
-    // and reporting that as a passing check tells a first-run user their weakest
+    // and reporting that as a passing check tells an operator their weakest
     // retrieval configuration is the healthy one. Stale is this report's
     // advisory tier: it renders as a yellow warning and counts as needing
     // attention, without blocking readiness the way Missing/Misconfigured do,
     // because a degraded profile still serves.
-    let status = if levers_off.is_empty() {
-        HealthStatus::Healthy
-    } else {
-        HealthStatus::Stale
+    //
+    // That is the right answer for a configuration someone chose. It is the
+    // wrong answer for an install nobody has configured yet, where every lever
+    // is off because the stock profile is opt-out of nothing and the reranker
+    // model has not been downloaded: the levers were never turned off, they
+    // have never been available here. A check that scores that as degraded is
+    // permanently yellow on every machine the second its install succeeds,
+    // which is the failure `Report expected first-run states as skipped rather
+    // than failed` removed from the four checks beside this one. Unsupported is
+    // that answer: skipped rather than failed, still carrying the remediation
+    // the renderer prints for any non-Healthy check, so the opt-in stays
+    // discoverable without claiming anything is wrong.
+    let status = match (levers_off.is_empty(), ever_configured) {
+        (true, _) => HealthStatus::Healthy,
+        (false, true) => HealthStatus::Stale,
+        (false, false) => HealthStatus::Unsupported,
     };
+    // Keyed on the status rather than on the conditions that produced it, so
+    // the sentence and the tier cannot drift apart.
+    if matches!(status, HealthStatus::Unsupported) {
+        detail.push_str("; opt-in, and the reranker model downloads on first use");
+    }
     let check = HealthCheck::new(
         "retrieval_profile",
         "Retrieval quality profile",
@@ -1842,7 +1872,14 @@ fn check_retrieval_profile() -> HealthCheck {
     // what is off, and name the better profile from its own identifier so this
     // string cannot drift from the enum.
     let best = crate::retrieval_profile::RetrievalProfile::AccuracyV1;
-    let mut fix = format!("off: {}", levers_off.join(", "));
+    let mut fix = if ever_configured {
+        format!("off: {}", levers_off.join(", "))
+    } else {
+        format!(
+            "not enabled by the stock profile: {}",
+            levers_off.join(", ")
+        )
+    };
     if profile != best {
         fix.push_str(&format!(
             "; set KIN_PROFILE={} for the measured-accuracy defaults",
@@ -3486,6 +3523,99 @@ mod tests {
             check.manual_fix.is_none(),
             "nothing to remediate when nothing is off: {:?}",
             check.manual_fix
+        );
+    }
+
+    /// The state every install is in the second it succeeds: no profile
+    /// selected and no reranker model fetched. Scoring that as a degraded
+    /// serving configuration puts a permanent yellow warning on every fresh
+    /// machine, and it refused the Windows repo-free install proof, whose
+    /// tolerance requires every check to be `repo_init`, healthy, or
+    /// unsupported.
+    ///
+    /// The two falsifying halves are the point. A lever that has never been
+    /// available here is a first-run state; the same lever on an install that
+    /// fetched the model once, or that selected a profile, is the configuration
+    /// the warning exists for and still reports Stale.
+    #[test]
+    #[serial]
+    fn a_never_configured_install_is_not_a_degraded_retrieval_profile() {
+        let cache = tempfile::tempdir().unwrap();
+        let _hf = EnvVarGuard::set("HF_HOME", cache.path());
+        let _model = EnvVarGuard::set("KIN_LOCATE_CROSS_ENCODER_MODEL", "BAAI/bge-reranker-base");
+        let _ce = EnvVarGuard::unset("KIN_LOCATE_CROSS_ENCODER_ENABLED");
+        let mut profile = EnvVarGuard::unset("KIN_PROFILE");
+
+        let check = check_retrieval_profile();
+
+        assert!(
+            matches!(check.status, HealthStatus::Unsupported),
+            "levers nobody has turned off are not a degradation: {:?} ({})",
+            check.status,
+            check.detail
+        );
+        assert!(
+            check.detail.contains("stock defaults")
+                && check.detail.contains("downloads on first use"),
+            "the detail must name the state it is reporting: {}",
+            check.detail
+        );
+        let fix = check.manual_fix.as_deref().expect(
+            "the opt-in stays discoverable: the renderer prints a fix for any non-Healthy check",
+        );
+        assert!(
+            fix.contains("accuracy-v1") && fix.contains("cross-encoder rerank"),
+            "the remediation still names the better profile and what it turns on: {fix}"
+        );
+
+        let report = assemble_health_report("test".to_string(), vec![check]);
+        assert!(report.healthy);
+        let summary = report.summary();
+        assert_eq!(
+            (summary.attention, summary.skipped),
+            (0, 1),
+            "a correct fresh install must close on zero checks needing attention"
+        );
+        assert_eq!(
+            serde_json::to_value(&report).unwrap()["checks"][0]["status"],
+            "unsupported",
+            "the repo-free proof tolerance keys on this serialized status"
+        );
+
+        // Falsification one: this install fetched the reranker model once and no
+        // usable snapshot survives. That is a lever it had and lost, which is
+        // what the degraded warning exists to report.
+        std::fs::create_dir_all(
+            cache
+                .path()
+                .join("hub")
+                .join("models--BAAI--bge-reranker-base")
+                .join("blobs"),
+        )
+        .unwrap();
+        let after_fetch = check_retrieval_profile();
+        assert!(
+            matches!(after_fetch.status, HealthStatus::Stale),
+            "a model this install fetched once must keep the warning: {:?} ({})",
+            after_fetch.status,
+            after_fetch.detail
+        );
+        assert!(after_fetch.detail.contains("degraded"));
+        assert_eq!(
+            assemble_health_report("test".to_string(), vec![after_fetch])
+                .summary()
+                .attention,
+            1
+        );
+
+        // Falsification two: nothing fetched, but a profile was selected. The
+        // discriminator is whether anyone has engaged with retrieval
+        // configuration on this install, not the model cache alone.
+        std::fs::remove_dir_all(cache.path().join("hub")).unwrap();
+        profile.apply("KIN_PROFILE", Some("compat-v0"));
+        assert!(
+            matches!(check_retrieval_profile().status, HealthStatus::Stale),
+            "a profile someone chose is a serving decision they can be told about"
         );
     }
 }

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -209,13 +209,39 @@ pub fn cosine_to_relevance(cosine: f32) -> f32 {
 /// dependency; a false negative merely means the reranker stays off by
 /// default until the model is fetched explicitly.
 pub fn cross_encoder_model_cached(model_id: &str) -> bool {
-    let base = hf_cache_base(
+    cached_under_base(resolved_hf_cache_base().as_deref(), model_id)
+}
+
+/// True when this install has ever fetched `model_id` into the local Hugging
+/// Face hub cache, whether or not a usable snapshot is there now.
+///
+/// `hf-hub` creates `hub/models--{org}--{name}` the first time it downloads a
+/// model and leaves that directory behind (with its `blobs`, `refs`, and
+/// `snapshots` children) when a snapshot is pruned or a download is
+/// interrupted. So its existence is the coarser fact that this machine has
+/// fetched the model at some point, and [`cross_encoder_model_cached`] is the
+/// finer one that a resolved snapshot is usable right now. The pair separates
+/// a lever that has never been available here from one that was and is not.
+///
+/// A cache root deleted wholesale reads as never fetched. That is the side to
+/// err on: it treats the install as one nobody has configured yet rather than
+/// one that lost a capability, which understates rather than invents.
+pub fn cross_encoder_model_ever_fetched(model_id: &str) -> bool {
+    let Some(base) = resolved_hf_cache_base() else {
+        return false;
+    };
+    model_cache_dir(&base, model_id).is_dir()
+}
+
+/// The cache root for this process, with the platform and home resolvers the
+/// two probes above both need bound once.
+fn resolved_hf_cache_base() -> Option<PathBuf> {
+    hf_cache_base(
         cfg!(windows),
         |key| std::env::var_os(key),
         || directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
         || directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
-    );
-    cached_under_base(base.as_deref(), model_id)
+    )
 }
 
 /// The root `hf-hub` would resolve its cache under, given the platform and the
@@ -270,15 +296,20 @@ fn cached_under_base(base: Option<&Path>, model_id: &str) -> bool {
     let Some(base) = base else {
         return false;
     };
-    let model_dir = base
-        .join("hub")
-        .join(format!("models--{}", model_id.replace('/', "--")));
     // A usable cache entry has at least one resolved snapshot directory.
-    let snapshots = model_dir.join("snapshots");
+    let snapshots = model_cache_dir(base, model_id).join("snapshots");
     match std::fs::read_dir(&snapshots) {
         Ok(mut entries) => entries.any(|entry| entry.is_ok()),
         Err(_) => false,
     }
+}
+
+/// Where `hf-hub` keeps everything it has fetched for `model_id`. Expressed
+/// once so the has-ever-been-fetched and is-usable-now probes cannot drift onto
+/// different layouts.
+fn model_cache_dir(base: &Path, model_id: &str) -> PathBuf {
+    base.join("hub")
+        .join(format!("models--{}", model_id.replace('/', "--")))
 }
 
 #[cfg(test)]
@@ -466,6 +497,41 @@ mod tests {
         assert!(
             !cached_under_base(base.as_deref(), CE_MODEL),
             "an empty cache must report absent"
+        );
+    }
+
+    /// A model directory left behind with no resolved snapshot is what a pruned
+    /// cache or an interrupted download leaves. The two probes have to disagree
+    /// there: that disagreement is the whole of what separates a lever this
+    /// install has never had from one it had and lost. Walked as three states
+    /// on one fixture, so each assertion falsifies the one before it.
+    #[test]
+    #[serial_test::serial]
+    fn a_pruned_model_reads_as_fetched_but_not_cached() {
+        let temp = tempfile::tempdir().unwrap();
+        let _hf = kin_core::test_env::EnvVarGuard::set("HF_HOME", temp.path());
+        let model_dir = model_cache_dir(temp.path(), CE_MODEL);
+
+        assert!(
+            !cross_encoder_model_ever_fetched(CE_MODEL),
+            "an untouched cache root must read as never fetched"
+        );
+        assert!(!cross_encoder_model_cached(CE_MODEL));
+
+        std::fs::create_dir_all(model_dir.join("blobs")).unwrap();
+        assert!(
+            cross_encoder_model_ever_fetched(CE_MODEL),
+            "a model directory left behind means this install fetched the model once"
+        );
+        assert!(
+            !cross_encoder_model_cached(CE_MODEL),
+            "with no resolved snapshot the model is not usable now"
+        );
+
+        std::fs::create_dir_all(model_dir.join("snapshots").join("0123456789abcdef")).unwrap();
+        assert!(
+            cross_encoder_model_ever_fetched(CE_MODEL) && cross_encoder_model_cached(CE_MODEL),
+            "a resolved snapshot is both fetched and usable"
         );
     }
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1087,6 +1087,12 @@ UNIX_REQUIRED_VALIDATOR_CHECKS = {
 UNIX_VALIDATOR_CHECKS = {
     **UNIX_REQUIRED_VALIDATOR_CHECKS,
     "semantic_query_readiness": "stale",
+    # Carried for the same reason the Windows fixture carries it: the real
+    # report has it, the pre-embed tolerance reads every check rather than only
+    # the named ones, and a fixture that omits it cannot fail the way the real
+    # leg does. A fresh install has selected no profile and fetched no reranker
+    # model, which is a first-run state and reports unsupported.
+    "retrieval_profile": "unsupported",
 }
 
 
@@ -1096,8 +1102,12 @@ def unix_node_validator_fixture() -> tuple[
     """Build a complete valid Unix release-byte proof fixture."""
 
     pre_embed_report = validator_health_report(UNIX_VALIDATOR_CHECKS, healthy=False)
+    # The post-embed capture reads the aggregate rather than every check, and
+    # `unsupported` must not move it. Carrying the check here is what makes that
+    # a tested claim instead of an assumed one.
     embedded_report = validator_health_report(
-        {"semantic_query_readiness": "healthy"}, healthy=True
+        {"semantic_query_readiness": "healthy", "retrieval_profile": "unsupported"},
+        healthy=True,
     )
     fallback_report = validator_health_report(
         {"mcp_client_claude": "healthy"}, healthy=True
@@ -1793,6 +1803,15 @@ def assert_unix_node_validator_behavior(step: str) -> None:
                 f"{report_path} required {check_id}={wrong}",
                 fixture_with_check_status(proof, report_path, check_id, wrong),
             )
+        # The pre-embed tolerance accepts an aggregate held false by pending
+        # embeddings only while every OTHER check is healthy or unsupported, so
+        # a genuinely degraded retrieval profile still closes it. That is what
+        # refused v0.5.7 on this leg, and it is why the accepted `unsupported`
+        # above is a real answer rather than a hole in the fixture.
+        reject(
+            f"{report_path} degraded retrieval profile",
+            fixture_with_check_status(proof, report_path, "retrieval_profile", "stale"),
+        )
         reject(
             f"{report_path} contradictory duplicate check",
             fixture_with_duplicate_check(

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -1005,7 +1005,7 @@ def validator_health_report(
     }
 
 
-WINDOWS_VALIDATOR_CHECKS = {
+WINDOWS_REQUIRED_VALIDATOR_CHECKS = {
     "kin_binary": "healthy",
     "kin_daemon_binary": "healthy",
     "shell_path": "healthy",
@@ -1014,11 +1014,21 @@ WINDOWS_VALIDATOR_CHECKS = {
     "vfs_projection": "unsupported",
     "semantic_query_readiness": "unsupported",
     "daemon_running": "unsupported",
-    "repo_init": "missing",
+    "repo_init": "unsupported",
     "mcp_client_claude": "healthy",
     "mcp_client_cursor": "healthy",
     "mcp_client_gemini": "healthy",
     "mcp_client_windsurf": "healthy",
+}
+# The repo-free report carries checks the required map does not name, and
+# omitting them here is how this harness kept passing while the real Windows
+# leg threw on one of them. `retrieval_profile` is the case that did it: a
+# fresh install has selected no profile and fetched no reranker model, which is
+# a first-run state rather than a degraded serving configuration, and the leg's
+# tolerance accepts it only as `unsupported`.
+WINDOWS_VALIDATOR_CHECKS = {
+    **WINDOWS_REQUIRED_VALIDATOR_CHECKS,
+    "retrieval_profile": "unsupported",
 }
 
 
@@ -1027,7 +1037,7 @@ def windows_node_validator_fixture() -> tuple[
 ]:
     """Build a complete valid repository-free Windows proof fixture."""
 
-    report = validator_health_report(WINDOWS_VALIDATOR_CHECKS, healthy=False)
+    report = validator_health_report(WINDOWS_VALIDATOR_CHECKS, healthy=True)
     return (
         {
             "expected-commit.txt": VALIDATOR_FIXTURE_COMMIT,
@@ -1381,12 +1391,21 @@ def assert_windows_node_validator_behavior(step: str) -> None:
     # failure predicates, leaving only the required-map comparison able to
     # reject it.
     for report_path in ("kin-windows-health.json", "kin-windows-doctor.json"):
-        for check_id, expected in WINDOWS_VALIDATOR_CHECKS.items():
+        for check_id, expected in WINDOWS_REQUIRED_VALIDATOR_CHECKS.items():
             wrong = wrong_required_check_status(expected)
             reject(
                 f"{report_path} required {check_id}={wrong}",
                 fixture_with_check_status(proof, report_path, check_id, wrong),
             )
+        # A retrieval profile that is genuinely degraded, meaning levers off on
+        # a configuration this install chose rather than levers it has never
+        # had, is not tolerated by the repo-free posture. This is the arm that
+        # keeps the accepted `unsupported` above from being a blanket pass on
+        # anything this check reports.
+        reject(
+            f"{report_path} degraded retrieval profile",
+            fixture_with_check_status(proof, report_path, "retrieval_profile", "stale"),
+        )
         reject(
             f"{report_path} contradictory duplicate check",
             fixture_with_duplicate_check(
@@ -1395,7 +1414,7 @@ def assert_windows_node_validator_behavior(step: str) -> None:
         )
         reject(
             f"{report_path} inconsistent healthy aggregate",
-            fixture_with_json_value(proof, report_path, ("healthy",), True),
+            fixture_with_json_value(proof, report_path, ("healthy",), False),
         )
         reject(
             f"{report_path} unexpected hard failure",
@@ -2554,7 +2573,7 @@ def assert_install_proof_repo_free_windows_proof(repo_free: str) -> None:
         "meta.embeddings?.embeddings_enabled !== true",
         "meta.embeddings?.metal_enabled !== false",
         'authority.checks[0]?.state !== "unsupported"',
-        '["repo_init", "missing"]',
+        '["repo_init", "unsupported"]',
         '["daemon_running", "unsupported"]',
         '["registry_authority", "unsupported"]',
         '["vfs_projection", "unsupported"]',
@@ -7560,8 +7579,8 @@ def main() -> None:
             "if false; then",
         ),
         (
-            "the repo-free posture stops requiring a missing repository",
-            '["repo_init", "missing"]',
+            "the repo-free posture stops requiring the no-repository answer",
+            '["repo_init", "unsupported"]',
             '["repo_init", "healthy"]',
         ),
         (
@@ -7571,8 +7590,8 @@ def main() -> None:
         ),
         (
             "a repo-free posture pin is commented out in the heredoc it lives in",
-            '["repo_init", "missing"]',
-            '// ["repo_init", "missing"]',
+            '["repo_init", "unsupported"]',
+            '// ["repo_init", "unsupported"]',
         ),
     ):
         expect_assertion(

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -25,7 +25,7 @@
     },
     {
       "file": "crates/kin-cli/src/retrieval_profile.rs",
-      "reason": "Config/capability IO: probes the local model cache directory for reranker availability; never reads repo content and is not a semantic answer path",
+      "reason": "Config/capability IO: probes the local model cache directory for reranker availability now and for whether this install ever fetched the model; never reads repo content and is not a semantic answer path",
       "owner": "kin-cli",
       "expiration": "2026-12-31"
     },


### PR DESCRIPTION
`kin doctor` and `kin setup status` scored `retrieval_profile` as a degraded
serving configuration on every machine the second its install succeeded, and
that refused the Windows repo-free leg of the public install proof.
`finalize_release` needs the whole `install_proof` matrix green, so it blocks
the mint.

## Mechanism, read out of the failing run rather than inferred

The v0.5.7 Windows job's own report:

```
"id": "retrieval_profile", "status": "stale",
"detail": "degraded: profile compat-v0 ... semantic_locate routing: cosine-only (compat); entity fusion: off; lexical parity floor: off; cross-encoder rerank: off (model BAAI/bge-reranker-base not cached)"
```

All four levers are off, not the reranker alone. `KIN_PROFILE` is unset, the
default profile is `compat-v0`, and `compat-v0` governs every lever this check
counts to false. Nothing in the install proof sets `KIN_PROFILE`. So an
uncached reranker is one term of four, and excusing it by itself would have
left the check stale and the leg red.

That whole state is a first run, not a serving decision. The levers were never
turned off; they have never been available here. Scoring it as degraded puts a
permanent yellow warning on every stock install, which is the failure #648
removed from the four checks sitting beside this one.

## What changes

`check_retrieval_profile` asks one more question before it grades: has anyone
configured retrieval on this install yet? Three signals, any one sufficient. A
profile was selected, the reranker was overridden in either direction, or a
reranker model was fetched into this install's cache at some point.

Any of them true and nothing changes. Levers off report `Stale`, count as
needing attention, and carry the remediation naming what is off and the better
profile. That is #646 in full, on every machine where somebody has expressed an
intent about retrieval.

None of them true and the check reports `Unsupported`: skipped rather than
failed, not counted as attention, and still carrying its remediation, which the
renderer prints for any non-Healthy check. The opt-in stays discoverable
without the report claiming anything is wrong.

Has-ever-been-fetched is read from `hf-hub`'s own layout rather than a new
persisted marker. `hub/models--{org}--{name}` is created on first download and
survives a pruned snapshot or an interrupted one, so its existence is the
coarser fact and the existing snapshot probe is the finer usable-now one. A
cache root deleted wholesale reads as never fetched, which understates rather
than invents.

#646's intent is preserved exactly, and both of its tests are unchanged and
still discriminate. `doctor_warns_on_a_profile_serving_with_levers_off` selects
`compat-v0` explicitly, so it is a configuration someone chose and still
reports `Stale` with the same detail and remediation.
`doctor_stays_green_when_every_lever_the_profile_governs_is_on` still needs its
explicit override to reach `Healthy`. The default-profile product decision #646
deliberately declined to make is still open; it just no longer rides on a check
that can never be green.

## A second Windows blocker, found while proving the first

The repo-free `required` map still pinned `repo_init` to `missing`. #648 made
"not inside a Kin repository yet" an expected first-run state, so the real
report says `unsupported`, and that leg would have thrown on the required-map
comparison the moment the tolerance above it stopped throwing. The map's own
comment asks for exactly this, and the `hardFailures` sweep below it already
exempts `repo_init`, so this pin was the last thing describing the old answer.
Re-pinned to what the product reports, not widened.

## Proof

The Windows validator is extracted from the workflow and executed, through the
harness `scripts/test-release-workflow-authority.py` already uses for it. That
harness's Windows fixture omitted `retrieval_profile` entirely, which is how it
kept passing while the real leg failed; it carries it now.

- The virgin fixture (`retrieval_profile=unsupported`, `repo_init=unsupported`,
  aggregate healthy) is accepted.
- Falsified by mutation: setting that fixture's `retrieval_profile` back to
  `stale` makes the extracted validator throw the production error string
  verbatim, `overall healthy=true; non-healthy checks: ...
  retrieval_profile=stale`. Restored, re-run, green.
- `retrieval_profile=stale` is pinned as a standing rejection beside it, so the
  accepted `unsupported` is not a blanket pass on whatever this check reports.

In Rust, `a_never_configured_install_is_not_a_degraded_retrieval_profile` walks
one fixture through three states with `HF_HOME` pointed at a temp cache. Never
configured reports `Unsupported` with a healthy aggregate and zero checks
needing attention. Staging a model directory with no resolved snapshot, which
is a model this install fetched once and cannot use now, flips it back to
`Stale` and back to one check needing attention. Selecting a profile with
nothing fetched flips it back to `Stale` too, so the discriminator is
engagement with retrieval configuration and not the model cache alone.
Collapsing the three-way status to #646's two-way fails that test at its first
assertion and nothing else; restored, re-run, green.

`a_pruned_model_reads_as_fetched_but_not_cached` pins the two probes
disagreeing on a pruned cache entry, which is the whole of the discriminator.

The Unix fixture had the same hole and now carries the check too, on both the
pre-embed and post-embed reports. That arm is falsified the same way: at
`unsupported` the pre-embed capture is accepted, and at `stale` it throws its
own production error string, `overall healthy=false; non-healthy checks:
semantic_query_readiness=stale, retrieval_profile=stale`.

That result is worth stating plainly, because it was not expected. The Unix
pre-embed tolerance accepts an aggregate held false by pending embeddings only
while every other check is healthy or unsupported, so moving this check off
`stale` satisfies it directly. On the evidence of the extracted validators,
this change clears all five legs on its own rather than only the Windows one.
It does not make the first-embedding-fill work unnecessary; that is a separate
correctness claim about what a fresh install should report, and it stands on
its own.

Closes FIR-2104
