### PR TITLE
Take the published v0.5.8 dependency ladder from the kin registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.13"
+version = "0.7.16"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "b7199f67903f9f2049ecbc73e67a363a76444011923bbe0c59829a7ae54d750f"
+checksum = "9a26e0d31085f0bb8fb5c8626502cfd295671f8898815c4d5397f05b138b589c"
 dependencies = [
  "bincode",
  "bstr",
@@ -3298,7 +3298,7 @@ dependencies = [
  "safetensors",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
@@ -3364,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.43"
+version = "0.2.44"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "d3ef97b62bdb2d0a175f9849513fdb29321c784ff4030c108d90d78b86206bd0"
+checksum = "ef68ba648007b5ad912bc968ad92fa9ab77c78569b2c5ecefcf31d1a51e08a07"
 dependencies = [
  "block",
  "half",
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.5"
+version = "0.7.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6c63c8f3dbc38fbbcea9f7781c234c97e65f944987a22b0590ac1068df3db3ff"
+checksum = "9e39741a0edad255687301dc087a915f787a31c0a9eee028150081c884e940ea"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3495,8 +3495,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha1 0.10.6",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "uuid",
 ]
@@ -3687,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "kin-search"
-version = "0.1.4"
+version = "0.1.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "c22df488cae18fe19e80f2e07e5a117f2c8362bf776509a3cb8a0b8a818bbbfa"
+checksum = "90b1943f2fa86bf338b63f662229f2fc009dff069a5851b928db1f7c0ebab5c1"
 dependencies = [
  "bincode",
  "parking_lot",
@@ -3737,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.8"
+version = "0.1.9"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ce7d0f0c3323b2cea676e7832d0f553874490cae7e157420dd7ddb8af49f70bd"
+checksum = "fd4c2a7ebb07f6ca4ae49fe57eaafa91adbca5e38e76d133b25008c87679f7e8"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -3748,7 +3748,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -6624,7 +6624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.5", registry = "kin" }
+kin-model = { version = "=0.7.7", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.13", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.16", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.3.0", registry = "kin" }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "sha2 0.11.0",
+ "sha2",
  "thiserror",
 ]
 
@@ -630,14 +630,14 @@ dependencies = [
 
 [[package]]
 name = "kin-blobs"
-version = "0.1.4"
+version = "0.1.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "83136143d2f8b72f835ca7d9e3d7793e415bd072445a648713d5d797e9e6bc9e"
+checksum = "bde2186360c16ff9fda080b4b9f6489e7aee8cb0cb30f803e8bd22b1ed4af609"
 dependencies = [
  "hex",
  "schemars",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "thiserror",
  "tracing",
  "windows-sys",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.5"
+version = "0.7.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6c63c8f3dbc38fbbcea9f7781c234c97e65f944987a22b0590ac1068df3db3ff"
+checksum = "9e39741a0edad255687301dc087a915f787a31c0a9eee028150081c884e940ea"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -658,8 +658,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2",
  "thiserror",
  "uuid",
 ]
@@ -671,7 +671,7 @@ dependencies = [
  "kin-model",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "thiserror",
  "tracing",
  "tree-sitter",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.8"
+version = "0.1.9"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ce7d0f0c3323b2cea676e7832d0f553874490cae7e157420dd7ddb8af49f70bd"
+checksum = "fd4c2a7ebb07f6ca4ae49fe57eaafa91adbca5e38e76d133b25008c87679f7e8"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -713,7 +713,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "thiserror",
  "tracing",
  "uuid",
@@ -1031,13 +1031,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1-checked"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest 0.10.7",
- "sha1",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -1045,17 +1056,6 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "sha2"


### PR DESCRIPTION
Pins kin-db =0.7.16 and kin-model =0.7.7, matching kin-db's own exact kin-model pin so the types crate resolves to a single version everywhere. The relock moves exactly five packages, all registry-sourced with checksums preserved: kin-db 0.7.13 to 0.7.16, kin-model 0.7.5 to 0.7.7, kin-infer 0.2.43 to 0.2.44, kin-search 0.1.4 to 0.1.5, kin-vector 0.1.8 to 0.1.9. Registry-pure relock (no cargo home, no patches) and a full-workspace cargo check --locked against the new pins passed locally.

This completes the dependency side of the v0.5.8 performance ladder ahead of the release reconcile.

Refs FIR-1109