### PR TITLE
Stop the reconcile loop retrying host content it will never admit

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1239,6 +1239,53 @@ mod tests {
         );
     }
 
+    /// The command names host content the loop declined to track, and does not
+    /// call it a fault.
+    ///
+    /// This is the FIR-2152 shape from the reader's side. A file was written, no
+    /// entity for it ever appeared, and the only surface that could have
+    /// explained why said nothing about it at all. Naming it as a warning would
+    /// be the opposite error: a working copy mid-edit holds untracked files
+    /// constantly, and a status command that cries fault over every one of them
+    /// is one nobody reads.
+    #[test]
+    fn graph_status_names_untracked_paths_without_calling_them_a_fault() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let entity = test_entity("run_task");
+        graph.upsert_entity(&entity).unwrap();
+
+        let response = build_graph_status_response(
+            &binding,
+            &graph,
+            &crate::commands::resources::ReconcileHealth {
+                untracked_path_count: 1,
+                untracked_paths_sample: vec!["fir2152_probe.rs".to_string()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.contains("fir2152_probe.rs")),
+            "the path a reader is looking for must be named: {:?}",
+            response.lines
+        );
+        assert!(
+            !response
+                .lines
+                .iter()
+                .any(|line| line.contains("reconcile loop degraded")),
+            "untracked content is not a degraded loop: {:?}",
+            response.lines
+        );
+        assert!(
+            response.error.is_none(),
+            "an ordinary working copy must not turn this command nonzero"
+        );
+    }
+
     /// A dropped reconcile event reaches the same verdict. This is the FIR-2145
     /// shape, where events errored and were skipped while every surface read
     /// clean.

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -410,6 +410,17 @@ fn build_graph_status_response(
             lines.push(format!("⚠ {}", w));
         }
     }
+    // Printed beside the verdict rather than as part of it. Untracked host
+    // content is not a fault, so it withholds no all-clear; it is the answer to
+    // the question a reader actually arrives with, which is why a file they can
+    // see on disk has no entities in the graph.
+    let notices = reconcile.notices();
+    if !notices.is_empty() {
+        lines.push(String::new());
+        for notice in notices {
+            lines.push(format!("ℹ {notice}"));
+        }
+    }
     append_health_notes(&mut lines, &health.notes);
 
     Ok(GraphCommandResponse {

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -1668,6 +1668,17 @@ pub fn background_work_health_from_state(
         .map(str::to_string)
         .collect();
     reasons.extend(work.reconcile.degraded_reasons());
+    // Carried on the detail of whichever verdict follows, never into `reasons`.
+    // A working copy holding untracked files is the normal state of one being
+    // edited, so it must not move this check off `Healthy`; it still has to be
+    // said, because the paths it names are precisely the ones whose entities a
+    // reader will go looking for and not find.
+    let notices = work.reconcile.notices();
+    let notice_detail = if notices.is_empty() {
+        String::new()
+    } else {
+        format!("; {}", notices.join("; "))
+    };
     if reasons.is_empty() {
         let working = work
             .passes
@@ -1680,7 +1691,7 @@ pub fn background_work_health_from_state(
             HealthStatus::Healthy,
             format!(
                 "{cpu}; {} background pass(es), {working} working, none stopped; reconcile \
-                 admitting normally",
+                 admitting normally{notice_detail}",
                 work.passes.len()
             ),
         );
@@ -1689,7 +1700,7 @@ pub fn background_work_health_from_state(
         "background_work",
         "Background work",
         HealthStatus::Stale,
-        format!("{cpu}; {}", reasons.join("; ")),
+        format!("{cpu}; {}{notice_detail}", reasons.join("; ")),
     )
     .with_manual_fix(
         "restart the daemon (`kin daemon restart`) to retry the stopped pass, and report the \

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -705,6 +705,40 @@ mod tests {
         }
     }
 
+    /// Untracked host content is announced and is not a fault.
+    ///
+    /// Both halves matter. Without the notice, a file a reader can see on disk
+    /// has no entities and no surface says why, which is the question FIR-2152
+    /// arrived as. Without the second assertion, every working copy mid-edit
+    /// would report `attention`, and a health signal that is always on is one
+    /// nobody reads.
+    #[test]
+    fn untracked_paths_are_announced_without_degrading_the_daemon() {
+        let health = ReconcileHealth {
+            untracked_path_count: 7,
+            untracked_paths_sample: vec!["src/new.rs".to_string(), "notes.md".to_string()],
+            ..Default::default()
+        };
+        assert!(!health.degraded(), "{:?}", health.degraded_reasons());
+        let notices = health.notices();
+        assert_eq!(notices.len(), 1, "{notices:?}");
+        let notice = &notices[0];
+        assert!(notice.contains('7'), "the count is the headline: {notice}");
+        assert!(
+            notice.contains("src/new.rs") && notice.contains("notes.md"),
+            "the sample must name paths a reader can act on: {notice}"
+        );
+        assert!(
+            notice.contains("5 more"),
+            "a sample that hid the remainder would understate it: {notice}"
+        );
+
+        assert!(
+            ReconcileHealth::default().notices().is_empty(),
+            "a working copy with nothing untracked says nothing"
+        );
+    }
+
     #[test]
     fn a_failing_admission_streak_is_a_degraded_reason_that_names_its_threshold() {
         let reasons = failing_admission().degraded_reasons();

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -259,6 +259,21 @@ pub struct ReconcileHealth {
     /// Absent when the backlog is empty.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backlog_age_seconds: Option<u64>,
+    /// Host paths the most recent complete scan observed that repository
+    /// authority does not track.
+    ///
+    /// Ambient observation revises graph-owned history but never enlarges it, so
+    /// a path the workspace has never tracked stays untracked until an explicit
+    /// seam admits it. That is deliberate, and it is also the exact reason a
+    /// freshly written file is not queryable. Reported so the answer to "why is
+    /// my new file missing" is on the status surface instead of inferable only
+    /// from the loop's source.
+    #[serde(default)]
+    pub untracked_path_count: u64,
+    /// A bounded sample of `untracked_path_count`, so the notice names paths a
+    /// reader can act on without a large working copy flooding the surface.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub untracked_paths_sample: Vec<String>,
 }
 
 impl ReconcileHealth {
@@ -317,6 +332,40 @@ impl ReconcileHealth {
     /// healthy daemon.
     pub fn degraded(&self) -> bool {
         !self.degraded_reasons().is_empty()
+    }
+
+    /// What the loop is deliberately not doing, stated so no surface has to
+    /// leave it unexplained.
+    ///
+    /// Separate from [`Self::degraded_reasons`] on purpose. Untracked host
+    /// content is the ordinary state of a working copy mid-edit, so calling it a
+    /// fault would put every healthy repository into `attention` and teach every
+    /// reader to ignore the field. It still has to be said: a path the loop
+    /// declines to admit is a path whose entities never appear, and silence
+    /// there is what made a deliberate refusal look like a stuck daemon.
+    pub fn notices(&self) -> Vec<String> {
+        let mut notices = Vec::new();
+        if self.untracked_path_count > 0 {
+            let sample = if self.untracked_paths_sample.is_empty() {
+                String::new()
+            } else {
+                let more = self
+                    .untracked_path_count
+                    .saturating_sub(self.untracked_paths_sample.len() as u64);
+                let listed = self.untracked_paths_sample.join(", ");
+                if more > 0 {
+                    format!(": {listed}, and {more} more")
+                } else {
+                    format!(": {listed}")
+                }
+            };
+            notices.push(format!(
+                "{} host path(s) observed but not tracked{sample}. Watching a file never enlarges \
+                 the repository, so these stay unqueryable until a commit admits them.",
+                self.untracked_path_count
+            ));
+        }
+        notices
     }
 }
 

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -585,7 +585,19 @@ struct ReconcileProbesInner {
     /// moment the loop drains it, so the reported age is the age of one
     /// unbroken backlog rather than of the oldest one this daemon ever saw.
     backlog_since: Option<Instant>,
+    /// How many host paths the most recent complete scan observed that
+    /// repository authority does not track.
+    untracked_path_count: u64,
+    /// A bounded sample of those paths.
+    untracked_paths_sample: Vec<String>,
 }
+
+/// How many untracked paths a disclosure names outright.
+///
+/// A working copy can hold thousands of them, and a surface that printed every
+/// one would bury the count that matters. Five is enough to recognize the file
+/// you just wrote.
+const UNTRACKED_SAMPLE_LIMIT: usize = 5;
 
 impl ReconcileProbes {
     fn lock(&self) -> std::sync::MutexGuard<'_, ReconcileProbesInner> {
@@ -634,6 +646,29 @@ impl ReconcileProbes {
         }
     }
 
+    /// What one complete scan saw on the host that authority does not track.
+    ///
+    /// Replaces the previous record rather than accumulating. The scan behind it
+    /// is complete, so its answer is the current truth about the working copy,
+    /// and a count that only ever grew would keep naming files a commit has
+    /// since admitted or a delete has since removed.
+    pub fn record_untracked_observation<T: std::fmt::Display>(
+        &self,
+        paths: impl IntoIterator<Item = T>,
+    ) {
+        let mut count: u64 = 0;
+        let mut sample = Vec::new();
+        for path in paths {
+            count = count.saturating_add(1);
+            if sample.len() < UNTRACKED_SAMPLE_LIMIT {
+                sample.push(path.to_string());
+            }
+        }
+        let mut inner = self.lock();
+        inner.untracked_path_count = count;
+        inner.untracked_paths_sample = sample;
+    }
+
     /// The disclosure surfaces' view of all of it.
     pub fn report(&self, now: Instant) -> ReconcileHealth {
         let inner = self.lock();
@@ -660,6 +695,8 @@ impl ReconcileProbes {
             backlog_age_seconds: inner
                 .backlog_since
                 .map(|since| now.saturating_duration_since(since).as_secs()),
+            untracked_path_count: inner.untracked_path_count,
+            untracked_paths_sample: inner.untracked_paths_sample.clone(),
         }
     }
 }

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -575,22 +575,45 @@ pub(crate) fn observed_tree_from_complete_scan(
     }
 
     for scanned in scan.entries() {
-        let content = read_scanned_entry(scanned)?;
-        let blob_digest = blobs.write(&content).map_err(DaemonError::from)?;
-        if blob_digest.0 != scanned.content_hash {
-            return Err(DaemonError::Io(std::io::Error::other(format!(
-                "repository entry changed after complete scan: {}",
-                scanned.repo_path
-            ))));
-        }
         let entry = match scanned.kind {
             kin_index::ScannedEntryKind::Regular { executable } => {
-                TreeEntry::blob(Hash256::from_bytes(blob_digest.0), executable)
+                TreeEntry::blob(Hash256::from_bytes(scanned.content_hash), executable)
             }
             kin_index::ScannedEntryKind::Symlink => {
-                TreeEntry::symlink(Hash256::from_bytes(blob_digest.0))
+                TreeEntry::symlink(Hash256::from_bytes(scanned.content_hash))
             }
         };
+        // Only an entry that differs from authority is read a second time.
+        //
+        // The walk has already opened, read, and hashed every leaf; reading each
+        // one again here made the cost of observing a working copy proportional
+        // to the whole working copy rather than to what moved in it, and the
+        // reconcile loop pays this on every tick. When the scanned identity
+        // matches the entry authority already carries at that path, the bytes
+        // behind it are by definition already a blob this store resolves, so the
+        // second read would re-derive a digest nothing is waiting for and rewrite
+        // a blob that is already there.
+        //
+        // The re-read is kept exactly where it earns its place. An entry that
+        // does differ is about to cross the compare-and-swap, so its bytes are
+        // read and their digest is checked against the walk's, which is what
+        // catches a file rewritten between the walk and the publication and
+        // refuses the whole observation rather than admitting a hash for content
+        // the store never held.
+        if previous
+            .artifact_at_path(&scanned.repo_path)
+            .map(|artifact| artifact.entry)
+            != Some(entry)
+        {
+            let content = read_scanned_entry(scanned)?;
+            let blob_digest = blobs.write(&content).map_err(DaemonError::from)?;
+            if blob_digest.0 != scanned.content_hash {
+                return Err(DaemonError::Io(std::io::Error::other(format!(
+                    "repository entry changed after complete scan: {}",
+                    scanned.repo_path
+                ))));
+            }
+        }
         observed.insert(scanned.repo_path.clone(), entry);
     }
 
@@ -1526,6 +1549,105 @@ mod tests {
             delta,
             TreeDelta::Removed { old, .. } if old.path == gone
         )));
+    }
+
+    /// An entry the walk found identical to authority is observed from the
+    /// walk's own proof, with no second read of the host.
+    ///
+    /// Asserted by deleting the file between the scan and the observation. The
+    /// walk already opened, read, and hashed it, and authority already holds a
+    /// blob for those exact bytes, so nothing is left to read and this succeeds;
+    /// the earlier code read every leaf a second time and fails here.
+    ///
+    /// This is the whole-store phase FIR-2152 found inside the per-event path.
+    /// The reconcile loop runs this on every tick, so a working copy of twenty
+    /// thousand files paid two complete reads of itself to observe that one file
+    /// had moved. What it costs now is proportional to what moved.
+    #[test]
+    fn an_unchanged_entry_is_observed_without_a_second_host_read() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = kin_core::init(tmp.path()).unwrap();
+        let layout = init.layout;
+        let blobs = BlobStore::new(layout.ingest_cas_dir()).unwrap();
+        let working = layout.working_dir();
+
+        let bytes = b"pub fn unchanged() {}\n";
+        std::fs::write(working.join("unchanged.rs"), bytes).unwrap();
+        let hash = Hash256::from_bytes(blobs.write(bytes).unwrap().0);
+        let path = RepoPath::from_utf8("unchanged.rs").unwrap();
+        let previous = resolved_tree(vec![(
+            ArtifactId::new(),
+            path.clone(),
+            TreeEntry::blob(hash, false),
+        )]);
+
+        let ignore = kin_index::RepositoryIgnore::load(&working).unwrap();
+        let scan = kin_index::scan_repository(
+            &working,
+            &ignore,
+            previous.artifacts_by_path().map(|artifact| &artifact.path),
+        )
+        .unwrap();
+
+        std::fs::remove_file(working.join("unchanged.rs")).unwrap();
+
+        let observed = observed_tree_from_complete_scan(&blobs, &scan, &previous).unwrap();
+        assert_eq!(
+            observed.entries().get(&path),
+            Some(&TreeEntry::blob(hash, false)),
+            "an unchanged entry is carried by the walk's hash, not by reading it again"
+        );
+        let deltas =
+            kin_core::plan_observed_tree_deltas(&previous, observed.entries().clone()).unwrap();
+        assert!(
+            deltas.is_empty(),
+            "an unchanged working copy plans no transition: {deltas:?}"
+        );
+    }
+
+    /// Falsification: an entry that differs from authority is still read, and
+    /// its bytes are still checked against the digest the walk recorded.
+    ///
+    /// Without this the saving above would be a hole rather than an economy: a
+    /// file rewritten between the walk and the publication would reach authority
+    /// as a hash for content the store never held.
+    #[test]
+    fn a_changed_entry_is_still_read_and_checked_against_the_walk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = kin_core::init(tmp.path()).unwrap();
+        let layout = init.layout;
+        let blobs = BlobStore::new(layout.ingest_cas_dir()).unwrap();
+        let working = layout.working_dir();
+
+        std::fs::write(working.join("changed.rs"), b"pub fn before() {}\n").unwrap();
+        let stale = Hash256::from_bytes(blobs.write(b"pub fn stale() {}\n").unwrap().0);
+        let path = RepoPath::from_utf8("changed.rs").unwrap();
+        let previous = resolved_tree(vec![(
+            ArtifactId::new(),
+            path.clone(),
+            TreeEntry::blob(stale, false),
+        )]);
+
+        let ignore = kin_index::RepositoryIgnore::load(&working).unwrap();
+        let scan = kin_index::scan_repository(
+            &working,
+            &ignore,
+            previous.artifacts_by_path().map(|artifact| &artifact.path),
+        )
+        .unwrap();
+
+        // Rewritten after the walk hashed it, which is the race the check exists
+        // for. The observation must refuse rather than publish the stale digest.
+        std::fs::write(working.join("changed.rs"), b"pub fn after() {}\n").unwrap();
+
+        let Err(error) = observed_tree_from_complete_scan(&blobs, &scan, &previous) else {
+            panic!("a changed entry must still be read and refused when it moved mid-pass");
+        };
+        let error = error.to_string();
+        assert!(
+            error.contains("changed.rs") || error.contains("changed after"),
+            "{error}"
+        );
     }
 
     /// A file whose content changed since the last commit appears as Modified.

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -594,7 +594,7 @@ pub(crate) fn observed_tree_from_complete_scan(
         // second read would re-derive a digest nothing is waiting for and rewrite
         // a blob that is already there.
         //
-        // The re-read is kept exactly where it earns its place. An entry that
+        // The re-read is kept where it can still catch something. An entry that
         // does differ is about to cross the compare-and-swap, so its bytes are
         // read and their digest is checked against the walk's, which is what
         // catches a file rewritten between the walk and the publication and

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -538,8 +538,8 @@ fn exact_tree_admission(
         // them: this refusal is why a freshly written file is not queryable, and
         // a surface that reports only what the loop admitted cannot say so. The
         // scan behind this is complete, so it replaces the previous answer
-        // instead of adding to it, and a path a commit later admits stops being
-        // reported on the very next tick.
+        // instead of adding to it, and the explicit seam below replaces it again
+        // as soon as a commit admits what was declined.
         state
             .background_work
             .reconcile()
@@ -628,6 +628,22 @@ fn exact_tree_admission(
             tree_deltas: deltas.clone(),
             ..TransactionDelta::default()
         })?;
+    }
+
+    if observation.is_none() {
+        // An explicit seam admits every host path the complete walk met, so
+        // once it publishes, nothing the working copy holds is untracked. Say
+        // so here rather than waiting for the next ambient tick: a commit
+        // produces no watcher event of its own, since the daemon's own writes
+        // land under `.kin` and the watcher drops control paths before they
+        // reach the queue. On a quiescent working copy the next tick never
+        // arrives, and the surfaces would keep naming a path this admission
+        // just made queryable. It is recorded after publication, not before, so
+        // a refused observation leaves a still-true record standing.
+        state
+            .background_work
+            .reconcile()
+            .record_untracked_observation(std::iter::empty::<&RepoPath>());
     }
 
     Ok(ExactTreeAdmission {
@@ -2428,6 +2444,57 @@ mod tests {
         };
         assert!(tree_changed);
         assert!(tree_entry(&state, "brand_new.rs").is_some());
+    }
+
+    /// The disclosure is the loop's answer to why a file is not queryable, so it
+    /// has to stop being that answer the moment a commit admits the path.
+    ///
+    /// Nothing else would clear it. A commit reaches authority through the
+    /// explicit seam and produces no watcher event of its own, so on a working
+    /// copy nobody is editing there is no next ambient tick to replace the
+    /// record. The surface would keep naming a path whose entities resolve,
+    /// which is the same misdirection FIR-2152 set out to remove.
+    #[test]
+    fn admitting_a_declined_path_clears_its_disclosure_without_another_host_event() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let path = repo.path().join("brand_new.rs");
+        std::fs::write(&path, b"pub fn brand_new() -> u32 { 2152 }\n").unwrap();
+
+        admit_file_event_ambient(&state, &FileEvent::Changed(path)).unwrap();
+        let declined = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(declined.untracked_path_count, 1);
+        assert_eq!(declined.untracked_paths_sample, vec!["brand_new.rs"]);
+
+        // The commit seam, and nothing after it: no watcher event is delivered,
+        // which is exactly the quiescent working copy the stale record survived
+        // on.
+        exact_tree_admission(&state, None).unwrap();
+        assert!(
+            tree_entry(&state, "brand_new.rs").is_some(),
+            "the seam must admit the path this disclosure was about"
+        );
+
+        let admitted = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(
+            admitted.untracked_path_count, 0,
+            "a path repository authority now carries is not untracked host content"
+        );
+        assert!(admitted.untracked_paths_sample.is_empty());
+        assert!(
+            !admitted
+                .notices()
+                .iter()
+                .any(|notice| notice.contains("brand_new.rs")),
+            "no surface may keep calling an admitted path untracked: {:?}",
+            admitted.notices()
+        );
     }
 
     /// The control that keeps the decline narrow: once a path is tracked, an

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -112,6 +112,17 @@ enum AdmittedFileEvent {
         file_id: Option<FilePathId>,
         tree_changed: bool,
     },
+    /// Host content at a path repository authority does not track, which the
+    /// preceding complete admission deliberately declined to enlarge the
+    /// workspace with.
+    ///
+    /// Distinct from [`Self::Ignored`], which is a path the rules exclude. This
+    /// one is admissible content that simply has not been admitted yet, and the
+    /// distinction is what the status surfaces report: an ignored path is doing
+    /// what was asked of it, an untracked one is waiting for a commit.
+    Untracked {
+        repo_path: RepoPath,
+    },
     Ignored,
 }
 
@@ -121,7 +132,7 @@ impl AdmittedFileEvent {
             Self::Regular { tree_changed, .. }
             | Self::Symlink { tree_changed, .. }
             | Self::Removed { tree_changed, .. } => *tree_changed,
-            Self::Ignored => false,
+            Self::Untracked { .. } | Self::Ignored => false,
         }
     }
 }
@@ -521,6 +532,20 @@ fn exact_tree_admission(
             }
             observed.insert(artifact.path.clone(), artifact.entry);
         }
+        // Everything the walk met that authority does not carry is about to be
+        // dropped, because ambient observation may revise graph-owned history
+        // but never enlarge it. Publish the count and a sample before dropping
+        // them: this refusal is why a freshly written file is not queryable, and
+        // a surface that reports only what the loop admitted cannot say so. The
+        // scan behind this is complete, so it replaces the previous answer
+        // instead of adding to it, and a path a commit later admits stops being
+        // reported on the very next tick.
+        state.background_work.reconcile().record_untracked_observation(
+            observed
+                .entries()
+                .keys()
+                .filter(|path| previous.artifact_id_at_path(path).is_none()),
+        );
         observed.retain(|path, _| previous.artifact_id_at_path(path).is_some());
     }
     // A bounded tick re-inserts every tracked path its observation did not
@@ -675,6 +700,25 @@ fn admit_file_event_with_exact_tree(
     };
 
     let file_type = metadata.file_type();
+    if !tracked && (file_type.is_file() || file_type.is_symlink()) {
+        // Admissible host content at a path repository authority does not carry.
+        // Ambient observation revises graph-owned history and never enlarges it,
+        // so the complete admission that just ran deliberately refused to plan
+        // this path in. Enriching it anyway is not available either: the
+        // revalidation below compares host bytes against the tree entry authority
+        // holds, and authority holds none, so this path can only ever fail that
+        // comparison.
+        //
+        // It is declined here rather than deferred because a deferral would be a
+        // promise the loop cannot keep. Every retry costs one complete exact-tree
+        // admission over the whole working copy and arrives at the identical
+        // refusal, so the ladder never converges: the backlog stays non-empty for
+        // as long as the daemon lives, reconciliation_status never returns to
+        // idle, backlog_age climbs without bound, and the store spends a core
+        // rescanning itself while admitting nothing. Declining once, out loud, is
+        // the fix.
+        return Ok(AdmittedFileEvent::Untracked { repo_path });
+    }
     let (content, blob_hash, entry, is_symlink) = if file_type.is_symlink() {
         let target = std::fs::read_link(path).map_err(DaemonError::Io)?;
         let content = symlink_target_bytes(&target).map_err(DaemonError::Io)?;
@@ -1445,6 +1489,18 @@ pub async fn run_loop(
             if matches!(admitted, AdmittedFileEvent::Ignored) {
                 continue;
             }
+            if let AdmittedFileEvent::Untracked { repo_path } = &admitted {
+                // Terminal for this tick, and deliberately not a deferral. The
+                // complete scan that ran above already counted every untracked
+                // path for the status surfaces, so this event has nothing left to
+                // contribute and nothing to retry. Leaving it out of the ladder is
+                // what lets the backlog drain and the loop go idle.
+                debug!(
+                    file = %repo_path,
+                    "observed untracked host content; leaving it for an explicit admission seam"
+                );
+                continue;
+            }
 
             let tree_changed = admitted.tree_changed();
             // Exact tree changes were admitted atomically for the whole batch
@@ -1459,7 +1515,9 @@ pub async fn run_loop(
                 AdmittedFileEvent::Regular { repo_path, .. }
                 | AdmittedFileEvent::Symlink { repo_path, .. }
                 | AdmittedFileEvent::Removed { repo_path, .. } => repo_path,
-                AdmittedFileEvent::Ignored => unreachable!(),
+                AdmittedFileEvent::Untracked { .. } | AdmittedFileEvent::Ignored => {
+                    unreachable!()
+                }
             };
             match host_entry_matches_graph(&state, path, admitted_repo_path) {
                 Ok(true) => {}
@@ -1652,7 +1710,9 @@ pub async fn run_loop(
                     }
                     continue;
                 }
-                AdmittedFileEvent::Ignored => unreachable!(),
+                AdmittedFileEvent::Untracked { .. } | AdmittedFileEvent::Ignored => {
+                    unreachable!()
+                }
             };
 
             match reconciler.reconcile_file_change(
@@ -3572,7 +3632,10 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
                 continue;
             }
         };
-        if matches!(admitted, AdmittedFileEvent::Ignored) {
+        if matches!(
+            admitted,
+            AdmittedFileEvent::Ignored | AdmittedFileEvent::Untracked { .. }
+        ) {
             continue;
         }
         let tree_changed = admitted.tree_changed();
@@ -3587,7 +3650,7 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
             AdmittedFileEvent::Regular { repo_path, .. }
             | AdmittedFileEvent::Symlink { repo_path, .. }
             | AdmittedFileEvent::Removed { repo_path, .. } => repo_path,
-            AdmittedFileEvent::Ignored => unreachable!(),
+            AdmittedFileEvent::Untracked { .. } | AdmittedFileEvent::Ignored => unreachable!(),
         };
         if !host_entry_matches_graph(state, path, admitted_repo_path)? {
             return Err(DaemonError::Io(std::io::Error::other(format!(
@@ -3725,7 +3788,7 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
                 }
                 continue;
             }
-            AdmittedFileEvent::Ignored => unreachable!(),
+            AdmittedFileEvent::Untracked { .. } | AdmittedFileEvent::Ignored => unreachable!(),
         };
 
         match reconciler.reconcile_file_change(&semantic_event, &state.blobs, state.graph.as_ref())

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -540,12 +540,15 @@ fn exact_tree_admission(
         // scan behind this is complete, so it replaces the previous answer
         // instead of adding to it, and a path a commit later admits stops being
         // reported on the very next tick.
-        state.background_work.reconcile().record_untracked_observation(
-            observed
-                .entries()
-                .keys()
-                .filter(|path| previous.artifact_id_at_path(path).is_none()),
-        );
+        state
+            .background_work
+            .reconcile()
+            .record_untracked_observation(
+                observed
+                    .entries()
+                    .keys()
+                    .filter(|path| previous.artifact_id_at_path(path).is_none()),
+            );
         observed.retain(|path, _| previous.artifact_id_at_path(path).is_some());
     }
     // A bounded tick re-inserts every tracked path its observation did not

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -789,6 +789,21 @@ fn admit_file_event(state: &DaemonState, event: &FileEvent) -> Result<AdmittedFi
     admit_file_event_with_exact_tree(state, event, &admission.changed_paths)
 }
 
+/// Mirror the reconcile loop's ambient tick rather than the explicit seam.
+///
+/// The distinction is the whole subject of the untracked-path tests: the same
+/// host event reaches a different verdict depending on whether an explicit
+/// admission asked for the working copy or a watcher merely noticed it.
+#[cfg(test)]
+fn admit_file_event_ambient(state: &DaemonState, event: &FileEvent) -> Result<AdmittedFileEvent> {
+    let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
+    let observation = repo_path(path, state.layout.working_dir())?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let admission = exact_tree_admission(state, Some(&observation))?;
+    admit_file_event_with_exact_tree(state, event, &admission.changed_paths)
+}
+
 fn clear_incompatible_facets(
     state: &DaemonState,
     file_id: &FilePathId,
@@ -2341,6 +2356,104 @@ mod tests {
             "{error}"
         );
         assert_eq!(tree_entry(&state, "tracked.sock"), Some(old_entry));
+    }
+
+    /// A watcher event for host content the repository has never tracked is
+    /// declined outright, and the decline is published.
+    ///
+    /// This is FIR-2152. The path could not be admitted, because ambient
+    /// observation may revise graph-owned history but never enlarge it, and it
+    /// could not be enriched either, because the revalidation compares host
+    /// bytes against a tree entry authority does not hold. The loop deferred it
+    /// instead, and every retry bought another complete exact-tree admission
+    /// over the whole working copy that arrived at the identical refusal: the
+    /// backlog never emptied, the status never returned to idle, the reported
+    /// backlog age climbed without bound, and a flagship store spent a core
+    /// rescanning itself for as long as the daemon lived.
+    #[test]
+    fn an_ambient_event_declines_untracked_host_content_and_says_so() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let untracked = repo.path().join("brand_new.rs");
+        std::fs::write(&untracked, b"pub fn brand_new() -> u32 { 2152 }\n").unwrap();
+
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(untracked)).unwrap();
+        let AdmittedFileEvent::Untracked { repo_path } = admitted else {
+            panic!("untracked host content must be declined, not admitted: {admitted:?}");
+        };
+        assert_eq!(repo_path, test_repo_path("brand_new.rs"));
+        assert!(
+            tree_entry(&state, "brand_new.rs").is_none(),
+            "a declined path must not enter repository authority"
+        );
+
+        // The surfaces have to be able to answer why the file is not queryable.
+        // Silence here is what made a deliberate refusal read as a wedged loop.
+        let report = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(report.untracked_path_count, 1);
+        assert_eq!(report.untracked_paths_sample, vec!["brand_new.rs"]);
+        assert!(
+            !report.degraded(),
+            "untracked content is the ordinary state of a working copy and must not degrade the daemon"
+        );
+        assert!(
+            report
+                .notices()
+                .iter()
+                .any(|notice| notice.contains("brand_new.rs")),
+            "the notice must name the path a reader is looking for: {:?}",
+            report.notices()
+        );
+    }
+
+    /// Falsification: the identical file reaches the opposite verdict through an
+    /// explicit admission seam, so the decline above is about how the event
+    /// arrived and not about the file.
+    #[test]
+    fn an_explicit_seam_still_admits_the_same_untracked_path() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let path = repo.path().join("brand_new.rs");
+        std::fs::write(&path, b"pub fn brand_new() -> u32 { 2152 }\n").unwrap();
+
+        let admitted = admit_file_event(&state, &FileEvent::Changed(path)).unwrap();
+        let AdmittedFileEvent::Regular { tree_changed, .. } = admitted else {
+            panic!("an explicit seam admits untracked host content: {admitted:?}");
+        };
+        assert!(tree_changed);
+        assert!(tree_entry(&state, "brand_new.rs").is_some());
+    }
+
+    /// The control that keeps the decline narrow: once a path is tracked, an
+    /// ambient watcher event for it is admitted exactly as before.
+    #[test]
+    fn an_ambient_event_for_a_tracked_path_is_still_admitted() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let path = repo.path().join("tracked.rs");
+        std::fs::write(&path, b"pub fn tracked() -> u32 { 1 }\n").unwrap();
+        admit_file_event(&state, &FileEvent::Changed(path.clone())).unwrap();
+        let admitted_entry = tree_entry(&state, "tracked.rs").unwrap();
+
+        std::fs::write(&path, b"pub fn tracked() -> u32 { 2 }\n").unwrap();
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(path)).unwrap();
+        let AdmittedFileEvent::Regular { tree_changed, .. } = admitted else {
+            panic!("an edit to a tracked path must still be admitted: {admitted:?}");
+        };
+        assert!(tree_changed);
+        assert_ne!(tree_entry(&state, "tracked.rs").unwrap(), admitted_entry);
+        assert_eq!(
+            state
+                .background_work
+                .reconcile()
+                .report(std::time::Instant::now())
+                .untracked_path_count,
+            0,
+            "a working copy holding only tracked paths reports none untracked"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -429,9 +429,15 @@ pub(crate) fn commit_session_workspace_admission(
 ///
 /// The caller has already performed the explicit filesystem-ingestion scan and
 /// carries its completion proof in `admitted`. This boundary consumes only that
-/// admitted exact tree plus bodies in the non-authoritative ingestion CAS,
-/// copies newly referenced bodies into repository CAS, and compare-and-swaps
-/// the workspace. It never creates a history node or advances a ref.
+/// admitted exact tree plus bodies the repository already owns or the
+/// non-authoritative ingestion CAS still stages, copies newly referenced bodies
+/// into repository CAS, and compare-and-swaps the workspace. It never creates a
+/// history node or advances a ref.
+///
+/// Bodies are read from ingestion staging first and from repository CAS when
+/// staging no longer has them. Staging is not authority and promises no
+/// retention, so a source the repository already published stays publishable
+/// whether or not its staged copy survives.
 ///
 /// Authority that moved after the observation was planned fails the whole
 /// publication. The desired tree describes one transition out of one observed
@@ -493,13 +499,30 @@ pub(crate) fn publish_workspace_tree(
             if let Some(length) = source_lengths.get(&hash) {
                 return Ok(*length);
             }
-            let body = blobs
-                .read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))
-                .map_err(|error| {
-                    ModelError::InvalidOperation(format!(
-                        "read admitted workspace policy source {hash}: {error}"
-                    ))
-                })?;
+            // Every rule file in the desired tree is measured here, changed or
+            // not, because the policy is derived from the whole tree. Ingestion
+            // staging is not authority and carries no retention promise, while
+            // a source the repository already published is durable in its own
+            // CAS. Reading staging first and authority second is what keeps an
+            // untouched `.gitignore` from making publication depend on a
+            // staging directory that any restore or cleanup may have dropped.
+            let body = match blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes())) {
+                Ok(body) => body,
+                Err(ingestion_error) => authority
+                    .load_source_blob(hash)
+                    .map_err(|error| {
+                        ModelError::InvalidOperation(format!(
+                            "read repository source {hash} while deriving the admitted workspace \
+                             policy: {error}"
+                        ))
+                    })?
+                    .ok_or_else(|| {
+                        ModelError::InvalidOperation(format!(
+                            "admitted workspace policy source {hash} is absent from both \
+                             ingestion and repository CAS ({ingestion_error})"
+                        ))
+                    })?,
+            };
             let length = u64::try_from(body.len()).map_err(|_| {
                 ModelError::InvalidOperation(format!(
                     "admitted workspace policy source {hash} exceeds u64"
@@ -573,8 +596,19 @@ pub(crate) fn publish_workspace_tree(
     drop(lease);
 
     for hash in source_hashes {
-        let body = blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))?;
-        authority.save_source_blob(hash, &body)?;
+        // Copying a staged body into repository CAS is how a newly referenced
+        // source becomes durable. An unchanged rule source is already there and
+        // needs no copy, so staging having dropped it is not a failure. A body
+        // neither store holds still fails the publication, as the typed blob
+        // absence a caller can match on.
+        match blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes())) {
+            Ok(body) => authority.save_source_blob(hash, &body)?,
+            Err(ingestion_error) => {
+                if authority.load_source_blob(hash)?.is_none() {
+                    return Err(DaemonError::from(ingestion_error));
+                }
+            }
+        }
     }
     let receipt = authority.commit_repository_transaction(transaction)?;
     receipt.validate()?;
@@ -1517,6 +1551,95 @@ mod tests {
         .unwrap()
         .is_none());
         assert_eq!(reopen(&init).read_authority().roots().generation, 2);
+    }
+
+    /// Publication must not depend on ingestion staging still holding a body the
+    /// repository already owns.
+    ///
+    /// Every `.gitignore` and `.kinignore` blob in the desired tree is measured
+    /// on every publication, because the shared admission policy is derived from
+    /// the whole tree and not from what changed. Bounding one tick to what moved
+    /// removed the per-scan rewrite that used to restage every leaf ahead of
+    /// every publication, so that read now has to reach the store that actually
+    /// promises the body. Staging is not authority and keeps no retention
+    /// promise; a store that loses it while its authority survives must still
+    /// publish, instead of failing every admission until someone happens to edit
+    /// a rule file.
+    #[test]
+    fn an_unchanged_rule_source_publishes_after_ingestion_staging_is_lost() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        let rules = add_artifact(&graph, &blobs, b".gitignore", b"target/\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let first = add_artifact(
+            &graph,
+            &blobs,
+            b"first.rs",
+            b"pub fn first() {}\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+        publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &ResolvedTree::from_artifacts([rules.clone(), first.clone()]).unwrap(),
+            OperationId::new(),
+            AuthorId::new("fir2152"),
+        )
+        .unwrap()
+        .expect("the first transition must advance workspace authority");
+
+        // Lose the staging directory the way a restore that carries the
+        // authority database but not a directory named like a cache does.
+        let rules_hash = rules.entry.blob_identity().unwrap();
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        assert!(
+            blobs.read(&rules_hash).is_err(),
+            "the fixture only proves anything while the staged rule body is genuinely gone"
+        );
+
+        let second = add_artifact(
+            &graph,
+            &blobs,
+            b"second.rs",
+            b"pub fn second() {}\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+        let desired = ResolvedTree::from_artifacts([rules.clone(), first, second]).unwrap();
+        let result = publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &desired,
+            OperationId::new(),
+            AuthorId::new("fir2152"),
+        )
+        .unwrap()
+        .expect("a transition that leaves the rule file untouched must still advance authority");
+        assert_eq!(result.receipt.generation, 3);
+
+        let authority = reopen(&init);
+        let lease = authority.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == init.workspace_id)
+            .unwrap();
+        assert_eq!(workspace.tree, desired);
+        assert_eq!(
+            workspace
+                .shared_admission_policy
+                .sources
+                .iter()
+                .map(|source| source.path.clone())
+                .collect::<Vec<_>>(),
+            vec![rules.path.clone()],
+            "the derived policy still names the rule file whose body only authority holds"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Writing one new file into a working copy could put the reconcile loop into `processing` and leave it there for as long as the daemon lived. The generation never moved, the reported backlog age climbed one second per second and never cleared, admission never failed once, and the daemon held most of a core the whole time. None of those readings were wrong. They were describing a loop retrying an event it had already decided it could not accept.

Ambient observation is bounded on purpose. A watcher may revise history the graph already owns but it never enlarges it, so a path the workspace has never tracked becomes repository truth when someone commits it and not because a file appeared on disk. The complete admission planned nothing for the new path, which is correct. What happened next was not. The per-event revalidation compares the bytes on disk against the tree entry authority holds for that path. Authority held none, so the comparison failed, and the loop read that failure as the host moving underneath it and deferred the path into its retry ladder. The ladder tops out at 6.4 seconds, and every step buys another complete exact-tree admission over the entire working copy that arrives at the identical refusal. It cannot converge. The backlog predicate stays true for as long as the daemon lives, so the status never returns to idle and the age it reports is really the age of the daemon.

`admit_file_event_with_exact_tree` now returns a distinct `Untracked` verdict for admissible host content at a path authority does not carry, and the loop treats it as terminal. Nothing is deferred and nothing is retried. No blob is written for content the repository declined. The backlog drains and the loop goes idle.

The refusal is no longer silent. The complete scan already knows every path it is about to drop, so it records the count and a bounded sample onto the reconcile probes, and `kin graph status` and `/health` both name those paths. They appear as a notice and not as a fault. A working copy holding untracked files is the ordinary state of one being edited, and a health signal that is always on is one nobody reads.

The second change is the whole-store phase that made each of those futile passes expensive. Building the observed tree read every leaf a second time, after the walk had already opened, read, and hashed all of them, and wrote each one back into the blob store. That made observing a working copy cost the whole working copy rather than what moved in it, on every tick of the reconcile loop and ahead of every `/commands/commit` and `/commands/stash`, which run the same admission before doing any work of their own. An entry whose scanned identity already equals what authority carries at that path is now taken from the walk's own hash, because those bytes are by definition already a blob the store resolves. Only an entry that differs is read again, so the compare-and-swap that catches a file rewritten between the walk and the publication stays on the entries that are actually about to cross authority. Publication no longer leans on that staging store having kept anything either: an unchanged rule file, whose body every publication measures whether or not it moved, is now read from the repository's own source CAS when ingestion staging no longer holds it, so a lost staging directory cannot wedge every later admission.

The tests assert phases and counters rather than durations. Ambient observation declines an untracked path while an explicit seam still admits the same file. An edit to a tracked path is admitted as before and reports nothing untracked. The decline reaches both status surfaces without degrading either. An unchanged entry is observed after its file has been deleted, which fails if anything reads it a second time, and a changed entry still refuses when it moved mid-pass.

One thing this deliberately does not change is that the new file stays unqueryable until something admits it. That is the documented rule, and it is the reason an explicit admission seam exists. What changes is that the daemon says so, once, instead of spending a core failing to.

Closes FIR-2152

