### PR TITLE
Disclose the projection rebuild and stop a wedged LSP worker

### DIFF
--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -41,6 +41,27 @@ use kin_cli::commands::resources::{BackgroundPassReport, DaemonWorkState};
 pub const PASS_EMBED: &str = "embed";
 /// The filesystem reconciliation loop.
 pub const PASS_RECONCILE: &str = "reconcile";
+/// The LSP enrichment worker.
+pub const PASS_LSP: &str = "lsp_enrichment";
+/// The startup projection rebuild. Disclosed only; see [`PassEnforcement`].
+pub const PASS_PROJECTION: &str = "projection_rebuild";
+
+/// Whether the supervisor may stop a pass, or only report on it.
+///
+/// Stopping is cooperative: the supervisor raises a flag and the pass reads it at
+/// its own checkpoint. A pass with no checkpoint therefore cannot be stopped, and
+/// halting one anyway would publish a `stopped` state and a reason for work that
+/// is still running. A watchdog that reports a stop it did not perform is worse
+/// than one that reports nothing, so the distinction is in the type rather than
+/// left to whoever registers next.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassEnforcement {
+    /// The pass polls [`BackgroundPass::halted`] and will stop when told.
+    Stoppable,
+    /// The pass has nowhere to observe a halt. It is disclosed — working
+    /// stretch, progress age, CPU — and never claimed to have been stopped.
+    DiscloseOnly,
+}
 
 /// How long a pass may hold the CPU with no persisted progress before the daemon
 /// stops it.
@@ -92,6 +113,7 @@ pub fn configured_retry_budget() -> Duration {
 #[derive(Debug)]
 pub struct BackgroundPass {
     name: &'static str,
+    enforcement: PassEnforcement,
     /// Mirrors `inner.halt.is_some()` so a pass can poll its own checkpoint
     /// without taking the lock. Published after the reason, so a reader that
     /// observes `true` always finds a reason behind it.
@@ -115,9 +137,10 @@ struct PassInner {
 }
 
 impl BackgroundPass {
-    fn new(name: &'static str) -> Self {
+    fn new(name: &'static str, enforcement: PassEnforcement) -> Self {
         Self {
             name,
+            enforcement,
             halted: AtomicBool::new(false),
             inner: Mutex::new(PassInner {
                 progress: 0,
@@ -127,6 +150,11 @@ impl BackgroundPass {
                 retry_spent: Duration::ZERO,
             }),
         }
+    }
+
+    /// Whether the supervisor may stop this pass or only report on it.
+    pub fn enforcement(&self) -> PassEnforcement {
+        self.enforcement
     }
 
     /// A poisoned lock must not disarm the watchdog. A panic elsewhere in the
@@ -338,6 +366,20 @@ impl BackgroundWorkSupervisor {
     /// worker without its feature, the reconcile loop on a bare repository —
     /// never appears in the report claiming to be idle when it does not exist.
     pub fn pass(&self, name: &'static str) -> Arc<BackgroundPass> {
+        self.register(name, PassEnforcement::Stoppable)
+    }
+
+    /// The handle for a pass the supervisor may report on but never stop.
+    ///
+    /// For work with no checkpoint between start and finish. It still answers
+    /// "why is my fan on" through its working stretch and progress age, which is
+    /// the disclosure the product owes; what it does not do is claim a stop that
+    /// could not happen.
+    pub fn disclosed_pass(&self, name: &'static str) -> Arc<BackgroundPass> {
+        self.register(name, PassEnforcement::DiscloseOnly)
+    }
+
+    fn register(&self, name: &'static str, enforcement: PassEnforcement) -> Arc<BackgroundPass> {
         if let Some(pass) = self.passes().get(name) {
             return Arc::clone(pass);
         }
@@ -345,7 +387,7 @@ impl BackgroundWorkSupervisor {
         Arc::clone(
             passes
                 .entry(name)
-                .or_insert_with(|| Arc::new(BackgroundPass::new(name))),
+                .or_insert_with(|| Arc::new(BackgroundPass::new(name, enforcement))),
         )
     }
 
@@ -381,6 +423,13 @@ impl BackgroundWorkSupervisor {
                 continue;
             }
             if !is_stalled(working_for, since_progress, self.stall_threshold) {
+                continue;
+            }
+            // A pass with no checkpoint cannot honour a halt, so raising one
+            // would publish `stopped` for work that is still running. It stays
+            // disclosed — its working stretch and progress age keep climbing
+            // where a user can see them — and is not announced as stopped.
+            if pass.enforcement() == PassEnforcement::DiscloseOnly {
                 continue;
             }
             let working_for = working_for.unwrap_or_default();
@@ -564,6 +613,53 @@ mod tests {
             .halt_reason()
             .expect("a stopped pass carries a reason")
             .contains("without recording any progress"));
+    }
+
+    /// A pass with nowhere to read a halt must never be announced as stopped.
+    ///
+    /// Paired with the test above rather than written alone: the two run the
+    /// identical wedged scenario and differ only in how the pass registered, so
+    /// a sweep that stopped everything, or one that stopped nothing, fails one
+    /// of them. The projection rebuild is the real case — a single `await` with
+    /// no loop — and publishing `stopped` for work still running would make the
+    /// health surface lie about the one thing it exists to report.
+    #[test]
+    fn a_disclose_only_pass_is_reported_but_never_claimed_stopped() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.disclosed_pass(PASS_PROJECTION);
+        let base = Instant::now();
+
+        pass.working(base);
+        assert!(
+            supervisor.sweep(at(base, 61)).is_empty(),
+            "a pass that cannot observe a halt must not be stopped by the sweep"
+        );
+        assert!(!pass.halted());
+        assert_eq!(pass.halt_reason(), None);
+        assert!(!supervisor.any_stopped());
+
+        // It is still disclosed: the working stretch is what answers "why is my
+        // fan on" for work the supervisor cannot end.
+        let report = supervisor
+            .reports(at(base, 61))
+            .into_iter()
+            .find(|report| report.name == PASS_PROJECTION)
+            .expect("a disclose-only pass still reports");
+        assert_eq!(report.state, "working");
+        assert_eq!(report.working_seconds, Some(61));
+    }
+
+    #[test]
+    fn registration_records_which_passes_the_supervisor_may_stop() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        assert_eq!(
+            supervisor.pass(PASS_LSP).enforcement(),
+            PassEnforcement::Stoppable
+        );
+        assert_eq!(
+            supervisor.disclosed_pass(PASS_PROJECTION).enforcement(),
+            PassEnforcement::DiscloseOnly
+        );
     }
 
     /// The other half of the same scenario. Only the progress feed differs, so a

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1394,13 +1394,27 @@ pub async fn run_with_authority(
 
     // Spawn projection rebuild in background — VFS needs it but locate doesn't.
     // The reconcile loop and API server can start immediately.
+    //
+    // Registered with the self-limit supervisor as disclose-only. The whole pass
+    // is a single `rebuild_projection().await`: there is no loop and so nowhere
+    // between start and finish for it to read a halt. Making it stoppable means
+    // threading cancellation through `ProjectionState::from_resolved_tree`,
+    // which is an API change rather than a registration. Until then the honest
+    // thing is to let a user see it working and how long since it advanced, and
+    // to never claim it was stopped.
     let projection_state = Arc::clone(&state);
+    let projection_pass = state
+        .background_work
+        .disclosed_pass(crate::background_work::PASS_PROJECTION);
     tokio::spawn(async move {
+        projection_pass.working(Instant::now());
         if let Err(error) = projection_state.rebuild_projection().await {
             tracing::error!(error = %error, "failed to rebuild projection state on startup");
         } else {
+            projection_pass.advanced(1, Instant::now());
             tracing::info!("projection state rebuilt in background");
         }
+        projection_pass.idle();
     });
 
     // Spawn the orphan session sweeper (Phase 7).
@@ -1965,6 +1979,10 @@ pub async fn run_with_authority(
             .working_dir()
             .canonicalize()
             .unwrap_or_else(|_| state.layout.working_dir().to_path_buf());
+        // Registered with the self-limit supervisor. Unlike the projection
+        // rebuild this pass is a real loop, so it has a checkpoint to read a
+        // halt at and can be stopped rather than only disclosed.
+        let lsp_pass = state.background_work.pass(crate::background_work::PASS_LSP);
         let _lsp_handle = tokio::spawn(async move {
             info!("LSP enrichment worker started");
             let source_view = match lsp_state.graph_owned_source_view() {
@@ -1992,10 +2010,27 @@ pub async fn run_with_authority(
             loop {
                 use crate::state::LspEnrichmentMessage;
 
+                // The supervisor's verdict is read here, at the worker's own
+                // checkpoint, so an enrichment in flight finishes rather than
+                // being torn out from under the LSP server it is talking to.
+                if lsp_pass.halted() {
+                    for (lang, server) in servers {
+                        info!(language = %lang, "shutting down LSP server");
+                        let _ = server.shutdown().await;
+                    }
+                    info!("LSP enrichment worker stopped by the background-work supervisor");
+                    break;
+                }
+
                 // Process buffered requests first (always incremental), then wait for new messages.
                 let message = if let Some(buffered) = pending_buffer.pop() {
                     LspEnrichmentMessage::Incremental(buffered)
                 } else {
+                    // Blocked on the channel is genuinely doing nothing, so the
+                    // working stretch ends here. A wedged enrichment never
+                    // reaches this point, which is exactly why the stretch it
+                    // started keeps accumulating and becomes observable.
+                    lsp_pass.idle();
                     tokio::select! {
                         Some(msg) = lsp_rx.recv() => msg,
                         _ = lsp_cancel.changed() => {
@@ -2008,6 +2043,7 @@ pub async fn run_with_authority(
                         }
                     }
                 };
+                lsp_pass.working(Instant::now());
 
                 match message {
                     LspEnrichmentMessage::Incremental(request) => {
@@ -2238,6 +2274,12 @@ pub async fn run_with_authority(
                                 "LSP enrichment added relations"
                             );
                             lsp_state.mark_dirty();
+                            // Relations reaching the graph is this pass's unit of
+                            // durable work, so it is what the supervisor is told
+                            // about. Querying an LSP server and finding nothing is
+                            // not progress, and crediting it would let a worker
+                            // that answers "no relations" forever look healthy.
+                            lsp_pass.advanced(total_relations as u64, Instant::now());
                         } else {
                             info!(
                                 path = %rel_path,
@@ -2461,6 +2503,14 @@ pub async fn run_with_authority(
 
                             files_processed += 1;
                             total_relations += file_relations;
+                            // Credited per file rather than once at the end. A
+                            // cold sweep walks the whole graph, and a pass that
+                            // reported nothing until it finished would look
+                            // stalled for the entire run and be stopped part
+                            // way through exactly the work a user asked for.
+                            if file_relations > 0 {
+                                lsp_pass.advanced(file_relations as u64, Instant::now());
+                            }
 
                             if file_relations > 0 {
                                 info!(
@@ -2473,6 +2523,14 @@ pub async fn run_with_authority(
 
                             // Check for shutdown between files.
                             if *lsp_cancel.borrow() {
+                                break;
+                            }
+                            // Same checkpoint, for the supervisor's verdict. A
+                            // sweep that is burning the CPU without enriching
+                            // anything stops here, between files, rather than
+                            // mid-request to a language server.
+                            if lsp_pass.halted() {
+                                info!("LSP cold sweep stopped by the background-work supervisor");
                                 break;
                             }
                         }


### PR DESCRIPTION
Closes FIR-2101

Two of the four background passes FIR-2101 names were still unaccounted for after
#694. They are not the same problem, and the task that produced this PR assumed
they were: "one registration call each". pw-selflimit's report already warned
against exactly that framing, and reading the code confirmed it.

## LSP enrichment worker: instrumented and stoppable

A real `loop` over `lsp_rx.recv()`, so it has checkpoints. It now declares when it
is working, goes idle while blocked on its channel, credits relations that reach
the graph, and reads the supervisor's verdict at the top of each turn and between
files in a cold sweep.

Two judgement calls worth naming:

- **Progress is credited per file in the cold sweep, not once at the end.** A
  sweep walks the whole graph. Crediting at completion would make it report zero
  progress for its entire run and get it stopped part way through exactly the work
  a user asked for.
- **Relations found is the unit, not files queried.** Asking a language server and
  getting nothing back is not durable work. Crediting it would let a worker that
  answers "no relations" forever look perfectly healthy, which is the failure this
  supervisor exists to catch.

## Projection rebuild: disclosed, and honestly not stoppable

`daemon.rs` spawns one `rebuild_projection().await`. Inside, `state.rs:4760` takes
a write lock, calls `ProjectionState::from_resolved_tree`, and assigns. There is no
loop and no await between start and finish, so there is nowhere to read a halt.

Registering it as an ordinary pass would have been actively harmful: the sweep
would have published `state: "stopped"` with a reason for work that was still
running. A watchdog that reports a stop it did not perform is worse than one that
reports nothing, because the health surface is the only thing a user has.

So registration now carries `PassEnforcement`: whether the supervisor may stop a
pass or only report on it. `sweep()` skips halting the ones it cannot end. The
rebuild is registered `DiscloseOnly`: its working stretch and progress age still
answer "why is my fan on", and nothing claims it was stopped.

Existing call sites are untouched; `pass()` still registers `Stoppable`.

## Tests

Both directions, on the identical wedged scenario, differing only in how the pass
registered: so a sweep that stopped everything and one that stopped nothing each
fail one of them:

- `a_disclose_only_pass_is_reported_but_never_claimed_stopped`: not halted, no
  reason, `any_stopped()` false, and still reported `working` with a 61s stretch.
- `the_working_mark_latches_so_a_wedged_loop_cannot_restart_its_own_clock` (existing)
 : the same wedge, registered stoppable, is halted with a reason.
- `registration_records_which_passes_the_supervisor_may_stop`.

**Falsified:** deleting the `DiscloseOnly` skip from `sweep()` fails exactly the
new test (19 passed, 1 failed) and restoring it returns 20 passed. The guard can
break, so it is evidence.

## Why Refs and not Closes

FIR-2101's mechanism 1 asks that a pass consuming CPU with zero progress delta *is
stopped*. After this PR the projection rebuild can be **seen** but still not
**ended**. Closing the ticket here would overstate what ships.

Making it stoppable means threading cancellation through
`ProjectionState::from_resolved_tree`: an API change across a module boundary and
a design decision, not a registration. That wants its own owner. pw-selflimit
asked for this call to be made explicitly rather than absorbed; this is it.

## Gates

Raw exit codes: `cargo fmt --all -- --check` 0; `cargo clippy -p kin-daemon
--all-targets` under `RUSTFLAGS=-D warnings` with CI's exact 90-entry allowlist 0;
`cargo check -p kin-daemon --no-default-features --all-targets` 0;
`python3 scripts/verify-zero-file-search.py` 0 (153 files scanned, invariant
holds); `bin/kin-dev local-test kin` 0 (nextest workspace + doctests). The last two
are the gates pw-selflimit's report asked to be made standard after they turned CI
red twice: neither is reachable by fmt/check/test alone.