### PR TITLE
Declare v0.5.7 abandoned so the release train can plan v0.5.8

### DIFF
--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -462,8 +462,11 @@ fn a_store_below_its_git_object_store_prints_a_fraction() {
         "a store below its Git object store must print a fraction, not {printed}x: {stdout}"
     );
     let expected = store as f64 / git as f64;
+    // 0.005 is half the quantum of the two-decimal print; for small ratios the
+    // 5% band alone is narrower than print rounding, which makes the assertion
+    // fail on formatting rather than on the measured ratio.
     assert!(
-        (printed - expected).abs() < 0.05 * expected.max(0.01),
+        (printed - expected).abs() < 0.005 + 0.05 * expected.max(0.01),
         "init printed {printed}x for {store} store bytes over {git} Git object bytes \
          (expected about {expected:.2}x): {stdout}"
     );

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10633,11 +10633,14 @@ pub fn bind_api_listener_pair(
     let bind_host = bind_host_from_env();
     let auth_present = resolve_serve_auth_token(layout).is_some();
     let bound = bind_std_listener(&bind_host, port, auth_present)?;
-    // `try_clone` duplicates the descriptor rather than the socket, so both
-    // handles share one listen queue and one set of status flags -- including
-    // the non-blocking mode Tokio requires, which is why the clone needs no
-    // further configuration.
+    // Both handles share one bound socket and one listen queue, but only on
+    // Unix does the dup share status flags. On Windows, WSA socket duplication
+    // does not carry FIONBIO, so the clone comes back blocking and an accept
+    // loop handed to Tokio parks a worker thread on the syscall: the daemon
+    // reports listening while never accepting. The mode must be set on the
+    // duplicate explicitly.
     let duplicate = bound.try_clone()?;
+    duplicate.set_nonblocking(true)?;
     let bound_port = bound.local_addr()?.port();
     Ok((
         tokio::net::TcpListener::from_std(bound)?,

--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -49,6 +49,13 @@
       "reason": "The provenance aggregator frozen at this tag requires every per-artifact manifest to carry the same run_attempt as the publishing job. The five platform builds succeeded on the first attempt and were never re-run, so their manifests record attempt 1, while a runner outage failed the daemon-image job on that same attempt and pushed the aggregator to attempt 3, where Publish Release is refused with 'kin-linux-x86_64.provenance.json run attempt does not match this run'. Automatic release recovery cannot remedy this and made it worse on each pass, because rerunning failed jobs is its only remedy and every retry moves the publishing attempt further from the attempt the manifests record. The repair for FIR-1571 landed on main only after the tag, and the release workflow resolves from the tag, so no later change to main can reach the failing step. All three attempts of the cited run failed, no GitHub Release object was ever created for this tag, and no channel published it.",
       "superseded_by": "v0.5.7",
       "failed_release_run_id": "31114407438"
+    },
+    {
+      "tag": "v0.5.7",
+      "sha": "6321ecc936b340710451d5e1de7d8b747716074b",
+      "reason": "The Public Install Proof frozen at this tag fails on all five platforms because the tagged binary reports semantic_query_readiness=stale while a fresh install's first embedding fill is still in progress, and the health rollup at the tag treats that state as blocking; the same report also scores an unconfigured retrieval profile as stale on Windows. The discriminators that tell a first fill apart from lost coverage and an unconfigured install apart from a degraded one landed on main only after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing checks. Both attempts of the cited run failed with the same signature on all five legs, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm and Homebrew were verified untouched, and the tag never became the finalized Latest release.",
+      "superseded_by": "v0.5.8",
+      "failed_release_run_id": "31193919695"
     }
   ]
 }


### PR DESCRIPTION
Adds the v0.5.7 entry to scripts/abandoned-release-tags.json in the established format: the Public Install Proof frozen at the tag fails on all five platforms because the tagged binary reports a first embedding fill as blocking staleness (and the Windows leg scores an unconfigured retrieval profile as degraded), the discriminators landed on main only after the tag (kin 696 and 697), and both the proof workflow and binary resolve from the tag, so no later change to main can reach the failing checks. Both attempts of Release run 31193919695 failed with the same signature; the only Release object is the unpromoted prerelease and npm and Homebrew were verified untouched.

Falsified with the train's own selector run exactly as release-train.yml invokes it: with this entry the highest admissible tag is v0.5.5, matching GitHub Latest, so the reconcile gate opens; without it the selector answers v0.5.7 and the train defers to recovery, which has no remedy for a proof failure frozen into a tag.

Also carries a one-line widening of the init_json store-ratio assertion, which this PR' first CI round exposed as structurally flaky: the test allows five percent of the expected ratio while init prints at two decimals, so for small ratios print rounding alone exceeds the band (the observed miss was three millionths past the bound, on a change that touches no init code). The bound now adds half the print quantum, verified by running the test on this branch.

Also carries the Windows fix for the kin 692 listener pair: Windows socket duplication does not carry FIONBIO, so the duplicated handle came back blocking and the full API server never accepted, failing daemon_status_and_stop_lifecycle on every Windows run whose tree contains 692 (three occurrences today) while 700, whose merge ref predated 692, passed the same leg. The duplicate is now set non-blocking explicitly. This is mint-critical twice over: main is currently red on that Windows leg for every PR, and the v0.5.8 install proof runs the daemon on windows-latest.