### PR TITLE
Align the README trust line with the brand canon

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ add local vector similarity over them, and confirm coverage with
 
 ## Review an AI-written change
 
-**AI writes code. Kin proves what changed.**
+**AI writes code. Kin proves the change.**
 
 Run `kin init` on the branch you want to review so the relevant Git history is in
 the graph, then pass explicit commit SHAs to the report-only shadow gate:


### PR DESCRIPTION
Closes FIR-2122

README.md line 285 headed the review section with a non-canon variant of the trust line. The messaging canon (docs/brand v1.2) locks the line as 'AI writes code. Kin proves the change.', and the kin-db README already carries the canonical form. One line changed, no other content touched.