### PR TITLE
Retract already-admitted paths when ignore rules begin covering them

### DIFF
--- a/crates/kin-cli/src/commands/purge_ignored.rs
+++ b/crates/kin-cli/src/commands/purge_ignored.rs
@@ -4,15 +4,18 @@
 //! Wire types and CLI transport for retiring tracked paths that ignore rules
 //! now cover.
 //!
-//! Ignore rules never hide tracked paths, so a repository that admitted derived
-//! output before a rule existed keeps carrying it in graph truth forever. That
-//! retention is deliberate: an ignore rule must never turn into a silent
-//! deletion. Retiring the backlog is therefore an operator action with its own
-//! surface, and this is that surface.
+//! Admission retracts a tracked path once the rules cover it, so the backlog a
+//! repository built up before a rule existed clears on its own. This surface
+//! exists for the operator who wants to see the set first, or to retire it now
+//! rather than on the next observation.
 //!
 //! The default is a dry run. It names how many tracked paths the current rules
 //! cover, how many would remain, and a bounded sample of the paths themselves.
 //! Nothing moves until `--confirm`.
+//!
+//! Retiring a path removes the artifact and the entities, layout, and index
+//! presence derived from it, because those are what let it rank. The file stays
+//! on disk; this untracks rather than deletes.
 
 use anyhow::{anyhow, Context, Result};
 use kin_model::{AuthorId, OperationId, RepositoryId};

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -18139,7 +18139,10 @@ mod tests {
         // The rule lands after the admission, which is the whole scenario: a
         // repository that already carries a path is told to stop carrying it.
         for (path, content) in [
-            ("investor/deck/build_deck.py", &b"def valuation(): pass\n"[..]),
+            (
+                "investor/deck/build_deck.py",
+                &b"def valuation(): pass\n"[..],
+            ),
             ("src/lib.py", &b"def kept(): pass\n"[..]),
             (".kinignore", &b"investor\n"[..]),
         ] {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -18126,6 +18126,58 @@ mod tests {
         assert!(tracked_paths(&state).contains("target/debug/app.o"));
     }
 
+    /// Untracking is not enough. Entities are what rank, so a purge that left
+    /// them behind produced the worst reading of all: the artifact listing no
+    /// longer names the file while search and locate still return it.
+    #[tokio::test]
+    async fn purge_ignored_evicts_the_entities_that_made_a_path_rank() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        // The rule lands after the admission, which is the whole scenario: a
+        // repository that already carries a path is told to stop carrying it.
+        for (path, content) in [
+            ("investor/deck/build_deck.py", &b"def valuation(): pass\n"[..]),
+            ("src/lib.py", &b"def kept(): pass\n"[..]),
+            (".kinignore", &b"investor\n"[..]),
+        ] {
+            install_working_copy_file(&state, path, content, false);
+            install_repository_file(&state, path, content);
+        }
+
+        let private = test_entity("valuation", "investor/deck/build_deck.py");
+        let kept = test_entity("kept", "src/lib.py");
+        state.graph.upsert_entity(&private).unwrap();
+        state.graph.upsert_entity(&kept).unwrap();
+        assert!(state.graph.get_entity(&private.id).unwrap().is_some());
+
+        let app = router(Arc::clone(&state));
+        let (_, applied) = purge_ignored_through_api(&app, true).await;
+        assert_eq!(applied["report"]["purge_count"], json!(1));
+
+        let live = tracked_paths(&state);
+        assert!(!live.contains("investor/deck/build_deck.py"));
+        assert!(
+            state.graph.get_entity(&private.id).unwrap().is_none(),
+            "a purged path's entity still resolves, so it still ranks"
+        );
+        assert!(state
+            .graph
+            .query_entities(&kin_db::EntityFilter {
+                file_path: Some(kin_model::FilePathId::new("investor/deck/build_deck.py")),
+                ..Default::default()
+            })
+            .unwrap()
+            .is_empty());
+
+        // The two-sided arm: an unnamed sibling keeps both its artifact and its
+        // entity, so the purge removed one path rather than clearing the graph.
+        assert!(live.contains("src/lib.py"));
+        assert_eq!(state.graph.get_entity(&kept.id).unwrap(), Some(kept));
+    }
+
     fn branch_change(state: &DaemonState) -> SemanticChangeId {
         let authority = ActiveApiRepositoryAuthority::open(state).unwrap();
         let lease = authority.manager.read_authority();

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -308,6 +308,17 @@ fn host_entry_matches_graph(
         .artifact_id_at_path(repo_path)
         .and_then(|artifact_id| state.graph.resolved_artifact(&artifact_id))
         .map(|artifact| artifact.entry);
+    if expected.is_none() && observed.is_some() {
+        // A file present on disk with no graph entry is what an excluded path
+        // looks like once the rules cover it. Retraction untracks rather than
+        // deletes, so the file outliving its artifact is the intended end state
+        // here and not evidence that the host moved under the admission.
+        let ignore = kin_index::RepositoryIgnore::load(state.layout.working_dir())
+            .map_err(kin_index::IndexError::from)?;
+        if ignore.matches(repo_path) {
+            return Ok(true);
+        }
+    }
     Ok(observed == expected)
 }
 
@@ -460,10 +471,44 @@ fn exact_tree_admission(
     }
     let ignore =
         kin_index::RepositoryIgnore::load(working_dir).map_err(kin_index::IndexError::from)?;
+    // A rule that begins matching an already-admitted path retracts it. Ignoring
+    // a path is a statement about the semantic index rather than about future
+    // walks alone, so the rules are applied to graph-owned tracked identity here
+    // and not only to the leaves the walk meets.
+    let retracted = kin_index::tracked_paths_retracted_by_ignore(
+        &ignore,
+        tracked_paths.iter(),
+        graph_only_paths.iter(),
+    );
+    let retracted_paths = retracted.paths().iter().cloned().collect::<BTreeSet<_>>();
+    announce_retraction(&retracted);
+    // Planned from graph-owned identity rather than inferred from the walk. The
+    // observation planner refuses an unmatched removal beside an unmatched
+    // addition, because a walk cannot tell that pair apart from a move, and
+    // writing a rule produces exactly that pair: `.kinignore` arrives as the
+    // addition in the same tick its rule retracts something. The artifact this
+    // removes is already known by id, so it is named outright and never has to
+    // be guessed at.
+    let retraction_deltas = retracted
+        .paths()
+        .iter()
+        .filter_map(|path| previous.artifact_at_path(path))
+        .map(|artifact| TreeDelta::Removed {
+            artifact_id: artifact.artifact_id,
+            old: artifact.located_entry(),
+        })
+        .collect::<Vec<_>>();
+    let planning_base = previous
+        .apply(&retraction_deltas)
+        .map_err(invalid_tree_transition)?;
+    let scanned_tracked = tracked_paths
+        .iter()
+        .filter(|path| !retracted_paths.contains(*path))
+        .collect::<Vec<&RepoPath>>();
     let scan = kin_index::scan_repository_preserving_graph_only(
         working_dir,
         &ignore,
-        tracked_paths.iter(),
+        scanned_tracked.into_iter(),
         graph_only_paths.iter(),
     )
     .map_err(kin_index::IndexError::from)?;
@@ -478,7 +523,16 @@ fn exact_tree_admission(
         }
         observed.retain(|path, _| previous.artifact_id_at_path(path).is_some());
     }
-    let deltas = kin_core::plan_observed_tree_deltas(&previous, observed.entries().clone())?;
+    // A bounded tick re-inserts every tracked path its observation did not
+    // cover, which would restore the paths the rules just retracted. Editing
+    // `.kinignore` is exactly that shape of event, so without this the surface a
+    // user writes the rule on is the one surface where it never takes effect.
+    observed.retain(|path, _| !retracted_paths.contains(path));
+    let mut deltas = retraction_deltas;
+    deltas.extend(kin_core::plan_observed_tree_deltas(
+        &planning_base,
+        observed.entries().clone(),
+    )?);
 
     let removed_count = deltas
         .iter()
@@ -533,6 +587,13 @@ fn exact_tree_admission(
             desired_tree,
         );
         let _ = publish_exact_workspace_tree(state, &admitted)?;
+        // Authority has committed the removal, so the entities derived from
+        // those paths go before the graph is asked to match. kin-db refuses a
+        // tree transition that leaves an entity on a path the staged tree no
+        // longer carries, and it is right to: an artifact that stops existing
+        // while its entities keep ranking is the exposure this ordering exists
+        // to prevent.
+        evict_enrichment_for_removed_paths(state, &deltas)?;
         state.graph.apply_transaction_delta(&TransactionDelta {
             entity_deltas: Vec::new(),
             relation_deltas: Vec::new(),
@@ -580,11 +641,23 @@ fn admit_file_event_with_exact_tree(
         return Ok(AdmittedFileEvent::Ignored);
     }
     let file_id = semantic_file_id(&repo_path);
-    let tracked = state.graph.artifact_id_at_path(&repo_path).is_some()
-        || admitted_paths.contains(&repo_path);
+    let in_graph = state.graph.artifact_id_at_path(&repo_path).is_some();
+    let tracked = in_graph || admitted_paths.contains(&repo_path);
     let ignore =
         kin_index::RepositoryIgnore::load(working_dir).map_err(kin_index::IndexError::from)?;
-    if !tracked && ignore.matches(&repo_path) {
+    if !in_graph && ignore.matches(&repo_path) {
+        // The rules exclude this path and graph truth no longer carries it. If
+        // the preceding transition is what took it out, it is a retraction and
+        // its enrichment has to go with it. Reading the host here instead would
+        // find the file still present, classify it as an ordinary change, and
+        // re-enrich a path the repository just stopped tracking.
+        if admitted_paths.contains(&repo_path) {
+            return Ok(AdmittedFileEvent::Removed {
+                repo_path,
+                file_id,
+                tree_changed: true,
+            });
+        }
         return Ok(AdmittedFileEvent::Ignored);
     }
 
@@ -713,6 +786,69 @@ fn clear_incompatible_facets(
     }
 
     Ok(cleanup)
+}
+
+/// Retracted paths named in one operator-facing line, with a bounded sample.
+///
+/// A retraction removes graph-owned identity, so it is never allowed to happen
+/// quietly. A rule broad enough to cover a source tree has to be visible in the
+/// log the moment it takes effect rather than discovered later as a gap in
+/// query results.
+pub(crate) const ANNOUNCED_RETRACTION_SAMPLE: usize = 20;
+
+fn announce_retraction(retracted: &kin_index::IgnoredTrackedPaths) {
+    if retracted.is_empty() {
+        return;
+    }
+    let sample = retracted
+        .paths()
+        .iter()
+        .take(ANNOUNCED_RETRACTION_SAMPLE)
+        .map(RepoPath::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    warn!(
+        retracted = retracted.len(),
+        tracked = retracted.tracked_total(),
+        retained = retracted.retained_total(),
+        sample = %sample,
+        "ignore rules now cover tracked paths; retracting them from graph truth with their \
+         entities and embeddings. The files stay on disk."
+    );
+}
+
+/// Remove the enrichment derived from every path a tree transition drops.
+///
+/// Entities, their relations, and their text and vector index presence are what
+/// make a path rankable, and none of it is inferred from the tree: kin-db keeps
+/// entity removal an explicit transition and refuses a tree change that would
+/// strand one. Clearing here is what lets a removal of any kind, a deleted file
+/// or a newly ignored one, take the whole artifact out rather than only its
+/// tree entry.
+pub(crate) fn evict_enrichment_for_removed_paths(
+    state: &DaemonState,
+    deltas: &[TreeDelta],
+) -> Result<Vec<EntityId>> {
+    let mut removed_entities = Vec::new();
+    for delta in deltas {
+        let TreeDelta::Removed { old, .. } = delta else {
+            continue;
+        };
+        let Some(file_id) = semantic_file_id(&old.path) else {
+            continue;
+        };
+        let cleanup = clear_incompatible_facets(state, &file_id, EnrichmentFacet::None)?;
+        for id in cleanup.removed_entities {
+            state.emit_event(DaemonEvent::EntityChanged {
+                entity_id: id,
+                change_type: ChangeType::Deleted,
+                file_path: Some(file_id.0.clone()),
+                session_id: None,
+            });
+            removed_entities.push(id);
+        }
+    }
+    Ok(removed_entities)
 }
 
 /// Clear UTF-8-only enrichment for an artifact the exact-tree transaction has
@@ -3047,6 +3183,122 @@ mod tests {
             pass.progress() > 0,
             "the supervisor must observe the reconcile pass admitting work"
         );
+    }
+
+    fn entity_ids_for(state: &DaemonState, file: &str) -> Vec<EntityId> {
+        let mut ids = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(file)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .map(|entity| entity.id)
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    /// Deleting a source file takes its entities with it.
+    ///
+    /// Entity removal is an explicit transition rather than something a tree
+    /// change implies, so an admission that dropped the artifact and left the
+    /// entities behind was refused outright: authority had already committed
+    /// the removal, the graph kept the old tree, and the watcher retried that
+    /// path for as long as the daemon ran.
+    #[tokio::test]
+    async fn deleting_an_entity_bearing_file_removes_its_entities_with_the_artifact() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        std::fs::write(root.join("gone.rs"), b"pub fn gone() -> u32 { 3 }\n").unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        let ids = entity_ids_for(&state, "gone.rs");
+        assert!(
+            !ids.is_empty(),
+            "the fixture admitted no entities, so nothing below proves an eviction"
+        );
+
+        std::fs::remove_file(root.join("gone.rs")).unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        assert!(tree_entry(&state, "gone.rs").is_none());
+        assert!(entity_ids_for(&state, "gone.rs").is_empty());
+        for id in &ids {
+            assert!(
+                state.graph.get_entity(id).unwrap().is_none(),
+                "a deleted file's entity id still resolves: {id}"
+            );
+        }
+        assert_eq!(
+            authority_tree(&state).artifact_at_path(&test_repo_path("gone.rs")),
+            None,
+            "graph truth and repository authority disagree about the removal"
+        );
+    }
+
+    /// A rule written after admission retracts what it names.
+    ///
+    /// Listing a path in `.kinignore` is a statement about the semantic index,
+    /// not only about future walks. The next admission therefore has to remove
+    /// the artifact and every entity, layout, and enrichment facet that let it
+    /// rank, while the file itself stays on disk.
+    #[tokio::test]
+    async fn a_rule_added_after_admission_retracts_the_path_and_its_entities() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+
+        std::fs::create_dir_all(root.join("investor/deck")).unwrap();
+        std::fs::write(
+            root.join("investor/deck/build_deck.rs"),
+            b"pub fn valuation_slide() -> u32 { 7 }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("keep.rs"), b"pub fn kept() -> u32 { 1 }\n").unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        let private_entities = entity_ids_for(&state, "investor/deck/build_deck.rs");
+        let kept_entities = entity_ids_for(&state, "keep.rs");
+        assert!(
+            !private_entities.is_empty(),
+            "the fixture admitted no entities, so nothing below proves an eviction"
+        );
+        assert!(!kept_entities.is_empty());
+
+        std::fs::write(root.join(".kinignore"), b"investor\n").unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        assert!(
+            tree_entry(&state, "investor/deck/build_deck.rs").is_none(),
+            "a newly ignored path is still tracked"
+        );
+        assert!(
+            entity_ids_for(&state, "investor/deck/build_deck.rs").is_empty(),
+            "a retracted path still owns entities"
+        );
+        for id in &private_entities {
+            assert!(
+                state.graph.get_entity(id).unwrap().is_none(),
+                "a retracted entity id still resolves: {id}"
+            );
+        }
+        assert!(!state
+            .graph
+            .entity_bearing_file_paths()
+            .contains(&"investor/deck/build_deck.rs".to_string()));
+        assert!(
+            root.join("investor/deck/build_deck.rs").exists(),
+            "retraction untracks a path; it must never delete the file"
+        );
+
+        // The two-sided arm: an unnamed sibling keeps its artifact and the
+        // exact entity ids it had, so the rule retracted one path rather than
+        // resetting the graph.
+        assert!(tree_entry(&state, "keep.rs").is_some());
+        assert_eq!(entity_ids_for(&state, "keep.rs"), kept_entities);
     }
 
     /// A file wide enough that indexing it takes long enough for a replacement to

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3299,6 +3299,49 @@ mod tests {
         assert_eq!(entity_ids_for(&state, "keep.rs"), kept_entities);
     }
 
+    /// A rule wide enough to empty the repository is refused, not obeyed.
+    ///
+    /// Retraction is automatic now, so a careless rule reaches graph truth
+    /// without anyone confirming it. The mass-deletion guard is what stands
+    /// between a mistyped `.kinignore` and a wiped graph, and it has to count
+    /// retractions the same way it counts deletions.
+    #[tokio::test]
+    async fn a_retraction_wide_enough_to_be_a_wipe_is_refused() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        std::fs::create_dir_all(root.join("bulk")).unwrap();
+        for index in 0..20 {
+            std::fs::write(
+                root.join(format!("bulk/member{index}.rs")),
+                format!("pub fn member_{index}() -> u32 {{ {index} }}\n"),
+            )
+            .unwrap();
+        }
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        let before = state.graph.resolved_tree();
+        assert_eq!(before.len(), 20, "the guard needs a non-trivial tree");
+
+        std::fs::write(root.join(".kinignore"), b"bulk\n").unwrap();
+        let error = sync_filesystem_with_graph(&state)
+            .await
+            .expect_err("a rule covering the whole repository must be refused");
+        assert!(
+            error.to_string().contains("unconfirmed mass deletion"),
+            "{error}"
+        );
+        assert_eq!(
+            state.graph.resolved_tree(),
+            before,
+            "a refused observation must retain graph truth whole"
+        );
+        assert!(
+            !entity_ids_for(&state, "bulk/member0.rs").is_empty(),
+            "a refused retraction must not have evicted anything"
+        );
+    }
+
     /// A file wide enough that indexing it takes long enough for a replacement to
     /// land between the reconciler's two reads.
     ///

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2028,7 +2028,6 @@ mod tests {
         state.blobs.read(&kin_blobs::Hash256(hash.0)).unwrap()
     }
 
-    #[cfg(unix)]
     fn authority_tree(state: &DaemonState) -> kin_model::ResolvedTree {
         let manifest =
             kin_core::manifest::KinManifest::load(&state.layout.manifest_path()).unwrap();

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -794,7 +794,7 @@ fn clear_incompatible_facets(
 /// quietly. A rule broad enough to cover a source tree has to be visible in the
 /// log the moment it takes effect rather than discovered later as a gap in
 /// query results.
-pub(crate) const ANNOUNCED_RETRACTION_SAMPLE: usize = 20;
+const ANNOUNCED_RETRACTION_SAMPLE: usize = 20;
 
 fn announce_retraction(retracted: &kin_index::IgnoredTrackedPaths) {
     if retracted.is_empty() {
@@ -828,8 +828,7 @@ fn announce_retraction(retracted: &kin_index::IgnoredTrackedPaths) {
 pub(crate) fn evict_enrichment_for_removed_paths(
     state: &DaemonState,
     deltas: &[TreeDelta],
-) -> Result<Vec<EntityId>> {
-    let mut removed_entities = Vec::new();
+) -> Result<()> {
     for delta in deltas {
         let TreeDelta::Removed { old, .. } = delta else {
             continue;
@@ -845,10 +844,9 @@ pub(crate) fn evict_enrichment_for_removed_paths(
                 file_path: Some(file_id.0.clone()),
                 session_id: None,
             });
-            removed_entities.push(id);
         }
     }
-    Ok(removed_entities)
+    Ok(())
 }
 
 /// Clear UTF-8-only enrichment for an artifact the exact-tree transaction has

--- a/crates/kin-daemon/src/repository_purge.rs
+++ b/crates/kin-daemon/src/repository_purge.rs
@@ -57,17 +57,11 @@ pub(crate) fn execute(
         }
     }
 
-    let covered = kin_index::tracked_paths_covered_by_ignore(&ignore, tracked.iter());
-    // A graph-only member's identity is owned by import truth and cannot be
-    // reconstructed from a host walk, so it is never retired by a rule that
-    // happens to match its path. Dropping it from the tracked set would also
-    // break the scanner's graph-only-is-a-subset-of-tracked precondition.
-    let purge_set = covered
-        .paths()
-        .iter()
-        .filter(|path| !graph_only.contains(*path))
-        .cloned()
-        .collect::<BTreeSet<_>>();
+    // The same rule source the daemon's own admission reads, so what this
+    // command reports and what a tick retracts can never be two different sets.
+    let covered =
+        kin_index::tracked_paths_retracted_by_ignore(&ignore, tracked.iter(), graph_only.iter());
+    let purge_set = covered.paths().iter().cloned().collect::<BTreeSet<_>>();
 
     let sample_paths = purge_set
         .iter()
@@ -158,6 +152,10 @@ pub(crate) fn execute(
     // artifacts, which would otherwise still be served as complete.
     let graph_mutation = state.begin_graph_authority_mutation();
     let generation = crate::loop_runner::publish_exact_workspace_tree(state, &admitted)?;
+    // Untracking an artifact while its entities keep ranking is the exposure a
+    // purge exists to close, so the enrichment goes with the tree entry and it
+    // goes before the graph is asked to accept a tree that no longer carries it.
+    crate::loop_runner::evict_enrichment_for_removed_paths(state, &deltas)?;
     state.graph.apply_transaction_delta(&TransactionDelta {
         entity_deltas: Vec::new(),
         relation_deltas: Vec::new(),

--- a/crates/kin-daemon/src/repository_purge.rs
+++ b/crates/kin-daemon/src/repository_purge.rs
@@ -3,11 +3,12 @@
 
 //! Daemon-owned retirement of tracked paths that ignore rules now cover.
 //!
-//! Ignore rules deliberately never hide tracked paths, so adding a rule cannot
-//! turn graph-owned identity into a deletion. The cost of that safety is a
-//! backlog: a repository that admitted derived output before a rule existed
-//! keeps carrying it. This module is the deliberate operator action that
-//! retires the backlog, and nothing here runs without an explicit confirmation.
+//! Admission retracts a covered path on its own, so this module is not what
+//! makes a rule take effect. It is the operator's surface for seeing the set
+//! before anything moves, and for retiring it now instead of on the next
+//! observation. Nothing here runs without an explicit confirmation, and it
+//! reads the same rule source admission does so the two cannot name different
+//! sets.
 //!
 //! The removal is published as one complete exact-tree observation, the same
 //! transition shape the watch loop admits, with one difference: the scan is
@@ -16,6 +17,10 @@
 //! as removed. Doing it through a real completed walk rather than a synthesized
 //! delta means the purge inherits the same completion proof, authority
 //! compare-and-swap, and mass-deletion guard as every other admission.
+//!
+//! The enrichment derived from a retired path goes with it. Untracking an
+//! artifact while its entities keep ranking is the exposure this exists to
+//! close, not an acceptable halfway state.
 
 use anyhow::{Context, Result};
 use kin_cli::commands::purge_ignored::{

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -68,7 +68,8 @@ pub use pipeline::{
 pub use repository::{
     host_path_from_repo_path, is_repository_control_path, read_verified_scanned_entry,
     repo_path_from_host_relative, scan_repository, scan_repository_preserving_graph_only,
-    should_track_host_relative_path, tracked_paths_covered_by_ignore, CompleteRepositoryScan,
+    should_track_host_relative_path, tracked_paths_covered_by_ignore,
+    tracked_paths_retracted_by_ignore, CompleteRepositoryScan,
     CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
     RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
 };

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -69,9 +69,9 @@ pub use repository::{
     host_path_from_repo_path, is_repository_control_path, read_verified_scanned_entry,
     repo_path_from_host_relative, scan_repository, scan_repository_preserving_graph_only,
     should_track_host_relative_path, tracked_paths_covered_by_ignore,
-    tracked_paths_retracted_by_ignore, CompleteRepositoryScan,
-    CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
-    RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
+    tracked_paths_retracted_by_ignore, CompleteRepositoryScan, CompleteScanToken,
+    IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore, RepositoryScanDiagnostics,
+    ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
 };
 pub use support::{compute_coverage_report, CoverageReport};
 pub use watcher::{FileEvent, FileWatcher};

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -526,6 +526,30 @@ pub fn tracked_paths_covered_by_ignore<'a>(
     }
 }
 
+/// Name the tracked paths that `ignore` retracts.
+///
+/// This is the one source every retraction reads, so what a rule excludes at
+/// admission and what it removes afterwards are decided by the same compiled
+/// rules and can never drift apart. [`RepositoryIgnore::matches`] is the single
+/// predicate underneath: the scanner applies it to decide whether an untracked
+/// leaf is admitted, and this applies it to decide whether an already-tracked
+/// path stays.
+///
+/// `graph_only` members are withheld. Their identity comes from import truth
+/// rather than from a host walk, so nothing could reconstruct them if a rule
+/// happened to match their path, and dropping them would also break the
+/// scanner's graph-only-is-a-subset-of-tracked precondition.
+pub fn tracked_paths_retracted_by_ignore<'a>(
+    ignore: &RepositoryIgnore,
+    tracked: impl IntoIterator<Item = &'a RepoPath>,
+    graph_only: impl IntoIterator<Item = &'a RepoPath>,
+) -> IgnoredTrackedPaths {
+    let graph_only = graph_only.into_iter().collect::<BTreeSet<_>>();
+    let mut covered = tracked_paths_covered_by_ignore(ignore, tracked);
+    covered.paths.retain(|path| !graph_only.contains(path));
+    covered
+}
+
 /// Convert a host-relative path to Kin's byte-exact repository path.
 pub fn repo_path_from_host_relative(path: &Path) -> io::Result<RepoPath> {
     let mut bytes = Vec::new();

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -1428,6 +1428,39 @@ mod tests {
         assert_eq!(none.retained_total(), 5);
     }
 
+    /// The retraction set is the covered set less graph-only membership, and it
+    /// answers with the same predicate the scanner admits by, so a rule cannot
+    /// exclude a path at admission while a retraction disagrees about it.
+    #[test]
+    fn retraction_matches_admission_and_withholds_graph_only_members() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::write(root.join(".kinignore"), b"investor\n").unwrap();
+        let ignore = RepositoryIgnore::load(root).unwrap();
+
+        let gitlink = path("investor/vendored");
+        let tracked = [
+            path("src/main.rs"),
+            path("investor/deck/build_deck.py"),
+            gitlink.clone(),
+        ];
+
+        let retracted =
+            tracked_paths_retracted_by_ignore(&ignore, tracked.iter(), std::iter::once(&gitlink));
+        assert_eq!(retracted.paths(), [path("investor/deck/build_deck.py")]);
+        assert_eq!(retracted.tracked_total(), 3);
+        assert_eq!(retracted.retained_total(), 2);
+
+        // Every retracted path is one the scanner would also refuse to admit.
+        for retracted in retracted.paths() {
+            assert!(ignore.matches(retracted), "{retracted}");
+        }
+        // Falsification: without the graph-only exemption the Gitlink is covered
+        // too, so the assertion above is testing the exemption and not the rule.
+        let covered = tracked_paths_covered_by_ignore(&ignore, tracked.iter());
+        assert!(covered.paths().contains(&gitlink));
+    }
+
     #[cfg(unix)]
     #[test]
     fn unsupported_untracked_special_entry_is_diagnosed_and_skipped() {

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -11,12 +11,18 @@
 //! system of record for source truth, not for derived bytes that any build
 //! reproduces.
 //!
-//! Ignore rules apply only to paths that are not already tracked. A tracked
-//! path remains observable after a rule begins matching it, so ignore
-//! configuration can never silently turn graph-owned truth into a deletion.
-//! Retiring already-admitted derived output is therefore a deliberate operator
-//! action: [`tracked_paths_covered_by_ignore`] names exactly which tracked
-//! paths a purge would untrack.
+//! The scanner itself applies ignore rules only to paths that are not already
+//! tracked, so a walk can never turn graph-owned identity into a deletion on
+//! its own. Deciding that an already-admitted path should go is the caller's,
+//! and it is made against graph truth rather than against the walk:
+//! [`tracked_paths_retracted_by_ignore`] names exactly which tracked paths the
+//! current rules retract, and a caller withholds those from the tracked set it
+//! passes here. Admission and retraction therefore read one compiled rule set
+//! through one predicate, [`RepositoryIgnore::matches`].
+//!
+//! Imported graph-only members are never in that set. Their identity comes from
+//! import truth and no host walk could rebuild it, so a rule matching their path
+//! does not retire them.
 //!
 //! A caller receives [`CompleteRepositoryScan`] only after every representable
 //! directory entry, metadata lookup, file read, and symbolic-link read


### PR DESCRIPTION
Adding a path to `.kinignore` said nothing about what the graph already held. The rules were read only while walking untracked leaves, so a file admitted before its rule existed stayed in graph truth and kept ranking in locate and search. Private material a user had listed as excluded remained queryable by name, path, and signature.

Admission now reads the same rules against graph-owned tracked identity. A tracked path the rules cover is retracted on the next observation, and the retraction takes the whole artifact rather than only its tree entry. Entities, relations, file layout, and text and vector index presence all go with it, because those are what let a path rank at all. The file itself stays on disk, since a rule untracks rather than deletes. Every retraction is announced with its count, the tracked total, and a bounded sample of paths, because removing graph-owned identity should never happen quietly. Imported graph-only members are withheld from the set, as their identity comes from import truth and no host walk could rebuild it.

Retractions are planned from the artifact ids the repository already holds instead of being inferred from the walk. The observation planner refuses an unmatched removal beside an unmatched addition, since a walk cannot tell that pair apart from a move, and writing the rule produces exactly that pair, because the `.kinignore` file arrives as the addition in the same observation its rule retracts something. Naming the removal by id keeps that guard intact and still lets a rule take effect on the surface a user writes it on.

Removing an entity-bearing file was already broken, and the retraction path reached the same defect a second way. kin-db keeps entity removal an explicit transition and refuses a tree change that would strand one, so the admission published the removal to repository authority and was then refused by the graph. Authority and graph disagreed about the file, and the watcher retried that path for the life of the daemon. Enrichment is now cleared before the graph is asked to accept the new tree, so the artifact leaves as one piece. `kin purge-ignored` gets the same treatment. It had been untracking artifacts while leaving behind the entities that made them rank, which is the exact shape of the reported symptom, where the artifact listing omits a file that locate still returns.

Admission filtering and retraction read one compiled rule set through one predicate, so what a rule excludes and what it removes cannot drift apart.

Tests cover the acceptance directly. A file is admitted with entities, a rule is added, and after the next observation the path no longer ranks while its entity ids resolve nowhere. An unnamed sibling keeps its artifact and the exact entity ids it had, so the change is shown to retract one path rather than reset the graph. The purge command carries the same two-sided arm, and the shared rule source is proved to answer with the predicate the scanner admits by and to withhold graph-only members. Each arm was falsified once by breaking the fix and watching it fail.

Closes FIR-2133
