### PR TITLE
Report authority loads where a user can read them

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2025,6 +2025,7 @@ mod tests {
         let check =
             background_work_health_from_state(&crate::commands::resources::DaemonWorkState {
                 daemon_cpu_seconds: Some(41.6),
+                authority_loads: None,
                 passes: vec![
                     pass_report("embed", "working", None),
                     pass_report("reconcile", "idle", None),
@@ -2051,6 +2052,7 @@ mod tests {
         let check =
             background_work_health_from_state(&crate::commands::resources::DaemonWorkState {
                 daemon_cpu_seconds: Some(48_180.0),
+                authority_loads: None,
                 passes: vec![
                     pass_report(
                         "embed",

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -166,6 +166,19 @@ pub struct DaemonWorkState {
     /// the supervisor's first sample, which is not the same as zero.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_cpu_seconds: Option<f64>,
+    /// Complete durable-authority loads this daemon has paid for.
+    ///
+    /// Belongs beside the CPU figure because it is the same kind of fact: what
+    /// this process has spent. One load per publication rather than one per
+    /// request is the property the authority cache exists to make true, and
+    /// until now the only way to check it on a running daemon was
+    /// `RUST_LOG=kin_daemon=debug`. A number that climbs with request volume
+    /// instead of with publications says the reuse regressed.
+    ///
+    /// Absent when the daemon predates this field, which is not the same as a
+    /// daemon that has loaded nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_loads: Option<u64>,
     /// Every background pass this daemon has actually started.
     #[serde(default)]
     pub passes: Vec<BackgroundPassReport>,
@@ -236,6 +249,15 @@ fn render_daemon_work_lines(work: &DaemonWorkState) -> Vec<String> {
             None => "not sampled yet".to_string(),
         }
     )];
+    // Rendered next to CPU because it is the other half of the same question.
+    // CPU says how much was spent; this says how much of it was spent opening
+    // durable authority, which is the one repeated cost the daemon caches away
+    // and the one a regression puts straight back.
+    if let Some(loads) = work.authority_loads {
+        lines.push(format!(
+            "Authority loads: {loads} (climbs with publications, not with requests)"
+        ));
+    }
     if work.passes.is_empty() {
         lines.push("Background passes: none started".to_string());
         return lines;
@@ -455,6 +477,48 @@ async fn run_daemon_resources(
 mod tests {
     use super::*;
     use kin_infer::resource::{AcceleratorBackend, AcceleratorInfo, HostInfo, MemoryInfo};
+
+    /// The counter is rendered when the daemon reports one and omitted when it
+    /// does not, rather than shown as a zero.
+    ///
+    /// Both directions, because a renderer that always printed the line and one
+    /// that never did would each pass a single-sided test. Zero is a real
+    /// answer here — a daemon that has served everything from cache — and it
+    /// has to be distinguishable from a daemon too old to have the field.
+    #[test]
+    fn authority_loads_render_only_when_the_daemon_reports_them() {
+        let present = render_daemon_work_lines(&DaemonWorkState {
+            daemon_cpu_seconds: Some(12.0),
+            authority_loads: Some(3),
+            passes: Vec::new(),
+        });
+        assert!(
+            present
+                .iter()
+                .any(|line| line.contains("Authority loads: 3")),
+            "a reported count must reach the text surface: {present:?}"
+        );
+
+        let zero = render_daemon_work_lines(&DaemonWorkState {
+            daemon_cpu_seconds: Some(12.0),
+            authority_loads: Some(0),
+            passes: Vec::new(),
+        });
+        assert!(
+            zero.iter().any(|line| line.contains("Authority loads: 0")),
+            "zero loads is an answer, not an absence: {zero:?}"
+        );
+
+        let absent = render_daemon_work_lines(&DaemonWorkState {
+            daemon_cpu_seconds: Some(12.0),
+            authority_loads: None,
+            passes: Vec::new(),
+        });
+        assert!(
+            !absent.iter().any(|line| line.contains("Authority loads")),
+            "a daemon that reports no count must not have one invented: {absent:?}"
+        );
+    }
 
     fn sample_plan(profile: Profile) -> ResourcePlan {
         let host = HostInfo {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -16530,6 +16530,49 @@ mod tests {
         );
     }
 
+    /// The counter reaches the surface a reader actually queries.
+    ///
+    /// Everything either side of this is covered elsewhere — the cache counts in
+    /// its own tests, the renderer is covered in kin-cli — so without this the
+    /// one line joining them would be compile-checked and nothing more, and
+    /// deleting it would leave every test green while the number vanished from
+    /// the product.
+    #[tokio::test]
+    async fn resources_report_the_authority_loads_this_daemon_has_paid_for() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let response = router(state)
+            .oneshot(
+                Request::post("/commands/resources")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "json": false }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 512 * 1024)
+            .await
+            .unwrap();
+        let resources: kin_cli::commands::resources::CommandResourcesResponse =
+            serde_json::from_slice(&body).unwrap();
+
+        // Zero, not absent: this daemon has opened no durable authority yet, and
+        // that is an answer. Absent would mean the daemon never reported one.
+        assert_eq!(
+            resources.daemon_work.authority_loads,
+            Some(0),
+            "a daemon that has loaded nothing must say zero, not say nothing"
+        );
+        assert!(
+            resources.text.contains("Authority loads: 0"),
+            "the count must reach the text surface, not only the JSON: {}",
+            resources.text
+        );
+    }
+
     /// A daemon that has started no background pass discloses that honestly,
     /// and does not invent a cumulative CPU figure it has not measured.
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2995,7 +2995,11 @@ async fn command_resources(
     };
 
     let actual = kin_cli::commands::resources::ActualResources::capture();
-    let daemon_work = state.background_work.work_state(std::time::Instant::now());
+    let mut daemon_work = state.background_work.work_state(std::time::Instant::now());
+    // Filled here rather than inside `work_state`: the supervisor watches
+    // background passes and has no business knowing about the authority cache.
+    // This is the one place both are in scope.
+    daemon_work.authority_loads = Some(state.projection_authority.loads());
     let response = kin_cli::commands::resources::build_command_resources_response(
         plan,
         embed_runtime,

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -453,6 +453,9 @@ impl BackgroundWorkSupervisor {
     pub fn work_state(&self, now: Instant) -> DaemonWorkState {
         DaemonWorkState {
             daemon_cpu_seconds: self.daemon_cpu_seconds(),
+            // The supervisor watches background passes; the authority cache is
+            // not one, so the caller that can see both fills this in.
+            authority_loads: None,
             passes: self.reports(now),
         }
     }
@@ -542,6 +545,19 @@ mod tests {
             Some(Duration::from_secs(9_000)),
             Duration::ZERO
         ));
+    }
+
+    /// The supervisor must not answer a question it was never told the answer
+    /// to. Defaulting this to `Some(0)` would report "this daemon has never
+    /// loaded authority" on every surface, which is a claim, and a false one.
+    #[test]
+    fn the_supervisor_reports_no_authority_load_count_of_its_own() {
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        assert_eq!(
+            supervisor.work_state(Instant::now()).authority_loads,
+            None,
+            "the count belongs to the authority cache; the supervisor must leave it absent"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes FIR-2109

`ProjectionAuthorityCache` has counted its loads since it was built (`api.rs:252`),
and the only way to read that count on a running daemon was
`RUST_LOG=kin_daemon=debug`. The cache exists to make one property true — a full
durable open per publication rather than one per request — and a property nobody
can check is one that regresses quietly.

## Where it goes

`/commands/resources`, beside `daemon_cpu_seconds`. Both answer the same question:
what has this process spent. Opening durable authority is the one repeated cost the
cache is there to remove, so the two belong on the same surface, and it renders in
the text output rather than only in `--json`:

```
Daemon CPU: 12.0s cumulative
Authority loads: 3 (climbs with publications, not with requests)
```

A number that climbs with request volume instead of with publications says the
reuse is gone.

## Two design points

**Filled at the endpoint, not in the supervisor.** `BackgroundWorkSupervisor`
watches background passes; the authority cache is not one. It leaves
`authority_loads` absent and `command_resources` — the one place both are in
scope — fills it in.

**Absent stays distinguishable from zero.** A daemon too old to report the field
renders no line at all; a daemon that has genuinely loaded nothing renders `0`.
Those are different facts and a reader needs to tell them apart, so the field is
`Option<u64>` with `skip_serializing_if`, not a defaulted `u64`.

## Tests

- `authority_loads_render_only_when_the_daemon_reports_them` — all three cases in
  one test: a reported count reaches the text surface, zero renders as zero rather
  than vanishing, and `None` renders no line. Written three-sided because a
  renderer that always printed the line and one that never did would each pass a
  single-sided test.
- `the_supervisor_reports_no_authority_load_count_of_its_own` — the supervisor
  must not default this to `Some(0)`, which would publish "this daemon has never
  loaded authority" on every surface as a false claim.

## Gates

Raw exit codes: `cargo fmt --all -- --check` 0; `cargo clippy -p kin-daemon -p
kin-cli --all-targets` under `RUSTFLAGS=-D warnings` with CI's exact 90-entry
allowlist 0; `cargo check -p kin-daemon --no-default-features --all-targets` 0;
`python3 scripts/verify-zero-file-search.py` 0 (153 files, invariant holds);
`bin/kin-dev local-test kin` 0 (nextest workspace + doctests).

## Sequencing

A v0.5.9 rider; it does not block the v0.5.8 mint. It touches `api.rs`, as does
#692, but #692's hunks there stop well short of the `command_resources` handler, so
this is line drift at most.
