### PR TITLE
Lead with the version gap when a store predates the layout this build serves

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -167,6 +167,23 @@ pub async fn open_snapshot_explicit_admin_read_only(
     }
 }
 
+/// Carry a failed daemon resolution into a channel that can only hold a string.
+///
+/// A store this build cannot open answers the question by itself, so it passes
+/// through as the whole message rather than as a cause under a missing daemon.
+/// Anything else keeps the daemon framing and brings its cause with it:
+/// rendering an `anyhow` chain with `{error}` prints the outermost context only,
+/// which reduced every failure here to "kin daemon is required but unavailable:
+/// kin daemon is required".
+fn daemon_resolution_storage_error(error: anyhow::Error) -> kin_db::KinDbError {
+    if let Some(crate::daemon_client::AutoStartError::IncompatibleStore(message)) =
+        error.downcast_ref::<crate::daemon_client::AutoStartError>()
+    {
+        return kin_db::KinDbError::StorageError(message.clone());
+    }
+    kin_db::KinDbError::StorageError(format!("kin daemon is required but unavailable: {error:#}"))
+}
+
 /// Whether the offline/admin local-snapshot escape hatch is enabled.
 fn daemon_bootstrap_admin_allowed() -> bool {
     std::env::var("KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN")
@@ -187,11 +204,7 @@ async fn open_snapshot_daemon_first_with_mode(
     .entered();
     let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
         .await
-        .map_err(|error| {
-            kin_db::KinDbError::StorageError(format!(
-                "kin daemon is required but unavailable: {error}"
-            ))
-        })?
+        .map_err(daemon_resolution_storage_error)?
         .ok_or_else(|| {
             kin_db::KinDbError::StorageError(
                 "kin daemon is required but no daemon endpoint is available".to_string(),

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -153,13 +153,25 @@ fn ensure_directory(dir: &Path) -> Result<()> {
 
 fn reject_existing_repository(dir: &Path) -> Result<()> {
     if path_exists(&dir.join(".kin"))? {
-        anyhow::bail!(
-            "Kin repository already exists at {}; `kin init` never rebuilds graph authority from \
-             the working tree",
-            dir.display()
-        );
+        anyhow::bail!(existing_repository_refusal(dir));
     }
     Ok(())
+}
+
+/// The refusal `kin init` raises over a directory that already holds a store.
+///
+/// The reader who arrives here most often is the one the store wall just sent,
+/// after an older store refused to open. That wall names a rebuild, and `kin
+/// init` is half of it, so this refusal names the same rebuild instead of
+/// stopping at the fact that a store exists.
+fn existing_repository_refusal(dir: &Path) -> String {
+    format!(
+        "Kin repository already exists at {}; `kin init` never rebuilds graph authority from the \
+         working tree. If this build cannot open that store, {} again to rebuild it from the \
+         repository's Git history.",
+        dir.display(),
+        super::REBUILD_INCOMPATIBLE_STORE
+    )
 }
 
 fn require_empty_native_boundary(dir: &Path) -> Result<()> {
@@ -484,6 +496,42 @@ mod tests {
         assert!(
             absent.contains("not installed") && absent.contains("git"),
             "a host without git must be told before being sent to a git commit: {absent}"
+        );
+    }
+
+    /// The store wall and this refusal are read in sequence by one reader, so
+    /// they have to name one remedy between them.
+    ///
+    /// They did not. The wall sent the reader to `kin init` in a fresh checkout,
+    /// and `kin init` answered that a repository already exists and that it
+    /// never rebuilds graph authority, which reads as a flat contradiction and
+    /// leaves no next move.
+    #[test]
+    fn the_store_wall_and_the_existing_repository_refusal_name_one_remedy() {
+        let wall = crate::commands::incompatible_store_refusal(
+            std::path::Path::new("/repo/.kin"),
+            &kin_core::KinError::IncompatibleVersion {
+                found: 1,
+                supported: 2,
+            },
+        );
+        let refusal = existing_repository_refusal(std::path::Path::new("/repo"));
+
+        assert!(
+            wall.contains(crate::commands::REBUILD_INCOMPATIBLE_STORE),
+            "the store wall must name the shared remedy: {wall}"
+        );
+        assert!(
+            refusal.contains(crate::commands::REBUILD_INCOMPATIBLE_STORE),
+            "the existing-repository refusal must name the same remedy: {refusal}"
+        );
+        assert!(
+            wall.contains("found v1, this binary requires v2"),
+            "the wall must lead with the version gap it is about: {wall}"
+        );
+        assert!(
+            !wall.contains("fresh checkout") && !refusal.contains("fresh checkout"),
+            "neither text may send the reader to a checkout they do not have"
         );
     }
 

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -128,6 +128,33 @@ pub(crate) fn not_a_kin_repository() -> anyhow::Error {
     anyhow::anyhow!(NOT_A_KIN_REPOSITORY)
 }
 
+/// The one remedy for a `.kin/` store this build cannot open.
+///
+/// Two messages have to agree on it. The store wall sends the reader to
+/// `kin init`, and `kin init` refuses over an existing store, so a refusal that
+/// named a different path would send the reader in a circle. The consistency
+/// test in `commands::init` holds both texts against this token.
+pub(crate) const REBUILD_INCOMPATIBLE_STORE: &str = "remove .kin/ and run `kin init`";
+
+/// The wall a store written by an older kin is refused with.
+///
+/// The version gap leads, because it is the whole reason nothing else will
+/// work. There is no in-place upgrade and no migration command, so the remedy
+/// is the rebuild the reader can actually perform, and the case where that
+/// rebuild has no source to draw on is named rather than left to be discovered.
+pub(crate) fn incompatible_store_refusal(
+    kin_root: &std::path::Path,
+    error: &kin_core::KinError,
+) -> String {
+    format!(
+        "{error} ({})\nAn older kin wrote this store and there is no in-place upgrade. Kin \
+         re-derives the store from the repository's Git history, so {REBUILD_INCOMPATIBLE_STORE} \
+         here to rebuild it. If the repository has no Git history to re-admit, keep a copy of \
+         .kin/ and open it with the kin that wrote it.",
+        kin_root.display()
+    )
+}
+
 #[cfg(test)]
 mod repository_refusal_tests {
     use super::{require_repository_layout_at, NOT_A_KIN_REPOSITORY};

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -45,6 +45,14 @@ const DAEMON_BINARY_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 pub enum AutoStartError {
     #[error("kin-daemon binary not found (not in PATH or next to kin binary)")]
     BinaryNotFound,
+    /// The `.kin/` store predates the layout this build serves.
+    ///
+    /// Its own text is the whole answer, so callers render it as the headline
+    /// rather than as a cause under a missing daemon. No daemon can start
+    /// against such a store, and saying the daemon is required first states a
+    /// consequence and buries the reason.
+    #[error("{0}")]
+    IncompatibleStore(String),
     #[error("daemon startup failed: {0}")]
     SpawnFailed(String),
     #[error("daemon failed to become ready before the startup deadline: {0}")]
@@ -6723,6 +6731,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     kin_root: &Path,
     idle_timeout_override: Option<&'static str>,
 ) -> std::result::Result<String, AutoStartError> {
+    refuse_incompatible_store(kin_root)?;
     install_spawn_registrar();
     let supervisor_url = ensure_supervisor_running()
         .await
@@ -6825,6 +6834,31 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     Ok(base_url)
 }
 
+/// Refuse a `.kin/` store this build cannot serve before anything is spawned.
+///
+/// The daemon holds the same gate, but reaching it costs a supervisor, a binary
+/// probe and a daemon process that all exist only to die, and it turns the
+/// answer into a line quoted out of a log tail underneath "kin daemon is
+/// required". Checking the on-disk marker here is one file read and it makes the
+/// version gap the thing the reader is told.
+///
+/// Only the version gap is answered here. Any other failure to read the marker
+/// is recorded and left to the daemon, whose gate sees the same file.
+fn refuse_incompatible_store(kin_root: &Path) -> std::result::Result<(), AutoStartError> {
+    match kin_core::KinLayout::new(kin_root.to_path_buf()).check_version() {
+        Ok(()) => Ok(()),
+        Err(error @ kin_core::KinError::IncompatibleVersion { .. }) => {
+            Err(AutoStartError::IncompatibleStore(
+                crate::commands::incompatible_store_refusal(kin_root, &error),
+            ))
+        }
+        Err(error) => {
+            tracing::debug!(%error, kin_root = %kin_root.display(), "could not read the .kin/ layout version before starting a daemon");
+            Ok(())
+        }
+    }
+}
+
 fn map_supervisor_auto_start_error(error: anyhow::Error) -> AutoStartError {
     if matches!(
         error.downcast_ref::<DaemonBinaryDiscoveryError>(),
@@ -6892,6 +6926,10 @@ async fn resolve_daemon_url_inner(
 
     match ensure_daemon_running_with_idle_timeout(layout.root(), idle_timeout_override).await {
         Ok(url) => Ok(Some(url)),
+        // A store this build cannot open is the whole answer. Adding the daemon
+        // framing over it would promote the consequence to the headline and
+        // demote the reason to a nested cause.
+        Err(err @ AutoStartError::IncompatibleStore(_)) => Err(anyhow::Error::new(err)),
         Err(err) => Err(anyhow::Error::new(err).context("kin daemon is required")),
     }
 }

--- a/crates/kin-cli/tests/incompatible_store_wall.rs
+++ b/crates/kin-cli/tests/incompatible_store_wall.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! How a `.kin/` store this build cannot serve refuses a command.
+//!
+//! The gap itself has to be the headline. When it was reported as a line quoted
+//! out of a daemon log tail underneath "kin daemon is required", every reader
+//! was told a daemon was missing and left to find the sentence saying why one
+//! could never start.
+
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::IsolatedDaemonRuntime;
+
+/// A `.kin/` exactly as a released 0.3.6 wrote one.
+///
+/// The manifest carries the field set of that release and there is no `version`
+/// marker, which `KinLayout::read_version` reports as v1.
+fn seed_pre_v2_store(repo: &Path) {
+    let kin_dir = repo.join(".kin");
+    fs::create_dir_all(&kin_dir).expect("create pre-v2 .kin");
+    fs::write(
+        kin_dir.join("manifest.json"),
+        r#"{"kin_version":"0.3.6","languages":[],"adapters":[],"repo_id":"54c48711-e6f0-4950-b00d-5585b59188fe","created_at":"2026-07-28T03:10:45Z"}"#,
+    )
+    .expect("write pre-v2 manifest");
+}
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = common::Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn seed_git_repo(path: &Path) {
+    fs::create_dir_all(path).expect("create repo dir");
+    run_git(path, &["init", "--initial-branch=main"]);
+    run_git(path, &["config", "user.email", "kin@example.invalid"]);
+    run_git(path, &["config", "user.name", "Kin"]);
+    fs::write(path.join("README.md"), "first\n").expect("write a tracked file");
+    run_git(path, &["add", "--all"]);
+    run_git(path, &["commit", "-m", "first"]);
+}
+
+#[test]
+fn a_pre_v2_store_refuses_a_command_by_leading_with_the_version_gap() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("pre-v2");
+    fs::create_dir_all(&repo).expect("create repository directory");
+    seed_pre_v2_store(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = runtime
+        .kin_command()
+        .args(["locate", "anything"])
+        .current_dir(&repo)
+        .output()
+        .expect("run a daemon-backed command against a pre-v2 store");
+
+    assert!(
+        !output.status.success(),
+        "a store this build cannot serve must refuse: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("incompatible .kin/ version: found v1, this binary requires v2"),
+        "the refusal must name the version gap: {stderr}"
+    );
+    assert!(
+        !stderr.contains("kin daemon is required"),
+        "the missing daemon is a consequence of the gap and must not be the headline: {stderr}"
+    );
+    assert!(
+        !stderr.contains("recent log:"),
+        "the cause must be stated, not quoted out of a log tail: {stderr}"
+    );
+    assert!(
+        !stderr.contains("failed cleanup during Drop"),
+        "a refusal that spawns nothing has no cleanup to report: {stderr}"
+    );
+    assert!(
+        stderr.contains("remove .kin/ and run `kin init`"),
+        "the refusal must name the remedy that works in place: {stderr}"
+    );
+    assert!(
+        !stderr.contains("fresh checkout"),
+        "the remedy must not send the reader to a checkout they do not have: {stderr}"
+    );
+    assert!(
+        !repo.join(".kin/daemon.log").exists(),
+        "the gap is settled from the on-disk marker, so no daemon is started to discover it"
+    );
+}
+
+#[test]
+fn init_over_an_existing_store_names_the_same_remedy_the_wall_does() {
+    // A reader the wall sent to `kin init` runs it in place first. The refusal
+    // they get has to continue that instruction rather than contradict it.
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("pre-v2-init");
+    fs::create_dir_all(&repo).expect("create repository directory");
+    seed_pre_v2_store(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = runtime
+        .kin_command()
+        .arg("init")
+        .arg(&repo)
+        .output()
+        .expect("run kin init over an existing store");
+
+    assert!(
+        !output.status.success(),
+        "kin init never rebuilds over an existing store: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Kin repository already exists"),
+        "the refusal must state its condition: {stderr}"
+    );
+    assert!(
+        stderr.contains("remove .kin/ and run `kin init`"),
+        "the refusal must name the same remedy the store wall does: {stderr}"
+    );
+}
+
+#[test]
+fn the_remedy_the_wall_names_rebuilds_the_store_in_place() {
+    // A remedy nothing checks is a guess. This runs the exact instruction the
+    // wall gives, in the directory the reader is standing in, and requires it
+    // to produce a store the current build wrote.
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("worked-in");
+    seed_git_repo(&repo);
+    seed_pre_v2_store(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    fs::remove_dir_all(repo.join(".kin")).expect("remove the store the wall said to remove");
+    let output = runtime
+        .kin_command()
+        .arg("init")
+        .arg(&repo)
+        .output()
+        .expect("run the rebuild the wall names");
+
+    assert!(
+        output.status.success(),
+        "the named remedy must rebuild the store: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(repo.join(".kin/version"))
+            .expect("the rebuilt store carries a layout marker")
+            .trim(),
+        kin_core::layout::KIN_LAYOUT_VERSION.to_string(),
+        "the rebuilt store must be one this build serves"
+    );
+}
+
+#[test]
+fn a_refused_init_leaves_no_partial_store_behind() {
+    // Whatever the refusal says, it must not leave a half-written `.kin` that
+    // the next command then has to interpret.
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("non-empty");
+    fs::create_dir_all(&repo).expect("create repository directory");
+    fs::write(repo.join("notes.txt"), "untracked\n").expect("write an untracked file");
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = runtime
+        .kin_command()
+        .arg("init")
+        .arg(&repo)
+        .output()
+        .expect("run kin init over a non-empty non-Git directory");
+
+    assert!(
+        !output.status.success(),
+        "a non-empty directory with no Git history is refused: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !repo.join(".kin").exists(),
+        "a refused init must leave no store at all"
+    );
+}

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -907,6 +907,7 @@ impl ProcessGroupGuardianLauncher {
                         watcher_status: None,
                         watcher_failure: None,
                         group_barrier_completed: false,
+                        finalized: false,
                         cleanup_timeout: self.cleanup_timeout,
                         watcher_reaper,
                     });
@@ -1092,6 +1093,17 @@ pub struct ProcessGroupGuardian {
     watcher_status: Option<std::process::ExitStatus>,
     watcher_failure: Option<String>,
     group_barrier_completed: bool,
+    /// Whether launcher-side finalization has already consumed the terminal
+    /// watcher status, so no later call can do anything but report that.
+    ///
+    /// Finalization happens exactly once. Reporting the already-finalized
+    /// sentinel to an explicit caller is right, and reporting it from `Drop` is
+    /// pure noise: an owner that reaped its guardian and then dropped the handle
+    /// is the ordinary end of a bounded probe, not a cleanup failure. Every
+    /// bounded daemon probe took that shape, so a single failed daemon start
+    /// printed one "failed cleanup during Drop" warning per probe and buried the
+    /// real cause under them.
+    finalized: bool,
     cleanup_timeout: Duration,
     watcher_reaper: std::sync::mpsc::Sender<WatcherReaperJob>,
 }
@@ -1234,6 +1246,7 @@ impl ProcessGroupGuardian {
                 "process-group watcher was already finalized",
             ));
         };
+        self.finalized = true;
 
         self.ownership.take();
         let finalization = finalize_owned_process_group(
@@ -1347,6 +1360,18 @@ impl ProcessGroupGuardian {
 #[cfg(unix)]
 impl Drop for ProcessGroupGuardian {
     fn drop(&mut self) {
+        // A guardian its owner already reaped owns nothing and can only report
+        // the already-finalized sentinel. That is the ordinary end of a bounded
+        // probe, so it is recorded and not warned about. Warning here printed
+        // one "failed cleanup during Drop" line per daemon binary probe and
+        // pushed the real reason a start failed out of the reader's view.
+        if self.finalized {
+            tracing::debug!(
+                process_group = self.process_group,
+                "process-group guardian dropped after its owner finalized it"
+            );
+            return;
+        }
         self.request_cleanup();
         let deadline = std::time::Instant::now()
             + self.cleanup_timeout
@@ -4342,6 +4367,117 @@ mod tests {
         guardian
             .reap_until(std::time::Instant::now() + Duration::from_secs(5))
             .unwrap();
+    }
+
+    /// Every WARN and ERROR message a closure emits on this thread.
+    ///
+    /// A missing log line is invisible to an ordinary assertion, so the quiet
+    /// path has to be captured to be checked at all.
+    #[derive(Clone, Default)]
+    struct CapturedDiagnostics(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+    impl CapturedDiagnostics {
+        fn messages(&self) -> Vec<String> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl tracing::field::Visit for CapturedDiagnostics {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.0.lock().unwrap().push(format!("{value:?}"));
+            }
+        }
+    }
+
+    impl tracing::Subscriber for CapturedDiagnostics {
+        fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+            *metadata.level() <= tracing::Level::WARN
+        }
+
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+        fn event(&self, event: &tracing::Event<'_>) {
+            let mut visitor = self.clone();
+            event.record(&mut visitor);
+        }
+
+        fn enter(&self, _: &tracing::span::Id) {}
+
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_a_guardian_its_owner_reaped_reports_no_cleanup_failure() {
+        // Every bounded probe reaps its guardian and then drops the handle, so
+        // the second finalization attempt is the normal case, not a fault. When
+        // Drop warned about it, a single failed daemon start printed one
+        // "failed cleanup during Drop" line per probe above the one line saying
+        // why the daemon would not start.
+        let root = tempfile::tempdir().unwrap();
+        let readiness_path = root.path().join("guardian.ready");
+        let executable = std::env::current_exe().unwrap();
+        let launcher = ProcessGroupGuardianLauncher::exact_test(
+            &executable,
+            "tests::process_group_guardian_worker",
+        );
+        let mut guardian = launcher
+            .spawn_with(
+                &readiness_path,
+                std::time::Instant::now() + Duration::from_secs(5),
+                |_| {},
+            )
+            .unwrap();
+        assert!(
+            !guardian.finalized,
+            "a live guardian has not been finalized yet"
+        );
+        guardian.request_cleanup();
+        guardian
+            .reap_until(std::time::Instant::now() + Duration::from_secs(5))
+            .unwrap();
+        assert!(
+            guardian.finalized,
+            "an explicit reap must record that finalization already happened"
+        );
+        let repeated = guardian
+            .try_reap()
+            .expect_err("a guardian finalizes exactly once");
+        assert!(
+            repeated.to_string().contains("already finalized"),
+            "unexpected repeat-finalization error: {repeated}"
+        );
+
+        let captured = CapturedDiagnostics::default();
+        tracing::subscriber::with_default(captured.clone(), || drop(guardian));
+        assert!(
+            captured.messages().is_empty(),
+            "dropping an already-reaped guardian must stay quiet: {:?}",
+            captured.messages()
+        );
+    }
+
+    #[test]
+    fn captured_diagnostics_records_a_warning_it_is_meant_to_catch() {
+        // The check above passes when nothing is logged, which is also what it
+        // would report if the capture never worked. This is the positive
+        // control that proves the capture can see a warning at all.
+        let captured = CapturedDiagnostics::default();
+        tracing::subscriber::with_default(captured.clone(), || {
+            tracing::warn!("process-group guardian reported failed cleanup during Drop");
+        });
+        assert_eq!(
+            captured.messages(),
+            vec!["process-group guardian reported failed cleanup during Drop".to_string()],
+            "the capture must see a warning emitted inside its scope"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1945,11 +1945,16 @@ impl DaemonState {
         // namespace, so letting either path speak first buries the real story
         // under a serde or storage error instead of the version gap.
         if let Err(error) = layout.check_version() {
+            // The remedy has to be one `kin init` will actually honor. Sending
+            // the reader to a fresh checkout read as sound advice and was not:
+            // `kin init` refuses over an existing store, so the instruction
+            // dead-ended in the working tree the reader was standing in.
             return Err(DaemonError::IncompatibleRepo(format!(
                 "{error}. This repository was created before the \
-                 repository-authority layout change; re-create it with this \
-                 build (`kin clone` or `kin init` in a fresh checkout), or \
-                 open it with a matching older kin."
+                 repository-authority layout change and there is no in-place \
+                 upgrade. Remove .kin/ and run `kin init` to rebuild the store \
+                 from the repository's Git history, or open it with a matching \
+                 older kin."
             )));
         }
 
@@ -6735,8 +6740,13 @@ mod tests {
             "message must name the layout gap: {message}"
         );
         assert!(
-            message.contains("kin clone") || message.contains("kin init"),
+            message.contains("Remove .kin/ and run `kin init`"),
             "message must name a remediation path: {message}"
+        );
+        assert!(
+            !message.contains("fresh checkout"),
+            "the remedy must be one `kin init` honors in the tree the reader is in, and `kin \
+             init` refuses over an existing store: {message}"
         );
         assert!(
             !message.contains("missing field"),


### PR DESCRIPTION
Opening a repository whose `.kin/` predates the current layout answered with a missing daemon. Four guardian cleanup warnings came first, then "kin daemon is required" as the headline, and the real reason sat inside a quoted daemon log tail underneath it. The remedy that tail offered was `kin init` in a fresh checkout, which is a remedy `kin init` refuses to honor, so following the error led straight into "Kin repository already exists ... never rebuilds graph authority".

The CLI now settles the layout gap from the on-disk marker before it starts anything. The gap becomes the headline, and no supervisor, binary probe or daemon is spawned to discover it. The daemon-backed snapshot path stops wrapping that answer in daemon framing, and its storage error now carries its cause instead of printing only the outermost context.

The remedy names a path that works where the reader is standing. There is no in-place upgrade and no migration command, so the wall says to remove `.kin/` and run `kin init`, which re-admits the repository from its Git history, and it names the case where there is no history to re-admit. The `kin init` refusal over an existing store and the daemon's own layout refusal now say the same thing, and a test holds them against one remedy token.

A guardian its owner already reaped stays quiet when the handle drops. Every bounded daemon probe reaps and then drops, so the second finalization attempt is the ordinary end of a probe rather than a fault, and warning about it printed one line per probe above the one line that mattered.

An integration test drives a pre-v2 store end to end. The refusal leads with the gap, names the remedy, and starts no daemon. The test then performs the named remedy and requires it to produce a store this build serves. A refused init still leaves no `.kin` behind.

Closes FIR-2143
