### PR TITLE
Match each parsed declaration to a distinct entity

### DIFF
--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3341,6 +3341,99 @@ mod tests {
         );
     }
 
+    fn entity_names_for(state: &DaemonState, file: &str) -> Vec<String> {
+        let mut names = state
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new(file)),
+                ..Default::default()
+            })
+            .unwrap()
+            .into_iter()
+            .map(|entity| entity.name)
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    /// An edit reaches the graph even when the file declares one name twice.
+    ///
+    /// Entity identity is derived from the declaration's start line, so an edit
+    /// above a declaration invalidates the identity the graph holds for it.
+    /// Re-matching then falls back to name and kind, and a file carrying a
+    /// cfg-gated pair collapsed both parsed halves onto whichever half the graph
+    /// returned first. Two deltas for one entity is not a transaction, so the
+    /// whole reconcile was refused and the edit never became queryable.
+    #[tokio::test]
+    async fn an_edit_above_a_duplicated_declaration_admits_the_new_entity() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        std::fs::write(
+            root.join("hooks.rs"),
+            b"#[cfg(unix)]\npub fn hook() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn hook() -> u32 { 2 }\n",
+        )
+        .unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+        assert_eq!(
+            entity_names_for(&state, "hooks.rs"),
+            vec!["hook".to_string(), "hook".to_string()],
+            "the fixture needs both halves of the duplicated declaration admitted"
+        );
+
+        std::fs::write(
+            root.join("hooks.rs"),
+            b"pub fn probe() -> u32 { 9 }\n\n#[cfg(unix)]\npub fn hook() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn hook() -> u32 { 2 }\n",
+        )
+        .unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        assert!(
+            entity_names_for(&state, "hooks.rs").contains(&"probe".to_string()),
+            "a function added by an ordinary edit never became queryable: {:?}",
+            entity_names_for(&state, "hooks.rs")
+        );
+        assert_eq!(
+            entity_names_for(&state, "hooks.rs"),
+            vec!["hook".to_string(), "hook".to_string(), "probe".to_string()],
+            "the edit must leave one entity per declaration"
+        );
+    }
+
+    /// A comment-only edit advances the same file's entities.
+    ///
+    /// Every entity in an edited file carries the file's blob hash, so a comment
+    /// is a real modification of each of them. The pass therefore has to hold the
+    /// one-delta-per-entity invariant on an edit that changes no declaration at
+    /// all, and it must keep the entity ids it already published.
+    #[tokio::test]
+    async fn a_comment_only_edit_keeps_the_files_entities_and_their_ids() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        std::fs::write(
+            root.join("notes.rs"),
+            b"// leading note\n#[cfg(unix)]\npub fn note() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn note() -> u32 { 2 }\n",
+        )
+        .unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+        let before = entity_ids_for(&state, "notes.rs");
+        assert_eq!(before.len(), 2, "the fixture needs both declarations");
+
+        std::fs::write(
+            root.join("notes.rs"),
+            b"// leading note\n#[cfg(unix)]\npub fn note() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn note() -> u32 { 2 }\n\n// trailing note\n",
+        )
+        .unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        assert_eq!(
+            entity_ids_for(&state, "notes.rs"),
+            before,
+            "a comment-only edit must leave every declaration's identity alone"
+        );
+    }
+
     /// A file wide enough that indexing it takes long enough for a replacement to
     /// land between the reconciler's two reads.
     ///

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1805,7 +1805,16 @@ pub async fn run_loop(
                         let deferral = retry_lane.defer(path, Instant::now(), retry_base);
                         report_modified_during_reconcile(path, &e, deferral);
                     } else {
-                        warn!(error = %e, "reconciliation error for event, skipping");
+                        // Retrying a deterministic failure would re-derive the
+                        // same rejected transaction forever, so the event is
+                        // dropped. Name the path: its enrichment now stays at
+                        // whatever the last accepted pass admitted, and an
+                        // error without a path cannot be traced back to it.
+                        warn!(
+                            file = %semantic_repo_path,
+                            error = %e,
+                            "reconciliation error for event; dropping it and leaving this path's enrichment stale"
+                        );
                     }
                     if tree_changed {
                         state.bump_version();
@@ -3746,7 +3755,11 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
                 }
             }
             Err(e) => {
-                warn!(error = %e, "sync reconciliation error for event, skipping");
+                warn!(
+                    file = %semantic_repo_path,
+                    error = %e,
+                    "sync reconciliation error for event; dropping it and leaving this path's enrichment stale"
+                );
             }
         }
     }

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -1864,8 +1864,8 @@ fn merge_deltas(
 mod tests {
     use super::*;
     use kin_model::{
-        EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, Hash256, LanguageId,
-        SemanticFingerprint, Visibility,
+        EntityKind, EntityMetadata, EntityRole, EntityStore, FingerprintAlgorithm, Hash256,
+        LanguageId, SemanticFingerprint, Visibility,
     };
 
     fn make_entity(name: &str, file: &str) -> Entity {
@@ -1946,6 +1946,107 @@ mod tests {
 
         reconciler.lkg.record(entity, vec![]);
         assert!(reconciler.lkg().get(&id).is_some());
+    }
+
+    /// Reconcile a file twice, returning the delta the second pass derived.
+    fn reconcile_twice(first: &str, second: &str) -> Result<TransactionDelta> {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let blobs = BlobStore::new(root.join(".kin-blobs")).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let mut reconciler = Reconciler::new(root.clone());
+        let path = root.join("hooks.rs");
+
+        // Seed graph truth entity by entity. Committing the first delta whole
+        // would need a staged tree carrying the artifact, and the tree plays no
+        // part in how the second pass re-matches what it parses.
+        std::fs::write(&path, first).unwrap();
+        let seeded = reconciler
+            .reconcile_file_change(&FileEvent::Changed(path.clone()), &blobs, &graph)?
+            .delta;
+        for entity_delta in &seeded.entity_deltas {
+            if let EntityDelta::Added { new } = entity_delta {
+                graph.upsert_entity(new).unwrap();
+            }
+        }
+
+        std::fs::write(&path, second).unwrap();
+        Ok(reconciler
+            .reconcile_file_change(&FileEvent::Changed(path), &blobs, &graph)?
+            .delta)
+    }
+
+    /// A file may declare one name twice, and each declaration is its own entity.
+    ///
+    /// Identity is derived from the declaration's start line, so an edit above a
+    /// declaration invalidates the identity the graph holds for it. Re-matching
+    /// then falls back to name and kind, and both parsed halves of a cfg-gated
+    /// pair claimed whichever half the graph returned first. Two deltas for one
+    /// entity is not a transaction, so the edit was refused whole and nothing in
+    /// the file ever advanced again.
+    #[test]
+    fn an_edit_above_a_duplicated_declaration_yields_one_delta_per_entity() {
+        let delta = reconcile_twice(
+            "#[cfg(unix)]\npub fn hook() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn hook() -> u32 { 2 }\n",
+            "pub fn probe() -> u32 { 9 }\n\n#[cfg(unix)]\npub fn hook() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn hook() -> u32 { 2 }\n",
+        )
+        .expect("an ordinary edit must derive a valid transaction");
+
+        let mut targets = delta
+            .entity_deltas
+            .iter()
+            .map(EntityDelta::target_id)
+            .collect::<Vec<_>>();
+        let before = targets.len();
+        targets.sort();
+        targets.dedup();
+        assert_eq!(
+            targets.len(),
+            before,
+            "the transaction carries more than one delta for some entity"
+        );
+        assert!(
+            delta
+                .entity_deltas
+                .iter()
+                .any(|entity_delta| matches!(entity_delta, EntityDelta::Added { new } if new.name == "probe")),
+            "the added declaration never reached the transaction"
+        );
+    }
+
+    /// Each half of a duplicated declaration keeps its own identity across an edit.
+    ///
+    /// Matching one parsed entity to one existing entity is what holds the
+    /// invariant, and matching them to the same one both breaks the transaction
+    /// and loses a declaration. Pin the surviving count, not only the delta shape.
+    #[test]
+    fn both_halves_of_a_duplicated_declaration_survive_an_edit() {
+        let delta = reconcile_twice(
+            "#[cfg(unix)]\npub fn hook() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn hook() -> u32 { 2 }\n",
+            "pub fn probe() -> u32 { 9 }\n\n#[cfg(unix)]\npub fn hook() -> u32 { 1 }\n\n#[cfg(not(unix))]\npub fn hook() -> u32 { 2 }\n",
+        )
+        .expect("an ordinary edit must derive a valid transaction");
+
+        let removed = delta
+            .entity_deltas
+            .iter()
+            .filter(|entity_delta| matches!(entity_delta, EntityDelta::Removed { .. }))
+            .count();
+        assert_eq!(
+            removed, 0,
+            "an edit that removed no declaration must remove no entity"
+        );
+        let hooks = delta
+            .entity_deltas
+            .iter()
+            .filter(|entity_delta| {
+                matches!(entity_delta, EntityDelta::Modified { new, .. } if new.name == "hook")
+            })
+            .count();
+        assert_eq!(
+            hooks, 2,
+            "both halves of the duplicated declaration must advance"
+        );
     }
 
     #[test]

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -588,9 +588,10 @@ impl Reconciler {
         let mut delta = TransactionDelta::default();
         let blob_hash = serde_json::Value::String(indexed.blob_hash.to_string());
 
-        // Track which existing entities we've matched
-        let mut matched_existing: HashMap<EntityId, bool> =
-            existing.iter().map(|e| (e.id, false)).collect();
+        // Every entity id this transaction already speaks for. One delta per
+        // entity is the transaction invariant, so an id enters this set the
+        // moment a delta names it and no later delta may name it again.
+        let mut claimed: HashSet<EntityId> = HashSet::new();
 
         // Process new entities from the parse
         for new_entity in &indexed.entities {
@@ -621,18 +622,32 @@ impl Reconciler {
             // exact id first, while still requiring the entity kind to match;
             // ordinary filesystem reconciliation continues to match by name
             // and kind as before.
+            //
+            // Both passes skip an entity another parsed declaration already
+            // claimed, so the match is one-to-one. Identity is derived from the
+            // declaration's start line, so an edit above a declaration retires
+            // the id the graph holds for it and drops it to the name-and-kind
+            // pass. A file that declares one name twice, which a cfg-gated pair
+            // does routinely, would otherwise collapse both halves onto
+            // whichever half the graph returned first.
             let existing_match = existing
                 .iter()
-                .find(|entity| entity.id == new_entity.id && entity.kind == new_entity.kind)
+                .find(|entity| {
+                    entity.id == new_entity.id
+                        && entity.kind == new_entity.kind
+                        && !claimed.contains(&entity.id)
+                })
                 .or_else(|| {
                     existing.iter().find(|entity| {
-                        entity.name == new_entity.name && entity.kind == new_entity.kind
+                        entity.name == new_entity.name
+                            && entity.kind == new_entity.kind
+                            && !claimed.contains(&entity.id)
                     })
                 });
 
             match existing_match {
                 Some(old) => {
-                    matched_existing.insert(old.id, true);
+                    claimed.insert(old.id);
 
                     let mut updated = new_entity.clone();
                     updated.id = old.id;
@@ -669,8 +684,19 @@ impl Reconciler {
                     }
                 }
                 None => {
-                    // New entity
+                    // New entity. Identity is derived from the file, name,
+                    // kind, and start line, so two declarations sharing all
+                    // four are one entity as far as the graph can tell and only
+                    // the first of them can be carried.
                     let mut added_entity = new_entity.clone();
+                    if !claimed.insert(added_entity.id) {
+                        warn!(
+                            entity = %added_entity.name,
+                            id = %added_entity.id,
+                            "declaration repeats an identity this transaction already carries, skipping"
+                        );
+                        continue;
+                    }
                     added_entity
                         .metadata
                         .extra
@@ -691,19 +717,18 @@ impl Reconciler {
             }
         }
 
-        // Entities that existed before but are no longer in the file -> removed
-        for (id, matched) in &matched_existing {
-            if !matched {
-                let old = existing
-                    .iter()
-                    .find(|entity| entity.id == *id)
-                    .expect("matched-existing map is derived from existing entities");
+        // Entities that existed before but are no longer in the file -> removed.
+        // Claiming as we go keeps one delta per entity even if graph truth
+        // handed back the same entity twice, and walking `existing` rather than
+        // a map keeps the removal order the order the graph reported.
+        for old in &existing {
+            if claimed.insert(old.id) {
                 delta
                     .entity_deltas
                     .push(EntityDelta::Removed { old: old.clone() });
-                self.lkg.remove(id);
-                removed.push(*id);
-                debug!(id = %id, "entity removed from file");
+                self.lkg.remove(&old.id);
+                removed.push(old.id);
+                debug!(id = %old.id, "entity removed from file");
             }
         }
 


### PR DESCRIPTION
Every live edit's semantic enrichment was rejected and dropped, so the graph kept
serving init-time truth while the workspace moved on.

Entity identity is derived from the file, the name, the kind, and the
declaration's start line. An edit above a declaration therefore retires the id
graph truth holds for it, and the next reconcile falls back to matching on name
and kind. That fallback re-scanned the existing entities from the top without
skipping one an earlier declaration had already claimed, so a file that declares
a name twice collapsed both halves onto whichever half the graph returned first.
Both pushed a modification for the same entity, the transaction carried two
deltas for one id, and kin-model refused it whole. The daemon logged the failure
and dropped the event, so nothing in that file ever advanced again.

A cfg-gated pair is enough to trigger this, which is why it fired on ordinary
files. Both entities named in the report are declared twice in their own file:
`run_local_cleanup_after_quarantine_hook` sits at snapshot.rs L251 and L260, and
`semantic_search_batch` at graph.rs L4283 and L4359. Init is unaffected because
there are no existing entities to mis-claim.

The match is now one to one. Both passes skip an entity another declaration
already claimed, the add path refuses an identity the transaction already
carries, and the removal loop claims as it goes so it emits one removal even if
graph truth hands the same entity back twice. Ordinary edits derive a valid
transaction again.

A dropped reconcile now names the file it dropped and says that path's
enrichment is stale. Retrying is deliberately not the answer here:
`reconcile_error_earns_retry` restricts retries to the mid-read race because a
deterministic failure re-derives the same rejected transaction forever, which is
the hot loop FIR-2131 fixed.

Four tests pin this. Two in kin-reconcile pin the delta shape directly, one for
one delta per entity and one for both halves surviving an edit. One in kin-daemon
proves the consequence end to end through the sync path: an added function
becomes queryable after an edit, where before it stayed absent and the file's
entities stayed frozen. A fourth pins that a comment-only edit does not churn
entity identity. The file-add and file-delete behavior from #713 stays green, as
does the rename path the id-first match exists for.

Refs FIR-2145

Not yet proven, and named rather than papered over: the report's second repro
appended a comment to the END of a file, which shifts no line, and that arm does
not reproduce in the harness because every id stays stable and the id-first pass
matches correctly. The likely live mechanism is a persisted store returning the
same entity row twice, which the removal-loop change also covers, but confirming
it needs one live re-dogfood on a fresh init and this lane opened no real store.
