### PR TITLE
Repair the eight CLI surface defects the audit ranked highest

### DIFF
--- a/crates/kin-cli/src/commands/cache.rs
+++ b/crates/kin-cli/src/commands/cache.rs
@@ -11,7 +11,9 @@
 //!
 //! - `kin cache status` reports size, entry count, per-schema-version breakdown,
 //!   and an age distribution, and warns loudly when a configured budget is
-//!   exceeded.
+//!   exceeded. It names the directory it is about to read before reading it and
+//!   streams entry counts as it walks, because on a bench-scale cache the walk
+//!   runs for minutes and a silent command is indistinguishable from a hang.
 //! - `kin cache gc` reclaims space: it can drop abandoned schema-version
 //!   subtrees and evict the oldest entries down to a byte budget.
 //!
@@ -23,12 +25,16 @@
 //! corrupt read.
 
 #[cfg(feature = "embeddings")]
+use std::path::{Path, PathBuf};
+#[cfg(feature = "embeddings")]
 use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
 
 #[cfg(feature = "embeddings")]
-use kin_db::embed::cache_admin::{self, CacheStats, GcOptions, GcReport};
+use kin_db::embed::cache_admin::{
+    self, AgeBucket, CacheStats, GcOptions, GcReport, SchemaVersionStats,
+};
 
 /// Render a byte count as a short human-readable string.
 #[cfg(feature = "embeddings")]
@@ -88,37 +94,294 @@ fn resolve_budget(budget_gb: Option<f64>) -> Option<u64> {
     }
 }
 
-/// `kin cache status [--json]` — report cache size, composition, and age.
+/// Entries walked between progress reports. The walk is IO-bound on directory
+/// reads, so reporting per entry would cost more than the scan; a report every
+/// 25k entries puts several lines on a bench-scale cache and none on a small one.
 #[cfg(feature = "embeddings")]
-pub async fn status(json: bool) -> Result<()> {
+const SCAN_PROGRESS_INTERVAL: u64 = 25_000;
+
+/// Age bands, by exclusive upper bound in seconds, youngest first.
+///
+/// A mirror of the private band table behind [`cache_admin::scan_cache`]. The
+/// bands are duplicated rather than imported because the scan that owns them
+/// takes no progress callback and cannot be bounded, and this command needs
+/// both. [`streaming_scan_matches_the_kin_db_scan`] holds the two in agreement
+/// by asserting the whole [`CacheStats`] is equal on a fixture, so a band that
+/// changes upstream fails a test here rather than silently relabelling output.
+#[cfg(feature = "embeddings")]
+const AGE_BANDS: &[(&str, Option<u64>)] = &[
+    ("< 1h", Some(3_600)),
+    ("1h–1d", Some(86_400)),
+    ("1d–7d", Some(604_800)),
+    ("7d–30d", Some(2_592_000)),
+    ("30d–90d", Some(7_776_000)),
+    ("> 90d", None),
+];
+
+/// Whether a scan saw the whole cache or stopped at the caller's bound.
+#[cfg(feature = "embeddings")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScanBound {
+    Complete,
+    /// Stopped after `limit` entries; every total covers only those entries.
+    Truncated { limit: u64 },
+}
+
+#[cfg(feature = "embeddings")]
+impl ScanBound {
+    fn is_complete(self) -> bool {
+        self == ScanBound::Complete
+    }
+}
+
+/// Assign an age to its band index in [`AGE_BANDS`].
+#[cfg(feature = "embeddings")]
+fn age_band_index(age: Duration) -> usize {
+    let secs = age.as_secs();
+    AGE_BANDS
+        .iter()
+        .position(|(_, upper)| upper.is_none_or(|bound| secs < bound))
+        .unwrap_or(AGE_BANDS.len() - 1)
+}
+
+/// The schema-version subtrees directly under `base`, as `(version, path)`.
+#[cfg(feature = "embeddings")]
+fn schema_version_dirs(base: &Path) -> Vec<(String, PathBuf)> {
+    let mut out = Vec::new();
+    let Ok(read_dir) = std::fs::read_dir(base) else {
+        return out;
+    };
+    for entry in read_dir.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        if let Some(name) = entry.file_name().to_str() {
+            out.push((name.to_string(), entry.path()));
+        }
+    }
+    out
+}
+
+/// Visit every finalized `*.bin` entry under `dir`, stopping once `remaining`
+/// is exhausted. Returns false when the walk stopped early.
+///
+/// `truncated` is set only when an entry is actually refused, never merely
+/// because the budget reached zero. A bound that lands exactly on the last
+/// entry read the whole cache, and reporting that as partial would tell a
+/// caller their totals understate a cache the walk had in fact finished.
+///
+/// Best-effort like the scan it mirrors: an unreadable directory or file is
+/// skipped rather than fatal, so a cache with a stray permission is still
+/// reportable. In-flight `*.tmp-*` writes are not entries and are ignored.
+#[cfg(feature = "embeddings")]
+fn visit_bounded(
+    dir: &Path,
+    remaining: &mut Option<u64>,
+    truncated: &mut bool,
+    f: &mut dyn FnMut(u64, SystemTime),
+) -> bool {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return true;
+    };
+    for entry in read_dir.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if !visit_bounded(&entry.path(), remaining, truncated, f) {
+                return false;
+            }
+        } else if file_type.is_file() {
+            if entry.path().extension().and_then(|e| e.to_str()) != Some("bin") {
+                continue;
+            }
+            if remaining.is_some_and(|left| left == 0) {
+                *truncated = true;
+                return false;
+            }
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            f(meta.len(), meta.modified().unwrap_or(SystemTime::UNIX_EPOCH));
+            if let Some(left) = remaining.as_mut() {
+                *left -= 1;
+            }
+        }
+    }
+    true
+}
+
+/// Scan the cache under `base`, calling `on_progress(entries, bytes)` every
+/// [`SCAN_PROGRESS_INTERVAL`] entries and stopping after `limit` entries.
+///
+/// With `limit` unset this produces exactly what [`cache_admin::scan_cache`]
+/// produces; the difference is that the caller can watch it and bound it.
+#[cfg(feature = "embeddings")]
+fn scan_cache_streaming(
+    base: &Path,
+    now: SystemTime,
+    limit: Option<u64>,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> (CacheStats, ScanBound) {
+    let mut total_bytes = 0u64;
+    let mut entry_count = 0u64;
+    let mut oldest: Option<SystemTime> = None;
+    let mut newest: Option<SystemTime> = None;
+    let mut bands: Vec<(u64, u64)> = vec![(0, 0); AGE_BANDS.len()];
+    let mut schema_versions = Vec::new();
+    let mut next_report = SCAN_PROGRESS_INTERVAL;
+
+    let mut remaining = limit;
+    let mut truncated = false;
+    let mut walking = true;
+
+    let current = cache_admin::current_schema_version();
+
+    // Every subtree is still listed once the bound stops the walk, so the
+    // schema-version rollup keeps naming the versions present on disk; only
+    // their counts stop growing.
+    for (version, dir) in schema_version_dirs(base) {
+        let mut sv_bytes = 0u64;
+        let mut sv_count = 0u64;
+        if walking {
+            walking = visit_bounded(&dir, &mut remaining, &mut truncated, &mut |bytes, modified| {
+                sv_bytes += bytes;
+                sv_count += 1;
+                total_bytes += bytes;
+                entry_count += 1;
+                oldest = Some(oldest.map_or(modified, |o| o.min(modified)));
+                newest = Some(newest.map_or(modified, |n| n.max(modified)));
+                let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
+                let band = &mut bands[age_band_index(age)];
+                band.0 += bytes;
+                band.1 += 1;
+                if entry_count >= next_report {
+                    on_progress(entry_count, total_bytes);
+                    next_report += SCAN_PROGRESS_INTERVAL;
+                }
+            });
+        }
+        schema_versions.push(SchemaVersionStats {
+            is_current: version == current,
+            version,
+            bytes: sv_bytes,
+            entry_count: sv_count,
+        });
+    }
+
+    // Current version first, then largest subtrees, so a status view leads with
+    // the live cache and the biggest reclaim candidates.
+    schema_versions.sort_by(|a, b| {
+        b.is_current
+            .cmp(&a.is_current)
+            .then_with(|| b.bytes.cmp(&a.bytes))
+    });
+
+    let age_buckets = AGE_BANDS
+        .iter()
+        .zip(bands)
+        .map(|((label, _), (bytes, entry_count))| AgeBucket {
+            label,
+            bytes,
+            entry_count,
+        })
+        .collect();
+
+    let stats = CacheStats {
+        base: base.to_path_buf(),
+        total_bytes,
+        entry_count,
+        oldest,
+        newest,
+        schema_versions,
+        age_buckets,
+        current_schema_version: current,
+    };
+    let bound = match limit {
+        Some(limit) if truncated => ScanBound::Truncated { limit },
+        _ => ScanBound::Complete,
+    };
+    (stats, bound)
+}
+
+/// `kin cache status [--json] [--limit N]` — report cache size, composition,
+/// and age.
+///
+/// The resolved directory is named before the walk starts and entry counts
+/// stream to stderr as it proceeds. Both exist because this walk is unbounded
+/// by nature: the cache is never evicted from disk, so on a proof machine it
+/// reaches hundreds of thousands of entries and the scan runs for minutes.
+/// Printing only on completion made the command indistinguishable from a hang,
+/// on the command `kin cache gc` recommends by name.
+#[cfg(feature = "embeddings")]
+pub async fn status(json: bool, limit: Option<u64>) -> Result<()> {
+    use std::io::Write;
+
     let Some(base) = cache_admin::embedding_cache_base_dir() else {
         println!("kin cache status: no cache directory resolved (no home directory and KIN_EMBED_CACHE_DIR unset)");
         return Ok(());
     };
 
-    let now = SystemTime::now();
-    let stats = cache_admin::scan_cache(&base, now);
-    let budget = cache_admin::budget_bytes_from_env();
-
+    // Name the tree before reading it. In JSON mode this goes to stderr so
+    // stdout stays one parseable document.
     if json {
-        print_status_json(&stats, budget, now);
+        eprintln!("kin cache status: scanning {}", base.display());
     } else {
-        print_status_human(&stats, budget, now);
+        print_status_header(&base);
+        let _ = std::io::stdout().flush();
+    }
+
+    let now = SystemTime::now();
+    let mut progress = crate::progress::Progress::stderr();
+    let mut reported = false;
+    let (stats, bound) = scan_cache_streaming(&base, now, limit, &mut |entries, bytes| {
+        reported = true;
+        progress.update(format_args!(
+            "scanned {entries} entries, {} so far",
+            human_bytes(bytes)
+        ));
+    });
+    if reported {
+        progress.finish();
+    }
+
+    let budget = cache_admin::budget_bytes_from_env();
+    if json {
+        print_status_json(&stats, budget, now, bound);
+    } else {
+        print_status_body(&stats, budget, now, bound);
     }
     Ok(())
 }
 
 #[cfg(not(feature = "embeddings"))]
-pub async fn status(_json: bool) -> Result<()> {
+pub async fn status(_json: bool, _limit: Option<u64>) -> Result<()> {
     anyhow::bail!(
         "embedding cache management is unsupported in this build; install a Kin build with embedding support"
     )
 }
 
+/// The part of the human report that is known before the walk: what is being
+/// read. Printed and flushed first so a long scan is attributable to a path.
 #[cfg(feature = "embeddings")]
-fn print_status_human(stats: &CacheStats, budget: Option<u64>, now: SystemTime) {
+fn print_status_header(base: &Path) {
     println!("kin cache status");
-    println!("  location: {}", stats.base.display());
+    println!("  location: {}", base.display());
+}
+
+#[cfg(feature = "embeddings")]
+fn print_status_body(
+    stats: &CacheStats,
+    budget: Option<u64>,
+    now: SystemTime,
+    bound: ScanBound,
+) {
+    if let ScanBound::Truncated { limit } = bound {
+        println!(
+            "  WARNING: stopped at the --limit of {limit} entries; every number below covers \
+             only those entries and understates the cache"
+        );
+    }
 
     if stats.entry_count == 0 {
         println!("  cache is empty");
@@ -196,7 +459,12 @@ fn print_status_human(stats: &CacheStats, budget: Option<u64>, now: SystemTime) 
 }
 
 #[cfg(feature = "embeddings")]
-fn print_status_json(stats: &CacheStats, budget: Option<u64>, now: SystemTime) {
+fn print_status_json(
+    stats: &CacheStats,
+    budget: Option<u64>,
+    now: SystemTime,
+    bound: ScanBound,
+) {
     let schema_versions: Vec<_> = stats
         .schema_versions
         .iter()
@@ -232,6 +500,13 @@ fn print_status_json(stats: &CacheStats, budget: Option<u64>, now: SystemTime) {
         "age_buckets": age_buckets,
         "budget_bytes": budget,
         "over_budget": budget.is_some_and(|b| stats.total_bytes > b),
+        // A bounded scan reports real numbers for a subset of the cache, which
+        // reads exactly like a small cache unless the document says otherwise.
+        "scan_complete": bound.is_complete(),
+        "scan_limit": match bound {
+            ScanBound::Truncated { limit } => Some(limit),
+            ScanBound::Complete => None,
+        },
     });
     println!(
         "{}",
@@ -352,7 +627,7 @@ mod unsupported_tests {
     #[tokio::test]
     async fn cache_commands_fail_loud_when_embeddings_are_disabled() {
         for result in [
-            super::status(false).await,
+            super::status(false, None).await,
             super::gc(true, None, false).await,
         ] {
             let message = result.expect_err("vector-free cache command must be unsupported");
@@ -378,6 +653,131 @@ mod tests {
         assert_eq!(human_age(Duration::from_secs(120)), "2m");
         assert_eq!(human_age(Duration::from_secs(7_200)), "2h");
         assert_eq!(human_age(Duration::from_secs(3 * 86_400)), "3d");
+    }
+
+    /// Build a cache fixture: `base/<version>/<shard>/<name>.bin`, plus the
+    /// non-entry files a real cache carries, so the walk has something to skip.
+    fn fixture(entries: &[(&str, &str, u64)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (version, name, bytes) in entries {
+            let shard = dir.path().join(version).join(&name[..2]);
+            std::fs::create_dir_all(&shard).expect("mkdir");
+            std::fs::write(shard.join(format!("{name}.bin")), vec![0u8; *bytes as usize])
+                .expect("write entry");
+            // An in-flight write is not a finalized entry and must not count.
+            std::fs::write(shard.join(format!("{name}.tmp-1")), b"partial").expect("write tmp");
+        }
+        dir
+    }
+
+    fn scan(base: &Path, limit: Option<u64>) -> (CacheStats, ScanBound) {
+        scan_cache_streaming(base, SystemTime::now(), limit, &mut |_, _| {})
+    }
+
+    /// The streaming walk exists only because [`cache_admin::scan_cache`] takes
+    /// no progress callback and cannot be bounded. It must otherwise agree with
+    /// it exactly, including the age-band labels duplicated above. Comparing the
+    /// whole struct is what makes this test able to fail: a band renamed or
+    /// rebounded upstream, a changed sort, or a skipped file all break equality.
+    #[test]
+    fn streaming_scan_matches_the_kin_db_scan() {
+        let dir = fixture(&[
+            ("v2", "aaaa", 4_096),
+            ("v2", "bbbb", 128),
+            ("v1", "cccc", 1_024),
+        ]);
+        let now = SystemTime::now();
+
+        let (streamed, bound) = scan_cache_streaming(dir.path(), now, None, &mut |_, _| {});
+        let authoritative = cache_admin::scan_cache(dir.path(), now);
+
+        assert_eq!(streamed, authoritative);
+        assert_eq!(bound, ScanBound::Complete);
+        assert_eq!(streamed.entry_count, 3, "the .tmp- writes must not count");
+        assert_eq!(streamed.total_bytes, 4_096 + 128 + 1_024);
+    }
+
+    /// An empty cache is a complete scan of nothing, not a truncated one.
+    #[test]
+    fn an_empty_cache_scans_complete() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (stats, bound) = scan(dir.path(), None);
+        assert_eq!(stats.entry_count, 0);
+        assert_eq!(bound, ScanBound::Complete);
+        assert_eq!(stats, cache_admin::scan_cache(dir.path(), SystemTime::now()));
+    }
+
+    /// The bound stops the walk and says so. Without the [`ScanBound`] the
+    /// partial totals are indistinguishable from a small cache.
+    #[test]
+    fn a_limit_stops_the_walk_and_reports_itself_as_partial() {
+        let dir = fixture(&[
+            ("v2", "aaaa", 100),
+            ("v2", "bbbb", 100),
+            ("v2", "cccc", 100),
+            ("v2", "dddd", 100),
+        ]);
+
+        let (stats, bound) = scan(dir.path(), Some(2));
+        assert_eq!(bound, ScanBound::Truncated { limit: 2 });
+        assert_eq!(stats.entry_count, 2);
+        assert_eq!(stats.total_bytes, 200);
+
+        // A bound landing exactly on the last entry read the whole cache. This
+        // is the case the budget-exhausted reading gets wrong, and calling it
+        // partial would understate a total that is in fact exact.
+        let (full, bound) = scan(dir.path(), Some(4));
+        assert_eq!(bound, ScanBound::Complete);
+        assert_eq!(full.entry_count, 4);
+        assert_eq!(full, scan(dir.path(), None).0);
+        let (over, bound) = scan(dir.path(), Some(99));
+        assert_eq!(bound, ScanBound::Complete);
+        assert_eq!(over.entry_count, 4);
+
+        // Zero reads nothing, and must not pass itself off as a complete scan.
+        let (none, bound) = scan(dir.path(), Some(0));
+        assert_eq!(bound, ScanBound::Truncated { limit: 0 });
+        assert_eq!(none.entry_count, 0);
+
+        // But zero against an empty cache IS complete: nothing was refused.
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert_eq!(scan(empty.path(), Some(0)).1, ScanBound::Complete);
+    }
+
+    /// Progress has to arrive while the walk is running, which is the whole
+    /// point: the command was unusable because it printed only on completion.
+    #[test]
+    fn progress_reports_during_the_walk_and_counts_up() {
+        let entries: Vec<(String, u64)> = (0..SCAN_PROGRESS_INTERVAL * 2 + 10)
+            .map(|i| (format!("{i:08x}"), 1))
+            .collect();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let shard = dir.path().join("v2").join("sh");
+        std::fs::create_dir_all(&shard).expect("mkdir");
+        for (name, _) in &entries {
+            std::fs::write(shard.join(format!("{name}.bin")), b"x").expect("write");
+        }
+
+        let mut seen: Vec<(u64, u64)> = Vec::new();
+        let (stats, _) = scan_cache_streaming(
+            dir.path(),
+            SystemTime::now(),
+            None,
+            &mut |count, bytes| seen.push((count, bytes)),
+        );
+
+        assert_eq!(
+            seen.len(),
+            2,
+            "one report per {SCAN_PROGRESS_INTERVAL} entries: {seen:?}"
+        );
+        assert_eq!(seen[0].0, SCAN_PROGRESS_INTERVAL);
+        assert_eq!(seen[1].0, SCAN_PROGRESS_INTERVAL * 2);
+        assert!(
+            seen[0].0 < stats.entry_count,
+            "the first report must land before the walk ends"
+        );
+        assert!(seen[1].1 > seen[0].1, "bytes must accumulate: {seen:?}");
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/cache.rs
+++ b/crates/kin-cli/src/commands/cache.rs
@@ -124,7 +124,9 @@ const AGE_BANDS: &[(&str, Option<u64>)] = &[
 enum ScanBound {
     Complete,
     /// Stopped after `limit` entries; every total covers only those entries.
-    Truncated { limit: u64 },
+    Truncated {
+        limit: u64,
+    },
 }
 
 #[cfg(feature = "embeddings")]
@@ -202,7 +204,10 @@ fn visit_bounded(
             let Ok(meta) = entry.metadata() else {
                 continue;
             };
-            f(meta.len(), meta.modified().unwrap_or(SystemTime::UNIX_EPOCH));
+            f(
+                meta.len(),
+                meta.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            );
             if let Some(left) = remaining.as_mut() {
                 *left -= 1;
             }
@@ -244,22 +249,27 @@ fn scan_cache_streaming(
         let mut sv_bytes = 0u64;
         let mut sv_count = 0u64;
         if walking {
-            walking = visit_bounded(&dir, &mut remaining, &mut truncated, &mut |bytes, modified| {
-                sv_bytes += bytes;
-                sv_count += 1;
-                total_bytes += bytes;
-                entry_count += 1;
-                oldest = Some(oldest.map_or(modified, |o| o.min(modified)));
-                newest = Some(newest.map_or(modified, |n| n.max(modified)));
-                let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
-                let band = &mut bands[age_band_index(age)];
-                band.0 += bytes;
-                band.1 += 1;
-                if entry_count >= next_report {
-                    on_progress(entry_count, total_bytes);
-                    next_report += SCAN_PROGRESS_INTERVAL;
-                }
-            });
+            walking = visit_bounded(
+                &dir,
+                &mut remaining,
+                &mut truncated,
+                &mut |bytes, modified| {
+                    sv_bytes += bytes;
+                    sv_count += 1;
+                    total_bytes += bytes;
+                    entry_count += 1;
+                    oldest = Some(oldest.map_or(modified, |o| o.min(modified)));
+                    newest = Some(newest.map_or(modified, |n| n.max(modified)));
+                    let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
+                    let band = &mut bands[age_band_index(age)];
+                    band.0 += bytes;
+                    band.1 += 1;
+                    if entry_count >= next_report {
+                        on_progress(entry_count, total_bytes);
+                        next_report += SCAN_PROGRESS_INTERVAL;
+                    }
+                },
+            );
         }
         schema_versions.push(SchemaVersionStats {
             is_current: version == current,
@@ -370,12 +380,7 @@ fn print_status_header(base: &Path) {
 }
 
 #[cfg(feature = "embeddings")]
-fn print_status_body(
-    stats: &CacheStats,
-    budget: Option<u64>,
-    now: SystemTime,
-    bound: ScanBound,
-) {
+fn print_status_body(stats: &CacheStats, budget: Option<u64>, now: SystemTime, bound: ScanBound) {
     if let ScanBound::Truncated { limit } = bound {
         println!(
             "  WARNING: stopped at the --limit of {limit} entries; every number below covers \
@@ -459,12 +464,7 @@ fn print_status_body(
 }
 
 #[cfg(feature = "embeddings")]
-fn print_status_json(
-    stats: &CacheStats,
-    budget: Option<u64>,
-    now: SystemTime,
-    bound: ScanBound,
-) {
+fn print_status_json(stats: &CacheStats, budget: Option<u64>, now: SystemTime, bound: ScanBound) {
     let schema_versions: Vec<_> = stats
         .schema_versions
         .iter()
@@ -662,8 +662,11 @@ mod tests {
         for (version, name, bytes) in entries {
             let shard = dir.path().join(version).join(&name[..2]);
             std::fs::create_dir_all(&shard).expect("mkdir");
-            std::fs::write(shard.join(format!("{name}.bin")), vec![0u8; *bytes as usize])
-                .expect("write entry");
+            std::fs::write(
+                shard.join(format!("{name}.bin")),
+                vec![0u8; *bytes as usize],
+            )
+            .expect("write entry");
             // An in-flight write is not a finalized entry and must not count.
             std::fs::write(shard.join(format!("{name}.tmp-1")), b"partial").expect("write tmp");
         }
@@ -704,7 +707,10 @@ mod tests {
         let (stats, bound) = scan(dir.path(), None);
         assert_eq!(stats.entry_count, 0);
         assert_eq!(bound, ScanBound::Complete);
-        assert_eq!(stats, cache_admin::scan_cache(dir.path(), SystemTime::now()));
+        assert_eq!(
+            stats,
+            cache_admin::scan_cache(dir.path(), SystemTime::now())
+        );
     }
 
     /// The bound stops the walk and says so. Without the [`ScanBound`] the
@@ -759,12 +765,10 @@ mod tests {
         }
 
         let mut seen: Vec<(u64, u64)> = Vec::new();
-        let (stats, _) = scan_cache_streaming(
-            dir.path(),
-            SystemTime::now(),
-            None,
-            &mut |count, bytes| seen.push((count, bytes)),
-        );
+        let (stats, _) =
+            scan_cache_streaming(dir.path(), SystemTime::now(), None, &mut |count, bytes| {
+                seen.push((count, bytes))
+            });
 
         assert_eq!(
             seen.len(),

--- a/crates/kin-cli/src/commands/capabilities.rs
+++ b/crates/kin-cli/src/commands/capabilities.rs
@@ -97,7 +97,7 @@ pub fn require_ready(command: &str) -> Result<()> {
     )
 }
 
-pub fn run(json: bool) -> Result<()> {
+pub fn run(json: bool, verbose: bool) -> Result<()> {
     let inventory = inventory()?;
     let required = inventory
         .commands
@@ -182,15 +182,24 @@ pub fn run(json: bool) -> Result<()> {
             CapabilityStatus::OpenGate => "OPEN ",
         };
         let dogfood = if capability.required_for_bounded_dogfood {
-            " required"
+            "  required"
         } else {
             ""
         };
-        println!(
-            "{status}  {:18}  {}{dogfood}",
-            capability.command, capability.authority
-        );
-        println!("       {}", capability.note);
+        // Root help sends every caller here to answer "what works", and status
+        // against command name is that answer. Authority and note are prose,
+        // several of them running past a terminal width and one past three
+        // thousand characters on a single line, and printing them by default
+        // buried the answer under 27KB.
+        println!("{status}  {:18}{dogfood}", capability.command);
+        if verbose {
+            println!("       authority: {}", capability.authority);
+            println!("       {}", capability.note);
+        }
+    }
+    if !verbose {
+        println!();
+        println!("`--verbose` adds authority and notes per command, `--json` the full inventory.");
     }
     Ok(())
 }

--- a/crates/kin-cli/src/commands/capabilities.rs
+++ b/crates/kin-cli/src/commands/capabilities.rs
@@ -307,7 +307,10 @@ mod tests {
                 }
                 files += 1;
                 let text = std::fs::read_to_string(&path).expect("read source file");
-                for (_, rest) in text.match_indices("require_ready(\"").map(|(i, m)| (i, &text[i + m.len()..])) {
+                for (_, rest) in text
+                    .match_indices("require_ready(\"")
+                    .map(|(i, m)| (i, &text[i + m.len()..]))
+                {
                     if let Some(end) = rest.find('"') {
                         gated.insert(rest[..end].to_string());
                     }
@@ -317,7 +320,10 @@ mod tests {
 
         // Positive controls. A wrong root or a changed call spelling would
         // otherwise scan nothing and pass as "no undeclared commands".
-        assert!(files > 20, "scanned only {files} source files under {src:?}");
+        assert!(
+            files > 20,
+            "scanned only {files} source files under {src:?}"
+        );
         assert!(
             gated.len() >= 20,
             "found only {} gated commands, so the scan is not seeing the call sites: {gated:?}",

--- a/crates/kin-cli/src/commands/capabilities.rs
+++ b/crates/kin-cli/src/commands/capabilities.rs
@@ -71,8 +71,14 @@ pub fn require_ready(command: &str) -> Result<()> {
         .iter()
         .find(|capability| capability.command == command)
         .ok_or_else(|| {
+            // An undeclared command cannot be satisfied by any repository
+            // state, so this arm is reached only on a build whose command tree
+            // and inventory disagree. It has to name the command and the one
+            // thing a caller can do about it. The old wording named an internal
+            // table nobody has seen and offered no remedy at all.
             anyhow::anyhow!(
-                "command capability '{}' is not declared; refusing an unversioned authority path",
+                "`kin {}` is not available in this build\n\
+                 hint: run `kin capabilities` to see which commands are ready",
                 command
             )
         })?;
@@ -264,6 +270,69 @@ mod tests {
                 "{command} must no longer refuse at the CLI boundary"
             );
         }
+    }
+
+    /// Every command that gates itself on the inventory must be in it.
+    ///
+    /// An undeclared command takes the not-found arm, which no repository state
+    /// can satisfy, so it is dead on every host rather than gated on one.
+    /// `purge-ignored` shipped that way: a complete implementation, a daemon
+    /// route, its own tests, and a root-help entry, refusing everywhere because
+    /// nothing named it here. The gate tests could not see it, because they all
+    /// start from the inventory and it was the inventory that was missing.
+    #[test]
+    fn every_gated_command_is_declared_in_the_inventory() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut gated: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut files = 0usize;
+        let mut stack = vec![src.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("read source dir").flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                files += 1;
+                let text = std::fs::read_to_string(&path).expect("read source file");
+                for (_, rest) in text.match_indices("require_ready(\"").map(|(i, m)| (i, &text[i + m.len()..])) {
+                    if let Some(end) = rest.find('"') {
+                        gated.insert(rest[..end].to_string());
+                    }
+                }
+            }
+        }
+
+        // Positive controls. A wrong root or a changed call spelling would
+        // otherwise scan nothing and pass as "no undeclared commands".
+        assert!(files > 20, "scanned only {files} source files under {src:?}");
+        assert!(
+            gated.len() >= 20,
+            "found only {} gated commands, so the scan is not seeing the call sites: {gated:?}",
+            gated.len()
+        );
+        for expected in ["commit", "purge-ignored", "stash", "doctor --heal"] {
+            assert!(
+                gated.contains(expected),
+                "the scan must find the known call site {expected:?}: {gated:?}"
+            );
+        }
+
+        let declared: std::collections::BTreeSet<String> = inventory()
+            .unwrap()
+            .commands
+            .into_iter()
+            .map(|capability| capability.command)
+            .collect();
+        let undeclared: Vec<&String> = gated.difference(&declared).collect();
+        assert!(
+            undeclared.is_empty(),
+            "these commands gate on the inventory but are not in it, so they refuse on every \
+             host: {undeclared:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -54,12 +54,44 @@ pub struct ContextRequest {
     pub assistant: Option<String>,
 }
 
+/// Names the structured half of [`ContextResponse`]. A daemon predating it
+/// answers with `lines` only and leaves this empty, which is what lets `--json`
+/// refuse loudly instead of emitting a document missing everything it promises.
+pub const CONTEXT_RESPONSE_SCHEMA_VERSION: &str = "kin-context-response-v1";
+
+/// What the pack was built for. The human rendering opens with the same three
+/// facts, so a structured caller is not reading a different resolution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextTarget {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+    pub budget_tokens: usize,
+}
+
+/// The context response, structured half added alongside the rendered lines.
+///
+/// `lines` stays first and required so an older client keeps decoding this, and
+/// the structured fields default so this client keeps decoding an older daemon.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContextResponse {
     pub lines: Vec<String>,
+    #[serde(default)]
+    pub schema_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<ContextTarget>,
+    /// Absent when the entity did not resolve, which is the one case the human
+    /// rendering answers with guidance rather than a pack.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pack: Option<kin_model::context::ContextPack>,
 }
 
-pub async fn run(entity: String, budget: String, assistant: Option<String>) -> Result<()> {
+pub async fn run(
+    entity: String,
+    budget: String,
+    assistant: Option<String>,
+    json: bool,
+) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "context").await?;
     let response = run_daemon_context(
@@ -71,8 +103,17 @@ pub async fn run(entity: String, budget: String, assistant: Option<String>) -> R
         },
     )
     .await?;
-    for line in response.lines {
-        println!("{line}");
+    if json {
+        if response.schema_version.is_empty() {
+            anyhow::bail!(
+                "the running daemon does not support structured context packs; restart it with the current Kin build"
+            );
+        }
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        for line in response.lines {
+            println!("{line}");
+        }
     }
     Ok(())
 }
@@ -116,6 +157,11 @@ pub fn build_context_response(
     let Some(target) = resolve_context_target(graph, &request.entity)? else {
         return Ok(ContextResponse {
             lines: context_not_found_guidance(&request.entity),
+            // Stamped even here: an unresolved entity is an answer, and leaving
+            // this empty would report it as a daemon too old to answer at all.
+            schema_version: CONTEXT_RESPONSE_SCHEMA_VERSION.to_string(),
+            target: None,
+            pack: None,
         });
     };
     let opts = kin_context::ContextOptions {
@@ -158,7 +204,17 @@ pub fn build_context_response(
         lines.push(entry.content.clone());
     }
 
-    Ok(ContextResponse { lines })
+    Ok(ContextResponse {
+        lines,
+        schema_version: CONTEXT_RESPONSE_SCHEMA_VERSION.to_string(),
+        target: Some(ContextTarget {
+            id: target.id.to_string(),
+            name: target.name.clone(),
+            kind: format!("{:?}", target.kind),
+            budget_tokens: token_budget.max_tokens(),
+        }),
+        pack: Some(pack),
+    })
 }
 
 fn resolve_context_target(
@@ -307,6 +363,82 @@ mod tests {
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    /// `--json` is why the structured half exists, and it must carry the pack
+    /// rather than the rendered lines. Serializing `lines` alone would be human
+    /// text in a JSON envelope, which is what the surface already had.
+    #[test]
+    fn a_resolved_context_carries_its_pack_and_target_for_machines() {
+        let graph = kin_db::InMemoryGraph::new();
+        let entity = test_entity("checkout");
+        graph.upsert_entity(&entity).unwrap();
+
+        let response = build_context_response(
+            &graph,
+            &ContextRequest {
+                entity: "checkout".to_string(),
+                budget: "8k".to_string(),
+                assistant: None,
+            },
+        )
+        .expect("a resolved entity builds a context response");
+
+        assert_eq!(response.schema_version, CONTEXT_RESPONSE_SCHEMA_VERSION);
+        let target = response.target.as_ref().expect("a resolved target");
+        assert_eq!(target.name, "checkout");
+        assert_eq!(target.kind, "Function");
+        assert_eq!(target.budget_tokens, 8000);
+        let pack = response.pack.as_ref().expect("a resolved pack");
+        assert!(!pack.focal_entities.is_empty(), "the pack names its focus");
+
+        // The document a caller receives holds the structure, not just prose.
+        let rendered = serde_json::to_string(&response).expect("serialize");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("parse");
+        assert_eq!(value["target"]["name"], "checkout");
+        assert!(
+            value["pack"]["focal_entities"].is_array(),
+            "the pack must survive serialization: {rendered}"
+        );
+        assert!(value["pack"]["actual_tokens"].is_number());
+    }
+
+    /// An unresolved entity is an answer, so it is stamped. Leaving the version
+    /// empty there would make `--json` report it as a daemon too old to answer.
+    #[test]
+    fn an_unresolved_entity_is_stamped_but_carries_no_pack() {
+        let graph = kin_db::InMemoryGraph::new();
+        let response = build_context_response(
+            &graph,
+            &ContextRequest {
+                entity: "frobnicate".to_string(),
+                budget: "8k".to_string(),
+                assistant: None,
+            },
+        )
+        .expect("an unresolved entity still answers");
+
+        assert_eq!(response.schema_version, CONTEXT_RESPONSE_SCHEMA_VERSION);
+        assert!(response.pack.is_none());
+        assert!(response.target.is_none());
+        assert!(!response.lines.is_empty(), "guidance is still rendered");
+    }
+
+    /// The version guard has to be able to fire, which means an older daemon's
+    /// reply must still decode and must still leave the version empty. If the
+    /// field were required, this would be a decode error and `--json` would
+    /// report a transport failure for a version skew.
+    #[test]
+    fn an_older_daemons_reply_still_decodes_and_reports_no_schema() {
+        let older: ContextResponse =
+            serde_json::from_str(r#"{"lines":["Context pack for 'Foo' (Function):"]}"#)
+                .expect("a lines-only reply must still decode");
+        assert!(
+            older.schema_version.is_empty(),
+            "an unstamped reply is what makes `--json` refuse rather than emit an empty document"
+        );
+        assert!(older.pack.is_none());
+        assert_eq!(older.lines.len(), 1);
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/resolve.rs
+++ b/crates/kin-cli/src/commands/resolve.rs
@@ -237,6 +237,9 @@ fn plan_action(
     if abort {
         return Ok(ResolveAction::Abort);
     }
+    // Clap's `resolution` group refuses this before dispatch, so a caller gets
+    // a usage block and exit 2. This stays as the backstop for any other caller
+    // of this function, and because it names the full remedy set inline.
     if !settling {
         bail!(
             "nothing to resolve; name a conflict with --ours/--theirs/--base/--remove/--keep-path, \

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -318,6 +318,9 @@ async fn resolve_feature_target(work_id: &str) -> Result<String> {
 }
 
 pub async fn run(change_id: Option<String>, feature: Option<String>) -> Result<()> {
+    // Clap refuses both arms below before dispatch, with a usage block and
+    // exit 2. They stay as the backstop for any other caller, and because they
+    // name the remedy and the command that supplies the missing value.
     let change_id = match (change_id, feature) {
         (Some(_), Some(_)) => {
             anyhow::bail!("name a change to roll back to, or a work item with --feature, not both")

--- a/crates/kin-cli/src/commands/session_run.rs
+++ b/crates/kin-cli/src/commands/session_run.rs
@@ -543,17 +543,7 @@ pub fn editor_program(editor: &str) -> Result<&'static str> {
 /// automatic admission on. `kin reconcile <session>` is both the admission and
 /// the collector: it removes the projection once the daemon has taken its
 /// delta, so a retained projection lives exactly until its changes land.
-pub async fn open(
-    editor: String,
-    restrict_discovery: bool,
-    restrict_filesystem: bool,
-) -> Result<()> {
-    if restrict_discovery || restrict_filesystem {
-        bail!(
-            "--restrict-discovery and --restrict-filesystem belonged to the discontinued native \
-             editor fork and are fail-closed; the session projection is the boundary now"
-        );
-    }
+pub async fn open(editor: String) -> Result<()> {
     let program = editor_program(&editor)?;
     let layout = discover_layout()?;
     let projection = materialize(layout, None, None).await?;
@@ -586,35 +576,7 @@ pub fn assistant_program(assistant: &str) -> Result<&'static str> {
 }
 
 /// `kin with <assistant> [-- <task...>]`.
-pub async fn with(
-    assistant: String,
-    session: bool,
-    passive_guidance: bool,
-    restrict_discovery: bool,
-    restrict_filesystem: bool,
-    semantic_only: bool,
-    task: Vec<String>,
-) -> Result<()> {
-    if restrict_discovery || restrict_filesystem {
-        bail!(
-            "--restrict-discovery and --restrict-filesystem belonged to the discontinued native \
-             editor fork and are fail-closed; the session projection is the boundary now"
-        );
-    }
-    if passive_guidance {
-        bail!(
-            "--passive-guidance is fail-closed: prompt-guidance injection was removed with the \
-             legacy assistant path, so there is no guidance to suppress"
-        );
-    }
-    if session {
-        bail!(
-            "--session is fail-closed: it was the opt-in when an unprojected assistant launch \
-             existed, and every launch is now a session projection, so the flag can only mean \
-             something it no longer selects"
-        );
-    }
-
+pub async fn with(assistant: String, semantic_only: bool, task: Vec<String>) -> Result<()> {
     let adapter = super::assistant_adapter::adapter_for(&assistant)?;
     let program = adapter.program();
 

--- a/crates/kin-cli/src/commands/stash.rs
+++ b/crates/kin-cli/src/commands/stash.rs
@@ -131,6 +131,12 @@ pub async fn list(json: bool) -> Result<()> {
 
 pub async fn push(message: Option<String>, yes: bool) -> Result<()> {
     super::capabilities::require_ready("stash")?;
+    // Discover before asking for consent. Outside a repository there is nothing
+    // to seal and nothing to discard, so the confirmation named a cause that
+    // was not the cause: a caller who supplied --yes learned the real problem
+    // on the second try. `stash list` and `stash pop` already fail on
+    // discovery here, and this is what puts `push` back beside them.
+    let _ = crate::commands::require_repository_layout()?;
     if !yes {
         confirm_workspace_reset()?;
     }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2625,8 +2625,8 @@ fn main() -> Result<()> {
                     // nothing to operate on gets a usage block and exit 2 like
                     // the other 45 leaves, instead of exit 1 and one line.
                     if bulk_json {
-                        let entities = entities
-                            .expect("clap requires --entities alongside --bulk-json");
+                        let entities =
+                            entities.expect("clap requires --entities alongside --bulk-json");
                         let effective_compact = compact && !no_compact;
                         commands::refs::run_bulk(entities, kind, effective_compact).await
                     } else {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -35,15 +35,45 @@ Start here:
 Ask the graph:
   kin locate / search / trace / impact / refs / context
 
-Commands marked [OPEN GATE] are fail-closed on repository-v6 and say why when
-run. `kin capabilities` prints the full readiness matrix, `--json` for machines.";
+`kin capabilities` prints the full readiness matrix, `--json` for machines.";
+
+/// The `[OPEN GATE]` legend, which is only true while something carries the
+/// marker.
+const OPEN_GATE_LEGEND: &str = "\n\nCommands marked [OPEN GATE] are fail-closed on \
+repository-v6 and say why when run.";
+
+/// Root after-help, with the open-gate legend appended only when the inventory
+/// actually reports a gate.
+///
+/// The legend teaches a marker, so printing it when nothing is marked tells a
+/// caller scanning the list for what works that everything is ready. It had
+/// been doing exactly that: the gates all closed, the markers came off, and the
+/// sentence describing them stayed, pinned by a test asserting the bare string.
+///
+/// An unreadable inventory drops the legend rather than failing, because help
+/// has to render; a broken inventory is reported by `kin capabilities`, which
+/// is the command that exists to read it.
+fn after_help() -> String {
+    let gated = commands::capabilities::inventory()
+        .map(|inventory| {
+            inventory.commands.iter().any(|capability| {
+                capability.status == commands::capabilities::CapabilityStatus::OpenGate
+            })
+        })
+        .unwrap_or(false);
+    if gated {
+        format!("{AFTER_HELP}{OPEN_GATE_LEGEND}")
+    } else {
+        AFTER_HELP.to_string()
+    }
+}
 
 #[derive(Parser)]
 #[command(
     name = "kin",
     version = kin_buildinfo::version(),
     about = "Kin semantic VCS",
-    after_help = AFTER_HELP,
+    after_help = after_help(),
 )]
 struct Cli {
     /// Write a machine-readable execution profile to this JSON file
@@ -3943,13 +3973,46 @@ mod tests {
                 "kin status",
                 "kin commit",
                 "kin capabilities",
-                "[OPEN GATE]",
             ] {
                 assert!(
                     help.contains(anchor),
                     "help must orient a caller with {anchor:?}"
                 );
             }
+        });
+    }
+
+    /// The legend teaches a marker, so it may only appear while a marker does.
+    ///
+    /// Asserting the bare string was what let it outlive the thing it
+    /// describes: every gate closed, every marker came off, and the sentence
+    /// stayed, telling a caller to look for a signal that no command carried.
+    #[test]
+    fn the_open_gate_legend_appears_exactly_when_a_gate_does() {
+        on_cli_test_stack(|| {
+            let mut command = Cli::command();
+            let help = command.render_long_help().to_string();
+            let inventory =
+                commands::capabilities::inventory().expect("capability inventory must parse");
+            let gated = inventory.commands.iter().any(|capability| {
+                capability.status == commands::capabilities::CapabilityStatus::OpenGate
+            });
+
+            assert_eq!(
+                help.contains(OPEN_GATE_MARKER),
+                gated,
+                "the legend must track the inventory, which reports gated={gated}"
+            );
+
+            // The conditional is what is under test, so exercise both arms
+            // rather than only the one this inventory happens to select.
+            assert!(after_help().contains("Start here:"));
+            assert!(!AFTER_HELP.contains(OPEN_GATE_MARKER));
+            assert!(OPEN_GATE_LEGEND.contains(OPEN_GATE_MARKER));
+            assert!(
+                format!("{AFTER_HELP}{OPEN_GATE_LEGEND}").contains(OPEN_GATE_MARKER),
+                "the gated arm must carry the legend it exists to add"
+            );
         });
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -413,14 +413,14 @@ enum Command {
     /// Show upstream callers/importers/references for an entity
     Refs {
         /// Entity name or ID. Required unless --bulk-json + --entities is provided.
-        #[arg(default_value = "")]
-        entity: String,
+        #[arg(required_unless_present = "bulk_json")]
+        entity: Option<String>,
         /// Filter relation kinds: all, calls, imports, or references (or Any for bulk mode)
         #[arg(long, default_value = "all")]
         kind: String,
         /// Bulk mode: classify many entities by reachability in one daemon call.
         /// Outputs JSON to stdout. Requires --entities.
-        #[arg(long, default_value_t = false)]
+        #[arg(long, default_value_t = false, requires = "entities")]
         bulk_json: bool,
         /// Comma-separated entity UUIDs for --bulk-json. Required when --bulk-json is set.
         #[arg(long)]
@@ -537,6 +537,18 @@ enum Command {
         json: bool,
     },
     /// Resolve repository-v6 merge conflicts
+    ///
+    /// Nine flags name a resolution and at least one is required, which is a
+    /// group rather than a per-argument condition. `kin conflicts` is the
+    /// read-only view of the same transaction, so nothing here has to accept
+    /// an empty invocation in order to be inspectable.
+    #[command(group = clap::ArgGroup::new("resolution")
+        .required(true)
+        .multiple(true)
+        .args([
+            "ours", "theirs", "base", "remove", "keep_path",
+            "all_ours", "all_theirs", "do_continue", "abort",
+        ]))]
     Resolve {
         /// Keep your (target branch) version of a conflicting identity
         #[arg(long, value_name = "SELECTOR")]
@@ -793,6 +805,7 @@ enum Command {
     #[command(visible_alias = "revert")]
     Rollback {
         /// Change ID to rollback to. Omit when naming a work item with --feature.
+        #[arg(required_unless_present = "feature", conflicts_with = "feature")]
         change_id: Option<String>,
         /// Roll back every change the named work item records
         #[arg(long)]
@@ -1415,12 +1428,16 @@ enum ReviewAction {
     Shadow {
         /// Change range as <base>..<head>. Refs accept branch names,
         /// semantic change IDs, and imported Git commit SHAs.
+        #[arg(
+            required_unless_present = "base",
+            conflicts_with_all = ["base", "head"]
+        )]
         range: Option<String>,
-        /// Base ref (alternative to the positional range)
-        #[arg(long)]
+        /// Base ref (alternative to the positional range; pair with --head)
+        #[arg(long, requires = "head")]
         base: Option<String>,
-        /// Head ref (alternative to the positional range)
-        #[arg(long)]
+        /// Head ref (alternative to the positional range; pair with --base)
+        #[arg(long, requires = "base")]
         head: Option<String>,
         /// Change title for the report (e.g. PR title)
         #[arg(long)]
@@ -2600,20 +2617,16 @@ fn main() -> Result<()> {
                     compact,
                     no_compact,
                 } => {
+                    // Both requirements are clap's now, so a caller who names
+                    // nothing to operate on gets a usage block and exit 2 like
+                    // the other 45 leaves, instead of exit 1 and one line.
                     if bulk_json {
-                        let entities = entities.ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "--bulk-json requires --entities (comma-separated entity UUIDs)"
-                            )
-                        })?;
+                        let entities = entities
+                            .expect("clap requires --entities alongside --bulk-json");
                         let effective_compact = compact && !no_compact;
                         commands::refs::run_bulk(entities, kind, effective_compact).await
                     } else {
-                        if entity.is_empty() {
-                            anyhow::bail!(
-                                "missing positional entity argument (or use --bulk-json --entities)"
-                            );
-                        }
+                        let entity = entity.expect("clap requires an entity without --bulk-json");
                         commands::refs::run(entity, kind).await
                     }
                 }
@@ -2636,8 +2649,14 @@ fn main() -> Result<()> {
                                 author,
                                 json,
                             } => {
+                                // Clap owns the choice between the positional
+                                // range and the --base/--head pair, and pairs
+                                // the two flags. What it cannot own is the
+                                // shape of the range string, which is checked
+                                // here because a value parser is the only other
+                                // place to put it.
                                 let (base, head) = match (range, base, head) {
-                                    (Some(range), None, None) => match range.split_once("..") {
+                                    (Some(range), _, _) => match range.split_once("..") {
                                         Some((base, head))
                                             if !base.is_empty() && !head.is_empty() =>
                                         {
@@ -2649,8 +2668,8 @@ fn main() -> Result<()> {
                                         ),
                                     },
                                     (None, Some(base), Some(head)) => (base, head),
-                                    _ => anyhow::bail!(
-                                        "provide a <base>..<head> range or both --base and --head"
+                                    _ => unreachable!(
+                                        "clap requires a range or both --base and --head"
                                     ),
                                 };
                                 commands::review::shadow_report(
@@ -3865,6 +3884,78 @@ mod tests {
                     feature: None,
                 } if change == "abc123"
             ));
+        });
+    }
+
+    /// Not supplying the thing to operate on is one mistake, and it produced
+    /// two contracts: 45 leaves exited 2 with a usage block through clap, and a
+    /// handful exited 1 with a bare line. A caller keying on exit 2 for "I
+    /// called this wrong" misclassified the second set.
+    ///
+    /// These four moved to clap. `kin locate` and `kin scope` deliberately did
+    /// not: `locate --next` takes its query from a persisted cursor and `scope`
+    /// reads KIN_SESSION_ID, so a parse-time requirement would reject
+    /// invocations that work. Their argument is not optional to the command,
+    /// only to the command line, which is not something clap can express.
+    #[test]
+    fn a_missing_required_argument_is_a_usage_error_not_a_runtime_one() {
+        on_cli_test_stack(|| {
+            for argv in [
+                &["kin", "refs"][..],
+                &["kin", "rollback"][..],
+                &["kin", "resolve"][..],
+                &["kin", "review", "shadow"][..],
+            ] {
+                let error = Cli::try_parse_from(argv)
+                    .err()
+                    .unwrap_or_else(|| panic!("{argv:?} must not parse"));
+                assert_eq!(
+                    error.exit_code(),
+                    2,
+                    "{argv:?} must fail the way every other misuse does"
+                );
+                let rendered = error.to_string();
+                assert!(
+                    rendered.contains("Usage:"),
+                    "{argv:?} must print usage: {rendered}"
+                );
+            }
+
+            // Every shape that did work still parses. A required-group that
+            // over-reaches would take these with it, and each is the reason its
+            // command's requirement is conditional rather than plain.
+            for argv in [
+                &["kin", "refs", "Foo"][..],
+                &["kin", "refs", "--bulk-json", "--entities", "a,b"][..],
+                &["kin", "resolve", "--abort"][..],
+                &["kin", "resolve", "--all-ours", "--json"][..],
+                &["kin", "resolve", "--ours", "x", "--theirs", "y"][..],
+                &["kin", "review", "shadow", "main..head"][..],
+                &["kin", "review", "shadow", "--base", "a", "--head", "b"][..],
+                // Untouched on purpose: both take their input from somewhere
+                // the command line cannot see.
+                &["kin", "locate", "--next"][..],
+                &["kin", "scope"][..],
+            ] {
+                assert!(
+                    Cli::try_parse_from(argv).is_ok(),
+                    "{argv:?} must stay a complete invocation"
+                );
+            }
+
+            // Half-supplied pairs are refused at parse time too, rather than
+            // reaching a command body that has to re-derive what is missing.
+            for argv in [
+                &["kin", "refs", "--bulk-json"][..],
+                &["kin", "review", "shadow", "--base", "a"][..],
+                &["kin", "review", "shadow", "--head", "b"][..],
+                &["kin", "rollback", "abc123", "--feature", "w-1"][..],
+            ] {
+                let error = Cli::try_parse_from(argv)
+                    .err()
+                    .unwrap_or_else(|| panic!("{argv:?} must not parse"));
+                assert_eq!(error.exit_code(), 2, "{argv:?} must be a usage error");
+            }
         });
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -95,6 +95,9 @@ enum Command {
         /// Output the versioned capability inventory as JSON
         #[arg(long, default_value_t = false)]
         json: bool,
+        /// Add the per-command notes under each matrix row
+        #[arg(long, default_value_t = false, conflicts_with = "json")]
+        verbose: bool,
     },
     /// Initialize a new Kin repository
     Init {
@@ -2229,7 +2232,9 @@ fn main() -> Result<()> {
     let result = runtime.block_on(
         (async move {
             match cli.command {
-                Command::Capabilities { json } => commands::capabilities::run(json),
+                Command::Capabilities { json, verbose } => {
+                    commands::capabilities::run(json, verbose)
+                }
                 Command::Init { path, json } => commands::init::run(path, json).await,
                 Command::Status { json, wait_quiesce } => {
                     commands::status::run(json, std::time::Duration::from_secs(wait_quiesce)).await

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -836,31 +836,11 @@ enum Command {
     Open {
         /// Editor to launch: code or cursor
         editor: String,
-        /// In native mode, block filesystem discovery commands and require Kin discovery
-        #[arg(long)]
-        restrict_discovery: bool,
-        /// In native mode, block both filesystem discovery and direct file reads
-        #[arg(long, conflicts_with = "restrict_discovery")]
-        restrict_filesystem: bool,
     },
     /// Launch an assistant in an exact graph-derived session workspace
     With {
         /// Assistant to launch: claude, codex, gemini
         assistant: String,
-        /// Launch inside a graph-backed session workspace: the assistant starts
-        /// with its cwd in the session, receives session/daemon env, and its
-        /// changes reconcile into the graph on a successful exit
-        #[arg(long)]
-        session: bool,
-        /// Pass the raw task only; keep AGENTS/bootstrap docs on disk but do not inject prompt guidance
-        #[arg(long)]
-        passive_guidance: bool,
-        /// In native mode, block filesystem discovery commands and require Kin discovery
-        #[arg(long)]
-        restrict_discovery: bool,
-        /// In native mode, block both filesystem discovery and direct file reads
-        #[arg(long, conflicts_with = "restrict_discovery")]
-        restrict_filesystem: bool,
         /// Deny the assistant's native discovery tools for this launch, leaving
         /// Kin's semantic tools as the only discovery surface; the enforcement
         /// tier is printed at launch and differs per assistant
@@ -899,12 +879,6 @@ enum Command {
         /// Materialization strategy
         #[arg(long)]
         strategy: Option<String>,
-        /// In native mode, block filesystem discovery commands and require Kin discovery
-        #[arg(long)]
-        restrict_discovery: bool,
-        /// In native mode, block both filesystem discovery and direct file reads
-        #[arg(long, conflicts_with = "restrict_discovery")]
-        restrict_filesystem: bool,
     },
     /// Show a quick codebase overview (entity counts by kind, language, top files)
     Overview {
@@ -3098,14 +3072,9 @@ fn main() -> Result<()> {
                 Command::Todo { action } => match action {
                     TodoAction::Import { path } => commands::note::todo_import(path).await,
                 },
-                Command::Open {
-                    editor,
-                    restrict_discovery,
-                    restrict_filesystem,
-                } => {
+                Command::Open { editor } => {
                     commands::capabilities::require_ready("open")?;
-                    commands::session_run::open(editor, restrict_discovery, restrict_filesystem)
-                        .await
+                    commands::session_run::open(editor).await
                 }
                 Command::PurgeIgnored {
                     confirm,
@@ -3123,43 +3092,19 @@ fn main() -> Result<()> {
                 }
                 Command::With {
                     assistant,
-                    session,
-                    passive_guidance,
-                    restrict_discovery,
-                    restrict_filesystem,
                     semantic_only,
                     task,
                 } => {
                     commands::capabilities::require_ready("with")?;
-                    commands::session_run::with(
-                        assistant,
-                        session,
-                        passive_guidance,
-                        restrict_discovery,
-                        restrict_filesystem,
-                        semantic_only,
-                        task,
-                    )
-                    .await
+                    commands::session_run::with(assistant, semantic_only, task).await
                 }
                 // Adjudicated before the runtime starts; see the early return
                 // at the top of `main`.
                 Command::SemanticOnlyGuard => {
                     commands::assistant_adapter::run_semantic_only_guard()
                 }
-                Command::Shell {
-                    strategy,
-                    restrict_discovery,
-                    restrict_filesystem,
-                } => {
+                Command::Shell { strategy } => {
                     commands::capabilities::require_ready("shell")?;
-                    if restrict_discovery || restrict_filesystem {
-                        anyhow::bail!(
-                            "--restrict-discovery and --restrict-filesystem belonged to the \
-                             discontinued native editor fork and are fail-closed; the session \
-                             projection is the boundary now"
-                        );
-                    }
                     commands::session_run::shell(strategy).await
                 }
                 Command::Overview { compact, json } => {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1271,6 +1271,11 @@ enum CacheAction {
         /// Output machine-readable JSON instead of a human summary
         #[arg(long, default_value_t = false)]
         json: bool,
+        /// Stop scanning after this many entries and report the partial totals.
+        /// Unset scans the whole cache, which on a bench-scale tree takes minutes
+        /// but is the only way the totals are exact
+        #[arg(long, value_name = "ENTRIES")]
+        limit: Option<u64>,
     },
     /// Reclaim space: drop abandoned schema versions and/or evict oldest entries to a budget
     Gc {
@@ -2980,7 +2985,9 @@ fn main() -> Result<()> {
                 Command::Bench { args } => commands::bench::bench_proxy(&args),
                 Command::Migrate { source, target } => commands::migrate::run(source, target).await,
                 Command::Cache { action } => match action {
-                    CacheAction::Status { json } => commands::cache::status(json).await,
+                    CacheAction::Status { json, limit } => {
+                        commands::cache::status(json, limit).await
+                    }
                     CacheAction::Gc {
                         dry_run,
                         budget_gb,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -191,6 +191,9 @@ enum Command {
         /// Assistant hint for tuning context pack strategy
         #[arg(long)]
         assistant: Option<String>,
+        /// Emit the resolved target and the whole context pack as JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     /// Hidden ContextBench locate wrapper that keeps benchmark query shaping inside Kin
     #[command(hide = true)]
@@ -2304,7 +2307,8 @@ fn main() -> Result<()> {
                     entity,
                     budget,
                     assistant,
-                } => commands::context::run(entity, budget, assistant).await,
+                    json,
+                } => commands::context::run(entity, budget, assistant, json).await,
                 Command::ContextbenchLocate {
                     task_file,
                     json,

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -231,10 +231,11 @@ fn session_commands_reach_the_session_surface_instead_of_the_capability_gate() {
         );
     }
 
-    // The discontinued native-fork flags still refuse before anything runs, and
-    // so does `--session`: every launch is a session projection now, so a flag
-    // that used to select one can only mean something it no longer selects.
-    // Accepting and ignoring it would let a caller believe it chose something.
+    // The discontinued native-fork flags are gone rather than refused. A flag
+    // clap accepts and the body then rejects is advertised in help as though it
+    // works, which is what these four did: `--session` even described the
+    // current default, so its page sold an opt-in for something already true.
+    // Removal makes the parser the only answer, and it answers before launch.
     for args in [
         &["shell", "--restrict-discovery"][..],
         &["open", "code", "--restrict-filesystem"][..],
@@ -246,11 +247,59 @@ fn session_commands_reach_the_session_surface_instead_of_the_capability_gate() {
             .current_dir(root.path())
             .output()
             .unwrap_or_else(|error| panic!("run kin {args:?}: {error}"));
-        assert!(!output.status.success());
         let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "kin {args:?} must exit 2 through clap, not 1 from a command body: {stderr}"
+        );
         assert!(
-            stderr.contains("fail-closed"),
-            "kin {args:?} must stay fail-closed: {stderr}"
+            stderr.contains("unexpected argument"),
+            "kin {args:?} must be refused by the parser: {stderr}"
+        );
+        assert!(
+            !stderr.contains("fail-closed"),
+            "kin {args:?} must no longer be advertised then refused: {stderr}"
+        );
+    }
+
+    // And they are absent from the pages that used to advertise them, which is
+    // the half a caller reads before typing anything.
+    for (command, gone) in [
+        (
+            &["shell", "--help"][..],
+            &["--restrict-discovery", "--restrict-filesystem"][..],
+        ),
+        (
+            &["open", "--help"][..],
+            &["--restrict-discovery", "--restrict-filesystem"][..],
+        ),
+        (
+            &["with", "--help"][..],
+            &[
+                "--session",
+                "--passive-guidance",
+                "--restrict-discovery",
+                "--restrict-filesystem",
+            ][..],
+        ),
+    ] {
+        let output = kin_command(&home)
+            .args(command)
+            .output()
+            .unwrap_or_else(|error| panic!("run kin {command:?}: {error}"));
+        let help = String::from_utf8_lossy(&output.stdout);
+        for flag in gone {
+            assert!(
+                !help.contains(flag),
+                "kin {command:?} must not advertise {flag}: {help}"
+            );
+        }
+        // A positive control: the page still renders the flags it does carry,
+        // so an empty or failed render cannot pass this as an absence.
+        assert!(
+            help.contains("--help"),
+            "kin {command:?} must still render its options: {help}"
         );
     }
 

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -336,6 +336,104 @@ fn session_commands_reach_the_session_surface_instead_of_the_capability_gate() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("unknown editor"));
 }
 
+/// All three `kin stash` verbs name the same cause outside a repository.
+///
+/// `push` asked for a typed confirmation first, so it demanded consent to
+/// discard projected working files that do not exist, in a directory with
+/// nothing to seal. Its two siblings already reported discovery, which is what
+/// makes this a divergence rather than a house style.
+#[test]
+fn stash_push_names_the_missing_repository_before_asking_for_consent() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    for args in [
+        &["stash", "push"][..],
+        &["stash", "push", "--yes"][..],
+        &["stash", "list"][..],
+        &["stash", "pop"][..],
+    ] {
+        let output = kin_command(&home)
+            .args(args)
+            .current_dir(root.path())
+            .output()
+            .unwrap_or_else(|error| panic!("run kin {args:?}: {error}"));
+        assert!(!output.status.success(), "kin {args:?} must fail here");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("not a Kin repository"),
+            "kin {args:?} must name the missing repository: {stderr}"
+        );
+        assert!(
+            !stderr.contains("pass --yes"),
+            "kin {args:?} must not ask for consent it cannot act on: {stderr}"
+        );
+    }
+}
+
+/// `kin capabilities` is where root help sends a caller to learn what works.
+/// It answered with 27KB of prose, one line of it past three thousand
+/// characters, which no terminal presents as an answer.
+#[test]
+fn capabilities_defaults_to_the_matrix_and_keeps_the_prose_behind_verbose() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    let render = |args: &[&str]| {
+        let output = kin_command(&home)
+            .args(args)
+            .output()
+            .unwrap_or_else(|error| panic!("run kin {args:?}: {error}"));
+        assert!(output.status.success(), "kin {args:?} must succeed");
+        String::from_utf8_lossy(&output.stdout).to_string()
+    };
+
+    let default = render(&["capabilities"]);
+    let verbose = render(&["capabilities", "--verbose"]);
+
+    // One row per command, and every row fits a terminal.
+    let widest = default.lines().map(str::len).max().unwrap_or(0);
+    assert!(
+        widest <= 80,
+        "the default view must fit a terminal; widest line is {widest} chars"
+    );
+    assert!(
+        default.len() < verbose.len() / 4,
+        "the default view must be far smaller than the prose one: {} vs {}",
+        default.len(),
+        verbose.len()
+    );
+
+    // Both views still answer the question, and both list every command.
+    for view in [&default, &verbose] {
+        assert!(view.contains("Bounded dogfood ready:"), "{view}");
+        for command in ["commit", "stash", "purge-ignored"] {
+            assert!(view.contains(command), "missing {command}: {view}");
+        }
+    }
+    assert!(
+        default.contains("--verbose"),
+        "the default view must say where the notes went: {default}"
+    );
+
+    // The notes are intact behind --verbose and complete in --json, which is
+    // what keeps this a change of default rather than a loss of detail.
+    let json = render(&["capabilities", "--json"]);
+    let report: Value = serde_json::from_str(&json).expect("capabilities --json must be JSON");
+    let note = report["commands"][0]["note"]
+        .as_str()
+        .expect("every command carries a note")
+        .to_string();
+    assert!(!note.is_empty());
+    assert!(verbose.contains(&note), "--verbose must render the note");
+    assert!(
+        !default.contains(&note),
+        "the default view must not render the note"
+    );
+}
+
 #[test]
 fn top_level_help_marks_open_git_replacement_surfaces() {
     let root = tempdir().expect("temp root");

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,14 +40,14 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["all_declared_command_surfaces_enabled"], true);
-    assert_eq!(report["enabled_commands"], 33);
+    assert_eq!(report["enabled_commands"], 34);
     assert_eq!(report["full_git_replacement_ready"], false);
     // Exact counts, so a silent re-seal cannot pass. They are also the reason
     // two lanes must never flip a gate in the same wave: both bumps merge
     // without conflict and main goes red with every pull request green.
     // Recount from the merged fixture rather than from either branch.
-    assert_eq!(report["ready_commands"], 32);
-    assert_eq!(report["command_total"], 33);
+    assert_eq!(report["ready_commands"], 33);
+    assert_eq!(report["command_total"], 34);
 
     let commands = report["commands"]
         .as_array()
@@ -136,6 +136,29 @@ fn exposed_mutation_commands_reach_repository_discovery() {
     assert!(
         !stderr.contains("is fail-closed on repository-v6"),
         "rename must no longer answer from the capability gate: {stderr}"
+    );
+    assert!(stderr.contains("not a Kin repository"), "{stderr}");
+
+    // `purge-ignored` was in the command tree with no inventory entry at all,
+    // so it took the undeclared arm and refused on every host, in every
+    // repository state. An undeclared command is unreachable rather than
+    // gated, which is why the absence of the gate message is not enough here:
+    // the discovery failure has to be present for this to mean the command
+    // runs.
+    let output = kin_command(&home)
+        .arg("purge-ignored")
+        .current_dir(root.path())
+        .output()
+        .expect("run purge-ignored outside a repository");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("is not available in this build"),
+        "purge-ignored must be declared in the capability inventory: {stderr}"
+    );
+    assert!(
+        !stderr.contains("is fail-closed on repository-v6"),
+        "purge-ignored must not answer from the capability gate: {stderr}"
     );
     assert!(stderr.contains("not a Kin repository"), "{stderr}");
 }

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -386,6 +386,28 @@
       "note": "The session scanner performs retained-root double observation and authority-root CAS, and its observation now owns the retained no-follow directory capability it was taken through. Every field is private, so the observation cannot be built outside the scanner, and planning re-proves the retained capability before anything is planned against it."
     },
     {
+      "command": "purge-ignored",
+      "status": "ready",
+      "exposure": "enabled",
+      "authority": "repository-v6 authority transition published through the daemon coordination gate",
+      "required_for_bounded_dogfood": false,
+      "acceptance_spec": [
+        "report the tracked paths current ignore rules cover without changing anything unless --confirm is given",
+        "publish the retirement as one authority transition, holding the coordination gate so the watch loop cannot admit a competing observation between the reported set and the published change",
+        "evict the entities, layout, and index presence derived from a retired path so it stops ranking, leaving the file on disk",
+        "refuse a purge that removes more than 75% of a non-trivial tree unless --confirm-mass-deletion accepts it"
+      ],
+      "evidence_tests": [
+        "kin_cli::commands::purge_ignored::tests::dry_run_summary_names_counts_and_refuses_to_claim_a_change",
+        "kin_cli::commands::purge_ignored::tests::applied_summary_reports_the_published_transition_not_the_planned_set",
+        "kin_cli::commands::purge_ignored::tests::a_transition_wider_than_the_purge_set_is_reported_as_such",
+        "kin_daemon::api::tests::purge_ignored_untracks_admitted_derived_output_and_survives_restart",
+        "kin_daemon::api::tests::purge_ignored_honors_a_readmitted_default",
+        "kin_daemon::api::tests::purge_ignored_evicts_the_entities_that_made_a_path_rank"
+      ],
+      "note": "Admission retracts a tracked path once the rules cover it, so this exists for the operator who wants to see the covered set before the next observation clears it, or to retire it now. The default is a dry run naming counts and a bounded path sample. A confirmed purge plans from a complete working-directory walk and reports what the transition did rather than what was planned, because that walk can also carry an edit made since the last watch-loop tick."
+    },
+    {
       "command": "conflicts",
       "status": "ready",
       "exposure": "enabled",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -20252,7 +20252,7 @@ mod tests {
         std::fs::set_permissions(&editor, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         let scope = ProcessScope::enter(state.layout.working_dir(), editor_dir.path());
-        let opened = kin_cli::commands::session_run::open("code".to_string(), false, false).await;
+        let opened = kin_cli::commands::session_run::open("code".to_string()).await;
         drop(scope);
         opened.expect("launch an allowlisted editor over a session projection");
 

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ Native Windows x86_64 support is early. Repository admission works: `kin init` i
 - `kin setup` — configure your shell and connect agents (Claude, Cursor, Codex, Gemini) to the MCP server.
 - `kin doctor` — verify the install and daemon health.
 - `kin init` turns a Git repo into a Kin workspace. `kin status` and `kin search` require the bundled `kin-daemon` runtime (installed by every channel above).
-- `kin exec -- <cmd>` runs ordinary project tools (npm, make, docker) through a graph-backed session workspace; `kin shell` opens an interactive one; `kin with --session <assistant>` launches an agent inside one.
+- `kin exec -- <cmd>` runs ordinary project tools (npm, make, docker) through a graph-backed session workspace; `kin shell` opens an interactive one; `kin with <assistant>` launches an agent inside one.
 
 ## For AI agents (MCP)
 


### PR DESCRIPTION
The overnight CLI audit ranked ten defects by user pain. This takes the top
eight. Seven land whole; the seventh lands in half and the rest of it is scoped
out below rather than left implied.

`kin cache status` printed nothing until its walk returned, which on a cache
that is never evicted from disk means minutes of silence on the command
`kin cache gc` recommends by name. It now names the directory before reading
it, streams entry counts as it goes, and takes `--limit` to stop early and say
so. The walk moved into the CLI because the scan behind it takes no progress
callback and cannot be bounded, and a test asserts the two produce equal stats
on a fixture so an upstream change fails here rather than quietly relabelling
output.

`kin with`, `kin shell` and `kin open` advertised four flags that clap accepted
and the command body then rejected, eight slots across the three commands. All
four are gone. `--session` was the worst of them: its help described the
behavior that is now the default, so the page sold an opt-in for something that
already happens.

Root help taught callers to look for an `[OPEN GATE]` marker that no command
carried. Every gate had closed, the markers came off, and the legend stayed,
pinned by a test asserting the bare string. It now renders only when the
inventory reports a gate, and the test asserts that conditional.

`kin purge-ignored` was in the command tree and refused on every host, because
nothing declared it. The command is real: a full implementation, a daemon route,
its own tests. It is declared now, and a new test scans for every command that
gates on the inventory and asserts each one is in it. The existing gate tests
all start from the inventory, so a command missing from it was invisible to
every one of them.

`kin capabilities` is where root help sends a caller to learn what works, and it
answered with 27KB, one line of it past three thousand characters. The default
is the matrix now, 1.2KB, with authority and notes behind `--verbose` and intact
in `--json`.

`kin stash push` outside a repository asked for consent to discard files that do
not exist. It discovers first now, like its two siblings already did.

`kin context` gained `--json` carrying the resolved target and the whole context
pack, additive on the wire with a schema-version guard, matching how `kin impact`
does it. The thirteen list-shaped commands still lack it: each receives only
rendered lines from the daemon, so each needs its own response extension, and
serializing the lines array would be human text in an envelope rather than a fix.

`kin refs`, `kin rollback`, `kin resolve` and `kin review shadow` now state their
requirements to clap, so a caller who names nothing to operate on gets a usage
block and exit 2 like the other forty-five leaves. `kin locate` and `kin scope`
are deliberately untouched: `locate --next` takes its query from a persisted
cursor and `scope` reads KIN_SESSION_ID, so a parse-time requirement would reject
invocations that work today.

Gates: fmt clean, clippy clean under the ci.yml allowlist, `cargo test -p kin-cli`
green across 43 suites, and `kin-dev local-test kin` green. Three tests failed on
first write and each was a real defect: a bound landing exactly on the last entry
reported exact totals as partial, and two rendered lines overran a terminal width.

Refs FIR-2155
