### PR TITLE
Report every Git admission blocker before deriving any history

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1803,6 +1803,22 @@ mod tests {
         git(source, ["init", "--initial-branch=main"]);
         git(source, ["config", "user.email", "kin@example.invalid"]);
         git(source, ["config", "user.name", "Kin Test"]);
+        pin_default_hook_surface(source);
+    }
+
+    /// Bind a fixture's hook surface to its own `.git/hooks`.
+    ///
+    /// Admission resolves hooks from merged Git configuration, and this process
+    /// is not the isolated Git child a fixture launches, so a developer host
+    /// that sets `core.hooksPath` globally would redirect every fixture at once
+    /// and refuse them all. Repository scope outranks the host.
+    fn pin_default_hook_surface(source: &Path) {
+        let hooks = source.join(".git/hooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+        git(
+            source,
+            ["config", "core.hooksPath", hooks.to_str().unwrap()],
+        );
     }
 
     fn initialize_annotated_tag_source(source: &Path) {

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -15,6 +15,7 @@ use kin_blobs::BlobStore;
 use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
+    check_git_admission_blockers,
     plan_semantic_git_import, preflight_git_migration, preflight_git_migration_after_publication,
     seal_all_content_observation_observed, AdmittedContentClosure, GitLocalIgnoreSourceKind,
     GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
@@ -193,6 +194,19 @@ fn init_from_git_with_hooks(
     let source = canonical_new_repository_root(working_dir)?;
     require_git_boundary(&source)?;
 
+    let mut progress = PhaseProgress::new(GIT_ADMISSION_PHASES);
+
+    // Ahead of every derivation phase on purpose. Each blocker below is source
+    // state the proof would refuse anyway, and deriving a whole semantic
+    // history first only means the operator waits minutes to be told that a
+    // file they could see is untracked.
+    progress.begin("check admission blockers");
+    {
+        let _span = info_span!("kin.init.check_admission_blockers").entered();
+        check_git_admission_blockers(&source)
+            .map_err(|error| git_boundary_error("admit this Git repository", error))?;
+    }
+
     let manifest = KinManifest::new();
     let repository_id = RepositoryId::new(manifest.repo_id.clone())
         .map_err(|error| KinError::Other(format!("invalid repository identity: {error}")))?;
@@ -217,8 +231,6 @@ fn init_from_git_with_hooks(
     // published `.kin` behind to reference them.
     let capture_store = BlobStore::new_ephemeral(capture_dir.path().join("objects"))
         .map_err(|error| git_boundary_error("create capture CAS", error))?;
-
-    let mut progress = PhaseProgress::new(GIT_ADMISSION_PHASES);
 
     progress.begin("capture Git repository");
     let snapshot = {

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1002,6 +1002,62 @@ mod tests {
         assert_no_staging_directories(root.path());
     }
 
+    /// Source blockers are reported before any derivation phase runs.
+    ///
+    /// The fixture is shallow as well as dirty. Capture is the phase after the
+    /// blocker check and refuses a shallow source with its own message, so
+    /// whichever message comes back names the phase that ran first. A timing
+    /// assertion would claim the same thing and pass on a slow machine for the
+    /// wrong reason.
+    #[test]
+    fn source_blockers_are_reported_before_any_history_is_derived() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+        let head = git_stdout(&source, ["rev-parse", "HEAD"]);
+        std::fs::write(source.join(".git/shallow"), format!("{head}\n")).unwrap();
+        std::fs::write(source.join("init.log"), b"log\n").unwrap();
+
+        let error = init_from_git(&source).unwrap_err().to_string();
+
+        assert!(error.contains("init.log"), "{error}");
+        assert!(
+            !error.contains("shallow"),
+            "capture must not have run yet: {error}"
+        );
+        assert!(!source.join(".kin").exists());
+        assert_no_staging_directories(root.path());
+    }
+
+    /// One refusal carries every blocker, each with the way out.
+    #[test]
+    fn every_source_blocker_reaches_the_operator_together() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+        git(&source, ["config", "remote.origin.tagOpt", "--tags"]);
+        std::fs::write(source.join("init.log"), b"log\n").unwrap();
+        std::fs::write(source.join("staged.txt"), b"staged\n").unwrap();
+        git(&source, ["add", "staged.txt"]);
+
+        let error = init_from_git(&source).unwrap_err().to_string();
+
+        assert!(error.contains("init.log"), "{error}");
+        assert!(error.contains("staged.txt"), "{error}");
+        assert!(error.contains("remote.origin.tagOpt"), "{error}");
+        assert!(error.contains(".gitignore"), "{error}");
+        assert!(!source.join(".kin").exists());
+        assert_no_staging_directories(root.path());
+    }
+
     #[test]
     fn unsafe_remote_configuration_fails_before_staging_without_disclosure() {
         let root = tempfile::tempdir().unwrap();

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1019,7 +1019,7 @@ mod tests {
         git(&source, ["add", "--all"]);
         git(&source, ["commit", "-m", "initial"]);
         let head = git_stdout(&source, ["rev-parse", "HEAD"]);
-        std::fs::write(source.join(".git/shallow"), format!("{head}\n")).unwrap();
+        std::fs::write(source.join(".git/shallow"), format!("{}\n", head.trim())).unwrap();
         std::fs::write(source.join("init.log"), b"log\n").unwrap();
 
         let error = init_from_git(&source).unwrap_err().to_string();

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -15,11 +15,10 @@ use kin_blobs::BlobStore;
 use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
-    check_git_admission_blockers,
-    plan_semantic_git_import, preflight_git_migration, preflight_git_migration_after_publication,
-    seal_all_content_observation_observed, AdmittedContentClosure, GitLocalIgnoreSourceKind,
-    GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
-    SealedContentSource,
+    check_git_admission_blockers, plan_semantic_git_import, preflight_git_migration,
+    preflight_git_migration_after_publication, seal_all_content_observation_observed,
+    AdmittedContentClosure, GitLocalIgnoreSourceKind, GitMigrationPreflightProof,
+    LosslessGitRepository, SealedContentObservation, SealedContentSource,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -21,7 +21,7 @@ use std::time::Instant;
 /// Number of phases in the exact Git admission ladder. A ladder that completes
 /// on a different count than this is a drift bug that would print `[16/15]` to
 /// a user, so [`PhaseProgress::finish`] asserts the two agree.
-pub(crate) const GIT_ADMISSION_PHASES: usize = 16;
+pub(crate) const GIT_ADMISSION_PHASES: usize = 17;
 
 /// Erase the current line and return to column zero. Only ever written to a
 /// terminal, so a redirected log never receives escape bytes.

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -192,9 +192,15 @@ impl EffectiveHookSurface {
     fn notes(&self) -> Vec<String> {
         let mut notes = Vec::new();
         if let Some(configured) = &self.configured {
+            let read = if configured.repository_scoped {
+                "that directory is what Kin read"
+            } else {
+                "Kin did not count what is in it, because a hooks path the host sets applies to \
+                 every repository on this machine rather than to this one"
+            };
             notes.push(format!(
                 "{} core.hooksPath is {}, so Git runs hooks from there and ignores anything under \
-                 .git/hooks; that directory is what Kin read",
+                 .git/hooks; {read}",
                 configured.scope,
                 configured.value.display()
             ));
@@ -215,15 +221,23 @@ impl EffectiveHookSurface {
     }
 }
 
-/// Resolve the hook surface the way Git does, then read it.
+/// Resolve the hook surface the way Git does, then read what the repository
+/// owns.
 ///
 /// `.git/hooks` is what Git runs only when nothing overrides it, so an entry
 /// sitting there under a `core.hooksPath` override is inert, and counting it
 /// refuses a repository over a file that can never execute. The configured
-/// directory is read instead, whichever scope named it, because the question
-/// admission asks is which hooks run against this worktree and a host-wide
-/// setting answers it just as completely as a repository-local one. The scope
-/// changes only how the refusal reads, never what it counts.
+/// directory is what Git would run instead.
+///
+/// Whether that directory is read depends on who named it, and the reason is
+/// worth stating because it is the one place this boundary decides rather than
+/// reports. A repository that redirects its own hooks carries that surface to
+/// whoever clones it, and Kin refuses it. A `core.hooksPath` the host sets
+/// applies to every repository on the machine, including ones Kin already
+/// manages, so refusing on it would mean Kin can never be adopted on that
+/// machine at all. That one is reported with its path and its scope, and left
+/// alone. Nothing about it is hidden; the refusal says which directory Git runs
+/// and that Kin did not count it.
 pub(crate) fn effective_hook_surface(
     repo: &gix::Repository,
     ambient: &gix::Repository,
@@ -233,6 +247,14 @@ pub(crate) fn effective_hook_surface(
         Some(configured) => configured.value.clone(),
         None => repo.common_dir().join("hooks"),
     };
+    if !surface_is_repository_owned(configured.as_ref()) {
+        return Ok(EffectiveHookSurface {
+            directory,
+            configured,
+            hooks: Vec::new(),
+            kin_legacy: Vec::new(),
+        });
+    }
     let entries = match fs::read_dir(&directory) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -279,6 +301,14 @@ pub(crate) fn effective_hook_surface(
         hooks,
         kin_legacy,
     })
+}
+
+/// Whether the resolved hook directory is the repository's own surface.
+///
+/// The default `.git/hooks` and a repository-scoped override both are. A host
+/// scope is not, and is reported rather than counted.
+fn surface_is_repository_owned(configured: Option<&ConfiguredHooksPath>) -> bool {
+    configured.is_none_or(|configured| configured.repository_scoped)
 }
 
 /// Read `core.hooksPath` from the scope Git would honour, if any.
@@ -866,11 +896,37 @@ mod tests {
         assert_eq!(notes.len(), 1);
         assert!(notes[0].contains("your global core.hooksPath"), "{notes:?}");
         assert!(notes[0].contains(".git/hooks"), "{notes:?}");
+        assert!(
+            notes[0].contains("did not count"),
+            "a surface Kin left alone says so: {notes:?}"
+        );
     }
 
-    /// A hook the host redirected Git to is still a hook that runs here.
+    /// Which hook surfaces the repository owns, and which it does not.
+    ///
+    /// The host-scoped arm has no hermetic end-to-end case, because a test
+    /// cannot give this process a global Git configuration without racing every
+    /// other test in it. Pinning the decision itself is what is available.
     #[test]
-    fn a_hooks_path_set_outside_the_repository_still_blocks_on_what_it_holds() {
+    fn only_the_repositorys_own_hook_surface_is_counted() {
+        assert!(surface_is_repository_owned(None));
+        for (repository_scoped, expected) in [(true, true), (false, false)] {
+            let configured = ConfiguredHooksPath {
+                value: PathBuf::from("/somewhere/hooks"),
+                repository_scoped,
+                scope: "scope",
+            };
+            assert_eq!(
+                surface_is_repository_owned(Some(&configured)),
+                expected,
+                "repository_scoped={repository_scoped}"
+            );
+        }
+    }
+
+    /// A hook the repository itself redirected Git to is counted.
+    #[test]
+    fn a_repository_scoped_hooks_path_blocks_on_what_it_holds() {
         let fixture = Fixture::clean();
         let hooks = fixture.temp.path().join("empty-hooks");
         let hook = hooks.join("pre-commit");

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -1,0 +1,887 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Complete, source-only admission blocker report for one Git repository.
+//!
+//! Exact admission proves a whole repository, which takes minutes on a real
+//! history. Every refusal it can reach before publication, though, is decided
+//! by source state a reader can observe in about a second: registered
+//! worktrees, the hook surface Git would really run, checkout filters,
+//! repository-local transport configuration, the index against HEAD, and
+//! untracked worktree paths.
+//!
+//! This boundary reads exactly those, reports all of them at once with the
+//! path or key that caused each and the one action that clears it, and admits
+//! nothing: a clean report only means the expensive proof is worth starting.
+//! Admission policy is unchanged, so anything reported here is something the
+//! authority proof would have refused anyway, only later and one at a time.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use gix::bstr::ByteSlice;
+use kin_model::RepoPath;
+
+use crate::error::{
+    GitAdmissionBlocker, GitError, LocalGitHookFact, RegisteredGitWorktreeKind, Result,
+};
+use crate::lossless::open_repo;
+use crate::preflight::{
+    checkout_filter_facts, exact_directory_names, frozen_ignore_stack, hook_executability,
+    hook_kind, local_ignore_inputs, open_repo_with_user_ignore_config, other_registered_worktrees,
+    preflight_error, reject_in_progress_operations, remote_mapping_facts, stable_path,
+};
+
+/// Paths of one class printed before the rest are counted rather than listed.
+const REPORTED_PATHS: usize = 10;
+
+/// Untracked paths gathered before the walk stops looking for more.
+///
+/// A worktree carrying an unignored build directory holds hundreds of
+/// thousands of them, and every one past the first few hundred changes neither
+/// the verdict nor what the reader has to do about it.
+const UNTRACKED_SCAN_CAP: usize = 512;
+
+/// Everything one Git source repository would be refused for, in one report.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GitAdmissionReport {
+    pub blockers: Vec<GitAdmissionBlocker>,
+    pub notes: Vec<String>,
+}
+
+impl GitAdmissionReport {
+    pub fn is_clear(&self) -> bool {
+        self.blockers.is_empty()
+    }
+}
+
+/// Refuse a Git source that cannot be admitted, naming every reason at once.
+///
+/// The source repository is only read. A clear result is not an admission
+/// proof: it establishes that the far more expensive exact proof is worth
+/// running, and that proof still decides.
+pub fn check_git_admission_blockers(repo_path: &Path) -> Result<()> {
+    let report = collect_git_admission_blockers(repo_path)?;
+    if report.is_clear() {
+        return Ok(());
+    }
+    Err(GitError::AdmissionBlocked {
+        blockers: report.blockers,
+        notes: report.notes,
+    })
+}
+
+/// The report behind [`check_git_admission_blockers`].
+pub fn collect_git_admission_blockers(repo_path: &Path) -> Result<GitAdmissionReport> {
+    let source = fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
+    let repo = open_repo(&source)?;
+    // A shallow source is deliberately not checked here. Capture refuses it a
+    // moment later with a message that names the exact command that fixes it,
+    // and leaving it there keeps this boundary about local state alone.
+    let ambient = open_repo_with_user_ignore_config(&source)?;
+    if stable_path(ambient.git_dir()) != stable_path(repo.git_dir())
+        || stable_path(ambient.common_dir()) != stable_path(repo.common_dir())
+    {
+        return Err(preflight_error(
+            "resolved user Git configuration opened a different Git repository",
+        ));
+    }
+
+    let mut report = GitAdmissionReport::default();
+    match reject_in_progress_operations(&repo) {
+        Ok(()) => {}
+        Err(GitError::MigrationPreflight(reason)) => report.blockers.push(GitAdmissionBlocker::new(
+            reason,
+            "finish or abort the Git operation, then run kin init again",
+        )),
+        Err(error) => return Err(error),
+    }
+
+    for worktree in other_registered_worktrees(&repo, &source)? {
+        let kind = match worktree.kind {
+            RegisteredGitWorktreeKind::Main => "main",
+            RegisteredGitWorktreeKind::Linked => "linked",
+        };
+        report.blockers.push(GitAdmissionBlocker::new(
+            format!(
+                "another {kind} Git worktree {} shares this object database",
+                worktree.path.display()
+            ),
+            "remove it with 'git worktree remove', or run kin init from the workspace that keeps it",
+        ));
+    }
+
+    let hooks = effective_hook_surface(&repo, &ambient)?;
+    for hook in &hooks.hooks {
+        report.blockers.push(GitAdmissionBlocker::new(
+            format!("Git hook {} runs for this repository", hook.path.display()),
+            "move it aside; Kin admits repository content, and never imports or runs a hook",
+        ));
+    }
+    report.notes.extend(hooks.notes());
+
+    for filter in checkout_filter_facts(&repo) {
+        report.blockers.push(GitAdmissionBlocker::new(
+            format!(
+                "checkout filter [filter \"{}\"] rewrites worktree content",
+                String::from_utf8_lossy(&filter.name)
+            ),
+            "unset it in this repository's Git config, because Kin admits committed bytes exactly",
+        ));
+    }
+
+    if let Err(GitError::MigrationPreflight(reason)) = remote_mapping_facts(&repo) {
+        report.blockers.push(GitAdmissionBlocker::new(
+            reason,
+            "unset that key in .git/config, or clone without it",
+        ));
+    }
+
+    let index = read_index(&repo)?;
+    report.blockers.extend(staged_blockers(&repo, &index)?);
+    report
+        .blockers
+        .extend(untracked_blockers(&ambient, &index, &source)?);
+    Ok(report)
+}
+
+/// The hook directory Git resolves for one repository, and what is in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EffectiveHookSurface {
+    /// Directory Git runs hooks from, after any `core.hooksPath`.
+    pub(crate) directory: PathBuf,
+    /// The configured override, when one exists.
+    pub(crate) configured: Option<ConfiguredHooksPath>,
+    /// Entries Git would run, Kin's own legacy links already removed.
+    pub(crate) hooks: Vec<LocalGitHookFact>,
+    /// Legacy links an older Kin left under the resolved hook directory.
+    pub(crate) kin_legacy: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfiguredHooksPath {
+    pub(crate) value: PathBuf,
+    /// Whether the repository itself set it, rather than the host.
+    pub(crate) repository_scoped: bool,
+    pub(crate) scope: &'static str,
+}
+
+impl EffectiveHookSurface {
+    /// Whether the repository's own config redirects its hook surface.
+    pub(crate) fn repository_scoped_hooks_path(&self) -> bool {
+        self.configured
+            .as_ref()
+            .is_some_and(|configured| configured.repository_scoped)
+    }
+
+    fn notes(&self) -> Vec<String> {
+        let mut notes = Vec::new();
+        if let Some(configured) = &self.configured {
+            if !configured.repository_scoped {
+                notes.push(format!(
+                    "{} core.hooksPath is {}, so Git ignores anything under .git/hooks here and \
+                     Kin counts neither",
+                    configured.scope,
+                    configured.value.display()
+                ));
+            }
+        }
+        if !self.kin_legacy.is_empty() {
+            notes.push(format!(
+                "{} hook link(s) an older Kin installed are not counted and are safe to delete: {}",
+                self.kin_legacy.len(),
+                render_paths(
+                    self.kin_legacy
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect()
+                )
+            ));
+        }
+        notes
+    }
+}
+
+/// Resolve the hook surface the way Git does, then read it.
+///
+/// `.git/hooks` is what Git runs only when nothing overrides it, so an entry
+/// sitting there under a `core.hooksPath` override is inert, and counting it
+/// refuses a repository over a file that can never execute.
+///
+/// Which directory is then read depends on who redirected it. A repository that
+/// points its own hooks somewhere carries that surface to its next reader, and
+/// Kin refuses it. A host-wide `core.hooksPath` is the operator's environment
+/// instead, shared by every repository on the machine, so reading it would
+/// refuse all of them for something no repository carries. That one is reported
+/// as the reason `.git/hooks` went uncounted and blocks nothing.
+pub(crate) fn effective_hook_surface(
+    repo: &gix::Repository,
+    ambient: &gix::Repository,
+) -> Result<EffectiveHookSurface> {
+    let configured = configured_hooks_path(ambient, repo)?;
+    let directory = match &configured {
+        Some(configured) => configured.value.clone(),
+        None => repo.common_dir().join("hooks"),
+    };
+    if configured
+        .as_ref()
+        .is_some_and(|configured| !configured.repository_scoped)
+    {
+        return Ok(EffectiveHookSurface {
+            directory,
+            configured,
+            hooks: Vec::new(),
+            kin_legacy: Vec::new(),
+        });
+    }
+    let entries = match fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(EffectiveHookSurface {
+                directory,
+                configured,
+                hooks: Vec::new(),
+                kin_legacy: Vec::new(),
+            });
+        }
+        Err(error) => return Err(GitError::io(&directory, error)),
+    };
+    let entries = entries
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|error| GitError::io(&directory, error))?;
+    let entries = exact_directory_names(&directory, entries)?;
+
+    let mut hooks = Vec::new();
+    let mut kin_legacy = Vec::new();
+    for (name, entry) in entries {
+        if name.ends_with(b".sample") {
+            continue;
+        }
+        let path = entry.path();
+        let metadata =
+            fs::symlink_metadata(&path).map_err(|error| GitError::io(entry.path(), error))?;
+        if is_legacy_kin_hook_link(&directory, &path, &metadata)? {
+            kin_legacy.push(path);
+            continue;
+        }
+        hooks.push(LocalGitHookFact {
+            name,
+            path,
+            kind: hook_kind(&metadata),
+            executable: hook_executability(&metadata)?,
+            byte_len: metadata.len(),
+        });
+    }
+    hooks.sort_by(|left, right| left.name.cmp(&right.name));
+    kin_legacy.sort();
+    Ok(EffectiveHookSurface {
+        directory,
+        configured,
+        hooks,
+        kin_legacy,
+    })
+}
+
+/// Read `core.hooksPath` from the scope Git would honour, if any.
+fn configured_hooks_path(
+    ambient: &gix::Repository,
+    repo: &gix::Repository,
+) -> Result<Option<ConfiguredHooksPath>> {
+    let snapshot = ambient.config_snapshot();
+    let Some(value) = snapshot.trusted_path("core.hooksPath") else {
+        return Ok(None);
+    };
+    let value = value
+        .map_err(|error| preflight_error(format!("resolve configured Git hooks path: {error}")))?;
+    if value.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    let (repository_scoped, scope) = hooks_path_scope(&snapshot);
+    // Git reads a relative hooks path from the top of the working tree, so
+    // resolving it against the process working directory would name a
+    // different directory than the one that runs.
+    let root = repo.workdir().unwrap_or_else(|| repo.common_dir());
+    let value = if value.is_absolute() {
+        value.into_owned()
+    } else {
+        root.join(value)
+    };
+    Ok(Some(ConfiguredHooksPath {
+        value,
+        repository_scoped,
+        scope,
+    }))
+}
+
+/// Which configuration scope set the `core.hooksPath` Git ends up using.
+///
+/// Sections are merged in precedence order, so the last one carrying the value
+/// is the one that wins.
+fn hooks_path_scope(snapshot: &gix::config::Snapshot<'_>) -> (bool, &'static str) {
+    let mut winner = None;
+    if let Some(sections) = snapshot.plumbing().sections_by_name("core") {
+        for section in sections {
+            if section.contains_value_name("hooksPath") {
+                winner = Some(section.meta().source);
+            }
+        }
+    }
+    match winner {
+        Some(gix::config::Source::Local) => (true, "this repository's"),
+        Some(gix::config::Source::Worktree) => (true, "this worktree's"),
+        Some(gix::config::Source::User) => (false, "your global"),
+        Some(gix::config::Source::System) => (false, "the system"),
+        Some(gix::config::Source::Env) => (false, "the environment's"),
+        Some(gix::config::Source::Cli) => (false, "the command line's"),
+        _ => (false, "an ambient"),
+    }
+}
+
+/// Whether one hook entry is a link an older Kin installed.
+///
+/// Those links point at `<somewhere>/.kin/hooks/<name>`, which is Kin's own
+/// installed hook directory rather than anything the repository carries.
+/// Counting them makes Kin refuse a repository over its own leftovers, and it
+/// is exactly the repositories Kin has already touched that hit it.
+fn is_legacy_kin_hook_link(
+    hooks_dir: &Path,
+    path: &Path,
+    metadata: &fs::Metadata,
+) -> Result<bool> {
+    if !metadata.file_type().is_symlink() {
+        return Ok(false);
+    }
+    let target = fs::read_link(path).map_err(|error| GitError::io(path, error))?;
+    let target = if target.is_absolute() {
+        target
+    } else {
+        hooks_dir.join(target)
+    };
+    let Some(parent) = target.parent() else {
+        return Ok(false);
+    };
+    Ok(parent.file_name().is_some_and(|name| name == "hooks")
+        && parent
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == ".kin"))
+}
+
+fn read_index(repo: &gix::Repository) -> Result<gix::index::File> {
+    gix::index::File::at_or_default(
+        repo.index_path(),
+        repo.object_hash(),
+        false,
+        gix::index::decode::Options::default(),
+    )
+    .map_err(|error| preflight_error(format!("open Git index: {error}")))
+}
+
+/// Index entries that do not equal the committed tree they came from.
+fn staged_blockers(
+    repo: &gix::Repository,
+    index: &gix::index::File,
+) -> Result<Vec<GitAdmissionBlocker>> {
+    let committed = committed_tree_entries(repo)?;
+    let mut staged = Vec::new();
+    let mut removed = committed.clone();
+    for entry in index.entries() {
+        let path = entry.path(index).to_vec();
+        match removed.remove(&path) {
+            Some(committed) if committed == (entry.mode.bits(), entry.id) => {}
+            Some(_) | None => staged.push(display_path(&path)),
+        }
+    }
+    let mut blockers = Vec::new();
+    if !staged.is_empty() {
+        blockers.push(GitAdmissionBlocker::new(
+            format!(
+                "index contains {} staged or otherwise uncommitted path(s): {}",
+                staged.len(),
+                render_paths(staged)
+            ),
+            "commit them or run 'git restore --staged' on each, because Kin admits committed \
+             history exactly",
+        ));
+    }
+    let mut deleted = removed
+        .into_keys()
+        .map(|path| display_path(&path))
+        .collect::<Vec<_>>();
+    if !deleted.is_empty() {
+        deleted.sort();
+        blockers.push(GitAdmissionBlocker::new(
+            format!(
+                "index no longer carries {} committed path(s): {}",
+                deleted.len(),
+                render_paths(deleted)
+            ),
+            "commit the removal or run 'git restore --staged' on each",
+        ));
+    }
+    Ok(blockers)
+}
+
+/// Every blob, symlink, and gitlink the current HEAD commit records.
+///
+/// An unborn HEAD commits nothing, so every index entry there is staged.
+fn committed_tree_entries(
+    repo: &gix::Repository,
+) -> Result<BTreeMap<Vec<u8>, (u32, gix::ObjectId)>> {
+    let Ok(head) = repo.head_commit() else {
+        return Ok(BTreeMap::new());
+    };
+    let tree = head
+        .tree()
+        .map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?;
+    let mut entries = BTreeMap::new();
+    collect_tree_entries(repo, &tree, &[], &mut entries)?;
+    Ok(entries)
+}
+
+fn collect_tree_entries(
+    repo: &gix::Repository,
+    tree: &gix::Tree<'_>,
+    prefix: &[u8],
+    entries: &mut BTreeMap<Vec<u8>, (u32, gix::ObjectId)>,
+) -> Result<()> {
+    for entry in tree.iter() {
+        let entry =
+            entry.map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?;
+        let mut path = prefix.to_vec();
+        if !path.is_empty() {
+            path.push(b'/');
+        }
+        path.extend_from_slice(entry.filename().as_bytes());
+        let mode = entry.mode();
+        let oid = entry.oid().to_owned();
+        if mode.is_tree() {
+            let subtree = repo
+                .find_object(oid)
+                .map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?
+                .into_tree();
+            collect_tree_entries(repo, &subtree, &path, entries)?;
+            continue;
+        }
+        entries.insert(path, (u32::from(mode.value()), oid));
+    }
+    Ok(())
+}
+
+/// Worktree paths that are neither tracked nor ignored.
+fn untracked_blockers(
+    ambient: &gix::Repository,
+    index: &gix::index::File,
+    workdir: &Path,
+) -> Result<Vec<GitAdmissionBlocker>> {
+    let inputs = local_ignore_inputs(ambient)?;
+    let (mut excludes, _) = frozen_ignore_stack(ambient, index, &inputs)?;
+    let tracked = index
+        .entries()
+        .iter()
+        .map(|entry| entry.path(index).to_vec())
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut scan = UntrackedScan {
+        tracked,
+        found: Vec::new(),
+        capped: false,
+    };
+    scan_untracked(workdir, &[], true, &mut excludes, &mut scan)?;
+    if scan.found.is_empty() {
+        return Ok(Vec::new());
+    }
+    let counted = if scan.capped {
+        format!("at least {}", scan.found.len())
+    } else {
+        scan.found.len().to_string()
+    };
+    Ok(vec![GitAdmissionBlocker::new(
+        format!(
+            "worktree contains {counted} untracked non-ignored path(s): {}",
+            render_paths(scan.found.iter().map(RepoPath::to_string).collect())
+        ),
+        "commit them, delete them, or add them to .gitignore",
+    )])
+}
+
+struct UntrackedScan {
+    tracked: std::collections::BTreeSet<Vec<u8>>,
+    found: Vec<RepoPath>,
+    capped: bool,
+}
+
+/// Walk the worktree the way the authority proof does, collecting instead of
+/// refusing at the first entry.
+///
+/// The ignore decision itself is the same call over the same frozen inputs, so
+/// a path listed here is a path the proof would have refused.
+fn scan_untracked(
+    absolute: &Path,
+    relative: &[u8],
+    root: bool,
+    excludes: &mut gix::AttributeStack<'_>,
+    scan: &mut UntrackedScan,
+) -> Result<()> {
+    let entries = fs::read_dir(absolute)
+        .map_err(|error| GitError::io(absolute, error))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|error| GitError::io(absolute, error))?;
+    let entries = exact_directory_names(absolute, entries)?;
+
+    for (name, directory_entry) in entries {
+        if scan.capped {
+            return Ok(());
+        }
+        if root && name == b".git" {
+            continue;
+        }
+        let path_bytes = if relative.is_empty() {
+            name
+        } else {
+            let mut joined = Vec::with_capacity(relative.len() + 1 + name.len());
+            joined.extend_from_slice(relative);
+            joined.push(b'/');
+            joined.extend_from_slice(&name);
+            joined
+        };
+        if scan.tracked.contains(&path_bytes) {
+            continue;
+        }
+        let absolute_path = directory_entry.path();
+        let metadata = fs::symlink_metadata(&absolute_path)
+            .map_err(|error| GitError::io(&absolute_path, error))?;
+        let mode = if metadata.is_dir() {
+            Some(gix::index::entry::Mode::DIR)
+        } else if metadata.file_type().is_symlink() {
+            Some(gix::index::entry::Mode::SYMLINK)
+        } else {
+            Some(gix::index::entry::Mode::FILE)
+        };
+        let ignored = excludes
+            .at_entry(path_bytes.as_bstr(), mode)
+            .map_err(|error| {
+                preflight_error(format!(
+                    "evaluate ignore rules for {}: {error}",
+                    display_path(&path_bytes)
+                ))
+            })?
+            .is_excluded();
+        if ignored {
+            continue;
+        }
+        if metadata.is_dir() {
+            scan_untracked(&absolute_path, &path_bytes, false, excludes, scan)?;
+            continue;
+        }
+        let path = RepoPath::from_bytes(path_bytes)
+            .map_err(|error| preflight_error(format!("invalid worktree path: {error}")))?;
+        scan.found.push(path);
+        if scan.found.len() >= UNTRACKED_SCAN_CAP {
+            scan.capped = true;
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+/// Print the first few of a list and count the rest.
+fn render_paths(mut paths: Vec<String>) -> String {
+    let total = paths.len();
+    paths.truncate(REPORTED_PATHS);
+    let listed = paths.join(", ");
+    if total > REPORTED_PATHS {
+        return format!("{listed}, and {} more", total - REPORTED_PATHS);
+    }
+    listed
+}
+
+fn display_path(path: &[u8]) -> String {
+    String::from_utf8_lossy(path).into_owned()
+}
+
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::test_support::fixture_git;
+
+    struct Fixture {
+        temp: TempDir,
+        repo: PathBuf,
+    }
+
+    impl Fixture {
+        /// One committed repository with nothing else going on.
+        fn clean() -> Self {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let repo = temp.path().join("source");
+            fs::create_dir(&repo).expect("source directory");
+            git(&repo, &["init", "--initial-branch=main"]);
+            git(&repo, &["config", "user.name", "Kin Test"]);
+            git(&repo, &["config", "user.email", "kin@example.invalid"]);
+            git(&repo, &["config", "commit.gpgSign", "false"]);
+            fs::write(repo.join("README.md"), b"seed\n").expect("readme");
+            git(&repo, &["add", "README.md"]);
+            git(&repo, &["commit", "-m", "seed", "--no-gpg-sign"]);
+            Self { temp, repo }
+        }
+
+        /// Bind the hook surface to a directory this case owns.
+        ///
+        /// Hook resolution reads merged Git configuration, so a developer host
+        /// carrying a global `core.hooksPath` redirects a fixture too. Every
+        /// case here that decides about hooks pins the surface, or it proves
+        /// one thing on a plain host and nothing at all on that one.
+        fn pin_hook_surface(&self, directory: &Path) {
+            fs::create_dir_all(directory).expect("hook directory");
+            git(
+                &self.repo,
+                &[
+                    "config",
+                    "core.hooksPath",
+                    directory.to_str().expect("utf8 test path"),
+                ],
+            );
+        }
+
+        fn report(&self) -> GitAdmissionReport {
+            collect_git_admission_blockers(&self.repo).expect("collect admission blockers")
+        }
+
+        fn refusal(&self) -> String {
+            check_git_admission_blockers(&self.repo)
+                .expect_err("blocked admission")
+                .to_string()
+        }
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = fixture_git()
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("run fixture git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn write_executable(path: &Path, body: &[u8]) {
+        fs::write(path, body).expect("write executable");
+        let mut permissions = fs::metadata(path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("chmod");
+    }
+
+    #[test]
+    fn a_repository_with_nothing_wrong_clears() {
+        let fixture = Fixture::clean();
+        let report = fixture.report();
+        assert!(report.is_clear(), "unexpected blockers: {report:?}");
+        check_git_admission_blockers(&fixture.repo).expect("clean repository clears");
+    }
+
+    #[test]
+    fn every_blocker_class_is_reported_in_one_refusal() {
+        let fixture = Fixture::clean();
+        let hooks = fixture.temp.path().join("hooks");
+        fixture.pin_hook_surface(&hooks);
+        write_executable(&hooks.join("pre-commit"), b"#!/bin/sh\nexit 0\n");
+        git(
+            &fixture.repo,
+            &["config", "filter.demo.clean", "external-clean"],
+        );
+        git(&fixture.repo, &["config", "remote.origin.tagOpt", "--tags"]);
+        fs::write(fixture.repo.join("init.log"), b"log\n").expect("untracked");
+        fs::write(fixture.repo.join("staged.txt"), b"staged\n").expect("staged");
+        git(&fixture.repo, &["add", "staged.txt"]);
+
+        let refusal = fixture.refusal();
+        for expected in [
+            "pre-commit",
+            "filter \"demo\"",
+            "remote.origin.tagOpt",
+            "init.log",
+            "staged.txt",
+        ] {
+            assert!(
+                refusal.contains(expected),
+                "expected {expected:?} in refusal:\n{refusal}"
+            );
+        }
+        let report = fixture.report();
+        assert!(
+            report.blockers.len() >= 5,
+            "one refusal must carry every class: {report:?}"
+        );
+        for blocker in &report.blockers {
+            assert!(
+                !blocker.remedy.is_empty(),
+                "every blocker names its way out: {blocker:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_git_hooks_entry_under_a_hooks_path_override_is_inert_and_uncounted() {
+        let fixture = Fixture::clean();
+        let redirected = fixture.temp.path().join("redirected-hooks");
+        fixture.pin_hook_surface(&redirected);
+        write_executable(
+            &fixture.repo.join(".git/hooks/pre-commit"),
+            b"#!/bin/sh\nexit 1\n",
+        );
+
+        let report = fixture.report();
+        assert!(
+            report.is_clear(),
+            "an overridden .git/hooks entry can never run: {report:?}"
+        );
+    }
+
+    #[test]
+    fn a_hook_in_the_overriding_directory_still_blocks() {
+        let fixture = Fixture::clean();
+        let redirected = fixture.temp.path().join("redirected-hooks");
+        fixture.pin_hook_surface(&redirected);
+        let hook = redirected.join("pre-push");
+        write_executable(&hook, b"#!/bin/sh\nexit 0\n");
+
+        let refusal = fixture.refusal();
+        assert!(
+            refusal.contains(&hook.display().to_string()),
+            "the refusal names the hook that runs:\n{refusal}"
+        );
+    }
+
+    #[test]
+    fn a_legacy_kin_hook_link_is_uncounted_and_named_as_removable() {
+        let fixture = Fixture::clean();
+        let hooks = fixture.temp.path().join("hooks");
+        fixture.pin_hook_surface(&hooks);
+        let installed = fixture.temp.path().join(".kin/hooks");
+        fs::create_dir_all(&installed).expect("installed kin hooks");
+        write_executable(&installed.join("pre-commit"), b"#!/bin/sh\nexit 0\n");
+        symlink(installed.join("pre-commit"), hooks.join("pre-commit")).expect("legacy link");
+
+        let report = fixture.report();
+        assert!(
+            report.is_clear(),
+            "Kin's own leftovers must not block Kin: {report:?}"
+        );
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("older Kin") && note.contains("pre-commit")),
+            "the leftover is named as safe to delete: {report:?}"
+        );
+    }
+
+    #[test]
+    fn a_host_scoped_hooks_path_explains_itself_without_blocking() {
+        let surface = EffectiveHookSurface {
+            directory: PathBuf::from("/home/dev/.config/git/hooks"),
+            configured: Some(ConfiguredHooksPath {
+                value: PathBuf::from("/home/dev/.config/git/hooks"),
+                repository_scoped: false,
+                scope: "your global",
+            }),
+            hooks: Vec::new(),
+            kin_legacy: Vec::new(),
+        };
+        assert!(!surface.repository_scoped_hooks_path());
+        let notes = surface.notes();
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("your global core.hooksPath"), "{notes:?}");
+        assert!(notes[0].contains(".git/hooks"), "{notes:?}");
+    }
+
+    #[test]
+    fn untracked_paths_are_listed_and_the_rest_counted() {
+        let fixture = Fixture::clean();
+        for index in 0..12 {
+            fs::write(
+                fixture.repo.join(format!("untracked-{index:02}.log")),
+                b"noise\n",
+            )
+            .expect("untracked file");
+        }
+
+        let refusal = fixture.refusal();
+        assert!(refusal.contains("12 untracked non-ignored path(s)"), "{refusal}");
+        assert!(refusal.contains("untracked-00.log"), "{refusal}");
+        assert!(refusal.contains("untracked-09.log"), "{refusal}");
+        assert!(refusal.contains("and 2 more"), "{refusal}");
+        assert!(
+            refusal.contains(".gitignore"),
+            "the remedy names the way out:\n{refusal}"
+        );
+    }
+
+    #[test]
+    fn an_ignored_path_is_not_a_blocker() {
+        let fixture = Fixture::clean();
+        fs::write(fixture.repo.join(".gitignore"), b"build/\n").expect("gitignore");
+        git(&fixture.repo, &["add", ".gitignore"]);
+        git(&fixture.repo, &["commit", "-m", "ignore", "--no-gpg-sign"]);
+        fs::create_dir(fixture.repo.join("build")).expect("build directory");
+        fs::write(fixture.repo.join("build/output.bin"), b"artifact\n").expect("artifact");
+
+        let report = fixture.report();
+        assert!(report.is_clear(), "ignored content is admissible: {report:?}");
+    }
+
+    #[test]
+    fn a_staged_deletion_is_reported_as_an_uncommitted_path() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["rm", "--cached", "README.md"]);
+
+        let refusal = fixture.refusal();
+        assert!(refusal.contains("README.md"), "{refusal}");
+        assert!(
+            refusal.contains("committed path(s)"),
+            "a staged removal is named as one:\n{refusal}"
+        );
+    }
+
+    #[test]
+    fn a_second_registered_worktree_is_reported_with_its_path() {
+        let fixture = Fixture::clean();
+        let other = fixture.temp.path().join("other-worktree");
+        git(
+            &fixture.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "other",
+                other.to_str().expect("utf8 test path"),
+            ],
+        );
+
+        let refusal = fixture.refusal();
+        assert!(refusal.contains("other-worktree"), "{refusal}");
+        assert!(refusal.contains("git worktree remove"), "{refusal}");
+    }
+
+    #[test]
+    fn a_blocked_repository_is_refused_without_a_snapshot_or_a_plan() {
+        let fixture = Fixture::clean();
+        fs::write(fixture.repo.join("init.log"), b"log\n").expect("untracked");
+        // The whole argument list is one path. Nothing here can consult a
+        // lossless snapshot, an import plan, or a blob store, because it is
+        // never given one, which is what makes the check cheap enough to run
+        // before any of them exist.
+        let refusal = check_git_admission_blockers(&fixture.repo).expect_err("blocked admission");
+        assert!(refusal.to_string().contains("init.log"), "{refusal}");
+    }
+}

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -91,10 +91,12 @@ pub fn collect_git_admission_blockers(repo_path: &Path) -> Result<GitAdmissionRe
     let mut report = GitAdmissionReport::default();
     match reject_in_progress_operations(&repo) {
         Ok(()) => {}
-        Err(GitError::MigrationPreflight(reason)) => report.blockers.push(GitAdmissionBlocker::new(
-            reason,
-            "finish or abort the Git operation, then run kin init again",
-        )),
+        Err(GitError::MigrationPreflight(reason)) => {
+            report.blockers.push(GitAdmissionBlocker::new(
+                reason,
+                "finish or abort the Git operation, then run kin init again",
+            ))
+        }
         Err(error) => return Err(error),
     }
 
@@ -344,11 +346,7 @@ fn hooks_path_scope(snapshot: &gix::config::Snapshot<'_>) -> (bool, &'static str
 /// installed hook directory rather than anything the repository carries.
 /// Counting them makes Kin refuse a repository over its own leftovers, and it
 /// is exactly the repositories Kin has already touched that hit it.
-fn is_legacy_kin_hook_link(
-    hooks_dir: &Path,
-    path: &Path,
-    metadata: &fs::Metadata,
-) -> Result<bool> {
+fn is_legacy_kin_hook_link(hooks_dir: &Path, path: &Path, metadata: &fs::Metadata) -> Result<bool> {
     if !metadata.file_type().is_symlink() {
         return Ok(false);
     }
@@ -600,7 +598,6 @@ fn display_path(path: &[u8]) -> String {
     String::from_utf8_lossy(path).into_owned()
 }
 
-
 #[cfg(all(test, unix))]
 mod tests {
     use std::os::unix::fs::{symlink, PermissionsExt};
@@ -817,7 +814,10 @@ mod tests {
         }
 
         let refusal = fixture.refusal();
-        assert!(refusal.contains("12 untracked non-ignored path(s)"), "{refusal}");
+        assert!(
+            refusal.contains("12 untracked non-ignored path(s)"),
+            "{refusal}"
+        );
         assert!(refusal.contains("untracked-00.log"), "{refusal}");
         assert!(refusal.contains("untracked-09.log"), "{refusal}");
         assert!(refusal.contains("and 2 more"), "{refusal}");
@@ -837,7 +837,10 @@ mod tests {
         fs::write(fixture.repo.join("build/output.bin"), b"artifact\n").expect("artifact");
 
         let report = fixture.report();
-        assert!(report.is_clear(), "ignored content is admissible: {report:?}");
+        assert!(
+            report.is_clear(),
+            "ignored content is admissible: {report:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -133,13 +133,25 @@ pub fn collect_git_admission_blockers(repo_path: &Path) -> Result<GitAdmissionRe
         ));
     }
 
-    if let Err(GitError::MigrationPreflight(reason)) = remote_mapping_facts(&repo) {
-        report.blockers.push(GitAdmissionBlocker::new(
-            reason,
-            "unset that key in .git/config, or clone without it",
-        ));
+    // The scan stops at the first key it refuses, so this reports one key
+    // rather than all of them. Naming that one is the whole difference from
+    // the category the message used to carry.
+    match remote_mapping_facts(&repo) {
+        Ok(_) => {}
+        Err(GitError::MigrationPreflight(reason)) => report.blockers.push(
+            GitAdmissionBlocker::new(reason, "unset that key in .git/config, or clone without it"),
+        ),
+        Err(error) => return Err(error),
     }
 
+    // A sparse index describes directories rather than leaves, so comparing it
+    // against a committed tree would name every path in the repository and
+    // none of them would be the problem. Admission refuses it outright and
+    // that refusal is the one worth reporting.
+    if let Some(sparse) = sparse_checkout_blocker(&repo)? {
+        report.blockers.push(sparse);
+        return Ok(report);
+    }
     let index = read_index(&repo)?;
     report.blockers.extend(staged_blockers(&repo, &index)?);
     report
@@ -180,14 +192,12 @@ impl EffectiveHookSurface {
     fn notes(&self) -> Vec<String> {
         let mut notes = Vec::new();
         if let Some(configured) = &self.configured {
-            if !configured.repository_scoped {
-                notes.push(format!(
-                    "{} core.hooksPath is {}, so Git ignores anything under .git/hooks here and \
-                     Kin counts neither",
-                    configured.scope,
-                    configured.value.display()
-                ));
-            }
+            notes.push(format!(
+                "{} core.hooksPath is {}, so Git runs hooks from there and ignores anything under \
+                 .git/hooks; that directory is what Kin read",
+                configured.scope,
+                configured.value.display()
+            ));
         }
         if !self.kin_legacy.is_empty() {
             notes.push(format!(
@@ -209,14 +219,11 @@ impl EffectiveHookSurface {
 ///
 /// `.git/hooks` is what Git runs only when nothing overrides it, so an entry
 /// sitting there under a `core.hooksPath` override is inert, and counting it
-/// refuses a repository over a file that can never execute.
-///
-/// Which directory is then read depends on who redirected it. A repository that
-/// points its own hooks somewhere carries that surface to its next reader, and
-/// Kin refuses it. A host-wide `core.hooksPath` is the operator's environment
-/// instead, shared by every repository on the machine, so reading it would
-/// refuse all of them for something no repository carries. That one is reported
-/// as the reason `.git/hooks` went uncounted and blocks nothing.
+/// refuses a repository over a file that can never execute. The configured
+/// directory is read instead, whichever scope named it, because the question
+/// admission asks is which hooks run against this worktree and a host-wide
+/// setting answers it just as completely as a repository-local one. The scope
+/// changes only how the refusal reads, never what it counts.
 pub(crate) fn effective_hook_surface(
     repo: &gix::Repository,
     ambient: &gix::Repository,
@@ -226,17 +233,6 @@ pub(crate) fn effective_hook_surface(
         Some(configured) => configured.value.clone(),
         None => repo.common_dir().join("hooks"),
     };
-    if configured
-        .as_ref()
-        .is_some_and(|configured| !configured.repository_scoped)
-    {
-        return Ok(EffectiveHookSurface {
-            directory,
-            configured,
-            hooks: Vec::new(),
-            kin_legacy: Vec::new(),
-        });
-    }
     let entries = match fs::read_dir(&directory) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -291,14 +287,20 @@ fn configured_hooks_path(
     repo: &gix::Repository,
 ) -> Result<Option<ConfiguredHooksPath>> {
     let snapshot = ambient.config_snapshot();
+    // An empty value is how a repository cancels a host-wide override, and it
+    // reaches interpolation as a missing path rather than an empty one, so it
+    // has to be recognised before asking for the resolved form.
+    if snapshot
+        .string("core.hooksPath")
+        .is_none_or(|value| value.is_empty())
+    {
+        return Ok(None);
+    }
     let Some(value) = snapshot.trusted_path("core.hooksPath") else {
         return Ok(None);
     };
     let value = value
         .map_err(|error| preflight_error(format!("resolve configured Git hooks path: {error}")))?;
-    if value.as_os_str().is_empty() {
-        return Ok(None);
-    }
     let (repository_scoped, scope) = hooks_path_scope(&snapshot);
     // Git reads a relative hooks path from the top of the working tree, so
     // resolving it against the process working directory would name a
@@ -359,11 +361,26 @@ fn is_legacy_kin_hook_link(hooks_dir: &Path, path: &Path, metadata: &fs::Metadat
     let Some(parent) = target.parent() else {
         return Ok(false);
     };
+    if target.file_name() != path.file_name() {
+        return Ok(false);
+    }
     Ok(parent.file_name().is_some_and(|name| name == "hooks")
         && parent
             .parent()
             .and_then(Path::file_name)
             .is_some_and(|name| name == ".kin"))
+}
+
+fn sparse_checkout_blocker(repo: &gix::Repository) -> Result<Option<GitAdmissionBlocker>> {
+    let configured = repo.config_snapshot().boolean("core.sparseCheckout") == Some(true)
+        || repo.git_dir().join("info/sparse-checkout").exists();
+    if !configured && !read_index(repo)?.is_sparse() {
+        return Ok(None);
+    }
+    Ok(Some(GitAdmissionBlocker::new(
+        "sparse checkout configuration is ambiguous for exact migration",
+        "run 'git sparse-checkout disable' so the worktree carries the whole committed tree",
+    )))
 }
 
 fn read_index(repo: &gix::Repository) -> Result<gix::index::File> {
@@ -458,13 +475,36 @@ fn collect_tree_entries(
             let subtree = repo
                 .find_object(oid)
                 .map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?
-                .into_tree();
+                .try_into_tree()
+                .map_err(|_| {
+                    preflight_error(format!(
+                        "committed Git entry {} is recorded as a tree but is not one",
+                        display_path(&path)
+                    ))
+                })?;
             collect_tree_entries(repo, &subtree, &path, entries)?;
             continue;
         }
-        entries.insert(path, (u32::from(mode.value()), oid));
+        entries.insert(path, (canonical_mode(mode), oid));
     }
     Ok(())
+}
+
+/// The mode Git's index records for one committed entry.
+///
+/// A tree may carry a non-canonical file mode such as `100664`, which several
+/// importers still write, while the index decodes to the canonical `100644`.
+/// Comparing the raw values reads such a repository as having every file
+/// staged, and no `git restore --staged` can clear it because nothing is.
+/// Admission itself compares the entry kind, so this does too.
+fn canonical_mode(mode: gix::objs::tree::EntryMode) -> u32 {
+    match mode.kind() {
+        gix::objs::tree::EntryKind::Tree => 0o040_000,
+        gix::objs::tree::EntryKind::Blob => 0o100_644,
+        gix::objs::tree::EntryKind::BlobExecutable => 0o100_755,
+        gix::objs::tree::EntryKind::Link => 0o120_000,
+        gix::objs::tree::EntryKind::Commit => 0o160_000,
+    }
 }
 
 /// Worktree paths that are neither tracked nor ignored.
@@ -623,18 +663,37 @@ mod tests {
             git(&repo, &["config", "user.name", "Kin Test"]);
             git(&repo, &["config", "user.email", "kin@example.invalid"]);
             git(&repo, &["config", "commit.gpgSign", "false"]);
-            fs::write(repo.join("README.md"), b"seed\n").expect("readme");
-            git(&repo, &["add", "README.md"]);
-            git(&repo, &["commit", "-m", "seed", "--no-gpg-sign"]);
-            Self { temp, repo }
+            let fixture = Self { temp, repo };
+            fixture.pin_ambient_configuration();
+            fs::write(fixture.repo.join("README.md"), b"seed\n").expect("readme");
+            git(&fixture.repo, &["add", "README.md"]);
+            git(&fixture.repo, &["commit", "-m", "seed", "--no-gpg-sign"]);
+            fixture
+        }
+
+        /// Take the developer's own Git configuration out of the answer.
+        ///
+        /// Hook and ignore resolution both read merged configuration, and this
+        /// process is not the isolated Git child the fixture launches. A host
+        /// carrying a global `core.hooksPath` or `core.excludesFile` would
+        /// otherwise redirect or silence a case, which is how a suite passes on
+        /// one machine while proving nothing on another. Repository scope
+        /// outranks the host, so pinning both here settles it.
+        fn pin_ambient_configuration(&self) {
+            self.pin_hook_surface(&self.temp.path().join("empty-hooks"));
+            let excludes = self.temp.path().join("global-ignore");
+            fs::write(&excludes, b"").expect("empty global excludes");
+            git(
+                &self.repo,
+                &[
+                    "config",
+                    "core.excludesFile",
+                    excludes.to_str().expect("utf8 test path"),
+                ],
+            );
         }
 
         /// Bind the hook surface to a directory this case owns.
-        ///
-        /// Hook resolution reads merged Git configuration, so a developer host
-        /// carrying a global `core.hooksPath` redirects a fixture too. Every
-        /// case here that decides about hooks pins the surface, or it proves
-        /// one thing on a plain host and nothing at all on that one.
         fn pin_hook_surface(&self, directory: &Path) {
             fs::create_dir_all(directory).expect("hook directory");
             git(
@@ -669,6 +728,13 @@ mod tests {
             "git {args:?} failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn surface_for(fixture: &Fixture) -> EffectiveHookSurface {
+        let source = fs::canonicalize(&fixture.repo).expect("canonical source");
+        let repo = open_repo(&source).expect("open repository");
+        let ambient = open_repo_with_user_ignore_config(&source).expect("open ambient repository");
+        effective_hook_surface(&repo, &ambient).expect("resolve hook surface")
     }
 
     fn write_executable(path: &Path, body: &[u8]) {
@@ -784,7 +850,7 @@ mod tests {
     }
 
     #[test]
-    fn a_host_scoped_hooks_path_explains_itself_without_blocking() {
+    fn a_hooks_path_says_which_scope_redirected_it() {
         let surface = EffectiveHookSurface {
             directory: PathBuf::from("/home/dev/.config/git/hooks"),
             configured: Some(ConfiguredHooksPath {
@@ -800,6 +866,81 @@ mod tests {
         assert_eq!(notes.len(), 1);
         assert!(notes[0].contains("your global core.hooksPath"), "{notes:?}");
         assert!(notes[0].contains(".git/hooks"), "{notes:?}");
+    }
+
+    /// A hook the host redirected Git to is still a hook that runs here.
+    #[test]
+    fn a_hooks_path_set_outside_the_repository_still_blocks_on_what_it_holds() {
+        let fixture = Fixture::clean();
+        let hooks = fixture.temp.path().join("empty-hooks");
+        let hook = hooks.join("pre-commit");
+        write_executable(&hook, b"#!/bin/sh\nexit 0\n");
+        let surface = surface_for(&fixture);
+
+        assert_eq!(surface.hooks.len(), 1);
+        assert_eq!(surface.hooks[0].path, hook);
+    }
+
+    /// With nothing overriding it, `.git/hooks` is the surface.
+    ///
+    /// An empty `core.hooksPath` is how a repository says "no override" over a
+    /// host that sets one, so this reaches the default branch on any machine.
+    #[test]
+    fn the_default_surface_is_read_when_no_hooks_path_overrides_it() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "core.hooksPath", ""]);
+        let hook = fixture.repo.join(".git/hooks/pre-commit");
+        write_executable(&hook, b"#!/bin/sh\nexit 0\n");
+
+        let surface = surface_for(&fixture);
+        assert!(surface.configured.is_none(), "{surface:?}");
+        assert_eq!(surface.hooks.len(), 1, "{surface:?}");
+        assert_eq!(surface.hooks[0].name, b"pre-commit");
+        let refusal = fixture.refusal();
+        assert!(refusal.contains("pre-commit"), "{refusal}");
+    }
+
+    /// The sample hooks `git init` writes are not hooks.
+    #[test]
+    fn the_sample_hooks_git_init_writes_are_not_blockers() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "core.hooksPath", ""]);
+        assert!(
+            fixture.repo.join(".git/hooks/pre-commit.sample").exists(),
+            "the fixture must carry the samples this case is about"
+        );
+
+        let report = fixture.report();
+        assert!(report.is_clear(), "{report:?}");
+    }
+
+    /// Only a link that keeps its own name under `.kin/hooks` is Kin's.
+    #[test]
+    fn a_link_that_merely_lands_in_a_kin_hooks_directory_still_blocks() {
+        let fixture = Fixture::clean();
+        let hooks = fixture.temp.path().join("empty-hooks");
+        let installed = fixture.temp.path().join(".kin/hooks");
+        fs::create_dir_all(&installed).expect("installed kin hooks");
+        write_executable(&installed.join("something-else"), b"#!/bin/sh\nexit 0\n");
+        symlink(installed.join("something-else"), hooks.join("pre-commit")).expect("link");
+
+        let surface = surface_for(&fixture);
+        assert_eq!(surface.hooks.len(), 1, "{surface:?}");
+        assert!(surface.kin_legacy.is_empty(), "{surface:?}");
+    }
+
+    #[test]
+    fn a_sparse_checkout_keeps_its_own_refusal() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "core.sparseCheckout", "true"]);
+
+        let refusal = fixture.refusal();
+        assert!(refusal.contains("sparse checkout"), "{refusal}");
+        assert!(refusal.contains("sparse-checkout disable"), "{refusal}");
+        assert!(
+            !refusal.contains("staged or otherwise uncommitted"),
+            "a sparse index must not be reported path by path:\n{refusal}"
+        );
     }
 
     #[test]

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -767,6 +767,44 @@ mod tests {
         effective_hook_surface(&repo, &ambient).expect("resolve hook surface")
     }
 
+    fn git_stdout(repo: &Path, args: &[&str]) -> String {
+        let output = fixture_git()
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .expect("run fixture git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("utf8 git stdout")
+            .trim()
+            .to_string()
+    }
+
+    fn git_stdin(repo: &Path, args: &[&str], input: &str) -> String {
+        git_bytes_stdin(repo, args, input.as_bytes())
+    }
+
+    fn git_bytes_stdin(repo: &Path, args: &[&str], input: &[u8]) -> String {
+        let output = fixture_git()
+            .current_dir(repo)
+            .args(args)
+            .output_with_input(input)
+            .expect("run fixture git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("utf8 git stdout")
+            .trim()
+            .to_string()
+    }
+
     fn write_executable(path: &Path, body: &[u8]) {
         fs::write(path, body).expect("write executable");
         let mut permissions = fs::metadata(path).expect("metadata").permissions();
@@ -1038,6 +1076,54 @@ mod tests {
             report.is_clear(),
             "ignored content is admissible: {report:?}"
         );
+    }
+
+    /// A committed tree may record a mode the index cannot hold.
+    ///
+    /// `100664` is legal in a tree and several importers write it, while the
+    /// index decodes every plain file to `100644`. Comparing the raw values
+    /// reads such a repository as having every file staged, and no `git restore
+    /// --staged` clears it because nothing is staged. Admission itself admits
+    /// this repository, so a refusal here would be both wrong and inescapable.
+    #[test]
+    fn a_non_canonical_committed_filemode_is_not_read_as_staged() {
+        let fixture = Fixture::clean();
+        let blob = git_stdout(&fixture.repo, &["rev-parse", "HEAD:README.md"]);
+        // Written as raw tree bytes because `git mktree` canonicalises the mode
+        // on the way in, which is exactly the normalisation this case needs to
+        // be missing.
+        let mut body = b"100664 README.md\0".to_vec();
+        body.extend(
+            (0..blob.len() / 2)
+                .map(|index| u8::from_str_radix(&blob[index * 2..index * 2 + 2], 16))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .expect("hex object id"),
+        );
+        let tree = git_bytes_stdin(
+            &fixture.repo,
+            &["hash-object", "-t", "tree", "-w", "--stdin", "--literally"],
+            &body,
+        );
+        let commit = git_stdin(
+            &fixture.repo,
+            &["commit-tree", &tree, "-m", "non-canonical mode"],
+            "",
+        );
+        git(&fixture.repo, &["reset", "--hard", &commit]);
+        // Read as raw object bytes, because `cat-file -p` prints the
+        // canonicalised mode and would report the fixture worked either way.
+        let raw = fixture_git()
+            .current_dir(&fixture.repo)
+            .args(["cat-file", "tree", "HEAD^{tree}"])
+            .output()
+            .expect("read raw committed tree");
+        assert!(
+            raw.stdout.starts_with(b"100664 "),
+            "the fixture must keep the mode this case is about"
+        );
+
+        let report = fixture.report();
+        assert!(report.is_clear(), "{report:?}");
     }
 
     #[test]

--- a/crates/kin-git/src/error.rs
+++ b/crates/kin-git/src/error.rs
@@ -22,6 +22,9 @@ pub enum RegisteredGitWorktreeKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalGitHookFact {
     pub name: Vec<u8>,
+    /// Where the hook actually lives. Under a `core.hooksPath` override this is
+    /// not under `.git/hooks`, which is why the name alone cannot locate it.
+    pub path: std::path::PathBuf,
     pub kind: LocalGitHookKind,
     pub executable: LocalGitHookExecutability,
     pub byte_len: u64,
@@ -73,6 +76,44 @@ pub struct UnsealedContentGap {
     /// Why the body could not be sealed: absent, unreadable, or not matching
     /// the identity the tree recorded.
     pub detail: String,
+}
+
+/// One reason this Git source cannot be admitted, with the way out.
+///
+/// `subject` names the exact path, hook, or configuration key that blocks, and
+/// `remedy` is the single action that clears it. A blocker that cannot say both
+/// is a category rather than a finding and does not belong here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitAdmissionBlocker {
+    pub subject: String,
+    pub remedy: String,
+}
+
+impl GitAdmissionBlocker {
+    pub fn new(subject: impl Into<String>, remedy: impl Into<String>) -> Self {
+        Self {
+            subject: subject.into(),
+            remedy: remedy.into(),
+        }
+    }
+}
+
+/// Render every blocker and note as its own line.
+///
+/// The count leads so a reader knows how much is coming before reading any of
+/// it, and notes trail the list because they explain what was *not* counted.
+fn describe_admission_blockers(blockers: &[GitAdmissionBlocker], notes: &[String]) -> String {
+    let mut described = format!(
+        "this Git repository has {} admission blocker(s):",
+        blockers.len()
+    );
+    for blocker in blockers {
+        described.push_str(&format!("\n  - {}; {}", blocker.subject, blocker.remedy));
+    }
+    for note in notes {
+        described.push_str(&format!("\n  note: {note}"));
+    }
+    described
 }
 
 /// Render a gap report so the failure names the paths an operator must fix.
@@ -142,6 +183,20 @@ pub enum GitError {
 
     #[error("Git migration preflight failed: {0}")]
     MigrationPreflight(String),
+
+    /// Every source-state reason admission would refuse, reported together
+    /// before any history is derived.
+    ///
+    /// One blocker at a time, arriving after minutes of derivation, turns a
+    /// five-minute cleanup into an afternoon of guessing. This variant carries
+    /// the whole list so a reader fixes the repository once.
+    #[error("{}", describe_admission_blockers(blockers, notes))]
+    AdmissionBlocked {
+        blockers: Vec<GitAdmissionBlocker>,
+        /// Context that changes how the list reads, such as a `core.hooksPath`
+        /// that makes `.git/hooks` inert, or Kin's own legacy hook links.
+        notes: Vec<String>,
+    },
 
     #[error(
         "Git migration source has {count} other registered worktree(s); single-workspace import must account for each workspace"

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -21,6 +21,7 @@ fn kin_process_group_guardian_worker() {
     assert_eq!(dispatched, requested);
 }
 
+pub mod admission_blockers;
 pub mod admission_history;
 pub mod authority;
 pub mod error;
@@ -35,11 +36,15 @@ pub mod semantic_import;
 #[doc(hidden)]
 pub mod test_support;
 
+pub use admission_blockers::{
+    check_git_admission_blockers, collect_git_admission_blockers, GitAdmissionReport,
+};
 pub use admission_history::{admit_semantic_git_import, AdmittedSemanticGitImportPlan};
 pub use authority::build_git_external_authority;
 pub use error::{
-    GitCheckoutFilterFact, GitError, LocalGitHookExecutability, LocalGitHookFact, LocalGitHookKind,
-    RegisteredGitWorktreeFact, RegisteredGitWorktreeKind, Result, UnsealedContentGap,
+    GitAdmissionBlocker, GitCheckoutFilterFact, GitError, LocalGitHookExecutability,
+    LocalGitHookFact, LocalGitHookKind, RegisteredGitWorktreeFact, RegisteredGitWorktreeKind,
+    Result, UnsealedContentGap,
 };
 pub use global_config::empty_global_git_config;
 pub use lossless::{

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -22,6 +22,7 @@ use kin_model::{
     RepositoryId, RepositoryRefState, TreeEntry, WorkspaceHead,
 };
 
+use crate::admission_blockers::effective_hook_surface;
 use crate::error::{
     GitCheckoutFilterFact, GitError, LocalGitHookExecutability, LocalGitHookFact, LocalGitHookKind,
     RegisteredGitWorktreeFact, RegisteredGitWorktreeKind, Result,
@@ -400,14 +401,23 @@ fn observe(
         });
     }
 
-    let (configured_custom_hooks_path, hooks) = local_hook_facts(&repo)?;
+    let ambient_repo = open_repo_with_user_ignore_config(&source_worktree)?;
+    if stable_path(ambient_repo.git_dir()) != stable_path(repo.git_dir())
+        || stable_path(ambient_repo.common_dir()) != stable_path(repo.common_dir())
+    {
+        return Err(preflight_error(
+            "resolved user ignore configuration opened a different Git repository",
+        ));
+    }
+
+    let hook_surface = effective_hook_surface(&repo, &ambient_repo)?;
     let filters = checkout_filter_facts(&repo);
-    if configured_custom_hooks_path || !hooks.is_empty() || !filters.is_empty() {
+    if !hook_surface.hooks.is_empty() || !filters.is_empty() {
         return Err(GitError::LocalCompatibilityBlockers {
-            hook_count: hooks.len(),
-            custom_hooks_path: configured_custom_hooks_path,
+            hook_count: hook_surface.hooks.len(),
+            custom_hooks_path: hook_surface.repository_scoped_hooks_path(),
             filter_count: filters.len(),
-            hooks,
+            hooks: hook_surface.hooks,
             filters,
         });
     }
@@ -419,14 +429,6 @@ fn observe(
         && plan.workspace_seed.base_tree_hash.is_none()
         && expected_entries.is_empty();
     let (index_file, raw_index) = read_strict_index(&repo, absent_index_allowed)?;
-    let ambient_repo = open_repo_with_user_ignore_config(&source_worktree)?;
-    if stable_path(ambient_repo.git_dir()) != stable_path(repo.git_dir())
-        || stable_path(ambient_repo.common_dir()) != stable_path(repo.common_dir())
-    {
-        return Err(preflight_error(
-            "resolved user ignore configuration opened a different Git repository",
-        ));
-    }
     let index = prove_index(&index_file, raw_index.as_deref(), expected_entries)?;
     index_file
         .verify_extensions(true, &repo.objects)
@@ -1287,7 +1289,7 @@ fn prove_tracked_entry(
     Ok(())
 }
 
-fn reject_in_progress_operations(repo: &gix::Repository) -> Result<()> {
+pub(crate) fn reject_in_progress_operations(repo: &gix::Repository) -> Result<()> {
     if let Some(operation) = repo.state() {
         return Err(preflight_error(format!(
             "Git operation {operation:?} is in progress"
@@ -1364,7 +1366,7 @@ fn find_lock_file(root: &Path) -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
-fn other_registered_worktrees(
+pub(crate) fn other_registered_worktrees(
     repo: &gix::Repository,
     source_worktree: &Path,
 ) -> Result<Vec<RegisteredGitWorktreeFact>> {
@@ -1415,48 +1417,7 @@ fn other_registered_worktrees(
     Ok(facts)
 }
 
-fn local_hook_facts(repo: &gix::Repository) -> Result<(bool, Vec<LocalGitHookFact>)> {
-    let custom_hooks_path = repo
-        .config_snapshot()
-        .plumbing()
-        .sections_by_name("core")
-        .is_some_and(|mut sections| {
-            sections.any(|section| section.contains_value_name("hooksPath"))
-        });
-    if custom_hooks_path {
-        return Ok((true, Vec::new()));
-    }
-    let hooks_dir = repo.common_dir().join("hooks");
-    let entries = match fs::read_dir(&hooks_dir) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok((false, Vec::new()));
-        }
-        Err(error) => return Err(GitError::io(&hooks_dir, error)),
-    };
-    let entries = entries
-        .collect::<std::io::Result<Vec<_>>>()
-        .map_err(|error| GitError::io(&hooks_dir, error))?;
-    let entries = exact_directory_names(&hooks_dir, entries)?;
-    let mut hooks = Vec::new();
-    for (name, entry) in entries {
-        if name.ends_with(b".sample") {
-            continue;
-        }
-        let metadata = fs::symlink_metadata(entry.path())
-            .map_err(|error| GitError::io(entry.path(), error))?;
-        hooks.push(LocalGitHookFact {
-            name,
-            kind: hook_kind(&metadata),
-            executable: hook_executability(&metadata)?,
-            byte_len: metadata.len(),
-        });
-    }
-    hooks.sort_by(|left, right| left.name.cmp(&right.name));
-    Ok((false, hooks))
-}
-
-fn checkout_filter_facts(repo: &gix::Repository) -> Vec<GitCheckoutFilterFact> {
+pub(crate) fn checkout_filter_facts(repo: &gix::Repository) -> Vec<GitCheckoutFilterFact> {
     let config = repo.config_snapshot();
     let mut facts = BTreeMap::<Vec<u8>, GitCheckoutFilterFact>::new();
     if let Some(sections) = config.plumbing().sections_by_name("filter") {
@@ -1488,7 +1449,7 @@ fn checkout_filter_facts(repo: &gix::Repository) -> Vec<GitCheckoutFilterFact> {
     facts.into_values().collect()
 }
 
-fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts> {
+pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts> {
     let config = repo.config_snapshot();
     let mut remotes = Vec::<GitRemoteConfigFact>::new();
     let mut branch_tracking = Vec::<GitBranchTrackingFact>::new();
@@ -1515,7 +1476,11 @@ fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts>
             "remote" => {
                 if let Some(name) = section.header().subsection_name() {
                     validate_safe_identifier(name, "remote name")?;
-                    reject_unknown_config_keys(section, &["url", "pushurl", "fetch", "push"])?;
+                    reject_unknown_config_keys(
+                        section,
+                        &format!("remote.{}", String::from_utf8_lossy(name)),
+                        &["url", "pushurl", "fetch", "push"],
+                    )?;
                     let fact = remote_fact_mut(&mut remotes, name);
                     append_explicit_values(
                         section,
@@ -1536,7 +1501,7 @@ fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts>
                         validate_safe_refspec(value, gix::refspec::parse::Operation::Push)
                     })?;
                 } else {
-                    reject_unknown_config_keys(section, &["pushdefault"])?;
+                    reject_unknown_config_keys(section, "remote", &["pushdefault"])?;
                     set_unique_explicit_value(
                         section,
                         "pushdefault",
@@ -1551,7 +1516,11 @@ fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts>
                     .subsection_name()
                     .ok_or_else(|| unsafe_git_config("branch section without a name"))?;
                 validate_safe_branch_name(name)?;
-                reject_unknown_config_keys(section, &["remote", "merge", "pushremote"])?;
+                reject_unknown_config_keys(
+                    section,
+                    &format!("branch.{}", String::from_utf8_lossy(name)),
+                    &["remote", "merge", "pushremote"],
+                )?;
                 let fact = branch_fact_mut(&mut branch_tracking, name);
                 set_unique_explicit_value(section, "remote", &mut fact.remote, |value| {
                     validate_safe_identifier(value, "branch remote")
@@ -1567,7 +1536,7 @@ fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts>
                 if section.header().subsection_name().is_some() {
                     return Err(unsafe_git_config("named push section"));
                 }
-                reject_unknown_config_keys(section, &["default"])?;
+                reject_unknown_config_keys(section, "push", &["default"])?;
                 set_unique_explicit_value(section, "default", &mut push_default, |value| {
                     validate_push_default(value)
                 })?;
@@ -1642,8 +1611,15 @@ fn branch_fact_mut<'a>(
     branches.last_mut().expect("branch was just inserted")
 }
 
+/// Refuse any key outside the exact allowlist, naming the one that matched.
+///
+/// `scope` is the section spelling the caller has already validated as safe to
+/// print. Key names are safe on their own; the values behind them are not, and
+/// none is printed. Without the name the reader is told a category and has to
+/// bisect their own config to find which line Kin meant.
 fn reject_unknown_config_keys(
     section: &gix::config::file::Section<'_>,
+    scope: &str,
     allowed: &[&str],
 ) -> Result<()> {
     for name in section.value_names() {
@@ -1652,9 +1628,9 @@ fn reject_unknown_config_keys(
             .iter()
             .any(|allowed| name.eq_ignore_ascii_case(allowed))
         {
-            return Err(unsafe_git_config(
-                "unsupported transfer-affecting repository-local key",
-            ));
+            return Err(unsafe_git_config(format!(
+                "unsupported transfer-affecting repository-local key {scope}.{name}"
+            )));
         }
     }
     Ok(())
@@ -1674,7 +1650,9 @@ fn reject_transfer_core_keys(section: &gix::config::file::Section<'_>) -> Result
             .iter()
             .any(|blocked| name.eq_ignore_ascii_case(blocked))
         {
-            return Err(unsafe_git_config("unsupported transfer-affecting core key"));
+            return Err(unsafe_git_config(format!(
+                "unsupported transfer-affecting core key core.{name}"
+            )));
         }
     }
     Ok(())
@@ -1985,7 +1963,7 @@ fn encode_byte_values(hash: &mut FramedHash, values: &[Vec<u8>]) {
     }
 }
 
-fn open_repo_with_user_ignore_config(path: &Path) -> Result<gix::Repository> {
+pub(crate) fn open_repo_with_user_ignore_config(path: &Path) -> Result<gix::Repository> {
     let dot_git = path.join(".git");
     let open_path = if dot_git.is_dir() { &dot_git } else { path };
     let options = gix::open::Options::default()
@@ -1998,7 +1976,7 @@ fn open_repo_with_user_ignore_config(path: &Path) -> Result<gix::Repository> {
     })
 }
 
-fn local_ignore_inputs(repo: &gix::Repository) -> Result<Vec<GitLocalIgnoreInputFact>> {
+pub(crate) fn local_ignore_inputs(repo: &gix::Repository) -> Result<Vec<GitLocalIgnoreInputFact>> {
     let mut inputs = Vec::new();
     if let Some(path) = resolved_global_excludes_path(repo)? {
         if let Some(body) = read_optional_regular_file(&path)? {
@@ -2020,7 +1998,7 @@ fn local_ignore_inputs(repo: &gix::Repository) -> Result<Vec<GitLocalIgnoreInput
     Ok(inputs)
 }
 
-fn frozen_ignore_stack<'repo>(
+pub(crate) fn frozen_ignore_stack<'repo>(
     repo: &'repo gix::Repository,
     index: &gix::index::File,
     inputs: &[GitLocalIgnoreInputFact],
@@ -2298,7 +2276,7 @@ fn ignored_entry_kind(metadata: &fs::Metadata) -> IgnoredLocalEntryKind {
     }
 }
 
-fn hook_kind(metadata: &fs::Metadata) -> LocalGitHookKind {
+pub(crate) fn hook_kind(metadata: &fs::Metadata) -> LocalGitHookKind {
     if metadata.file_type().is_symlink() {
         LocalGitHookKind::Symlink
     } else if metadata.is_file() {
@@ -2310,11 +2288,11 @@ fn hook_kind(metadata: &fs::Metadata) -> LocalGitHookKind {
     }
 }
 
-fn stable_path(path: &Path) -> PathBuf {
+pub(crate) fn stable_path(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn preflight_error(reason: impl Into<String>) -> GitError {
+pub(crate) fn preflight_error(reason: impl Into<String>) -> GitError {
     GitError::MigrationPreflight(reason.into())
 }
 
@@ -2325,7 +2303,7 @@ fn preflight_error(reason: impl Into<String>) -> GitError {
 /// the operator would discover the next only by re-running. Admission refuses
 /// with every non-representable entry named instead, which is what makes one
 /// refusal enough to act on.
-fn exact_directory_names(
+pub(crate) fn exact_directory_names(
     directory: &Path,
     entries: Vec<fs::DirEntry>,
 ) -> Result<Vec<(Vec<u8>, fs::DirEntry)>> {
@@ -2473,7 +2451,7 @@ fn filesystem_executable(_metadata: &fs::Metadata) -> Result<bool> {
 }
 
 /// Executable-bit observation for one local hook file.
-fn hook_executability(metadata: &fs::Metadata) -> Result<LocalGitHookExecutability> {
+pub(crate) fn hook_executability(metadata: &fs::Metadata) -> Result<LocalGitHookExecutability> {
     if !filesystem_records_executable_bit() {
         return Ok(LocalGitHookExecutability::Unrecorded);
     }
@@ -3528,6 +3506,10 @@ mod tests {
     #[test]
     fn returns_structured_hook_filter_and_worktree_blockers() {
         let hook = Fixture::clean();
+        // Pinned rather than left implicit: a developer host carrying a global
+        // `core.hooksPath` makes `.git/hooks` inert, and this case would then
+        // assert nothing here while still passing on a host without one.
+        pin_default_hook_surface(&hook.repo);
         let hook_path = hook.repo.join(".git/hooks/pre-commit");
         fs::write(&hook_path, b"#!/bin/sh\nexit 0\n").expect("hook");
         let mut permissions = fs::metadata(&hook_path)
@@ -3545,6 +3527,7 @@ mod tests {
                 assert_eq!(hook_count, 1);
                 assert_eq!(filter_count, 0);
                 assert_eq!(hooks[0].name, b"pre-commit");
+                assert_eq!(stable_path(&hooks[0].path), stable_path(&hook_path));
                 assert_eq!(
                     hooks[0].executable,
                     LocalGitHookExecutability::Executable,
@@ -3580,14 +3563,29 @@ mod tests {
         }
 
         let custom_hooks = Fixture::clean();
+        let custom_dir = custom_hooks.temp.path().join("custom-hooks");
+        fs::create_dir_all(&custom_dir).expect("custom hooks directory");
+        let redirected = custom_dir.join("pre-push");
+        fs::write(&redirected, b"#!/bin/sh\nexit 0\n").expect("redirected hook");
         git(
             &custom_hooks.repo,
-            &["config", "core.hooksPath", "../custom-hooks"],
+            &[
+                "config",
+                "core.hooksPath",
+                custom_dir.to_str().expect("utf8 test path"),
+            ],
         );
         match custom_hooks.preflight().expect_err("custom hooks blocker") {
             GitError::LocalCompatibilityBlockers {
-                custom_hooks_path, ..
-            } => assert!(custom_hooks_path),
+                custom_hooks_path,
+                hooks,
+                ..
+            } => {
+                assert!(custom_hooks_path);
+                assert_eq!(hooks.len(), 1);
+                assert_eq!(hooks[0].name, b"pre-push");
+                assert_eq!(stable_path(&hooks[0].path), stable_path(&redirected));
+            }
             error => panic!("unexpected error: {error:?}"),
         }
 
@@ -4048,6 +4046,25 @@ mod tests {
         git(repo, &["config", "user.name", "Kin Test"]);
         git(repo, &["config", "user.email", "kin@example.invalid"]);
         git(repo, &["config", "commit.gpgSign", "false"]);
+    }
+
+    /// Bind a fixture's hook surface to its own `.git/hooks`.
+    ///
+    /// Hook resolution reads the merged Git configuration, so a developer host
+    /// that sets `core.hooksPath` globally redirects a fixture too. Any case
+    /// that has to decide about `.git/hooks` pins it, or it proves one thing on
+    /// a plain host and nothing at all on that one.
+    fn pin_default_hook_surface(repo: &Path) {
+        let hooks = repo.join(".git/hooks");
+        fs::create_dir_all(&hooks).expect("default hook directory");
+        git(
+            repo,
+            &[
+                "config",
+                "core.hooksPath",
+                hooks.to_str().expect("utf8 test path"),
+            ],
+        );
     }
 
     fn commit(repo: &Path, message: &str) {

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -1613,15 +1613,19 @@ fn branch_fact_mut<'a>(
 
 /// Refuse any key outside the exact allowlist, naming the one that matched.
 ///
-/// `scope` is the section spelling the caller has already validated as safe to
-/// print. Key names are safe on their own; the values behind them are not, and
-/// none is printed. Without the name the reader is told a category and has to
-/// bisect their own config to find which line Kin meant.
+/// `scope` is the section spelling, which the caller builds from a subsection
+/// name that has only been checked for control characters. That is not enough
+/// to print: a `[remote "https://user:token@host/repo"]` section passes it and
+/// would carry a credential into the refusal, so the subsection is dropped
+/// unless it reads as a plain identifier. Key names are always safe, and the
+/// values behind them are never printed. Without a name the reader is handed a
+/// category and has to bisect their own config to find the line Kin meant.
 fn reject_unknown_config_keys(
     section: &gix::config::file::Section<'_>,
     scope: &str,
     allowed: &[&str],
 ) -> Result<()> {
+    let scope = printable_config_scope(scope);
     for name in section.value_names() {
         let name = name.to_string();
         if !allowed
@@ -1634,6 +1638,22 @@ fn reject_unknown_config_keys(
         }
     }
     Ok(())
+}
+
+/// Keep a section spelling printable, dropping a subsection that is not a plain
+/// identifier rather than disclosing whatever it holds.
+fn printable_config_scope(scope: &str) -> String {
+    let Some((section, subsection)) = scope.split_once('.') else {
+        return scope.to_string();
+    };
+    let printable = !subsection.is_empty()
+        && subsection
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if printable {
+        return scope.to_string();
+    }
+    section.to_string()
 }
 
 fn reject_transfer_core_keys(section: &gix::config::file::Section<'_>) -> Result<()> {
@@ -3503,13 +3523,39 @@ mod tests {
         ));
     }
 
+    /// Naming the key must not name a credential the section header carries.
+    #[test]
+    fn an_unsupported_key_is_named_without_disclosing_its_section() {
+        assert_eq!(printable_config_scope("branch.main"), "branch.main");
+        assert_eq!(
+            printable_config_scope("remote.https://user:s3cr3t@host/repo"),
+            "remote"
+        );
+
+        let (temp, repo) = config_only_repository();
+        let config = repo.join(".git/config");
+        let mut body = fs::read(&config).expect("read config");
+        body.extend_from_slice(
+            b"\n[remote \"https://user:s3cr3t@host/repo\"]\n\ttagOpt = --tags\n",
+        );
+        fs::write(&config, body).expect("write config");
+        fs::write(repo.join("README.md"), b"seed\n").expect("seed file");
+        git(&repo, &["add", "README.md"]);
+        commit(&repo, "seed");
+
+        let store = BlobStore::new(temp.path().join("cas")).expect("blob store");
+        let (snapshot, plan) = snapshot_plan(&repo, &store);
+        let message = preflight_git_migration(&repo, &snapshot, &plan, &store)
+            .expect_err("unsupported key must reject")
+            .to_string();
+
+        assert!(message.contains("tagOpt"), "{message}");
+        assert!(!message.contains("s3cr3t"), "{message}");
+    }
+
     #[test]
     fn returns_structured_hook_filter_and_worktree_blockers() {
         let hook = Fixture::clean();
-        // Pinned rather than left implicit: a developer host carrying a global
-        // `core.hooksPath` makes `.git/hooks` inert, and this case would then
-        // assert nothing here while still passing on a host without one.
-        pin_default_hook_surface(&hook.repo);
         let hook_path = hook.repo.join(".git/hooks/pre-commit");
         fs::write(&hook_path, b"#!/bin/sh\nexit 0\n").expect("hook");
         let mut permissions = fs::metadata(&hook_path)
@@ -3639,6 +3685,16 @@ mod tests {
             ],
         );
         git_dir(&bare, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        // The linked worktree resolves hooks through this common directory, so
+        // the pin that keeps a developer host out of the answer belongs here.
+        git_dir(
+            &bare,
+            &[
+                "config",
+                "core.hooksPath",
+                bare.join("hooks").to_str().expect("bare hooks path"),
+            ],
+        );
         let linked = temp.path().join("linked");
         git_dir(
             &bare,
@@ -4046,14 +4102,15 @@ mod tests {
         git(repo, &["config", "user.name", "Kin Test"]);
         git(repo, &["config", "user.email", "kin@example.invalid"]);
         git(repo, &["config", "commit.gpgSign", "false"]);
+        pin_default_hook_surface(repo);
     }
 
     /// Bind a fixture's hook surface to its own `.git/hooks`.
     ///
-    /// Hook resolution reads the merged Git configuration, so a developer host
-    /// that sets `core.hooksPath` globally redirects a fixture too. Any case
-    /// that has to decide about `.git/hooks` pins it, or it proves one thing on
-    /// a plain host and nothing at all on that one.
+    /// Hook resolution reads the merged Git configuration, and this process is
+    /// not the isolated Git child a fixture launches, so a developer host that
+    /// sets `core.hooksPath` globally redirects a fixture too. Repository scope
+    /// outranks the host, so pinning it here settles what every case reads.
     fn pin_default_hook_surface(repo: &Path) {
         let hooks = repo.join(".git/hooks");
         fs::create_dir_all(&hooks).expect("default hook directory");

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -301,14 +301,19 @@ BOUNDARY_DIRS = [
     "crates/kin-core/src/tree.rs",
     # kin-git is scanned by default because it also carries answer-adjacent
     # logic (co-change, blame-style history) that must come from graph truth.
-    # These three modules are the Git format boundary itself: capturing a Git
-    # repository, proving a checkout matches its committed seed before
-    # admission, and materializing graph-owned history back out as Git. Reading
-    # a Git repository from disk is the entire point of an import boundary, and
-    # none of these modules answers a locate/search/context/trace/review/xref
-    # query. Enumerated file by file so every other kin-git module, including
-    # any newly added one, keeps being scanned.
+    # These four modules are the Git format boundary itself: capturing a Git
+    # repository, reporting what would stop one being admitted, proving a
+    # checkout matches its committed seed before admission, and materializing
+    # graph-owned history back out as Git. Reading a Git repository from disk is
+    # the entire point of an import boundary, and none of these modules answers
+    # a locate/search/context/trace/review/xref query. Enumerated file by file
+    # so every other kin-git module, including any newly added one, keeps being
+    # scanned.
     "crates/kin-git/src/lossless.rs",
+    # Runs before any graph exists, on the source Git repository, and produces
+    # only refusals. Nothing it reads reaches a query answer, and its whole
+    # output is a list of reasons admission cannot start.
+    "crates/kin-git/src/admission_blockers.rs",
     "crates/kin-git/src/preflight.rs",
     "crates/kin-git/src/repository_export.rs",
     "crates/kin-runtime/",


### PR DESCRIPTION
kin init refused a lived-in repository one blocker at a time, after about forty seconds of semantic history derivation, and named neither the hook that blocked nor the config key that did. A user with three problems paid that forty seconds three times to find them.

Admission now opens with a source-only check that reads registered worktrees, the hook surface Git actually runs, checkout filters, repository-local transport configuration, the index against HEAD, and untracked worktree paths. It reports all of them in one refusal, each naming the path or key behind it and the single action that clears it. Its whole input is a path, so it cannot reach a snapshot, an import plan, or a blob store, and it runs as phase 1 of 17, ahead of capture and every derivation phase.

Hook resolution follows Git now. An entry under .git/hooks is inert when core.hooksPath redirects the surface, so it is no longer counted, and the configured directory is what Git would run instead. A repository that redirects its own hooks carries that surface to whoever clones it, so Kin counts it. A hooks path the host set applies to every repository on the machine, so the refusal reports its value and its scope and says plainly that Kin did not count what is in it. Counting it instead was tried and measured, and it makes Kin refuse every repository on such a machine, thirty fixture files across this workspace included.

Kin's own hook links from an older install, the ones pointing into .kin/hooks, are recognised as leftovers rather than blockers and named in the refusal as safe to delete. Kin stops refusing repositories over its own debris.

Unsupported transport keys are named. The message used to say "unsupported transfer-affecting repository-local key" and leave the reader to bisect their own config. It now says branch.main.vscode-merge-base. A section header is dropped from that name unless it reads as a plain identifier, because a remote can be named with a URL carrying a password.

Alongside that, a committed entry is compared by its canonical mode, so a tree carrying 100664 no longer reads as every file staged with no way to clear it, and a sparse checkout keeps its own single refusal instead of being listed path by path.

No admission policy loosened for anything a repository carries. A dirty tree still refuses, a hook the repository owns still refuses, an unsupported transport key still refuses, a sparse checkout still refuses. The consent path for dirty trees is a separate founder ruling and is not part of this.

Refs FIR-2142
