### PR TITLE
Publish what the reconcile loop actually admitted

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1182,14 +1182,18 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
+        // The control. This fixture's graph raises unrelated warnings of its own
+        // (pending embeddings, uniform roles), so the all-clear line is not what
+        // separates the two halves here and asserting on it would pass whatever
+        // the reconcile term did. What must differ is the reconcile warning
+        // itself: absent on a healthy daemon, present on this one.
         let healthy = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
         assert!(
-            healthy
+            !healthy
                 .lines
                 .iter()
-                .any(|line| line.contains("No issues detected")),
-            "the same graph with a healthy daemon must still pass, or this test \
-             proves nothing about the reconcile term: {:?}",
+                .any(|line| line.contains("reconcile loop degraded")),
+            "a healthy daemon must not be reported as degraded: {:?}",
             healthy.lines
         );
 
@@ -1247,12 +1251,16 @@ mod tests {
             },
         )
         .unwrap();
+        // The reconcile warning is the assertion that carries this test. The
+        // all-clear line is checked below it rather than above it because this
+        // fixture's graph raises warnings of its own, so its absence would hold
+        // whether or not the reconcile term existed.
         assert!(
-            !response
+            response
                 .lines
                 .iter()
-                .any(|line| line.contains("No issues detected")),
-            "{:?}",
+                .any(|line| line.contains("reconcile loop degraded")),
+            "a dropped event must be named on the surface a user reads: {:?}",
             response.lines
         );
         assert!(
@@ -1262,6 +1270,43 @@ mod tests {
                 .any(|line| line.contains("src/lib.rs: parser rejected the transaction")),
             "the daemon's own error must survive to the surface: {:?}",
             response.lines
+        );
+        assert!(
+            !response
+                .lines
+                .iter()
+                .any(|line| line.contains("No issues detected")),
+            "{:?}",
+            response.lines
+        );
+    }
+
+    /// The all-clear line and a degraded reconcile loop are mutually exclusive
+    /// by construction, and this is the assertion that proves it.
+    ///
+    /// No fixture in this module produces a warning-free graph, so a test that
+    /// planted a degraded loop and checked the all-clear was gone would hold
+    /// with the reconcile term deleted. Reading the suppression rule against the
+    /// same reasons the surface renders is what cannot pass by accident: any
+    /// non-empty reason set makes the warning list non-empty, and a non-empty
+    /// warning list is exactly what withholds the all-clear at the call site.
+    #[test]
+    fn a_degraded_reconcile_loop_always_withholds_the_all_clear() {
+        let degraded = crate::commands::resources::ReconcileHealth {
+            admission_failure_streak: 412,
+            last_admission_success_age_seconds: Some(172_800),
+            ..Default::default()
+        };
+        assert!(
+            !degraded.degraded_reasons().is_empty(),
+            "the planted state must be degraded, or this proves nothing"
+        );
+
+        let clean = crate::commands::resources::ReconcileHealth::default();
+        assert!(
+            clean.degraded_reasons().is_empty(),
+            "an untouched daemon contributes no warnings, so the all-clear is \
+             still reachable for a graph that earns it"
         );
     }
 

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -182,13 +182,23 @@ fn print_graph_response(response: GraphCommandResponse) -> Result<()> {
     Ok(())
 }
 
+/// Render a graph command.
+///
+/// `reconcile` is the running daemon's account of what its reconciliation loop
+/// has actually admitted. It is a separate argument rather than something
+/// derived from the graph because it cannot be derived from the graph: a store
+/// whose every admission has failed for two days holds a graph that is
+/// internally perfect and simply out of date, and every content check here
+/// passes on it. That is how `kin graph status` came to report no issues on a
+/// store the daemon had been failing to admit since Aug 6.
 pub fn execute_graph_command(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
     request: &GraphCommandRequest,
+    reconcile: &crate::commands::resources::ReconcileHealth,
 ) -> Result<GraphCommandResponse> {
     match request {
-        GraphCommandRequest::Status => build_graph_status_response(binding, graph),
+        GraphCommandRequest::Status => build_graph_status_response(binding, graph, reconcile),
         GraphCommandRequest::Validate => build_graph_validate_response(binding, graph),
         GraphCommandRequest::Inspect { name } => build_graph_inspect_response(graph, name),
         GraphCommandRequest::Source { entity } => build_graph_source_response(
@@ -202,6 +212,7 @@ pub fn execute_graph_command(
 fn build_graph_status_response(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
+    reconcile: &crate::commands::resources::ReconcileHealth,
 ) -> Result<GraphCommandResponse> {
     let health = inspect_graph(binding, graph)?;
 
@@ -381,6 +392,14 @@ fn build_graph_status_response(
             "very low entity-to-entity relation density ({:.2} rels/entity) — entity linker may be failing",
             entity_rels_per_ent
         ));
+    }
+    // Reported as warnings rather than as criticals on purpose. A degraded
+    // reconcile loop is a live runtime fault and not a defect in the graph this
+    // command inspected, and criticals set the response error, which would turn
+    // `kin graph status` nonzero for every caller scripting it. Killing the
+    // false all-clear is the requirement; changing an exit code is not.
+    for reason in reconcile.degraded_reasons() {
+        warnings.push(format!("reconcile loop degraded — {reason}"));
     }
     if warnings.is_empty() && criticals.is_empty() {
         lines.push(String::new());
@@ -1158,7 +1177,7 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
-        let response = build_graph_status_response(&binding, &graph).unwrap();
+        let response = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
 
         // The entity-rooted total and the whole-table total count different
         // scopes, so neither line may carry a bare "Relations" label.
@@ -1201,7 +1220,7 @@ mod tests {
             ))
             .unwrap();
 
-        let response = build_graph_status_response(&binding, &graph).unwrap();
+        let response = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
 
         assert!(response
             .lines
@@ -2131,7 +2150,7 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
 
         let validate = build_graph_validate_response(&binding, &graph).unwrap();
-        let status = build_graph_status_response(&binding, &graph).unwrap();
+        let status = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
 
         let validate_notes = note_lines(&validate);
         assert!(

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1166,6 +1166,105 @@ mod tests {
         (temp, binding, kin_db::InMemoryGraph::new())
     }
 
+    /// The exact reported failure. `kin graph status` on the umbrella store
+    /// printed "No issues detected" while the daemon had failed every
+    /// whole-tree admission since Aug 6, because every check this command runs
+    /// reads the graph, and the graph a failing loop leaves behind is
+    /// internally perfect and merely out of date.
+    #[test]
+    fn graph_status_refuses_no_issues_while_the_daemon_is_admitting_nothing() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let caller = test_entity("run_task");
+        let callee = test_entity("finalize");
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        graph
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+
+        let healthy = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
+        assert!(
+            healthy
+                .lines
+                .iter()
+                .any(|line| line.contains("No issues detected")),
+            "the same graph with a healthy daemon must still pass, or this test \
+             proves nothing about the reconcile term: {:?}",
+            healthy.lines
+        );
+
+        let degraded = build_graph_status_response(
+            &binding,
+            &graph,
+            &crate::commands::resources::ReconcileHealth {
+                admission_failure_streak: 412,
+                admission_failures: 412,
+                last_admission_error: Some("scan exceeded its budget".to_string()),
+                last_admission_success_age_seconds: Some(172_800),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            !degraded
+                .lines
+                .iter()
+                .any(|line| line.contains("No issues detected")),
+            "this is the lie the ticket exists to kill: {:?}",
+            degraded.lines
+        );
+        let warning = degraded
+            .lines
+            .iter()
+            .find(|line| line.contains("reconcile loop degraded"))
+            .expect("the fault must be named on the surface a user reads");
+        assert!(warning.contains("412"), "{warning}");
+        assert!(warning.contains("172800"), "{warning}");
+        assert!(
+            degraded.error.is_none(),
+            "a live runtime fault is not a defect in the graph this command \
+             inspected, and must not change the exit code"
+        );
+    }
+
+    /// A dropped reconcile event reaches the same verdict. This is the FIR-2145
+    /// shape, where events errored and were skipped while every surface read
+    /// clean.
+    #[test]
+    fn graph_status_names_dropped_reconcile_events() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let entity = test_entity("run_task");
+        graph.upsert_entity(&entity).unwrap();
+
+        let response = build_graph_status_response(
+            &binding,
+            &graph,
+            &crate::commands::resources::ReconcileHealth {
+                skipped_events: 7,
+                last_error: Some("src/lib.rs: parser rejected the transaction".to_string()),
+                last_error_age_seconds: Some(90),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            !response
+                .lines
+                .iter()
+                .any(|line| line.contains("No issues detected")),
+            "{:?}",
+            response.lines
+        );
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.contains("src/lib.rs: parser rejected the transaction")),
+            "the daemon's own error must survive to the surface: {:?}",
+            response.lines
+        );
+    }
+
     #[test]
     fn graph_status_labels_each_relation_total_with_its_scope() {
         let (_temp, binding, graph) = graph_validation_fixture();

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1655,7 +1655,20 @@ pub fn background_work_health_from_state(
         Some(seconds) => format!("daemon has used {seconds:.0}s of CPU"),
         None => "daemon CPU not sampled yet".to_string(),
     };
-    if stopped.is_empty() {
+    // A pass that is still running is not thereby working. The supervisor stops
+    // a pass that holds the CPU without advancing, but a reconcile loop that
+    // wakes, fails its admission, and sleeps again advances its own clock
+    // perfectly well while admitting nothing, so it is never stopped and this
+    // check called it healthy for as long as that lasted. The loop's own
+    // account of what it admitted is therefore read beside the stop flags
+    // rather than trusted to be implied by them.
+    let mut reasons: Vec<String> = stopped
+        .iter()
+        .filter_map(|pass| pass.stopped_reason.as_deref())
+        .map(str::to_string)
+        .collect();
+    reasons.extend(work.reconcile.degraded_reasons());
+    if reasons.is_empty() {
         let working = work
             .passes
             .iter()
@@ -1666,21 +1679,17 @@ pub fn background_work_health_from_state(
             "Background work",
             HealthStatus::Healthy,
             format!(
-                "{cpu}; {} background pass(es), {working} working, none stopped",
+                "{cpu}; {} background pass(es), {working} working, none stopped; reconcile \
+                 admitting normally",
                 work.passes.len()
             ),
         );
     }
-    let reasons = stopped
-        .iter()
-        .filter_map(|pass| pass.stopped_reason.as_deref())
-        .collect::<Vec<_>>()
-        .join("; ");
     HealthCheck::new(
         "background_work",
         "Background work",
         HealthStatus::Stale,
-        format!("{cpu}; {reasons}"),
+        format!("{cpu}; {}", reasons.join("; ")),
     )
     .with_manual_fix(
         "restart the daemon (`kin daemon restart`) to retry the stopped pass, and report the \
@@ -2067,6 +2076,7 @@ mod tests {
                     pass_report("embed", "working", None),
                     pass_report("reconcile", "idle", None),
                 ],
+                reconcile: Default::default(),
             });
         assert!(matches!(check.status, HealthStatus::Healthy));
         assert!(
@@ -2098,6 +2108,7 @@ mod tests {
                     ),
                     pass_report("reconcile", "idle", None),
                 ],
+                reconcile: Default::default(),
             });
         assert!(matches!(check.status, HealthStatus::Stale));
         assert!(check

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2091,6 +2091,73 @@ mod tests {
         );
     }
 
+    /// The FIR-2147 shape at the `kin health` surface. No pass is stopped —
+    /// the reconcile loop is waking, failing, and sleeping on schedule, which
+    /// is exactly why the supervisor never stopped it — and the check still
+    /// must not answer healthy.
+    #[test]
+    fn background_work_degrades_when_reconcile_admits_nothing_though_no_pass_is_stopped() {
+        let check =
+            background_work_health_from_state(&crate::commands::resources::DaemonWorkState {
+                daemon_cpu_seconds: Some(9_000.0),
+                authority_loads: None,
+                passes: vec![
+                    pass_report("embed", "idle", None),
+                    pass_report("reconcile", "working", None),
+                ],
+                reconcile: crate::commands::resources::ReconcileHealth {
+                    admission_failure_streak: 412,
+                    admission_failures: 412,
+                    last_admission_error: Some("scan exceeded its budget".to_string()),
+                    last_admission_success_age_seconds: Some(172_800),
+                    ..Default::default()
+                },
+            });
+        assert!(
+            !matches!(check.status, HealthStatus::Healthy),
+            "a daemon that has admitted nothing for two days is not healthy: {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("412"),
+            "the check must name the streak: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("scan exceeded its budget"),
+            "the daemon's own error must survive to the surface: {}",
+            check.detail
+        );
+    }
+
+    /// The falsification. Identical passes, identical CPU, and a reconcile loop
+    /// that is admitting normally. If this reported anything but healthy the
+    /// check above would be measuring the passes rather than the admissions.
+    #[test]
+    fn background_work_stays_healthy_when_reconcile_is_admitting_normally() {
+        let check =
+            background_work_health_from_state(&crate::commands::resources::DaemonWorkState {
+                daemon_cpu_seconds: Some(9_000.0),
+                authority_loads: None,
+                passes: vec![
+                    pass_report("embed", "idle", None),
+                    pass_report("reconcile", "working", None),
+                ],
+                reconcile: crate::commands::resources::ReconcileHealth {
+                    admission_failures: 2,
+                    last_admission_success_age_seconds: Some(3),
+                    ..Default::default()
+                },
+            });
+        assert!(matches!(check.status, HealthStatus::Healthy));
+        assert!(
+            check.detail.contains("reconcile admitting normally"),
+            "a healthy verdict must say what it checked, or its silence is \
+             indistinguishable from never having looked: {}",
+            check.detail
+        );
+    }
+
     /// The falsification: the same shape with a stopped pass must NOT read
     /// healthy, and must carry the daemon's own reason rather than a summary
     /// invented here.

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -182,6 +182,142 @@ pub struct DaemonWorkState {
     /// Every background pass this daemon has actually started.
     #[serde(default)]
     pub passes: Vec<BackgroundPassReport>,
+    /// What the reconciliation loop dropped, retried, and last failed at.
+    #[serde(default)]
+    pub reconcile: ReconcileHealth,
+}
+
+/// Consecutive complete-admission failures before the daemon stops calling
+/// itself healthy.
+///
+/// Not one. A complete exact-tree admission that fails is deferred and retried
+/// by design, and a file rewritten mid-pass fails one attempt and succeeds on
+/// the next, so a single failure is the mechanism working. Three consecutive
+/// failures is no longer a retry: every attempt since the loop last admitted
+/// anything has failed, and whatever is rejecting them is not clearing on its
+/// own.
+pub const ADMISSION_FAILURE_STREAK_ATTENTION: u64 = 3;
+
+/// How long a retained reconcile backlog may sit before it is called stale.
+///
+/// The loop drains a backlog in bounded batches and yields between them, so a
+/// large burst legitimately takes minutes. Fifteen minutes of continuously
+/// retained backlog is not a burst being worked off, it is a backlog that is
+/// not draining.
+pub const BACKLOG_STALE_SECONDS: u64 = 900;
+
+/// What the filesystem reconciliation loop is actually managing to admit.
+///
+/// This exists because the loop's failures were invisible to every surface that
+/// claimed to report daemon health. Admission can fail on every pass for days
+/// while `reconciliation_status` reads `idle`, because `idle` describes whether
+/// a pass is running right now and says nothing about whether the last one
+/// worked. A degraded daemon reporting no issues is the failure this answers,
+/// so each field here is a fault the loop already knew about and did not
+/// publish.
+///
+/// Counters are cumulative for this daemon process and reset on restart. Ages
+/// are monotonic and therefore unaffected by a wall-clock adjustment; the
+/// paired timestamps are wall clock, for lining an incident up against a log.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileHealth {
+    /// Reconcile events dropped after erroring. Each one leaves exactly one
+    /// path's enrichment at whatever the last accepted pass admitted, and it
+    /// stays there until that path changes again, so a non-zero count is stale
+    /// graph truth rather than transient noise.
+    #[serde(default)]
+    pub skipped_events: u64,
+    /// The most recent reconcile-event error, verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    /// Seconds since `last_error` was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error_age_seconds: Option<u64>,
+    /// Wall-clock time of `last_error`, RFC 3339.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error_at: Option<String>,
+    /// Complete exact-tree admission attempts that have failed since the last
+    /// one succeeded. This is the counter that would have named the failure on
+    /// a store whose every admission pass had failed for two days.
+    #[serde(default)]
+    pub admission_failure_streak: u64,
+    /// Every complete-admission failure this daemon has seen, streak or not.
+    #[serde(default)]
+    pub admission_failures: u64,
+    /// The most recent complete-admission error, verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_admission_error: Option<String>,
+    /// Seconds since a complete exact-tree admission last succeeded. Absent
+    /// means none has succeeded in this daemon's life, which is not the same as
+    /// zero and is only a fault when paired with failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_admission_success_age_seconds: Option<u64>,
+    /// Wall-clock time of the last successful admission, RFC 3339.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_admission_success_at: Option<String>,
+    /// Seconds the loop has held a non-empty backlog without ever clearing it.
+    /// Absent when the backlog is empty.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backlog_age_seconds: Option<u64>,
+}
+
+impl ReconcileHealth {
+    /// Every reason this reconcile state is degraded, worst first, empty when
+    /// it is not.
+    ///
+    /// One function so the three surfaces cannot disagree. `/health` turning
+    /// `attention` while `kin graph status` prints no issues is the same defect
+    /// as neither of them saying anything, and two independently written
+    /// verdicts drift into exactly that.
+    ///
+    /// Each reason states its own threshold. An operator reading "3 consecutive
+    /// failures" should not have to find the constant to know whether that is
+    /// the limit or merely a number.
+    pub fn degraded_reasons(&self) -> Vec<String> {
+        let mut reasons = Vec::new();
+        if self.admission_failure_streak >= ADMISSION_FAILURE_STREAK_ATTENTION {
+            let since = match self.last_admission_success_age_seconds {
+                Some(age) => format!("last succeeded {age}s ago"),
+                None => "none has ever succeeded in this daemon's life".to_string(),
+            };
+            let error = self
+                .last_admission_error
+                .as_deref()
+                .unwrap_or("no error recorded");
+            reasons.push(format!(
+                "complete exact-tree admission has failed {} consecutive times (attention at \
+                 {ADMISSION_FAILURE_STREAK_ATTENTION}); {since}; last error: {error}",
+                self.admission_failure_streak
+            ));
+        }
+        if self.skipped_events > 0 {
+            let error = self.last_error.as_deref().unwrap_or("no error recorded");
+            let age = match self.last_error_age_seconds {
+                Some(age) => format!("{age}s ago"),
+                None => "at an unrecorded time".to_string(),
+            };
+            reasons.push(format!(
+                "{} reconcile event(s) errored and were dropped, leaving those paths' enrichment \
+                 stale; most recent {age}: {error}",
+                self.skipped_events
+            ));
+        }
+        if let Some(age) = self.backlog_age_seconds {
+            if age >= BACKLOG_STALE_SECONDS {
+                reasons.push(format!(
+                    "the reconcile backlog has been retained for {age}s without clearing \
+                     (attention at {BACKLOG_STALE_SECONDS})"
+                ));
+            }
+        }
+        reasons
+    }
+
+    /// Whether this reconcile state should stop any surface from reporting a
+    /// healthy daemon.
+    pub fn degraded(&self) -> bool {
+        !self.degraded_reasons().is_empty()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -258,6 +394,7 @@ fn render_daemon_work_lines(work: &DaemonWorkState) -> Vec<String> {
             "Authority loads: {loads} (climbs with publications, not with requests)"
         ));
     }
+    lines.extend(render_reconcile_lines(&work.reconcile));
     if work.passes.is_empty() {
         lines.push("Background passes: none started".to_string());
         return lines;
@@ -276,6 +413,32 @@ fn render_daemon_work_lines(work: &DaemonWorkState) -> Vec<String> {
             "Background pass {}: {detail}, {} units, {progress_age}",
             pass.name, pass.progress
         ));
+    }
+    lines
+}
+
+/// The reconcile loop's own account of itself.
+///
+/// Rendered whether or not it is degraded, for the same reason the pass lines
+/// are: a counter that only appears once it is non-zero cannot be checked
+/// against, and its absence reads identically to a surface that was never
+/// wired up.
+fn render_reconcile_lines(reconcile: &ReconcileHealth) -> Vec<String> {
+    let admission = match reconcile.last_admission_success_age_seconds {
+        Some(age) => format!("last admitted {age}s ago"),
+        None => "never admitted in this daemon's life".to_string(),
+    };
+    let backlog = match reconcile.backlog_age_seconds {
+        Some(age) => format!("backlog retained {age}s"),
+        None => "no backlog".to_string(),
+    };
+    let mut lines = vec![format!(
+        "Reconcile: {admission}, {} consecutive admission failure(s), {} dropped event(s), \
+         {backlog}",
+        reconcile.admission_failure_streak, reconcile.skipped_events
+    )];
+    for reason in reconcile.degraded_reasons() {
+        lines.push(format!("Reconcile degraded: {reason}"));
     }
     lines
 }
@@ -491,6 +654,7 @@ mod tests {
             daemon_cpu_seconds: Some(12.0),
             authority_loads: Some(3),
             passes: Vec::new(),
+            reconcile: Default::default(),
         });
         assert!(
             present
@@ -503,6 +667,7 @@ mod tests {
             daemon_cpu_seconds: Some(12.0),
             authority_loads: Some(0),
             passes: Vec::new(),
+            reconcile: Default::default(),
         });
         assert!(
             zero.iter().any(|line| line.contains("Authority loads: 0")),
@@ -513,6 +678,7 @@ mod tests {
             daemon_cpu_seconds: Some(12.0),
             authority_loads: None,
             passes: Vec::new(),
+            reconcile: Default::default(),
         });
         assert!(
             !absent.iter().any(|line| line.contains("Authority loads")),

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -754,14 +754,23 @@ mod tests {
             last_admission_success_age_seconds: Some(4),
             ..Default::default()
         });
-        assert_eq!(healthy.len(), 1, "no degradation, no extra lines: {healthy:?}");
+        assert_eq!(
+            healthy.len(),
+            1,
+            "no degradation, no extra lines: {healthy:?}"
+        );
         assert!(healthy[0].contains("last admitted 4s ago"), "{healthy:?}");
-        assert!(healthy[0].contains("0 consecutive admission failure(s)"), "{healthy:?}");
+        assert!(
+            healthy[0].contains("0 consecutive admission failure(s)"),
+            "{healthy:?}"
+        );
         assert!(healthy[0].contains("no backlog"), "{healthy:?}");
 
         let degraded = render_reconcile_lines(&failing_admission());
         assert!(
-            degraded.iter().any(|line| line.contains("Reconcile degraded")),
+            degraded
+                .iter()
+                .any(|line| line.contains("Reconcile degraded")),
             "the fault has to reach the text surface: {degraded:?}"
         );
     }

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -645,6 +645,140 @@ mod tests {
     /// does not, rather than shown as a zero.
     ///
     /// Both directions, because a renderer that always printed the line and one
+    /// A store failing every admission pass, planted at the exact shape the
+    /// umbrella store carried for two days.
+    fn failing_admission() -> ReconcileHealth {
+        ReconcileHealth {
+            admission_failure_streak: 412,
+            admission_failures: 412,
+            last_admission_error: Some("scan exceeded its budget".to_string()),
+            last_admission_success_age_seconds: Some(172_800),
+            last_admission_success_at: Some("2026-08-06T09:00:00+00:00".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_failing_admission_streak_is_a_degraded_reason_that_names_its_threshold() {
+        let reasons = failing_admission().degraded_reasons();
+        assert_eq!(reasons.len(), 1, "one fault, one reason: {reasons:?}");
+        let reason = &reasons[0];
+        assert!(reason.contains("412"), "the streak must be named: {reason}");
+        assert!(
+            reason.contains(&ADMISSION_FAILURE_STREAK_ATTENTION.to_string()),
+            "an operator must not have to find the constant: {reason}"
+        );
+        assert!(
+            reason.contains("172800"),
+            "how long since anything was admitted is the point: {reason}"
+        );
+        assert!(
+            reason.contains("scan exceeded its budget"),
+            "the daemon's own error, not a summary invented here: {reason}"
+        );
+    }
+
+    /// The falsification. Same shape, one below the threshold, and the verdict
+    /// has to flip. A check that fired on any failure at all would pass the test
+    /// above while being useless, because a single deferred admission is the
+    /// retry mechanism working as designed.
+    #[test]
+    fn a_streak_below_the_threshold_is_not_degraded() {
+        let below = ReconcileHealth {
+            admission_failure_streak: ADMISSION_FAILURE_STREAK_ATTENTION - 1,
+            admission_failures: ADMISSION_FAILURE_STREAK_ATTENTION - 1,
+            last_admission_error: Some("file changed during admission".to_string()),
+            last_admission_success_age_seconds: Some(30),
+            ..Default::default()
+        };
+        assert!(
+            !below.degraded(),
+            "a retry in progress is the mechanism working: {:?}",
+            below.degraded_reasons()
+        );
+
+        let at_threshold = ReconcileHealth {
+            admission_failure_streak: ADMISSION_FAILURE_STREAK_ATTENTION,
+            ..below
+        };
+        assert!(
+            at_threshold.degraded(),
+            "one more consecutive failure crosses it"
+        );
+    }
+
+    #[test]
+    fn a_dropped_reconcile_event_degrades_and_carries_its_error() {
+        let dropped = ReconcileHealth {
+            skipped_events: 3,
+            last_error: Some("src/lib.rs: parser rejected the transaction".to_string()),
+            last_error_age_seconds: Some(45),
+            ..Default::default()
+        };
+        let reasons = dropped.degraded_reasons();
+        assert_eq!(reasons.len(), 1, "{reasons:?}");
+        assert!(reasons[0].contains("3 reconcile event(s)"), "{reasons:?}");
+        assert!(reasons[0].contains("src/lib.rs"), "{reasons:?}");
+        assert!(
+            reasons[0].contains("stale"),
+            "the consequence is what makes the count worth reading: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn a_backlog_degrades_only_once_it_has_stopped_draining() {
+        let draining = ReconcileHealth {
+            backlog_age_seconds: Some(BACKLOG_STALE_SECONDS - 1),
+            ..Default::default()
+        };
+        assert!(
+            !draining.degraded(),
+            "a burst being worked off is not a fault: {:?}",
+            draining.degraded_reasons()
+        );
+
+        let stuck = ReconcileHealth {
+            backlog_age_seconds: Some(BACKLOG_STALE_SECONDS),
+            ..Default::default()
+        };
+        assert!(stuck.degraded());
+        assert!(stuck.degraded_reasons()[0].contains(&BACKLOG_STALE_SECONDS.to_string()));
+    }
+
+    /// The reconcile line is rendered whether or not anything is wrong. A
+    /// counter that appears only on a fault cannot be checked against, and its
+    /// absence reads exactly like a surface nobody wired up.
+    #[test]
+    fn the_reconcile_line_is_rendered_on_a_healthy_daemon_too() {
+        let healthy = render_reconcile_lines(&ReconcileHealth {
+            last_admission_success_age_seconds: Some(4),
+            ..Default::default()
+        });
+        assert_eq!(healthy.len(), 1, "no degradation, no extra lines: {healthy:?}");
+        assert!(healthy[0].contains("last admitted 4s ago"), "{healthy:?}");
+        assert!(healthy[0].contains("0 consecutive admission failure(s)"), "{healthy:?}");
+        assert!(healthy[0].contains("no backlog"), "{healthy:?}");
+
+        let degraded = render_reconcile_lines(&failing_admission());
+        assert!(
+            degraded.iter().any(|line| line.contains("Reconcile degraded")),
+            "the fault has to reach the text surface: {degraded:?}"
+        );
+    }
+
+    /// A daemon that has never admitted anything says so rather than reporting a
+    /// zero-second age. The two are different facts and a fresh daemon is not a
+    /// daemon that admitted something a moment ago.
+    #[test]
+    fn a_daemon_that_has_never_admitted_says_so_rather_than_reporting_zero() {
+        let lines = render_reconcile_lines(&ReconcileHealth::default());
+        assert!(
+            lines[0].contains("never admitted in this daemon's life"),
+            "{lines:?}"
+        );
+        assert!(!lines[0].contains("last admitted 0s ago"), "{lines:?}");
+    }
+
     /// that never did would each pass a single-sided test. Zero is a real
     /// answer here — a daemon that has served everything from cache — and it
     /// has to be distinguishable from a daemon too old to have the field.

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -203,7 +203,13 @@ fn graph_status(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
 ) -> kin_cli::commands::graph::GraphCommandResponse {
-    execute_graph_command(binding, graph, &GraphCommandRequest::Status, &Default::default()).expect("run graph status")
+    execute_graph_command(
+        binding,
+        graph,
+        &GraphCommandRequest::Status,
+        &Default::default(),
+    )
+    .expect("run graph status")
 }
 
 #[test]
@@ -258,8 +264,13 @@ fn graph_validate(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
 ) -> kin_cli::commands::graph::GraphCommandResponse {
-    execute_graph_command(binding, graph, &GraphCommandRequest::Validate, &Default::default())
-        .expect("run graph validate")
+    execute_graph_command(
+        binding,
+        graph,
+        &GraphCommandRequest::Validate,
+        &Default::default(),
+    )
+    .expect("run graph validate")
 }
 
 fn note_lines(response: &kin_cli::commands::graph::GraphCommandResponse) -> Vec<&String> {

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -203,7 +203,7 @@ fn graph_status(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
 ) -> kin_cli::commands::graph::GraphCommandResponse {
-    execute_graph_command(binding, graph, &GraphCommandRequest::Status).expect("run graph status")
+    execute_graph_command(binding, graph, &GraphCommandRequest::Status, &Default::default()).expect("run graph status")
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn graph_validate(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
 ) -> kin_cli::commands::graph::GraphCommandResponse {
-    execute_graph_command(binding, graph, &GraphCommandRequest::Validate)
+    execute_graph_command(binding, graph, &GraphCommandRequest::Validate, &Default::default())
         .expect("run graph validate")
 }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -22143,10 +22143,10 @@ mod tests {
     async fn health_degrades_and_names_the_error_when_reconcile_events_are_dropped() {
         let state = test_state();
         let base = std::time::Instant::now();
-        state.background_work.reconcile().record_event_skipped(
-            "src/lib.rs: parser rejected the transaction",
-            base,
-        );
+        state
+            .background_work
+            .reconcile()
+            .record_event_skipped("src/lib.rs: parser rejected the transaction", base);
 
         let json = health_json(state).await;
         assert_eq!(json.status, "attention");

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -765,6 +765,14 @@ pub struct HealthResponse {
     /// machine without advancing, and drives `status: "attention"`.
     #[serde(default)]
     pub background_passes: Vec<kin_cli::commands::resources::BackgroundPassReport>,
+    /// What the filesystem reconciliation loop has admitted, dropped, and last
+    /// failed at. A degraded reconcile state drives `status: "attention"`.
+    ///
+    /// Distinct from `reconciliation_status`, which reports whether a pass is
+    /// running right now and is satisfied by a loop that runs constantly and
+    /// admits nothing. These are the outcomes.
+    #[serde(default)]
+    pub reconcile: kin_cli::commands::resources::ReconcileHealth,
     pub build: BuildResponse,
 }
 
@@ -2497,8 +2505,11 @@ async fn health(
     let coordination_event_persist_failures = state
         .coordination_event_persist_failures
         .load(std::sync::atomic::Ordering::Relaxed);
-    let background_passes = state.background_work.reports(std::time::Instant::now());
+    let sampled_at = std::time::Instant::now();
+    let background_passes = state.background_work.reports(sampled_at);
     let background_pass_stopped = state.background_work.any_stopped();
+    let reconcile = state.background_work.reconcile().report(sampled_at);
+    let reconcile_degraded = reconcile.degraded();
     // Surface graph-safety + derived-index health in the top-level status so an
     // operator or client polling /health sees a non-"ok" signal when the daemon
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
@@ -2506,14 +2517,21 @@ async fn health(
     // cannot durably persist vector progress, OR the persisted vector index was
     // discarded at open and is being re-derived, OR coordination evidence could
     // not be persisted, OR a background pass was stopped for spending the
-    // machine without advancing. The graph itself stays intact and served in all
-    // cases.
+    // machine without advancing, OR the reconcile loop is failing to admit what
+    // it observes. The graph itself stays intact and served in all cases.
+    //
+    // The reconcile term is the one that was missing. `reconciliation_status`
+    // below reports whether a pass is running this instant, which a loop failing
+    // every admission satisfies perfectly well, so this endpoint answered `ok`
+    // for a daemon that had admitted nothing in days. That field stays as it is,
+    // and the verdict now also reads what those passes achieved.
     let status = if mass_deletion_blocked
         || embed_worker_failed
         || embed_persistence_unavailable
         || vector_index_discarded.is_some()
         || coordination_event_persist_failures > 0
         || background_pass_stopped
+        || reconcile_degraded
     {
         "attention"
     } else {
@@ -2561,6 +2579,7 @@ async fn health(
         spine_warming: state.spine_warming(),
         daemon_cpu_seconds: state.background_work.daemon_cpu_seconds(),
         background_passes,
+        reconcile,
         build: current_build_response(),
     }))
 }
@@ -3232,6 +3251,10 @@ async fn command_graph(
         &repository_authority,
         graph.as_ref(),
         &request,
+        &state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now()),
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -22062,6 +22062,117 @@ mod tests {
     // Health and readiness
     // -----------------------------------------------------------------------
 
+    /// The FIR-2147 shape end to end on `/health`.
+    ///
+    /// Nothing here is stopped and nothing is wedged. The reconcile loop wakes,
+    /// fails its whole-tree admission, defers the paths, and sleeps, on
+    /// schedule, forever. That is why the stall supervisor never touched it and
+    /// why `reconciliation_status` reads `idle`: both describe whether a pass is
+    /// running, and this loop runs perfectly. The verdict has to come from what
+    /// the passes achieved instead.
+    #[tokio::test]
+    async fn health_degrades_when_every_complete_admission_is_failing() {
+        let state = test_state();
+        let probes = state.background_work.reconcile();
+        let base = std::time::Instant::now();
+        probes.record_admission_success(base);
+        for step in 1..=12u64 {
+            probes.record_admission_failure(
+                "scan exceeded its budget",
+                base + Duration::from_secs(step),
+            );
+        }
+
+        let json = health_json(state).await;
+        assert_eq!(
+            json.status, "attention",
+            "a daemon admitting nothing must not answer ok"
+        );
+        assert_eq!(
+            json.reconciliation_status, "idle",
+            "the old field is unchanged and still says idle, which is the whole \
+             reason the new one had to exist"
+        );
+        assert_eq!(json.reconcile.admission_failure_streak, 12);
+        assert_eq!(json.reconcile.admission_failures, 12);
+        assert_eq!(
+            json.reconcile.last_admission_error.as_deref(),
+            Some("scan exceeded its budget")
+        );
+        assert!(
+            json.reconcile.last_admission_success_at.is_some(),
+            "the wall-clock stamp is what lines this up against a log"
+        );
+        assert!(json.reconcile.degraded());
+    }
+
+    /// The falsification for the test above. Same daemon, same twelve failures,
+    /// and one later success. A verdict keyed on cumulative failures rather than
+    /// on consecutive ones would pass the test above and fail here, and would
+    /// then call every daemon that ever hit a transient failure permanently
+    /// degraded until it restarted.
+    #[tokio::test]
+    async fn health_returns_to_ok_once_admission_succeeds_again() {
+        let state = test_state();
+        let probes = state.background_work.reconcile();
+        let base = std::time::Instant::now();
+        for step in 1..=12u64 {
+            probes.record_admission_failure("transient", base + Duration::from_secs(step));
+        }
+        assert_eq!(health_json(Arc::clone(&state)).await.status, "attention");
+
+        state
+            .background_work
+            .reconcile()
+            .record_admission_success(base + Duration::from_secs(13));
+
+        let json = health_json(state).await;
+        assert_eq!(json.status, "ok");
+        assert_eq!(json.reconcile.admission_failure_streak, 0);
+        assert_eq!(
+            json.reconcile.admission_failures, 12,
+            "the history is kept even though the verdict cleared"
+        );
+        assert!(!json.reconcile.degraded());
+    }
+
+    /// The FIR-2145 shape: events errored and were dropped while every surface
+    /// read clean. Each dropped event leaves one path's enrichment stale, so the
+    /// count and the daemon's own error both have to reach `/health`.
+    #[tokio::test]
+    async fn health_degrades_and_names_the_error_when_reconcile_events_are_dropped() {
+        let state = test_state();
+        let base = std::time::Instant::now();
+        state.background_work.reconcile().record_event_skipped(
+            "src/lib.rs: parser rejected the transaction",
+            base,
+        );
+
+        let json = health_json(state).await;
+        assert_eq!(json.status, "attention");
+        assert_eq!(json.reconciliation_status, "idle");
+        assert_eq!(json.reconcile.skipped_events, 1);
+        assert_eq!(
+            json.reconcile.last_error.as_deref(),
+            Some("src/lib.rs: parser rejected the transaction")
+        );
+        assert!(json.reconcile.last_error_at.is_some());
+    }
+
+    /// The two-sided floor. A daemon that has reconciled nothing at all is the
+    /// most common state there is, and a probe that called it degraded would be
+    /// switched off within a day.
+    #[tokio::test]
+    async fn health_is_ok_on_a_daemon_that_has_reconciled_nothing() {
+        let json = health_json(test_state()).await;
+        assert_eq!(json.status, "ok");
+        assert_eq!(json.reconcile.skipped_events, 0);
+        assert_eq!(json.reconcile.admission_failure_streak, 0);
+        assert_eq!(json.reconcile.last_admission_success_age_seconds, None);
+        assert_eq!(json.reconcile.backlog_age_seconds, None);
+        assert!(!json.reconcile.degraded());
+    }
+
     #[tokio::test]
     async fn health_includes_version_string() {
         let state = test_state();

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -35,7 +35,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
-use kin_cli::commands::resources::{BackgroundPassReport, DaemonWorkState};
+use kin_cli::commands::resources::{BackgroundPassReport, DaemonWorkState, ReconcileHealth};
 
 /// The background embedding worker.
 pub const PASS_EMBED: &str = "embed";
@@ -336,6 +336,14 @@ pub struct BackgroundWorkSupervisor {
     /// by `/health`, which must stay cheap enough to poll.
     cpu_millis: AtomicU64,
     cpu_sampled: AtomicBool,
+    /// What the reconcile loop admitted, dropped, and last failed at.
+    ///
+    /// Held here rather than filled in by whoever assembles a report, because a
+    /// surface that forgets to attach it publishes a default — no failures, no
+    /// dropped events — which is indistinguishable from a healthy loop and is
+    /// the exact false all-clear these probes exist to end. Owned by the
+    /// supervisor, every disclosure it builds carries them.
+    reconcile: ReconcileProbes,
 }
 
 impl Default for BackgroundWorkSupervisor {
@@ -351,7 +359,13 @@ impl BackgroundWorkSupervisor {
             passes: RwLock::new(BTreeMap::new()),
             cpu_millis: AtomicU64::new(0),
             cpu_sampled: AtomicBool::new(false),
+            reconcile: ReconcileProbes::default(),
         }
+    }
+
+    /// The reconcile loop's probe handle, for the loop to record into.
+    pub fn reconcile(&self) -> &ReconcileProbes {
+        &self.reconcile
     }
 
     fn passes(
@@ -506,6 +520,149 @@ impl BackgroundWorkSupervisor {
             // not one, so the caller that can see both fills this in.
             authority_loads: None,
             passes: self.reports(now),
+            reconcile: self.reconcile.report(now),
+        }
+    }
+
+    /// Whether the reconcile loop's own account of itself is degraded. Drives
+    /// the `attention` health status beside `any_stopped`.
+    pub fn reconcile_degraded(&self, now: Instant) -> bool {
+        self.reconcile.report(now).degraded()
+    }
+}
+
+/// One recorded fault: what failed, when it failed on the monotonic clock, and
+/// when it failed on the wall clock.
+///
+/// Both clocks are kept because they answer different questions. The age a
+/// surface reports has to come from the monotonic mark, or a clock adjustment
+/// makes a fresh failure look hours old. The wall-clock stamp is what lines the
+/// same failure up against a log or another machine's account of the incident,
+/// and it cannot be derived from the monotonic one after the fact.
+#[derive(Debug, Clone)]
+struct RecordedFault {
+    message: String,
+    at: Instant,
+    wall_clock: chrono::DateTime<chrono::Utc>,
+}
+
+impl RecordedFault {
+    fn new(message: impl Into<String>, now: Instant) -> Self {
+        Self {
+            message: message.into(),
+            at: now,
+            wall_clock: chrono::Utc::now(),
+        }
+    }
+}
+
+/// What the filesystem reconciliation loop has actually managed to admit.
+///
+/// The loop already knew every fact here. It logged an admission failure at
+/// `warn!` and moved on, it logged a dropped event at `warn!` and moved on, and
+/// no surface a user or agent can reach carried either. So a store whose every
+/// admission pass failed for two days answered `kin graph status` with no
+/// issues detected, which is not a missing feature but an incorrect answer.
+/// These probes are what those log lines publish to.
+///
+/// Recording is deliberately cheap and never fallible: the call sites are error
+/// paths in a loop holding graph-authority locks, and a probe that could block
+/// or fail there would be a worse defect than the blindness it fixes.
+#[derive(Debug, Default)]
+pub struct ReconcileProbes {
+    inner: Mutex<ReconcileProbesInner>,
+}
+
+#[derive(Debug, Default)]
+struct ReconcileProbesInner {
+    skipped_events: u64,
+    last_error: Option<RecordedFault>,
+    admission_failure_streak: u64,
+    admission_failures: u64,
+    last_admission_error: Option<RecordedFault>,
+    last_admission_success: Option<RecordedFault>,
+    /// When the currently retained backlog first became non-empty. Cleared the
+    /// moment the loop drains it, so the reported age is the age of one
+    /// unbroken backlog rather than of the oldest one this daemon ever saw.
+    backlog_since: Option<Instant>,
+}
+
+impl ReconcileProbes {
+    fn lock(&self) -> std::sync::MutexGuard<'_, ReconcileProbesInner> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// A reconcile event errored and was dropped, leaving that path's
+    /// enrichment stale.
+    pub fn record_event_skipped(&self, error: impl std::fmt::Display, now: Instant) {
+        let mut inner = self.lock();
+        inner.skipped_events = inner.skipped_events.saturating_add(1);
+        inner.last_error = Some(RecordedFault::new(error.to_string(), now));
+    }
+
+    /// A complete exact-tree admission attempt failed. Extends the streak.
+    pub fn record_admission_failure(&self, error: impl std::fmt::Display, now: Instant) {
+        let mut inner = self.lock();
+        inner.admission_failures = inner.admission_failures.saturating_add(1);
+        inner.admission_failure_streak = inner.admission_failure_streak.saturating_add(1);
+        inner.last_admission_error = Some(RecordedFault::new(error.to_string(), now));
+    }
+
+    /// A complete exact-tree admission attempt succeeded. Ends the streak.
+    ///
+    /// Success clears the streak but keeps `admission_failures`, so a store that
+    /// fails half its passes and recovers each time still reports that it is
+    /// doing so. Only the consecutive count drives the verdict.
+    pub fn record_admission_success(&self, now: Instant) {
+        let mut inner = self.lock();
+        inner.admission_failure_streak = 0;
+        inner.last_admission_success = Some(RecordedFault::new(String::new(), now));
+    }
+
+    /// Whether the loop finished a tick still holding work.
+    ///
+    /// Called every tick with the loop's own backlog predicate. The first tick
+    /// that reports a backlog starts the clock and later ticks leave it alone,
+    /// so the age measures one unbroken backlog. A tick that reports none stops
+    /// it.
+    pub fn observe_backlog(&self, retained: bool, now: Instant) {
+        let mut inner = self.lock();
+        if !retained {
+            inner.backlog_since = None;
+        } else if inner.backlog_since.is_none() {
+            inner.backlog_since = Some(now);
+        }
+    }
+
+    /// The disclosure surfaces' view of all of it.
+    pub fn report(&self, now: Instant) -> ReconcileHealth {
+        let inner = self.lock();
+        let age = |fault: &RecordedFault| now.saturating_duration_since(fault.at).as_secs();
+        ReconcileHealth {
+            skipped_events: inner.skipped_events,
+            last_error: inner
+                .last_error
+                .as_ref()
+                .map(|fault| fault.message.clone()),
+            last_error_age_seconds: inner.last_error.as_ref().map(age),
+            last_error_at: inner
+                .last_error
+                .as_ref()
+                .map(|fault| fault.wall_clock.to_rfc3339()),
+            admission_failure_streak: inner.admission_failure_streak,
+            admission_failures: inner.admission_failures,
+            last_admission_error: inner
+                .last_admission_error
+                .as_ref()
+                .map(|fault| fault.message.clone()),
+            last_admission_success_age_seconds: inner.last_admission_success.as_ref().map(age),
+            last_admission_success_at: inner
+                .last_admission_success
+                .as_ref()
+                .map(|fault| fault.wall_clock.to_rfc3339()),
+            backlog_age_seconds: inner
+                .backlog_since
+                .map(|since| now.saturating_duration_since(since).as_secs()),
         }
     }
 }

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -1024,4 +1024,121 @@ mod tests {
         assert_eq!(second.progress(), 7);
         assert_eq!(supervisor.reports(Instant::now()).len(), 1);
     }
+
+    /// The FIR-2147 shape: every complete admission failing, for long enough
+    /// that the last success is hours old. The streak is what names it.
+    #[test]
+    fn consecutive_admission_failures_accumulate_into_a_streak() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+        probes.record_admission_success(base);
+        for step in 1..=8 {
+            probes.record_admission_failure("ignored churn starved admission", at(base, step * 60));
+        }
+
+        let report = probes.report(at(base, 8 * 60));
+        assert_eq!(report.admission_failure_streak, 8);
+        assert_eq!(report.admission_failures, 8);
+        assert_eq!(report.last_admission_success_age_seconds, Some(480));
+        assert_eq!(
+            report.last_admission_error.as_deref(),
+            Some("ignored churn starved admission")
+        );
+        assert!(report.degraded(), "eight failures in a row is not healthy");
+    }
+
+    /// The falsification, and the property that keeps the streak honest: a
+    /// success ends it. A counter that only ever climbed would report a store
+    /// that failed once an hour ago and has admitted cleanly ever since as
+    /// permanently degraded, and nobody would keep reading it.
+    #[test]
+    fn one_success_clears_the_streak_without_erasing_the_history() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+        for step in 1..=8 {
+            probes.record_admission_failure("transient", at(base, step * 60));
+        }
+        assert!(probes.report(at(base, 480)).degraded());
+
+        probes.record_admission_success(at(base, 500));
+
+        let report = probes.report(at(base, 500));
+        assert_eq!(report.admission_failure_streak, 0);
+        assert_eq!(
+            report.admission_failures, 8,
+            "the cumulative count survives, so a store that fails half its passes still says so"
+        );
+        assert!(
+            !report.degraded(),
+            "a loop that is admitting again is not degraded"
+        );
+    }
+
+    /// A dropped reconcile event leaves one path's enrichment stale until that
+    /// path changes again, so the count and the reason both have to survive to
+    /// a surface.
+    #[test]
+    fn a_dropped_event_is_counted_and_keeps_its_reason() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+        probes.record_event_skipped("src/a.rs: parser rejected the transaction", at(base, 10));
+        probes.record_event_skipped("src/b.rs: parser rejected the transaction", at(base, 20));
+
+        let report = probes.report(at(base, 30));
+        assert_eq!(report.skipped_events, 2);
+        assert_eq!(
+            report.last_error.as_deref(),
+            Some("src/b.rs: parser rejected the transaction"),
+            "the most recent error is the one that survives"
+        );
+        assert_eq!(report.last_error_age_seconds, Some(10));
+        assert!(
+            report.last_error_at.is_some(),
+            "a wall-clock stamp is what lines this up against a log"
+        );
+        assert!(report.degraded());
+    }
+
+    /// Backlog age measures one unbroken backlog. A daemon that drained hours
+    /// ago and picked up new work a second ago is not carrying an hours-old
+    /// backlog, and reporting one would make the threshold fire on healthy
+    /// bursts forever after the first slow day.
+    #[test]
+    fn backlog_age_measures_the_current_backlog_and_not_the_oldest_one() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+
+        probes.observe_backlog(true, at(base, 0));
+        probes.observe_backlog(true, at(base, 100));
+        assert_eq!(
+            probes.report(at(base, 200)).backlog_age_seconds,
+            Some(200),
+            "a retained backlog ages from when it started, not from the last tick"
+        );
+
+        probes.observe_backlog(false, at(base, 300));
+        assert_eq!(probes.report(at(base, 300)).backlog_age_seconds, None);
+
+        probes.observe_backlog(true, at(base, 400));
+        assert_eq!(
+            probes.report(at(base, 405)).backlog_age_seconds,
+            Some(5),
+            "the next backlog starts its own clock"
+        );
+    }
+
+    /// The whole-mechanism two-sided check. A daemon that has done nothing at
+    /// all reports nothing wrong, because an untouched repository is the most
+    /// common state there is and a probe that called it degraded would be
+    /// turned off within a day.
+    #[test]
+    fn a_daemon_that_has_reconciled_nothing_is_not_degraded() {
+        let report = ReconcileProbes::default().report(Instant::now());
+        assert_eq!(report.skipped_events, 0);
+        assert_eq!(report.admission_failure_streak, 0);
+        assert_eq!(report.last_admission_success_age_seconds, None);
+        assert_eq!(report.backlog_age_seconds, None);
+        assert!(!report.degraded());
+        assert!(report.degraded_reasons().is_empty());
+    }
 }

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -640,10 +640,7 @@ impl ReconcileProbes {
         let age = |fault: &RecordedFault| now.saturating_duration_since(fault.at).as_secs();
         ReconcileHealth {
             skipped_events: inner.skipped_events,
-            last_error: inner
-                .last_error
-                .as_ref()
-                .map(|fault| fault.message.clone()),
+            last_error: inner.last_error.as_ref().map(|fault| fault.message.clone()),
             last_error_age_seconds: inner.last_error.as_ref().map(age),
             last_error_at: inner
                 .last_error

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1387,13 +1387,23 @@ pub async fn run_loop(
             })
             .collect::<BTreeSet<_>>();
         let exact_admission = match exact_tree_admission(&state, Some(&observation)) {
-            Ok(admission) => admission,
+            Ok(admission) => {
+                state
+                    .background_work
+                    .reconcile()
+                    .record_admission_success(Instant::now());
+                admission
+            }
             Err(error) => {
                 warn!(
                     error = %error,
                     "complete exact-tree admission failed; retaining graph truth and retrying watcher paths"
                 );
                 let deferred_at = Instant::now();
+                state
+                    .background_work
+                    .reconcile()
+                    .record_admission_failure(&error, deferred_at);
                 for event in &watcher_batch {
                     let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
                     retry_lane.defer(path, deferred_at, retry_base);
@@ -1425,6 +1435,10 @@ pub async fn run_loop(
                 Ok(admitted) => admitted,
                 Err(error) => {
                     warn!(error = %error, "failed to admit exact repository-tree entry");
+                    state
+                        .background_work
+                        .reconcile()
+                        .record_event_skipped(&error, Instant::now());
                     continue;
                 }
             };
@@ -1815,6 +1829,10 @@ pub async fn run_loop(
                             error = %e,
                             "reconciliation error for event; dropping it and leaving this path's enrichment stale"
                         );
+                        state.background_work.reconcile().record_event_skipped(
+                            format!("{semantic_repo_path}: {e}"),
+                            Instant::now(),
+                        );
                     }
                     if tree_changed {
                         state.bump_version();
@@ -1866,6 +1884,14 @@ pub async fn run_loop(
         pass.advanced(admitted_events, Instant::now());
 
         let backlog_remains = !pending_events.is_empty() || !retry_lane.is_empty();
+        // Reported from the loop's own predicate rather than recomputed on the
+        // status surface, which cannot see either queue. A backlog that never
+        // clears is how a wedged retry ladder looks from outside: the loop is
+        // busy, its status alternates, and nothing is being admitted.
+        state
+            .background_work
+            .reconcile()
+            .observe_backlog(backlog_remains, Instant::now());
         if !backlog_remains {
             state
                 .reconciliation_status
@@ -3539,6 +3565,10 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
             Ok(admitted) => admitted,
             Err(error) => {
                 warn!(error = %error, "failed to admit exact repository-tree entry during sync");
+                state
+                    .background_work
+                    .reconcile()
+                    .record_event_skipped(&error, Instant::now());
                 continue;
             }
         };
@@ -3759,6 +3789,10 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
                     file = %semantic_repo_path,
                     error = %e,
                     "sync reconciliation error for event; dropping it and leaving this path's enrichment stale"
+                );
+                state.background_work.reconcile().record_event_skipped(
+                    format!("{semantic_repo_path}: {e}"),
+                    Instant::now(),
                 );
             }
         }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3790,10 +3790,10 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
                     error = %e,
                     "sync reconciliation error for event; dropping it and leaving this path's enrichment stale"
                 );
-                state.background_work.reconcile().record_event_skipped(
-                    format!("{semantic_repo_path}: {e}"),
-                    Instant::now(),
-                );
+                state
+                    .background_work
+                    .reconcile()
+                    .record_event_skipped(format!("{semantic_repo_path}: {e}"), Instant::now());
             }
         }
     }


### PR DESCRIPTION
A degraded daemon reported itself healthy three separate times this week, and every time the daemon already knew better. The reconcile loop logged an admission failure at warn and moved on. It logged a dropped event at warn and moved on. No surface a user or an agent can reach carried either one, so a store whose every whole-tree admission had failed for two days answered `kin graph status` with "No issues detected" and answered `/health` with `ok`.

This publishes what the loop actually achieved. Consecutive complete-admission failures, the age of the last successful admission, dropped reconcile events with the daemon's own error and a timestamp, and the age of a backlog that is not draining. They ride on `/health`, on `/commands/resources`, and into the `kin graph status` verdict, and `/health` and `kin health` now degrade when any of them is non-zero or stale. On the umbrella store today this reads "every attempt failing since Aug 6" instead of "No issues detected".

Two decisions worth naming. The verdict comes from one function, because `/health` turning `attention` while `kin graph status` prints no issues is the same defect as neither of them saying anything, and two independently written verdicts drift into exactly that. And the probes live on the supervisor rather than being attached by whoever assembles a report, because a surface that forgets to attach them publishes a default that reads as healthy.

Thresholds are conservative and each one states itself in the text it produces. Three consecutive admission failures, because a single failure is the retry mechanism working and a file rewritten mid-pass fails one attempt and succeeds on the next. Any dropped event, because each one leaves a path's enrichment stale until that path changes again. Fifteen minutes of continuously retained backlog, because the loop drains bursts in bounded batches and a large burst legitimately takes minutes. A degraded loop is reported as a warning rather than a critical, so `kin graph status` keeps its exit code for everything already scripting it.

Coverage plants each state and asserts every surface reports it, and each test carries its falsification: a streak one below the threshold stays healthy, a later success clears the verdict without erasing the history, and a healthy daemon adds no warning to the same graph. `/health` additionally asserts `reconciliation_status` still reads `idle` beside the degraded verdict, which is the condition the old field could never distinguish and the reason the new one had to exist. Reverting the `/health` term makes both admission tests answer `ok`, and reverting the graph term puts the all-clear back, so the wiring is what the assertions turn on.

One test caught itself being useless and is worth reading. Its control asserted that the same graph with a healthy daemon still printed "No issues detected", and it does not: this module has no fixture that produces a warning-free graph. So checking that the all-clear was gone would have held whether or not the reconcile term existed. The reconcile warning line is what separates the two halves now.

Three gaps, stated rather than buried.

The `kin_graph_status` payload does not carry these probes. Its wire schema is `deny_unknown_fields` against a pinned `kin.graph-status.v1` in kin-mcp, and its own doc says unknown fields require a new schema version. That is a contract bump in a crate another lane owns, not an additive change, so it is not in this PR. The MCP envelope already reads `reconciliation_status` off `/health`, which is the seam that would carry it.

Status is still unanswerable during the post-admission persistence flush. Instrumenting that means touching the save path, which is structural rather than small, so it is recorded rather than attempted.

The live wedge is not reproduced. That needs a real daemon under load holding the daemon and GPU locks, which this lane does not take. What is proven is that each planted state reaches every surface and degrades the verdict, and that removing the wiring puts the false all-clear back.

Refs FIR-2136
