### PR TITLE
State the proof page's actual promise and de-em-dash two installer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ those callers pull in behind them.
 Recorded against a prepared graph at ripgrep commit
 `e89fff89ac9af12e8d4ce9d5fd07beb408ca730f`. 13 impacted entities within 3 hops,
 including 3 direct callers of the changed signature. The graph was built
-beforehand. No compiler ran. Exact commands and raw traces:
-[kinlab.ai/proof](https://kinlab.ai/proof).
+beforehand. No compiler ran. Exact commands:
+[kinlab.ai/proof](https://kinlab.ai/proof). The raw run directory is not
+public yet, so this is a recipe you can re-run, not a trace you can audit.
 
 Kin surfaces what the change touches. Whether the change is correct stays with
 your compiler, tests, and review. The graph is built beforehand by `kin init`,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -364,7 +364,7 @@ if [ "$HAVE_VFS" = "1" ] && [ "$HAVE_SHIM" = "1" ]; then
         info "Filesystem projection is unavailable on this platform; core CLI and daemon are fully functional without it."
     fi
 else
-    info "Filesystem projection (kin-vfs) not bundled in this archive — core CLI and daemon are fully functional without it."
+    info "Filesystem projection (kin-vfs) not bundled in this archive. The core CLI and daemon are fully functional without it."
 fi
 
 # ── PATH setup ──────────────────────────────────────────────────────────
@@ -412,7 +412,7 @@ if has_cmd "$KIN_BIN/kin"; then
         ok "kin ${INSTALLED_VERSION:-installed}"
     fi
 else
-    err "Installation failed — kin binary not found"
+    err "Installation failed: kin binary not found"
     exit 1
 fi
 


### PR DESCRIPTION
The README demo section (line 46) said 'Exact commands and raw traces: kinlab.ai/proof'. The proof page is live and serves the commands, but the evidence page it delegates to (firelock.ai/labs/kin-proof) states the full harness repository and raw run directory are not public today. The most checkable sentence on the landing page was overpromising by half. It now reads: 'Exact commands: kinlab.ai/proof. The raw run directory is not public yet, so this is a recipe you can re-run, not a trace you can audit.'

Also rewrites the two installer messages that print em dashes to a user's terminal (scripts/install.sh lines 367 and 415): the kin-vfs notice becomes two sentences, and the failure-path message uses a plain colon. The failure path is exactly when a new user reads most carefully.

No claims added. One claim narrowed to what the linked page actually delivers.