### PR TITLE
Share one repository authority across the kin-cli-backed source tools

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -191,9 +191,11 @@ pub fn execute_graph_command(
         GraphCommandRequest::Status => build_graph_status_response(binding, graph),
         GraphCommandRequest::Validate => build_graph_validate_response(binding, graph),
         GraphCommandRequest::Inspect { name } => build_graph_inspect_response(graph, name),
-        GraphCommandRequest::Source { entity } => {
-            build_graph_source_response(binding, graph, entity)
-        }
+        GraphCommandRequest::Source { entity } => build_graph_source_response(
+            &super::repository_authority::RequestRepositoryAuthority::pinned(binding.clone()),
+            graph,
+            entity,
+        ),
     }
 }
 
@@ -738,7 +740,7 @@ fn graph_entity_not_found_lines(name: &str) -> Vec<String> {
 /// daemon MCP path consumes this directly so those cases surface distinctly to
 /// agents instead of collapsing into one opaque message.
 pub fn build_entity_source_outcome(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: &super::repository_authority::RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     entity_query: &str,
 ) -> Result<EntitySourceOutcome> {
@@ -767,16 +769,16 @@ pub fn build_entity_source_outcome(
         )));
     }
 
-    let record = graph_source_record(binding, graph, &entity)?;
+    let record = graph_source_record(repository_authority, graph, &entity)?;
     Ok(EntitySourceOutcome::Found(record))
 }
 
 pub fn build_graph_source_response(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: &super::repository_authority::RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     entity_query: &str,
 ) -> Result<GraphCommandResponse> {
-    match build_entity_source_outcome(binding, graph, entity_query)? {
+    match build_entity_source_outcome(repository_authority, graph, entity_query)? {
         EntitySourceOutcome::Found(record) => {
             let mut lines = vec![
                 format!(
@@ -861,11 +863,11 @@ fn resolve_source_entity(
 }
 
 fn graph_source_record(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: &super::repository_authority::RequestRepositoryAuthority,
     _graph: &kin_db::InMemoryGraph,
     entity: &Entity,
 ) -> Result<GraphSourceRecord> {
-    let authority = super::repository_authority::ActiveRepositoryAuthority::open(binding)?;
+    let authority = repository_authority.open()?;
     let workspace = authority.workspace()?;
     graph_source_record_from(&authority, &workspace, entity)
 }
@@ -1577,6 +1579,79 @@ mod tests {
         file_id: FilePathId,
     }
 
+    impl GraphSourceFixture {
+        /// The pinned arm, which is what a one-shot CLI invocation holds: these
+        /// tests measure the source-resolution taxonomy, not authority sharing.
+        fn authority(&self) -> super::super::repository_authority::RequestRepositoryAuthority {
+            super::super::repository_authority::RequestRepositoryAuthority::pinned(
+                self.binding.clone(),
+            )
+        }
+    }
+
+    /// A batch of source resolutions costs ONE authority open, not one each.
+    ///
+    /// `get_entity_sources` resolves source per entity, and every resolution
+    /// used to open authority for itself: a batch of N entities paid N
+    /// whole-store verifications. The shared arm makes the batch cost one, which
+    /// also makes it coherent, since per-entity opens could straddle a
+    /// publication and return rows from two different generations.
+    ///
+    /// Both arms are measured in one test on purpose. The bound is only evidence
+    /// if the counter can tell them apart, and the pinned half is what proves it
+    /// can: it still climbs with batch size, which is exactly right for a
+    /// one-shot invocation and exactly what the daemon must not do.
+    #[test]
+    fn a_batch_of_source_resolutions_shares_one_authority_open() {
+        const BATCH: usize = 4;
+        const SOURCE: &[u8] = b"fn target() {}\n";
+        let fixture = graph_source_fixture(Some(SOURCE));
+        let entity = source_entity("target", fixture.file_id.clone(), 0, SOURCE.len() - 1);
+        let id = entity.id;
+        commit_source_entity(&fixture, &entity);
+        let opens = super::super::repository_authority::repository_authority_opens_on_this_thread;
+
+        let shared = std::sync::Arc::new(
+            super::super::repository_authority::ActiveRepositoryAuthority::open(&fixture.binding)
+                .expect("open authority for the batch"),
+        );
+        let shared_authority =
+            super::super::repository_authority::RequestRepositoryAuthority::shared(
+                fixture.binding.clone(),
+                std::sync::Arc::new(move || Ok(std::sync::Arc::clone(&shared))),
+            );
+
+        let before = opens();
+        for _ in 0..BATCH {
+            let outcome =
+                build_entity_source_outcome(&shared_authority, &fixture.graph, &id.to_string())
+                    .expect("resolve source through the shared authority");
+            assert!(
+                matches!(outcome, EntitySourceOutcome::Found(_)),
+                "each resolution must actually project a body, or the count proves nothing"
+            );
+        }
+        assert_eq!(
+            opens() - before,
+            0,
+            "a batch reading through one already-open authority must not open again, once per \
+             item or at all"
+        );
+
+        let pinned = fixture.authority();
+        let before = opens();
+        for _ in 0..BATCH {
+            build_entity_source_outcome(&pinned, &fixture.graph, &id.to_string())
+                .expect("resolve source through the pinned authority");
+        }
+        assert_eq!(
+            opens() - before,
+            BATCH as u64,
+            "the pinned arm opens per resolution, which is what a one-shot CLI invocation wants \
+             and what proves this counter can see the difference"
+        );
+    }
+
     fn graph_source_fixture(source: Option<&[u8]>) -> GraphSourceFixture {
         // Publication proves the Git source three times and requires all three
         // proofs to agree, and the proof deliberately includes the contents of
@@ -1679,7 +1754,8 @@ mod tests {
         commit_source_entity(&fixture, &entity);
 
         let response =
-            build_graph_source_response(&fixture.binding, &fixture.graph, &id.to_string()).unwrap();
+            build_graph_source_response(&fixture.authority(), &fixture.graph, &id.to_string())
+                .unwrap();
         let source = response.source.unwrap();
 
         assert_eq!(source.body, body);
@@ -1714,8 +1790,9 @@ mod tests {
         let id = entity.id;
         commit_source_entity(&fixture, &entity);
 
-        let error = build_graph_source_response(&fixture.binding, &fixture.graph, &id.to_string())
-            .expect_err("a span derived from other bytes must not serve a mis-sliced body");
+        let error =
+            build_graph_source_response(&fixture.authority(), &fixture.graph, &id.to_string())
+                .expect_err("a span derived from other bytes must not serve a mis-sliced body");
         let message = format!("{error:#}");
         assert!(
             message.contains("does not describe these bytes"),
@@ -1744,7 +1821,8 @@ mod tests {
         commit_source_entity(&fixture, &entity);
 
         let response =
-            build_graph_source_response(&fixture.binding, &fixture.graph, &id.to_string()).unwrap();
+            build_graph_source_response(&fixture.authority(), &fixture.graph, &id.to_string())
+                .unwrap();
         let record = response.source.unwrap();
         assert_eq!(record.body, "fn target() {}");
         assert_eq!(record.span_coherence, "digest_verified");
@@ -1764,7 +1842,8 @@ mod tests {
         )
         .unwrap();
         let response =
-            build_graph_source_response(&fixture.binding, &fixture.graph, &id.to_string()).unwrap();
+            build_graph_source_response(&fixture.authority(), &fixture.graph, &id.to_string())
+                .unwrap();
         assert_eq!(response.source.unwrap().body, "fn target() {}");
     }
 
@@ -1777,9 +1856,10 @@ mod tests {
         let id = entity.id;
         commit_source_entity(&fixture, &entity);
 
-        let err = build_graph_source_response(&fixture.binding, &fixture.graph, &id.to_string())
-            .unwrap_err()
-            .to_string();
+        let err =
+            build_graph_source_response(&fixture.authority(), &fixture.graph, &id.to_string())
+                .unwrap_err()
+                .to_string();
 
         assert!(
             err.contains(&format!("source span 0..{end} is out of bounds")),
@@ -1795,9 +1875,10 @@ mod tests {
         let id = entity.id;
         commit_source_entity(&fixture, &entity);
 
-        let err = build_graph_source_response(&fixture.binding, &fixture.graph, &id.to_string())
-            .unwrap_err()
-            .to_string();
+        let err =
+            build_graph_source_response(&fixture.authority(), &fixture.graph, &id.to_string())
+                .unwrap_err()
+                .to_string();
 
         assert!(
             err.contains("source 'src/lib.rs' is absent from repository-v6 workspace"),
@@ -1817,7 +1898,7 @@ mod tests {
         let id = entity.id;
         commit_source_entity(&fixture, &entity);
 
-        match build_entity_source_outcome(&fixture.binding, &fixture.graph, &id.to_string())
+        match build_entity_source_outcome(&fixture.authority(), &fixture.graph, &id.to_string())
             .unwrap()
         {
             EntitySourceOutcome::Found(record) => assert_eq!(record.body, body),
@@ -1830,8 +1911,12 @@ mod tests {
         let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
         let invented = uuid::Uuid::new_v4();
 
-        match build_entity_source_outcome(&fixture.binding, &fixture.graph, &invented.to_string())
-            .unwrap()
+        match build_entity_source_outcome(
+            &fixture.authority(),
+            &fixture.graph,
+            &invented.to_string(),
+        )
+        .unwrap()
         {
             EntitySourceOutcome::NotFound(message) => {
                 assert!(message.contains(&invented.to_string()), "{message}");
@@ -1852,7 +1937,7 @@ mod tests {
         let id = entity.id;
         fixture.graph.upsert_entity(&entity).unwrap();
 
-        match build_entity_source_outcome(&fixture.binding, &fixture.graph, &id.to_string())
+        match build_entity_source_outcome(&fixture.authority(), &fixture.graph, &id.to_string())
             .unwrap()
         {
             EntitySourceOutcome::NoSource(message) => {
@@ -1869,17 +1954,23 @@ mod tests {
         let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
 
         let invented = uuid::Uuid::new_v4();
-        let not_found =
-            build_entity_source_outcome(&fixture.binding, &fixture.graph, &invented.to_string())
-                .unwrap();
+        let not_found = build_entity_source_outcome(
+            &fixture.authority(),
+            &fixture.graph,
+            &invented.to_string(),
+        )
+        .unwrap();
 
         let mut spanless = source_entity("target", fixture.file_id.clone(), 0, 8);
         spanless.span = None;
         let spanless_id = spanless.id;
         fixture.graph.upsert_entity(&spanless).unwrap();
-        let no_source =
-            build_entity_source_outcome(&fixture.binding, &fixture.graph, &spanless_id.to_string())
-                .unwrap();
+        let no_source = build_entity_source_outcome(
+            &fixture.authority(),
+            &fixture.graph,
+            &spanless_id.to_string(),
+        )
+        .unwrap();
 
         let (nf, ns) = match (not_found, no_source) {
             (EntitySourceOutcome::NotFound(nf), EntitySourceOutcome::NoSource(ns)) => (nf, ns),
@@ -1896,9 +1987,12 @@ mod tests {
         let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
         let invented = uuid::Uuid::new_v4();
 
-        let response =
-            build_graph_source_response(&fixture.binding, &fixture.graph, &invented.to_string())
-                .unwrap();
+        let response = build_graph_source_response(
+            &fixture.authority(),
+            &fixture.graph,
+            &invented.to_string(),
+        )
+        .unwrap();
 
         assert!(response.source.is_none());
         let error = response.error.expect("not-found must populate error");

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -63,7 +63,7 @@ pub mod release_cmd;
 pub mod release_orch;
 pub mod remote;
 pub mod rename;
-pub(crate) mod repository_authority;
+pub mod repository_authority;
 pub mod resolve;
 pub mod resources;
 pub mod review;

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -16,15 +16,126 @@ use kin_model::{
     WorkspaceState,
 };
 
-pub(crate) struct ActiveRepositoryAuthority {
+pub struct ActiveRepositoryAuthority {
     manager: RepositoryAuthorityManager<LocalFileBackend>,
     payload_stats: Option<AuthorityPayloadStats>,
     pub(crate) repository_id: RepositoryId,
     pub(crate) workspace_id: WorkspaceId,
 }
 
+thread_local! {
+    static REPOSITORY_AUTHORITY_OPENS_ON_THREAD: std::cell::Cell<u64> =
+        const { std::cell::Cell::new(0) };
+}
+
+/// Repository-authority opens this crate's wrapper has performed ON THE CALLING
+/// THREAD.
+///
+/// An open decodes the persisted snapshot and re-verifies every persisted body
+/// against its content address, so its cost is a property of the store rather
+/// than of the request. That makes the COUNT, not the wall clock, the honest
+/// thing for a test to bound: a helper that opens once per item stays O(items)
+/// here no matter how small the fixture is, where a timing assertion on a small
+/// fixture passes with the defect present.
+///
+/// Per-thread rather than per-process because test binaries run in parallel and
+/// a sibling test that projects a body would otherwise land in the same counter.
+/// The caller must keep the measured section on one thread; a section that hands
+/// its work to a worker reads zero, which fails an `== 1` bound loudly rather
+/// than passing it silently.
+pub fn repository_authority_opens_on_this_thread() -> u64 {
+    REPOSITORY_AUTHORITY_OPENS_ON_THREAD.with(std::cell::Cell::get)
+}
+
+/// The repository authority one command reads at, and who paid for the open.
+///
+/// The same contract kin-mcp's `RequestRepositoryAuthority` states for the MCP
+/// query tools, for the commands that read source through *this* crate's
+/// wrapper. A one-shot CLI invocation has nobody to share an open with and opens
+/// for itself, which is what every command helper did before this type existed.
+/// A long-lived daemon does: it resolves one open per durable publication and
+/// hands the same authority to every request reading at that publication.
+///
+/// Both arms answer from an open that passed KinDB's complete open-time
+/// validation. There is no arm that produces authority which skipped it, and
+/// reuse can only hand back the result of a validation that already ran over
+/// these exact durable bytes. What a server must get right is not WHETHER the
+/// authority it shares was validated but WHICH publication it was validated at;
+/// see [`Self::shared`].
+#[derive(Clone)]
+pub struct RequestRepositoryAuthority {
+    binding: kin_core::LocalRepositoryAuthorityBinding,
+    shared: Option<SharedAuthorityResolver>,
+}
+
+/// A server's promise to produce authority for the publication a request reads
+/// at, run only when a command actually reaches a source read.
+pub type SharedAuthorityResolver =
+    std::sync::Arc<dyn Fn() -> Result<std::sync::Arc<ActiveRepositoryAuthority>> + Send + Sync>;
+
+impl RequestRepositoryAuthority {
+    /// Authority this command opens for itself.
+    pub fn pinned(binding: kin_core::LocalRepositoryAuthorityBinding) -> Self {
+        Self {
+            binding,
+            shared: None,
+        }
+    }
+
+    /// Authority a server resolves for the publication this request reads at.
+    ///
+    /// The server owns the freshness argument, and it is the whole of what this
+    /// type cannot check for itself. Each call to the resolver must return an
+    /// authority opened at a durable publication the server confirmed is still
+    /// the one local storage holds, with that confirmation read BEFORE the open
+    /// it labels rather than after. A label taken afterwards can name a
+    /// publication that landed during the load, which marks older bytes as
+    /// current and serves them past the commit that replaced them.
+    pub fn shared(
+        binding: kin_core::LocalRepositoryAuthorityBinding,
+        resolve: SharedAuthorityResolver,
+    ) -> Self {
+        Self {
+            binding,
+            shared: Some(resolve),
+        }
+    }
+
+    /// The startup-pinned identity and storage capability behind this authority,
+    /// for the surfaces that still take a binding.
+    pub fn binding(&self) -> &kin_core::LocalRepositoryAuthorityBinding {
+        &self.binding
+    }
+
+    /// The open authority to read this command from.
+    ///
+    /// Reuses the caller's open when there is one, and otherwise performs the
+    /// full validating open. Read paths call this rather than
+    /// [`ActiveRepositoryAuthority::open`] so a server's shared open is not
+    /// silently bypassed by one of them.
+    ///
+    /// A helper that resolves per item — the batched source tools resolve once
+    /// per entity — costs one open for the whole batch on the shared arm and one
+    /// per item on the pinned arm, which is exactly the one-shot behavior that
+    /// arm is for.
+    pub(crate) fn open(&self) -> Result<std::sync::Arc<ActiveRepositoryAuthority>> {
+        match &self.shared {
+            Some(resolve) => resolve(),
+            None => ActiveRepositoryAuthority::open(&self.binding).map(std::sync::Arc::new),
+        }
+    }
+}
+
 impl ActiveRepositoryAuthority {
-    pub(crate) fn open(binding: &kin_core::LocalRepositoryAuthorityBinding) -> Result<Self> {
+    /// Open the authority from durable storage.
+    ///
+    /// This re-verifies every persisted body against its content address, so it
+    /// costs whatever the whole store is worth rather than whatever the caller
+    /// asked for. `pub` so a long-lived server can pay for one open and hand it
+    /// to the requests that read at that publication, through
+    /// [`RequestRepositoryAuthority::shared`].
+    pub fn open(binding: &kin_core::LocalRepositoryAuthorityBinding) -> Result<Self> {
+        REPOSITORY_AUTHORITY_OPENS_ON_THREAD.with(|opens| opens.set(opens.get() + 1));
         let repository_id = binding.repository_id().clone();
         let workspace_id = binding.workspace_id();
         let (manager, payload_stats) = binding

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -23,7 +23,9 @@ use std::time::{Duration, Instant};
 
 use crate::commands::graph::{graph_source_record_from, GraphSourceRecord};
 use crate::commands::locate::{record_degradation, RetrievalDegradation};
-use crate::commands::repository_authority::ActiveRepositoryAuthority;
+use crate::commands::repository_authority::{
+    ActiveRepositoryAuthority, RequestRepositoryAuthority,
+};
 
 const DEFAULT_DEPTH: usize = 3;
 const MAX_DEPTH: usize = 8;
@@ -400,11 +402,16 @@ async fn run_daemon_trace_data_flow(
 /// This is the single substrate primitive used by both the CLI route and the
 /// MCP tool dispatcher so the chain construction stays in one place.
 pub fn build_trace_data_flow_response(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: &RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     request: &TraceDataFlowRequest,
 ) -> Result<TraceDataFlowResponse> {
-    build_trace_data_flow_response_within(binding, graph, request, TraceBudget::default())
+    build_trace_data_flow_response_within(
+        repository_authority,
+        graph,
+        request,
+        TraceBudget::default(),
+    )
 }
 
 /// The same walk under caller-supplied work ceilings.
@@ -413,7 +420,7 @@ pub fn build_trace_data_flow_response(
 /// the shipped budget is measured in seconds and hundreds of thousands of
 /// edges, and a test that had to exhaust it would be as slow as the defect.
 pub fn build_trace_data_flow_response_within(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: &RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     request: &TraceDataFlowRequest,
     budget: TraceBudget,
@@ -450,7 +457,7 @@ pub fn build_trace_data_flow_response_within(
     // always optional per step, and hoisting the open must not turn a payload
     // that used to arrive body-less into a failed call — so the failure is
     // disclosed and the walk continues on identity alone.
-    let projection = match open_body_projection(binding) {
+    let projection = match open_body_projection(repository_authority) {
         Ok(projection) => Some(projection),
         Err(error) => {
             record_degradation(
@@ -669,14 +676,15 @@ fn resolve_trace_focal(graph: &kin_db::InMemoryGraph, query: &str) -> Result<Opt
 /// Held for the whole walk so the repeated per-step open is structurally
 /// impossible rather than merely avoided at the current call sites.
 struct BodyProjection {
-    authority: ActiveRepositoryAuthority,
+    authority: std::sync::Arc<ActiveRepositoryAuthority>,
     workspace: kin_model::WorkspaceState,
 }
 
 fn open_body_projection(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: &RequestRepositoryAuthority,
 ) -> Result<BodyProjection> {
-    let authority = ActiveRepositoryAuthority::open(binding)
+    let authority = repository_authority
+        .open()
         .context("open repository authority for trace-data-flow")?;
     let workspace = authority
         .workspace()
@@ -776,7 +784,7 @@ mod tests {
         let graph = InMemoryGraph::new();
         let (_t, binding) = empty_binding();
         let err = build_trace_data_flow_response(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &TraceDataFlowRequest {
                 focal: "   ".to_string(),
@@ -797,7 +805,7 @@ mod tests {
         let graph = InMemoryGraph::new();
         let (_t, binding) = empty_binding();
         let err = build_trace_data_flow_response(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &TraceDataFlowRequest {
                 focal: "does_not_exist".to_string(),
@@ -844,7 +852,7 @@ mod tests {
             .unwrap();
 
         let response = build_trace_data_flow_response(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &TraceDataFlowRequest {
                 focal: focal_id.to_string(),
@@ -899,7 +907,7 @@ mod tests {
             .unwrap();
 
         let response = build_trace_data_flow_response(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &TraceDataFlowRequest {
                 focal: focal_id.to_string(),
@@ -943,7 +951,7 @@ mod tests {
         }
 
         let response = build_trace_data_flow_response(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &TraceDataFlowRequest {
                 focal: focal_id.to_string(),
@@ -991,7 +999,7 @@ mod tests {
         let (_t, binding) = empty_binding();
 
         let response = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &hub_request(focal_id),
             TraceBudget {
@@ -1032,7 +1040,7 @@ mod tests {
         // A zero budget is already spent at the first check, so this asserts
         // the bound without making the test wait for a real one to elapse.
         let response = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &hub_request(focal_id),
             TraceBudget {
@@ -1064,7 +1072,7 @@ mod tests {
         let (_t, binding) = empty_binding();
 
         let response = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &hub_request(focal_id),
             TraceBudget::default(),
@@ -1093,7 +1101,7 @@ mod tests {
         let (_t, binding) = empty_binding();
 
         let response = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &hub_request(focal_id),
             TraceBudget::default(),
@@ -1123,7 +1131,7 @@ mod tests {
         let cancel = TraceCancel::new();
         cancel.cancel();
         let response = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &hub_request(focal_id),
             TraceBudget::cancellable(cancel),
@@ -1170,7 +1178,7 @@ mod tests {
         };
 
         let uncancelled = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &request,
             TraceBudget::bounded(),
@@ -1191,7 +1199,7 @@ mod tests {
         let cancel = TraceCancel::new();
         cancel.cancel();
         let cancelled = build_trace_data_flow_response_within(
-            &binding,
+            &RequestRepositoryAuthority::pinned(binding.clone()),
             &graph,
             &request,
             TraceBudget::cancellable(cancel),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -202,18 +202,26 @@ fn read_local_publication_identity(
 /// revalidating it against the durable publication record keeps the answer
 /// exactly as fresh while making the common request a small metadata read.
 ///
-/// Two readers hold slots here, because they read through different crates'
-/// authority wrappers: the projection routes (`ActiveApiRepositoryAuthority`,
-/// for workspace tree state) and the MCP query tools (kin-mcp's
-/// `ActiveRepositoryAuthority`, for source projection). Both slots key on the
-/// same [`LocalPublicationIdentity`] under the same load gate and count into
-/// the same [`Self::loads`], so the contract is one contract; only the wrapper
-/// differs. The name predates the second reader and is kept because the field
-/// it fills is declared elsewhere.
+/// Three readers hold slots here, because they read through three different
+/// crates' authority wrappers: the projection routes
+/// (`ActiveApiRepositoryAuthority`, for workspace tree state), the MCP query
+/// tools (kin-mcp's `ActiveRepositoryAuthority`, for source projection), and the
+/// tools served by kin-cli command helpers (kin-cli's
+/// `ActiveRepositoryAuthority`, for entity source and trace bodies). All three
+/// slots key on the same [`LocalPublicationIdentity`] under the same load gate
+/// and count into the same [`Self::loads`], so the contract is one contract;
+/// only the wrapper differs. The name predates the other two readers and is kept
+/// because the field it fills is declared elsewhere.
+///
+/// Three wrappers over one durable state is migration debt, not the design.
+/// Collapsing them onto one shared `RepositoryAuthorityManager` would reshape
+/// the projection path, so each keeps its own slot and the cost stays
+/// O(publications) rather than O(requests) on all three.
 #[derive(Default)]
 pub(crate) struct ProjectionAuthorityCache {
     held: std::sync::Mutex<Option<HeldProjectionAuthority>>,
     query: std::sync::Mutex<Option<HeldQueryAuthority>>,
+    command: std::sync::Mutex<Option<HeldCommandAuthority>>,
     /// Serializes misses so a burst of concurrent cold requests pays for one
     /// full load rather than one per request.
     load_gate: std::sync::Mutex<()>,
@@ -238,6 +246,14 @@ struct HeldQueryAuthority {
     /// [`HeldProjectionAuthority::published`] and for the same reason.
     published: LocalPublicationIdentity,
     authority: Arc<kin_mcp::handlers::ActiveRepositoryAuthority>,
+}
+
+#[derive(Clone)]
+struct HeldCommandAuthority {
+    /// Read strictly before the authority it labels was loaded, exactly as for
+    /// [`HeldProjectionAuthority::published`] and for the same reason.
+    published: LocalPublicationIdentity,
+    authority: Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
 }
 
 impl ProjectionAuthorityCache {
@@ -297,9 +313,31 @@ impl ProjectionAuthorityCache {
         });
     }
 
+    fn reuse_command(
+        &self,
+        published: &LocalPublicationIdentity,
+    ) -> Option<Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>> {
+        lock_recover(&self.command)
+            .as_ref()
+            .filter(|held| &held.published == published)
+            .map(|held| Arc::clone(&held.authority))
+    }
+
+    fn install_command(
+        &self,
+        published: LocalPublicationIdentity,
+        authority: Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
+    ) {
+        *lock_recover(&self.command) = Some(HeldCommandAuthority {
+            published,
+            authority,
+        });
+    }
+
     fn invalidate(&self) {
         *lock_recover(&self.held) = None;
         *lock_recover(&self.query) = None;
+        *lock_recover(&self.command) = None;
     }
 }
 
@@ -444,6 +482,102 @@ fn query_repository_authority(
         "query repository authority loaded"
     );
     Ok(authority)
+}
+
+/// Resolve the repository-v6 authority the kin-cli-backed query tools read
+/// source from: `get_entity_source`, `get_entity_sources`, `trace_data_flow`.
+///
+/// The same contract as [`query_repository_authority`], for the third wrapper.
+/// Those three tools resolve source through kin-cli command helpers, whose own
+/// `ActiveRepositoryAuthority` is a different type over the same durable state,
+/// so sharing the query slot's authority with them is not possible without
+/// reshaping how they read. Sharing the CONTRACT is: same publication key, same
+/// load gate, same counter, and the full staleness argument stated at
+/// [`query_repository_authority`] applies here unchanged.
+///
+/// What this removes is worse than one open per request. `get_entity_sources`
+/// resolves source per entity, and each resolution opened its own authority, so
+/// a batch of N entities paid N whole-store verifications. Every batch now reads
+/// at one publication through one open, which also makes the batch coherent:
+/// per-entity opens could straddle a publication and return rows from two
+/// different generations.
+///
+/// Blocking: reads storage metadata and, on a publication change, loads the
+/// complete durable authority.
+fn command_repository_authority(
+    state: &DaemonState,
+) -> Result<
+    Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
+    (StatusCode, String),
+> {
+    let backend = state.local_repository_backend().ok_or_else(|| {
+        repository_authority_error("local daemon is missing its startup storage capability")
+    })?;
+    let binding = state
+        .local_repository_authority_binding()
+        .map_err(repository_authority_error)?;
+    let repository_id = binding.repository_id().clone();
+
+    if let Err(error) = confirm_pinned_projection_namespace(&backend, &repository_id) {
+        state.projection_authority.invalidate();
+        return Err(error);
+    }
+
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(authority) = state.projection_authority.reuse_command(&published) {
+        return Ok(authority);
+    }
+
+    let _load = lock_recover(&state.projection_authority.load_gate);
+    // Re-read under the gate: the publication may have moved while this request
+    // waited, and the label installed below must be the one taken before the
+    // load it describes.
+    let published = read_local_publication_identity(&backend, &repository_id)?;
+    if let Some(authority) = state.projection_authority.reuse_command(&published) {
+        return Ok(authority);
+    }
+    let authority = Arc::new(
+        kin_cli::commands::repository_authority::ActiveRepositoryAuthority::open(&binding)
+            .map_err(repository_authority_error)?,
+    );
+    state.projection_authority.record_load();
+    state
+        .projection_authority
+        .install_command(published, Arc::clone(&authority));
+    tracing::debug!(
+        repository = %repository_id,
+        loads = state.projection_authority.loads(),
+        "command repository authority loaded"
+    );
+    Ok(authority)
+}
+
+/// Hand a command helper an authority this daemon already resolved.
+///
+/// The eager form: every caller reaches it only after deciding the request
+/// projects bodies, so there is no publication it might not consult and nothing
+/// to defer. The freshness obligation the shared arm states is discharged by
+/// [`command_repository_authority`], which read the publication record before
+/// the load it labels.
+fn shared_command_authority(
+    binding: kin_core::LocalRepositoryAuthorityBinding,
+    authority: Arc<kin_cli::commands::repository_authority::ActiveRepositoryAuthority>,
+) -> kin_cli::commands::repository_authority::RequestRepositoryAuthority {
+    kin_cli::commands::repository_authority::RequestRepositoryAuthority::shared(
+        binding,
+        Arc::new(move || Ok(Arc::clone(&authority))),
+    )
+}
+
+/// The authority source for an MCP route that resolves source through a kin-cli
+/// command helper.
+fn require_mcp_command_repository_authority(
+    state: &DaemonState,
+) -> kin_mcp::Result<kin_cli::commands::repository_authority::RequestRepositoryAuthority> {
+    let binding = require_mcp_local_repository_binding(state)?;
+    let authority =
+        command_repository_authority(state).map_err(|(_, message)| mcp_authority_gap(message))?;
+    Ok(shared_command_authority(binding, authority))
 }
 
 /// Fail closed when an explicit filesystem-admission command is unavailable.
@@ -3200,9 +3334,12 @@ async fn command_trace_data_flow(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let repository_authority = state
-        .local_repository_authority_binding()
-        .map_err(repository_authority_error)?;
+    let repository_authority = shared_command_authority(
+        state
+            .local_repository_authority_binding()
+            .map_err(repository_authority_error)?,
+        command_repository_authority(&state)?,
+    );
     let response = run_trace_data_flow_off_runtime(repository_authority, graph, request)
         .await
         .map_err(internal_error)?;
@@ -3234,7 +3371,7 @@ async fn command_trace_data_flow(
 /// The walk carries its own time and edge ceilings, so this seam does not need
 /// a timeout of its own: it moves the work, and the budget bounds it.
 async fn run_trace_data_flow_off_runtime(
-    repository_authority: kin_core::LocalRepositoryAuthorityBinding,
+    repository_authority: kin_cli::commands::repository_authority::RequestRepositoryAuthority,
     graph: Arc<kin_db::InMemoryGraph>,
     request: kin_cli::commands::trace_data_flow::TraceDataFlowRequest,
 ) -> anyhow::Result<kin_cli::commands::trace_data_flow::TraceDataFlowResponse> {
@@ -7076,8 +7213,8 @@ async fn mcp_tools_call(
                 "missing required parameter: entity_id".to_string(),
             )));
         };
-        let repository_authority = match require_mcp_local_repository_binding(&state) {
-            Ok(binding) => binding,
+        let repository_authority = match require_mcp_command_repository_authority(&state) {
+            Ok(authority) => authority,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
         let result =
@@ -7099,8 +7236,11 @@ async fn mcp_tools_call(
             Ok(parsed) => parsed,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
-        let repository_authority = match require_mcp_local_repository_binding(&state) {
-            Ok(binding) => binding,
+        // Resolved ONCE for the batch. Each entity used to resolve its own
+        // authority, so N entities cost N whole-store verifications and could
+        // straddle a publication; the batch now reads every row at one.
+        let repository_authority = match require_mcp_command_repository_authority(&state) {
+            Ok(authority) => authority,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
         let resolved = entity_ids
@@ -7166,8 +7306,8 @@ async fn mcp_tools_call(
             direction: parsed_direction,
             limit_per_step,
         };
-        let repository_authority = match require_mcp_local_repository_binding(&state) {
-            Ok(binding) => binding,
+        let repository_authority = match require_mcp_command_repository_authority(&state) {
+            Ok(authority) => authority,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),
         };
         // Same off-runtime seam as the CLI route. This is the arm the reported
@@ -25779,6 +25919,145 @@ mod tests {
         let repeat =
             call_mcp_tool(app, "get_entity", json!({ "entity_id": after.to_string() })).await;
         assert!(repeat["source_excerpt"].as_str().is_some());
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            2,
+            "a second read at the new publication must reuse the load the first one paid for"
+        );
+    }
+
+    /// The three tools that resolve source through kin-cli command helpers share
+    /// ONE authority load at one publication.
+    ///
+    /// The other wrapper, and the gap FIR-2079 left open. `get_entity_source`,
+    /// `get_entity_sources`, and `trace_data_flow` do not read through kin-mcp's
+    /// authority; they route into kin-cli's, which opened per call. The batched
+    /// one was worse than per-request: it resolves source per entity, so N
+    /// entities cost N whole-store verifications.
+    ///
+    /// A count, not elapsed time, for the same reason as the query-tool bound
+    /// above: what an open costs is a property of the store, so a timing
+    /// assertion on a small fixture would pass with the defect present.
+    #[tokio::test]
+    async fn kin_cli_backed_source_tools_share_one_authority_load_per_publication() {
+        const PAGE: usize = 3;
+        let state = test_state();
+        let entities = install_locate_page(&state, PAGE);
+        let app = router(Arc::clone(&state));
+
+        let before = state.projection_authority.loads();
+        let single = call_mcp_tool(
+            app.clone(),
+            "get_entity_source",
+            json!({ "entity_id": entities[0].to_string() }),
+        )
+        .await;
+        let batch = call_mcp_tool(
+            app.clone(),
+            "get_entity_sources",
+            json!({
+                "entity_ids": entities.iter().map(ToString::to_string).collect::<Vec<_>>()
+            }),
+        )
+        .await;
+        let traced = call_mcp_tool(
+            app.clone(),
+            "trace_data_flow",
+            json!({ "focal": entities[1].to_string(), "depth": 1 }),
+        )
+        .await;
+
+        // Non-vacuity: each call must actually have projected graph-owned
+        // source. A tool that returned without reading a body needs no authority
+        // at all, and three such calls would hold the count at one while proving
+        // nothing about sharing.
+        let single_text = single.to_string();
+        assert!(
+            single_text.contains("parse_config0"),
+            "get_entity_source must serve its graph-owned body: {single}"
+        );
+        let batch_text = batch.to_string();
+        for index in 0..PAGE {
+            assert!(
+                batch_text.contains(&format!("parse_config{index}")),
+                "get_entity_sources must serve every requested body, missing {index}: {batch}"
+            );
+        }
+        assert!(
+            traced.to_string().contains("parse_config1"),
+            "trace_data_flow must serve its focal body: {traced}"
+        );
+
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            1,
+            "the three kin-cli-backed source tools reading at one publication must load \
+             repository authority exactly once; a count that climbs with request volume -- or \
+             with BATCH SIZE -- is the per-call open this shares"
+        );
+    }
+
+    /// A publication boundary forces a fresh, fully validating load on this
+    /// wrapper too.
+    ///
+    /// The half that keeps the bound above honest: a count held at one by never
+    /// reloading would be a cache serving authority the store has moved past.
+    /// Freshness is asserted on the ANSWER as well as the counter -- the entity
+    /// installed after the boundary lives on a path the previous publication's
+    /// workspace tree does not carry, so authority reused across it could not
+    /// serve that body at all.
+    #[tokio::test]
+    async fn a_publication_boundary_costs_one_more_load_on_the_command_wrapper() {
+        const AFTER: &str = "def trace_after(path):\n    return {\"which\": \"after\"}\n";
+        let state = test_state();
+        let entities = install_locate_page(&state, 1);
+        let app = router(Arc::clone(&state));
+
+        let before = state.projection_authority.loads();
+        let first = call_mcp_tool(
+            app.clone(),
+            "get_entity_source",
+            json!({ "entity_id": entities[0].to_string() }),
+        )
+        .await;
+        assert!(
+            first.to_string().contains("parse_config0"),
+            "the first read must project a body, or it loaded no authority: {first}"
+        );
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            1,
+            "the first read must load once"
+        );
+
+        let after = install_source_entity(&state, "trace_after", "src/trace_after.py", AFTER);
+
+        let served = call_mcp_tool(
+            app.clone(),
+            "get_entity_source",
+            json!({ "entity_id": after.to_string() }),
+        )
+        .await;
+        assert!(
+            served.to_string().contains("trace_after"),
+            "a read after the boundary must serve the publication that replaced the one the \
+             previous read loaded: {served}"
+        );
+        assert_eq!(
+            state.projection_authority.loads() - before,
+            2,
+            "crossing one publication boundary must cost exactly one more full validating load: \
+             fewer means authority was reused past the commit that replaced it, more means the \
+             reuse stopped holding within a publication"
+        );
+
+        let repeat = call_mcp_tool(
+            app,
+            "get_entity_source",
+            json!({ "entity_id": after.to_string() }),
+        )
+        .await;
+        assert!(repeat.to_string().contains("trace_after"));
         assert_eq!(
             state.projection_authority.loads() - before,
             2,


### PR DESCRIPTION
Refs FIR-2118

Base is `main`, not the FIR-2084 branch. This shares no file with kin#699 and neither change touches the other's API, so both enqueue in parallel rather than one waiting on the other.

FIR-2079 shared one validated repository authority per publication across the MCP query tools, and left three tools out: `get_entity_source`, `get_entity_sources`, and `trace_data_flow` resolve source through kin-cli command helpers rather than through kin-mcp's authority. They opened kin-cli's own `ActiveRepositoryAuthority` per call, and an open decodes the persisted snapshot and re-verifies every persisted body against its content address, so each call cost whatever the whole store is worth.

The batched tool was worse than per-request. `get_entity_sources` resolves source once per entity and every resolution opened for itself, so a batch of N entities paid N whole-store verifications: and could straddle a publication, returning rows read at two different generations.

## What changed

kin-cli gains the same two-arm request authority kin-mcp already has. The **pinned** arm opens for itself, which is what a one-shot CLI invocation wants and what every helper did before. The **shared** arm reads through an authority a server resolved for the publication this request reads at. `build_entity_source_outcome`, `build_graph_source_response`, and both `build_trace_data_flow_response` entry points take that type instead of a raw binding; every CLI caller passes the pinned arm, so nothing about one-shot behavior changes.

The daemon resolves the shared arm through a third slot on `ProjectionAuthorityCache`: same publication key, same load gate, same counter as the projection and query slots. `command_repository_authority` mirrors `query_repository_authority` exactly: pinned-namespace probe, publication read, reuse, gated re-read, one full validating open, install: and the staleness contract stated in full at that function applies here unchanged. Four routes move onto it: the three MCP tools and the `/commands/trace-data-flow` CLI route.

Validation is untouched. `validate_all_authority_bodies` remains unconditional in kin-db. Reuse can only hand back the result of a validation that already ran over these exact durable bytes, and any publication change forces a fresh, fully validating open.

## Evidence

Three bounds, all load-independent counters, never wall clock. What an open costs is a property of the store, so a timing assertion on a small fixture would pass with the defect present.

- `kin_cli_backed_source_tools_share_one_authority_load_per_publication`: the three tools at one publication hold `loads() == 1`, each asserted to have actually projected graph-owned source so the bound is not vacuous.
- `a_publication_boundary_costs_one_more_load_on_the_command_wrapper`: the boundary costs exactly +1, the entity published after it is served, and a second read at the new publication reuses.
- `a_batch_of_source_resolutions_shares_one_authority_open`: a 4-entity batch through one shared authority costs **zero** further opens, and the same batch through the pinned arm costs **four**. Both halves in one test on purpose: the bound is only evidence if the counter can tell the arms apart, and the pinned half is what proves it can.

That last one needed a new per-thread open counter on kin-cli's wrapper, because the daemon's `loads()` counts only opens it performs and is structurally blind to opens a helper takes for itself. Without it the batch-size claim would have been unfalsifiable: the assertion message would have said "or with BATCH SIZE" while nothing tested it.

### Falsification

| Mechanism broken | Test that failed |
|---|---|
| `reuse_command` always misses | `kin_cli_backed_source_tools_...`: `left: 3, right: 1` |
| generation check removed from `reuse_command` | `a_publication_boundary_costs_one_more_load_...`: fails with the stale-serve symptom itself: `entity source 'src/trace_after.py' is absent from repository-v6 workspace ... at generation 1` |

The pinned/shared split inside `a_batch_of_source_resolutions_shares_one_authority_open` is its own falsification: the two halves disagree by construction, so a counter that could not see per-item opens would fail the second assertion.

## Scope held deliberately

21 `ActiveRepositoryAuthority::open` sites across 15 files in kin-cli. This touches two. Everything else is enumerated in FIR-2118, including the classification that decides the order:

- **A fourth daemon-served read tool has the same defect.** `commands/trace.rs::render_entity_source` reaches `read_entity_file_bytes_with_digest`, which opens per call, and it backs the `/commands/trace` route. Outside the three tools this PR was scoped to, and the highest-value item left.
- **Seven write-path sites must not be ported mechanically.** kin-db's open takes an exclusive recovery lock, so handing a write path somebody else's open skips that acquisition. `reconcile.rs` (2), `session_workspace.rs`, `eject.rs` (2), `remote.rs`, `verify.rs::store_evidence_blob` each need their own argument about what the lock was protecting.
- **Two sites are re-checks and must keep opening.** `eject.rs`'s second open and `verify.rs::resolve_change` ask "has this moved?", and a shared open can only return what its owner already sampled.

The daemon now caches three wrappers over one durable state, so one publication can cost up to three opens. Deliberate: collapsing them onto one `RepositoryAuthorityManager` would reshape the projection path. Still O(publications) rather than O(requests) on all three. `ProjectionAuthorityCache` is correspondingly more misnamed; renaming touches `state.rs`, which another lane owns.

## Gates

Raw rc, on this branch alone rather than stacked, from inside the lane worktree.

| Gate | rc |
|---|---|
| `cargo fmt --all --check` under the dev cargo home | 0 |
| `bin/kin-dev local-check kin` | 0 |
| `bin/kin-dev local-test kin` | 0 |
| `python3 scripts/verify-zero-file-search.py` | 0 |
| `python3 scripts/test-assertion-reachability.py` | 0 |
| `bash scripts/check_runtime_boundaries.sh` | 0 |
| `cargo check -p kin-cli --no-default-features` | 0 |
| `cargo check -p kin-daemon --no-default-features` | 0 |

`Cargo.lock` unchanged from HEAD, `.cargo/config.toml` carrying `[registries.kin]` and no patch section, both verified after the gates ran.

## Not claiming

- No wall-clock speedup. Nothing was timed and no daemon or GPU was touched. The counter is the claim: authority opens on these paths go from O(requests), and O(batch size) for the batched tool, to O(publications).
- Not claiming the first query at a publication got cheaper. It still pays one full validating open; what changed is that the second and later ones, and every entity after the first in a batch, do not.
- Not claiming every kin-cli authority open is routed: 19 remain, enumerated above and in FIR-2118.
- Not claiming anything about CI; only the local lane gates ran.

