### PR TITLE
Keep kin init progress on the terminal it was drawn for

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -12,6 +12,8 @@
 //! This command deliberately does not parse a checkout, synthesize a snapshot
 //! change, or rebuild an existing repository from raw filesystem contents.
 
+use std::fmt::Write as _;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -235,8 +237,7 @@ fn print_json_result(
         store_footprint: StoreFootprint::measure(&result.layout),
         uncommitted_worktree: uncommitted_worktree_payload(&result.workspace_divergence),
     };
-    println!("{}", serde_json::to_string_pretty(&payload)?);
-    Ok(())
+    emit(&format!("{}\n", serde_json::to_string_pretty(&payload)?))
 }
 
 fn uncommitted_worktree_payload(
@@ -266,57 +267,92 @@ fn print_human_result(
     boundary: InitBoundary,
     semantic_enrichment: &SemanticEnrichmentStatus,
 ) -> Result<()> {
+    emit(&render_human_result(result, boundary, semantic_enrichment)?)
+}
+
+/// Hand a finished result to stdout, tolerating a reader that already left.
+///
+/// The store is durable before a single byte of this is written, so a consumer
+/// that closed its pipe must not turn a completed admission into a failure.
+/// `println!` panics on a write error, which is exactly what `kin init | head`
+/// did. Every write error that is not a departed reader is still reported.
+fn emit(rendered: &str) -> Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    match stdout
+        .write_all(rendered.as_bytes())
+        .and_then(|()| stdout.flush())
+    {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error).context("write the kin init result to stdout"),
+    }
+}
+
+/// The whole human result as one string, so it reaches stdout in one write.
+fn render_human_result(
+    result: &kin_core::InitResult,
+    boundary: InitBoundary,
+    semantic_enrichment: &SemanticEnrichmentStatus,
+) -> Result<String> {
     let default_ref = initialized_default_ref(result);
-    println!(
+    let mut out = String::new();
+    writeln!(
+        out,
         "Initialized Kin repository authority at {}",
         result.layout.root().display()
-    );
-    println!("  Authority: repository-v6 (graph-owned)");
-    println!("  Repository: {}", result.repository_id);
-    println!("  Workspace: {}", result.workspace_id);
+    )?;
+    writeln!(out, "  Authority: repository-v6 (graph-owned)")?;
+    writeln!(out, "  Repository: {}", result.repository_id)?;
+    writeln!(out, "  Workspace: {}", result.workspace_id)?;
     match default_ref {
-        Some(default_ref) => println!("  Default ref: {default_ref}"),
-        None => println!("  Default ref: none (detached workspace)"),
+        Some(default_ref) => writeln!(out, "  Default ref: {default_ref}")?,
+        None => writeln!(out, "  Default ref: none (detached workspace)")?,
     }
-    println!(
+    writeln!(
+        out,
         "  Authority generation: {}",
         result.authority.receipt.generation
-    );
-    println!(
+    )?;
+    writeln!(
+        out,
         "  Workspace generation: {}",
         result.authority.workspace.workspace_generation
-    );
-    println!(
+    )?;
+    writeln!(
+        out,
         "  Workspace head: {}",
         serde_json::to_string(&result.authority.workspace.workspace_head)?
-    );
+    )?;
     match boundary {
         InitBoundary::ExactGit => {
-            println!(
+            writeln!(
+                out,
                 "  Imported: exact reachable Git history, refs, raw objects, workspace, and admission policy"
-            );
+            )?;
         }
         InitBoundary::NativeUnborn => {
-            println!("  History: unborn (no synthetic commit)");
-            println!("  Workspace: empty exact tree");
+            writeln!(out, "  History: unborn (no synthetic commit)")?;
+            writeln!(out, "  Workspace: empty exact tree")?;
         }
     }
-    println!(
+    writeln!(
+        out,
         "  Semantic enrichment: {}",
         render_semantic_enrichment(semantic_enrichment)
-    );
+    )?;
     if let Some(notice) = semantic_absence_notice(semantic_enrichment) {
-        println!("{notice}");
+        writeln!(out, "{notice}")?;
     }
-    println!(
+    writeln!(
+        out,
         "  Store size: {}",
         StoreFootprint::measure(&result.layout).render()
-    );
-    println!("  {}", store_size_notice());
+    )?;
+    writeln!(out, "  {}", store_size_notice())?;
     for line in uncommitted_worktree_disclosure(&result.workspace_divergence) {
-        println!("{line}");
+        writeln!(out, "{line}")?;
     }
-    Ok(())
+    Ok(out)
 }
 
 /// Paths listed by name before the rest are counted rather than named.

--- a/crates/kin-cli/tests/init_non_tty_output.rs
+++ b/crates/kin-cli/tests/init_non_tty_output.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What `kin init` writes when nobody is watching a terminal.
+//!
+//! An in-place bar redraws with a carriage return, which a terminal reads as an
+//! overwrite and a pipe records as a frame. Captured runs therefore kept every
+//! frame, and a consumer that stopped reading took the admission down with it.
+
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::IsolatedDaemonRuntime;
+
+/// Entity-source files above the linker's bar threshold, in one commit.
+///
+/// The bar only draws past a file count, so a fixture under it would make every
+/// assertion here pass for the wrong reason.
+const LINKED_FILES: usize = 64;
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = common::Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn seed_linkable_git_repo(path: &Path) {
+    fs::create_dir_all(path).expect("create repo dir");
+    run_git(path, &["init", "--initial-branch=main"]);
+    run_git(path, &["config", "user.email", "kin@example.invalid"]);
+    run_git(path, &["config", "user.name", "Kin"]);
+    for index in 0..LINKED_FILES {
+        let next = (index + 1) % LINKED_FILES;
+        fs::write(
+            path.join(format!("m{index}.rs")),
+            format!("pub fn f{index}() -> usize {{ g{next}() }}\npub fn g{index}() -> usize {{ {index} }}\n"),
+        )
+        .expect("write a linkable source file");
+    }
+    run_git(path, &["add", "--all"]);
+    run_git(path, &["commit", "-m", "first"]);
+}
+
+#[test]
+fn a_captured_init_writes_phase_summaries_and_no_progress_frames() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("captured");
+    seed_linkable_git_repo(&repo);
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let output = runtime
+        .kin_command()
+        .arg("init")
+        .arg(&repo)
+        .output()
+        .expect("run kin init with both streams captured");
+
+    assert!(
+        output.status.success(),
+        "init must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let frames = output.stderr.iter().filter(|byte| **byte == b'\r').count();
+    assert_eq!(
+        frames,
+        0,
+        "a captured run must carry no carriage-return frames: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Linking:"),
+        "the in-place bar belongs to a terminal: {stderr}"
+    );
+    assert!(
+        stderr.contains("derive semantic history"),
+        "the per-phase summaries are what a captured run keeps: {stderr}"
+    );
+    assert!(
+        stderr.contains("build bootstrap transaction"),
+        "every phase still reports: {stderr}"
+    );
+    assert!(
+        output.stderr.len() < 16 * 1024,
+        "a captured run stays small; got {} bytes",
+        output.stderr.len()
+    );
+}
+
+#[test]
+fn init_finishes_its_store_when_the_reader_closes_the_pipe() {
+    // `kin init | head` closed the reading end partway through and the write
+    // that followed panicked, so a repository that was mid-admission was left
+    // with no store at all. Progress is advisory; the admission is not.
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("head-capped");
+    seed_linkable_git_repo(&repo);
+    let status_file = root.path().join("init-status");
+
+    let runtime = IsolatedDaemonRuntime::new(&repo);
+    let script = format!(
+        "{{ {kin} init {repo} 2>&1; echo $? > {status}; }} | head -1 > /dev/null",
+        kin = shell_quote(env!("CARGO_BIN_EXE_kin")),
+        repo = shell_quote(&repo.display().to_string()),
+        status = shell_quote(&status_file.display().to_string()),
+    );
+    let output = runtime
+        .process_command_for_test("sh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run kin init into a reader that closes early");
+    assert!(
+        output.status.success(),
+        "the shell driving the pipeline must itself succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let recorded = fs::read_to_string(&status_file).expect("init recorded its own exit status");
+    assert_eq!(
+        recorded.trim(),
+        "0",
+        "the exit status must report the admission, not the pipe"
+    );
+    assert_eq!(
+        fs::read_to_string(repo.join(".kin/version"))
+            .expect("a completed admission leaves a store")
+            .trim(),
+        kin_core::layout::KIN_LAYOUT_VERSION.to_string(),
+        "the store must be the one this build writes"
+    );
+}
+
+/// Single-quote a path for `sh`, so a temporary directory with a space in it
+/// cannot silently turn one argument into two.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::Hash;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -384,14 +385,14 @@ fn link_cross_file_against_entity_refs(
                     let total =
                         found.fetch_add(relations.len(), Ordering::Relaxed) + relations.len();
                     if done.is_multiple_of(progress_interval) || done == total_files {
-                        eprint!(
+                        draw_progress(format_args!(
                             "\r  Linking: [{}/{}] {}% | {} relations | {:.1}s",
                             done,
                             total_files,
                             (done * 100) / total_files,
                             total,
                             link_start.elapsed().as_secs_f64()
-                        );
+                        ));
                     }
                 }
                 relations
@@ -402,7 +403,7 @@ fn link_cross_file_against_entity_refs(
     let resolved = merge_resolved(per_file_relations, files, &ctx, artifact_ids, completeness);
 
     if shows_progress_bar(total_files) {
-        eprintln!(); // newline after \r progress
+        draw_progress(format_args!("\n")); // newline after \r progress
     }
     debug!(resolved = resolved.len(), "cross-file linking complete");
     Ok(resolved)
@@ -3950,7 +3951,31 @@ const PROGRESS_BAR_MIN_FILES: usize = 50;
 /// Whether this link pass prints a progress bar, and therefore whether it has a
 /// line to terminate.
 fn shows_progress_bar(total_files: usize) -> bool {
-    total_files > PROGRESS_BAR_MIN_FILES
+    progress_bar_is_drawn(total_files, std::io::stderr().is_terminal())
+}
+
+/// The bar decision, split from the terminal probe so both halves are testable.
+///
+/// The terminal half is not cosmetic. The bar redraws in place with a carriage
+/// return, which a terminal shows as one line and a pipe records as one frame
+/// per update, so a captured run kept every frame instead of the final one. Off
+/// a terminal the surrounding phase ladder already reports this phase with a
+/// start line and an end line carrying its elapsed time, which is the whole of
+/// what a log needs.
+fn progress_bar_is_drawn(total_files: usize, stderr_is_terminal: bool) -> bool {
+    total_files > PROGRESS_BAR_MIN_FILES && stderr_is_terminal
+}
+
+/// Draw one frame of the in-place bar, or the newline that ends it.
+///
+/// Progress is advisory and the work is not. `eprint!` panics when its write
+/// fails, so a consumer that closed the reading end used to take a running
+/// admission down with it partway through, leaving no store behind. Failures
+/// here are dropped and the link pass carries on.
+fn draw_progress(args: std::fmt::Arguments<'_>) {
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_fmt(args);
+    let _ = stderr.flush();
 }
 
 /// Resolve cross-file relations using the incrementally updated linker state.
@@ -4019,21 +4044,21 @@ fn link_cross_file_incremental_internal(
                 let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
                 let total = found.fetch_add(relations.len(), Ordering::Relaxed) + relations.len();
                 if done.is_multiple_of(progress_interval) || done == total_files {
-                    eprint!(
+                    draw_progress(format_args!(
                         "\r  Linking: [{}/{}] {}% | {} relations | {:.1}s",
                         done,
                         total_files,
                         (done * 100) / total_files,
                         total,
                         link_start.elapsed().as_secs_f64()
-                    );
+                    ));
                 }
             }
             relations
         })
         .collect();
     if shows_progress_bar(total_files) {
-        eprintln!(); // newline after \r progress
+        draw_progress(format_args!("\n")); // newline after \r progress
     }
 
     Ok(merge_incremental_resolved(
@@ -4679,10 +4704,25 @@ mod tests {
 
     #[test]
     fn the_progress_gate_excludes_its_own_threshold() {
-        assert!(!shows_progress_bar(0));
-        assert!(!shows_progress_bar(1));
-        assert!(!shows_progress_bar(PROGRESS_BAR_MIN_FILES));
-        assert!(shows_progress_bar(PROGRESS_BAR_MIN_FILES + 1));
+        assert!(!progress_bar_is_drawn(0, true));
+        assert!(!progress_bar_is_drawn(1, true));
+        assert!(!progress_bar_is_drawn(PROGRESS_BAR_MIN_FILES, true));
+        assert!(progress_bar_is_drawn(PROGRESS_BAR_MIN_FILES + 1, true));
+    }
+
+    /// The bar redraws with a carriage return, which only a terminal reads as an
+    /// overwrite. A pipe keeps every frame, so a captured admission of a large
+    /// repository collected megabytes of `Linking:` lines that a reader had to
+    /// scroll past to find the phase summaries underneath.
+    ///
+    /// The terminal probe is passed in rather than read here on purpose. Reading
+    /// the real stderr would make this test pass or fail on whether a human ran
+    /// it from a terminal, which is a check that answers a different question
+    /// every time it runs.
+    #[test]
+    fn the_in_place_bar_is_never_drawn_off_a_terminal() {
+        assert!(!progress_bar_is_drawn(PROGRESS_BAR_MIN_FILES + 1, false));
+        assert!(!progress_bar_is_drawn(100_000, false));
     }
 
     /// A progress bar and the newline that terminates it must be decided by the


### PR DESCRIPTION
`kin init` drew its cross-file linking bar with a carriage return no matter what it was writing to. A terminal reads that as an overwrite and a pipe records it as a frame, so every captured admission kept one line per update instead of one line total. Measured on a one-commit repository of 80 linkable files, a captured run carried 80 carriage returns. A real repository is where the megabyte-scale logs came from.

Worse than the noise, a consumer that stopped reading killed the run. The macro behind the bar panics when its write fails, so `kin init | head` took the admission down partway through and left no store behind. Measured before this change on a 120-file repository, that exit was 101 with no `.kin` at all. A repository below the bar's file threshold exited 101 too, with a complete store, which isolates the second writer as the result printing that happens after the work is already durable.

The bar is now drawn only when stderr is a terminal, and both bar writes and both terminators go through one helper that drops write errors instead of panicking. Off a terminal the phase ladder already reports every phase with a start line and an end line carrying its elapsed time, which is the whole of what a log needs. The result itself renders into one string and goes out through a write that treats a departed reader as the end of the output rather than the end of the work, so the exit status reports the admission.

The same fixtures after the change carry zero carriage returns, keep their phase summaries, and exit 0 with a v2 store through a head-capped pipe in both the bar and the no-bar case.

Tests cover both halves. A captured run of a 64-file repository, deliberately above the 50-file threshold so the assertion cannot pass for the wrong reason, has to hold zero carriage returns while still carrying its phase summaries in under 16 KB of stderr. A shell pipeline into `head -1` records init's own exit status to a file and requires zero plus a store this build wrote. The unit test on the bar predicate takes the terminal flag as a parameter rather than probing the real stderr, so it does not answer a different question depending on whether a human ran it from a terminal.

Closes FIR-2144
