### PR TITLE
Rewrite the em dashes out of six public docs and complete the ecosystem manifest

### DIFF
--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -241,7 +241,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_EMBED_PASS_SECONDS", kind: Kind::Secs, default: "", sensitivity: Sensitivity::Operational, summary: "per-pass wall-clock budget for an embed run" },
     EnvVarSpec { name: "KIN_EMBED_MAX_TOTAL_SECONDS", kind: Kind::Secs, default: "600", sensitivity: Sensitivity::Operational, summary: "total wall-clock budget for a single `kin embed` under the interactive/small resource profiles; the run stops at the budget with a resumable partial index; unconstrained profiles ignore it" },
     EnvVarSpec { name: "KIN_EMBED_HTTP_TIMEOUT_SECS", kind: Kind::Secs, default: "", sensitivity: Sensitivity::Operational, summary: "HTTP timeout for the embedding service client" },
-    EnvVarSpec { name: "KIN_DAEMON_HTTP_TIMEOUT_SECS", kind: Kind::Secs, default: "300", sensitivity: Sensitivity::Operational, summary: "per-request HTTP timeout for the CLI's daemon client; 0 or invalid falls back to 300 — long-running requests (large-repo review) need a higher value" },
+    EnvVarSpec { name: "KIN_DAEMON_HTTP_TIMEOUT_SECS", kind: Kind::Secs, default: "300", sensitivity: Sensitivity::Operational, summary: "per-request HTTP timeout for the CLI's daemon client; 0 or invalid falls back to 300, and long-running requests (large-repo review) need a higher value" },
     EnvVarSpec { name: "KIN_RESOURCE_PROFILE", kind: Kind::OneOf(&["proof", "interactive", "throughput", "ci"]), default: "interactive", sensitivity: Sensitivity::Correctness, summary: "runtime resource profile (kin-cli/kin-daemon/kin-infer/kin-db): proof/interactive/throughput/ci; unset, the kin binaries select interactive at startup (value-preserving Metal kernels, proof's embedding budgets), while a library caller that never selects still resolves to proof; throughput additionally scales the batch budgets, may engage CPU/GPU hybrid embedding and overlaps persist with compute, and is non-citable" },
     EnvVarSpec { name: "KIN_INFER_METAL_PROFILE", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "Metal inference profile selection" },
     EnvVarSpec { name: "KIN_REGISTRY_URL", kind: Kind::Url, default: "", sensitivity: Sensitivity::Operational, summary: "kin registry base URL" },
@@ -329,7 +329,7 @@ pub const DOWNSTREAM: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_EMBED_HYBRID_GPU_TPUT_RATIO", kind: Kind::NonNegF32, default: "", sensitivity: Sensitivity::Correctness, summary: "kin-db hybrid split ratio: pins the GPU:CPU throughput ratio for the balanced split; unset (or <= 0) measures it adaptively per batch" },
     // ---- kin-db: embedding cache (perf/lifecycle, identical vectors) ----------
     EnvVarSpec { name: "KIN_EMBED_CACHE", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache; set to 0 to disable and always recompute (only the literal '0' disables), default on" },
-    EnvVarSpec { name: "KIN_EMBED_CACHE_BUDGET_GB", kind: Kind::NonNegF32, default: "", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache disk budget in GB for `kin cache gc`; unset (default) evicts nothing — the cache is pruned only by an explicit budget or command" },
+    EnvVarSpec { name: "KIN_EMBED_CACHE_BUDGET_GB", kind: Kind::NonNegF32, default: "", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache disk budget in GB for `kin cache gc`; unset (default) evicts nothing, so the cache is pruned only by an explicit budget or command" },
     EnvVarSpec { name: "KIN_EMBED_CACHE_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache directory; unset uses ~/.kin/cache/embeddings" },
     // ---- kin-vfs shim: projection authority -----------------------------------
     EnvVarSpec { name: "KIN_NO_VFS", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "kin-vfs shim projection bypass: set to 1 to skip VFS initialization and exec the real binary directly (only the literal '1' bypasses), default off" },
@@ -869,7 +869,7 @@ pub fn render_reference_markdown() -> String {
         "At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, \
          default `warn`):\n\n",
     );
-    out.push_str("- an unrecognized `KIN_*` name is warned (a likely typo — it has no effect);\n");
+    out.push_str("- an unrecognized `KIN_*` name is warned as a likely typo, because setting it has no effect;\n");
     out.push_str("- an invalid value is a hard startup error for a **correctness** variable, otherwise a warning;\n");
     out.push_str("- a correctness variable set away from its default is logged, so behavior drift is never silent.\n\n");
     out.push_str(
@@ -878,7 +878,7 @@ pub fn render_reference_markdown() -> String {
     );
     out.push_str(
         "**Zero-bound rule.** For a `*_TIMEOUT_MS`, `*_BUDGET_MS`, or bounded `*_TIMEOUT_SECS` \
-         knob, `0` means **disabled / unbounded** — the bound never fires. It is never an \
+         knob, `0` means **disabled / unbounded**, so the bound never fires. It is never an \
          instant zero-length timeout.\n\n",
     );
     out.push_str(

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -718,7 +718,7 @@ pub fn enforce_startup_env() -> Result<(), String> {
         }
         tracing::warn!(
             unknown = %report.unknown.join(", "),
-            "unrecognized KIN_* environment variable(s); possible typo — these have no effect (see docs/env-vars.md)"
+            "unrecognized KIN_* environment variable(s); these have no effect and are probably typos (see docs/env-vars.md)"
         );
     }
 

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -7,7 +7,7 @@
     "summary": "Firelock (the company) builds Kin (the semantic repo and collaboration substrate). KinLab is the hosted collaboration product; @kinlab is the shared package and registry scope.",
     "product": {
       "name": "Kin",
-      "descriptor": "The semantic repo and collaboration substrate — the system of record for AI-written software.",
+      "descriptor": "The semantic repo and collaboration substrate, the system of record for AI-written software.",
       "github": "https://github.com/firelock-ai/kin"
     },
     "company": {
@@ -153,7 +153,15 @@
         "kin",
         "kin-db"
       ],
-      "note": "Private benchmarking and proof-packaging harness. Kept private/trade-secret per IP strategy — not one of the open supporting repos."
+      "note": "Private benchmarking and proof-packaging harness. Kept private/trade-secret per IP strategy, not one of the open supporting repos."
+    },
+    {
+      "name": "kin-bench-spec",
+      "layer": "support",
+      "role": "public-benchmark-spec-and-verifier",
+      "dependsOn": [],
+      "status": "active",
+      "note": "Public specification and standalone verifier for Kin's merge-trust benchmark. Open counterpart to the private kin-bench harness, whose runner and proof infrastructure stay proprietary."
     },
     {
       "name": "kin-lsp",
@@ -178,7 +186,17 @@
       "layer": "infrastructure",
       "role": "shared-ci-and-release-workflows",
       "dependsOn": [],
-      "note": "Reusable GitHub Actions workflows for CI and release pipelines. Infrastructure/CI-only — not a product surface."
+      "note": "Reusable GitHub Actions workflows for CI and release pipelines. Infrastructure/CI-only, not a product surface."
+    },
+    {
+      "name": "homebrew-kin",
+      "layer": "infrastructure",
+      "role": "homebrew-distribution-tap",
+      "dependsOn": [
+        "kin"
+      ],
+      "status": "active",
+      "note": "Homebrew tap carrying the kin formula. Delivery infrastructure that installs published kin release archives, not a product surface."
     },
     {
       "name": "experimental/kin-kernel",

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -7,13 +7,13 @@ This is the authoritative list of supported `KIN_*` environment variables (422 t
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
-- an unrecognized `KIN_*` name is warned (a likely typo — it has no effect);
+- an unrecognized `KIN_*` name is warned as a likely typo, because setting it has no effect;
 - an invalid value is a hard startup error for a **correctness** variable, otherwise a warning;
 - a correctness variable set away from its default is logged, so behavior drift is never silent.
 
 Variables owned by sibling components (e.g. `KIN_VFS_*` from kin-vfs) are recognized as external and left alone.
 
-**Zero-bound rule.** For a `*_TIMEOUT_MS`, `*_BUDGET_MS`, or bounded `*_TIMEOUT_SECS` knob, `0` means **disabled / unbounded** — the bound never fires. It is never an instant zero-length timeout.
+**Zero-bound rule.** For a `*_TIMEOUT_MS`, `*_BUDGET_MS`, or bounded `*_TIMEOUT_SECS` knob, `0` means **disabled / unbounded**, so the bound never fires. It is never an instant zero-length timeout.
 
 Sensitivity legend: **correctness** (affects retrieval/ranking/output or data safety), **operational** (perf/resources/lifecycle), **diagnostic** (debug/telemetry), **secret** (credential; value never logged).
 
@@ -99,7 +99,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_DAEMON_DISABLE_LSP` | bool | false | correctness | disable LSP enrichment in the daemon, reducing relation coverage |
 | `KIN_DAEMON_EMBED_BATCH_SIZE` | usize | *(unset)* | operational | embedding batch size for daemon-side embed passes |
 | `KIN_DAEMON_EXISTING_READY_TIMEOUT_SECS` | seconds>=0 | 3 | operational | readiness wait for an already-running daemon |
-| `KIN_DAEMON_HTTP_TIMEOUT_SECS` | seconds>=0 | 300 | operational | per-request HTTP timeout for the CLI's daemon client; 0 or invalid falls back to 300 — long-running requests (large-repo review) need a higher value |
+| `KIN_DAEMON_HTTP_TIMEOUT_SECS` | seconds>=0 | 300 | operational | per-request HTTP timeout for the CLI's daemon client; 0 or invalid falls back to 300, and long-running requests (large-repo review) need a higher value |
 | `KIN_DAEMON_IDLE_FLUSH_SECS` | seconds>=0 | 2 | operational | idle debounce before a full-graph persistence flush |
 | `KIN_DAEMON_IDLE_TIMEOUT_SECS` | seconds>=0 | 3600 | operational | auto-shutdown after this idle period; 0 disables idle shutdown |
 | `KIN_DAEMON_LOCATE_ONLY` | bool | false | correctness | daemon serves locate-only from a snapshot, changing what it answers |
@@ -152,7 +152,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | --- | --- | --- | --- | --- |
 | `KIN_EMBED_BACKEND` | enum | auto | correctness | kin-db embedding compute backend: auto (default) uses batched Metal, 'cpu' forces the SIMD/pure path, 'metal'/'gpu' forces Metal; cpu vs metal shifts embeddings in the last ULPs |
 | `KIN_EMBED_CACHE` | bool | true | operational | kin-db on-disk embedding cache; set to 0 to disable and always recompute (only the literal '0' disables), default on |
-| `KIN_EMBED_CACHE_BUDGET_GB` | float>=0 | *(unset)* | operational | kin-db on-disk embedding cache disk budget in GB for `kin cache gc`; unset (default) evicts nothing — the cache is pruned only by an explicit budget or command |
+| `KIN_EMBED_CACHE_BUDGET_GB` | float>=0 | *(unset)* | operational | kin-db on-disk embedding cache disk budget in GB for `kin cache gc`; unset (default) evicts nothing, so the cache is pruned only by an explicit budget or command |
 | `KIN_EMBED_CACHE_DIR` | path | *(unset)* | operational | kin-db on-disk embedding cache directory; unset uses ~/.kin/cache/embeddings |
 | `KIN_EMBED_HTTP_TIMEOUT_SECS` | seconds>=0 | *(unset)* | operational | HTTP timeout for the embedding service client |
 | `KIN_EMBED_HYBRID` | string | off | correctness | kin-db hybrid CPU/GPU embedding split: off (default), 'seq'/'floor' for the sequence-length floor, or any other truthy value for the balanced split; engaging the CPU twin computes some vectors off the Metal device |

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -3,7 +3,7 @@
 Kin preserves every admitted file in exact repository authority regardless of
 language. A separate graph-native enrichment stage classifies supported content
 and extracts as much semantic structure as the language's adapter provides.
-This page states exactly what each language gets from that enrichment — no tier
+This page states exactly what each language gets from that enrichment. No tier
 is implied beyond what the extraction actually emits.
 
 ## How classification works
@@ -14,12 +14,12 @@ tiers:
 | Tier | What the graph stores |
 | --- | --- |
 | **Full semantic** | Entities (functions, classes, methods, types…), relations (calls, containment, inheritance…), test detection, doc/comment summaries |
-| **Shallow syntax** | Coarse top-level declarations + imports + a syntax fingerprint — no call graph, no nested entities, no tests, no docs |
+| **Shallow syntax** | Coarse top-level declarations + imports + a syntax fingerprint, with no call graph, no nested entities, no tests, and no docs |
 | **Structured artifact** | Dedicated extractors for manifests and configs (Cargo.toml, package.json, go.mod, pom.xml, Dockerfile, CI configs, SQL migrations…) |
 | **Opaque artifact** | Content hash + MIME hint. Never dropped, never parsed |
 
 Incremental edits (reconcile/watch) resolve adapters by file extension and can
-reach further than whole-repo ingest for a few languages — noted below.
+reach further than whole-repo ingest for a few languages, noted below.
 
 ## Full semantic support
 
@@ -32,10 +32,10 @@ reach further than whole-repo ingest for a few languages — noted below.
 | Java | ✓ | calls, contains, extends, implements, references | ✓ (junit) | ✓ | ✓ jdtls |
 | Rust | ✓ | calls, contains, implements, references | ✓ (cargo) | ✓ | ✓ rust-analyzer |
 | C++ | ✓ | calls, contains, extends, imports, references, uses-macro | ✓ | ✓ | ✓ clangd |
-| C | ✓ | calls, imports, references, uses-macro | — | ✓ | ✓ clangd |
-| Kotlin | ✓ | calls, contains, extends, implements, references | ✓ | ✓ | — |
-| C# | ✓ | calls, contains, extends, references | — | ✓ | — |
-| Ruby | ✓ | calls, contains, extends, references | — | ✓ | — |
+| C | ✓ | calls, imports, references, uses-macro | ✗ | ✓ | ✓ clangd |
+| Kotlin | ✓ | calls, contains, extends, implements, references | ✓ | ✓ | ✗ |
+| C# | ✓ | calls, contains, extends, references | ✗ | ✓ | ✗ |
+| Ruby | ✓ | calls, contains, extends, references | ✗ | ✓ | ✗ |
 
 ## Full adapters not yet routed by whole-repo ingest
 
@@ -48,8 +48,8 @@ effective support as the lower tier.
 ## Shallow syntax support
 
 Grammar-backed shallow extraction (declarations + imports + fingerprint, no
-call graph): C, C++, C#, Ruby, PHP, Swift — used when a file reaches the
-shallow tier.
+call graph) covers C, C++, C#, Ruby, PHP, and Swift. It applies when a file
+reaches the shallow tier.
 
 The following extensions are currently **classified as shallow but have no
 grammar wired**, so they degrade to opaque in practice: Scala, Lua, R, Zig,
@@ -60,7 +60,7 @@ extraction today.
 
 When the corresponding language server binary is installed, Kin adds
 type-resolved relations on top of the parser output (call hierarchy,
-overrides, uses-type, references — each tagged with LSP origin and a
+overrides, uses-type, references, each tagged with LSP origin and a
 confidence weight): Rust, Python, TypeScript, JavaScript, Go, Java, C, C++.
 Enrichment is skipped silently when the server binary is absent.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -56,7 +56,7 @@ command line (the flag wins):
 
 | profile | surface |
 | -- | -- |
-| `agent-default` | the curated agent belt — **the default** |
+| `agent-default` | the curated agent belt, **the default** |
 | `full` | every tool this reference documents |
 | `benchmark` | the retrieval belt the benchmark arm drives |
 | `context-bench` | read-only graph-native retrieval, no write-side session or transaction tools |
@@ -69,20 +69,20 @@ falls back to `agent-default` and says on stderr what it was asked for and what 
 ## 1. Retrieval & Codebase Exploration
 *Tools:* `semantic_search`, `semantic_locate`, `get_entity`, `get_entity_source`, `get_entity_body`, `get_context_pack`, `explore_codebase`, `graph_neighborhood`
 
-- **`semantic_search`**: Find declarations by **name, kind, or language** (functions, classes, structs, traits, enums, interfaces, types, constants). This matches real parsed declarations — not raw string occurrences like grep — and returns each match's file path, line range, signature, and stable entity ID. Note: despite the name, this is a metadata matcher; it does **not** rank by vector similarity. Use it as your first step to find "the thing called X."
-- **`semantic_locate`**: Rank the code most relevant to a **natural-language** query using Kin's vector index — the same embedding-backed retrieval that powers `kin locate`. Use it when you only have a description of the behavior, not an exact symbol name. Supports `granularity` of `entity` (default) or `file`, reports `semantic_coverage`, and requires the running daemon.
+- **`semantic_search`**: Find declarations by **name, kind, or language** (functions, classes, structs, traits, enums, interfaces, types, constants). This matches real parsed declarations rather than raw string occurrences like grep, and returns each match's file path, line range, signature, and stable entity ID. Note: despite the name, this is a metadata matcher; it does **not** rank by vector similarity. Use it as your first step to find "the thing called X."
+- **`semantic_locate`**: Rank the code most relevant to a **natural-language** query using Kin's vector index, the same embedding-backed retrieval that powers `kin locate`. Use it when you only have a description of the behavior, not an exact symbol name. Supports `granularity` of `entity` (default) or `file`, reports `semantic_coverage`, and requires the running daemon.
 - **`get_entity`**: Fetch metadata about a specific entity (kind, language, path, line range, signature) without its source body.
 - **`get_entity_source` / `get_entity_body`**: Retrieve the implementation source of an entity, served from the graph.
 - **`get_context_pack`**: Package a target entity alongside its caller/import neighborhood into a single prompt-friendly bundle.
 - **`explore_codebase`**: Get a one-shot map of the codebase via a selectable strategy (e.g. `overview`: entity counts by kind and language, plus the top public declarations).
-- **`graph_neighborhood`**: Return the dependency neighborhood of an entity — what it depends on and what depends on it — traversed to a given depth. `direction` selects which side to walk: `out` for dependencies, `in` for dependents (blast radius), `both` (default) for the merged neighborhood; every returned edge is tagged with the direction it was traversed in.
+- **`graph_neighborhood`**: Return the dependency neighborhood of an entity, traversed to a given depth. The neighborhood covers what it depends on and what depends on it. `direction` selects which side to walk: `out` for dependencies, `in` for dependents (blast radius), `both` (default) for the merged neighborhood; every returned edge is tagged with the direction it was traversed in.
 
 ---
 
 ## 2. Tracing & References
 *Tools:* `trace_computation`, `trace_data_flow`, `find_references`, `bulk_check_references`, `entity_history`
 
-- **`trace_computation`**: Get a focal entity together with its control-/data-flow neighborhood — its body plus callers, callees, and imports — in one structured response (a flat snapshot, not an ordered walk).
+- **`trace_computation`**: Get a focal entity together with its control-/data-flow neighborhood in one structured response (a flat snapshot, not an ordered walk). The response carries its body plus callers, callees, and imports.
 - **`trace_data_flow`**: Walk the directional call/data-flow chain rooted at a focal entity and return it as an ordered list of steps (the path-walk counterpart to `trace_computation`'s flat neighborhood).
 - **`find_references`**: Find all entities that import, call, or reference a target symbol.
 - **`bulk_check_references`**: Classify many entities by reachability in one call.
@@ -93,9 +93,9 @@ falls back to `agent-default` and says on stderr what it was asked for and what 
 ## 3. Semantic Change, Impact & Review
 *Tools:* `impact_analysis`, `semantic_diff`, `semantic_review`
 
-- **`semantic_diff`**: Compute an entity-level diff — which declarations were added, removed, or changed — rather than a line-by-line text diff. Target it by base/head change IDs, entity IDs, file paths, or a list of change IDs.
+- **`semantic_diff`**: Compute an entity-level diff of which declarations were added, removed, or changed, rather than a line-by-line text diff. Target it by base/head change IDs, entity IDs, file paths, or a list of change IDs.
 - **`impact_analysis`**: Walk the relation graph from what changed to find the downstream entities that could be affected ("if I change this, what else might break?").
-- **`semantic_review`**: Produce a complete review of a change in one call — entity-level diff, downstream impact, and an overall risk assessment — in `text` or `json` form.
+- **`semantic_review`**: Produce a complete review of a change in one call. It covers entity-level diff, downstream impact, and an overall risk assessment, in `text` or `json` form.
 
 ---
 
@@ -141,12 +141,12 @@ falls back to `agent-default` and says on stderr what it was asked for and what 
 ## 8. Verification & Compliance
 *Tools:* `kin_verify_entity`, `kin_coverage_summary`, `kin_security_scan`, `kin_release_check`, `kin_contract_check`, `kin_provenance_query`
 
-- **`kin_verify_entity`**: Inspect the test coverage recorded for an entity — which tests are linked to it and whether it is covered (optionally filtered by runner).
-- **`kin_coverage_summary`**: Report repo-wide test coverage — total entities, how many are covered, the ratio, and what's still untested.
+- **`kin_verify_entity`**: Inspect the test coverage recorded for an entity, reporting which tests are linked to it and whether it is covered (optionally filtered by runner).
+- **`kin_coverage_summary`**: Report repo-wide test coverage, including total entities, how many are covered, the ratio, and what's still untested.
 - **`kin_security_scan`**: Run a graph-based security/quality scan that returns findings with severity (today it surfaces dead/unreachable code; `propagate=true` also computes each finding's downstream impact).
 - **`kin_release_check`**: Run a graph-only advisory against a named branch and immutable source change. It checks exact history/tree completeness and an optional source entity count; `require_approval` covers every reachable non-root change, while `require_proof` currently fails closed for every non-empty source because verification runs are not yet source-bound. Final object availability and mutation CAS remain daemon `kin release` authority.
 - **`kin_contract_check`**: Check whether a specific behavioral contract has backing tests (which tests cover it, and whether it is covered).
-- **`kin_provenance_query`**: Answer who-changed-and-whether-approved for an entity — its change count, latest change, recorded approvals, and recent audit events.
+- **`kin_provenance_query`**: Answer who-changed-and-whether-approved for an entity, returning its change count, latest change, recorded approvals, and recent audit events.
 
 ---
 
@@ -165,4 +165,4 @@ falls back to `agent-default` and says on stderr what it was asked for and what 
 
 - **`dead_code` / `find_dead_code_seeded`**: Identify unreachable or orphaned entities (whole-repo or seeded by a semantic query).
 - **`benchmark`**: Run Kin's retrieval/locate benchmarks.
-- **`kin_graph_status`**: Report one schema-bound, point-in-time status view of the exact daemon graph selected for the call — entity and relation counts, selected-graph embedding coverage (indexed / total / pending), temporal-session versus HEAD scope, a process-local authority epoch, and backing authority. The daemon holds its normal embedding-work fence while reading internally synchronized coverage counters, then revalidates graph/scope authority before publishing; observed counts still do not attest enrichment completeness.
+- **`kin_graph_status`**: Report one schema-bound, point-in-time status view of the exact daemon graph selected for the call, covering entity and relation counts, selected-graph embedding coverage (indexed / total / pending), temporal-session versus HEAD scope, a process-local authority epoch, and backing authority. The daemon holds its normal embedding-work fence while reading internally synchronized coverage counters, then revalidates graph/scope authority before publishing; observed counts still do not attest enrichment completeness.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ This is the recommended first-run path for Kin. One flow works on macOS, Linux, 
 Windows (via WSL2):
 
 1. **Install** the binaries with the one-line installer.
-2. **`kin setup`** — answer a couple of questions; the guided wizard configures your
+2. **`kin setup`** asks a couple of questions, and the guided wizard configures your
    shell, PATH, daemon, and AI clients.
 3. **`kin init`** admits repository authority atomically and derives the semantic
    entity layer for supported sources; embeddings are a separate graph-native stage.
@@ -26,11 +26,12 @@ curl -fsSL https://get.kinlab.dev/install | sh
 
 The installer downloads the latest release from GitHub, **verifies its SHA-256 checksum**
 (and refuses to install an unverified or tampered download), installs the `kin` and
-`kin-daemon` binaries — plus the optional `kin-vfs` projection client and shim where the
-archive bundles them — into `~/.kin/bin` (and `~/.kin/lib`), updates your shell profile
-(`.zshrc` / `.bashrc`), and then runs the `kin setup` wizard. `kin-daemon` is mandatory;
-the installer aborts cleanly rather than leaving a daemon-less install. Re-running the
-installer upgrades an existing install in place and reports the version change.
+`kin-daemon` binaries into `~/.kin/bin` (and `~/.kin/lib`), updates your shell profile
+(`.zshrc` / `.bashrc`), and then runs the `kin setup` wizard. Where the archive bundles
+them, the optional `kin-vfs` projection client and shim are installed alongside.
+`kin-daemon` is mandatory; the installer aborts cleanly rather than leaving a daemon-less
+install. Re-running the installer upgrades an existing install in place and reports the
+version change.
 
 ### npm / npx
 
@@ -173,7 +174,7 @@ publication.
 
 Admission is a one-time cost that scales with the size of your history rather
 than the size of your checkout, because every reachable commit's tree is
-observed and proven. On a small repository it takes seconds. On a repository
+observed and recorded. On a small repository it takes seconds. On a repository
 with thousands of commits it takes minutes and can hold several gigabytes of
 memory while it runs.
 
@@ -303,7 +304,7 @@ kin diff
 
 ### Run your normal tools
 
-Ordinary project commands run through a graph-backed **session workspace** — the
+Ordinary project commands run through a graph-backed **session workspace**, the
 venv-like execution contract, so you never need to know which files are
 materialized before running the repo:
 
@@ -363,7 +364,7 @@ kin locate "users can't reset their password" --explain
 If you chose the **AI agents** intent in step 2, `kin setup` already wrote Kin's MCP
 server entry into every detected AI client (Claude Code, Cursor, Codex CLI, Gemini CLI,
 Windsurf) and added a Kin-first discovery reminder to your agent instruction files. There
-is **nothing else to configure** — open your agent in a Kin repository and ask it to use
+is **nothing else to configure**. Open your agent in a Kin repository and ask it to use
 the semantic tools:
 
 ```
@@ -393,7 +394,7 @@ processes that do not inherit your `PATH`.)
 
 > Vector-backed MCP retrieval (`semantic_locate`) and the stateful session / transaction /
 > work / review tools operate against the repo's running Kin daemon. Daemon auto-start is
-> on by default, so these tools have a live graph to query — `semantic_locate` returns an
+> on by default, so these tools have a live graph to query. `semantic_locate` returns an
 > explicit error in offline / no-daemon mode.
 
 For the full tool surface, see the [MCP Tools Reference](mcp-tools.md). To wire up a
@@ -404,8 +405,8 @@ client by hand (or use the npm wrapper), see
 
 ## 8. Verify your setup (`kin setup status`)
 
-Run the health checklist at any time. It probes real filesystem, daemon, and agent state —
-nothing is assumed healthy:
+Run the health checklist at any time. It probes real filesystem, daemon, and agent state,
+so nothing is assumed healthy:
 
 ```sh
 kin setup status          # human-readable table
@@ -414,11 +415,11 @@ kin setup status --json   # machine-readable report
 
 Each line shows a status mark:
 
-- `✓` **ok** — healthy.
-- `✗` **MISSING** / **MISCONFIGURED** — failing; these are the only states that make the
-  overall report unhealthy.
-- `!` **STALE** — present but not fully ready (e.g. embeddings pending).
-- `→` **n/a** — unsupported / not applicable on this platform or context.
+- `✓` **ok** means healthy.
+- `✗` **MISSING** / **MISCONFIGURED** means failing, and these are the only states that
+  make the overall report unhealthy.
+- `!` **STALE** means present but not fully ready (e.g. embeddings pending).
+- `→` **n/a** means unsupported / not applicable on this platform or context.
 
 The checks (IDs as emitted in `--json`):
 
@@ -460,15 +461,15 @@ kin doctor --fix    # apply safe repairs, then re-check
 
 ## 9. Advanced configuration
 
-You do not need anything here for a normal first run — the guided wizard covers it. This
-section is for manual wiring, troubleshooting, and non-standard environments.
+You do not need anything here for a normal first run, because the guided wizard covers
+it. This section is for manual wiring, troubleshooting, and non-standard environments.
 
 ### Manual MCP client configuration
 
 If you skipped the wizard's agent step, or your client wasn't auto-detected, add Kin's MCP
 server to your client's config by hand. Use `$KIN_HOME/bin/kin` (normally `~/.kin/bin/kin`)
 when that managed launcher exists; otherwise run `command -v kin`. Substitute that exact
-absolute path for `/absolute/path/to/kin` below. Match the wizard exactly — including the
+absolute path for `/absolute/path/to/kin` below. Match the wizard exactly, including the
 `agent-default` profile:
 
 ```json
@@ -489,7 +490,7 @@ Config file locations the wizard targets (and `kin setup status` inspects):
 | --- | --- |
 | Claude Code | `~/.claude.json` (falls back to `~/.claude/config.json`) |
 | Cursor | `~/.cursor/mcp.json` |
-| Codex CLI | `~/.codex/config.toml` (TOML — see below) |
+| Codex CLI | `~/.codex/config.toml` (TOML, see below) |
 | Gemini CLI | `~/.gemini/settings.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 
@@ -503,11 +504,11 @@ args = ["mcp", "start", "--repo", "/absolute/path/to/repository"]
 env = { KIN_MCP_TOOL_PROFILE = "agent-default" }
 ```
 
-`kin mcp start` launches the MCP **stdio** server. You normally do not run this by hand —
-your AI client launches it as a subprocess via the config above. The server binds
+`kin mcp start` launches the MCP **stdio** server. You normally do not run this by hand,
+because your AI client launches it as a subprocess via the config above. The server binds
 per invocation: it uses `KIN_DAEMON_URL` when set (agent sessions launched with
 `kin with` pin it), and otherwise resolves the repository by walking up
-from the working directory — so each agent session talks to the daemon of the
+from the working directory, so each agent session talks to the daemon of the
 repository it is actually working in.
 
 ### npm wrapper (`@kinlab/kin`)
@@ -552,14 +553,14 @@ normal use. The escape hatches:
   `KIN_DAEMON_URL`).
 - `KIN_DAEMON_URL`: point the CLI at an explicit daemon endpoint.
 - `KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN=1`: offline/admin escape hatch that lets the read-only
-  in-process commands fall back to reading the local `.kin` snapshot directly. Never used
-  for writes — all graph mutations still route through the daemon.
+  in-process commands fall back to reading the local `.kin` snapshot directly. It is never
+  used for writes, and all graph mutations still route through the daemon.
 
 ---
 
 ## 10. Removing Kin
 
-Kin is ejectable — there is no data lock-in. Eject remains graph-first all the
+Kin is ejectable, with no data lock-in. Eject remains graph-first all the
 way through the exit:
 
 ```sh

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -29,8 +29,8 @@ Kin replaces the file-first, diff-first substrate with a semantic, graph-first m
 2. **The filesystem is a projection**: Editor views and on-disk files are not the source
    of truth; they are derived views computed from the graph state.
 3. **Change tracking via semantic fingerprints**: Changes are tracked as semantic changes
-   to graph nodes — using AST hashes, signature hashes, behavior hashes, and stability
-   scores — rather than as line diffs.
+   to graph nodes rather than as line diffs, using AST hashes, signature hashes, behavior
+   hashes, and stability scores.
 
 ---
 

--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -42,8 +42,8 @@ projection and the same behavior the project tests and benchmarks against.
    Reboot if prompted, then open the **Ubuntu** shell to finish first-time
    user setup.
 
-2. Inside the WSL2 Linux shell, install Kin the same way you would on Linux —
-   this is the **same one-path flow** documented in the
+2. Inside the WSL2 Linux shell, install Kin the same way you would on Linux.
+   This is the **same one-path flow** documented in the
    [quickstart](./quickstart.md):
 
    ```sh
@@ -52,7 +52,7 @@ projection and the same behavior the project tests and benchmarks against.
 
    The installer launches the `kin setup` guided wizard for you. Answer its
    "What do you want Kin for?" prompt (the **AI agents** intent is the default),
-   then verify with `kin setup status` — inside WSL2 the VFS projection check is
+   then verify with `kin setup status`. Inside WSL2 the VFS projection check is
    supported, unlike native Windows.
 
 3. Work on your repositories from inside the WSL2 filesystem (e.g.


### PR DESCRIPTION
The em dash is gone from all six public docs, quickstart.md, mcp-tools.md, language-support.md, env-vars.md, thesis.md, and windows-wsl2.md, and the ecosystem manifest now lists the two public repos it was missing.

Every dash was rewritten, not swapped for another mark. A mechanical substitution pass earlier today produced ungrammatical splices in release notes and had to be repaired, so each sentence here was read and restructured on its own terms. Parenthetical dash pairs became separate sentences or comma-bracketed clauses. Single dashes became commas or periods, with the clause order changed wherever that read better. The diff was reviewed sentence by sentence, and two entries in mcp-tools.md were rewritten a second time because the first pass left them comma-muddled. Six cells in the language-support matrix used a bare dash as a "not provided" placeholder; those now carry the cross glyph that matches the tick vocabulary already sitting in the same columns.

No command, path, flag, link, version, count, or claim changed anywhere in this diff. The one wording change beyond punctuation is in quickstart.md, where admission is now described as observing and recording every reachable commit's tree rather than proving it.

docs/env-vars.md is a generated file, so it is handled in its own commit and fixed at the source. It is produced by kin_core::env_registry::render_reference_markdown, and env_doc_matches_registry compares the committed file to the rendered output byte for byte, which means hand-editing the markdown alone would turn CI red. Four string literals in crates/kin-core/src/env_registry.rs carried the dashes, the two literal preamble lines the renderer pushes plus the summary fields on KIN_DAEMON_HTTP_TIMEOUT_SECS and KIN_EMBED_CACHE_BUDGET_GB. Those were rewritten and the rendered markdown updated in the same commit. The committed markdown was then confirmed to be the generator's own output: regenerating it under KIN_REGEN_ENV_DOC=1 reproduced the committed file byte for byte, leaving the working tree clean.

A fifth string in that file is the warning env validation logs when it sees an unknown KIN_* name. It prints to a terminal at CLI and daemon startup, so it is public prose under the same rule, and it now reads "these have no effect and are probably typos". That string does not feed the generated reference, confirmed against a positive control, and nothing in the repo asserts on it. Across all five, only string contents moved, so no variable, kind, default, sensitivity, or bound changed and behavior is untouched. Internal Rust doc comments were deliberately left alone.

The manifest gains kin-bench-spec, the public benchmark specification and standalone bundle verifier that sits opposite the private kin-bench harness, and homebrew-kin, the tap whose formula installs published kin release archives. Both were verified against the live repos rather than assumed: each is public, and the formula does interpolate release-asset URLs. Both entries use the existing field set and layer vocabulary and sit beside their siblings. Nothing in the repo validates this file, so it was checked with python3 -m json.tool, which parses it clean. Three pre-existing dashes in the manifest were rewritten too; the product descriptor was checked against the brand canon first, and the canon phrase survives verbatim with only the joining punctuation changed.

Verification: the U+2014 count is zero across all six markdown files and the manifest, measured by occurrence rather than by line, alongside a planted canary in the same command that the detector correctly finds. The en dash count is zero as well, so nothing was quietly downgraded to a different dash. cargo test -p kin-core --locked env_doc_matches_registry passes locally, and Cargo.lock and .cargo/config.toml hash identically before and after every cargo run, checked against a canary proving the comparison fails when a file really does change.
