### PR TITLE
Admit a worked-in Git repository and disclose what it did not admit

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -84,12 +84,20 @@ struct InitResultPayload<'a> {
 /// The uncommitted delta initialization saw and did not admit.
 #[derive(Debug, Serialize)]
 struct UncommittedWorktreePayload {
-    /// Paths observed, including any past the listing cap.
+    /// Paths observed, including every one this payload does not carry.
     observed_paths: usize,
-    /// Observed paths not carried in `paths`, because the walk stopped listing.
+    /// Observed paths not carried in `paths`.
     unlisted_paths: usize,
     paths: Vec<UncommittedPathPayload>,
 }
+
+/// Paths one machine-readable result carries by name.
+///
+/// Nothing bounds how many paths can differ: a repository whose checkout Git
+/// rewrote reports every text file it holds. A count of those is useful on a
+/// piped stdout and tens of thousands of path strings are not, so the payload
+/// carries a sample and says exactly how many it left out.
+const SERIALIZED_PATHS: usize = 200;
 
 #[derive(Debug, Serialize)]
 struct UncommittedPathPayload {
@@ -237,17 +245,19 @@ fn uncommitted_worktree_payload(
     if divergence.is_empty() {
         return None;
     }
+    let paths = divergence
+        .entries
+        .iter()
+        .take(SERIALIZED_PATHS)
+        .map(|entry| UncommittedPathPayload {
+            path: entry.path.to_string(),
+            state: entry.kind.label(),
+        })
+        .collect::<Vec<_>>();
     Some(UncommittedWorktreePayload {
         observed_paths: divergence.observed_paths(),
-        unlisted_paths: divergence.untracked_beyond_cap,
-        paths: divergence
-            .entries
-            .iter()
-            .map(|entry| UncommittedPathPayload {
-                path: entry.path.to_string(),
-                state: entry.kind.label(),
-            })
-            .collect(),
+        unlisted_paths: divergence.observed_paths() - paths.len(),
+        paths,
     })
 }
 
@@ -580,6 +590,41 @@ mod tests {
         assert!(lines.contains("untracked-09.log"), "{lines}");
         assert!(!lines.contains("untracked-10.log"), "{lines}");
         assert!(lines.contains("and 9 more"), "{lines}");
+    }
+
+    /// The machine-readable payload carries a sample and counts the rest.
+    ///
+    /// A repository whose checkout Git rewrote reports every text file it
+    /// holds, so an unbounded array here is tens of thousands of path strings
+    /// on a piped stdout. The count stays exact either way, and the two
+    /// numbers must always add up to it.
+    #[test]
+    fn the_uncommitted_payload_bounds_its_path_list_without_losing_the_count() {
+        let entries = (0..SERIALIZED_PATHS + 40)
+            .map(|index| {
+                (
+                    format!("src/file-{index:04}.rs"),
+                    kin_git::GitWorkspaceDivergenceKind::Modified,
+                )
+            })
+            .collect::<Vec<_>>();
+        let payload = uncommitted_worktree_payload(&divergence(
+            entries
+                .iter()
+                .map(|(path, kind)| (path.as_str(), *kind))
+                .collect(),
+            13,
+        ))
+        .expect("a divergent source carries a payload");
+
+        assert_eq!(payload.observed_paths, SERIALIZED_PATHS + 53);
+        assert_eq!(payload.paths.len(), SERIALIZED_PATHS);
+        assert_eq!(payload.unlisted_paths, 53);
+        assert_eq!(
+            payload.paths.len() + payload.unlisted_paths,
+            payload.observed_paths,
+            "what is listed plus what is not must be what was observed"
+        );
     }
 
     /// The falsification: a source that matched prints nothing, or the

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -347,7 +347,10 @@ fn uncommitted_worktree_disclosure(
         if paths.is_empty() {
             continue;
         }
-        let unlisted = paths.len().saturating_sub(DISCLOSED_PATHS)
+        // Paths the walk stopped naming are part of the total this line states
+        // and are not among the ones it can list, so they count once in each
+        // and never in both.
+        let observed = paths.len()
             + if kind == kin_git::GitWorkspaceDivergenceKind::Untracked {
                 divergence.untracked_beyond_cap
             } else {
@@ -359,14 +362,11 @@ fn uncommitted_worktree_disclosure(
             .cloned()
             .collect::<Vec<_>>()
             .join(", ");
+        let unlisted = observed - paths.len().min(DISCLOSED_PATHS);
         if unlisted > 0 {
             rendered.push_str(&format!(", and {unlisted} more"));
         }
-        lines.push(format!(
-            "    {} ({}): {rendered}",
-            kind.label(),
-            paths.len() + unlisted
-        ));
+        lines.push(format!("    {} ({observed}): {rendered}", kind.label()));
     }
     lines.push(
         "  None of it entered repository authority, and none of it was touched. It becomes \
@@ -504,6 +504,94 @@ mod tests {
         assert!(
             semantic_absence_notice(&enrichment(SemanticEnrichmentPresence::Present, 19_405))
                 .is_none()
+        );
+    }
+
+    fn divergence(
+        entries: Vec<(&str, kin_git::GitWorkspaceDivergenceKind)>,
+        beyond_cap: usize,
+    ) -> kin_git::GitWorkspaceDivergenceFacts {
+        let mut facts = kin_git::GitWorkspaceDivergenceFacts::none();
+        facts.entries = entries
+            .into_iter()
+            .map(|(path, kind)| kin_git::GitWorkspaceDivergence {
+                path: kin_model::RepoPath::from_bytes(path.as_bytes().to_vec())
+                    .expect("test repo path"),
+                kind,
+                detail: String::new(),
+                observed: None,
+            })
+            .collect();
+        facts.untracked_beyond_cap = beyond_cap;
+        facts
+    }
+
+    /// The disclosure names the paths and says where they went.
+    ///
+    /// A list with no disposition reads as damage, so the sentence about what
+    /// happens to the delta is asserted alongside the paths themselves.
+    #[test]
+    fn the_uncommitted_disclosure_names_paths_and_their_disposition() {
+        let lines = uncommitted_worktree_disclosure(&divergence(
+            vec![
+                ("src/main.rs", kin_git::GitWorkspaceDivergenceKind::Modified),
+                ("notes.txt", kin_git::GitWorkspaceDivergenceKind::Untracked),
+                ("staged.rs", kin_git::GitWorkspaceDivergenceKind::Staged),
+            ],
+            0,
+        ))
+        .join("\n");
+
+        assert!(lines.contains("3 path(s) differ"), "{lines}");
+        assert!(lines.contains("staged (1): staged.rs"), "{lines}");
+        assert!(lines.contains("modified (1): src/main.rs"), "{lines}");
+        assert!(lines.contains("untracked (1): notes.txt"), "{lines}");
+        assert!(
+            lines.contains("None of it entered repository authority"),
+            "{lines}"
+        );
+        assert!(lines.contains("the first time the daemon runs"), "{lines}");
+    }
+
+    /// A long list is capped and the rest counted, including what the walk
+    /// stopped naming, so the total the header states is never contradicted by
+    /// the lines beneath it.
+    #[test]
+    fn the_uncommitted_disclosure_counts_what_it_does_not_list() {
+        let entries = (0..12)
+            .map(|index| (index, kin_git::GitWorkspaceDivergenceKind::Untracked))
+            .collect::<Vec<_>>();
+        let named = entries
+            .iter()
+            .map(|(index, kind)| (format!("untracked-{index:02}.log"), *kind))
+            .collect::<Vec<_>>();
+        let lines = uncommitted_worktree_disclosure(&divergence(
+            named
+                .iter()
+                .map(|(path, kind)| (path.as_str(), *kind))
+                .collect(),
+            7,
+        ))
+        .join("\n");
+
+        assert!(lines.contains("19 path(s) differ"), "{lines}");
+        assert!(lines.contains("untracked (19)"), "{lines}");
+        assert!(lines.contains("untracked-00.log"), "{lines}");
+        assert!(lines.contains("untracked-09.log"), "{lines}");
+        assert!(!lines.contains("untracked-10.log"), "{lines}");
+        assert!(lines.contains("and 9 more"), "{lines}");
+    }
+
+    /// The falsification: a source that matched prints nothing, or the
+    /// disclosure is noise on every clean init.
+    #[test]
+    fn a_source_that_matched_gets_no_disclosure() {
+        assert!(
+            uncommitted_worktree_disclosure(&kin_git::GitWorkspaceDivergenceFacts::none())
+                .is_empty()
+        );
+        assert!(
+            uncommitted_worktree_payload(&kin_git::GitWorkspaceDivergenceFacts::none()).is_none()
         );
     }
 }

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -75,6 +75,26 @@ struct InitResultPayload<'a> {
     /// object store it was admitted from costs. Measured after publication, so
     /// it describes the store the caller now has rather than a projection of it.
     store_footprint: StoreFootprint,
+    /// Source paths that were not the committed state, and are therefore not in
+    /// what was admitted. Absent when the source carried none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uncommitted_worktree: Option<UncommittedWorktreePayload>,
+}
+
+/// The uncommitted delta initialization saw and did not admit.
+#[derive(Debug, Serialize)]
+struct UncommittedWorktreePayload {
+    /// Paths observed, including any past the listing cap.
+    observed_paths: usize,
+    /// Observed paths not carried in `paths`, because the walk stopped listing.
+    unlisted_paths: usize,
+    paths: Vec<UncommittedPathPayload>,
+}
+
+#[derive(Debug, Serialize)]
+struct UncommittedPathPayload {
+    path: String,
+    state: &'static str,
 }
 
 pub async fn run(path: Option<String>, json: bool) -> Result<()> {
@@ -205,9 +225,30 @@ fn print_json_result(
         initial_change_id: result.authority.initial_change_id.as_ref(),
         exact_reachable_git_history: boundary == InitBoundary::ExactGit,
         store_footprint: StoreFootprint::measure(&result.layout),
+        uncommitted_worktree: uncommitted_worktree_payload(&result.workspace_divergence),
     };
     println!("{}", serde_json::to_string_pretty(&payload)?);
     Ok(())
+}
+
+fn uncommitted_worktree_payload(
+    divergence: &kin_git::GitWorkspaceDivergenceFacts,
+) -> Option<UncommittedWorktreePayload> {
+    if divergence.is_empty() {
+        return None;
+    }
+    Some(UncommittedWorktreePayload {
+        observed_paths: divergence.observed_paths(),
+        unlisted_paths: divergence.untracked_beyond_cap,
+        paths: divergence
+            .entries
+            .iter()
+            .map(|entry| UncommittedPathPayload {
+                path: entry.path.to_string(),
+                state: entry.kind.label(),
+            })
+            .collect(),
+    })
 }
 
 fn print_human_result(
@@ -262,7 +303,77 @@ fn print_human_result(
         StoreFootprint::measure(&result.layout).render()
     );
     println!("  {}", store_size_notice());
+    for line in uncommitted_worktree_disclosure(&result.workspace_divergence) {
+        println!("{line}");
+    }
     Ok(())
+}
+
+/// Paths listed by name before the rest are counted rather than named.
+const DISCLOSED_PATHS: usize = 10;
+
+/// What to say about a source that had been worked in before it was admitted.
+///
+/// Authority is the committed state, so none of this is in the repository this
+/// command published, and none of it was lost either: it is still in the
+/// worktree, and the daemon admits it as workspace state the same way it admits
+/// every later edit. Both halves have to be said. A list with no disposition
+/// reads as damage, and a disposition with no list is a claim the operator
+/// cannot check.
+///
+/// Returns the exact lines to print, so absence is one empty vector rather than
+/// a branch at the call site.
+fn uncommitted_worktree_disclosure(
+    divergence: &kin_git::GitWorkspaceDivergenceFacts,
+) -> Vec<String> {
+    if divergence.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec![format!(
+        "  Uncommitted worktree state: {} path(s) differ from the committed state that was admitted",
+        divergence.observed_paths()
+    )];
+    for kind in [
+        kin_git::GitWorkspaceDivergenceKind::Staged,
+        kin_git::GitWorkspaceDivergenceKind::StagedRemoval,
+        kin_git::GitWorkspaceDivergenceKind::Modified,
+        kin_git::GitWorkspaceDivergenceKind::Missing,
+        kin_git::GitWorkspaceDivergenceKind::Untracked,
+    ] {
+        let paths = divergence
+            .of_kind(kind)
+            .map(|entry| entry.path.to_string())
+            .collect::<Vec<_>>();
+        if paths.is_empty() {
+            continue;
+        }
+        let unlisted = paths.len().saturating_sub(DISCLOSED_PATHS)
+            + if kind == kin_git::GitWorkspaceDivergenceKind::Untracked {
+                divergence.untracked_beyond_cap
+            } else {
+                0
+            };
+        let mut rendered = paths
+            .iter()
+            .take(DISCLOSED_PATHS)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        if unlisted > 0 {
+            rendered.push_str(&format!(", and {unlisted} more"));
+        }
+        lines.push(format!(
+            "    {} ({}): {rendered}",
+            kind.label(),
+            paths.len() + unlisted
+        ));
+    }
+    lines.push(
+        "  None of it entered repository authority, and none of it was touched. It becomes \
+         workspace state the first time the daemon runs here."
+            .to_string(),
+    );
+    lines
 }
 
 /// What to say when initialization produced no semantic entities at all.

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -12,12 +12,13 @@
         "fresh Git repositories import the complete exact reachable object, ref, change, tree, mode, symlink, gitlink, and non-code-artifact closure atomically",
         "fresh non-Git repositories create only an unborn repository-v6 authority",
         "existing .kin and non-empty non-Git directories fail without mutation",
-        "safe exact Git remote mappings are sealed into graph-adjacent local transport config while unsafe mappings fail closed before .kin publication"
+        "safe exact Git remote mappings are sealed into graph-adjacent local transport config while unsafe mappings fail closed before .kin publication",
+        "a Git worktree carrying uncommitted work is admitted at its committed state, with every differing path disclosed in human and JSON output rather than refused"
       ],
       "evidence_tests": [
         "crates/kin-cli/tests/init_json.rs"
       ],
-      "note": "The clean-slate admission dispatcher is implemented and covered by exact Git and native-unborn acceptance tests."
+      "note": "The clean-slate admission dispatcher is implemented and covered by exact Git and native-unborn acceptance tests. Repository authority is the committed workspace seed and nothing else, so index and worktree state that is not the seed is observed and reported rather than refused: it stays in the worktree and the daemon admits it as workspace state through the same seam it admits every later edit. What still refuses is ambiguity about the source itself, where the committed state a migration would seal is not decidable, which is an in-progress Git operation, a conflicted or sparse index, an entry Git has been told not to compare, a materialized nested repository, a hook the repository owns, a checkout filter, another registered worktree, and repository-local transport configuration outside the safe exact subset. That last refusal now names every offending key rather than the first."
     },
     {
       "command": "status",

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -152,6 +152,97 @@ fn fresh_git_init_json_reports_exact_reachable_authority() {
     assert!(!payload["initial_change_id"].is_null());
     assert!(repo.join(".kin/manifest.json").is_file());
     assert!(!repo.join("AGENTS.md").exists());
+    assert!(
+        payload["uncommitted_worktree"].is_null(),
+        "a source that matched carries no disclosure: {payload}"
+    );
+}
+
+/// A repository someone has been working in initializes and says what it saw.
+///
+/// The first repository a new adopter points `kin init` at has untracked files
+/// and unstaged edits in it, so this is the shape that decides whether adoption
+/// starts at all. Both halves are asserted: init succeeds, and the delta it did
+/// not admit is named on the surface the operator is looking at.
+#[test]
+fn a_worked_in_git_repository_initializes_and_discloses_the_delta() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("worked-in");
+    fs::create_dir_all(&home).expect("create home");
+    seed_git_repo(&repo);
+    fs::write(repo.join("README.md"), "edited after the commit\n").expect("unstaged edit");
+    fs::write(repo.join("scratch.log"), "log\n").expect("untracked file");
+    fs::write(repo.join("staged.txt"), "staged\n").expect("staged file");
+    run_git(&repo, &["add", "staged.txt"]);
+
+    let output = kin_init(&repo, &home, &["--json"]);
+    assert!(
+        output.status.success(),
+        "a worked-in repository must initialize: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("init stdout should be JSON");
+    let disclosed = &payload["uncommitted_worktree"];
+    assert_eq!(disclosed["observed_paths"], 3, "{payload}");
+    assert_eq!(disclosed["unlisted_paths"], 0, "{payload}");
+    let states = disclosed["paths"]
+        .as_array()
+        .expect("disclosed paths")
+        .iter()
+        .map(|entry| {
+            (
+                entry["path"].as_str().expect("path").to_string(),
+                entry["state"].as_str().expect("state").to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        states.contains(&("README.md".to_string(), "modified".to_string())),
+        "{states:?}"
+    );
+    assert!(
+        states.contains(&("staged.txt".to_string(), "staged".to_string())),
+        "{states:?}"
+    );
+    assert!(
+        states.contains(&("scratch.log".to_string(), "untracked".to_string())),
+        "{states:?}"
+    );
+
+    // The worktree keeps everything it had, and the admitted state is the
+    // commit rather than what is on disk.
+    assert_eq!(
+        fs::read_to_string(repo.join("README.md")).expect("read README"),
+        "edited after the commit\n"
+    );
+    assert!(repo.join("scratch.log").is_file());
+    assert_eq!(payload["workspace_generation"], 0);
+}
+
+/// The same repository through the human surface.
+#[test]
+fn a_worked_in_git_repository_names_the_delta_in_human_output() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("worked-in-human");
+    fs::create_dir_all(&home).expect("create home");
+    seed_git_repo(&repo);
+    fs::write(repo.join("scratch.log"), "log\n").expect("untracked file");
+
+    let output = kin_init(&repo, &home, &[]);
+    assert!(output.status.success(), "init must succeed");
+    let printed = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        printed.contains("Uncommitted worktree state: 1 path(s) differ"),
+        "{printed}"
+    );
+    assert!(printed.contains("untracked (1): scratch.log"), "{printed}");
+    assert!(
+        printed.contains("None of it entered repository authority"),
+        "{printed}"
+    );
 }
 
 #[test]

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -183,7 +183,8 @@ fn a_worked_in_git_repository_initializes_and_discloses_the_delta() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let payload: Value = serde_json::from_slice(&output.stdout).expect("init stdout should be JSON");
+    let payload: Value =
+        serde_json::from_slice(&output.stdout).expect("init stdout should be JSON");
     let disclosed = &payload["uncommitted_worktree"];
     assert_eq!(disclosed["observed_paths"], 3, "{payload}");
     assert_eq!(disclosed["unlisted_paths"], 0, "{payload}");

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1148,7 +1148,10 @@ mod tests {
 
         let error = init_from_git(&source).unwrap_err().to_string();
 
-        assert!(error.contains("MERGE_HEAD") || error.contains("Merge"), "{error}");
+        assert!(
+            error.contains("MERGE_HEAD") || error.contains("Merge"),
+            "{error}"
+        );
         assert!(error.contains("finish or abort"), "{error}");
         assert!(!source.join(".kin").exists());
         assert_no_staging_directories(root.path());

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1009,7 +1009,7 @@ mod tests {
 
     /// Source blockers are reported before any derivation phase runs.
     ///
-    /// The fixture is shallow as well as dirty. Capture is the phase after the
+    /// The fixture is shallow as well as blocked. Capture is the phase after the
     /// blocker check and refuses a shallow source with its own message, so
     /// whichever message comes back names the phase that ran first. A timing
     /// assertion would claim the same thing and pass on a slow machine for the
@@ -1025,11 +1025,11 @@ mod tests {
         git(&source, ["commit", "-m", "initial"]);
         let head = git_stdout(&source, ["rev-parse", "HEAD"]);
         std::fs::write(source.join(".git/shallow"), format!("{}\n", head.trim())).unwrap();
-        std::fs::write(source.join("init.log"), b"log\n").unwrap();
+        git(&source, ["config", "remote.origin.tagOpt", "--tags"]);
 
         let error = init_from_git(&source).unwrap_err().to_string();
 
-        assert!(error.contains("init.log"), "{error}");
+        assert!(error.contains("remote.origin.tagOpt"), "{error}");
         assert!(
             !error.contains("shallow"),
             "capture must not have run yet: {error}"
@@ -1049,16 +1049,107 @@ mod tests {
         git(&source, ["add", "--all"]);
         git(&source, ["commit", "-m", "initial"]);
         git(&source, ["config", "remote.origin.tagOpt", "--tags"]);
+        git(&source, ["config", "branch.main.vscode-merge-base", "main"]);
+        git(&source, ["config", "filter.demo.clean", "external-clean"]);
+
+        let error = init_from_git(&source).unwrap_err().to_string();
+
+        assert!(error.contains("remote.origin.tagOpt"), "{error}");
+        assert!(error.contains("branch.main.vscode-merge-base"), "{error}");
+        assert!(error.contains("filter \"demo\""), "{error}");
+        assert!(!source.join(".kin").exists());
+        assert_no_staging_directories(root.path());
+    }
+
+    /// A repository someone has been working in initializes.
+    ///
+    /// This is the whole point of the change: the wall a first adopter hits is
+    /// an ordinary working tree, and the repository that comes out of it must
+    /// still be sealed at the committed state. The assertions are therefore both
+    /// halves, that init succeeded and that nothing uncommitted reached
+    /// authority, plus the disclosure that says where the delta went.
+    #[test]
+    fn a_worked_in_repository_initializes_and_discloses_what_it_did_not_admit() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        std::fs::write(source.join("kept.txt"), b"committed\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+        let committed_tree = git_stdout(&source, ["rev-parse", "HEAD^{tree}"]);
+
+        std::fs::write(source.join("README.md"), b"edited after the commit\n").unwrap();
         std::fs::write(source.join("init.log"), b"log\n").unwrap();
         std::fs::write(source.join("staged.txt"), b"staged\n").unwrap();
         git(&source, ["add", "staged.txt"]);
 
+        let result = init_from_git(&source).unwrap();
+
+        // The tree under authority is the committed one, byte for byte. Reading
+        // it back out of the repository and comparing against Git's own hash of
+        // the commit is what proves the edit did not enter, rather than the
+        // absence of an error.
+        assert_eq!(
+            git_stdout(&source, ["rev-parse", "HEAD^{tree}"]),
+            committed_tree
+        );
+        assert_eq!(result.authority.workspace.workspace_generation, 0);
+        let divergence = &result.workspace_divergence;
+        assert_eq!(divergence.observed_paths(), 3, "{divergence:?}");
+        let disclosed = divergence
+            .entries
+            .iter()
+            .map(|entry| (entry.path.to_string(), entry.kind))
+            .collect::<Vec<_>>();
+        assert!(
+            disclosed.contains(&(
+                "README.md".to_string(),
+                kin_git::GitWorkspaceDivergenceKind::Modified
+            )),
+            "{disclosed:?}"
+        );
+        assert!(
+            disclosed.contains(&(
+                "staged.txt".to_string(),
+                kin_git::GitWorkspaceDivergenceKind::Staged
+            )),
+            "{disclosed:?}"
+        );
+        assert!(
+            disclosed.contains(&(
+                "init.log".to_string(),
+                kin_git::GitWorkspaceDivergenceKind::Untracked
+            )),
+            "{disclosed:?}"
+        );
+        // The source keeps every one of them.
+        assert_eq!(
+            std::fs::read(source.join("README.md")).unwrap(),
+            b"edited after the commit\n"
+        );
+        assert!(source.join("init.log").exists());
+        assert_no_staging_directories(root.path());
+    }
+
+    /// An ambiguous source still refuses, and says so before deriving anything.
+    #[test]
+    fn an_in_progress_git_operation_still_refuses() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+        let head = git_stdout(&source, ["rev-parse", "HEAD"]);
+        std::fs::write(source.join(".git/MERGE_HEAD"), format!("{}\n", head.trim())).unwrap();
+
         let error = init_from_git(&source).unwrap_err().to_string();
 
-        assert!(error.contains("init.log"), "{error}");
-        assert!(error.contains("staged.txt"), "{error}");
-        assert!(error.contains("remote.origin.tagOpt"), "{error}");
-        assert!(error.contains(".gitignore"), "{error}");
+        assert!(error.contains("MERGE_HEAD") || error.contains("Merge"), "{error}");
+        assert!(error.contains("finish or abort"), "{error}");
         assert!(!source.join(".kin").exists());
         assert_no_staging_directories(root.path());
     }
@@ -1125,6 +1216,12 @@ mod tests {
         assert_no_staging_directories(root.path());
     }
 
+    /// A tracked edit racing publication is still fatal.
+    ///
+    /// The proof no longer refuses an edited worktree, so what catches this is
+    /// the comparison of the two proofs rather than the second one failing. The
+    /// outcome is the same and the reason is different, which is why the
+    /// assertion names the sentence the comparison produces.
     #[test]
     fn source_drift_immediately_after_publication_is_detected_fail_loud() {
         let root = tempfile::tempdir().unwrap();
@@ -1149,7 +1246,12 @@ mod tests {
             error,
             KinError::RepositoryPublishedButUncertain { .. }
         ));
-        assert!(error.to_string().contains("after publication"));
+        assert!(
+            error
+                .to_string()
+                .contains("changed across repository publication"),
+            "{error}"
+        );
         assert!(source.join(".kin").is_dir());
         assert_no_staging_directories(root.path());
     }

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -435,6 +435,12 @@ fn init_from_git_with_hooks(
     // proved that alias while validating the complete history; preserve it in
     // the initialization receipt instead of reporting an absent initial change.
     result.authority.initial_change_id = workspace_base_change_id;
+    // What the source held that the committed state does not. None of it is in
+    // the repository this call published; all of it is still in the worktree,
+    // where the daemon admits it as workspace state on its first run.
+    result
+        .workspace_divergence
+        .clone_from(&source_proof.workspace_divergence);
 
     info!(
         path = %source.display(),

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -64,6 +64,12 @@ pub struct InitResult {
     /// exact raw tag target remains in `GitExternalAuthority`.
     pub head: WorkspaceHead,
     pub authority: RepositoryBootstrap,
+    /// Source paths initialization observed differing from the state it
+    /// admitted, disclosed rather than admitted.
+    ///
+    /// Always empty for an unborn native repository, which has no source to
+    /// differ from.
+    pub workspace_divergence: kin_git::GitWorkspaceDivergenceFacts,
 }
 
 #[derive(Clone)]
@@ -1210,6 +1216,7 @@ fn publish_repository_layout_impl(
         workspace_id: prepared.workspace_id,
         head: bootstrap.workspace.workspace_head.clone(),
         authority: bootstrap,
+        workspace_divergence: kin_git::GitWorkspaceDivergenceFacts::none(),
     })
 }
 

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -7,41 +7,33 @@
 //! history. Every refusal it can reach before publication, though, is decided
 //! by source state a reader can observe in about a second: registered
 //! worktrees, the hook surface Git would really run, checkout filters,
-//! repository-local transport configuration, the index against HEAD, and
-//! untracked worktree paths.
+//! repository-local transport configuration, and a sparse checkout.
 //!
 //! This boundary reads exactly those, reports all of them at once with the
 //! path or key that caused each and the one action that clears it, and admits
 //! nothing: a clean report only means the expensive proof is worth starting.
 //! Admission policy is unchanged, so anything reported here is something the
 //! authority proof would have refused anyway, only later and one at a time.
+//!
+//! A worktree that has been worked in is not among them. Uncommitted state is
+//! not repository authority and never enters it, so the proof observes the
+//! delta and reports it rather than refusing; see [`crate::preflight`].
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-
-use gix::bstr::ByteSlice;
-use kin_model::RepoPath;
 
 use crate::error::{
     GitAdmissionBlocker, GitError, LocalGitHookFact, RegisteredGitWorktreeKind, Result,
 };
 use crate::lossless::open_repo;
 use crate::preflight::{
-    checkout_filter_facts, exact_directory_names, frozen_ignore_stack, hook_executability,
-    hook_kind, local_ignore_inputs, open_repo_with_user_ignore_config, other_registered_worktrees,
-    preflight_error, reject_in_progress_operations, remote_mapping_facts, stable_path,
+    checkout_filter_facts, exact_directory_names, hook_executability, hook_kind,
+    open_repo_with_user_ignore_config, other_registered_worktrees, preflight_error,
+    reject_in_progress_operations, scan_remote_mapping, stable_path,
 };
 
 /// Paths of one class printed before the rest are counted rather than listed.
 const REPORTED_PATHS: usize = 10;
-
-/// Untracked paths gathered before the walk stops looking for more.
-///
-/// A worktree carrying an unignored build directory holds hundreds of
-/// thousands of them, and every one past the first few hundred changes neither
-/// the verdict nor what the reader has to do about it.
-const UNTRACKED_SCAN_CAP: usize = 512;
 
 /// Everything one Git source repository would be refused for, in one report.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -133,30 +125,19 @@ pub fn collect_git_admission_blockers(repo_path: &Path) -> Result<GitAdmissionRe
         ));
     }
 
-    // The scan stops at the first key it refuses, so this reports one key
-    // rather than all of them. Naming that one is the whole difference from
-    // the category the message used to carry.
-    match remote_mapping_facts(&repo) {
-        Ok(_) => {}
-        Err(GitError::MigrationPreflight(reason)) => report.blockers.push(
-            GitAdmissionBlocker::new(reason, "unset that key in .git/config, or clone without it"),
-        ),
-        Err(error) => return Err(error),
+    // Every offending key, not the first. A repository outside the safe subset
+    // usually holds several, and one name per run is what turns a config edit
+    // into a sequence of them.
+    for reason in scan_remote_mapping(&repo)?.refusals {
+        report.blockers.push(GitAdmissionBlocker::new(
+            reason,
+            "unset that key in .git/config, or clone without it",
+        ));
     }
 
-    // A sparse index describes directories rather than leaves, so comparing it
-    // against a committed tree would name every path in the repository and
-    // none of them would be the problem. Admission refuses it outright and
-    // that refusal is the one worth reporting.
     if let Some(sparse) = sparse_checkout_blocker(&repo)? {
         report.blockers.push(sparse);
-        return Ok(report);
     }
-    let index = read_index(&repo)?;
-    report.blockers.extend(staged_blockers(&repo, &index)?);
-    report
-        .blockers
-        .extend(untracked_blockers(&ambient, &index, &source)?);
     Ok(report)
 }
 
@@ -423,236 +404,6 @@ fn read_index(repo: &gix::Repository) -> Result<gix::index::File> {
     .map_err(|error| preflight_error(format!("open Git index: {error}")))
 }
 
-/// Index entries that do not equal the committed tree they came from.
-fn staged_blockers(
-    repo: &gix::Repository,
-    index: &gix::index::File,
-) -> Result<Vec<GitAdmissionBlocker>> {
-    let committed = committed_tree_entries(repo)?;
-    let mut staged = Vec::new();
-    let mut removed = committed.clone();
-    for entry in index.entries() {
-        let path = entry.path(index).to_vec();
-        match removed.remove(&path) {
-            Some(committed) if committed == (entry.mode.bits(), entry.id) => {}
-            Some(_) | None => staged.push(display_path(&path)),
-        }
-    }
-    let mut blockers = Vec::new();
-    if !staged.is_empty() {
-        blockers.push(GitAdmissionBlocker::new(
-            format!(
-                "index contains {} staged or otherwise uncommitted path(s): {}",
-                staged.len(),
-                render_paths(staged)
-            ),
-            "commit them or run 'git restore --staged' on each, because Kin admits committed \
-             history exactly",
-        ));
-    }
-    let mut deleted = removed
-        .into_keys()
-        .map(|path| display_path(&path))
-        .collect::<Vec<_>>();
-    if !deleted.is_empty() {
-        deleted.sort();
-        blockers.push(GitAdmissionBlocker::new(
-            format!(
-                "index no longer carries {} committed path(s): {}",
-                deleted.len(),
-                render_paths(deleted)
-            ),
-            "commit the removal or run 'git restore --staged' on each",
-        ));
-    }
-    Ok(blockers)
-}
-
-/// Every blob, symlink, and gitlink the current HEAD commit records.
-///
-/// An unborn HEAD commits nothing, so every index entry there is staged.
-fn committed_tree_entries(
-    repo: &gix::Repository,
-) -> Result<BTreeMap<Vec<u8>, (u32, gix::ObjectId)>> {
-    let Ok(head) = repo.head_commit() else {
-        return Ok(BTreeMap::new());
-    };
-    let tree = head
-        .tree()
-        .map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?;
-    let mut entries = BTreeMap::new();
-    collect_tree_entries(repo, &tree, &[], &mut entries)?;
-    Ok(entries)
-}
-
-fn collect_tree_entries(
-    repo: &gix::Repository,
-    tree: &gix::Tree<'_>,
-    prefix: &[u8],
-    entries: &mut BTreeMap<Vec<u8>, (u32, gix::ObjectId)>,
-) -> Result<()> {
-    for entry in tree.iter() {
-        let entry =
-            entry.map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?;
-        let mut path = prefix.to_vec();
-        if !path.is_empty() {
-            path.push(b'/');
-        }
-        path.extend_from_slice(entry.filename().as_bytes());
-        let mode = entry.mode();
-        let oid = entry.oid().to_owned();
-        if mode.is_tree() {
-            let subtree = repo
-                .find_object(oid)
-                .map_err(|error| preflight_error(format!("read committed Git tree: {error}")))?
-                .try_into_tree()
-                .map_err(|_| {
-                    preflight_error(format!(
-                        "committed Git entry {} is recorded as a tree but is not one",
-                        display_path(&path)
-                    ))
-                })?;
-            collect_tree_entries(repo, &subtree, &path, entries)?;
-            continue;
-        }
-        entries.insert(path, (canonical_mode(mode), oid));
-    }
-    Ok(())
-}
-
-/// The mode Git's index records for one committed entry.
-///
-/// A tree may carry a non-canonical file mode such as `100664`, which several
-/// importers still write, while the index decodes to the canonical `100644`.
-/// Comparing the raw values reads such a repository as having every file
-/// staged, and no `git restore --staged` can clear it because nothing is.
-/// Admission itself compares the entry kind, so this does too.
-fn canonical_mode(mode: gix::objs::tree::EntryMode) -> u32 {
-    match mode.kind() {
-        gix::objs::tree::EntryKind::Tree => 0o040_000,
-        gix::objs::tree::EntryKind::Blob => 0o100_644,
-        gix::objs::tree::EntryKind::BlobExecutable => 0o100_755,
-        gix::objs::tree::EntryKind::Link => 0o120_000,
-        gix::objs::tree::EntryKind::Commit => 0o160_000,
-    }
-}
-
-/// Worktree paths that are neither tracked nor ignored.
-fn untracked_blockers(
-    ambient: &gix::Repository,
-    index: &gix::index::File,
-    workdir: &Path,
-) -> Result<Vec<GitAdmissionBlocker>> {
-    let inputs = local_ignore_inputs(ambient)?;
-    let (mut excludes, _) = frozen_ignore_stack(ambient, index, &inputs)?;
-    let tracked = index
-        .entries()
-        .iter()
-        .map(|entry| entry.path(index).to_vec())
-        .collect::<std::collections::BTreeSet<_>>();
-    let mut scan = UntrackedScan {
-        tracked,
-        found: Vec::new(),
-        capped: false,
-    };
-    scan_untracked(workdir, &[], true, &mut excludes, &mut scan)?;
-    if scan.found.is_empty() {
-        return Ok(Vec::new());
-    }
-    let counted = if scan.capped {
-        format!("at least {}", scan.found.len())
-    } else {
-        scan.found.len().to_string()
-    };
-    Ok(vec![GitAdmissionBlocker::new(
-        format!(
-            "worktree contains {counted} untracked non-ignored path(s): {}",
-            render_paths(scan.found.iter().map(RepoPath::to_string).collect())
-        ),
-        "commit them, delete them, or add them to .gitignore",
-    )])
-}
-
-struct UntrackedScan {
-    tracked: std::collections::BTreeSet<Vec<u8>>,
-    found: Vec<RepoPath>,
-    capped: bool,
-}
-
-/// Walk the worktree the way the authority proof does, collecting instead of
-/// refusing at the first entry.
-///
-/// The ignore decision itself is the same call over the same frozen inputs, so
-/// a path listed here is a path the proof would have refused.
-fn scan_untracked(
-    absolute: &Path,
-    relative: &[u8],
-    root: bool,
-    excludes: &mut gix::AttributeStack<'_>,
-    scan: &mut UntrackedScan,
-) -> Result<()> {
-    let entries = fs::read_dir(absolute)
-        .map_err(|error| GitError::io(absolute, error))?
-        .collect::<std::io::Result<Vec<_>>>()
-        .map_err(|error| GitError::io(absolute, error))?;
-    let entries = exact_directory_names(absolute, entries)?;
-
-    for (name, directory_entry) in entries {
-        if scan.capped {
-            return Ok(());
-        }
-        if root && name == b".git" {
-            continue;
-        }
-        let path_bytes = if relative.is_empty() {
-            name
-        } else {
-            let mut joined = Vec::with_capacity(relative.len() + 1 + name.len());
-            joined.extend_from_slice(relative);
-            joined.push(b'/');
-            joined.extend_from_slice(&name);
-            joined
-        };
-        if scan.tracked.contains(&path_bytes) {
-            continue;
-        }
-        let absolute_path = directory_entry.path();
-        let metadata = fs::symlink_metadata(&absolute_path)
-            .map_err(|error| GitError::io(&absolute_path, error))?;
-        let mode = if metadata.is_dir() {
-            Some(gix::index::entry::Mode::DIR)
-        } else if metadata.file_type().is_symlink() {
-            Some(gix::index::entry::Mode::SYMLINK)
-        } else {
-            Some(gix::index::entry::Mode::FILE)
-        };
-        let ignored = excludes
-            .at_entry(path_bytes.as_bstr(), mode)
-            .map_err(|error| {
-                preflight_error(format!(
-                    "evaluate ignore rules for {}: {error}",
-                    display_path(&path_bytes)
-                ))
-            })?
-            .is_excluded();
-        if ignored {
-            continue;
-        }
-        if metadata.is_dir() {
-            scan_untracked(&absolute_path, &path_bytes, false, excludes, scan)?;
-            continue;
-        }
-        let path = RepoPath::from_bytes(path_bytes)
-            .map_err(|error| preflight_error(format!("invalid worktree path: {error}")))?;
-        scan.found.push(path);
-        if scan.found.len() >= UNTRACKED_SCAN_CAP {
-            scan.capped = true;
-            return Ok(());
-        }
-    }
-    Ok(())
-}
-
 /// Print the first few of a list and count the rest.
 fn render_paths(mut paths: Vec<String>) -> String {
     let total = paths.len();
@@ -662,10 +413,6 @@ fn render_paths(mut paths: Vec<String>) -> String {
         return format!("{listed}, and {} more", total - REPORTED_PATHS);
     }
     listed
-}
-
-fn display_path(path: &[u8]) -> String {
-    String::from_utf8_lossy(path).into_owned()
 }
 
 #[cfg(all(test, unix))]

--- a/crates/kin-git/src/admission_blockers.rs
+++ b/crates/kin-git/src/admission_blockers.rs
@@ -514,44 +514,6 @@ mod tests {
         effective_hook_surface(&repo, &ambient).expect("resolve hook surface")
     }
 
-    fn git_stdout(repo: &Path, args: &[&str]) -> String {
-        let output = fixture_git()
-            .current_dir(repo)
-            .args(args)
-            .output()
-            .expect("run fixture git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8(output.stdout)
-            .expect("utf8 git stdout")
-            .trim()
-            .to_string()
-    }
-
-    fn git_stdin(repo: &Path, args: &[&str], input: &str) -> String {
-        git_bytes_stdin(repo, args, input.as_bytes())
-    }
-
-    fn git_bytes_stdin(repo: &Path, args: &[&str], input: &[u8]) -> String {
-        let output = fixture_git()
-            .current_dir(repo)
-            .args(args)
-            .output_with_input(input)
-            .expect("run fixture git");
-        assert!(
-            output.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        String::from_utf8(output.stdout)
-            .expect("utf8 git stdout")
-            .trim()
-            .to_string()
-    }
-
     fn write_executable(path: &Path, body: &[u8]) {
         fs::write(path, body).expect("write executable");
         let mut permissions = fs::metadata(path).expect("metadata").permissions();
@@ -578,17 +540,14 @@ mod tests {
             &["config", "filter.demo.clean", "external-clean"],
         );
         git(&fixture.repo, &["config", "remote.origin.tagOpt", "--tags"]);
-        fs::write(fixture.repo.join("init.log"), b"log\n").expect("untracked");
-        fs::write(fixture.repo.join("staged.txt"), b"staged\n").expect("staged");
-        git(&fixture.repo, &["add", "staged.txt"]);
+        git(&fixture.repo, &["config", "core.sshCommand", "ssh -v"]);
 
         let refusal = fixture.refusal();
         for expected in [
             "pre-commit",
             "filter \"demo\"",
             "remote.origin.tagOpt",
-            "init.log",
-            "staged.txt",
+            "core.sshCommand",
         ] {
             assert!(
                 refusal.contains(expected),
@@ -597,7 +556,7 @@ mod tests {
         }
         let report = fixture.report();
         assert!(
-            report.blockers.len() >= 5,
+            report.blockers.len() >= 4,
             "one refusal must carry every class: {report:?}"
         );
         for blocker in &report.blockers {
@@ -606,6 +565,68 @@ mod tests {
                 "every blocker names its way out: {blocker:?}"
             );
         }
+    }
+
+    /// Every offending transport key at once, not the first one found.
+    ///
+    /// Clearing them one refusal per attempt is the whole cost this reports
+    /// away, and it only shows up on a repository carrying more than one, which
+    /// an ordinary editor-configured checkout does.
+    #[test]
+    fn every_unsupported_transport_key_is_named_in_one_refusal() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "remote.origin.tagOpt", "--tags"]);
+        git(
+            &fixture.repo,
+            &["config", "branch.main.vscode-merge-base", "origin/main"],
+        );
+        git(&fixture.repo, &["config", "core.askPass", "/bin/true"]);
+
+        let refusal = fixture.refusal();
+        for expected in [
+            "remote.origin.tagOpt",
+            "branch.main.vscode-merge-base",
+            "core.askPass",
+        ] {
+            assert!(
+                refusal.contains(expected),
+                "expected {expected:?} in refusal:\n{refusal}"
+            );
+        }
+    }
+
+    /// Two offending keys inside one section are both named.
+    #[test]
+    fn a_section_carrying_two_unsupported_keys_names_both() {
+        let fixture = Fixture::clean();
+        git(&fixture.repo, &["config", "remote.origin.tagOpt", "--tags"]);
+        git(&fixture.repo, &["config", "remote.origin.prune", "true"]);
+
+        let refusal = fixture.refusal();
+        assert!(refusal.contains("remote.origin.tagOpt"), "{refusal}");
+        assert!(refusal.contains("remote.origin.prune"), "{refusal}");
+    }
+
+    /// A worked-in repository is admissible.
+    ///
+    /// Untracked, staged, and staged-removed paths are all worktree state
+    /// rather than repository authority, so none of them is a blocker. The
+    /// disclosure of what they are lives in the migration proof, which reads
+    /// content this boundary deliberately never opens.
+    #[test]
+    fn a_worked_in_worktree_is_not_a_blocker() {
+        let fixture = Fixture::clean();
+        fs::write(fixture.repo.join("init.log"), b"log\n").expect("untracked");
+        fs::write(fixture.repo.join("staged.txt"), b"staged\n").expect("staged");
+        git(&fixture.repo, &["add", "staged.txt"]);
+        git(&fixture.repo, &["rm", "--cached", "README.md"]);
+
+        let report = fixture.report();
+        assert!(
+            report.is_clear(),
+            "uncommitted state is not an admission blocker: {report:?}"
+        );
+        check_git_admission_blockers(&fixture.repo).expect("a worked-in repository clears");
     }
 
     #[test]
@@ -785,31 +806,6 @@ mod tests {
     }
 
     #[test]
-    fn untracked_paths_are_listed_and_the_rest_counted() {
-        let fixture = Fixture::clean();
-        for index in 0..12 {
-            fs::write(
-                fixture.repo.join(format!("untracked-{index:02}.log")),
-                b"noise\n",
-            )
-            .expect("untracked file");
-        }
-
-        let refusal = fixture.refusal();
-        assert!(
-            refusal.contains("12 untracked non-ignored path(s)"),
-            "{refusal}"
-        );
-        assert!(refusal.contains("untracked-00.log"), "{refusal}");
-        assert!(refusal.contains("untracked-09.log"), "{refusal}");
-        assert!(refusal.contains("and 2 more"), "{refusal}");
-        assert!(
-            refusal.contains(".gitignore"),
-            "the remedy names the way out:\n{refusal}"
-        );
-    }
-
-    #[test]
     fn an_ignored_path_is_not_a_blocker() {
         let fixture = Fixture::clean();
         fs::write(fixture.repo.join(".gitignore"), b"build/\n").expect("gitignore");
@@ -822,67 +818,6 @@ mod tests {
         assert!(
             report.is_clear(),
             "ignored content is admissible: {report:?}"
-        );
-    }
-
-    /// A committed tree may record a mode the index cannot hold.
-    ///
-    /// `100664` is legal in a tree and several importers write it, while the
-    /// index decodes every plain file to `100644`. Comparing the raw values
-    /// reads such a repository as having every file staged, and no `git restore
-    /// --staged` clears it because nothing is staged. Admission itself admits
-    /// this repository, so a refusal here would be both wrong and inescapable.
-    #[test]
-    fn a_non_canonical_committed_filemode_is_not_read_as_staged() {
-        let fixture = Fixture::clean();
-        let blob = git_stdout(&fixture.repo, &["rev-parse", "HEAD:README.md"]);
-        // Written as raw tree bytes because `git mktree` canonicalises the mode
-        // on the way in, which is exactly the normalisation this case needs to
-        // be missing.
-        let mut body = b"100664 README.md\0".to_vec();
-        body.extend(
-            (0..blob.len() / 2)
-                .map(|index| u8::from_str_radix(&blob[index * 2..index * 2 + 2], 16))
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .expect("hex object id"),
-        );
-        let tree = git_bytes_stdin(
-            &fixture.repo,
-            &["hash-object", "-t", "tree", "-w", "--stdin", "--literally"],
-            &body,
-        );
-        let commit = git_stdin(
-            &fixture.repo,
-            &["commit-tree", &tree, "-m", "non-canonical mode"],
-            "",
-        );
-        git(&fixture.repo, &["reset", "--hard", &commit]);
-        // Read as raw object bytes, because `cat-file -p` prints the
-        // canonicalised mode and would report the fixture worked either way.
-        let raw = fixture_git()
-            .current_dir(&fixture.repo)
-            .args(["cat-file", "tree", "HEAD^{tree}"])
-            .output()
-            .expect("read raw committed tree");
-        assert!(
-            raw.stdout.starts_with(b"100664 "),
-            "the fixture must keep the mode this case is about"
-        );
-
-        let report = fixture.report();
-        assert!(report.is_clear(), "{report:?}");
-    }
-
-    #[test]
-    fn a_staged_deletion_is_reported_as_an_uncommitted_path() {
-        let fixture = Fixture::clean();
-        git(&fixture.repo, &["rm", "--cached", "README.md"]);
-
-        let refusal = fixture.refusal();
-        assert!(refusal.contains("README.md"), "{refusal}");
-        assert!(
-            refusal.contains("committed path(s)"),
-            "a staged removal is named as one:\n{refusal}"
         );
     }
 
@@ -909,12 +844,14 @@ mod tests {
     #[test]
     fn a_blocked_repository_is_refused_without_a_snapshot_or_a_plan() {
         let fixture = Fixture::clean();
-        fs::write(fixture.repo.join("init.log"), b"log\n").expect("untracked");
+        let hooks = fixture.temp.path().join("hooks");
+        fixture.pin_hook_surface(&hooks);
+        write_executable(&hooks.join("pre-commit"), b"#!/bin/sh\nexit 0\n");
         // The whole argument list is one path. Nothing here can consult a
         // lossless snapshot, an import plan, or a blob store, because it is
         // never given one, which is what makes the check cheap enough to run
         // before any of them exist.
         let refusal = check_git_admission_blockers(&fixture.repo).expect_err("blocked admission");
-        assert!(refusal.to_string().contains("init.log"), "{refusal}");
+        assert!(refusal.to_string().contains("pre-commit"), "{refusal}");
     }
 }

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -56,8 +56,9 @@ pub use preflight::{
     preflight_git_migration, preflight_git_migration_after_publication, GitBranchTrackingFact,
     GitIndexPreflightProof, GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind,
     GitMigrationCompatibilityFacts, GitMigrationPreflightProof, GitRemoteConfigFact,
-    GitRemoteMappingFacts, GitTrackedWorktreeProof, IgnoredLocalEntry, IgnoredLocalEntryKind,
-    IgnoredLocalWorktreeFact,
+    GitRemoteMappingFacts, GitTrackedWorktreeProof, GitWorkspaceDivergence,
+    GitWorkspaceDivergenceFacts, GitWorkspaceDivergenceKind, IgnoredLocalEntry,
+    IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
 };
 pub use repository_export::{
     export_repository_to_git, verify_repository_git_export, RepositoryGitCommitBinding,

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -390,8 +390,9 @@ impl DivergenceLog {
     }
 
     fn finish(mut self) -> GitWorkspaceDivergenceFacts {
-        self.entries
-            .sort_by(|left, right| (left.kind.code(), &left.path).cmp(&(right.kind.code(), &right.path)));
+        self.entries.sort_by(|left, right| {
+            (left.kind.code(), &left.path).cmp(&(right.kind.code(), &right.path))
+        });
         let mut hash = FramedHash::new(b"kin.git.preflight.divergence.v1");
         hash.u64(self.entries.len() as u64);
         for entry in &self.entries {
@@ -1432,22 +1433,24 @@ fn prove_tracked_entry(
     match expected.tree_entry {
         TreeEntry::Blob { hash, executable } => {
             if !metadata.is_file() || metadata.file_type().is_symlink() {
-                return Ok(diverged(
+                diverged(
                     state,
                     path,
                     "the worktree no longer materializes it as a regular file",
                     None,
-                ));
+                );
+                return Ok(());
             }
             if state.executable_authority == ExecutableModeAuthority::WorktreeMode
                 && filesystem_executable(metadata)? != executable
             {
-                return Ok(diverged(
+                diverged(
                     state,
                     path,
                     "its executable mode differs from the committed tree",
                     None,
-                ));
+                );
+                return Ok(());
             }
             let actual =
                 fs::read(absolute_path).map_err(|error| GitError::io(absolute_path, error))?;
@@ -1464,7 +1467,8 @@ fn prove_tracked_entry(
                              normalization explains the difference"
                             .to_string(),
                     };
-                return Ok(diverged(state, path, detail, Some(digest(&actual))));
+                diverged(state, path, detail, Some(digest(&actual)));
+                return Ok(());
             }
             state.tracked_hash.u64(1);
             state.tracked_hash.bytes(hash.as_bytes());
@@ -1474,12 +1478,13 @@ fn prove_tracked_entry(
             let target = match state.symlink_materialization {
                 SymlinkMaterialization::Link => {
                     if !metadata.file_type().is_symlink() {
-                        return Ok(diverged(
+                        diverged(
                             state,
                             path,
                             "the worktree no longer materializes it as a symbolic link",
                             None,
-                        ));
+                        );
+                        return Ok(());
                     }
                     let target = fs::read_link(absolute_path)
                         .map_err(|error| GitError::io(absolute_path, error))?;
@@ -1492,56 +1497,62 @@ fn prove_tracked_entry(
                 // filesystem fallback for a missing link.
                 SymlinkMaterialization::TargetTextFile(source) => {
                     if metadata.file_type().is_symlink() {
-                        return Ok(diverged(
+                        diverged(
                             state,
                             path,
                             match source {
-                                SymlinkCapabilitySource::RepositoryRecorded =>
+                                SymlinkCapabilitySource::RepositoryRecorded => {
                                     "it is a real symbolic link, but the repository records \
                                      core.symlinks=false, so Git writes and compares the target \
-                                     as a regular file here",
-                                SymlinkCapabilitySource::PlatformDefault =>
+                                     as a regular file here"
+                                }
+                                SymlinkCapabilitySource::PlatformDefault => {
                                     "it is a real symbolic link, but this repository records no \
                                      core.symlinks value and Git's default on this platform \
                                      writes and compares the target as a regular file. Record \
                                      core.symlinks=true if this worktree really does carry real \
-                                     links",
+                                     links"
+                                }
                             },
                             None,
-                        ));
+                        );
+                        return Ok(());
                     }
                     if !metadata.is_file() {
-                        return Ok(diverged(
+                        diverged(
                             state,
                             path,
                             "it is not the regular file holding its target, which is what Git \
                              materializes under core.symlinks=off",
                             None,
-                        ));
+                        );
+                        return Ok(());
                     }
                     fs::read(absolute_path).map_err(|error| GitError::io(absolute_path, error))?
                 }
             };
             let committed = state.blob_store.read(&target_blob)?;
             if target != committed {
-                return Ok(diverged(
+                diverged(
                     state,
                     path,
                     "its link target differs from the committed tree",
                     Some(digest(&target)),
-                ));
+                );
+                return Ok(());
             }
             state.tracked_hash.u64(2);
             state.tracked_hash.bytes(target_blob.as_bytes());
         }
         TreeEntry::Gitlink { target } => {
             if !metadata.is_dir() || metadata.file_type().is_symlink() {
-                return Ok(diverged(
+                diverged(
                     state,
                     path,
                     "the worktree no longer materializes it as a directory",
                     None,
-                ));
+                );
+                return Ok(());
             }
             let mut entries =
                 fs::read_dir(absolute_path).map_err(|error| GitError::io(absolute_path, error))?;
@@ -1982,7 +1993,10 @@ fn printable_config_scope(scope: &str) -> String {
     section.to_string()
 }
 
-fn collect_transfer_core_keys(section: &gix::config::file::Section<'_>, refusals: &mut Vec<String>) {
+fn collect_transfer_core_keys(
+    section: &gix::config::file::Section<'_>,
+    refusals: &mut Vec<String>,
+) {
     const TRANSFER_KEYS: &[&str] = &[
         "askpass",
         "gitproxy",
@@ -3814,7 +3828,9 @@ mod tests {
         let untracked = Fixture::clean();
         fs::write(untracked.repo.join("surprise.txt"), b"surprise\n").expect("untracked");
         assert_discloses(
-            &untracked.preflight().expect("an untracked path is observed"),
+            &untracked
+                .preflight()
+                .expect("an untracked path is observed"),
             "surprise.txt",
             GitWorkspaceDivergenceKind::Untracked,
             "",
@@ -3918,7 +3934,8 @@ mod tests {
             "committed history is untouched by uncommitted work"
         );
         assert_eq!(
-            dirty_proof.semantic_plan_fingerprint, clean_proof.semantic_plan_fingerprint
+            dirty_proof.semantic_plan_fingerprint,
+            clean_proof.semantic_plan_fingerprint
         );
         assert_eq!(
             dirty_proof.workspace_divergence.observed_paths(),
@@ -4013,7 +4030,12 @@ mod tests {
         .trim()
         .to_string();
         let commit = String::from_utf8(
-            git_stdin(&repo, &["commit-tree", &tree, "-m", "non-canonical mode"], "").stdout,
+            git_stdin(
+                &repo,
+                &["commit-tree", &tree, "-m", "non-canonical mode"],
+                "",
+            )
+            .stdout,
         )
         .expect("utf8 object id")
         .trim()

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -3190,7 +3190,7 @@ mod platform_materialization_tests {
             "index authority settles the mode without rereading the worktree: {matched:?}"
         );
 
-        let diverged = prove_one_entry(
+        let compared = prove_one_entry(
             &tracked,
             TreeEntry::Blob {
                 hash,
@@ -3199,13 +3199,26 @@ mod platform_materialization_tests {
             &blob_store,
             ExecutableModeAuthority::WorktreeMode,
             SymlinkMaterialization::Link,
-        )
-        .expect("a worktree authority must still compare the filesystem");
-        let rendered = only_detail(&diverged);
-        assert!(
-            rendered.contains("executable mode differs"),
-            "unexpected detail: {rendered}"
         );
+        // Which outcome is correct is decided by the same predicate the
+        // production path decides on, so both hosts assert the behavior they
+        // actually have rather than one of them asserting the other's.
+        if filesystem_records_executable_bit() {
+            let rendered = only_detail(&compared.expect("a mode difference is observed"));
+            assert!(
+                rendered.contains("executable mode differs"),
+                "unexpected detail: {rendered}"
+            );
+        } else {
+            // A host with no executable bit never reaches worktree authority
+            // through `worktree_materialization`. Driving it here is what keeps
+            // the fail-closed backstop from rotting into a silent `false`.
+            let error = compared.expect_err("a mode this host cannot read is refused");
+            assert!(
+                error.to_string().contains("records no executable bit"),
+                "unexpected error: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -5,10 +5,22 @@
 //!
 //! A lossless object/ref snapshot proves committed repository history, not the
 //! mutable Git index or materialized checkout. This boundary independently
-//! proves that the source index and every tracked worktree leaf equal the
+//! observes the source index and every tracked worktree leaf against the
 //! committed workspace seed before a later admission lane may construct a
 //! workspace mutation. It never executes hooks or filters, never recurses into
 //! gitlinks, and never manufactures an admission token.
+//!
+//! Repository authority is the committed workspace seed and nothing else, so a
+//! path that differs from it is reported rather than refused: an index entry
+//! that is not the committed one, a tracked leaf the worktree materializes
+//! differently, a committed path the worktree no longer carries, and a worktree
+//! path that is neither tracked nor ignored are all recorded as divergence and
+//! carried in the proof. That is what a working repository looks like, and the
+//! daemon admits exactly this delta as workspace state on its first run.
+//! Ambiguity about the source itself still refuses, because there the committed
+//! state a migration would seal is not decidable: an in-progress Git operation,
+//! a conflicted or sparse index, an entry Git has been told not to compare, and
+//! a materialized nested repository.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -57,6 +69,9 @@ pub struct GitMigrationPreflightProof {
     pub semantic_plan_fingerprint: Hash256,
     pub index: GitIndexPreflightProof,
     pub tracked_worktree: GitTrackedWorktreeProof,
+    /// Index and worktree state that is not the committed workspace seed.
+    /// Observed, never admitted: authority is the seed alone.
+    pub workspace_divergence: GitWorkspaceDivergenceFacts,
     pub ignored_local: IgnoredLocalWorktreeFact,
     pub compatibility: GitMigrationCompatibilityFacts,
     pub remote_mapping: GitRemoteMappingFacts,
@@ -83,6 +98,101 @@ pub struct GitTrackedWorktreeProof {
     /// proves only as graph-owned, physically absent entries.
     pub host_unrepresentable_count: usize,
     pub fingerprint: Hash256,
+}
+
+/// Everything about one source that is not its committed workspace seed.
+///
+/// A working repository is edited, and none of that editing is repository
+/// authority: the seed is the committed tree, the delta is workspace state, and
+/// the daemon admits it through the same path it admits every later edit. The
+/// proof therefore carries the delta instead of refusing it, so init can say
+/// what it saw and what will happen to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitWorkspaceDivergenceFacts {
+    /// Divergent paths, grouped by kind and ordered by path within a kind.
+    pub entries: Vec<GitWorkspaceDivergence>,
+    /// Untracked paths found past the listing cap, counted rather than kept.
+    pub untracked_beyond_cap: usize,
+    pub fingerprint: Hash256,
+}
+
+impl GitWorkspaceDivergenceFacts {
+    /// The facts of a source with nothing to disclose.
+    ///
+    /// Its fingerprint is the one an observation of a repository that matched
+    /// its committed state produces, so a caller that has no source to observe
+    /// and one that observed no difference are not distinguishable by identity.
+    pub fn none() -> Self {
+        DivergenceLog::default().finish()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty() && self.untracked_beyond_cap == 0
+    }
+
+    /// Divergent paths observed, including the untracked ones past the cap.
+    pub fn observed_paths(&self) -> usize {
+        self.entries.len() + self.untracked_beyond_cap
+    }
+
+    pub fn of_kind(
+        &self,
+        kind: GitWorkspaceDivergenceKind,
+    ) -> impl Iterator<Item = &GitWorkspaceDivergence> {
+        self.entries.iter().filter(move |entry| entry.kind == kind)
+    }
+}
+
+/// One path whose source state differs from the committed workspace seed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitWorkspaceDivergence {
+    pub path: RepoPath,
+    pub kind: GitWorkspaceDivergenceKind,
+    /// One sentence naming what differs, for a kind that has more than one way
+    /// of differing. Empty when the kind already says everything.
+    pub detail: String,
+    /// Identity of the worktree bytes this observation read, where it read
+    /// them. A divergence proved by reading content carries what it read, so
+    /// repeating the observation detects content that moved under it.
+    pub observed: Option<Hash256>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitWorkspaceDivergenceKind {
+    /// Index entry that is not the committed entry for its path, or is a path
+    /// the committed tree does not carry at all.
+    Staged,
+    /// Committed path the index no longer carries.
+    StagedRemoval,
+    /// Tracked path the worktree materializes differently than committed.
+    Modified,
+    /// Committed path the worktree does not materialize at all.
+    Missing,
+    /// Worktree path that is neither tracked nor ignored.
+    Untracked,
+}
+
+impl GitWorkspaceDivergenceKind {
+    /// Stable ordering and encoding code, so grouping and the fingerprint agree.
+    fn code(self) -> u64 {
+        match self {
+            Self::Staged => 1,
+            Self::StagedRemoval => 2,
+            Self::Modified => 3,
+            Self::Missing => 4,
+            Self::Untracked => 5,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Staged => "staged",
+            Self::StagedRemoval => "staged removal",
+            Self::Modified => "modified",
+            Self::Missing => "missing",
+            Self::Untracked => "untracked",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,6 +336,72 @@ impl fmt::Debug for GitBranchTrackingFact {
             .field("push_remote_present", &self.push_remote.is_some())
             .field("values", &"<redacted>")
             .finish()
+    }
+}
+
+/// Untracked paths kept by name before the rest are only counted.
+///
+/// A worktree carrying an unignored build directory holds hundreds of
+/// thousands of them. The count stays exact because the walk has to visit every
+/// entry anyway to prove the tracked ones; only the list is bounded.
+const LISTED_UNTRACKED_CAP: usize = 512;
+
+/// Collects divergence while the index and worktree are observed.
+#[derive(Debug, Default)]
+struct DivergenceLog {
+    entries: Vec<GitWorkspaceDivergence>,
+    untracked_listed: usize,
+    untracked_beyond_cap: usize,
+}
+
+impl DivergenceLog {
+    fn record(
+        &mut self,
+        path: RepoPath,
+        kind: GitWorkspaceDivergenceKind,
+        detail: impl Into<String>,
+        observed: Option<Hash256>,
+    ) {
+        self.entries.push(GitWorkspaceDivergence {
+            path,
+            kind,
+            detail: detail.into(),
+            observed,
+        });
+    }
+
+    fn record_untracked(&mut self, path: RepoPath) {
+        if self.untracked_listed >= LISTED_UNTRACKED_CAP {
+            self.untracked_beyond_cap += 1;
+            return;
+        }
+        self.untracked_listed += 1;
+        self.record(path, GitWorkspaceDivergenceKind::Untracked, "", None);
+    }
+
+    fn finish(mut self) -> GitWorkspaceDivergenceFacts {
+        self.entries
+            .sort_by(|left, right| (left.kind.code(), &left.path).cmp(&(right.kind.code(), &right.path)));
+        let mut hash = FramedHash::new(b"kin.git.preflight.divergence.v1");
+        hash.u64(self.entries.len() as u64);
+        for entry in &self.entries {
+            hash.bytes(entry.path.as_bytes());
+            hash.u64(entry.kind.code());
+            hash.bytes(entry.detail.as_bytes());
+            match &entry.observed {
+                Some(observed) => {
+                    hash.u64(1);
+                    hash.bytes(observed.as_bytes());
+                }
+                None => hash.u64(0),
+            }
+        }
+        hash.u64(self.untracked_beyond_cap as u64);
+        GitWorkspaceDivergenceFacts {
+            entries: self.entries,
+            untracked_beyond_cap: self.untracked_beyond_cap,
+            fingerprint: hash.finish(),
+        }
     }
 }
 
@@ -429,7 +605,13 @@ fn observe(
         && plan.workspace_seed.base_tree_hash.is_none()
         && expected_entries.is_empty();
     let (index_file, raw_index) = read_strict_index(&repo, absent_index_allowed)?;
-    let index = prove_index(&index_file, raw_index.as_deref(), expected_entries)?;
+    let mut divergence = DivergenceLog::default();
+    let index = prove_index(
+        &index_file,
+        raw_index.as_deref(),
+        expected_entries,
+        &mut divergence,
+    )?;
     index_file
         .verify_extensions(true, &repo.objects)
         .map_err(|error| preflight_error(format!("verify Git index extensions: {error}")))?;
@@ -440,7 +622,9 @@ fn observe(
         expected_entries,
         blob_store,
         published_kin_dir,
+        &mut divergence,
     )?;
+    let workspace_divergence = divergence.finish();
     let snapshot_fingerprint = fingerprint_snapshot(&snapshot);
     let semantic_plan_fingerprint = fingerprint_plan(plan)?;
     let compatibility = GitMigrationCompatibilityFacts {
@@ -463,6 +647,7 @@ fn observe(
         semantic_plan_fingerprint,
         index,
         tracked_worktree,
+        workspace_divergence,
         ignored_local,
         compatibility,
         remote_mapping,
@@ -589,10 +774,21 @@ fn read_strict_index(
     Ok((index, before))
 }
 
+/// Observe the index against the committed workspace seed.
+///
+/// An entry that is not the committed one is staged work, which is recorded
+/// rather than refused. What still refuses is an index that cannot be read as a
+/// statement about the worktree at all: a conflict stage, a sparse directory
+/// entry, and the two flags with which Git is told to stop comparing a path, so
+/// a repository whose index disagrees with its own worktree by instruction is
+/// never observed as if it agreed. `INTENT_TO_ADD` is not among them, because
+/// it announces a path the operator has not committed, which is staged work
+/// like any other.
 fn prove_index(
     index: &gix::index::File,
     raw_file: Option<&[u8]>,
     expected: &BTreeMap<RepoPath, ExpectedIndexEntry>,
+    divergence: &mut DivergenceLog,
 ) -> Result<GitIndexPreflightProof> {
     if index.is_sparse() {
         return Err(preflight_error(
@@ -613,7 +809,6 @@ fn prove_index(
         }
         let ambiguous = gix::index::entry::Flags::ASSUME_VALID
             | gix::index::entry::Flags::SKIP_WORKTREE
-            | gix::index::entry::Flags::INTENT_TO_ADD
             | gix::index::entry::Flags::CONFLICTED;
         if entry.flags.intersects(ambiguous) {
             return Err(preflight_error(format!(
@@ -626,16 +821,25 @@ fn prove_index(
                 "index path {path} is a sparse directory entry"
             )));
         }
-        let expected_entry = expected.get(&path).ok_or_else(|| {
-            preflight_error(format!(
-                "index contains staged or otherwise uncommitted path {path}"
-            ))
-        })?;
         let actual_oid = git_object_id(entry.id)?;
-        if entry.mode != expected_entry.mode || actual_oid != expected_entry.oid {
-            return Err(preflight_error(format!(
-                "index entry {path} does not match committed workspace seed"
-            )));
+        match expected.get(&path) {
+            None => divergence.record(
+                path.clone(),
+                GitWorkspaceDivergenceKind::Staged,
+                "the committed tree does not carry this path",
+                None,
+            ),
+            Some(expected_entry)
+                if entry.mode != expected_entry.mode || actual_oid != expected_entry.oid =>
+            {
+                divergence.record(
+                    path.clone(),
+                    GitWorkspaceDivergenceKind::Staged,
+                    "the index entry is not the committed one",
+                    None,
+                )
+            }
+            Some(_) => {}
         }
         if !seen.insert(path.clone()) {
             return Err(preflight_error(format!("index repeats path {path}")));
@@ -645,14 +849,13 @@ fn prove_index(
         logical.bytes(actual_oid.as_bytes());
         logical.u64(u64::from(entry.flags.bits()));
     }
-    if seen.len() != expected.len() {
-        let missing = expected
-            .keys()
-            .find(|path| !seen.contains(*path))
-            .expect("different lengths imply a missing expected path");
-        return Err(preflight_error(format!(
-            "index is missing committed path {missing}"
-        )));
+    for path in expected.keys().filter(|path| !seen.contains(*path)) {
+        divergence.record(
+            path.clone(),
+            GitWorkspaceDivergenceKind::StagedRemoval,
+            "",
+            None,
+        );
     }
     Ok(GitIndexPreflightProof {
         present: raw_file.is_some(),
@@ -673,6 +876,7 @@ fn prove_worktree(
     expected: &BTreeMap<RepoPath, ExpectedIndexEntry>,
     blob_store: &BlobStore,
     published_kin_dir: Option<&Path>,
+    divergence: &mut DivergenceLog,
 ) -> Result<(GitTrackedWorktreeProof, IgnoredLocalWorktreeFact)> {
     let ignore_inputs = local_ignore_inputs(ignore_repo)?;
     let (mut excludes, ignore_case) = frozen_ignore_stack(ignore_repo, index, &ignore_inputs)?;
@@ -693,6 +897,7 @@ fn prove_worktree(
             repo: ignore_repo,
             index,
         }),
+        divergence,
     };
     let graph_only_paths = expected
         .iter()
@@ -724,14 +929,10 @@ fn prove_worktree(
             "local Git ignore inputs changed while the worktree was being verified",
         ));
     }
-    if state.seen.len() != expected.len() {
-        let missing = expected
-            .keys()
-            .find(|path| !state.seen.contains(*path))
-            .expect("different lengths imply a missing expected path");
-        return Err(preflight_error(format!(
-            "worktree is missing committed path {missing}"
-        )));
+    for path in expected.keys().filter(|path| !state.seen.contains(*path)) {
+        state
+            .divergence
+            .record(path.clone(), GitWorkspaceDivergenceKind::Missing, "", None);
     }
     for (path, entry) in &graph_only_paths {
         hash_host_unrepresentable_entry(&mut state.tracked_hash, path, entry.tree_entry);
@@ -782,8 +983,9 @@ struct WorktreeWalk<'a> {
     executable_authority: ExecutableModeAuthority,
     symlink_materialization: SymlinkMaterialization,
     /// Absent when a caller has no repository to consult, which costs only the
-    /// precision of a refusal and never changes whether one is raised.
+    /// precision of a report and never changes whether one is raised.
     diagnosis: Option<CheckoutDiagnosis<'a>>,
+    divergence: &'a mut DivergenceLog,
 }
 
 /// Read-only Git handles consulted solely to explain a refusal.
@@ -1149,14 +1351,40 @@ fn walk_directory(
                 byte_len: metadata.len(),
             });
         } else {
-            return Err(preflight_error(format!(
-                "worktree contains untracked non-ignored path {path}"
-            )));
+            state.divergence.record_untracked(path);
         }
     }
     Ok(())
 }
 
+/// Record one tracked leaf as materialized differently than committed.
+///
+/// The tracked fingerprint carries a marker rather than the committed identity,
+/// so a worktree that diverges never fingerprints as one that matched. What
+/// differs is carried by the divergence facts, which the marker deliberately
+/// does not repeat.
+fn diverged(
+    state: &mut WorktreeWalk<'_>,
+    path: &RepoPath,
+    detail: impl Into<String>,
+    observed: Option<Hash256>,
+) {
+    state.tracked_hash.u64(5);
+    state.divergence.record(
+        path.clone(),
+        GitWorkspaceDivergenceKind::Modified,
+        detail,
+        observed,
+    );
+}
+
+/// Observe one tracked leaf against its committed entry.
+///
+/// A leaf the worktree materializes differently is recorded and the walk
+/// continues, because the committed entry is authority and the worktree is
+/// workspace state. A materialized nested repository still refuses: its content
+/// belongs to another repository, and admitting it as this workspace's edits
+/// would swallow a checkout Kin never mapped.
 fn prove_tracked_entry(
     absolute_path: &Path,
     path: &RepoPath,
@@ -1173,35 +1401,39 @@ fn prove_tracked_entry(
     match expected.tree_entry {
         TreeEntry::Blob { hash, executable } => {
             if !metadata.is_file() || metadata.file_type().is_symlink() {
-                return Err(preflight_error(format!(
-                    "tracked blob {path} is not a regular file"
-                )));
+                return Ok(diverged(
+                    state,
+                    path,
+                    "the worktree no longer materializes it as a regular file",
+                    None,
+                ));
             }
             if state.executable_authority == ExecutableModeAuthority::WorktreeMode
                 && filesystem_executable(metadata)? != executable
             {
-                return Err(preflight_error(format!(
-                    "tracked blob {path} has a different executable mode than the committed tree"
-                )));
+                return Ok(diverged(
+                    state,
+                    path,
+                    "its executable mode differs from the committed tree",
+                    None,
+                ));
             }
             let actual =
                 fs::read(absolute_path).map_err(|error| GitError::io(absolute_path, error))?;
             let committed = state.blob_store.read(&hash)?;
             if actual != committed {
-                return Err(preflight_error(
+                let detail =
                     match classify_blob_divergence(state.diagnosis, path, &actual, &committed) {
                         BlobDivergence::CheckoutTransformation(reason) => format!(
-                            "tracked blob {path} differs from the committed tree because \
-                             {reason}; Kin cannot yet admit a repository whose worktree Git \
-                             rewrites on checkout. This is not an unstaged edit"
+                            "its worktree bytes differ from the committed tree because {reason}, \
+                             so this is not an unstaged edit"
                         ),
-                        BlobDivergence::UnstagedEdit => format!(
-                            "tracked blob {path} has unstaged edits; its worktree bytes differ \
-                             from the committed tree and no checkout filter, LFS pointer, or \
-                             line-ending normalization explains the difference"
-                        ),
-                    },
-                ));
+                        BlobDivergence::UnstagedEdit => "its worktree bytes differ from the \
+                             committed tree and no checkout filter, LFS pointer, or line-ending \
+                             normalization explains the difference"
+                            .to_string(),
+                    };
+                return Ok(diverged(state, path, detail, Some(digest(&actual))));
             }
             state.tracked_hash.u64(1);
             state.tracked_hash.bytes(hash.as_bytes());
@@ -1211,9 +1443,12 @@ fn prove_tracked_entry(
             let target = match state.symlink_materialization {
                 SymlinkMaterialization::Link => {
                     if !metadata.file_type().is_symlink() {
-                        return Err(preflight_error(format!(
-                            "tracked symlink {path} is not a symbolic link"
-                        )));
+                        return Ok(diverged(
+                            state,
+                            path,
+                            "the worktree no longer materializes it as a symbolic link",
+                            None,
+                        ));
                     }
                     let target = fs::read_link(absolute_path)
                         .map_err(|error| GitError::io(absolute_path, error))?;
@@ -1226,46 +1461,56 @@ fn prove_tracked_entry(
                 // filesystem fallback for a missing link.
                 SymlinkMaterialization::TargetTextFile(source) => {
                     if metadata.file_type().is_symlink() {
-                        return Err(preflight_error(match source {
-                            SymlinkCapabilitySource::RepositoryRecorded => format!(
-                                "tracked symlink {path} is a real symbolic link, but the \
-                                 repository records core.symlinks=false, so Git writes and \
-                                 compares the target as a regular file here; the worktree \
-                                 disagrees with the repository's own configuration"
-                            ),
-                            SymlinkCapabilitySource::PlatformDefault => format!(
-                                "tracked symlink {path} is a real symbolic link, but this \
-                                 repository records no core.symlinks value and Git's default on \
-                                 this platform writes and compares the target as a regular file; \
-                                 the worktree holds a link the Git that reads it would not have \
-                                 created. Record core.symlinks=true if this worktree really does \
-                                 carry real links"
-                            ),
-                        }));
+                        return Ok(diverged(
+                            state,
+                            path,
+                            match source {
+                                SymlinkCapabilitySource::RepositoryRecorded =>
+                                    "it is a real symbolic link, but the repository records \
+                                     core.symlinks=false, so Git writes and compares the target \
+                                     as a regular file here",
+                                SymlinkCapabilitySource::PlatformDefault =>
+                                    "it is a real symbolic link, but this repository records no \
+                                     core.symlinks value and Git's default on this platform \
+                                     writes and compares the target as a regular file. Record \
+                                     core.symlinks=true if this worktree really does carry real \
+                                     links",
+                            },
+                            None,
+                        ));
                     }
                     if !metadata.is_file() {
-                        return Err(preflight_error(format!(
-                            "tracked symlink {path} is not the regular file holding its target, \
-                             which is what Git materializes under core.symlinks=off"
-                        )));
+                        return Ok(diverged(
+                            state,
+                            path,
+                            "it is not the regular file holding its target, which is what Git \
+                             materializes under core.symlinks=off",
+                            None,
+                        ));
                     }
                     fs::read(absolute_path).map_err(|error| GitError::io(absolute_path, error))?
                 }
             };
             let committed = state.blob_store.read(&target_blob)?;
             if target != committed {
-                return Err(preflight_error(format!(
-                    "tracked symlink {path} target differs from the committed tree"
-                )));
+                return Ok(diverged(
+                    state,
+                    path,
+                    "its link target differs from the committed tree",
+                    Some(digest(&target)),
+                ));
             }
             state.tracked_hash.u64(2);
             state.tracked_hash.bytes(target_blob.as_bytes());
         }
         TreeEntry::Gitlink { target } => {
             if !metadata.is_dir() || metadata.file_type().is_symlink() {
-                return Err(preflight_error(format!(
-                    "gitlink {path} is not materialized as a directory"
-                )));
+                return Ok(diverged(
+                    state,
+                    path,
+                    "the worktree no longer materializes it as a directory",
+                    None,
+                ));
             }
             let mut entries =
                 fs::read_dir(absolute_path).map_err(|error| GitError::io(absolute_path, error))?;
@@ -1449,12 +1694,38 @@ pub(crate) fn checkout_filter_facts(repo: &gix::Repository) -> Vec<GitCheckoutFi
     facts.into_values().collect()
 }
 
+/// Everything one repository-local Git configuration says about transport.
+pub(crate) struct RemoteMappingScan {
+    pub(crate) facts: GitRemoteMappingFacts,
+    /// Every reason this configuration is outside the safe exact subset, in
+    /// configuration order. Non-empty means `facts` is incomplete, because a
+    /// section that carried a refusal contributed nothing.
+    pub(crate) refusals: Vec<String>,
+}
+
+/// Read the transport configuration, refusing at the first reason it carries.
 pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMappingFacts> {
+    let scan = scan_remote_mapping(repo)?;
+    match scan.refusals.into_iter().next() {
+        Some(reason) => Err(unsafe_git_config(reason)),
+        None => Ok(scan.facts),
+    }
+}
+
+/// Read the transport configuration, collecting every reason it carries.
+///
+/// A repository whose configuration is outside the safe subset usually holds
+/// more than one key that puts it there, and clearing them one refusal per run
+/// is what makes a five-minute edit an afternoon. Only a configuration this
+/// boundary cannot read at all still stops the scan, because past that point
+/// the remaining sections are not decidable.
+pub(crate) fn scan_remote_mapping(repo: &gix::Repository) -> Result<RemoteMappingScan> {
     let config = repo.config_snapshot();
     let mut remotes = Vec::<GitRemoteConfigFact>::new();
     let mut branch_tracking = Vec::<GitBranchTrackingFact>::new();
     let mut remote_push_default = None;
     let mut push_default = None;
+    let mut refusals = Vec::<String>::new();
 
     for section in config.plumbing().sections().filter(|section| {
         matches!(
@@ -1469,18 +1740,22 @@ pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMa
             .map_err(|_| unsafe_git_config("non-UTF-8 section name"))?
             .to_ascii_lowercase();
         if section.meta().level != 0 || matches!(section_name.as_str(), "include" | "includeif") {
-            return Err(unsafe_git_config("repository-local include"));
+            refusals.push("repository-local include".to_string());
+            continue;
         }
 
         match section_name.as_str() {
             "remote" => {
                 if let Some(name) = section.header().subsection_name() {
                     validate_safe_identifier(name, "remote name")?;
-                    reject_unknown_config_keys(
+                    if collect_unknown_config_keys(
                         section,
                         &format!("remote.{}", String::from_utf8_lossy(name)),
                         &["url", "pushurl", "fetch", "push"],
-                    )?;
+                        &mut refusals,
+                    ) {
+                        continue;
+                    }
                     let fact = remote_fact_mut(&mut remotes, name);
                     append_explicit_values(
                         section,
@@ -1501,7 +1776,14 @@ pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMa
                         validate_safe_refspec(value, gix::refspec::parse::Operation::Push)
                     })?;
                 } else {
-                    reject_unknown_config_keys(section, "remote", &["pushdefault"])?;
+                    if collect_unknown_config_keys(
+                        section,
+                        "remote",
+                        &["pushdefault"],
+                        &mut refusals,
+                    ) {
+                        continue;
+                    }
                     set_unique_explicit_value(
                         section,
                         "pushdefault",
@@ -1516,11 +1798,14 @@ pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMa
                     .subsection_name()
                     .ok_or_else(|| unsafe_git_config("branch section without a name"))?;
                 validate_safe_branch_name(name)?;
-                reject_unknown_config_keys(
+                if collect_unknown_config_keys(
                     section,
                     &format!("branch.{}", String::from_utf8_lossy(name)),
                     &["remote", "merge", "pushremote"],
-                )?;
+                    &mut refusals,
+                ) {
+                    continue;
+                }
                 let fact = branch_fact_mut(&mut branch_tracking, name);
                 set_unique_explicit_value(section, "remote", &mut fact.remote, |value| {
                     validate_safe_identifier(value, "branch remote")
@@ -1536,23 +1821,23 @@ pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMa
                 if section.header().subsection_name().is_some() {
                     return Err(unsafe_git_config("named push section"));
                 }
-                reject_unknown_config_keys(section, "push", &["default"])?;
+                if collect_unknown_config_keys(section, "push", &["default"], &mut refusals) {
+                    continue;
+                }
                 set_unique_explicit_value(section, "default", &mut push_default, |value| {
                     validate_push_default(value)
                 })?;
             }
-            "core" => reject_transfer_core_keys(section)?,
+            "core" => collect_transfer_core_keys(section, &mut refusals),
             // Split out of the arm below because it is the one section here a
             // user reaches without ever configuring transport: `git submodule
             // add` writes it for them.
-            "submodule" => {
-                return Err(unsafe_submodule_config(
-                    section
-                        .header()
-                        .subsection_name()
-                        .and_then(|name| name.to_str().ok()),
-                ));
-            }
+            "submodule" => refusals.push(unsafe_submodule_reason(
+                section
+                    .header()
+                    .subsection_name()
+                    .and_then(|name| name.to_str().ok()),
+            )),
             "credential" | "http" | "https" | "url" | "protocol" | "transport" | "transfer"
             | "fetch" | "receive" | "uploadpack" | "ssh" | "lfs" => {
                 // Twelve sections share this refusal, so naming the one that
@@ -1561,20 +1846,25 @@ pub(crate) fn remote_mapping_facts(repo: &gix::Repository) -> Result<GitRemoteMa
                 // these literals and is always safe to print; the subsection
                 // name is not, because for `url`, `http`, and `credential` it is
                 // itself a URL that can carry `user:password@`.
-                return Err(unsafe_git_config(format!(
+                refusals.push(format!(
                     "unsupported transfer-affecting section [{section_name}]"
-                )));
+                ));
             }
             _ => {}
         }
     }
 
-    validate_remote_relationships(&remotes, &branch_tracking, remote_push_default.as_deref())?;
-    Ok(GitRemoteMappingFacts {
-        remotes,
-        branch_tracking,
-        remote_push_default,
-        push_default,
+    if refusals.is_empty() {
+        validate_remote_relationships(&remotes, &branch_tracking, remote_push_default.as_deref())?;
+    }
+    Ok(RemoteMappingScan {
+        facts: GitRemoteMappingFacts {
+            remotes,
+            branch_tracking,
+            remote_push_default,
+            push_default,
+        },
+        refusals,
     })
 }
 
@@ -1611,7 +1901,7 @@ fn branch_fact_mut<'a>(
     branches.last_mut().expect("branch was just inserted")
 }
 
-/// Refuse any key outside the exact allowlist, naming the one that matched.
+/// Collect every key outside the exact allowlist, naming each one.
 ///
 /// `scope` is the section spelling, which the caller builds from a subsection
 /// name that has only been checked for control characters. That is not enough
@@ -1620,24 +1910,29 @@ fn branch_fact_mut<'a>(
 /// unless it reads as a plain identifier. Key names are always safe, and the
 /// values behind them are never printed. Without a name the reader is handed a
 /// category and has to bisect their own config to find the line Kin meant.
-fn reject_unknown_config_keys(
+///
+/// Answers whether the section carried any, because a section that did is not
+/// parsed for facts the caller would then have to discard.
+fn collect_unknown_config_keys(
     section: &gix::config::file::Section<'_>,
     scope: &str,
     allowed: &[&str],
-) -> Result<()> {
+    refusals: &mut Vec<String>,
+) -> bool {
     let scope = printable_config_scope(scope);
+    let before = refusals.len();
     for name in section.value_names() {
         let name = name.to_string();
         if !allowed
             .iter()
             .any(|allowed| name.eq_ignore_ascii_case(allowed))
         {
-            return Err(unsafe_git_config(format!(
+            refusals.push(format!(
                 "unsupported transfer-affecting repository-local key {scope}.{name}"
-            )));
+            ));
         }
     }
-    Ok(())
+    refusals.len() != before
 }
 
 /// Keep a section spelling printable, dropping a subsection that is not a plain
@@ -1656,7 +1951,7 @@ fn printable_config_scope(scope: &str) -> String {
     section.to_string()
 }
 
-fn reject_transfer_core_keys(section: &gix::config::file::Section<'_>) -> Result<()> {
+fn collect_transfer_core_keys(section: &gix::config::file::Section<'_>, refusals: &mut Vec<String>) {
     const TRANSFER_KEYS: &[&str] = &[
         "askpass",
         "gitproxy",
@@ -1670,12 +1965,11 @@ fn reject_transfer_core_keys(section: &gix::config::file::Section<'_>) -> Result
             .iter()
             .any(|blocked| name.eq_ignore_ascii_case(blocked))
         {
-            return Err(unsafe_git_config(format!(
+            refusals.push(format!(
                 "unsupported transfer-affecting core key core.{name}"
-            )));
+            ));
         }
     }
-    Ok(())
 }
 
 fn explicit_values(section: &gix::config::file::Section<'_>, key: &str) -> Result<Vec<Vec<u8>>> {
@@ -1866,16 +2160,16 @@ fn validate_remote_relationships(
 /// credential the way naming a `url` subsection would. A path that is not valid
 /// UTF-8 has no spelling worth printing and is left out rather than turning a
 /// refusal about submodules into one about encoding.
-fn unsafe_submodule_config(path: Option<&str>) -> GitError {
+fn unsafe_submodule_reason(path: Option<&str>) -> String {
     let subject = match path {
         Some(path) => format!("unsupported submodule section for '{path}'"),
         None => "unsupported submodule section".to_string(),
     };
-    unsafe_git_config(format!(
+    format!(
         "{subject}; Kin cannot yet import a repository that carries submodules. Remove them with \
          'git submodule deinit --all' and drop the matching .gitmodules entries, or run kin init \
          inside the submodule's own repository"
-    ))
+    )
 }
 
 fn unsafe_git_config(reason: impl Into<String>) -> GitError {
@@ -1949,6 +2243,7 @@ fn fingerprint_proof(proof: &GitMigrationPreflightProof) -> Hash256 {
     hash.bytes(proof.index.raw_file_hash.as_bytes());
     hash.bytes(proof.index.logical_fingerprint.as_bytes());
     hash.bytes(proof.tracked_worktree.fingerprint.as_bytes());
+    hash.bytes(proof.workspace_divergence.fingerprint.as_bytes());
     hash.bytes(proof.ignored_local.fingerprint.as_bytes());
     hash.u64(proof.remote_mapping.remotes.len() as u64);
     for remote in &proof.remote_mapping.remotes {

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -370,6 +370,16 @@ impl DivergenceLog {
         });
     }
 
+    /// Whether the index itself is carrying something the commit does not.
+    fn records_index_state(&self) -> bool {
+        self.entries.iter().any(|entry| {
+            matches!(
+                entry.kind,
+                GitWorkspaceDivergenceKind::Staged | GitWorkspaceDivergenceKind::StagedRemoval
+            )
+        })
+    }
+
     fn record_untracked(&mut self, path: RepoPath) {
         if self.untracked_listed >= LISTED_UNTRACKED_CAP {
             self.untracked_beyond_cap += 1;
@@ -612,9 +622,16 @@ fn observe(
         expected_entries,
         &mut divergence,
     )?;
-    index_file
-        .verify_extensions(true, &repo.objects)
-        .map_err(|error| preflight_error(format!("verify Git index extensions: {error}")))?;
+    // The tree extension caches the tree this index would write. An index that
+    // carries staged work has not written that tree, and Git invalidates the
+    // subtrees it covers rather than removing them, so resolving it against the
+    // object database asks for an object the source has never had a reason to
+    // create. The extension is verified where it describes something written.
+    if !divergence.records_index_state() {
+        index_file
+            .verify_extensions(true, &repo.objects)
+            .map_err(|error| preflight_error(format!("verify Git index extensions: {error}")))?;
+    }
     let (tracked_worktree, ignored_local) = prove_worktree(
         &ambient_repo,
         &index_file,
@@ -883,8 +900,14 @@ fn prove_worktree(
     let (executable_authority, symlink_materialization) = worktree_materialization(ignore_repo)?;
     let mut tracked_hash = FramedHash::new(b"kin.git.preflight.worktree.v2");
     tracked_hash.u64(expected.len() as u64);
+    let indexed = index
+        .entries()
+        .iter()
+        .map(|entry| entry.path(index).to_vec())
+        .collect::<BTreeSet<_>>();
     let mut state = WorktreeWalk {
         expected,
+        indexed: &indexed,
         blob_store,
         seen: BTreeSet::new(),
         tracked_hash,
@@ -974,6 +997,11 @@ fn prove_worktree(
 
 struct WorktreeWalk<'a> {
     expected: &'a BTreeMap<RepoPath, ExpectedIndexEntry>,
+    /// Every path the index carries, which is what Git means by tracked. A path
+    /// here but not in `expected` is staged work, already reported as such by
+    /// the index observation, so the walk neither repeats it as untracked nor
+    /// records it as ignored local content.
+    indexed: &'a BTreeSet<Vec<u8>>,
     blob_store: &'a BlobStore,
     seen: BTreeSet<RepoPath>,
     tracked_hash: FramedHash,
@@ -1314,6 +1342,9 @@ fn walk_directory(
 
         if let Some(expected) = state.expected.get(&path).copied() {
             prove_tracked_entry(&absolute_path, &path, &metadata, expected, state)?;
+            continue;
+        }
+        if state.indexed.contains(&path_bytes) {
             continue;
         }
 
@@ -2947,13 +2978,17 @@ mod platform_materialization_tests {
     /// the cases below would otherwise only be compiled here and never run. The
     /// walk state is small enough to build outright, which lets both platforms
     /// execute the same comparison logic against a real store and real files.
+    ///
+    /// Answers with what the entry was recorded as differing by, so a case
+    /// asserting agreement asserts an empty list rather than the absence of an
+    /// error a matching entry could never have produced.
     fn prove_one_entry(
         absolute: &std::path::Path,
         entry: TreeEntry,
         blob_store: &BlobStore,
         executable_authority: ExecutableModeAuthority,
         symlink_materialization: SymlinkMaterialization,
-    ) -> Result<()> {
+    ) -> Result<Vec<GitWorkspaceDivergence>> {
         let path = RepoPath::from_bytes(b"tracked".to_vec()).expect("repo path");
         let expected = ExpectedIndexEntry {
             mode: match entry {
@@ -2969,8 +3004,11 @@ mod platform_materialization_tests {
         };
         let mut expected_entries = BTreeMap::new();
         expected_entries.insert(path.clone(), expected);
+        let indexed = BTreeSet::new();
+        let mut divergence = DivergenceLog::default();
         let mut state = WorktreeWalk {
             expected: &expected_entries,
+            indexed: &indexed,
             blob_store,
             seen: BTreeSet::new(),
             tracked_hash: FramedHash::new(b"kin.git.preflight.worktree.test"),
@@ -2980,9 +3018,19 @@ mod platform_materialization_tests {
             executable_authority,
             symlink_materialization,
             diagnosis: None,
+            divergence: &mut divergence,
         };
         let metadata = fs::symlink_metadata(absolute).expect("entry metadata");
-        prove_tracked_entry(absolute, &path, &metadata, expected, &mut state)
+        prove_tracked_entry(absolute, &path, &metadata, expected, &mut state)?;
+        Ok(divergence.entries)
+    }
+
+    /// The one sentence a single recorded divergence carries.
+    fn only_detail(entries: &[GitWorkspaceDivergence]) -> String {
+        let [entry] = entries else {
+            panic!("expected exactly one divergence, got {entries:?}");
+        };
+        entry.detail.clone()
     }
 
     #[test]
@@ -2993,29 +3041,32 @@ mod platform_materialization_tests {
 
         let tracked = temp.path().join("tracked");
         fs::write(&tracked, b"src/main.rs").expect("target text file");
-        prove_one_entry(
+        let matched = prove_one_entry(
             &tracked,
             TreeEntry::Symlink { target_blob },
             &blob_store,
             ExecutableModeAuthority::IndexMode,
             SymlinkMaterialization::TargetTextFile(SymlinkCapabilitySource::RepositoryRecorded),
         )
-        .expect("the target text file matches the committed target");
+        .expect("the target text file is observed");
+        assert!(
+            matched.is_empty(),
+            "the target text file matches the committed target: {matched:?}"
+        );
 
         fs::write(&tracked, b"src/other.rs").expect("rewrite target text file");
-        let error = prove_one_entry(
+        let diverged = prove_one_entry(
             &tracked,
             TreeEntry::Symlink { target_blob },
             &blob_store,
             ExecutableModeAuthority::IndexMode,
             SymlinkMaterialization::TargetTextFile(SymlinkCapabilitySource::RepositoryRecorded),
         )
-        .expect_err("a different target is not the committed one");
+        .expect("a different target is observed rather than refused");
+        let detail = only_detail(&diverged);
         assert!(
-            error
-                .to_string()
-                .contains("target differs from the committed"),
-            "unexpected error: {error}"
+            detail.contains("target differs from the committed"),
+            "unexpected detail: {detail}"
         );
     }
 
@@ -3054,13 +3105,13 @@ mod platform_materialization_tests {
     }
 
     #[test]
-    fn a_real_link_where_links_are_off_is_refused_rather_than_read_through() {
+    fn a_real_link_where_links_are_off_is_reported_rather_than_read_through() {
         let temp = tempfile::tempdir().expect("tempdir");
         let blob_store = BlobStore::new(temp.path().join("cas")).expect("blob store");
         let target_blob = blob_store.write(b"src/main.rs").expect("target blob");
 
         // Both sources resolve to the same materialization and must produce
-        // the same refusal, but they must not blame the same party for it.
+        // the same report, but they must not blame the same party for it.
         for (source, blamed) in [
             (
                 SymlinkCapabilitySource::RepositoryRecorded,
@@ -3076,22 +3127,22 @@ mod platform_materialization_tests {
                 return;
             }
 
-            let error = prove_one_entry(
+            let diverged = prove_one_entry(
                 &tracked,
                 TreeEntry::Symlink { target_blob },
                 &blob_store,
                 ExecutableModeAuthority::IndexMode,
                 SymlinkMaterialization::TargetTextFile(source),
             )
-            .expect_err("a real link contradicts a worktree that cannot hold one");
-            let rendered = error.to_string();
+            .expect("a real link contradicts a worktree that cannot hold one");
+            let rendered = only_detail(&diverged);
             assert!(
                 rendered.contains("is a real symbolic link"),
-                "unexpected error: {rendered}"
+                "unexpected detail: {rendered}"
             );
             assert!(
                 rendered.contains(blamed),
-                "the refusal must name who decided the materialization: {rendered}"
+                "the report must name who decided the materialization: {rendered}"
             );
         }
     }
@@ -3107,9 +3158,9 @@ mod platform_materialization_tests {
 
         // The file carries no executable bit anywhere, yet the committed tree
         // says it is executable. Under index authority the index proof already
-        // settled that, so admission proceeds; under worktree authority the
-        // same file must be refused.
-        prove_one_entry(
+        // settled that, so the entry agrees; under worktree authority the same
+        // file must be reported as differing.
+        let matched = prove_one_entry(
             &tracked,
             TreeEntry::Blob {
                 hash,
@@ -3120,8 +3171,12 @@ mod platform_materialization_tests {
             SymlinkMaterialization::TargetTextFile(SymlinkCapabilitySource::RepositoryRecorded),
         )
         .expect("the index carries the exact mode");
+        assert!(
+            matched.is_empty(),
+            "index authority settles the mode without rereading the worktree: {matched:?}"
+        );
 
-        let error = prove_one_entry(
+        let diverged = prove_one_entry(
             &tracked,
             TreeEntry::Blob {
                 hash,
@@ -3131,12 +3186,11 @@ mod platform_materialization_tests {
             ExecutableModeAuthority::WorktreeMode,
             SymlinkMaterialization::Link,
         )
-        .expect_err("a worktree authority must still compare the filesystem");
-        let rendered = error.to_string();
+        .expect("a worktree authority must still compare the filesystem");
+        let rendered = only_detail(&diverged);
         assert!(
-            rendered.contains("different executable mode")
-                || rendered.contains("records no executable bit"),
-            "unexpected error: {rendered}"
+            rendered.contains("executable mode differs"),
+            "unexpected detail: {rendered}"
         );
     }
 
@@ -3556,8 +3610,13 @@ mod tests {
 
         let normal = fixture
             .preflight()
-            .expect_err("ordinary preflight must not hide an ambient .kin");
-        assert!(normal.to_string().contains("untracked non-ignored"));
+            .expect("ordinary preflight observes an ambient .kin");
+        assert_discloses(
+            &normal,
+            ".kin/version",
+            GitWorkspaceDivergenceKind::Untracked,
+            "",
+        );
         let after = preflight_git_migration_after_publication(
             &fixture.repo,
             &published_kin,
@@ -3569,35 +3628,70 @@ mod tests {
         assert_eq!(after, before);
 
         fs::write(fixture.repo.join("outside-kin.txt"), b"untracked\n").expect("untracked sibling");
-        let error = preflight_git_migration_after_publication(
+        let sibling = preflight_git_migration_after_publication(
             &fixture.repo,
             &published_kin,
             &fixture.snapshot,
             &fixture.plan,
             &fixture.store,
         )
-        .expect_err("post-publication proof must retain all other worktree authority");
-        assert!(error.to_string().contains("outside-kin.txt"));
+        .expect("post-publication proof must retain all other worktree authority");
+        assert_discloses(
+            &sibling,
+            "outside-kin.txt",
+            GitWorkspaceDivergenceKind::Untracked,
+            "",
+        );
+        assert_ne!(
+            sibling, after,
+            "a path that appeared after publication must change the proof"
+        );
     }
 
+    /// Tracked drift after publication is reported, and moves the proof.
+    ///
+    /// Init compares this proof against the one it took before publication and
+    /// refuses on any difference, so reporting the drift rather than refusing it
+    /// here keeps the same fail-closed outcome. Asserting the inequality is what
+    /// proves that: a report the proof did not carry would leave the caller's
+    /// comparison equal and the drift undetected.
     #[test]
-    fn post_publication_proof_still_rejects_tracked_source_drift() {
+    fn post_publication_proof_still_detects_tracked_source_drift() {
         let fixture = Fixture::clean();
         let published_kin = fixture.repo.join(".kin");
         fs::create_dir(&published_kin).expect("published Kin directory");
         fs::write(published_kin.join("version"), b"6\n").expect("published Kin metadata");
-        fs::write(fixture.repo.join("compose.yaml"), b"services: {}\n")
-            .expect("tracked source drift");
-
-        let error = preflight_git_migration_after_publication(
+        let clean = preflight_git_migration_after_publication(
             &fixture.repo,
             &published_kin,
             &fixture.snapshot,
             &fixture.plan,
             &fixture.store,
         )
-        .expect_err("tracked source drift must fail after publication");
-        assert!(error.to_string().contains("bytes differ"));
+        .expect("post-publication proof");
+        assert_no_divergence(&clean);
+
+        fs::write(fixture.repo.join("compose.yaml"), b"services: {}\n")
+            .expect("tracked source drift");
+        let drifted = preflight_git_migration_after_publication(
+            &fixture.repo,
+            &published_kin,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect("tracked source drift is observed after publication");
+        assert_discloses(
+            &drifted,
+            "compose.yaml",
+            GitWorkspaceDivergenceKind::Modified,
+            "bytes differ",
+        );
+        assert_ne!(drifted, clean, "drift must move the proof");
+        assert_ne!(
+            drifted.observation_fingerprint, clean.observation_fingerprint,
+            "drift must move the observation fingerprint"
+        );
     }
 
     #[test]
@@ -3619,18 +3713,52 @@ mod tests {
         assert_preflight_contains(&nested_worktree, "materialized nested-repository state");
     }
 
+    /// Staged work is reported, not refused.
+    ///
+    /// An edit that was staged and one that was only announced with
+    /// `git add -N` are both paths the operator has not committed, so both are
+    /// workspace state rather than a reason the source cannot be read.
     #[test]
-    fn rejects_staged_conflicted_intent_and_ambiguous_index_state() {
+    fn reports_staged_and_intent_to_add_index_state() {
         let staged = Fixture::clean();
         fs::write(staged.repo.join("compose.yaml"), b"services: {}\n").expect("edit");
         git(&staged.repo, &["add", "compose.yaml"]);
-        assert_preflight_contains(&staged, "index entry compose.yaml");
+        let proof = staged.preflight().expect("staged work is observed");
+        assert_discloses(
+            &proof,
+            "compose.yaml",
+            GitWorkspaceDivergenceKind::Staged,
+            "not the committed one",
+        );
 
         let intent = Fixture::clean();
         fs::write(intent.repo.join("intent.txt"), b"intent\n").expect("intent");
         git(&intent.repo, &["add", "--intent-to-add", "intent.txt"]);
-        assert_preflight_contains(&intent, "ambiguous flags");
+        let proof = intent.preflight().expect("an announced path is observed");
+        assert_discloses(
+            &proof,
+            "intent.txt",
+            GitWorkspaceDivergenceKind::Staged,
+            "does not carry this path",
+        );
+        // The index carries it, which is what Git calls tracked, so the worktree
+        // walk must not report the same path a second time as untracked.
+        assert_eq!(
+            proof.workspace_divergence.entries.len(),
+            1,
+            "{:?}",
+            proof.workspace_divergence
+        );
+    }
 
+    /// An index Git has been told not to compare is still refused.
+    ///
+    /// Under these the index no longer states anything about the worktree, so an
+    /// observation of one would not be an observation of the source at all. That
+    /// is ambiguity about the source rather than uncommitted work, which is the
+    /// line the in-progress-operation refusal already draws.
+    #[test]
+    fn rejects_conflicted_and_ambiguous_index_state() {
         let assume = Fixture::clean();
         git(
             &assume.repo,
@@ -3667,15 +3795,30 @@ mod tests {
         assert_preflight_contains(&sparse, "sparse checkout");
     }
 
+    /// Every shape of worktree edit is observed and reported.
+    ///
+    /// None of it enters authority, which the clean case above already proves is
+    /// the committed tree, so each one is workspace state whose only remaining
+    /// question is whether init said so.
     #[test]
-    fn rejects_unstaged_untracked_mode_symlink_and_byte_mismatches() {
+    fn reports_unstaged_untracked_mode_symlink_and_byte_mismatches() {
         let unstaged = Fixture::clean();
         fs::write(unstaged.repo.join("src/main.rs"), b"fn changed() {}\n").expect("edit");
-        assert_preflight_contains(&unstaged, "bytes differ");
+        assert_discloses(
+            &unstaged.preflight().expect("an edit is observed"),
+            "src/main.rs",
+            GitWorkspaceDivergenceKind::Modified,
+            "bytes differ",
+        );
 
         let untracked = Fixture::clean();
         fs::write(untracked.repo.join("surprise.txt"), b"surprise\n").expect("untracked");
-        assert_preflight_contains(&untracked, "untracked non-ignored");
+        assert_discloses(
+            &untracked.preflight().expect("an untracked path is observed"),
+            "surprise.txt",
+            GitWorkspaceDivergenceKind::Untracked,
+            "",
+        );
 
         let executable = Fixture::clean();
         let mut permissions = fs::metadata(executable.repo.join("script.sh"))
@@ -3683,7 +3826,12 @@ mod tests {
             .permissions();
         permissions.set_mode(0o644);
         fs::set_permissions(executable.repo.join("script.sh"), permissions).expect("chmod");
-        assert_preflight_contains(&executable, "executable mode");
+        assert_discloses(
+            &executable.preflight().expect("a mode change is observed"),
+            "script.sh",
+            GitWorkspaceDivergenceKind::Modified,
+            "executable mode differs",
+        );
 
         let symlink_target = Fixture::clean();
         fs::remove_file(symlink_target.repo.join("source-link")).expect("remove symlink");
@@ -3692,16 +3840,100 @@ mod tests {
             symlink_target.repo.join("source-link"),
         )
         .expect("new symlink");
-        assert_preflight_contains(&symlink_target, "target differs");
+        assert_discloses(
+            &symlink_target
+                .preflight()
+                .expect("a repointed link is observed"),
+            "source-link",
+            GitWorkspaceDivergenceKind::Modified,
+            "link target differs",
+        );
 
         let symlink_kind = Fixture::clean();
         fs::remove_file(symlink_kind.repo.join("source-link")).expect("remove symlink");
         fs::write(symlink_kind.repo.join("source-link"), b"src/main.rs").expect("regular file");
-        assert_preflight_contains(&symlink_kind, "not a symbolic link");
+        assert_discloses(
+            &symlink_kind
+                .preflight()
+                .expect("a replaced link is observed"),
+            "source-link",
+            GitWorkspaceDivergenceKind::Modified,
+            "no longer materializes it as a symbolic link",
+        );
+
+        let removed = Fixture::clean();
+        fs::remove_file(removed.repo.join("compose.yaml")).expect("remove tracked file");
+        assert_discloses(
+            &removed
+                .preflight()
+                .expect("a deleted committed path is observed"),
+            "compose.yaml",
+            GitWorkspaceDivergenceKind::Missing,
+            "",
+        );
+
+        let unstaged_removal = Fixture::clean();
+        git(&unstaged_removal.repo, &["rm", "--cached", "compose.yaml"]);
+        assert_discloses(
+            &unstaged_removal
+                .preflight()
+                .expect("a staged removal is observed"),
+            "compose.yaml",
+            GitWorkspaceDivergenceKind::StagedRemoval,
+            "",
+        );
+    }
+
+    /// A worked-in source seals authority at the committed tree regardless.
+    ///
+    /// This is the load-bearing half of admitting a dirty repository: the
+    /// workspace seed the proof is bound to has to stay the committed tree, and
+    /// the fingerprints of what was proven have to stay those of the clean
+    /// source, so nothing uncommitted can reach repository authority through a
+    /// path that merely stopped refusing.
+    #[test]
+    fn a_worked_in_source_still_seals_authority_at_the_committed_tree() {
+        // One repository observed twice, because a second fixture commits its
+        // own gitlink target and would differ for a reason this case is not
+        // about.
+        let fixture = Fixture::clean();
+        let clean_proof = fixture.preflight().expect("clean preflight");
+
+        fs::write(fixture.repo.join("src/main.rs"), b"fn edited() {}\n").expect("edit");
+        fs::write(fixture.repo.join("surprise.txt"), b"surprise\n").expect("untracked");
+        fs::write(fixture.repo.join("staged.txt"), b"staged\n").expect("staged");
+        git(&fixture.repo, &["add", "staged.txt"]);
+        let dirty_proof = fixture
+            .preflight()
+            .expect("a worked-in source is admissible");
+
+        assert_eq!(
+            dirty_proof.base_tree_hash, clean_proof.base_tree_hash,
+            "authority is the committed tree, not the worktree"
+        );
+        assert_eq!(dirty_proof.head, clean_proof.head);
+        assert_eq!(dirty_proof.base_target, clean_proof.base_target);
+        assert_eq!(
+            dirty_proof.snapshot_fingerprint, clean_proof.snapshot_fingerprint,
+            "committed history is untouched by uncommitted work"
+        );
+        assert_eq!(
+            dirty_proof.semantic_plan_fingerprint, clean_proof.semantic_plan_fingerprint
+        );
+        assert_eq!(
+            dirty_proof.workspace_divergence.observed_paths(),
+            3,
+            "{:?}",
+            dirty_proof.workspace_divergence
+        );
+        assert_ne!(
+            dirty_proof.observation_fingerprint, clean_proof.observation_fingerprint,
+            "what was observed must not fingerprint as a source that matched"
+        );
     }
 
     #[test]
-    fn rejects_clean_status_checkout_transformations() {
+    fn reports_clean_status_checkout_transformations() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("source");
         fs::create_dir(&repo).expect("source");
@@ -3724,24 +3956,95 @@ mod tests {
 
         let store = BlobStore::new(temp.path().join("cas")).expect("blob store");
         let (snapshot, plan) = snapshot_plan(&repo, &store);
-        let error =
-            preflight_git_migration(&repo, &snapshot, &plan, &store).expect_err("CRLF rejection");
-        let reported = error.to_string();
-        assert!(reported.contains("gradlew.bat"), "{reported}");
+        let proof = preflight_git_migration(&repo, &snapshot, &plan, &store)
+            .expect("a rewritten checkout is observed");
+        let reported = only_detail(&proof.workspace_divergence.entries);
         assert!(reported.contains("text eol=crlf"), "{reported}");
         assert!(reported.contains("line endings"), "{reported}");
         assert!(reported.contains("is not an unstaged edit"), "{reported}");
-        assert!(!reported.contains("has unstaged edits"), "{reported}");
+        assert!(!reported.contains("no checkout filter"), "{reported}");
+        assert_discloses(
+            &proof,
+            "gradlew.bat",
+            GitWorkspaceDivergenceKind::Modified,
+            "line endings",
+        );
+    }
+
+    /// A committed tree may record a mode the index cannot hold.
+    ///
+    /// `100664` is legal in a tree and several importers write it, while the
+    /// index decodes every plain file to `100644`. Comparing the raw values
+    /// reads such a repository as having every file staged, and no `git restore
+    /// --staged` clears it because nothing is. The comparison runs on the entry
+    /// kind for exactly this reason, and a repository that would have to answer
+    /// for a report it cannot act on is what asserts it.
+    #[test]
+    fn a_non_canonical_committed_filemode_is_not_reported_as_staged() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("source");
+        fs::create_dir(&repo).expect("source");
+        git(&repo, &["init", "--initial-branch=main"]);
+        configure_identity(&repo);
+        pin_default_hook_surface(&repo);
+        fs::write(repo.join("README.md"), b"seed\n").expect("readme");
+        git(&repo, &["add", "--all"]);
+        commit(&repo, "seed");
+
+        let blob = git_stdout(&repo, &["rev-parse", "HEAD:README.md"]);
+        // Written as raw tree bytes because `git mktree` canonicalises the mode
+        // on the way in, which is exactly the normalisation this case needs to
+        // be missing.
+        let mut body = b"100664 README.md\0".to_vec();
+        body.extend(
+            (0..blob.len() / 2)
+                .map(|index| u8::from_str_radix(&blob[index * 2..index * 2 + 2], 16))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .expect("hex object id"),
+        );
+        let tree = String::from_utf8(
+            git_command(&repo)
+                .args(["hash-object", "-t", "tree", "-w", "--stdin", "--literally"])
+                .output_with_input(&body)
+                .expect("write raw tree")
+                .stdout,
+        )
+        .expect("utf8 object id")
+        .trim()
+        .to_string();
+        let commit = String::from_utf8(
+            git_stdin(&repo, &["commit-tree", &tree, "-m", "non-canonical mode"], "").stdout,
+        )
+        .expect("utf8 object id")
+        .trim()
+        .to_string();
+        git(&repo, &["reset", "--hard", &commit]);
+        // Read as raw object bytes, because `cat-file -p` prints the
+        // canonicalised mode and would report the fixture worked either way.
+        let raw = git_command(&repo)
+            .args(["cat-file", "tree", "HEAD^{tree}"])
+            .output()
+            .expect("read raw committed tree");
+        assert!(
+            raw.stdout.starts_with(b"100664 "),
+            "the fixture must keep the mode this case is about"
+        );
+
+        let store = BlobStore::new(temp.path().join("cas")).expect("blob store");
+        let (snapshot, plan) = snapshot_plan(&repo, &store);
+        let proof = preflight_git_migration(&repo, &snapshot, &plan, &store)
+            .expect("a non-canonical mode is admissible");
+        assert_no_divergence(&proof);
     }
 
     /// The partner of the checkout-transformation case above.
     ///
     /// A tree Git rewrote on checkout and a tree its operator edited both reach
-    /// the same byte comparison, so the refusal is only useful if each names its
+    /// the same byte comparison, so the report is only useful if each names its
     /// own cause. Asserting that neither message carries the other's sentence is
     /// what keeps the two from collapsing back into one accusation.
     #[test]
-    fn rejects_unstaged_edits_without_blaming_a_checkout_filter() {
+    fn reports_unstaged_edits_without_blaming_a_checkout_filter() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("source");
         fs::create_dir(&repo).expect("source");
@@ -3756,11 +4059,15 @@ mod tests {
 
         let store = BlobStore::new(temp.path().join("cas")).expect("blob store");
         let (snapshot, plan) = snapshot_plan(&repo, &store);
-        let error = preflight_git_migration(&repo, &snapshot, &plan, &store)
-            .expect_err("unstaged edit rejection");
-        let reported = error.to_string();
-        assert!(reported.contains("text.txt"), "{reported}");
-        assert!(reported.contains("has unstaged edits"), "{reported}");
+        let proof =
+            preflight_git_migration(&repo, &snapshot, &plan, &store).expect("an edit is observed");
+        assert_discloses(
+            &proof,
+            "text.txt",
+            GitWorkspaceDivergenceKind::Modified,
+            "no checkout filter",
+        );
+        let reported = only_detail(&proof.workspace_divergence.entries);
         assert!(!reported.contains("is not an unstaged edit"), "{reported}");
         assert!(!reported.contains(".gitattributes"), "{reported}");
         assert!(!reported.contains("line endings"), "{reported}");
@@ -4390,6 +4697,46 @@ mod tests {
         assert!(
             error.to_string().contains(expected),
             "expected {expected:?} in {error:?}"
+        );
+    }
+
+    /// One path reported as diverging, of the expected kind and reason.
+    ///
+    /// Asserts the proof was produced at all, which is the half that would
+    /// silently disappear if the observation went back to refusing.
+    fn assert_discloses(
+        proof: &GitMigrationPreflightProof,
+        path: &str,
+        kind: GitWorkspaceDivergenceKind,
+        detail: &str,
+    ) {
+        let divergence = &proof.workspace_divergence;
+        let found = divergence
+            .entries
+            .iter()
+            .find(|entry| entry.path.to_string() == path && entry.kind == kind)
+            .unwrap_or_else(|| {
+                panic!("{path} is not reported as {}: {divergence:?}", kind.label())
+            });
+        assert!(
+            found.detail.contains(detail),
+            "expected {detail:?} in {found:?}"
+        );
+    }
+
+    /// The one sentence a single reported divergence carries.
+    fn only_detail(entries: &[GitWorkspaceDivergence]) -> String {
+        let [entry] = entries else {
+            panic!("expected exactly one divergence, got {entries:?}");
+        };
+        entry.detail.clone()
+    }
+
+    fn assert_no_divergence(proof: &GitMigrationPreflightProof) {
+        assert!(
+            proof.workspace_divergence.is_empty(),
+            "unexpected divergence: {:?}",
+            proof.workspace_divergence
         );
     }
 


### PR DESCRIPTION
Repository authority has always been the committed workspace seed and nothing else, but the migration proof refused any source whose index or worktree was not that seed. A working repository is edited, so first contact with `kin init` failed for most real adopters over files the proof was never going to admit anyway.

Init now observes that delta instead of refusing it. The proof records every path that differs from the committed state, and init discloses them: a count, a list per state with a capped tail, and one line saying none of it entered repository authority, none of it was touched, and it becomes workspace state the first time the daemon runs. The delta then flows through the daemon's existing workspace-admission seam, which is how the runtime already treats a moving worktree. `--json` carries the same thing under a new `uncommitted_worktree` key, absent when there is nothing to disclose, so a clean init is byte-identical to before.

Ambiguity about the source itself still refuses, because there the committed state a migration would seal is not decidable. That is an in-progress Git operation, a conflicted or sparse index, an entry Git has been told not to compare with `--assume-unchanged` or `--skip-worktree`, a materialized nested repository, a hook the repository owns, a checkout filter, another registered worktree, and repository-local transport configuration outside the safe exact subset. `git add -N` is not among them: an announced path is uncommitted work like any other.

The transport refusal also stops naming only the first offending key. The scan collects every one across every section and the blocker report names each, so a checkout carrying `remote.origin.tagOpt` beside an editor's `branch.main.vscode-merge-base` clears both in one edit rather than one run each.

Two consequences worth reading closely. Drift racing publication is still fatal, but it is now caught by init comparing its two proofs rather than by the second proof refusing, and the post-publication case asserts that inequality directly so a report the proof did not carry cannot pass silently. And the index tree extension is verified only where it describes a tree that was written, because a staged index invalidates the subtrees that cache covers and resolving it would ask the object database for something the source never had a reason to create.

Falsified in four runs. Dropping the untracked record failed three cases, stopping the key scan inside a section failed one, reporting only the first refusal failed four across both crates, and removing the index dedupe failed three. Full workspace gate green at 5205 tests with no failures, fmt and the ci.yml clippy allowlist clean under `-D warnings`, `build --all-targets` clean, and both runtime boundary guards pass.

Closes FIR-2142
