### PR TITLE
Qualify every absence these two retrieval tools report, including the ones they could not look up

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -481,6 +481,16 @@ fn first_payload_value(result: &ToolCallResult) -> Option<Value> {
     })
 }
 
+/// The first text content block verbatim. This is what a failed call carries
+/// instead of a payload: human-readable text that [`annotate_block`] preserves
+/// under `message`.
+fn first_message_text(result: &ToolCallResult) -> Option<&str> {
+    result.content.first().map(|block| {
+        let ContentBlock::Text { text } = block;
+        text.as_str()
+    })
+}
+
 /// The single call sites use to attach the envelope: lift any metadata the tool
 /// payload already carries (`semantic_coverage`, `graph_as_of`) into `base`,
 /// synthesize a confidence-qualified `negative` for retrieval tools that came
@@ -488,15 +498,25 @@ fn first_payload_value(result: &ToolCallResult) -> Option<Value> {
 /// lift + qualify + annotate together in one chokepoint means every dispatch
 /// path (offline and daemon) produces a consistently-enriched envelope and an
 /// identical negative contract regardless of which runtime answered.
+///
+/// A retrieval tool has two ways of reporting "nothing", and only one of them
+/// carries a payload. When the name a caller passed resolves to no entity the
+/// answer is a human message with no collection to count, which used to reach
+/// the agent as a bare `{"message": ...}` beside the envelope while every
+/// resolved answer from the same tool carried a full negative. That asymmetry
+/// is the one an agent cannot see, so the miss is qualified here too.
 pub fn finalize(result: ToolCallResult, base: Envelope, tool_name: &str) -> ToolCallResult {
     let payload = first_payload_value(&result);
     let envelope = match &payload {
         Some(payload) => base.with_payload_metadata(payload),
         None => base,
     };
-    let negative = payload
-        .as_ref()
-        .and_then(|payload| crate::negative::negative_for(tool_name, payload, &envelope));
+    let negative = match &payload {
+        Some(payload) => crate::negative::negative_for(tool_name, payload, &envelope),
+        None if result.is_error == Some(true) => first_message_text(&result)
+            .and_then(|message| crate::negative::resolution_miss_for(tool_name, message, &envelope)),
+        None => None,
+    };
     annotate_inner(result, &envelope, negative.as_ref())
 }
 

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -446,8 +446,8 @@ impl Envelope {
 ///   `{ "_kin": <envelope>, "result": <payload> }`.
 /// - Human-readable text (e.g. error messages that are not JSON) is wrapped as
 ///   `{ "_kin": <envelope>, "message": <text> }`, preserving the message, plus
-///   `negative` when one was synthesized for it — a resolution miss is reported
-///   as text and still has to be calibratable.
+///   `negative` when one was synthesized for it, since a resolution miss is
+///   reported as text and still has to be calibratable.
 ///
 /// `is_error` and any non-text content blocks are preserved unchanged.
 pub fn annotate(result: ToolCallResult, envelope: &Envelope) -> ToolCallResult {

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -515,8 +515,9 @@ pub fn finalize(result: ToolCallResult, base: Envelope, tool_name: &str) -> Tool
     };
     let negative = match &payload {
         Some(payload) => crate::negative::negative_for(tool_name, payload, &envelope),
-        None if result.is_error == Some(true) => first_message_text(&result)
-            .and_then(|message| crate::negative::resolution_miss_for(tool_name, message, &envelope)),
+        None if result.is_error == Some(true) => first_message_text(&result).and_then(|message| {
+            crate::negative::resolution_miss_for(tool_name, message, &envelope)
+        }),
         None => None,
     };
     annotate_inner(result, &envelope, negative.as_ref())

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -445,7 +445,9 @@ impl Envelope {
 /// - Non-object JSON payloads (arrays/scalars) are wrapped as
 ///   `{ "_kin": <envelope>, "result": <payload> }`.
 /// - Human-readable text (e.g. error messages that are not JSON) is wrapped as
-///   `{ "_kin": <envelope>, "message": <text> }`, preserving the message.
+///   `{ "_kin": <envelope>, "message": <text> }`, preserving the message, plus
+///   `negative` when one was synthesized for it — a resolution miss is reported
+///   as text and still has to be calibratable.
 ///
 /// `is_error` and any non-text content blocks are preserved unchanged.
 pub fn annotate(result: ToolCallResult, envelope: &Envelope) -> ToolCallResult {
@@ -548,6 +550,9 @@ fn annotate_block(
         Err(_) => {
             let mut map = Map::new();
             map.insert(ENVELOPE_KEY.to_string(), envelope_value.clone());
+            if let Some(negative) = negative {
+                map.insert(crate::negative::NEGATIVE_KEY.to_string(), negative.clone());
+            }
             map.insert("message".to_string(), Value::String(text));
             Value::Object(map)
         }

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2328,8 +2328,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     };
 
     // Resolve focal: UUID first, then exact-name lookup via the ranking path.
-    let addressed_by_id = uuid::Uuid::parse_str(trimmed).is_ok();
-    let focal_entity = if let Ok(uuid) = uuid::Uuid::parse_str(trimmed) {
+    let focal_id = uuid::Uuid::parse_str(trimmed).ok();
+    let focal_entity = if let Some(uuid) = focal_id {
         store
             .get_entity(&kin_model::ids::EntityId(uuid))
             .map_err(McpError::graph)?
@@ -2468,7 +2468,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         "total_steps": total_steps,
         "truncated": truncated,
         "focal_resolution": {
-            "addressed_by": if addressed_by_id { "entity_id" } else { "name" },
+            "addressed_by": if focal_id.is_some() { "entity_id" } else { "name" },
             "same_name_candidates": same_name_candidates,
         },
     });

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4273,8 +4273,7 @@ mod tests {
         assert_eq!(response["focal_resolution"]["same_name_candidates"], 1);
         assert_eq!(response["negative"]["kind"], "no_flow");
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            true,
+            response["negative"]["safe_to_conclude_absent"], true,
             "a resolved, uniquely named, non-method focal with no edges on a loaded graph is a \
              real absence: {}",
             response["negative"]
@@ -4298,8 +4297,7 @@ mod tests {
         );
         assert_eq!(response["negative"]["kind"], "no_flow");
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            false,
+            response["negative"]["safe_to_conclude_absent"], false,
             "an unattested runtime cannot certify absence: {}",
             response["negative"]
         );
@@ -4328,8 +4326,7 @@ mod tests {
         assert_eq!(response["total_steps"], 0);
         assert_eq!(response["focal_resolution"]["same_name_candidates"], 2);
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            false,
+            response["negative"]["safe_to_conclude_absent"], false,
             "a name the graph holds twice cannot certify absence for either twin: {}",
             response["negative"]
         );
@@ -4354,8 +4351,7 @@ mod tests {
             structurally_ready_envelope(),
         );
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            false,
+            response["negative"]["safe_to_conclude_absent"], false,
             "an empty callers walk on a method is not proof of disuse: {}",
             response["negative"]
         );
@@ -4426,8 +4422,7 @@ mod tests {
         assert_eq!(response["negative"]["kind"], "focal_not_resolved");
         assert_eq!(response["negative"]["interpretation"], "name_not_resolved");
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            true,
+            response["negative"]["safe_to_conclude_absent"], true,
             "a name no entity carries, on a loaded graph that holds entities, is a real answer: {}",
             response["negative"]
         );
@@ -4454,8 +4449,7 @@ mod tests {
         let response = parsed_response(&annotated);
 
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            false,
+            response["negative"]["safe_to_conclude_absent"], false,
             "a graph with no entities cannot report that a name is absent from the code: {}",
             response["negative"]
         );
@@ -4483,8 +4477,7 @@ mod tests {
         assert!(response[crate::ENVELOPE_KEY].is_object());
         assert_eq!(response["negative"]["kind"], "focal_not_resolved");
         assert_eq!(
-            response["negative"]["safe_to_conclude_absent"],
-            true,
+            response["negative"]["safe_to_conclude_absent"], true,
             "an id no entity carries, on a loaded graph that holds entities, is a real answer: {}",
             response["negative"]
         );

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4212,6 +4212,306 @@ mod tests {
         );
     }
 
+    /// A graph that is initialized, loaded, and holds entities: the only state
+    /// in which a structural absence is authoritative. Carries the entity count
+    /// `structurally_ready_envelope` leaves unknown, because a resolution miss
+    /// on a graph holding nothing is a fact about the graph, not the name.
+    fn populated_ready_envelope() -> crate::Envelope {
+        crate::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_generation": 12,
+            "graph_entity_count": 3,
+        }))
+    }
+
+    /// Run `trace_data_flow` through the annotation chokepoint, so the payload
+    /// key names the handler writes are pinned to the qualifier that reads them.
+    fn traced_response(
+        store: &InMemoryGraph,
+        focal: &str,
+        direction: &str,
+        envelope: crate::Envelope,
+    ) -> serde_json::Value {
+        let mut args = HashMap::new();
+        args.insert("focal".to_string(), serde_json::json!(focal));
+        args.insert("direction".to_string(), serde_json::json!(direction));
+        let annotated = crate::finalize_with_envelope(
+            handle_trace_data_flow(&args, store).unwrap(),
+            envelope,
+            "trace_data_flow",
+        );
+        parsed_response(&annotated)
+    }
+
+    fn trust_reason(response: &serde_json::Value) -> String {
+        response["negative"]["trust_reason"]
+            .as_str()
+            .unwrap_or_else(|| panic!("the negative must carry a trust_reason: {response}"))
+            .to_string()
+    }
+
+    /// The authoritative side of the trace absence: a focal that is in the
+    /// graph, carries a name nothing else shares, is not a method, and has no
+    /// edges at all. That is a real absence, and the qualifier must still be
+    /// willing to say so — a gate that never certifies anything is as useless
+    /// as one that certifies everything.
+    #[test]
+    fn trace_data_flow_isolated_focal_is_authoritative_on_a_ready_graph() {
+        let store = InMemoryGraph::new();
+        let lonely = make_entity("lonely", "src/lonely.rs");
+        store.upsert_entity(&lonely).unwrap();
+
+        let response = traced_response(
+            &store,
+            &lonely.id.to_string(),
+            "both",
+            structurally_ready_envelope(),
+        );
+        assert_eq!(response["focal_name"], "lonely");
+        assert_eq!(response["total_steps"], 0);
+        assert_eq!(response["focal_resolution"]["same_name_candidates"], 1);
+        assert_eq!(response["negative"]["kind"], "no_flow");
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            true,
+            "a resolved, uniquely named, non-method focal with no edges on a loaded graph is a \
+             real absence: {}",
+            response["negative"]
+        );
+    }
+
+    /// And the inconclusive side of the same walk. The in-process runtime is a
+    /// fallback surface, so the identical empty chain must not be handed back
+    /// as proof the entity is unused.
+    #[test]
+    fn trace_data_flow_isolated_focal_is_inconclusive_on_an_unattested_graph() {
+        let store = InMemoryGraph::new();
+        let lonely = make_entity("lonely", "src/lonely.rs");
+        store.upsert_entity(&lonely).unwrap();
+
+        let response = traced_response(
+            &store,
+            &lonely.id.to_string(),
+            "both",
+            crate::Envelope::offline(),
+        );
+        assert_eq!(response["negative"]["kind"], "no_flow");
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            false,
+            "an unattested runtime cannot certify absence: {}",
+            response["negative"]
+        );
+        assert!(trust_reason(&response).contains("offline_fallback"));
+    }
+
+    /// The reported shape: two cfg arms of one declaration are admitted as
+    /// distinct entities, a call the extractor cannot attribute to a single
+    /// candidate lands on neither, and the walk follows one twin. An empty
+    /// chain there answers for both twins a question that was asked of one, so
+    /// it must never be certified.
+    #[test]
+    fn trace_data_flow_same_named_twins_never_certify_absence() {
+        let store = InMemoryGraph::new();
+        let real = make_entity("process_embedding_queue", "src/engine/graph.rs");
+        let stub = make_entity("process_embedding_queue", "src/engine/graph_stub.rs");
+        store.upsert_entity(&real).unwrap();
+        store.upsert_entity(&stub).unwrap();
+
+        let response = traced_response(
+            &store,
+            &real.id.to_string(),
+            "callers",
+            structurally_ready_envelope(),
+        );
+        assert_eq!(response["total_steps"], 0);
+        assert_eq!(response["focal_resolution"]["same_name_candidates"], 2);
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            false,
+            "a name the graph holds twice cannot certify absence for either twin: {}",
+            response["negative"]
+        );
+        assert!(trust_reason(&response).contains("focal_resolution_ambiguous"));
+    }
+
+    /// Receiver-method calls are linked by bare name while method entities are
+    /// keyed by their qualified name, so a method's incoming call edges are
+    /// frequently missing. `find_references` has always refused to certify that
+    /// absence; the trace reads the same edges and now refuses too.
+    #[test]
+    fn trace_data_flow_method_focal_never_certifies_an_empty_callers_walk() {
+        let store = InMemoryGraph::new();
+        let mut method = make_entity("process_embedding_queue", "src/engine/graph.rs");
+        method.kind = EntityKind::Method;
+        store.upsert_entity(&method).unwrap();
+
+        let response = traced_response(
+            &store,
+            &method.id.to_string(),
+            "callers",
+            structurally_ready_envelope(),
+        );
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            false,
+            "an empty callers walk on a method is not proof of disuse: {}",
+            response["negative"]
+        );
+        assert!(trust_reason(&response).contains("method_call_resolution_incomplete"));
+    }
+
+    /// An empty walk is empty only on the side that was walked. This focal is
+    /// genuinely called by another entity, so a merged claim would be false;
+    /// the outgoing walk may say only that it calls nothing.
+    #[test]
+    fn trace_data_flow_absence_names_the_direction_that_was_walked() {
+        let (store, _, _, callee_id) = neighborhood_fixture();
+
+        let outgoing = traced_response(
+            &store,
+            &callee_id.to_string(),
+            "calls",
+            structurally_ready_envelope(),
+        );
+        assert_eq!(outgoing["total_steps"], 0);
+        let subject = outgoing["negative"]["subject"]
+            .as_str()
+            .expect("the negative must carry a subject")
+            .to_string();
+        assert!(
+            subject.contains("anything it calls") && !subject.contains("either direction"),
+            "an outgoing-only walk must claim only what the focal calls: {subject}"
+        );
+
+        let incoming = traced_response(
+            &store,
+            &callee_id.to_string(),
+            "callers",
+            structurally_ready_envelope(),
+        );
+        assert_eq!(
+            incoming["total_steps"], 2,
+            "the focal really is called, transitively, which is what makes the merged claim false"
+        );
+    }
+
+    /// The asymmetry an agent cannot see: every resolved answer from this tool
+    /// carried the full negative while a name that resolved to nothing arrived
+    /// as a bare message. The message still has to survive, because it is the
+    /// only part a human reads.
+    #[test]
+    fn trace_data_flow_focal_miss_carries_the_negative_beside_its_message() {
+        let store = InMemoryGraph::new();
+        let mut args = HashMap::new();
+        args.insert("focal".to_string(), serde_json::json!("absent_symbol"));
+        let annotated = crate::finalize_with_envelope(
+            handle_trace_data_flow(&args, &store).unwrap(),
+            populated_ready_envelope(),
+            "trace_data_flow",
+        );
+        let response = parsed_response(&annotated);
+
+        assert!(
+            response["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("absent_symbol")),
+            "the human-readable message must survive beside the qualifier: {response}"
+        );
+        assert!(
+            response[crate::ENVELOPE_KEY].is_object(),
+            "the envelope must ride along as it always did: {response}"
+        );
+        assert_eq!(response["negative"]["kind"], "focal_not_resolved");
+        assert_eq!(response["negative"]["interpretation"], "name_not_resolved");
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            true,
+            "a name no entity carries, on a loaded graph that holds entities, is a real answer: {}",
+            response["negative"]
+        );
+    }
+
+    /// The other half: a graph holding nothing at all answers every name the
+    /// same way, so a miss there is a fact about the graph rather than about
+    /// the symbol. This is the case that made a bare "not found" dangerous.
+    #[test]
+    fn trace_data_flow_focal_miss_on_an_empty_graph_is_not_authoritative() {
+        let store = InMemoryGraph::new();
+        let mut args = HashMap::new();
+        args.insert("focal".to_string(), serde_json::json!("absent_symbol"));
+        let empty_graph = crate::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 0,
+        }));
+        let annotated = crate::finalize_with_envelope(
+            handle_trace_data_flow(&args, &store).unwrap(),
+            empty_graph,
+            "trace_data_flow",
+        );
+        let response = parsed_response(&annotated);
+
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            false,
+            "a graph with no entities cannot report that a name is absent from the code: {}",
+            response["negative"]
+        );
+        assert!(trust_reason(&response).contains("graph_empty"));
+    }
+
+    /// `find_references` answered its own miss the same bare way, and gets the
+    /// same qualifier from the same chokepoint.
+    #[tokio::test]
+    async fn find_references_entity_miss_carries_the_negative_beside_its_message() {
+        let store = InMemoryGraph::new();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(EntityId::new().to_string()),
+        );
+        let annotated = crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            populated_ready_envelope(),
+            "find_references",
+        );
+        let response = parsed_response(&annotated);
+
+        assert_eq!(response["message"], "Entity not found");
+        assert!(response[crate::ENVELOPE_KEY].is_object());
+        assert_eq!(response["negative"]["kind"], "focal_not_resolved");
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            true,
+            "an id no entity carries, on a loaded graph that holds entities, is a real answer: {}",
+            response["negative"]
+        );
+    }
+
+    /// And its inconclusive side, so neither tool can certify a miss off a
+    /// fallback surface.
+    #[tokio::test]
+    async fn find_references_entity_miss_is_inconclusive_on_an_unattested_graph() {
+        let store = InMemoryGraph::new();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(EntityId::new().to_string()),
+        );
+        let annotated = crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            crate::Envelope::offline(),
+            "find_references",
+        );
+        let response = parsed_response(&annotated);
+
+        assert_eq!(response["message"], "Entity not found");
+        assert_eq!(response["negative"]["safe_to_conclude_absent"], false);
+        assert!(trust_reason(&response).contains("offline_fallback"));
+    }
+
     /// The declared tool schema must offer the parameter the handler honors,
     /// and the description must claim the direction the traversal delivers.
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2482,9 +2482,9 @@ pub fn handle_trace_data_flow<G: GraphStore>(
 /// A name the graph holds more than once is the cfg-twin shape: two arms of the
 /// same declaration are admitted as distinct entities, and a call the extractor
 /// cannot attribute to one of them lands on neither. The walk follows a single
-/// candidate, so an empty chain says nothing about the others — but only the
-/// handler can see how many there were, and the qualifier that reads this
-/// treats an unreported count as unknown rather than as one.
+/// candidate, so an empty chain says nothing about the others. Only the handler
+/// can see how many there were, and the qualifier that reads this treats an
+/// unreported count as unknown rather than as one.
 ///
 /// Never reports zero: the focal was resolved from this store, so it is its own
 /// first candidate whatever the pattern query matched.
@@ -4254,7 +4254,7 @@ mod tests {
     /// The authoritative side of the trace absence: a focal that is in the
     /// graph, carries a name nothing else shares, is not a method, and has no
     /// edges at all. That is a real absence, and the qualifier must still be
-    /// willing to say so — a gate that never certifies anything is as useless
+    /// willing to say so. A gate that never certifies anything is as useless
     /// as one that certifies everything.
     #[test]
     fn trace_data_flow_isolated_focal_is_authoritative_on_a_ready_graph() {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -836,7 +836,8 @@ this call per entity — bulk_check_references does the batch in one shot. \
 When no references come back, the additive `negative` object's `safe_to_conclude_absent` \
 flag says whether \"nothing depends on this\" is authoritative (daemon-owned graph, \
 complete coverage, no degraded signals) or merely \"not indexed yet\" — consult it \
-before treating the entity as safe to delete.";
+before treating the entity as safe to delete. An entity_id or name that resolves to nothing \
+carries the same object, naming the resolution miss rather than reporting an empty result.";
 
 fn normalize_cross_repo_repo_id(raw: Option<&str>) -> std::result::Result<String, String> {
     raw.map(str::trim)
@@ -2277,7 +2278,12 @@ happens substrate-side and comes back as one structured response, so you don't l
 get_entity_source per hop and exhaust your tool-call budget. Tune depth and \
 limit_per_step to control breadth; results flag when they were truncated. \
 When the chain comes back empty, the additive `negative` object's `safe_to_conclude_absent` \
-flag says whether \"no flow from here\" is authoritative or merely \"not indexed yet\".";
+flag says whether \"no flow from here\" is authoritative or merely \"not indexed yet\", and its \
+`subject` scopes the absence to the direction that was walked, so an empty 'callers' result is \
+never read as \"this calls nothing\". A focal name the graph holds more than once, and a method \
+whose incoming calls may not have been linked, each downgrade that flag rather than certifying \
+absence. A focal that resolves to no entity at all carries the same object, naming the \
+resolution miss rather than reporting an empty chain.";
 
 /// Trace the actual call/data-flow chain rooted at a focal entity.
 ///
@@ -2322,6 +2328,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     };
 
     // Resolve focal: UUID first, then exact-name lookup via the ranking path.
+    let addressed_by_id = uuid::Uuid::parse_str(trimmed).is_ok();
     let focal_entity = if let Ok(uuid) = uuid::Uuid::parse_str(trimmed) {
         store
             .get_entity(&kin_model::ids::EntityId(uuid))
@@ -2335,6 +2342,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             trimmed
         )));
     };
+    let same_name_candidates = same_name_entity_count(store, &focal_entity.name)?;
 
     let reference_kinds = [
         RelationKind::Calls,
@@ -2459,10 +2467,38 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         "chain": chain,
         "total_steps": total_steps,
         "truncated": truncated,
+        "focal_resolution": {
+            "addressed_by": if addressed_by_id { "entity_id" } else { "name" },
+            "same_name_candidates": same_name_candidates,
+        },
     });
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
+}
+
+/// How many entities carry `name` exactly, the focal included.
+///
+/// A name the graph holds more than once is the cfg-twin shape: two arms of the
+/// same declaration are admitted as distinct entities, and a call the extractor
+/// cannot attribute to one of them lands on neither. The walk follows a single
+/// candidate, so an empty chain says nothing about the others — but only the
+/// handler can see how many there were, and the qualifier that reads this
+/// treats an unreported count as unknown rather than as one.
+///
+/// Never reports zero: the focal was resolved from this store, so it is its own
+/// first candidate whatever the pattern query matched.
+fn same_name_entity_count<G: GraphStore>(store: &G, name: &str) -> Result<usize> {
+    let filter = EntityFilter {
+        name_pattern: Some(name.to_string()),
+        ..Default::default()
+    };
+    let matched = store.query_entities(&filter).map_err(McpError::graph)?;
+    Ok(matched
+        .iter()
+        .filter(|entity| entity.name == name)
+        .count()
+        .max(1))
 }
 
 pub const GRAPH_NEIGHBORHOOD_DESC: &str = "\

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -198,16 +198,109 @@ fn neighborhood_absence_subject(payload: &Value) -> Option<&'static str> {
     }
 }
 
+/// What an empty chain means for the side of the flow that was actually
+/// walked. A callers-only walk that comes back empty is evidence about what
+/// reaches the focal and says nothing about what the focal reaches, so the
+/// merged wording would claim a direction the traversal never followed. A
+/// payload without a direction keeps the unnarrowed wording rather than a guess.
+fn trace_absence_subject(payload: &Value) -> Option<&'static str> {
+    match payload.get("direction").and_then(Value::as_str)? {
+        "calls" => Some(
+            "no data-flow chain was found from the focal entity to anything it calls; its callers were not walked",
+        ),
+        "callers" => Some(
+            "no data-flow chain was found into the focal entity from anything that calls it; its callees were not walked",
+        ),
+        "both" => Some(
+            "no data-flow chain was found from the focal entity in either direction",
+        ),
+        _ => None,
+    }
+}
+
+/// Every reason an empty trace chain is unsafe to read as "nothing flows here",
+/// in a stable order. All that apply are reported: an absence with two causes
+/// has two, and naming only the first hands back a narrower explanation than
+/// the evidence supports.
+///
+/// The gates mirror the ones `find_references` already applies, because both
+/// tools answer from the same typed `Calls`/`Imports`/`References` edges and an
+/// absence over those edges is trustworthy under the same conditions for both.
+/// `trace_data_flow` used to skip all of them and certify absence on nothing but
+/// the substrate gate, which is how an entity with a live caller came back
+/// authoritative-absent.
+fn trace_flow_gaps(payload: &Value) -> Vec<String> {
+    let mut gaps = Vec::new();
+
+    // Receiver-method calls (`x.method()`) are linked by bare name while method
+    // entities are keyed by their qualified name, so a method's incoming `Calls`
+    // edges are frequently dropped — the same gate `find_references` applies.
+    // It bears on the walk only when the walk read incoming edges at all, which
+    // an unreported direction cannot rule out.
+    let direction = payload.get("direction").and_then(Value::as_str);
+    let walked_callers = !matches!(direction, Some("calls"));
+    if walked_callers && focal_is_method(payload) {
+        gaps.push(
+            "method_call_resolution_incomplete: receiver-method calls are linked by bare name \
+             and may be unresolved, so an empty chain is not an authoritative absence for a method"
+                .to_string(),
+        );
+    }
+
+    // A name the graph holds more than once (the cfg-twin shape: two arms of the
+    // same declaration admitted as distinct entities) means the walk followed
+    // one of them, and an edge the extractor could not attribute to a single
+    // candidate sits on neither. Certifying that as absence answers for every
+    // twin a question that was asked of one.
+    match payload
+        .get("focal_resolution")
+        .and_then(|resolution| resolution.get("same_name_candidates"))
+        .and_then(Value::as_u64)
+    {
+        None => gaps.push(
+            "focal_resolution_unreported: the walk did not report how many entities share the \
+             focal's name, so an empty chain may describe a same-named sibling rather than the \
+             entity that was asked about"
+                .to_string(),
+        ),
+        Some(candidates) if candidates > 1 => gaps.push(format!(
+            "focal_resolution_ambiguous: {candidates} entities share the focal's name and only \
+             one was walked, so an empty chain is not evidence about the others"
+        )),
+        Some(_) => {}
+    }
+
+    // A walk cut short by its own caps or work ceilings stopped before it could
+    // observe what it is being read as having ruled out.
+    if payload.get("truncated").and_then(Value::as_bool) == Some(true) {
+        gaps.push(
+            "trace_walk_truncated: the walk hit a per-step or total cap, so it stopped before \
+             examining everything an empty chain would have to rule out"
+                .to_string(),
+        );
+    }
+    if payload
+        .get("degradations")
+        .and_then(Value::as_array)
+        .is_some_and(|degradations| !degradations.is_empty())
+    {
+        gaps.push(
+            "trace_walk_degraded: the walk reported degradations, so it did not complete under \
+             its own work bounds"
+                .to_string(),
+        );
+    }
+
+    gaps
+}
+
 /// A human sentence spelling out "absent as-of X, coverage Y%, degraded Z" and
 /// the actionable consequence, so the negative is legible without cross-reading
-/// the envelope. `subject` is passed rather than read off `spec` because a tool
-/// may narrow its own framing before the advice is built.
-fn build_advice(
-    spec: &RetrievalSpec,
-    subject: &str,
-    envelope: &Envelope,
-    trustworthy: bool,
-) -> String {
+/// the envelope. `subject` and `consequence` are passed rather than read off a
+/// spec because a tool may narrow its own framing before the advice is built,
+/// and because a name that never resolved carries a different consequence than
+/// a lookup that ran and found nothing.
+fn build_advice(subject: &str, consequence: &str, envelope: &Envelope) -> String {
     let as_of = match &envelope.graph_as_of {
         Some(value) => format!("graph as-of {value}"),
         None => "an unversioned graph snapshot".to_string(),
@@ -227,30 +320,40 @@ fn build_advice(
         format!("degraded signals [{}]", degraded.join(", "))
     };
 
-    let consequence = if spec.always {
-        if trustworthy {
-            "A `has_references: false` row here is an authoritative negative — safe to treat that entity as unreferenced."
-        } else {
-            "Do NOT treat a `has_references: false` row as proof of disuse: the index is not authoritative yet, so a false verdict may simply mean 'not indexed'. Re-check once trust is authoritative."
-        }
-    } else if trustworthy {
-        "Absence is authoritative: safe to treat the target as genuinely absent/unused."
-    } else {
-        "Absence is NOT authoritative: do not conclude the target is unused or deletable — an empty result may mean 'not indexed'. Re-check after embedding is complete and the daemon is healthy."
-    };
-
     format!("{subject}, against {as_of} with {coverage} and {degraded}. {consequence}")
 }
 
-/// True when `payload.focal_entity.kind` is a method — the entity kind whose
-/// incoming call edges the linker under-resolves, so absence of
-/// references must not be certified as authoritative.
-fn focal_entity_is_method(payload: &Value) -> bool {
+/// The consequence sentence for a retrieval tool that ran and came back empty.
+fn absence_consequence(always: bool, trustworthy: bool) -> &'static str {
+    match (always, trustworthy) {
+        (true, true) => {
+            "A `has_references: false` row here is an authoritative negative — safe to treat that entity as unreferenced."
+        }
+        (true, false) => {
+            "Do NOT treat a `has_references: false` row as proof of disuse: the index is not authoritative yet, so a false verdict may simply mean 'not indexed'. Re-check once trust is authoritative."
+        }
+        (false, true) => "Absence is authoritative: safe to treat the target as genuinely absent/unused.",
+        (false, false) => {
+            "Absence is NOT authoritative: do not conclude the target is unused or deletable — an empty result may mean 'not indexed'. Re-check after embedding is complete and the daemon is healthy."
+        }
+    }
+}
+
+/// The kind the payload reports for its focal entity, whichever shape carries
+/// it: `find_references` nests the focal under `focal_entity`, `trace_data_flow`
+/// reports it flat as `focal_kind`.
+fn focal_kind(payload: &Value) -> Option<&str> {
     payload
         .get("focal_entity")
         .and_then(|focal| focal.get("kind"))
-        .and_then(|kind| kind.as_str())
-        .is_some_and(|kind| kind.eq_ignore_ascii_case("method"))
+        .or_else(|| payload.get("focal_kind"))
+        .and_then(Value::as_str)
+}
+
+/// True when the payload's focal is a method — the entity kind whose call edges
+/// the linker under-resolves, so absence must not be certified as authoritative.
+fn focal_is_method(payload: &Value) -> bool {
+    focal_kind(payload).is_some_and(|kind| kind.eq_ignore_ascii_case("method"))
 }
 
 fn cross_repo_references_gap(payload: &Value) -> Option<String> {
@@ -408,7 +511,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // verdict — the calls may simply never have been linked. Never let an agent
     // read "safe to delete" off an incomplete call graph: downgrade to
     // inconclusive so the absence is flagged as possibly-unresolved, not certain.
-    if tool == "find_references" && focal_entity_is_method(payload) {
+    if tool == "find_references" && focal_is_method(payload) {
         trustworthy = false;
         trust_reason = "method_call_resolution_incomplete: receiver-method calls are \
              linked by bare name and may be unresolved, so an empty result is not an \
@@ -494,6 +597,25 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         }
     }
 
+    // The same split the neighborhood makes: the substrate reason describes what
+    // is underneath every answer, the walk's own gaps describe this one, and a
+    // reader needs both to know whether to re-run or to stop trusting the graph.
+    if tool == "trace_data_flow" {
+        if let Some(directional) = trace_absence_subject(payload) {
+            subject = directional;
+        }
+        let gaps = trace_flow_gaps(payload);
+        if !gaps.is_empty() {
+            let gaps = gaps.join("; ");
+            trust_reason = if trustworthy {
+                gaps
+            } else {
+                format!("{trust_reason}; {gaps}")
+            };
+            trustworthy = false;
+        }
+    }
+
     let interpretation = if spec.always {
         "qualified_verdicts"
     } else {
@@ -526,7 +648,98 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     );
     negative.insert(
         "advice".to_string(),
-        json!(build_advice(&spec, subject, envelope, trustworthy)),
+        json!(build_advice(
+            subject,
+            absence_consequence(spec.always, trustworthy),
+            envelope
+        )),
+    );
+    Some(Value::Object(negative))
+}
+
+/// How one tool frames "I could not resolve what you named". These answers are
+/// a human message rather than an empty collection, so [`negative_for`] cannot
+/// see them at all: there is no payload to count, and the response used to
+/// arrive as a bare `{"message": ...}` with the envelope but no negative beside
+/// it — the one shape an agent cannot calibrate.
+fn resolution_miss_spec(tool: &str) -> Option<(&'static str, &'static str)> {
+    match tool {
+        "find_references" => Some((
+            "focal_not_resolved",
+            "the entity that was asked about could not be resolved, so no references were looked up",
+        )),
+        "trace_data_flow" => Some((
+            "focal_not_resolved",
+            "the focal that was asked about could not be resolved, so no data-flow chain was walked",
+        )),
+        _ => None,
+    }
+}
+
+/// True when an error message reports that the thing the caller named was not
+/// found, rather than a malformed request or a transport failure.
+///
+/// Matched on the family rather than one exact sentence, because three
+/// producers word this differently today — `Entity not found` from the
+/// references handler, `trace_data_flow: no entity matches focal 'X'` from the
+/// in-process trace handler, and `no entity found matching 'X'` from the
+/// daemon's trace route — and a qualifier that only fires for the wording it
+/// was written against would go quiet the moment one of them is reworded, which
+/// looks exactly like the tool having no miss to qualify.
+fn is_resolution_miss(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("no entity") || message.contains("entity not found")
+}
+
+/// Build a confidence-qualified negative for a resolution miss reported as
+/// `message`, or `None` when the tool has no miss framing or the message is
+/// some other failure (bad parameters, an unreachable daemon) that says nothing
+/// about whether the named symbol exists.
+///
+/// Trust is computed from the same structural gate a resolved-but-empty answer
+/// uses: on a daemon graph that is initialized, loaded, and undegraded, "the
+/// graph holds no entity under that name" is a real answer; on anything less it
+/// may only mean the name is not indexed yet.
+pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Option<Value> {
+    let (kind, subject) = resolution_miss_spec(tool)?;
+    if !is_resolution_miss(message) {
+        return None;
+    }
+
+    let (trustworthy, trust_reason) = envelope.negative_trust(NegativeClass::Structural);
+    let consequence = if trustworthy {
+        "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name, not about the symbol's usage — nothing was looked up."
+    } else {
+        "Absence is NOT authoritative: the name may simply not be indexed yet, so do not conclude the symbol does not exist. Re-check once the graph is complete and the daemon is healthy."
+    };
+
+    let mut negative = Map::new();
+    negative.insert("kind".to_string(), json!(kind));
+    negative.insert("subject".to_string(), json!(subject));
+    negative.insert("result_count".to_string(), json!(0));
+    negative.insert("interpretation".to_string(), json!("name_not_resolved"));
+    negative.insert("safe_to_conclude_absent".to_string(), json!(trustworthy));
+    negative.insert(
+        "trust".to_string(),
+        json!(if trustworthy {
+            "authoritative"
+        } else {
+            "inconclusive"
+        }),
+    );
+    negative.insert("trust_reason".to_string(), json!(trust_reason));
+    negative.insert(
+        "graph_as_of".to_string(),
+        envelope.graph_as_of.clone().unwrap_or(Value::Null),
+    );
+    negative.insert("semantic_coverage".to_string(), coverage_value(envelope));
+    negative.insert(
+        "degraded_signals".to_string(),
+        json!(envelope.degraded.active_labels()),
+    );
+    negative.insert(
+        "advice".to_string(),
+        json!(build_advice(subject, consequence, envelope)),
     );
     Some(Value::Object(negative))
 }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -234,9 +234,9 @@ fn trace_flow_gaps(payload: &Value) -> Vec<String> {
 
     // Receiver-method calls (`x.method()`) are linked by bare name while method
     // entities are keyed by their qualified name, so a method's incoming `Calls`
-    // edges are frequently dropped — the same gate `find_references` applies.
-    // It bears on the walk only when the walk read incoming edges at all, which
-    // an unreported direction cannot rule out.
+    // edges are frequently dropped, which is the gate `find_references` already
+    // applies. It bears on the walk only when the walk read incoming edges at
+    // all, which an unreported direction cannot rule out.
     let direction = payload.get("direction").and_then(Value::as_str);
     let walked_callers = !matches!(direction, Some("calls"));
     if walked_callers && focal_is_method(payload) {
@@ -350,7 +350,7 @@ fn focal_kind(payload: &Value) -> Option<&str> {
         .and_then(Value::as_str)
 }
 
-/// True when the payload's focal is a method — the entity kind whose call edges
+/// True when the payload's focal is a method, the entity kind whose call edges
 /// the linker under-resolves, so absence must not be certified as authoritative.
 fn focal_is_method(payload: &Value) -> bool {
     focal_kind(payload).is_some_and(|kind| kind.eq_ignore_ascii_case("method"))
@@ -661,7 +661,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
 /// a human message rather than an empty collection, so [`negative_for`] cannot
 /// see them at all: there is no payload to count, and the response used to
 /// arrive as a bare `{"message": ...}` with the envelope but no negative beside
-/// it — the one shape an agent cannot calibrate.
+/// it, which is the one shape an agent cannot calibrate.
 fn resolution_miss_spec(tool: &str) -> Option<(&'static str, &'static str)> {
     match tool {
         "find_references" => Some((
@@ -679,13 +679,13 @@ fn resolution_miss_spec(tool: &str) -> Option<(&'static str, &'static str)> {
 /// True when an error message reports that the thing the caller named was not
 /// found, rather than a malformed request or a transport failure.
 ///
-/// Matched on the family rather than one exact sentence, because three
-/// producers word this differently today — `Entity not found` from the
-/// references handler, `trace_data_flow: no entity matches focal 'X'` from the
-/// in-process trace handler, and `no entity found matching 'X'` from the
-/// daemon's trace route — and a qualifier that only fires for the wording it
-/// was written against would go quiet the moment one of them is reworded, which
-/// looks exactly like the tool having no miss to qualify.
+/// Matched on the family rather than one exact sentence. Three producers word
+/// this differently today: `Entity not found` from the references handler,
+/// `trace_data_flow: no entity matches focal 'X'` from the in-process trace
+/// handler, and `no entity found matching 'X'` from the daemon's trace route. A
+/// qualifier that only fires for the wording it was written against would go
+/// quiet the moment one of them is reworded, which looks exactly like the tool
+/// having no miss to qualify.
 fn is_resolution_miss(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
     message.contains("no entity") || message.contains("entity not found")
@@ -725,7 +725,7 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
     }
 
     let consequence = if trustworthy {
-        "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name, not about the symbol's usage — nothing was looked up."
+        "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name and not about the symbol's usage, because nothing was looked up."
     } else {
         "Absence is NOT authoritative: the name may simply not be indexed yet, so do not conclude the symbol does not exist. Re-check once the graph is complete and the daemon is healthy."
     };

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -706,7 +706,24 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
         return None;
     }
 
-    let (trustworthy, trust_reason) = envelope.negative_trust(NegativeClass::Structural);
+    let (mut trustworthy, trust_reason) = envelope.negative_trust(NegativeClass::Structural);
+    let mut trust_reason = trust_reason.to_string();
+
+    // A graph holding no entities answers every name identically, so a miss
+    // there describes the graph and not the code. That is the shape that made a
+    // bare "not found" dangerous: an agent reads it as proof the symbol does not
+    // exist and acts on it.
+    if envelope.graph_state.entity_count == Some(0) {
+        let gap = "graph_empty: the graph holds no entities at all, so a name that resolves to \
+                   nothing says nothing about whether the symbol exists";
+        trust_reason = if trustworthy {
+            gap.to_string()
+        } else {
+            format!("{trust_reason}; {gap}")
+        };
+        trustworthy = false;
+    }
+
     let consequence = if trustworthy {
         "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name, not about the symbol's usage — nothing was looked up."
     } else {
@@ -1313,6 +1330,259 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("focal_not_in_graph"));
+    }
+
+    /// A resolved trace chain that came back empty, reporting everything the
+    /// in-process handler reports: a unique, non-method focal and a walk that
+    /// finished inside its bounds.
+    fn clean_empty_trace(direction: &str) -> Value {
+        json!({
+            "focal_id": "00000000-0000-0000-0000-000000000001",
+            "focal_name": "do_work",
+            "focal_kind": "Function",
+            "direction": direction,
+            "depth": 3,
+            "chain": [],
+            "total_steps": 0,
+            "truncated": false,
+            "focal_resolution": {
+                "addressed_by": "name",
+                "same_name_candidates": 1,
+            },
+        })
+    }
+
+    #[test]
+    fn trace_on_loaded_graph_is_authoritative_when_the_walk_reports_no_gap() {
+        let negative = negative_for(
+            "trace_data_flow",
+            &clean_empty_trace("both"),
+            &structural_ready_envelope(),
+        )
+        .expect("an empty chain yields a negative");
+        assert_eq!(negative["kind"], json!("no_flow"));
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("structural_authoritative"));
+    }
+
+    /// The reported defect: the walk never reported how the focal resolved, and
+    /// the qualifier certified absence anyway. A count it cannot see is unknown,
+    /// and unknown never certifies.
+    #[test]
+    fn trace_without_a_resolution_report_is_inconclusive() {
+        let mut payload = clean_empty_trace("callers");
+        payload.as_object_mut().unwrap().remove("focal_resolution");
+        let negative = negative_for("trace_data_flow", &payload, &structural_ready_envelope())
+            .expect("an empty chain yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("focal_resolution_unreported"));
+        assert!(negative["advice"]
+            .as_str()
+            .unwrap()
+            .contains("NOT authoritative"));
+    }
+
+    #[test]
+    fn trace_with_same_named_twins_is_inconclusive() {
+        let mut payload = clean_empty_trace("callers");
+        payload["focal_resolution"]["same_name_candidates"] = json!(2);
+        let negative = negative_for("trace_data_flow", &payload, &structural_ready_envelope())
+            .expect("an empty chain yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("focal_resolution_ambiguous"), "{reason}");
+        assert!(reason.contains('2'), "the count must be named: {reason}");
+    }
+
+    /// The method gate is the one `find_references` already applies, and it
+    /// bears on a walk that read incoming edges. An outgoing-only walk never
+    /// looked at them, so the gate does not apply and the absence stands.
+    #[test]
+    fn trace_method_gate_follows_the_direction_that_was_walked() {
+        for direction in ["callers", "both"] {
+            let mut payload = clean_empty_trace(direction);
+            payload["focal_kind"] = json!("Method");
+            let negative =
+                negative_for("trace_data_flow", &payload, &structural_ready_envelope()).unwrap();
+            assert_eq!(
+                negative["safe_to_conclude_absent"],
+                json!(false),
+                "a {direction} walk reads incoming edges: {negative}"
+            );
+            assert!(negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .contains("method_call_resolution_incomplete"));
+        }
+
+        let mut outgoing = clean_empty_trace("calls");
+        outgoing["focal_kind"] = json!("Method");
+        let negative =
+            negative_for("trace_data_flow", &outgoing, &structural_ready_envelope()).unwrap();
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "an outgoing-only walk never read the under-resolved edges: {negative}"
+        );
+    }
+
+    /// A walk stopped by its own caps or work bounds did not examine what an
+    /// empty chain is read as having ruled out. `degradations` is the daemon
+    /// route's name for the same fact.
+    #[test]
+    fn trace_cut_short_by_its_own_bounds_is_inconclusive() {
+        let mut truncated = clean_empty_trace("both");
+        truncated["truncated"] = json!(true);
+        let negative =
+            negative_for("trace_data_flow", &truncated, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("trace_walk_truncated"));
+
+        let mut degraded = clean_empty_trace("both");
+        degraded["degradations"] = json!([{ "component": "entity_bodies", "reason": "budget" }]);
+        let negative =
+            negative_for("trace_data_flow", &degraded, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("trace_walk_degraded"));
+    }
+
+    /// An absence with two causes has two, and a reader deciding whether to
+    /// re-run or to stop trusting the graph needs both.
+    #[test]
+    fn trace_reports_every_gap_beside_the_substrate_reason() {
+        let mut payload = clean_empty_trace("callers");
+        payload["focal_kind"] = json!("Method");
+        payload.as_object_mut().unwrap().remove("focal_resolution");
+        let negative = negative_for("trace_data_flow", &payload, &Envelope::offline()).unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.contains("offline_fallback"), "{reason}");
+        assert!(reason.contains("method_call_resolution_incomplete"), "{reason}");
+        assert!(reason.contains("focal_resolution_unreported"), "{reason}");
+    }
+
+    #[test]
+    fn trace_absence_names_the_direction_that_was_walked() {
+        let outgoing =
+            negative_for("trace_data_flow", &clean_empty_trace("calls"), &Envelope::offline())
+                .unwrap();
+        let subject = outgoing["subject"].as_str().unwrap();
+        assert!(
+            subject.contains("anything it calls") && !subject.contains("either direction"),
+            "{subject}"
+        );
+        assert!(outgoing["advice"].as_str().unwrap().contains("callers were not walked"));
+
+        let incoming =
+            negative_for("trace_data_flow", &clean_empty_trace("callers"), &Envelope::offline())
+                .unwrap();
+        assert!(incoming["subject"]
+            .as_str()
+            .unwrap()
+            .contains("anything that calls it"));
+
+        let merged =
+            negative_for("trace_data_flow", &clean_empty_trace("both"), &Envelope::offline())
+                .unwrap();
+        assert!(merged["subject"].as_str().unwrap().contains("either direction"));
+    }
+
+    #[test]
+    fn a_populated_chain_still_gets_no_negative() {
+        let mut payload = clean_empty_trace("both");
+        payload["chain"] = json!([{ "step": 1, "entity_name": "caller" }]);
+        assert!(negative_for("trace_data_flow", &payload, &structural_ready_envelope()).is_none());
+    }
+
+    // ---- resolution misses: the answer with no collection to count ----
+
+    #[test]
+    fn resolution_miss_is_authoritative_on_a_populated_ready_graph() {
+        let envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 3,
+        }));
+        for (tool, message) in [
+            ("find_references", "Entity not found"),
+            ("trace_data_flow", "no entity found matching 'embed_batch'"),
+            (
+                "trace_data_flow",
+                "trace_data_flow: no entity matches focal 'embed_batch'",
+            ),
+        ] {
+            let negative = resolution_miss_for(tool, message, &envelope)
+                .unwrap_or_else(|| panic!("{tool} must qualify its miss: {message}"));
+            assert_eq!(negative["kind"], json!("focal_not_resolved"));
+            assert_eq!(negative["interpretation"], json!("name_not_resolved"));
+            assert_eq!(negative["result_count"], json!(0));
+            assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+            assert_eq!(negative["trust"], json!("authoritative"));
+        }
+    }
+
+    #[test]
+    fn resolution_miss_on_an_empty_graph_is_inconclusive() {
+        let envelope = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_entity_count": 0,
+        }));
+        let negative = resolution_miss_for("trace_data_flow", "no entity found matching 'x'", &envelope)
+            .expect("a miss is still qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"].as_str().unwrap().contains("graph_empty"));
+    }
+
+    #[test]
+    fn resolution_miss_offline_is_inconclusive() {
+        let negative = resolution_miss_for("find_references", "Entity not found", &Envelope::offline())
+            .expect("a miss is still qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("offline_fallback"));
+        assert!(negative["advice"].as_str().unwrap().contains("NOT authoritative"));
+    }
+
+    /// The guard has to be able to say no. A malformed request or an
+    /// unreachable daemon never looked anything up, so dressing either as an
+    /// absence would invent the very verdict this module exists to qualify.
+    #[test]
+    fn a_request_or_transport_failure_is_not_a_resolution_miss() {
+        for message in [
+            "missing required parameter: focal",
+            "invalid direction 'sideways': expected calls, callers, or both",
+            "unsupported relation kind 'sideways': use calls, imports, or references",
+            "kin-mcp has no Kin repository bound for 'trace_data_flow': not inside a kin repository",
+            "daemon is unreachable",
+        ] {
+            assert!(
+                resolution_miss_for("trace_data_flow", message, &structural_ready_envelope())
+                    .is_none(),
+                "must not be read as an absence: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_tool_with_no_miss_framing_gets_no_resolution_negative() {
+        assert!(
+            resolution_miss_for("semantic_search", "Entity not found", &Envelope::daemon())
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1468,34 +1468,52 @@ mod tests {
         let negative = negative_for("trace_data_flow", &payload, &Envelope::offline()).unwrap();
         let reason = negative["trust_reason"].as_str().unwrap();
         assert!(reason.contains("offline_fallback"), "{reason}");
-        assert!(reason.contains("method_call_resolution_incomplete"), "{reason}");
+        assert!(
+            reason.contains("method_call_resolution_incomplete"),
+            "{reason}"
+        );
         assert!(reason.contains("focal_resolution_unreported"), "{reason}");
     }
 
     #[test]
     fn trace_absence_names_the_direction_that_was_walked() {
-        let outgoing =
-            negative_for("trace_data_flow", &clean_empty_trace("calls"), &Envelope::offline())
-                .unwrap();
+        let outgoing = negative_for(
+            "trace_data_flow",
+            &clean_empty_trace("calls"),
+            &Envelope::offline(),
+        )
+        .unwrap();
         let subject = outgoing["subject"].as_str().unwrap();
         assert!(
             subject.contains("anything it calls") && !subject.contains("either direction"),
             "{subject}"
         );
-        assert!(outgoing["advice"].as_str().unwrap().contains("callers were not walked"));
+        assert!(outgoing["advice"]
+            .as_str()
+            .unwrap()
+            .contains("callers were not walked"));
 
-        let incoming =
-            negative_for("trace_data_flow", &clean_empty_trace("callers"), &Envelope::offline())
-                .unwrap();
+        let incoming = negative_for(
+            "trace_data_flow",
+            &clean_empty_trace("callers"),
+            &Envelope::offline(),
+        )
+        .unwrap();
         assert!(incoming["subject"]
             .as_str()
             .unwrap()
             .contains("anything that calls it"));
 
-        let merged =
-            negative_for("trace_data_flow", &clean_empty_trace("both"), &Envelope::offline())
-                .unwrap();
-        assert!(merged["subject"].as_str().unwrap().contains("either direction"));
+        let merged = negative_for(
+            "trace_data_flow",
+            &clean_empty_trace("both"),
+            &Envelope::offline(),
+        )
+        .unwrap();
+        assert!(merged["subject"]
+            .as_str()
+            .unwrap()
+            .contains("either direction"));
     }
 
     #[test]
@@ -1539,22 +1557,30 @@ mod tests {
             "graph_loaded": true,
             "graph_entity_count": 0,
         }));
-        let negative = resolution_miss_for("trace_data_flow", "no entity found matching 'x'", &envelope)
-            .expect("a miss is still qualified");
+        let negative =
+            resolution_miss_for("trace_data_flow", "no entity found matching 'x'", &envelope)
+                .expect("a miss is still qualified");
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
-        assert!(negative["trust_reason"].as_str().unwrap().contains("graph_empty"));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("graph_empty"));
     }
 
     #[test]
     fn resolution_miss_offline_is_inconclusive() {
-        let negative = resolution_miss_for("find_references", "Entity not found", &Envelope::offline())
-            .expect("a miss is still qualified");
+        let negative =
+            resolution_miss_for("find_references", "Entity not found", &Envelope::offline())
+                .expect("a miss is still qualified");
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
         assert!(negative["trust_reason"]
             .as_str()
             .unwrap()
             .contains("offline_fallback"));
-        assert!(negative["advice"].as_str().unwrap().contains("NOT authoritative"));
+        assert!(negative["advice"]
+            .as_str()
+            .unwrap()
+            .contains("NOT authoritative"));
     }
 
     /// The guard has to be able to say no. A malformed request or an


### PR DESCRIPTION
An empty trace walk no longer certifies an absence it never verified, and a name
that resolves to nothing no longer comes back as a bare message an agent cannot
calibrate.

trace_data_flow used to certify an empty walk on nothing but the substrate gate.
On a fully embedded kin-db store it answered "safe to treat the target as
genuinely absent/unused" for a method that has a live caller, while
find_references on the same graph, in the same minute, correctly refused to
certify the same kind of emptiness. Both tools read the same typed Calls,
Imports and References edges, so an absence over those edges is trustworthy
under the same conditions for both, and trace now applies the gates references
already applied.

A method focal whose incoming calls are linked by bare name may simply never
have been linked. A focal name the graph holds more than once is the cfg-twin
shape, where two arms of one declaration are admitted as distinct entities and a
call the extractor cannot attribute lands on neither. A walk stopped by its own
caps or work bounds did not examine what an empty chain gets read as having
ruled out. The subject also scopes the absence to the direction that was walked,
so an empty callers walk no longer claims the focal calls nothing.

The ambiguity gate needs a fact only the handler can see, so the chain payload
now reports how many entities carry the focal's name. A count the qualifier
cannot see stays unknown and never certifies, which is why the daemon route,
whose chain payload does not carry that count yet, comes back inconclusive
rather than guessing. That is the right answer for the reported case, and it is
the same treatment find_references gives a missing cross-repo authority.

Both tools also answered an unresolvable name with a bare message and no
negative beside it, while every resolved answer from the same tool carried the
full object. That asymmetry is the one an agent cannot see. The finalize
chokepoint now qualifies the miss too, keeps the human-readable message exactly
where it was, and computes its trust honestly. A name no entity carries, on a
loaded daemon graph that holds entities, is a real answer. The same miss on a
graph holding nothing at all is a fact about the graph, and the qualifier says
so instead of letting an agent conclude the symbol does not exist.

The guard can say no. A malformed request, an unreachable daemon, and a tool
with no miss framing all come back unqualified, and a test holds each of them
there. Every gate got its two-sided pair, so the authoritative side still reads
authoritative and a qualifier that certified nothing would fail just as loudly.

Both fixes were falsified rather than assumed. Removing the trace gate block
fails nine tests across the qualifier and the handler. Reverting the miss
annotation fails the four tests that drive the real handlers through the
annotation chokepoint.

Closes FIR-2146
Closes FIR-2134
