### PR TITLE
Derive Git artifact identity from content alone

### DIFF
--- a/crates/kin-cli/tests/init_reproducibility.rs
+++ b/crates/kin-cli/tests/init_reproducibility.rs
@@ -73,9 +73,10 @@ fn run_git(path: &Path, args: &[&str]) {
 
 /// Build the one fixture both admissions read.
 ///
-/// The rename in the second commit is load-bearing: artifact identity has to
-/// survive a path change, so a derivation keyed on the current path would pass
-/// a fixture without one and still be wrong.
+/// The rename in the second commit is load-bearing: it forces a later commit to
+/// mint identity for a path its parent tree has none for, which is the only
+/// case the derivation runs at all. A single-commit fixture would exercise the
+/// root-commit case and nothing else.
 fn seed_git_repo(path: &Path) {
     fs::create_dir_all(path).expect("create repo dir");
     run_git(path, &["init", "--initial-branch=main"]);

--- a/crates/kin-cli/tests/init_reproducibility.rs
+++ b/crates/kin-cli/tests/init_reproducibility.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Two admissions of one Git repository must agree on admitted content.
+//!
+//! Kin's thesis is that the graph is the canonical substrate, so a receipt
+//! field that names admitted content has to be a function of that content. If
+//! two people admit the same commit of the same repository and get different
+//! change ids and a different history root, nothing downstream — cross-repo
+//! dedup, "is this the same tree?", a before/after equivalence check that can
+//! tell a content regression apart from run-to-run drift — can be answered by
+//! comparing hashes.
+//!
+//! The two admissions here read byte-identical Git object stores: the fixture
+//! is built once and copied, so both runs see the same commit ids rather than
+//! two commits that merely carry the same message. Whatever differs between the
+//! receipts is therefore minted by Kin, not inherited from Git.
+//!
+//! Two groups of receipt fields are deliberately not asserted equal.
+//!
+//! `local_state` and `workspace_id` are per-workspace by design.
+//! `RootBundle::has_same_replicated_truth` roots workspace, session, and
+//! overlay authority under `local_state` and documents that it never
+//! participates in replica truth equality. The second test below pins that
+//! direction, so sharing content can never start meaning sharing local
+//! authority.
+//!
+//! `ref_state`, `replication`, and `ref_log` are repository-*scoped* rather
+//! than content-derived, and stay divergent here. `RepositoryRef`,
+//! `ExternalChangeAlias`, and `GitExternalAuthority` each carry the
+//! `RepositoryId` that `KinManifest::new` mints per admission, and the ref-log
+//! projection additionally carries a random operation id and the wall-clock
+//! commit time. Two admissions agree on those roots only by adopting one
+//! repository identity, which is what `KinManifest::adopting` is for and which
+//! two independent `kin init` runs deliberately do not do. Closing them is
+//! FIR-2068's follow-up and needs a repository-identity decision plus a root
+//! schema version, because every existing store validates that its recorded
+//! root bundle recomputes from its persisted envelope.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// Receipt fields that must be a function of admitted content alone.
+const CONTENT_IDENTITY_FIELDS: &[&str] = &[
+    "base_tree_hash",
+    "workspace_tree_hash",
+    "initial_change_id",
+    "roots/history/hash",
+    "roots/collaboration/hash",
+];
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Build the one fixture both admissions read.
+///
+/// The rename in the second commit is load-bearing: artifact identity has to
+/// survive a path change, so a derivation keyed on the current path would pass
+/// a fixture without one and still be wrong.
+fn seed_git_repo(path: &Path) {
+    fs::create_dir_all(path).expect("create repo dir");
+    run_git(path, &["init", "--initial-branch=main"]);
+    run_git(path, &["config", "user.email", "kin@example.invalid"]);
+    run_git(path, &["config", "user.name", "Kin"]);
+    fs::write(
+        path.join("lib.rs"),
+        "pub fn helper() -> u32 {\n    7\n}\n\npub fn caller() -> u32 {\n    helper() + 1\n}\n",
+    )
+    .expect("write first revision");
+    fs::write(path.join("README.md"), "first\n").expect("write readme");
+    run_git(path, &["add", "--all"]);
+    run_git(path, &["commit", "-m", "first"]);
+
+    run_git(path, &["mv", "lib.rs", "renamed.rs"]);
+    fs::write(path.join("README.md"), "second\n").expect("write second revision");
+    run_git(path, &["add", "--all"]);
+    run_git(path, &["commit", "-m", "second"]);
+}
+
+fn copy_tree(source: &Path, target: &Path) {
+    fs::create_dir_all(target).expect("create copy target");
+    for entry in fs::read_dir(source).expect("read fixture directory") {
+        let entry = entry.expect("read fixture entry");
+        let from = entry.path();
+        let to = target.join(entry.file_name());
+        if entry.file_type().expect("fixture entry type").is_dir() {
+            copy_tree(&from, &to);
+        } else {
+            fs::copy(&from, &to).expect("copy fixture file");
+        }
+    }
+}
+
+fn admit(repo: &Path, home: &Path) -> Value {
+    fs::create_dir_all(home).expect("create scratch home");
+    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(repo)
+        .arg("--json")
+        .env("HOME", home)
+        .output()
+        .expect("run kin init");
+    assert!(
+        output.status.success(),
+        "kin init failed for {}: stdout={} stderr={}",
+        repo.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("init stdout should be JSON")
+}
+
+fn field<'a>(receipt: &'a Value, pointer: &str) -> &'a Value {
+    receipt
+        .pointer(&format!("/{pointer}"))
+        .unwrap_or_else(|| panic!("receipt has no field {pointer}: {receipt}"))
+}
+
+#[test]
+fn two_admissions_of_one_repository_agree_on_admitted_content() {
+    let root = tempdir().expect("temp root");
+    let source = root.path().join("source");
+    seed_git_repo(&source);
+
+    let first_repo = root.path().join("first");
+    let second_repo = root.path().join("second");
+    copy_tree(&source, &first_repo);
+    copy_tree(&source, &second_repo);
+
+    let first = admit(&first_repo, &root.path().join("home-first"));
+    let second = admit(&second_repo, &root.path().join("home-second"));
+
+    // A fixture whose two copies disagreed on Git identity would make every
+    // later comparison meaningless, so prove they agree before reading Kin's.
+    assert_eq!(
+        field(&first, "raw_git_head"),
+        field(&second, "raw_git_head"),
+        "the two copies must admit the same Git commit for this test to mean anything"
+    );
+
+    let divergent = CONTENT_IDENTITY_FIELDS
+        .iter()
+        .filter(|pointer| field(&first, pointer) != field(&second, pointer))
+        .map(|pointer| {
+            format!(
+                "  {pointer}\n    first:  {}\n    second: {}",
+                field(&first, pointer),
+                field(&second, pointer)
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        divergent.is_empty(),
+        "{} of {} content-identity receipt fields are not a function of admitted content:\n{}",
+        divergent.len(),
+        CONTENT_IDENTITY_FIELDS.len(),
+        divergent.join("\n")
+    );
+}
+
+#[test]
+fn admissions_of_one_repository_are_distinct_workspaces() {
+    let root = tempdir().expect("temp root");
+    let source = root.path().join("source");
+    seed_git_repo(&source);
+
+    let first_repo = root.path().join("first");
+    let second_repo = root.path().join("second");
+    copy_tree(&source, &first_repo);
+    copy_tree(&source, &second_repo);
+
+    let first = admit(&first_repo, &root.path().join("home-first"));
+    let second = admit(&second_repo, &root.path().join("home-second"));
+
+    // The other half of the contract. Sharing replicated truth must not make
+    // two checkouts share local workspace authority, or one machine's
+    // uncommitted state would speak for another's.
+    assert_ne!(
+        field(&first, "workspace_id"),
+        field(&second, "workspace_id"),
+        "two admissions are two workspaces"
+    );
+    assert_ne!(
+        field(&first, "roots/local_state/hash"),
+        field(&second, "roots/local_state/hash"),
+        "local_state roots per-workspace authority and never replicated truth"
+    );
+}

--- a/crates/kin-cli/tests/init_reproducibility.rs
+++ b/crates/kin-cli/tests/init_reproducibility.rs
@@ -6,10 +6,10 @@
 //! Kin's thesis is that the graph is the canonical substrate, so a receipt
 //! field that names admitted content has to be a function of that content. If
 //! two people admit the same commit of the same repository and get different
-//! change ids and a different history root, nothing downstream — cross-repo
-//! dedup, "is this the same tree?", a before/after equivalence check that can
-//! tell a content regression apart from run-to-run drift — can be answered by
-//! comparing hashes.
+//! change ids and a different history root, then nothing downstream can be
+//! answered by comparing hashes: not cross-repo dedup, not "is this the same
+//! tree?", not a before/after equivalence check that can tell a content
+//! regression apart from run-to-run drift.
 //!
 //! The two admissions here read byte-identical Git object stores: the fixture
 //! is built once and copied, so both runs see the same commit ids rather than

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -783,9 +783,12 @@ fn assign_artifact_identities(
 /// opposite of content addressing and is what left two clones unable to agree
 /// on a single graph root.
 ///
-/// Keyed on the *introducing* commit rather than the current path, so identity
-/// survives a rename — the property that makes an artifact id worth carrying at
-/// all rather than just using the path.
+/// This runs only for a path the parent tree has no identity for. Continuity
+/// across a commit comes from reusing the first parent's id, and across a merge
+/// from the secondary-candidate matching above; neither is changed here. So the
+/// commit in the key is the commit that *introduced* the path, and the id stays
+/// a fact about where content entered history rather than about where the file
+/// currently sits.
 ///
 /// Two repositories deriving one id means they share the commit and the path,
 /// so they hold the same content under the same identity, which is the intended

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -295,7 +295,6 @@ fn build_semantic_git_import_plan(
             .collect::<Result<Vec<_>>>()?;
         let raw_tree = tree_decoder.resolved_entries(parsed.tree)?;
         let resolved_tree = assign_artifact_identities(
-            &snapshot.repository_id,
             oid,
             &first_parent_tree,
             &secondary_parent_trees,
@@ -685,7 +684,6 @@ fn insert_leaf(
 }
 
 fn assign_artifact_identities(
-    repository_id: &RepositoryId,
     introducing_commit: GitObjectId,
     first_parent: &ResolvedTree,
     secondary_parents: &[&ResolvedTree],
@@ -747,7 +745,7 @@ fn assign_artifact_identities(
             match candidate {
                 Some(candidate) => candidate,
                 None => {
-                    let derived = introduced_artifact_id(repository_id, introducing_commit, &path);
+                    let derived = introduced_artifact_id(introducing_commit, &path);
                     if known_artifact_ids.contains(&derived) || assigned.contains(&derived) {
                         return Err(GitError::InvalidSnapshot(format!(
                             "deterministic artifact identity collision at {} in commit {}",
@@ -773,13 +771,28 @@ fn assign_artifact_identities(
     })
 }
 
-fn introduced_artifact_id(
-    repository_id: &RepositoryId,
-    commit_oid: GitObjectId,
-    path: &kin_model::RepoPath,
-) -> ArtifactId {
+/// Derive the identity of an artifact from the content event that introduced
+/// it: the commit that first carried the path, and the path itself.
+///
+/// The commit id already addresses the whole tree and history behind it, so two
+/// admissions of one repository derive one identity and their trees, changes,
+/// and history root agree by hash rather than by structural walk. This
+/// deliberately excludes the repository identity, which `KinManifest::new`
+/// mints fresh per admission: including it made every derived id a function of
+/// which copy of a repository happened to observe the content, which is the
+/// opposite of content addressing and is what left two clones unable to agree
+/// on a single graph root.
+///
+/// Keyed on the *introducing* commit rather than the current path, so identity
+/// survives a rename — the property that makes an artifact id worth carrying at
+/// all rather than just using the path.
+///
+/// Two repositories deriving one id means they share the commit and the path,
+/// so they hold the same content under the same identity, which is the intended
+/// answer rather than a collision. Identity that must not be shared is refused
+/// against `known_artifact_ids` at the call site.
+fn introduced_artifact_id(commit_oid: GitObjectId, path: &kin_model::RepoPath) -> ArtifactId {
     let mut name = Vec::new();
-    append_identity_field(&mut name, repository_id.as_str().as_bytes());
     append_identity_field(&mut name, commit_oid.as_bytes());
     append_identity_field(&mut name, path.as_bytes());
     ArtifactId(Uuid::new_v5(&GIT_ARTIFACT_NAMESPACE, &name))

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -48,7 +48,7 @@ use crate::pipeline::IndexPipeline;
 /// authored to contain until it is admitted again, and reports nothing about
 /// which version authored it. Coupling the dial to graph authority so a
 /// version gap can be detected and refused is open follow-up work.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 7;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 8;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what a repository's past is said to contain the next time that repository is admitted. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together. Bumping the version records the decision; it does not migrate, invalidate, or re-enrich a repository that was already admitted, because nothing persists the version beside a graph or compares it when one is opened.",
-  "hydration_semantics_version": 7,
+  "hydration_semantics_version": 8,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
@@ -82,14 +82,14 @@
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "build_semantic_git_import_plan",
-      "digest": "sha256:ed32076e2e329bb714b10d8de562d262ee5a29a794a4b0d203a6268bbb863bb8",
+      "digest": "sha256:f7d2b5c5e1b35c9f62b5b920a5a7955e7922fbb4ede9ec2bc19f03972c473b45",
       "reason": "Builds the parent-first change sequence and tree map replay consumes. Its ordering and tree selection decide the baseline every historical delta is computed against.",
       "owner": "kin-git"
     },
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "assign_artifact_identities",
-      "digest": "sha256:9665b558bbd0b395f455a9db301c7d1769ceb17ccbe99f7bd92ec62440cb50e3",
+      "digest": "sha256:fed7906995c0ecd2272309ec87d356fbb1cc29cc96cdeec44b4455dcedb3482a",
       "reason": "Assigns the stable artifact identities trees and entities are keyed by across the imported history. Reassignment here silently repoints every historical file.",
       "owner": "kin-git"
     }


### PR DESCRIPTION
Two admissions of one Git repository produced different tree hashes, a
different initial change id, and a different history root for identical
content. No receipt field could tell a content regression apart from
run-to-run drift, and two clones could not agree on a graph root.

## Root cause, which is not what FIR-2068 records

The ticket traces this to `ArtifactId::new()` (`Uuid::new_v4`) reaching
`compute_resolved_tree_hash`. That call is not on the Git admission path.
`introduced_artifact_id` in kin-git has derived artifact ids as UUIDv5 since
b58834a2 (2026-07-26), before the measurement the ticket reports. A scan of
every `ArtifactId::new()` site in kin-model, kin, and kin-db finds exactly one
outside a test module, on the working-tree-edit delta path, unreachable from
init.

The derivation's *input* was the defect. `KinManifest::new` mints
`repo_id: Uuid::new_v4()` per admission, `git_init.rs` turns it into the
`RepositoryId`, and the derivation keyed on it. Every artifact id was a
function of which copy of a repository observed the content rather than of the
content, and `ResolvedTree` orders by those ids, so payload and canonical order
were both poisoned.

kin-model needs no change, so this does not need a version-bump ladder.

## Change

`introduced_artifact_id(commit_oid, path)`. The commit id already
content-addresses the tree and history behind it, so the id becomes a fact
about where content entered history and a second admission derives the same
one. The derivation runs only for a path the parent tree has no identity for;
continuity across a commit comes from reusing the first parent's id and across
a merge from the secondary-candidate matching, neither of which changes here.

Two derivations colliding requires the same commit and path, so the same
content under the same identity, which is the intended answer. The pre-existing
`known_artifact_ids` guard that refuses a genuine within-import collision is
unchanged.

## Replay semantics

Both functions this touches are pinned by the hydration replay-semantics guard,
which went red on the first run and is right to: what a repository's past is
said to contain the next time it is admitted now keys on the introducing commit
rather than the per-admission repository id. `HYDRATION_SEMANTICS_VERSION` goes
7 to 8, the manifest version matches, and the two digests are recorded.

Per that constant's own contract, bumping it does not migrate, invalidate, or
re-enrich an already-admitted repository: nothing persists it beside a graph,
nothing compares it when one is opened, and no path re-derives historical
deltas for a repository that was already admitted.

## Reproduction

`crates/kin-cli/tests/init_reproducibility.rs` builds one fixture, copies it so
both runs read byte-identical Git objects, runs `kin init --json` under two
scratch HOMEs, and diffs the receipts. Before: 7 of 8 replicated receipt fields
diverge. After: the five content-identity fields agree.

A companion test asserts the other direction, that two admissions remain two
workspaces, so sharing content can never start meaning sharing local authority.

## Still divergent, deliberately not addressed here

`ref_state`, `replication`, and `ref_log` are repository-scoped rather than
content-derived: `RepositoryRef`, `ExternalChangeAlias`, and
`GitExternalAuthority` each carry the per-admission `RepositoryId`, and the
ref-log projection additionally carries a random operation id and the
wall-clock commit time. Two admissions agree on those only by adopting one
repository identity, which is what `KinManifest::adopting` is for.

Closing them needs a decision on whether repository identity is an addressing
identity or a content identity, plus a root schema version: every store
validates that its recorded root bundle recomputes from its persisted
envelope, so changing a root formula makes existing stores fail to open.
Tracked in FIR-2107.

## Migration

No data migration. The derivation runs only at import; existing stores keep
their persisted ids and their roots recompute unchanged. Incremental import
reuses the first parent's id for any path already present, so only new paths
derive. The one other caller of `plan_semantic_git_import`, the export
re-verification, compares path and entry and deliberately not `artifact_id`.

Refs FIR-2068