### PR TITLE
Lead every daemon failure with its cause and keep the lifecycle noise off the terminal

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -371,7 +371,9 @@ pub async fn require_daemon_update_head(
 ) -> anyhow::Result<()> {
     let daemon_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout)
         .await
-        .ok_or_else(|| anyhow::anyhow!("Kin daemon is required for branch head updates"))?;
+        .ok_or_else(|| {
+            crate::daemon_client::running_daemon_required_error("branch head updates", layout)
+        })?;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .build()?;
@@ -412,7 +414,9 @@ pub async fn require_daemon_commit(
 ) -> anyhow::Result<()> {
     let daemon_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout)
         .await
-        .ok_or_else(|| anyhow::anyhow!("Kin daemon is required for semantic graph commits"))?;
+        .ok_or_else(|| {
+            crate::daemon_client::running_daemon_required_error("semantic graph commits", layout)
+        })?;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()?;
@@ -684,7 +688,7 @@ pub async fn require_daemon_graph_mutations(
 ) -> anyhow::Result<()> {
     let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
         .await?
-        .ok_or_else(|| anyhow::anyhow!("Kin daemon is required for graph mutations"))?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("graph mutations", layout))?;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()?;

--- a/crates/kin-cli/src/commands/approvals.rs
+++ b/crates/kin-cli/src/commands/approvals.rs
@@ -42,9 +42,8 @@ async fn run_daemon_approvals(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for approvals but no daemon endpoint is available")
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("approvals", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .approvals(request)

--- a/crates/kin-cli/src/commands/audit.rs
+++ b/crates/kin-cli/src/commands/audit.rs
@@ -65,9 +65,8 @@ async fn run_daemon_audit(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for audit but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("audit", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.audit(request).await.context("daemon audit failed")
 }

--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -36,9 +36,8 @@ async fn run_daemon_blame(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for blame but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("blame", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.blame(request).await.context("daemon blame failed")
 }

--- a/crates/kin-cli/src/commands/branch.rs
+++ b/crates/kin-cli/src/commands/branch.rs
@@ -161,11 +161,7 @@ async fn execute(request: BranchRequest) -> Result<BranchResponse> {
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for branch operations but no daemon endpoint is available"
-            )
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("branch operations", &layout))?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     daemon.branch(&request).await
 }

--- a/crates/kin-cli/src/commands/checkout.rs
+++ b/crates/kin-cli/src/commands/checkout.rs
@@ -52,11 +52,7 @@ pub async fn run(
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for checkout but no daemon endpoint is available"
-            )
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("checkout", &layout))?;
     let request = CheckoutRequest {
         path,
         path_hex,

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -41,9 +41,7 @@ async fn run_daemon_commit(
 ) -> Result<DaemonCommitResult> {
     let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!("Kin daemon is required for commit but no daemon endpoint is available")
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("commit", layout))?;
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(120))

--- a/crates/kin-cli/src/commands/conflicts.rs
+++ b/crates/kin-cli/src/commands/conflicts.rs
@@ -68,10 +68,7 @@ async fn execute(request: ConflictsRequest) -> Result<ConflictsResponse> {
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required to read merge conflict state but no daemon endpoint is \
-                 available"
-            )
+            crate::daemon_client::daemon_required_error("merge conflict state", &layout)
         })?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     daemon.conflicts(&request).await

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -86,9 +86,8 @@ async fn run_daemon_context(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for context but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("context", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .context(request)

--- a/crates/kin-cli/src/commands/dead_code.rs
+++ b/crates/kin-cli/src/commands/dead_code.rs
@@ -93,11 +93,8 @@ async fn run_daemon_dead_code(layout: &kin_core::KinLayout) -> Result<DeadCodeRe
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for dead-code scan but no daemon endpoint is available"
-        )
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("dead-code scan", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .dead_code(&DeadCodeRequest::default())
@@ -115,9 +112,7 @@ async fn run_daemon_dead_code_seeded(
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
     let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for seeded dead-code scan but no daemon endpoint is available"
-        )
+        crate::daemon_client::daemon_required_error("seeded dead-code scan", layout)
     })?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -171,7 +171,7 @@ pub fn inspect_with_endpoint_entities(
         .find(|workspace| workspace.workspace_id == authority.workspace_id)
         .ok_or_else(|| {
             anyhow!(
-                "repository {} has no workspace {} in repository-v6 authority",
+                "repository {} has no workspace {} in its authority",
                 authority.repository_id,
                 authority.workspace_id
             )
@@ -428,7 +428,13 @@ fn state_at_git_object(
                 .find(|alias| alias.oid == oid)
                 .map(|alias| RefTarget::change(alias.change_id))
         })
-        .ok_or_else(|| anyhow!("Git object '{oid}' is absent from repository-v6 authority"))?;
+        .ok_or_else(|| {
+            anyhow!(
+                "Git object '{oid}' was never imported into this repository, so there is nothing \
+                 to diff it against; import it with `kin init` in the source checkout, or name a \
+                 ref kin already holds"
+            )
+        })?;
     let change_id = lease
         .resolve_target_change_id(&target)
         .with_context(|| format!("resolve Git object '{oid}' semantic target"))?;
@@ -499,7 +505,10 @@ fn require_change(history: &kin_db::InMemoryGraph, change_id: SemanticChangeId) 
         .with_context(|| format!("read immutable semantic change {change_id}"))?
         .is_none()
     {
-        bail!("semantic change '{change_id}' is absent from repository-v6 authority");
+        bail!(
+            "semantic change '{change_id}' is not in this repository's authority, so there is \
+             nothing to diff it against; run `kin log` to see the changes kin holds"
+        );
     }
     Ok(())
 }

--- a/crates/kin-cli/src/commands/drift.rs
+++ b/crates/kin-cli/src/commands/drift.rs
@@ -69,10 +69,7 @@ pub async fn run(json: bool) -> Result<()> {
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for projection drift reporting but no daemon endpoint is \
-                 available"
-            )
+            crate::daemon_client::daemon_required_error("projection drift reporting", &layout)
         })?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     let response = daemon.drift(&DriftRequest { json }).await?;
@@ -128,9 +125,7 @@ pub async fn heal(json: bool) -> Result<()> {
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for projection healing but no daemon endpoint is available"
-            )
+            crate::daemon_client::daemon_required_error("projection healing", &layout)
         })?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
 

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -215,7 +215,7 @@ const RECOMMENDED_EMBED_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 /// covers a connection that was refused outright, and a daemon that never
 /// accepted the request was not lost during this pass, whatever the machine's
 /// memory says. An HTTP status the daemon returned reaches the caller as
-/// `daemon embed error (HTTP ...)` and matches nothing here either, and neither
+/// `kin embed refused (HTTP ...)` and matches nothing here either, and neither
 /// does a client-side timeout, so each keeps its own diagnosis.
 const LOST_CONNECTION_MARKERS: &[&str] = &[
     "connection closed before message completed",
@@ -477,9 +477,8 @@ async fn run_daemon_embed(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for embed but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("embed", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     // Embedding behavior is decided in the long-lived daemon worker; warn loudly
     // (or fail under KIN_STRICT_BEHAVIOR_ENV) if this command's environment
@@ -755,8 +754,9 @@ mod tests {
     /// The exact failure a 512 MB cgroup produced: the daemon is OOM-killed
     /// mid-pass and the CLI is handed a closed connection.
     const OOM_KILLED_MID_PASS: &str =
-        "send daemon embed request: error sending request for url (http://127.0.0.1:7654/embed): \
-         connection closed before message completed";
+        "the kin daemon at http://127.0.0.1:7654 stopped answering while the embed request was in \
+         flight: error sending request for url (http://127.0.0.1:7654/embed): connection closed \
+         before message completed";
 
     #[test]
     fn a_recorded_oom_kill_is_reported_as_observed_with_the_limit_and_the_remedy() {
@@ -815,7 +815,7 @@ mod tests {
         );
         assert!(
             embed_resource_exhaustion(
-                "daemon embed error (HTTP 500): Graph error: kindb foo",
+                "kin embed refused (HTTP 500): Graph error: kindb foo",
                 &evidence(512 * 1024 * 1024, Some(3)),
             )
             .is_none(),
@@ -823,7 +823,8 @@ mod tests {
         );
         assert!(
             embed_resource_exhaustion(
-                "send daemon embed request: operation timed out",
+                "the kin daemon at http://127.0.0.1:7654 stopped answering while the embed \
+                 request was in flight: operation timed out",
                 &evidence(512 * 1024 * 1024, Some(3)),
             )
             .is_none(),
@@ -831,7 +832,8 @@ mod tests {
         );
         assert!(
             embed_resource_exhaustion(
-                "send daemon embed request: error sending request for url \
+                "the kin daemon at http://127.0.0.1:7654 stopped answering while the embed \
+                 request was in flight: error sending request for url \
                  (http://127.0.0.1:7654/embed): tcp connect error: Connection refused (os error 61)",
                 &evidence(512 * 1024 * 1024, Some(3)),
             )

--- a/crates/kin-cli/src/commands/git.rs
+++ b/crates/kin-cli/src/commands/git.rs
@@ -78,7 +78,7 @@ pub(crate) fn capture_export_snapshot_from_state(
         .cloned()
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "repository {} has no workspace {} in repository-v6 authority",
+                "repository {} has no workspace {} in its authority",
                 repository_id,
                 workspace_id
             )

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -160,11 +160,8 @@ async fn run_daemon_graph(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for graph commands but no daemon endpoint is available"
-        )
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("graph commands", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .graph_command(request)

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1014,7 +1014,7 @@ pub(crate) fn read_entity_file_bytes_with_digest_from(
     })?;
     let artifact = workspace.tree.artifact_at_path(&path).ok_or_else(|| {
         anyhow::anyhow!(
-            "entity source '{}' is absent from repository-v6 workspace {} at generation {}",
+            "entity source '{}' is not in workspace {} at generation {}",
             file_id.0,
             workspace.workspace_id,
             workspace.generation
@@ -2041,7 +2041,7 @@ mod tests {
                 .to_string();
 
         assert!(
-            err.contains("source 'src/lib.rs' is absent from repository-v6 workspace"),
+            err.contains("source 'src/lib.rs' is not in workspace"),
             "{err}"
         );
     }

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -112,9 +112,8 @@ async fn run_daemon_history(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for history but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("history", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .history(request)

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -123,9 +123,8 @@ async fn run_daemon_impact(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for impact but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("impact", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.impact(request).await.context("daemon impact failed")
 }

--- a/crates/kin-cli/src/commands/intent.rs
+++ b/crates/kin-cli/src/commands/intent.rs
@@ -7,11 +7,7 @@ async fn daemon_base_url() -> Result<String> {
     let layout = crate::commands::require_repository_layout()?;
     crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for intent commands but no daemon endpoint is available"
-            )
-        })
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("intent commands", &layout))
 }
 
 /// `kin intent list` — Show all active intents via daemon API.

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1666,9 +1666,8 @@ async fn try_locate_via_daemon(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for locate but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("locate", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     let request = crate::daemon_client::LocateRequest {
         text: text.to_string(),

--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -82,7 +82,7 @@ pub fn inspect(
         .find(|workspace| workspace.workspace_id == authority.workspace_id)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "repository {} has no workspace {} in repository-v6 authority",
+                "repository {} has no workspace {} in its authority",
                 authority.repository_id,
                 authority.workspace_id
             )

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -593,7 +593,7 @@ async fn bind_daemon_for_repo_dir(dir: &Path) -> std::result::Result<String, Str
         .await
         .map_err(|e| format!("{e:#}"))?
         .ok_or_else(|| {
-            "Kin daemon is required for MCP startup but no daemon endpoint is available".to_string()
+            crate::daemon_client::daemon_required_error("MCP startup", &layout).to_string()
         })?;
     std::env::set_var("KIN_DAEMON_URL", &url);
     Ok(url)

--- a/crates/kin-cli/src/commands/merge.rs
+++ b/crates/kin-cli/src/commands/merge.rs
@@ -149,11 +149,7 @@ async fn execute(request: MergeRequest) -> Result<MergeResponse> {
     let layout = require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for merge operations but no daemon endpoint is available"
-            )
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("merge operations", &layout))?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     daemon.merge(&request).await
 }

--- a/crates/kin-cli/src/commands/note.rs
+++ b/crates/kin-cli/src/commands/note.rs
@@ -44,11 +44,8 @@ async fn run_daemon_note(request: &NoteRequest) -> Result<NoteResponse> {
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(&layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for note commands but no daemon endpoint is available"
-        )
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("note commands", &layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.note(request).await.context("daemon note failed")
 }

--- a/crates/kin-cli/src/commands/overview.rs
+++ b/crates/kin-cli/src/commands/overview.rs
@@ -57,9 +57,8 @@ async fn run_daemon_overview(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for overview but no daemon endpoint is available")
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("overview", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .overview(request)

--- a/crates/kin-cli/src/commands/purge_ignored.rs
+++ b/crates/kin-cli/src/commands/purge_ignored.rs
@@ -17,7 +17,7 @@
 //! presence derived from it, because those are what let it rank. The file stays
 //! on disk; this untracks rather than deletes.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use kin_model::{AuthorId, OperationId, RepositoryId};
 use serde::{Deserialize, Serialize};
 
@@ -151,7 +151,9 @@ pub async fn run(confirm: bool, confirm_mass_deletion: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout_at(&cwd)?;
     let base_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| anyhow!("Kin daemon is required to retire tracked paths"))?;
+        .ok_or_else(|| {
+            crate::daemon_client::daemon_required_error("retiring tracked paths", &layout)
+        })?;
     let client = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, &layout)?;
     let response = client
         .purge_ignored(&PurgeIgnoredRequest {

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -224,7 +224,9 @@ pub async fn run_for_layout(
     let session_dir = resolve_session_directory(layout, session_id)?;
     let base_url = crate::daemon_client::resolve_daemon_url(layout)
         .await?
-        .ok_or_else(|| anyhow!("Kin daemon is required for exact session reconciliation"))?;
+        .ok_or_else(|| {
+            crate::daemon_client::daemon_required_error("exact session reconciliation", layout)
+        })?;
     let client = crate::daemon_client::DaemonClient::from_base_url_for_layout(base_url, layout)?;
     let summary = client
         .reconcile(&ReconcileRequest {

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -266,7 +266,7 @@ where
     let authority = ActiveRepositoryAuthority::open(binding).map_err(|error| {
         ref_error(
             original,
-            format!("repository-v6 authority is unavailable: {error:#}"),
+            format!("this repository's authority could not be opened: {error:#}"),
         )
     })?;
 
@@ -276,10 +276,16 @@ where
             .map_err(|error| {
                 ref_error(
                     original,
-                    format!("repository-v6 workspace head is invalid: {error:#}"),
+                    format!("this workspace's head could not be read: {error:#}"),
                 )
             })?
-            .ok_or_else(|| ref_error(original, "repository-v6 workspace head is unborn"))?
+            .ok_or_else(|| {
+                ref_error(
+                    original,
+                    "this workspace has no commits yet, so HEAD names nothing; make one with \
+                     `kin commit`",
+                )
+            })?
     } else if let Some(branch_name) = core.strip_prefix("branch:") {
         resolve_named_authority_ref(&authority, original, branch_name)?
     } else if let Some(git_oid) = core.strip_prefix("git:") {
@@ -305,7 +311,9 @@ where
         return Err(ref_error(
             original,
             format!(
-                "repository-v6 authority resolves to semantic change {resolved}, but the active graph projection does not contain it"
+                "this repository's authority resolves to semantic change {resolved}, which the \
+                 active graph projection does not hold; run `kin status`, then `kin health` if it \
+                 repeats"
             ),
         ));
     }
@@ -641,7 +649,10 @@ mod tests {
         let binding = absent_binding(&layout);
         let error = resolve_ref(&graph, &binding, None).unwrap_err();
         assert!(is_ref_resolution_error(&error));
-        assert!(error.to_string().contains("repository-v6 authority"));
+        assert!(
+            error.to_string().contains("this repository's authority"),
+            "the layout version is not a noun the reader has: {error:#}"
+        );
     }
 
     #[test]
@@ -663,7 +674,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("has no imported repository-v6 alias"),
+                .contains("was never imported into this repository"),
             "{error:#}"
         );
     }

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -136,9 +136,8 @@ async fn run_daemon_refs(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for refs but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("refs", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.refs(request).await.context("daemon refs failed")
 }
@@ -152,9 +151,8 @@ async fn run_daemon_bulk_refs(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for bulk refs but no daemon endpoint is available")
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("bulk refs", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .bulk_refs(request)

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -568,24 +568,24 @@ pub(crate) async fn load_push_plan(requested_remote: Option<&str>) -> Result<Pus
         .map(|target| target.repo_id.clone())
         .unwrap_or_else(|| fallback_repo_id.clone());
 
-    let (local_head, approved, semantic_state_note) = if let Some(head) =
-        authority.current_change_id()?
-    {
-        let approvals = graph.get_approvals_for_change(&head)?;
-        let approved = approvals
-            .iter()
-            .any(|approval| approval.decision == ApprovalDecision::Approved);
-        (Some(head.to_string()), approved, None)
-    } else {
-        (
+    let (local_head, approved, semantic_state_note) =
+        if let Some(head) = authority.current_change_id()? {
+            let approvals = graph.get_approvals_for_change(&head)?;
+            let approved = approvals
+                .iter()
+                .any(|approval| approval.decision == ApprovalDecision::Approved);
+            (Some(head.to_string()), approved, None)
+        } else {
+            (
             None,
             false,
             Some(
-                "The repository-v6 workspace head is unborn; there is no semantic change to publish."
+                "This workspace has no commits yet, so there is no semantic change to publish; \
+                 make one with `kin commit`."
                     .to_string(),
             ),
         )
-    };
+        };
 
     let (remote_head, remote_state_note) = if let Some(target) = native_target.as_ref() {
         let status = fetch_native_remote_status(target, &remote.name).await?;

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -108,9 +108,7 @@ pub async fn run(
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!("Kin daemon is required for rename but no daemon endpoint is available")
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("rename", &layout))?;
     let request = RenameRequest {
         symbol,
         new_name,

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -177,7 +177,7 @@ impl ActiveRepositoryAuthority {
             .cloned()
             .ok_or_else(|| {
                 anyhow!(
-                    "repository {} has no workspace {} in repository-v6 authority",
+                    "repository {} has no workspace {} in its authority",
                     self.repository_id,
                     self.workspace_id
                 )
@@ -205,7 +205,7 @@ impl ActiveRepositoryAuthority {
             .find(|workspace| workspace.workspace_id == self.workspace_id)
             .ok_or_else(|| {
                 anyhow!(
-                    "repository {} has no workspace {} in repository-v6 authority",
+                    "repository {} has no workspace {} in its authority",
                     self.repository_id,
                     self.workspace_id
                 )

--- a/crates/kin-cli/src/commands/repository_authority.rs
+++ b/crates/kin-cli/src/commands/repository_authority.rs
@@ -225,7 +225,13 @@ impl ActiveRepositoryAuthority {
             .iter()
             .find(|alias| &alias.oid == oid)
             .map(|alias| alias.change_id)
-            .ok_or_else(|| anyhow!("Git commit '{oid}' has no imported repository-v6 alias"))
+            .ok_or_else(|| {
+                anyhow!(
+                    "Git commit '{oid}' was never imported into this repository, so kin holds no \
+                     semantic change for it; import it with `kin init` in the source checkout, or \
+                     name a ref kin already holds"
+                )
+            })
     }
 
     pub(crate) fn load_source_blob(&self, digest: kin_model::Hash256) -> Result<Vec<u8>> {

--- a/crates/kin-cli/src/commands/resolve.rs
+++ b/crates/kin-cli/src/commands/resolve.rs
@@ -320,11 +320,7 @@ async fn execute(request: ResolveRequest) -> Result<ResolveResponse> {
     let layout = super::merge::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required to resolve a merge but no daemon endpoint is available"
-            )
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("resolve", &layout))?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     daemon.resolve(&request).await
 }

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -620,9 +620,7 @@ async fn run_daemon_resources(
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(&layout).await?);
     let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for resource inspection but no daemon endpoint is available"
-        )
+        crate::daemon_client::daemon_required_error("resource inspection", &layout)
     })?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     // Resource sizing reflects the daemon worker's captured environment; warn

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -423,7 +423,12 @@ fn compute_review(
         ),
         None => crate::commands::repository_authority::ActiveRepositoryAuthority::open(binding)?
             .current_change_id()?
-            .ok_or_else(|| anyhow::anyhow!("repository-v6 workspace head is unborn"))?,
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "this workspace has no commits yet, so there is nothing to review; make one \
+                     with `kin commit`"
+                )
+            })?,
     };
 
     let semantic_change = graph

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -108,9 +108,8 @@ async fn run_daemon_review(request: &ReviewRequest) -> Result<ReviewResponse> {
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(&layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for review but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("review", &layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.review(request).await.context("daemon review failed")
 }

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -332,11 +332,7 @@ pub async fn run(change_id: Option<String>, feature: Option<String>) -> Result<(
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for rollback but no daemon endpoint is available"
-            )
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("rollback", &layout))?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     let response = daemon
         .rollback(&RollbackRequest {

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -464,9 +464,8 @@ async fn run_daemon_search(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for search but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("search", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.search(request).await.context("daemon search failed")
 }

--- a/crates/kin-cli/src/commands/security.rs
+++ b/crates/kin-cli/src/commands/security.rs
@@ -46,9 +46,8 @@ async fn run_daemon_security(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for security but no daemon endpoint is available")
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("security", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .security(request)

--- a/crates/kin-cli/src/commands/session_run.rs
+++ b/crates/kin-cli/src/commands/session_run.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 
 use crate::commands::reconcile::ReconcileRequest;
 use crate::commands::session_workspace::SessionWorkspaceRequest;
@@ -192,7 +192,10 @@ pub async fn materialize(
     let base_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {
-            anyhow!("Kin daemon is required to materialize an exact session workspace")
+            crate::daemon_client::daemon_required_error(
+                "session workspace materialization",
+                &layout,
+            )
         })?;
     let client = DaemonClient::from_base_url_for_layout(base_url, &layout)?;
 

--- a/crates/kin-cli/src/commands/stash.rs
+++ b/crates/kin-cli/src/commands/stash.rs
@@ -186,11 +186,7 @@ async fn execute(request: StashRequest) -> Result<StashResponse> {
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for stash operations but no daemon endpoint is available"
-            )
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("stash operations", &layout))?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     daemon.stash(&request).await
 }

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -772,14 +772,18 @@ pub fn inspect(
         .find(|workspace| workspace.workspace_id == authority.workspace_id)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "repository {} has no workspace {} in repository-v6 authority",
+                "repository {} has no workspace {} in its authority",
                 authority.repository_id,
                 authority.workspace_id
             )
         })?;
     let roots = lease.roots().clone();
     if roots.generation != metadata.roots.generation {
-        anyhow::bail!("repository-v6 lease exposed inconsistent root generations");
+        anyhow::bail!(
+            "this repository's store reported two different root generations for one lease, which \
+             means another process wrote it while this command was reading; re-run `kin status`, \
+             and run `kin health` if it repeats"
+        );
     }
 
     let artifact_count = workspace.tree.artifacts().len();
@@ -819,9 +823,13 @@ pub fn inspect(
     // refuses an illegal report; running the same check here means a future
     // coverage source that publishes an impossible triple fails in the process
     // that built it rather than in every consumer that parses it.
-    report
-        .validate()
-        .map_err(|error| anyhow::anyhow!("repository-v6 status report is invalid: {error}"))?;
+    report.validate().map_err(|error| {
+        anyhow::anyhow!(
+            "kin built a status report this build considers invalid ({error}), so it refused \
+                 to print it; run `kin health`, and `kin --version` against `kin daemon status` if \
+                 the two are on different builds"
+        )
+    })?;
     Ok(report)
 }
 

--- a/crates/kin-cli/src/commands/support.rs
+++ b/crates/kin-cli/src/commands/support.rs
@@ -108,9 +108,8 @@ async fn run_daemon_support(layout: &kin_core::KinLayout) -> Result<SupportJson>
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for support but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("support", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.support().await.context("daemon support failed")
 }

--- a/crates/kin-cli/src/commands/tag.rs
+++ b/crates/kin-cli/src/commands/tag.rs
@@ -196,9 +196,7 @@ async fn publish(
     let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!("Kin daemon is required for tags but no daemon endpoint is available")
-        })?;
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("tags", &layout))?;
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     let response = daemon
         .tag(&TagRequest {

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -117,9 +117,8 @@ async fn run_daemon_trace(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for trace but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("trace", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.trace(request).await.context("daemon trace failed")
 }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -385,11 +385,8 @@ async fn run_daemon_trace_data_flow(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for trace-data-flow but no daemon endpoint is available"
-        )
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("trace-data-flow", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .trace_data_flow(request)

--- a/crates/kin-cli/src/commands/traffic.rs
+++ b/crates/kin-cli/src/commands/traffic.rs
@@ -7,11 +7,7 @@ async fn daemon_base_url() -> Result<String> {
     let layout = crate::commands::require_repository_layout()?;
     crate::daemon_client::resolve_daemon_url(&layout)
         .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Kin daemon is required for traffic commands but no daemon endpoint is available"
-            )
-        })
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("traffic commands", &layout))
 }
 
 /// `kin traffic show <scope>` — Show active traffic via daemon API.

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -783,7 +783,12 @@ where
         Some(hash) => parse_change_id(hash)?,
         None => crate::commands::repository_authority::ActiveRepositoryAuthority::open(binding)?
             .current_change_id()?
-            .ok_or_else(|| anyhow!("repository-v6 workspace head is unborn"))?,
+            .ok_or_else(|| {
+                anyhow!(
+                    "this workspace has no commits yet, so there is nothing to verify; make one \
+                     with `kin commit`"
+                )
+            })?,
     };
 
     graph

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -124,9 +124,8 @@ async fn run_daemon_verify_run(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for verify run but no daemon endpoint is available")
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("verify run", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .verify_run(request)
@@ -143,9 +142,8 @@ async fn run_daemon_verify_command(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for verify but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("verify", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
         .verify_command(request)

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -92,11 +92,8 @@ async fn run_daemon_work(request: &WorkRequest) -> Result<WorkResponse> {
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(&layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Kin daemon is required for work commands but no daemon endpoint is available"
-        )
-    })?;
+    let base_url = daemon_url
+        .ok_or_else(|| crate::daemon_client::daemon_required_error("work commands", &layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.work(request).await.context("daemon work failed")
 }

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -40,9 +40,8 @@ async fn run_daemon_xref(
         .filter(|value| !value.trim().is_empty())
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(layout).await?);
-    let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for xref but no daemon endpoint is available")
-    })?;
+    let base_url =
+        daemon_url.ok_or_else(|| crate::daemon_client::daemon_required_error("xref", layout))?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client.xref(request).await.context("daemon xref failed")
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -509,11 +509,21 @@ impl DaemonClient {
     async fn send(
         &self,
         request: reqwest::RequestBuilder,
-        context: &'static str,
+        leaf: &str,
     ) -> Result<reqwest::Response> {
-        let resp = request.send().await.context(context)?;
+        let resp = request
+            .send()
+            .await
+            .with_context(|| daemon_send_failure_message(&self.base_url, leaf))?;
         check_response_build_match(resp.headers())?;
         Ok(resp)
+    }
+
+    /// Turn a non-success daemon response into the error the user reads.
+    async fn http_refusal(&self, leaf: &str, response: reqwest::Response) -> anyhow::Error {
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        daemon_http_error(&self.base_url, leaf, status, &body)
     }
 
     /// Try to connect to the daemon. Returns `None` if the daemon is
@@ -545,13 +555,11 @@ impl DaemonClient {
         let resp = self
             .send(
                 self.client.get(format!("{}/health", self.base_url)),
-                "send daemon health request",
+                "health",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("daemon error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("health", resp).await);
         }
         Ok(resp.json().await?)
     }
@@ -601,13 +609,9 @@ impl DaemonClient {
         if let Some(q) = query {
             url = format!("{}?query={}", url, urlencoding::encode(q));
         }
-        let resp = self
-            .send(self.client.get(&url), "send daemon entity search request")
-            .await?;
+        let resp = self.send(self.client.get(&url), "entity search").await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("daemon error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("entity search", resp).await);
         }
         let body: DaemonEntitiesResponse = resp.json().await?;
         Ok(body.entities)
@@ -634,7 +638,7 @@ impl DaemonClient {
         &self,
         path: &str,
         payload: &Req,
-        context: &'static str,
+        leaf: &str,
     ) -> Result<Resp>
     where
         Req: serde::Serialize + ?Sized,
@@ -655,7 +659,7 @@ impl DaemonClient {
                         .post(&url)
                         .header(reqwest::header::CONTENT_TYPE, "application/json")
                         .body(payload.clone()),
-                    context,
+                    leaf,
                 )
                 .await
             {
@@ -699,12 +703,20 @@ impl DaemonClient {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             if status.is_server_error() && attempt == 0 {
-                last_error = Some(anyhow::anyhow!(
-                    "daemon command returned HTTP {status}: {body}"
+                last_error = Some(daemon_http_error(
+                    &self.base_url,
+                    leaf,
+                    status.as_u16(),
+                    &body,
                 ));
                 continue;
             }
-            anyhow::bail!("daemon command failed (HTTP {status}): {body}");
+            return Err(daemon_http_error(
+                &self.base_url,
+                leaf,
+                status.as_u16(),
+                &body,
+            ));
         }
         Err(last_error.unwrap_or_else(|| anyhow::anyhow!("daemon command produced no response")))
     }
@@ -724,7 +736,7 @@ impl DaemonClient {
         path: &str,
         payload: &Req,
         operation_id: OperationId,
-        context: &'static str,
+        leaf: &str,
     ) -> Result<Resp>
     where
         Req: serde::Serialize + ?Sized,
@@ -743,7 +755,7 @@ impl DaemonClient {
                     .post(&url)
                     .header(reqwest::header::CONTENT_TYPE, "application/json")
                     .body(payload),
-                context,
+                leaf,
             )
             .await
             .map_err(|error| {
@@ -820,13 +832,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/locate", self.base_url))
                     .json(request),
-                "send daemon locate request",
+                "locate",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon locate error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("locate", resp).await);
         }
         resp.json().await.context("parse daemon locate response")
     }
@@ -840,13 +850,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/search", self.base_url))
                     .json(request),
-                "send daemon search request",
+                "search",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon search error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("search", resp).await);
         }
         resp.json().await.context("parse daemon search response")
     }
@@ -855,13 +863,11 @@ impl DaemonClient {
         let resp = self
             .send(
                 self.client.get(format!("{}/support", self.base_url)),
-                "send daemon support request",
+                "support",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon support error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("support", resp).await);
         }
         resp.json().await.context("parse daemon support response")
     }
@@ -875,13 +881,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/context", self.base_url))
                     .json(request),
-                "send daemon context request",
+                "context",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon context error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("context", resp).await);
         }
         resp.json().await.context("parse daemon context response")
     }
@@ -895,13 +899,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/trace", self.base_url))
                     .json(request),
-                "send daemon trace request",
+                "trace",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon trace error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("trace", resp).await);
         }
         resp.json().await.context("parse daemon trace response")
     }
@@ -915,13 +917,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/impact", self.base_url))
                     .json(request),
-                "send daemon impact request",
+                "impact",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon impact error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("impact", resp).await);
         }
         resp.json().await.context("parse daemon impact response")
     }
@@ -935,13 +935,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/review", self.base_url))
                     .json(request),
-                "send daemon review request",
+                "review",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon review error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("review", resp).await);
         }
         resp.json().await.context("parse daemon review response")
     }
@@ -978,13 +976,11 @@ impl DaemonClient {
                     .post(format!("{}/embed", self.base_url))
                     .timeout(embed_timeout)
                     .json(request),
-                "send daemon embed request",
+                "embed",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon embed error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("embed", resp).await);
         }
         resp.json().await.context("parse daemon embed response")
     }
@@ -998,13 +994,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/blame", self.base_url))
                     .json(request),
-                "send daemon blame request",
+                "blame",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon blame error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("blame", resp).await);
         }
         resp.json().await.context("parse daemon blame response")
     }
@@ -1018,13 +1012,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/history", self.base_url))
                     .json(request),
-                "send daemon history request",
+                "history",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon history error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("history", resp).await);
         }
         resp.json().await.context("parse daemon history response")
     }
@@ -1038,13 +1030,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/verify/run", self.base_url))
                     .json(request),
-                "send daemon verify run request",
+                "verify run",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon verify run error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("verify run", resp).await);
         }
         resp.json()
             .await
@@ -1060,13 +1050,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/verify", self.base_url))
                     .json(request),
-                "send daemon verify request",
+                "verify",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon verify error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("verify", resp).await);
         }
         resp.json().await.context("parse daemon verify response")
     }
@@ -1080,13 +1068,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/reconcile", self.base_url))
                     .json(request),
-                "send daemon reconcile request",
+                "reconcile",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon reconcile error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("reconcile", resp).await);
         }
         resp.json().await.context("parse daemon reconcile response")
     }
@@ -1100,13 +1086,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/status", self.base_url))
                     .json(request),
-                "send daemon command status request",
+                "command status",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon command status error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("command status", resp).await);
         }
         resp.json()
             .await
@@ -1149,13 +1133,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/{leaf}", self.base_url))
                     .json(request),
-                "send daemon transfer command",
+                leaf,
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("kin {leaf} refused (HTTP {status}): {body}");
+            return Err(self.http_refusal(leaf, resp).await);
         }
         resp.json()
             .await
@@ -1171,13 +1153,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/resources", self.base_url))
                     .json(request),
-                "send daemon command resources request",
+                "resources",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon command resources error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("resources", resp).await);
         }
         resp.json()
             .await
@@ -1193,13 +1173,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/graph", self.base_url))
                     .json(request),
-                "send daemon graph command request",
+                "graph",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon graph command error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("graph", resp).await);
         }
         resp.json()
             .await
@@ -1215,13 +1193,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/overview", self.base_url))
                     .json(request),
-                "send daemon overview request",
+                "overview",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon overview error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("overview", resp).await);
         }
         resp.json().await.context("parse daemon overview response")
     }
@@ -1235,13 +1211,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/dead-code", self.base_url))
                     .json(request),
-                "send daemon dead-code request",
+                "dead-code",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon dead-code error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("dead-code", resp).await);
         }
         resp.json().await.context("parse daemon dead-code response")
     }
@@ -1255,13 +1229,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/dead-code-seeded", self.base_url))
                     .json(request),
-                "send daemon seeded dead-code request",
+                "seeded dead-code",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon seeded dead-code error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("seeded dead-code", resp).await);
         }
         resp.json()
             .await
@@ -1277,13 +1249,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/trace-data-flow", self.base_url))
                     .json(request),
-                "send daemon trace-data-flow request",
+                "trace-data-flow",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon trace-data-flow error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("trace-data-flow", resp).await);
         }
         resp.json()
             .await
@@ -1299,13 +1269,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/refs", self.base_url))
                     .json(request),
-                "send daemon refs request",
+                "refs",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon refs error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("refs", resp).await);
         }
         resp.json().await.context("parse daemon refs response")
     }
@@ -1319,13 +1287,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/bulk-refs", self.base_url))
                     .json(request),
-                "send daemon bulk-refs request",
+                "bulk refs",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon bulk-refs error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("bulk refs", resp).await);
         }
         resp.json().await.context("parse daemon bulk-refs response")
     }
@@ -1339,13 +1305,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/xref", self.base_url))
                     .json(request),
-                "send daemon xref request",
+                "xref",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon xref error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("xref", resp).await);
         }
         resp.json().await.context("parse daemon xref response")
     }
@@ -1359,13 +1323,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/diff", self.base_url))
                     .json(request),
-                "send daemon diff request",
+                "diff",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon diff error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("diff", resp).await);
         }
         resp.json().await.context("parse daemon diff response")
     }
@@ -1379,13 +1341,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/log", self.base_url))
                     .json(request),
-                "send daemon log request",
+                "log",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon log error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("log", resp).await);
         }
         resp.json().await.context("parse daemon log response")
     }
@@ -1399,13 +1359,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/audit", self.base_url))
                     .json(request),
-                "send daemon audit request",
+                "audit",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon audit error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("audit", resp).await);
         }
         resp.json().await.context("parse daemon audit response")
     }
@@ -1419,13 +1377,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/approvals", self.base_url))
                     .json(request),
-                "send daemon approvals request",
+                "approvals",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon approvals error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("approvals", resp).await);
         }
         resp.json().await.context("parse daemon approvals response")
     }
@@ -1439,13 +1395,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/security", self.base_url))
                     .json(request),
-                "send daemon security request",
+                "security",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon security error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("security", resp).await);
         }
         resp.json().await.context("parse daemon security response")
     }
@@ -1454,37 +1408,24 @@ impl DaemonClient {
         &self,
         request: &crate::commands::branch::BranchRequest,
     ) -> Result<crate::commands::branch::BranchResponse> {
-        self.post_idempotent_json(
-            "/commands/branch",
-            request,
-            "send daemon-owned repository branch request",
-        )
-        .await
+        self.post_idempotent_json("/commands/branch", request, "branch")
+            .await
     }
 
     pub async fn merge(
         &self,
         request: &crate::commands::merge::MergeRequest,
     ) -> Result<crate::commands::merge::MergeResponse> {
-        self.post_non_idempotent_json(
-            "/commands/merge",
-            request,
-            request.operation_id,
-            "send daemon-owned repository merge request",
-        )
-        .await
+        self.post_non_idempotent_json("/commands/merge", request, request.operation_id, "merge")
+            .await
     }
 
     pub async fn conflicts(
         &self,
         request: &crate::commands::conflicts::ConflictsRequest,
     ) -> Result<crate::commands::conflicts::ConflictsResponse> {
-        self.post_idempotent_json(
-            "/commands/conflicts",
-            request,
-            "send daemon-owned merge conflict listing request",
-        )
-        .await
+        self.post_idempotent_json("/commands/conflicts", request, "conflicts")
+            .await
     }
 
     pub async fn resolve(
@@ -1495,7 +1436,7 @@ impl DaemonClient {
             "/commands/resolve",
             request,
             request.operation_id,
-            "send daemon-owned merge resolution request",
+            "resolve",
         )
         .await
     }
@@ -1504,48 +1445,32 @@ impl DaemonClient {
         &self,
         request: &crate::commands::tag::TagRequest,
     ) -> Result<crate::commands::tag::TagResponse> {
-        self.post_idempotent_json(
-            "/commands/tag",
-            request,
-            "send daemon-owned repository tag request",
-        )
-        .await
+        self.post_idempotent_json("/commands/tag", request, "tag")
+            .await
     }
 
     pub async fn stash(
         &self,
         request: &crate::commands::stash::StashRequest,
     ) -> Result<crate::commands::stash::StashResponse> {
-        self.post_idempotent_json(
-            "/commands/stash",
-            request,
-            "send daemon-owned repository stash request",
-        )
-        .await
+        self.post_idempotent_json("/commands/stash", request, "stash")
+            .await
     }
 
     pub async fn purge_ignored(
         &self,
         request: &crate::commands::purge_ignored::PurgeIgnoredRequest,
     ) -> Result<crate::commands::purge_ignored::PurgeIgnoredResponse> {
-        self.post_idempotent_json(
-            "/commands/purge-ignored",
-            request,
-            "send daemon-owned tracked-path purge request",
-        )
-        .await
+        self.post_idempotent_json("/commands/purge-ignored", request, "purge-ignored")
+            .await
     }
 
     pub async fn rollback(
         &self,
         request: &crate::commands::rollback::RollbackRequest,
     ) -> Result<crate::commands::rollback::RollbackResponse> {
-        self.post_idempotent_json(
-            "/commands/rollback",
-            request,
-            "send daemon-owned repository rollback request",
-        )
-        .await
+        self.post_idempotent_json("/commands/rollback", request, "rollback")
+            .await
     }
 
     pub async fn drift(
@@ -1557,13 +1482,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/drift", self.base_url))
                     .json(request),
-                "send daemon-owned projection drift request",
+                "drift",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon drift error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("drift", resp).await);
         }
         resp.json().await.context("parse daemon drift response")
     }
@@ -1572,24 +1495,16 @@ impl DaemonClient {
         &self,
         request: &crate::commands::checkout::CheckoutRequest,
     ) -> Result<crate::commands::checkout::CheckoutResponse> {
-        self.post_idempotent_json(
-            "/commands/checkout",
-            request,
-            "send daemon-owned exact checkout request",
-        )
-        .await
+        self.post_idempotent_json("/commands/checkout", request, "checkout")
+            .await
     }
 
     pub async fn rename(
         &self,
         request: &crate::commands::rename::RenameRequest,
     ) -> Result<crate::commands::rename::RenameResponse> {
-        self.post_idempotent_json(
-            "/commands/rename",
-            request,
-            "send daemon-owned exact rename request",
-        )
-        .await
+        self.post_idempotent_json("/commands/rename", request, "rename")
+            .await
     }
 
     pub async fn session_workspace(
@@ -1601,13 +1516,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/commands/session-workspace", self.base_url))
                     .json(request),
-                "send daemon session workspace request",
+                "session workspace",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon session workspace error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("session workspace", resp).await);
         }
         resp.json()
             .await
@@ -1640,13 +1553,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/session", self.base_url))
                     .json(&body),
-                "send daemon session registration",
+                "session start",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon session registration error (HTTP {status}): {body}");
+            return Err(self.http_refusal("session start", resp).await);
         }
         let value: serde_json::Value = resp
             .json()
@@ -1665,13 +1576,11 @@ impl DaemonClient {
             .send(
                 self.client
                     .delete(format!("{}/session/{}", self.base_url, session_id)),
-                "send daemon session end",
+                "session end",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon session end error (HTTP {status}): {body}");
+            return Err(self.http_refusal("session end", resp).await);
         }
         Ok(())
     }
@@ -1685,13 +1594,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/work", self.base_url))
                     .json(request),
-                "send daemon work request",
+                "work",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon work error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("work", resp).await);
         }
         resp.json().await.context("parse daemon work response")
     }
@@ -1705,13 +1612,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/note", self.base_url))
                     .json(request),
-                "send daemon note request",
+                "note",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon note error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("note", resp).await);
         }
         resp.json().await.context("parse daemon note response")
     }
@@ -1722,13 +1627,11 @@ impl DaemonClient {
                 self.client
                     .post(format!("{}/session/{}/scope", self.base_url, session_id))
                     .json(&serde_json::json!({ "ref_string": ref_string })),
-                "send set_scope request",
+                "scope update",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("scope update", resp).await);
         }
         resp.json().await.context("parse scope response")
     }
@@ -1738,13 +1641,11 @@ impl DaemonClient {
             .send(
                 self.client
                     .delete(format!("{}/session/{}/scope", self.base_url, session_id)),
-                "send clear_scope request",
+                "scope clear",
             )
             .await?;
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("scope clear", resp).await);
         }
         Ok(())
     }
@@ -1754,16 +1655,14 @@ impl DaemonClient {
             .send(
                 self.client
                     .get(format!("{}/session/{}/scope", self.base_url, session_id)),
-                "send get_scope request",
+                "scope read",
             )
             .await?;
         if resp.status().as_u16() == 404 {
             return Ok(None);
         }
         if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            bail!("daemon error (HTTP {}): {}", status, body);
+            return Err(self.http_refusal("scope read", resp).await);
         }
         Ok(Some(resp.json().await.context("parse scope response")?))
     }
@@ -1850,6 +1749,35 @@ fn behavior_env_divergence_message(divergences: &[kin_core::behavior_env::Diverg
          Set KIN_STRICT_BEHAVIOR_ENV=1 to make this a hard error.",
     );
     message
+}
+
+/// The headline a dropped daemon request leads with.
+///
+/// The worker exits after its idle window, so the ordinary cause of a request
+/// that never lands is a daemon that retired between URL resolution and this
+/// dispatch. Naming the endpoint and the command keeps the plumbing verb out of
+/// the headline.
+fn daemon_send_failure_message(base_url: &str, leaf: &str) -> String {
+    format!(
+        "the kin daemon at {base_url} stopped answering while the {leaf} request was in flight; \
+         it exits after its idle window, so re-run the command and kin will start a fresh one"
+    )
+}
+
+/// The error a non-success daemon response becomes.
+///
+/// An empty body is its own outcome rather than a refusal with nothing to say,
+/// so that branch names the log to read instead of rendering a status code and
+/// a colon with nothing after it.
+fn daemon_http_error(base_url: &str, leaf: &str, status: u16, body: &str) -> anyhow::Error {
+    if body.trim().is_empty() {
+        anyhow::anyhow!(
+            "the kin daemon at {base_url} answered HTTP {status} with an empty body for {leaf}; \
+             read .kin/daemon.log, then stop it with `kin daemon stop` and re-run"
+        )
+    } else {
+        anyhow::anyhow!("kin {leaf} refused (HTTP {status}): {body}")
+    }
 }
 
 fn check_response_build_match(headers: &reqwest::header::HeaderMap) -> Result<()> {
@@ -6899,6 +6827,34 @@ pub async fn resolve_daemon_url(layout: &KinLayout) -> Result<Option<String>> {
     resolve_daemon_url_inner(layout, None).await
 }
 
+/// The refusal a command gets when daemon resolution produced no endpoint.
+///
+/// [`resolve_daemon_url`] answers `Ok(None)` in exactly one situation:
+/// `KIN_NO_DAEMON` is set and no supervisor route is already published for this
+/// repository. Every other outcome returns `Err` carrying its own reason, so
+/// this branch is the one case where the cause is known exactly.
+pub fn daemon_required_error(command: &str, layout: &KinLayout) -> anyhow::Error {
+    anyhow::anyhow!(
+        "KIN_NO_DAEMON is set and no kin daemon is already running for {}, so there is no \
+         repository authority to answer {command}; unset KIN_NO_DAEMON and re-run, and kin will \
+         start one",
+        layout.root().display()
+    )
+}
+
+/// The refusal a caller gets when it needs a daemon that is already serving.
+///
+/// [`resolve_daemon_url_if_running_async`] never starts one, so an absent
+/// endpoint here means no daemon holds this repository yet rather than anything
+/// the caller asked for wrongly.
+pub fn running_daemon_required_error(command: &str, layout: &KinLayout) -> anyhow::Error {
+    anyhow::anyhow!(
+        "no kin daemon is serving {}, so there is no repository authority to record {command}; run \
+         `kin status` in that repository to start one, then re-run",
+        layout.root().display()
+    )
+}
+
 /// Like [`resolve_daemon_url`] but uses the 30-minute MCP idle timeout instead
 /// of the 60-second CLI default when autostarting a daemon.
 ///
@@ -10728,5 +10684,96 @@ mod tests {
         assert_eq!(idle_timeout_to_carry(Some(""), false), None);
         assert_eq!(idle_timeout_to_carry(Some("later"), false), None);
         assert_eq!(idle_timeout_to_carry(Some(" 900 "), false), Some(900));
+    }
+
+    #[test]
+    fn a_dropped_request_names_the_endpoint_the_command_and_the_way_back() {
+        let message = daemon_send_failure_message("http://127.0.0.1:51234", "locate");
+        assert!(
+            message.contains("http://127.0.0.1:51234"),
+            "the reader cannot tell which daemon went away without its endpoint: {message}"
+        );
+        assert!(
+            message.contains("locate"),
+            "the command in flight is the subject of this failure: {message}"
+        );
+        assert!(
+            message.contains("idle window") && message.contains("re-run"),
+            "an idle-window exit is recoverable and the message must say how: {message}"
+        );
+        assert!(
+            !message.starts_with("send "),
+            "the dispatch verb was the defect being fixed: {message}"
+        );
+    }
+
+    #[test]
+    fn an_empty_refusal_body_names_the_log_instead_of_rendering_a_bare_colon() {
+        let message = daemon_http_error("http://127.0.0.1:51234", "locate", 500, "   ").to_string();
+        assert!(
+            !message.ends_with(": "),
+            "a status code with nothing after the colon is the shape being removed: {message}"
+        );
+        assert!(
+            message.contains(".kin/daemon.log"),
+            "a body-less refusal leaves the log as the only remaining evidence: {message}"
+        );
+        assert!(
+            message.contains("500") && message.contains("http://127.0.0.1:51234"),
+            "{message}"
+        );
+    }
+
+    /// A refusal the daemon stayed alive to explain is surfaced verbatim: it has
+    /// already mapped its own error class onto a status and a body, and
+    /// rewording it here would hide which authority refused and why.
+    #[test]
+    fn a_refusal_with_a_body_keeps_the_daemons_own_words() {
+        let message = daemon_http_error(
+            "http://127.0.0.1:51234",
+            "merge",
+            409,
+            "branch main is ahead",
+        )
+        .to_string();
+        assert_eq!(
+            message,
+            "kin merge refused (HTTP 409): branch main is ahead"
+        );
+    }
+
+    #[test]
+    fn the_one_endpointless_resolution_names_the_variable_that_caused_it() {
+        let layout = KinLayout::new(std::path::PathBuf::from("/tmp/kin-fixture-repo"));
+        let message = daemon_required_error("commit", &layout).to_string();
+        assert!(
+            message.contains("KIN_NO_DAEMON"),
+            "this branch is reached only when KIN_NO_DAEMON is set, so it must say so: {message}"
+        );
+        assert!(
+            message.contains("/tmp/kin-fixture-repo"),
+            "the repository with no authority is the subject: {message}"
+        );
+        assert!(
+            message.contains("commit"),
+            "the command that went unanswered belongs in the message: {message}"
+        );
+        assert!(
+            message.contains("unset KIN_NO_DAEMON"),
+            "the remedy is one word away and must be stated: {message}"
+        );
+    }
+
+    /// The autostart path and the already-running path fail for different
+    /// reasons, so naming `KIN_NO_DAEMON` in the second would be a fabrication.
+    #[test]
+    fn a_caller_needing_a_live_daemon_is_not_told_an_unset_variable_caused_it() {
+        let layout = KinLayout::new(std::path::PathBuf::from("/tmp/kin-fixture-repo"));
+        let message = running_daemon_required_error("semantic graph commits", &layout).to_string();
+        assert!(!message.contains("KIN_NO_DAEMON"), "{message}");
+        assert!(
+            message.contains("/tmp/kin-fixture-repo") && message.contains("kin status"),
+            "{message}"
+        );
     }
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 pub(crate) mod probe_process;
@@ -2832,8 +2832,11 @@ fn retire_daemon_endpoint_with_probe(
         Some(pid) => {
             warn!(
                 pid,
-                repo = %kin_root.display(),
-                "preserving daemon endpoint because its recorded owner may still be alive"
+                pid_path = %repo_daemon_pid_path(kin_root).display(),
+                "the endpoint record at {} still names pid {pid}, which this machine will not \
+                 confirm dead, so kin left it published; if that pid belongs to something else, \
+                 remove the file and re-run",
+                repo_daemon_pid_path(kin_root).display()
             );
             Some(format!(
                 "recorded owner pid {pid} never became affirmatively dead"
@@ -2842,8 +2845,11 @@ fn retire_daemon_endpoint_with_probe(
         None if !recorded.pid_exists => retire_within_budget(kin_root, teardown_budget),
         None => {
             warn!(
-                repo = %kin_root.display(),
-                "preserving daemon endpoint because its PID record is unparseable"
+                pid_path = %repo_daemon_pid_path(kin_root).display(),
+                "the endpoint record at {} does not hold a pid kin can read, so kin left it \
+                 published rather than retiring an endpoint it cannot identify; remove the file \
+                 if no kin daemon is running for this repository",
+                repo_daemon_pid_path(kin_root).display()
             );
             Some("its PID record is unparseable".to_string())
         }
@@ -3158,19 +3164,21 @@ where
     let _authority = match try_acquire_daemon_endpoint_authority(kin_root) {
         Ok(authority) => authority,
         Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
-            warn!(
-                ?judged,
+            debug!(
+                judged_pid = ?judged.pid,
                 repo = %kin_root.display(),
-                "preserving daemon endpoint because lifecycle authority is contended"
+                "another kin command holds daemon lifecycle authority for this repository, so \
+                 this one left the published endpoint alone"
             );
             return DaemonEndpointRetirement::LifecycleContended;
         }
         Err(error) => {
-            warn!(
-                ?judged,
+            debug!(
+                judged_pid = ?judged.pid,
                 repo = %kin_root.display(),
                 %error,
-                "preserving daemon endpoint because lifecycle authority is unavailable"
+                "daemon lifecycle authority could not be taken for this repository, so this \
+                 command left the published endpoint alone"
             );
             return DaemonEndpointRetirement::CoordinationUnavailable(error.to_string());
         }
@@ -3196,11 +3204,12 @@ where
 
     let current = daemon_endpoint_snapshot(kin_root);
     if current != judged {
-        warn!(
-            ?judged,
-            ?current,
-            "endpoint files changed while this daemon was being judged; \
-             leaving the successor's endpoint intact"
+        debug!(
+            judged_pid = ?judged.pid,
+            successor_pid = ?current.pid,
+            repo = %kin_root.display(),
+            "a successor kin daemon published its own endpoint for this repository while the \
+             previous one was being retired; the successor's record is correct and was left intact"
         );
         return DaemonEndpointRetirement::Changed { current };
     }
@@ -3210,10 +3219,11 @@ where
     match singleton.try_lock_exclusive() {
         Ok(()) => {}
         Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
-            warn!(
-                ?judged,
+            debug!(
+                judged_pid = ?judged.pid,
                 repo = %kin_root.display(),
-                "preserving daemon endpoint because the daemon singleton is held"
+                "the per-repository daemon singleton is still held, so this command left the \
+                 published endpoint alone"
             );
             return DaemonEndpointRetirement::SingletonHeld;
         }
@@ -3233,11 +3243,12 @@ where
     match remove_stale_daemon_files_uncoordinated_with(kin_root, remove_file) {
         Ok(()) => DaemonEndpointRetirement::Retired,
         Err(error) => {
-            warn!(
-                ?judged,
+            debug!(
+                judged_pid = ?judged.pid,
                 repo = %kin_root.display(),
                 %error,
-                "preserving daemon startup authority because endpoint retirement failed"
+                "the endpoint files for this repository could not be removed, so kin kept its \
+                 startup authority rather than leaving a half-retired endpoint"
             );
             DaemonEndpointRetirement::CoordinationUnavailable(error.to_string())
         }
@@ -3349,17 +3360,19 @@ pub fn remove_stale_supervisor_files() {
     let startup_authority = match try_acquire_supervisor_startup_lock_for_cleanup(&dir) {
         Ok(authority) => authority,
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            warn!(
+            debug!(
                 dir = %dir.display(),
-                "preserving supervisor endpoint because cross-version startup authority is held"
+                "another kin command holds supervisor startup authority, so this one left the \
+                 published supervisor endpoint alone"
             );
             return;
         }
         Err(error) => {
-            warn!(
+            debug!(
                 dir = %dir.display(),
                 %error,
-                "preserving supervisor endpoint because cross-version startup authority is unavailable"
+                "supervisor startup authority could not be taken, so this command left the \
+                 published supervisor endpoint alone"
             );
             return;
         }
@@ -3386,23 +3399,27 @@ pub fn remove_stale_supervisor_files() {
             let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded, &startup_authority);
         }
         Some(_) => {
-            warn!(
-                ?recorded,
-                "preserving supervisor endpoint because its owner is live or indeterminate"
+            debug!(
+                pid = ?recorded.pid,
+                dir = %dir.display(),
+                "the supervisor endpoint still names an owner this machine will not confirm \
+                 dead, so kin left it published"
             );
         }
         None if recorded.pid_exists => {
-            warn!(
-                ?recorded,
-                "preserving supervisor endpoint because its owner is live or indeterminate"
+            debug!(
+                dir = %dir.display(),
+                "the supervisor endpoint still names an owner this machine will not confirm \
+                 dead, so kin left it published"
             );
         }
         None if owner_is_gone => {
             let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded, &startup_authority);
         }
-        None => warn!(
-            ?recorded,
-            "preserving supervisor endpoint because its ownership record is incomplete"
+        None => debug!(
+            dir = %dir.display(),
+            "the supervisor endpoint carries no complete ownership record, so kin left it \
+             published rather than retiring an endpoint it cannot identify"
         ),
     }
 }
@@ -3570,11 +3587,12 @@ where
     match remove_supervisor_endpoint_files_with(dir, remove_file) {
         Ok(()) => SupervisorEndpointRetirement::Retired,
         Err(error) => {
-            warn!(
-                ?judged,
+            debug!(
+                judged_pid = ?judged.pid,
                 dir = %dir.display(),
                 %error,
-                "preserving supervisor startup authority because endpoint retirement failed"
+                "the supervisor endpoint files could not be removed, so kin kept its startup \
+                 authority rather than leaving a half-retired endpoint"
             );
             SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string())
         }
@@ -4887,7 +4905,10 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
             }
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
                 if startup_lock_is_stale(&path, stale_after) {
-                    warn!(path = %path.display(), "removing stale daemon startup lock");
+                    debug!(
+                        path = %path.display(),
+                        "cleared a startup lock left by an interrupted kin command"
+                    );
                     let _ = std::fs::remove_file(&path);
                     continue;
                 }
@@ -6202,11 +6223,43 @@ async fn follow_existing_supervisor_publication(
     }
 }
 
+fn supervisor_log_path() -> PathBuf {
+    supervisor_dir().join("supervisor.log")
+}
+
+fn supervisor_log_len() -> u64 {
+    std::fs::metadata(supervisor_log_path())
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+/// Render the supervisor output produced by this start attempt only, mirroring
+/// [`daemon_log_tail_since`]. The exit status of a supervisor that died on
+/// launch is a symptom; the reason is in this log and was previously never read.
+fn supervisor_log_tail_since(since_offset: u64) -> String {
+    let path = supervisor_log_path();
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return format!("supervisor log unavailable at {}", path.display());
+    };
+    let fresh = content
+        .get(since_offset as usize..)
+        .unwrap_or(&content)
+        .trim();
+    if fresh.is_empty() {
+        return format!(
+            "no fresh supervisor output captured for this start attempt at {}",
+            path.display()
+        );
+    }
+    let lines: Vec<&str> = fresh.lines().rev().take(20).collect();
+    lines.into_iter().rev().collect::<Vec<_>>().join("\n")
+}
+
 fn open_supervisor_log() -> Result<File> {
     let dir = supervisor_dir();
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create supervisor state directory {}", dir.display()))?;
-    let log_path = dir.join("supervisor.log");
+    let log_path = supervisor_log_path();
     OpenOptions::new()
         .create(true)
         .append(true)
@@ -6218,6 +6271,7 @@ async fn wait_for_supervisor_ready(
     child: &mut Child,
     deadline: Instant,
     startup_authority: &mut SupervisorStartupLock,
+    log_offset: u64,
 ) -> Result<String> {
     let timeout = deadline.saturating_duration_since(Instant::now());
     let client = daemon_health_client();
@@ -6226,7 +6280,12 @@ async fn wait_for_supervisor_ready(
 
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().context("check supervisor child status")? {
-            bail!("supervisor exited during startup with status {status}");
+            bail!(
+                "the kin supervisor exited during startup with status {status}; recent log from \
+                 {}:\n{}",
+                supervisor_log_path().display(),
+                supervisor_log_tail_since(log_offset)
+            );
         }
         if Instant::now() >= next_startup_heartbeat {
             if !startup_authority
@@ -6348,6 +6407,7 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         SUPERVISOR_STARTUP_GENERATION_ENV,
         startup_authority.generation(),
     );
+    let log_offset = supervisor_log_len();
     let log = open_supervisor_log()?;
     let stderr = log
         .try_clone()
@@ -6365,7 +6425,8 @@ pub async fn ensure_supervisor_running() -> Result<String> {
 
     let mut child = cmd.spawn().context("spawn kin supervisor")?;
     let deadline = Instant::now() + Duration::from_secs(daemon_ready_timeout_secs());
-    let base_url = wait_for_supervisor_ready(&mut child, deadline, &mut startup_authority).await?;
+    let base_url =
+        wait_for_supervisor_ready(&mut child, deadline, &mut startup_authority, log_offset).await?;
     if let Err(error) = startup_authority.verify_adoption(child.id()) {
         let _ = child.kill();
         let _ = child.wait();

--- a/crates/kin-cli/tests/locate_json_stdout.rs
+++ b/crates/kin-cli/tests/locate_json_stdout.rs
@@ -566,8 +566,12 @@ fn locate_ref_resolves_admitted_history_without_hydrating_from_git() {
     );
     let absent_stderr = String::from_utf8_lossy(&absent.stderr);
     assert!(
-        absent_stderr.contains("has no imported repository-v6 alias"),
+        absent_stderr.contains("was never imported into this repository"),
         "absent ref must fail as an explicit graph gap: {absent_stderr}"
+    );
+    assert!(
+        !absent_stderr.contains("repository-v6"),
+        "the on-disk layout version is not a noun the reader has: {absent_stderr}"
     );
 }
 

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -23,8 +23,7 @@ use kin_model::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
-use tracing::warn;
-use tracing::{info, info_span};
+use tracing::{debug, info, info_span};
 
 use crate::config::KinConfig;
 use crate::error::{KinError, Result};
@@ -2204,6 +2203,7 @@ fn recover_orphaned_repository_stages(
             .map_err(|error| KinError::io(staging_parent, error))?;
         entries.sort_by_key(std::fs::DirEntry::file_name);
         let mut recovered = 0;
+        let mut retained = 0;
         for entry in entries {
             let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
                 continue;
@@ -2215,11 +2215,12 @@ fn recover_orphaned_repository_stages(
             let owner_file = match open_stage_owner_for_recovery(&owner_path) {
                 Ok(file) => file,
                 Err(error) => {
-                    warn!(
+                    debug!(
                         path = %owner_path.display(),
                         %error,
                         "retaining unprovable repository stage owner"
                     );
+                    retained += 1;
                     continue;
                 }
             };
@@ -2229,11 +2230,12 @@ fn recover_orphaned_repository_stages(
             let record = match read_stage_owner_record(&owner_file, &owner_path) {
                 Ok(record) => record,
                 Err(error) => {
-                    warn!(
+                    debug!(
                         path = %owner_path.display(),
                         %error,
                         "retaining repository stage with invalid owner record"
                     );
+                    retained += 1;
                     continue;
                 }
             };
@@ -2258,31 +2260,34 @@ fn recover_orphaned_repository_stages(
             let stage_exists = match filesystem_entry_exists(&stage_root) {
                 Ok(exists) => exists,
                 Err(error) => {
-                    warn!(
+                    debug!(
                         path = %stage_root.display(),
                         %error,
                         "retaining repository stage whose presence is not provable"
                     );
+                    retained += 1;
                     continue;
                 }
             };
             let reap_exists = match filesystem_entry_exists(&reap_root) {
                 Ok(exists) => exists,
                 Err(error) => {
-                    warn!(
+                    debug!(
                         path = %reap_root.display(),
                         %error,
                         "retaining repository stage whose recovery state is not provable"
                     );
+                    retained += 1;
                     continue;
                 }
             };
             if stage_exists && reap_exists {
-                warn!(
+                debug!(
                     stage = %stage_root.display(),
                     reap = %reap_root.display(),
                     "retaining ambiguous repository stage recovery state"
                 );
+                retained += 1;
                 continue;
             }
             let owned_root = if reap_exists {
@@ -2306,19 +2311,21 @@ fn recover_orphaned_repository_stages(
                         .map_err(|error| KinError::io(owned_root, error))?,
                 ) != record.stage_identity
             {
-                warn!(
+                debug!(
                     path = %owned_root.display(),
                     "retaining repository stage whose filesystem identity is not provable"
                 );
+                retained += 1;
                 continue;
             }
             if owned_root == &stage_root {
                 if let Err(error) = rename_directory_noreplace(&stage_root, &reap_root) {
-                    warn!(
+                    debug!(
                         path = %stage_root.display(),
                         %error,
                         "retaining repository stage after failed recovery claim"
                     );
+                    retained += 1;
                     continue;
                 }
                 let reaped_identity = recoverable_path_identity(
@@ -2327,10 +2334,11 @@ fn recover_orphaned_repository_stages(
                         .map_err(|error| KinError::io(&reap_root, error))?,
                 );
                 if reaped_identity != record.stage_identity {
-                    warn!(
+                    debug!(
                         path = %reap_root.display(),
                         "retaining claimed repository stage after identity changed"
                     );
+                    retained += 1;
                     continue;
                 }
             }
@@ -2348,6 +2356,21 @@ fn recover_orphaned_repository_stages(
                 count = recovered,
                 destination = %final_kin_dir.display(),
                 "recovered inactive repository initialization stages"
+            );
+        }
+        if retained > 0 {
+            let (noun, pronoun) = if retained == 1 {
+                ("staging directory", "it")
+            } else {
+                ("staging directories", "them")
+            };
+            info!(
+                count = retained,
+                parent = %staging_parent.display(),
+                "kin init kept {retained} earlier {noun} under {} because it could not prove \
+                 {pronoun} unused; that costs disk and nothing else, and {pronoun} can be deleted \
+                 by hand once no kin init is running here",
+                staging_parent.display()
             );
         }
         Ok(recovered)

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -23,7 +23,8 @@ use kin_model::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
-use tracing::{debug, info, info_span};
+use tracing::debug;
+use tracing::{info, info_span};
 
 use crate::config::KinConfig;
 use crate::error::{KinError, Result};

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -57,7 +57,7 @@ pub fn durable_semantic_enrichment_summary(
         .find(|workspace| &workspace.workspace_id == workspace_id)
         .ok_or_else(|| {
             KinError::Graph(format!(
-                "repository-v6 authority has no workspace {workspace_id}"
+                "this repository's authority has no workspace {workspace_id}"
             ))
         })?;
     workspace

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -96,7 +96,7 @@ impl ActiveApiRepositoryAuthority {
                 (
                     StatusCode::FAILED_DEPENDENCY,
                     format!(
-                        "repository-v6 authority has no workspace {}",
+                        "this repository's authority has no workspace {}",
                         self.workspace_id
                     ),
                 )
@@ -107,7 +107,7 @@ impl ActiveApiRepositoryAuthority {
 fn repository_authority_error(error: impl std::fmt::Display) -> (StatusCode, String) {
     (
         StatusCode::FAILED_DEPENDENCY,
-        format!("repository-v6 authority unavailable: {error}"),
+        format!("this repository's authority could not be opened: {error}"),
     )
 }
 
@@ -9310,7 +9310,10 @@ async fn vfs_read(
             .ok_or_else(|| {
                 vfs_read_error(
                     StatusCode::NOT_FOUND,
-                    format!("file not found in repository-v6 workspace tree: {path}"),
+                    format!(
+                        "this workspace holds no file at {path}; run `kin status` to see what it \
+                         does hold"
+                    ),
                 )
             })?;
         let digest = artifact.entry.blob_identity().ok_or_else(|| {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5549,7 +5549,7 @@ async fn review(
     .await
     .map_err(|error| {
         if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
-            (StatusCode::BAD_REQUEST, format!("{error:#}"))
+            (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
         } else {
             internal_error(error)
         }
@@ -5815,7 +5815,7 @@ async fn blame(
     )
     .map_err(|error| {
         if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
-            (StatusCode::BAD_REQUEST, format!("{error:#}"))
+            (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
         } else {
             internal_error(error)
         }
@@ -5851,7 +5851,7 @@ async fn history(
     )
     .map_err(|error| {
         if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
-            (StatusCode::BAD_REQUEST, format!("{error:#}"))
+            (StatusCode::BAD_REQUEST, crate::error::cause_first(&error))
         } else {
             internal_error(error)
         }

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -4,6 +4,19 @@
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// Render an error chain with its root cause as the headline.
+///
+/// `{error:#}` prints the outermost context first, which on the repository
+/// routes is an internal step description such as "resolve exact graph for
+/// branch main", leaving the reason the caller needs at the far end of the
+/// line. Reversing the chain puts the cause where a reader looks for it and
+/// keeps the steps that led there behind it.
+pub fn cause_first(error: &anyhow::Error) -> String {
+    let mut frames: Vec<String> = error.chain().map(ToString::to_string).collect();
+    frames.reverse();
+    frames.join(": ")
+}
+
 #[derive(Error, Debug)]
 pub enum DaemonError {
     #[error("Graph error: {0}")]
@@ -132,3 +145,38 @@ impl From<kin_model::ModelError> for DaemonError {
 }
 
 pub type Result<T> = std::result::Result<T, DaemonError>;
+
+#[cfg(test)]
+mod tests {
+    use super::cause_first;
+    use anyhow::Context;
+
+    #[test]
+    fn the_root_cause_leads_and_the_steps_that_reached_it_follow() {
+        let error = anyhow::anyhow!("branch main has no graph snapshot")
+            .context("resolve exact graph for branch main")
+            .context("prepare merge replay validation");
+        assert_eq!(
+            cause_first(&error),
+            "branch main has no graph snapshot: resolve exact graph for branch main: prepare \
+             merge replay validation"
+        );
+        assert_ne!(
+            cause_first(&error),
+            format!("{error:#}"),
+            "leading with the outermost step is the rendering being replaced"
+        );
+    }
+
+    /// Classification by substring survives the reordering: the repository
+    /// routes read their own refusal text to pick a status code, and a chain
+    /// rendered in either direction contains the same frames.
+    #[test]
+    fn an_uncontextualized_error_renders_exactly_as_itself() {
+        let error = anyhow::anyhow!("rename target is not a simple source identifier");
+        assert_eq!(
+            cause_first(&error),
+            "rename target is not a simple source identifier"
+        );
+    }
+}

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -4,6 +4,22 @@
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// The refusal a workspace whose generation counter cannot advance produces.
+///
+/// Shared because the same three words, "workspace generation overflow", stood
+/// alone at seven call sites across merge, switch, checkout, rollback, and
+/// stash, naming no workspace and offering nothing to do.
+pub fn workspace_generation_exhausted(
+    workspace_id: impl std::fmt::Display,
+    generation: impl std::fmt::Display,
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "workspace {workspace_id} is at generation {generation}, the highest kin can record, so \
+         this command cannot advance it; nothing was written, and a fresh checkout initialized \
+         with `kin init` will carry the work forward"
+    )
+}
+
 /// Render an error chain with its root cause as the headline.
 ///
 /// `{error:#}` prints the outermost context first, which on the repository
@@ -149,7 +165,6 @@ pub type Result<T> = std::result::Result<T, DaemonError>;
 #[cfg(test)]
 mod tests {
     use super::cause_first;
-    use anyhow::Context;
 
     #[test]
     fn the_root_cause_leads_and_the_steps_that_reached_it_follow() {

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -913,10 +913,12 @@ fn switch(
                 semantic_overlay_hash: workspace.semantic_overlay_hash,
                 admission_policy: workspace.admission_policy,
             },
-            new_generation: workspace
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_generation: workspace.generation.checked_add(1).ok_or_else(|| {
+                crate::error::workspace_generation_exhausted(
+                    workspace.workspace_id,
+                    workspace.generation,
+                )
+            })?,
             new_head: WorkspaceHead::Symbolic {
                 target: name.clone(),
             },
@@ -1162,7 +1164,9 @@ fn preflight_switch_delta(
         || snapshot.relations != desired.relations
     {
         bail!(
-            "branch-switch daemon graph preflight did not produce the exact target graph and tree"
+            "the switch preflighted to a graph and tree that do not match the target branch's \
+             head, so kin refused the switch; your workspace is unchanged, so run `kin status` \
+             and try again"
         );
     }
     Ok(())

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -1311,17 +1311,17 @@ fn classify_branch_error(error: anyhow::Error) -> WorkspaceMutationRefusal {
     // pattern-match. It is raised only under `TransitionPolicy::FollowMovedRef`,
     // and it carries no status because no client is ever answered with it.
     if error.downcast_ref::<WorkspaceTracksAnotherRef>().is_some() {
-        return WorkspaceMutationRefusal::TracksAnotherRef(format!("{error:#}"));
+        return WorkspaceMutationRefusal::TracksAnotherRef(crate::error::cause_first(&error));
     }
     client_branch_refusal(error).into()
 }
 
 fn client_branch_refusal(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<BranchBadRequest>().is_some() {
-        return (StatusCode::BAD_REQUEST, format!("{error:#}"));
+        return (StatusCode::BAD_REQUEST, crate::error::cause_first(&error));
     }
     if error.downcast_ref::<BranchConflict>().is_some() {
-        return (StatusCode::CONFLICT, format!("{error:#}"));
+        return (StatusCode::CONFLICT, crate::error::cause_first(&error));
     }
     if let Some(core) = error.downcast_ref::<kin_core::KinError>() {
         let status = match core {
@@ -1333,7 +1333,7 @@ fn client_branch_refusal(error: anyhow::Error) -> (StatusCode, String) {
             }
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
     if let Some(database) = error.downcast_ref::<kin_db::KinDbError>() {
         let status = match database {
@@ -1344,15 +1344,24 @@ fn client_branch_refusal(error: anyhow::Error) -> (StatusCode, String) {
             | kin_db::KinDbError::ConcurrentAccessError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
     if let Some(model) = error.downcast_ref::<kin_model::ModelError>() {
-        return (branch_model_status(model), format!("{error:#}"));
+        return (
+            branch_model_status(model),
+            crate::error::cause_first(&error),
+        );
     }
     if error.downcast_ref::<std::io::Error>().is_some() {
-        return (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"));
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::error::cause_first(&error),
+        );
     }
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn branch_model_status(error: &kin_model::ModelError) -> StatusCode {
@@ -1395,8 +1404,8 @@ fn branch_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode, 
     let identity = refusal.is_identity_refusal();
     let error = refusal.into_error();
     if identity {
-        (StatusCode::CONFLICT, format!("{error:#}"))
+        (StatusCode::CONFLICT, crate::error::cause_first(&error))
     } else {
-        internal_branch_error(format!("{error:#}"))
+        internal_branch_error(crate::error::cause_first(&error))
     }
 }

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -344,7 +344,12 @@ fn plan_and_commit(
             .workspace_mutation
             .as_ref()
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("checkout receipt has no workspace mutation"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "the recorded checkout carries no workspace change to replay, so kin cannot \
+                     resume it; your workspace is unchanged, so run `kin status` and try again"
+                )
+            })?;
         if mutation.workspace_id != workspace.workspace_id
             || mutation.new_generation != workspace.generation
             || mutation.new_tree_hash != workspace.tree_hash
@@ -370,7 +375,9 @@ fn plan_and_commit(
         } = &mutation.expected
         else {
             return Err(CheckoutCommandError::internal(anyhow::anyhow!(
-                "checkout receipt unexpectedly creates a new workspace"
+                "the recorded checkout would create a workspace rather than move this one, so \
+                 kin refused to replay it; your workspace is unchanged, so run `kin status` and \
+                 try again"
             )));
         };
         if previous_tree_hash != *expected_tree_hash {
@@ -437,7 +444,14 @@ fn plan_and_commit(
             .workspaces
             .iter()
             .find(|candidate| candidate.workspace_id == workspace.workspace_id)
-            .ok_or_else(|| anyhow::anyhow!("checkout workspace disappeared after recovery"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "workspace {} is no longer in this repository's authority after the checkout \
+                     was recovered, so kin cannot confirm the result; run `kin status`, then \
+                     `kin health` if it still does not resolve",
+                    workspace.workspace_id
+                )
+            })?;
         if current.generation != mutation.new_generation
             || current.tree_hash != mutation.new_tree_hash
             || current.tree != graph_plan.desired_tree
@@ -505,12 +519,16 @@ fn plan_and_commit(
     })?;
     if daemon_delta.admission_policy_delta.is_some() {
         return Err(CheckoutCommandError::internal(anyhow::anyhow!(
-            "checkout graph preflight unexpectedly changed repository admission policy"
+            "the checkout preflight would have changed this repository's admission policy, \
+             which a checkout never does, so kin refused it; your workspace is unchanged, so run \
+             `kin status` and try again"
         )));
     }
     if daemon_delta.tree_deltas != tree_deltas {
         return Err(CheckoutCommandError::internal(anyhow::anyhow!(
-            "checkout graph preflight was not bound to the exact repository tree transition"
+            "the checkout preflight produced a tree transition that does not match the one \
+             authority planned, so kin refused it; your workspace is unchanged, so run \
+             `kin status` and try again"
         )));
     }
     // The authority-side transition is planned from the workspace lease, not
@@ -519,7 +537,9 @@ fn plan_and_commit(
     // would ask authority to publish or retract semantics it never owned.
     let workspace_graph = workspace_graph.ok_or_else(|| {
         CheckoutCommandError::internal(anyhow::anyhow!(
-            "checkout planning reached the authority transition without a workspace authority graph"
+            "the checkout reached the point of publishing without a workspace authority graph \
+             to publish against, so kin refused it; your workspace is unchanged, so run \
+             `kin status` and try again"
         ))
     })?;
     let authority_graph = kin_db::InMemoryGraph::from_snapshot(workspace_graph)
@@ -666,10 +686,12 @@ fn plan_and_commit(
                 semantic_overlay_hash: workspace.semantic_overlay_hash,
                 admission_policy: workspace.admission_policy,
             },
-            new_generation: workspace
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_generation: workspace.generation.checked_add(1).ok_or_else(|| {
+                crate::error::workspace_generation_exhausted(
+                    workspace.workspace_id,
+                    workspace.generation,
+                )
+            })?,
             new_head: workspace.head.clone(),
             new_base_target: workspace.base_target.clone(),
             new_base_tree_hash: workspace.base_tree_hash,

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -87,9 +87,12 @@ impl CheckoutCommandError {
 
     fn into_http(self) -> (StatusCode, String) {
         match self {
-            Self::BadRequest(error) => (StatusCode::BAD_REQUEST, format!("{error:#}")),
-            Self::Conflict(error) => (StatusCode::CONFLICT, format!("{error:#}")),
-            Self::Internal(error) => (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}")),
+            Self::BadRequest(error) => (StatusCode::BAD_REQUEST, crate::error::cause_first(&error)),
+            Self::Conflict(error) => (StatusCode::CONFLICT, crate::error::cause_first(&error)),
+            Self::Internal(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                crate::error::cause_first(&error),
+            ),
         }
     }
 }

--- a/crates/kin-daemon/src/repository_drift.rs
+++ b/crates/kin-daemon/src/repository_drift.rs
@@ -168,7 +168,7 @@ fn local_workspace<'a>(
 
 fn classify_drift_error(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<DriftConflict>().is_some() {
-        return (StatusCode::CONFLICT, format!("{error:#}"));
+        return (StatusCode::CONFLICT, crate::error::cause_first(&error));
     }
     if let Some(core) = error.downcast_ref::<kin_core::KinError>() {
         let status = match core {
@@ -176,17 +176,23 @@ fn classify_drift_error(error: anyhow::Error) -> (StatusCode, String) {
             | kin_core::KinError::ProjectionConflict(_) => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn drift_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode, String) {
     let identity = refusal.is_identity_refusal();
     let error = refusal.into_error();
     if identity {
-        (StatusCode::CONFLICT, format!("{error:#}"))
+        (StatusCode::CONFLICT, crate::error::cause_first(&error))
     } else {
-        (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::error::cause_first(&error),
+        )
     }
 }

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -1938,10 +1938,10 @@ pub(crate) fn local_workspace<'a>(
 
 pub(crate) fn classify_merge_error(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<MergeBadRequest>().is_some() {
-        return (StatusCode::BAD_REQUEST, format!("{error:#}"));
+        return (StatusCode::BAD_REQUEST, crate::error::cause_first(&error));
     }
     if error.downcast_ref::<MergeConflictRefusal>().is_some() {
-        return (StatusCode::CONFLICT, format!("{error:#}"));
+        return (StatusCode::CONFLICT, crate::error::cause_first(&error));
     }
     if let Some(core) = error.downcast_ref::<kin_core::KinError>() {
         let status = match core {
@@ -1950,19 +1950,22 @@ pub(crate) fn classify_merge_error(error: anyhow::Error) -> (StatusCode, String)
             | kin_core::KinError::ProjectionConflict(_) => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
     if let Some(database) = error.downcast_ref::<kin_db::KinDbError>() {
         let status = match database {
             kin_db::KinDbError::Model(model) => merge_model_status(model),
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
     if let Some(model) = error.downcast_ref::<kin_model::ModelError>() {
-        return (merge_model_status(model), format!("{error:#}"));
+        return (merge_model_status(model), crate::error::cause_first(&error));
     }
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn merge_model_status(error: &kin_model::ModelError) -> StatusCode {
@@ -2000,9 +2003,12 @@ pub(crate) fn merge_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (St
     let identity = refusal.is_identity_refusal();
     let error = refusal.into_error();
     if identity {
-        (StatusCode::CONFLICT, format!("{error:#}"))
+        (StatusCode::CONFLICT, crate::error::cause_first(&error))
     } else {
-        (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::error::cause_first(&error),
+        )
     }
 }
 

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -621,7 +621,14 @@ fn three_way(
         .resolve_graph_at(&change.id)
         .context("replay the exact merge change")?;
     if authoritative.tree != desired_tree {
-        bail!("replaying the merge change did not reproduce the composed merged tree");
+        bail!(
+            "merging {} into {} produced a change that does not replay to the same tree, so kin \
+             refused to publish it; nothing was written, so re-run `kin merge {}` and report the \
+             mismatch if it repeats",
+            request.source,
+            plan.target_ref,
+            request.source
+        );
     }
     let desired_tree_hash =
         compute_resolved_tree_hash(&desired_tree).context("hash exact merged tree")?;
@@ -964,7 +971,13 @@ pub(crate) fn publish_resolved_merge(
         .resolve_graph_at(&change.id)
         .context("replay the exact merge change")?;
     if authoritative.tree != desired_tree {
-        bail!("replaying the merge change did not reproduce the resolved merged tree");
+        bail!(
+            "the resolution of {} into {} produced a change that does not replay to the same \
+             tree, so kin refused to publish it; nothing was written, and your recorded conflict \
+             resolutions are still there for another `kin resolve`",
+            record.binding.source_ref,
+            record.binding.target_ref
+        );
     }
     let desired_tree_hash =
         compute_resolved_tree_hash(&desired_tree).context("hash exact merged tree")?;
@@ -1502,10 +1515,12 @@ fn workspace_mutation(
             semantic_overlay_hash: workspace.semantic_overlay_hash,
             admission_policy: workspace.admission_policy,
         },
-        new_generation: workspace
-            .generation
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+        new_generation: workspace.generation.checked_add(1).ok_or_else(|| {
+            crate::error::workspace_generation_exhausted(
+                workspace.workspace_id,
+                workspace.generation,
+            )
+        })?,
         new_head: workspace.head.clone(),
         new_base_target: Some(new_base_target),
         new_base_tree_hash: Some(new_tree_hash),
@@ -1546,10 +1561,17 @@ fn preflight_merge_delta(
         .context("apply merge daemon graph preflight")?;
     let snapshot = preflight.to_snapshot();
     if snapshot.resolved_tree != *desired_tree {
-        bail!("merge daemon graph preflight did not produce the exact merged tree");
+        bail!(
+            "the merge preflighted to a tree that does not match the one it composed, so kin \
+             refused to publish it; your workspace is unchanged, so run `kin status` and try again"
+        );
     }
     if snapshot.entities != *desired_entities || snapshot.relations != *desired_relations {
-        bail!("merge daemon graph preflight did not produce the exact merged semantics");
+        bail!(
+            "the merge preflighted to graph semantics that do not match the ones it composed, so \
+             kin refused to publish it; your workspace is unchanged, so run `kin status` and try \
+             again"
+        );
     }
     Ok(())
 }

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -576,7 +576,7 @@ fn three_way(
     if admission_policy_delta.is_some() || shared_policy != plan.ours_policy {
         return Err(merge_conflict(format!(
             "merging {} into {} changes the shared admission policy; a merge that transitions \
-             admission policy is not a proven repository-v6 shape",
+             admission policy is not a shape kin merges",
             request.source, plan.target_ref
         )));
     }
@@ -927,7 +927,7 @@ pub(crate) fn publish_resolved_merge(
     if admission_policy_delta.is_some() || shared_policy != ours_policy {
         return Err(merge_conflict(format!(
             "merging {} into {} changes the shared admission policy; a merge that transitions \
-             admission policy is not a proven repository-v6 shape",
+             admission policy is not a shape kin merges",
             record.binding.source_ref, record.binding.target_ref
         )));
     }

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -184,16 +184,18 @@ fn plan_and_publish(
     let base = match bases.as_slice() {
         [] => {
             return Err(merge_conflict(format!(
-                "branch {} and the active branch {} share no common change; merging unrelated \
-                 histories is not a proven repository-v6 shape",
+                "branch {} and the active branch {} share no common ancestor, and kin does not \
+                 merge unrelated histories; rebase the source onto the target first, or import \
+                 them separately",
                 request.source, plan.target_ref
             )))
         }
         [base] => *base,
         multiple => {
             return Err(merge_conflict(format!(
-                "branch {} and the active branch {} have {} merge bases; a criss-cross merge is \
-                 not a proven repository-v6 shape",
+                "branch {} and the active branch {} have {} merge bases, and kin does not \
+                 resolve a criss-cross merge; merge one of the intermediate branches first so a \
+                 single base remains",
                 request.source,
                 plan.target_ref,
                 multiple.len()

--- a/crates/kin-daemon/src/repository_rename.rs
+++ b/crates/kin-daemon/src/repository_rename.rs
@@ -188,7 +188,9 @@ fn plan_commit_and_retain_authority(
     .context("plan one exact repository-v6 rename transaction")?;
     if native.change.tree_deltas.is_empty() || native.change.entity_deltas.is_empty() {
         bail!(
-            "rename transaction did not carry both exact tree and semantic deltas; refusing a partial publication"
+            "the rename produced only half of the change it has to publish, either the file edits \
+             or the graph edits but not both, so kin refused a partial publication; nothing was \
+             written, so re-run the rename and report it if it repeats"
         );
     }
     let planned_delta = TransactionDelta {
@@ -597,12 +599,21 @@ fn prove_plan_postconditions(
     after: &kin_db::InMemoryGraph,
     plan: &RenamePlan,
 ) -> Result<()> {
-    let old = before
-        .get_entity(&plan.entity_id)?
-        .ok_or_else(|| anyhow::anyhow!("rename target disappeared from its authority base"))?;
-    let new = after
-        .get_entity(&plan.entity_id)?
-        .ok_or_else(|| anyhow::anyhow!("rename target identity disappeared after reparse"))?;
+    let old = before.get_entity(&plan.entity_id)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "the entity {} being renamed is no longer in this repository's authority base, so \
+                 kin refused the rename; nothing was written, so run `kin status` and try again",
+            plan.entity_id
+        )
+    })?;
+    let new = after.get_entity(&plan.entity_id)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "the entity {} being renamed did not survive reparsing the edited source, so kin \
+                 refused the rename; nothing was written, so check the file still parses and try \
+                 again",
+            plan.entity_id
+        )
+    })?;
     if old.name != plan.old_name || new.name != plan.new_name || old.kind != new.kind {
         bail!(
             "rename did not preserve graph identity {} across '{}' -> '{}'",
@@ -633,9 +644,9 @@ fn prove_plan_postconditions(
             .copied()
             .collect::<Vec<_>>();
         bail!(
-            "rename reparse changed graph relation identity topology (dropped: {:?}, added: {:?}); refusing semantic drift",
-            dropped,
-            added
+            "reparsing the renamed source changed which relations this repository holds, \
+             dropping {dropped:?} and adding {added:?}, so kin refused the rename rather than \
+             publish semantic drift; nothing was written"
         );
     }
     for (relation_id, prior) in &before_snapshot.relations {
@@ -661,7 +672,11 @@ fn prove_plan_postconditions(
         .iter()
         .any(|relation_id| !after_snapshot.relations.contains_key(relation_id))
     {
-        bail!("rename reparse lost a graph relation that selected an edit site");
+        bail!(
+            "reparsing the renamed source lost a relation that had selected one of the edit \
+             sites, so kin refused the rename rather than publish an incomplete one; nothing was \
+             written"
+        );
     }
     Ok(())
 }

--- a/crates/kin-daemon/src/repository_rename.rs
+++ b/crates/kin-daemon/src/repository_rename.rs
@@ -793,7 +793,7 @@ fn stabilize_recovered_layout(
 }
 
 fn rename_error(error: anyhow::Error) -> (StatusCode, String) {
-    let message = format!("{error:#}");
+    let message = crate::error::cause_first(&error);
     let status = if message.contains("not a simple source identifier") {
         StatusCode::BAD_REQUEST
     } else {

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -809,10 +809,10 @@ fn parse_change_id(value: &str) -> Result<SemanticChangeId> {
 
 fn classify_rollback_error(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<RollbackBadRequest>().is_some() {
-        return (StatusCode::BAD_REQUEST, format!("{error:#}"));
+        return (StatusCode::BAD_REQUEST, crate::error::cause_first(&error));
     }
     if error.downcast_ref::<RollbackConflict>().is_some() {
-        return (StatusCode::CONFLICT, format!("{error:#}"));
+        return (StatusCode::CONFLICT, crate::error::cause_first(&error));
     }
     if let Some(core) = error.downcast_ref::<kin_core::KinError>() {
         let status = match core {
@@ -820,7 +820,7 @@ fn classify_rollback_error(error: anyhow::Error) -> (StatusCode, String) {
             | kin_core::KinError::ProjectionConflict(_) => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
     if let Some(model) = error.downcast_ref::<kin_model::ModelError>() {
         let status = match model {
@@ -833,9 +833,12 @@ fn classify_rollback_error(error: anyhow::Error) -> (StatusCode, String) {
             | kin_model::ModelError::ChangeNotFound(_) => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn repository_finalization_error(error: crate::error::DaemonError) -> (StatusCode, String) {
@@ -852,8 +855,11 @@ fn rollback_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode
     let identity = refusal.is_identity_refusal();
     let error = refusal.into_error();
     if identity {
-        (StatusCode::CONFLICT, format!("{error:#}"))
+        (StatusCode::CONFLICT, crate::error::cause_first(&error))
     } else {
-        (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::error::cause_first(&error),
+        )
     }
 }

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -381,10 +381,12 @@ fn plan_and_commit(
                 semantic_overlay_hash: workspace.semantic_overlay_hash,
                 admission_policy: workspace.admission_policy,
             },
-            new_generation: workspace
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_generation: workspace.generation.checked_add(1).ok_or_else(|| {
+                crate::error::workspace_generation_exhausted(
+                    workspace.workspace_id,
+                    workspace.generation,
+                )
+            })?,
             new_head: workspace.head.clone(),
             new_base_target: Some(new_target),
             new_base_tree_hash: Some(target_tree_hash),
@@ -788,7 +790,11 @@ fn preflight_rollback_delta(
         || snapshot.entities != desired.entities
         || snapshot.relations != desired.relations
     {
-        bail!("rollback daemon graph preflight did not produce the exact restored graph and tree");
+        bail!(
+            "the rollback preflighted to a graph and tree that do not match the state it is \
+             restoring, so kin refused to publish it; your workspace is unchanged, so run \
+             `kin status` and try again"
+        );
     }
     Ok(())
 }

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -1214,7 +1214,7 @@ fn render_list(report: &StashListReport) -> Vec<String> {
 
 fn classify_stash_error(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<StashConflict>().is_some() {
-        return (StatusCode::CONFLICT, format!("{error:#}"));
+        return (StatusCode::CONFLICT, crate::error::cause_first(&error));
     }
     if let Some(kin_core::KinError::ProjectionConflict(message)) =
         error.downcast_ref::<kin_core::KinError>()
@@ -1224,19 +1224,25 @@ fn classify_stash_error(error: anyhow::Error) -> (StatusCode, String) {
     for cause in error.chain() {
         if let Some(model) = cause.downcast_ref::<kin_model::ModelError>() {
             if matches!(model, kin_model::ModelError::Conflict(_)) {
-                return (StatusCode::CONFLICT, format!("{error:#}"));
+                return (StatusCode::CONFLICT, crate::error::cause_first(&error));
             }
         }
     }
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn repository_finalization_error(error: crate::error::DaemonError) -> (StatusCode, String) {
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
 }
 
 fn internal_stash_error(error: anyhow::Error) -> (StatusCode, String) {
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn stash_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode, String) {

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -434,10 +434,12 @@ fn push(
         workspace_mutation: Some(WorkspaceMutation {
             workspace_id: workspace.workspace_id,
             expected: expect_exact(&workspace),
-            new_generation: workspace
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_generation: workspace.generation.checked_add(1).ok_or_else(|| {
+                crate::error::workspace_generation_exhausted(
+                    workspace.workspace_id,
+                    workspace.generation,
+                )
+            })?,
             new_head: kin_model::WorkspaceHead::Detached {
                 target: RefTarget::change(sealed_change_id),
             },
@@ -580,44 +582,48 @@ fn return_to_base(
         admission_policy_delta: None,
         external_reference_deltas: Vec::new(),
     };
-    let transaction = RepositoryTransaction {
-        schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
-        operation_id: OperationId::new(),
-        repository_id: authority.repository_id.clone(),
-        expected_generation: roots.generation,
-        expected_roots: roots,
-        actor: plan.actor.clone(),
-        reason: RETURN_REASON.to_string(),
-        external_objects: Vec::new(),
-        git_authority_delta: None,
-        changes: Vec::new(),
-        aliases: Vec::new(),
-        ref_mutations: Vec::new(),
-        default_ref_mutation: None,
-        workspace_mutation: Some(WorkspaceMutation {
-            workspace_id: plan.sealed_workspace.workspace_id,
-            expected: expect_exact(&plan.sealed_workspace),
-            new_generation: plan
-                .sealed_workspace
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
-            new_head: plan.base_head,
-            new_base_target: Some(plan.base_target),
-            new_base_tree_hash: Some(base_tree_hash),
-            tree_deltas,
-            new_tree_hash: base_tree_hash,
-            semantic_delta,
-            new_shared_admission_policy: plan.base_policy.clone(),
-            new_admission_policy: EffectiveAdmissionPolicyStamp {
-                shared: plan.base_policy.stamp(),
-                local: plan.sealed_workspace.admission_policy.local,
-            },
-        }),
-        local_overlay_delta: None,
-        merge_transaction_delta: None,
-        sealed_observation: None,
-    };
+    let transaction =
+        RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::new(),
+            repository_id: authority.repository_id.clone(),
+            expected_generation: roots.generation,
+            expected_roots: roots,
+            actor: plan.actor.clone(),
+            reason: RETURN_REASON.to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: Vec::new(),
+            default_ref_mutation: None,
+            workspace_mutation: Some(WorkspaceMutation {
+                workspace_id: plan.sealed_workspace.workspace_id,
+                expected: expect_exact(&plan.sealed_workspace),
+                new_generation: plan.sealed_workspace.generation.checked_add(1).ok_or_else(
+                    || {
+                        crate::error::workspace_generation_exhausted(
+                            plan.sealed_workspace.workspace_id,
+                            plan.sealed_workspace.generation,
+                        )
+                    },
+                )?,
+                new_head: plan.base_head,
+                new_base_target: Some(plan.base_target),
+                new_base_tree_hash: Some(base_tree_hash),
+                tree_deltas,
+                new_tree_hash: base_tree_hash,
+                semantic_delta,
+                new_shared_admission_policy: plan.base_policy.clone(),
+                new_admission_policy: EffectiveAdmissionPolicyStamp {
+                    shared: plan.base_policy.stamp(),
+                    local: plan.sealed_workspace.admission_policy.local,
+                },
+            }),
+            local_overlay_delta: None,
+            merge_transaction_delta: None,
+            sealed_observation: None,
+        };
     transaction
         .validate()
         .context("validate the exact workspace return transaction")?;
@@ -810,10 +816,12 @@ fn pop(
         workspace_mutation: Some(WorkspaceMutation {
             workspace_id: workspace.workspace_id,
             expected: expect_exact(&workspace),
-            new_generation: workspace
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_generation: workspace.generation.checked_add(1).ok_or_else(|| {
+                crate::error::workspace_generation_exhausted(
+                    workspace.workspace_id,
+                    workspace.generation,
+                )
+            })?,
             new_head: workspace.head.clone(),
             new_base_target: workspace.base_target.clone(),
             new_base_tree_hash: workspace.base_tree_hash,
@@ -1096,9 +1104,13 @@ fn next_stash_ordinal(metadata: &kin_db::PersistedRepositoryAuthority) -> Result
         .filter_map(|repository_ref| stash_ref_ordinal(&repository_ref.name))
         .max();
     match highest {
-        Some(highest) => highest
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("repository stash ordinals are exhausted")),
+        Some(highest) => highest.checked_add(1).ok_or_else(|| {
+            anyhow::anyhow!(
+                "this repository has used every stash ordinal kin can record, so it cannot \
+                     take another stash; nothing was written, so drop stashes you no longer need \
+                     with `kin stash pop`"
+            )
+        }),
         None => Ok(0),
     }
 }

--- a/crates/kin-daemon/src/repository_tag.rs
+++ b/crates/kin-daemon/src/repository_tag.rs
@@ -272,7 +272,11 @@ fn bind_snapshot(
     }
     let artifact_count = source.tree.artifacts().len();
     let [mutation] = receipt.operation.ref_mutations.as_slice() else {
-        bail!("a released tag receipt must carry exactly one ref mutation");
+        bail!(
+            "the release for {change_id} recorded something other than exactly one ref change, so \
+             kin refused to publish the tag; nothing was written, so re-run `kin tag` and report \
+             it if it repeats"
+        );
     };
     ReleaseSnapshot {
         schema: RELEASE_SNAPSHOT_SCHEMA.to_string(),

--- a/crates/kin-daemon/src/repository_tag.rs
+++ b/crates/kin-daemon/src/repository_tag.rs
@@ -527,13 +527,16 @@ fn require_tag_ref(name: &RefName) -> Result<()> {
 
 fn classify_tag_error(error: anyhow::Error) -> (StatusCode, String) {
     if error.downcast_ref::<TagBadRequest>().is_some() {
-        return (StatusCode::BAD_REQUEST, format!("{error:#}"));
+        return (StatusCode::BAD_REQUEST, crate::error::cause_first(&error));
     }
     if error.downcast_ref::<TagPolicyRefusal>().is_some() {
-        return (StatusCode::PRECONDITION_FAILED, format!("{error:#}"));
+        return (
+            StatusCode::PRECONDITION_FAILED,
+            crate::error::cause_first(&error),
+        );
     }
     if error.downcast_ref::<TagConflict>().is_some() {
-        return (StatusCode::CONFLICT, format!("{error:#}"));
+        return (StatusCode::CONFLICT, crate::error::cause_first(&error));
     }
     if let Some(model) = error.downcast_ref::<kin_model::ModelError>() {
         let status = match model {
@@ -546,14 +549,17 @@ fn classify_tag_error(error: anyhow::Error) -> (StatusCode, String) {
             | kin_model::ModelError::ChangeNotFound(_) => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        return (status, format!("{error:#}"));
+        return (status, crate::error::cause_first(&error));
     }
     if let Some(database) = error.downcast_ref::<kin_db::KinDbError>() {
         if matches!(database, kin_db::KinDbError::Model(_)) {
-            return (StatusCode::CONFLICT, format!("{error:#}"));
+            return (StatusCode::CONFLICT, crate::error::cause_first(&error));
         }
     }
-    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::error::cause_first(&error),
+    )
 }
 
 fn repository_finalization_error(error: crate::error::DaemonError) -> (StatusCode, String) {
@@ -570,8 +576,11 @@ fn tag_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode, Str
     let identity = refusal.is_identity_refusal();
     let error = refusal.into_error();
     if identity {
-        (StatusCode::CONFLICT, format!("{error:#}"))
+        (StatusCode::CONFLICT, crate::error::cause_first(&error))
     } else {
-        (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            crate::error::cause_first(&error),
+        )
     }
 }


### PR DESCRIPTION
Every daemon-backed command used to report a dropped request as `send daemon
locate request`, with the real reason two frames down and nothing to act on. The
send context is now built from the endpoint and the command in flight, and it
names the idle-window exit that usually caused it. That is one change at one
call site covering the most common error in the product.

Three more shared constructors follow the same shape. The thirty-nine HTTP
refusal sites now go through one helper modelled on the transfer path that
already got it right, with a distinct branch for an empty body so `HTTP 500: `
with nothing after the colon can no longer be printed. The forty-seven commands
that answered a missing endpoint with "Kin daemon is required for X" now name
`KIN_NO_DAEMON`, which is the only condition that reaches that branch, and the
handful that need an already-serving daemon say that instead rather than blaming
a variable nobody set. The repository routes render their error chain cause
first, so `kin merge` leads with the reason rather than with "resolve exact graph
for branch main".

The noise came off the terminal too. The CLI installs its filter at warn with no
`RUST_LOG`, so eight stage-retention warnings printed above `kin init`'s own
admission report and thirteen more narrated endpoint retirement during `kin
daemon stop`, one of them reporting a success with a struct dump. Those are debug
now, with one summary naming how many staging directories were kept and where.
The two that stay warnings are the ones a user can act on, and each names the pid
file. The supervisor startup failure gains the log tail its repo-daemon twin
already printed.

Twenty-five internal assertions that shipped as HTTP bodies now carry a subject,
an effect, and a way forward. "workspace generation overflow" was the worst,
three words at seven call sites naming no workspace, and it is now one
constructor carrying the workspace id and the generation it reached. And
`repository-v6`, the on-disk layout generation, is out of twenty-nine
user-facing strings; the schema field values and doc comments keep it because
those are protocol, not prose.

Verification: `cargo fmt --check`, clippy under the ci.yml allowlist with
`-D warnings`, `cargo build --all-targets`, and `kin-dev local-test kin`
(5296 passed, 11 skipped). Ten tests pin the new constructors. Two of them were
falsified by reverting the change under test: removing the empty-body branch
reproduced `kin locate refused (HTTP 500):` with nothing after the colon and
failed its test, and restoring outermost-first rendering failed the cause-first
test with the frames in the old order.

Closes FIR-2157
