### PR TITLE
Add an on-demand complete exact-tree admission and label locate hits by id space

### DIFF
--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -16,13 +16,18 @@
 //! here inherits the same completion proof, authority compare-and-swap, and
 //! mass-deletion guard as every ambient one.
 //!
-//! Two properties matter beyond the request itself. The CLI registers a daemon
+//! Three properties matter beyond the request itself. The CLI registers a daemon
 //! session for the duration and releases it afterwards, because a daemon with no
 //! registered session idles out while a long first pass is still running, and an
 //! admission killed at its midpoint is the failure this command exists to
-//! resolve. And the outcome is read back from the reconcile probes rather than
+//! resolve. The outcome is read back from the reconcile probes rather than
 //! inferred from the request succeeding, because a pass that ran and admitted
-//! nothing and a pass that ran and failed are different answers.
+//! nothing and a pass that ran and failed are different answers. And the request
+//! is not the pass: the daemon runs the admission detached from the connection
+//! that asked for it, so this command waits by attaching to that pass, and an
+//! attempt that goes unanswered leaves the outcome unknown rather than
+//! canceled. The one answer it may never produce is a completed admission it
+//! did not see reported.
 
 use anyhow::{Context, Result};
 use kin_model::{AuthorId, OperationId, RepositoryId};
@@ -107,31 +112,53 @@ pub struct AdmitResponse {
     pub report: Option<AdmitReport>,
 }
 
+/// Whether the graph counts this pass reported actually moved.
+///
+/// Asked on the failure path as well as the success path, because the admission
+/// seam publishes repository authority before it enriches: a pass that fails
+/// afterwards has still moved the tree, and both the summary and `mutated` have
+/// to say so rather than describe the store the operator no longer has.
+pub fn census_moved(report: &AdmitReport) -> bool {
+    report.tracked_after != report.tracked_before || report.entities_after != report.entities_before
+}
+
 /// Render the operator-facing summary for one admission report.
 ///
 /// Kept separate from transport so the wording is asserted directly rather than
 /// through a daemon round trip.
 pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
     let mut lines = Vec::new();
+    let tracked_delta = report.tracked_after as i64 - report.tracked_before as i64;
+    let entity_delta = report.entities_after as i64 - report.entities_before as i64;
 
     if !report.admitted {
-        // Cause first: the operator needs the reason before the counters, and
-        // the counters below describe a tree the pass did not change.
+        // Cause first: the operator needs the reason before the counters.
         let cause = report
             .failure
             .as_deref()
             .or(report.reconcile.last_admission_error.as_deref())
             .unwrap_or("no cause recorded");
         lines.push(format!("Complete exact-tree admission failed: {cause}"));
-        lines.push(format!(
-            "Graph authority is unchanged: {} tracked artifacts, {} entities.",
-            report.tracked_before, report.entities_before
-        ));
+        if census_moved(report) {
+            // Authority crossed before the failure. Calling that unchanged is
+            // the one wording an operator cannot recover from, because it
+            // describes a settled store while the real one is half admitted:
+            // the tree published and the semantic enrichment for it did not.
+            lines.push(format!(
+                "Graph authority moved before the failure: {} tracked artifacts \
+                 ({tracked_delta:+}), {} entities ({entity_delta:+}). Enrichment for that \
+                 transition is incomplete; re-run `kin admit` once the cause above is resolved.",
+                report.tracked_after, report.entities_after
+            ));
+        } else {
+            lines.push(format!(
+                "Graph authority is unchanged: {} tracked artifacts, {} entities.",
+                report.tracked_before, report.entities_before
+            ));
+        }
         return lines;
     }
 
-    let tracked_delta = report.tracked_after as i64 - report.tracked_before as i64;
-    let entity_delta = report.entities_after as i64 - report.entities_before as i64;
     if tracked_delta == 0 && entity_delta == 0 {
         lines.push(format!(
             "Admitted the complete exact tree; nothing changed. {} tracked artifacts, {} entities.",
@@ -170,6 +197,136 @@ pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
     lines
 }
 
+/// Consecutive attempts that could not reach the daemon at all before this says
+/// so on stderr. One dropped request proves nothing: a daemon busy with a long
+/// pass can drop one and still be there. A run of them is worth announcing.
+const ADMIT_UNREACHABLE_WARN_AFTER: u32 = 4;
+
+/// Consecutive unreachable attempts before the wait ends without a verdict.
+///
+/// A daemon that has answered nothing for this long is gone, and the honest
+/// report is that the admission's outcome is unknown from here rather than that
+/// it failed.
+const ADMIT_UNREACHABLE_GIVE_UP_AFTER: u32 = 20;
+
+/// Backstop on total unanswered attempts against a daemon that keeps proving it
+/// is alive. Nothing should reach it, and a wait with no ceiling at all is a
+/// hang wearing a progress line.
+const ADMIT_UNANSWERED_GIVE_UP_AFTER: u32 = 288;
+
+/// Pause between attempts, so a dispatch that fails instantly cannot spin.
+const ADMIT_RETRY_PAUSE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// What a command waiting on an admission does after one unanswered dispatch.
+///
+/// There is deliberately no success in this enum. Nothing coming back
+/// establishes nothing about the pass, so an unanswered attempt has exactly two
+/// continuations, and reporting a completed admission is not one of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdmitWaitStep {
+    /// The daemon is still answering, so the pass it is running is still the
+    /// pass this command asked for. Attach again.
+    KeepWaiting,
+    GiveUp(AdmitWaitEnd),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdmitWaitEnd {
+    /// The daemon stopped answering anything at all.
+    DaemonUnreachable,
+    /// The daemon kept answering and the pass never reported.
+    NoOutcomeInBudget,
+}
+
+impl AdmitWaitEnd {
+    fn explain(self, attempts: u32) -> String {
+        match self {
+            Self::DaemonUnreachable => format!(
+                "the kin daemon stopped answering for {attempts} consecutive attempts while a \
+                 complete exact-tree admission was in flight, so whether that pass finished is \
+                 unknown from here; read `kin graph status` for the state the store is in, then \
+                 re-run `kin admit`"
+            ),
+            Self::NoOutcomeInBudget => format!(
+                "the kin daemon is still answering, but the complete exact-tree admission has not \
+                 reported an outcome across {attempts} attempts, so whether it finished is \
+                 unknown from here; read `kin graph status` for the state the store is in"
+            ),
+        }
+    }
+}
+
+/// Decide the next step from the states this command can actually observe: what
+/// the last dispatch established, whether the daemon is answering at all, and
+/// how long each has been true.
+fn admit_wait_step(daemon_reachable: bool, unanswered: u32, unreachable: u32) -> AdmitWaitStep {
+    if !daemon_reachable && unreachable >= ADMIT_UNREACHABLE_GIVE_UP_AFTER {
+        return AdmitWaitStep::GiveUp(AdmitWaitEnd::DaemonUnreachable);
+    }
+    if unanswered >= ADMIT_UNANSWERED_GIVE_UP_AFTER {
+        return AdmitWaitStep::GiveUp(AdmitWaitEnd::NoOutcomeInBudget);
+    }
+    AdmitWaitStep::KeepWaiting
+}
+
+/// Ask for one complete exact-tree admission and wait for that pass to report.
+///
+/// The request is not the pass. The daemon runs the admission detached from the
+/// connection that asked for it, so an unanswered attempt means the pass is
+/// still running or the daemon is gone, never that it was canceled, and a later
+/// attempt joins the same pass rather than starting a competing one. That is
+/// what makes waiting by re-attaching correct where a silent transport retry
+/// was not: a retry that re-observes an already-published tree finds nothing to
+/// do and reports a complete admission that enriched none of it.
+async fn wait_for_admission(
+    client: &crate::daemon_client::DaemonClient,
+    request: &AdmitRequest,
+) -> Result<AdmitResponse> {
+    let mut unanswered = 0u32;
+    let mut unreachable = 0u32;
+    loop {
+        let unanswered_error = match client.admit(request).await {
+            crate::daemon_client::AdmitDispatch::Answered(response) => return Ok(response),
+            crate::daemon_client::AdmitDispatch::Refused(error) => return Err(error),
+            crate::daemon_client::AdmitDispatch::Unanswered(error) => error,
+        };
+
+        // Liveness is a separate question from the answer, and the request that
+        // went unanswered cannot settle it: a daemon still working and a daemon
+        // that died look the same from a connection that produced nothing.
+        let reachable = client.is_reachable().await;
+        unanswered = unanswered.saturating_add(1);
+        unreachable = if reachable {
+            0
+        } else {
+            unreachable.saturating_add(1)
+        };
+
+        match admit_wait_step(reachable, unanswered, unreachable) {
+            AdmitWaitStep::GiveUp(end) => {
+                let attempts = if reachable { unanswered } else { unreachable };
+                return Err(unanswered_error.context(end.explain(attempts)));
+            }
+            AdmitWaitStep::KeepWaiting => {
+                if reachable {
+                    eprintln!(
+                        "kin admit: no answer yet after {unanswered} attempt(s); the daemon is up \
+                         and still running the pass. Interrupting this command stops the waiting, \
+                         not the admission."
+                    );
+                } else if unreachable >= ADMIT_UNREACHABLE_WARN_AFTER {
+                    eprintln!(
+                        "kin admit: {unreachable} consecutive attempts could not reach the \
+                         daemon; still retrying, and the outcome of the pass is unknown until one \
+                         of them answers."
+                    );
+                }
+                tokio::time::sleep(ADMIT_RETRY_PAUSE).await;
+            }
+        }
+    }
+}
+
 pub async fn run() -> Result<()> {
     let cwd = std::env::current_dir().context("resolve current directory")?;
     let layout = crate::commands::require_repository_layout_at(&cwd)?;
@@ -206,12 +363,14 @@ pub async fn run() -> Result<()> {
         .await
         .context("register the daemon session that keeps this admission alive")?;
 
-    let outcome = client
-        .admit(&AdmitRequest {
-            operation_id: OperationId::new(),
-            actor: AuthorId::new(kin_core::whoami()),
-        })
-        .await;
+    // One operation identity for the whole wait, however many attempts it
+    // takes: every attempt after the first joins the pass the first one started
+    // rather than asking for another.
+    let request = AdmitRequest {
+        operation_id: OperationId::new(),
+        actor: AuthorId::new(kin_core::whoami()),
+    };
+    let outcome = wait_for_admission(&client, &request).await;
 
     // Release the lease on every path. A leaked lease keeps the daemon awake
     // indefinitely, which is the same defect as the one this command fixes
@@ -272,11 +431,18 @@ mod tests {
         assert!(!text.contains("failed"), "{text}");
     }
 
-    /// The counters describe a tree the failed pass did not change, so the cause
+    /// A pass refused before the seam published changed nothing, so the cause
     /// has to lead and the counters have to say they are unchanged.
     #[test]
     fn a_failed_admission_leads_with_its_cause_and_refuses_to_claim_a_change() {
-        let text = summary_lines(&report(false)).join("\n");
+        let mut refused = report(false);
+        // The pre-publish refusals: the mass-deletion guard and the planning
+        // errors, where the census genuinely did not move.
+        refused.tracked_after = refused.tracked_before;
+        refused.entities_after = refused.entities_before;
+        assert!(!census_moved(&refused));
+
+        let text = summary_lines(&refused).join("\n");
         let first = text.lines().next().unwrap_or_default();
         assert!(
             first.starts_with("Complete exact-tree admission failed: host entry changed"),
@@ -284,6 +450,85 @@ mod tests {
         );
         assert!(text.contains("Graph authority is unchanged"), "{text}");
         assert!(!text.contains("4210"), "{text}");
+    }
+
+    /// A pass that fails AFTER the seam published has already moved graph
+    /// authority, and the report has to say so.
+    ///
+    /// The seam publishes the complete exact tree before it enriches, and the
+    /// reachable post-publish failure is the host-entry check. Calling that an
+    /// unchanged store describes a repository the operator no longer has: the
+    /// tree crossed authority and the enrichment for it did not, which is the
+    /// one state that needs a second pass.
+    #[test]
+    fn a_failed_pass_that_already_published_reports_the_authority_it_moved() {
+        let published = report(false);
+        assert!(
+            census_moved(&published),
+            "the fixture must describe a pass that published before it failed"
+        );
+
+        let text = summary_lines(&published).join("\n");
+        let first = text.lines().next().unwrap_or_default();
+        assert!(
+            first.starts_with("Complete exact-tree admission failed:"),
+            "{text}"
+        );
+        assert!(!text.contains("unchanged"), "{text}");
+        assert!(
+            text.contains("Graph authority moved before the failure"),
+            "{text}"
+        );
+        assert!(text.contains("4210 tracked artifacts (+4179)"), "{text}");
+        assert!(
+            text.contains("Enrichment for that transition is incomplete"),
+            "{text}"
+        );
+    }
+
+    /// Nothing coming back establishes nothing about the pass, so no run of
+    /// counters may turn an unanswered dispatch into a finished admission.
+    #[test]
+    fn an_unanswered_dispatch_never_reads_as_a_finished_admission() {
+        // A daemon that keeps answering is a pass still running, however long
+        // it has been running: attempts alone never end the wait.
+        for unanswered in [
+            1,
+            ADMIT_UNREACHABLE_GIVE_UP_AFTER,
+            ADMIT_UNANSWERED_GIVE_UP_AFTER - 1,
+        ] {
+            assert_eq!(
+                admit_wait_step(true, unanswered, 0),
+                AdmitWaitStep::KeepWaiting
+            );
+        }
+
+        // One refused connection proves nothing. A run of them is the daemon
+        // being gone, and that ends the wait with no verdict on the pass.
+        assert_eq!(admit_wait_step(false, 1, 1), AdmitWaitStep::KeepWaiting);
+        assert_eq!(
+            admit_wait_step(
+                false,
+                ADMIT_UNREACHABLE_GIVE_UP_AFTER,
+                ADMIT_UNREACHABLE_GIVE_UP_AFTER
+            ),
+            AdmitWaitStep::GiveUp(AdmitWaitEnd::DaemonUnreachable)
+        );
+        assert_eq!(
+            admit_wait_step(true, ADMIT_UNANSWERED_GIVE_UP_AFTER, 0),
+            AdmitWaitStep::GiveUp(AdmitWaitEnd::NoOutcomeInBudget)
+        );
+
+        // Both endings report an unknown outcome rather than naming one.
+        for end in [
+            AdmitWaitEnd::DaemonUnreachable,
+            AdmitWaitEnd::NoOutcomeInBudget,
+        ] {
+            let text = end.explain(ADMIT_UNREACHABLE_GIVE_UP_AFTER);
+            assert!(text.contains("unknown"), "{text}");
+            assert!(text.contains("kin graph status"), "{text}");
+            assert!(!text.contains("admitted"), "{text}");
+        }
     }
 
     /// A pass that ran and admitted nothing is a real answer, and it must not

--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Wire types and CLI transport for requesting one complete exact-tree
+//! admission on demand.
+//!
+//! The daemon admits a complete exact tree on startup, on `kin commit`, and on
+//! whatever the watcher happened to observe. None of those is a trigger an
+//! operator can pull. A store whose graph fell behind its working tree, because
+//! ingest was interrupted or because ignore rules changed what is admissible,
+//! therefore waits for an organic churn burst to recover, and a quiet daemon
+//! idles out before one arrives. This command is that trigger.
+//!
+//! It is not a second admission implementation. It asks the daemon to run the
+//! same complete exact-tree pass its own loop runs, so an admission requested
+//! here inherits the same completion proof, authority compare-and-swap, and
+//! mass-deletion guard as every ambient one.
+//!
+//! Two properties matter beyond the request itself. The CLI registers a daemon
+//! session for the duration and releases it afterwards, because a daemon with no
+//! registered session idles out while a long first pass is still running, and an
+//! admission killed at its midpoint is the failure this command exists to
+//! resolve. And the outcome is read back from the reconcile probes rather than
+//! inferred from the request succeeding, because a pass that ran and admitted
+//! nothing and a pass that ran and failed are different answers.
+
+use anyhow::{Context, Result};
+use kin_model::{AuthorId, OperationId, RepositoryId};
+use serde::{Deserialize, Serialize};
+
+use crate::commands::resources::ReconcileHealth;
+
+pub const ADMIT_SCHEMA: &str = "kin.admit.v1";
+
+/// Vendor recorded for the session this command holds.
+///
+/// Anything other than `kin-daemon` counts as an external session and suppresses
+/// idle shutdown, which is the whole reason the lease is taken. Naming the CLI
+/// specifically also means an operator reading `kin daemon sessions` mid-pass
+/// sees what is holding the daemon open.
+pub const ADMIT_SESSION_VENDOR: &str = "kin-cli";
+
+/// Client name recorded for the session this command holds.
+pub const ADMIT_SESSION_CLIENT: &str = "kin admit";
+
+/// A requested admission carries no options.
+///
+/// It deliberately has no mass-deletion confirmation of its own. The guard is
+/// evaluated inside the shared admission pass and its override is read from the
+/// daemon's environment, so a flag here would have to be a second control over
+/// the same guard reaching it by a different route, and two controls over one
+/// guard are two rules that can come to disagree. A refused admission reports
+/// the guard's own counts and names the variable instead.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdmitRequest {
+    pub operation_id: OperationId,
+    pub actor: AuthorId,
+}
+
+/// What one requested admission did, measured on both sides of the pass.
+///
+/// Counts are stated before and after rather than as a delta, so a pass that
+/// admitted nothing is distinguishable from a pass that could not run. The
+/// reconcile probes ride along because the request returning success only says
+/// the daemon accepted the call; whether the admission itself succeeded is what
+/// [`ReconcileHealth::admission_failure_streak`] and
+/// `last_admission_success_age_seconds` answer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AdmitReport {
+    pub schema: String,
+    pub repository_id: RepositoryId,
+    /// Tracked artifacts in graph authority before the pass.
+    pub tracked_before: usize,
+    /// Tracked artifacts in graph authority after the pass.
+    pub tracked_after: usize,
+    /// Graph entities before the pass.
+    pub entities_before: usize,
+    /// Graph entities after the pass.
+    pub entities_after: usize,
+    /// Retrievable objects the vector index holds after the pass, and the total
+    /// that want an embedding. An admission adds graph objects; embedding them
+    /// is the background pass that follows, so this is reported rather than
+    /// waited on.
+    pub embeddings_indexed: usize,
+    pub embeddings_total: usize,
+    /// The reconcile probes read AFTER the pass. This is the outcome surface:
+    /// the request can succeed while the admission inside it failed.
+    pub reconcile: ReconcileHealth,
+    /// False when the pass itself failed. The request still returns its report
+    /// so the operator sees the counters and the recorded cause; the CLI exits
+    /// nonzero.
+    pub admitted: bool,
+    /// Present only when the pass failed: the recorded cause, verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdmitResponse {
+    #[serde(default)]
+    pub lines: Vec<String>,
+    #[serde(default)]
+    pub mutated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub report: Option<AdmitReport>,
+}
+
+/// Render the operator-facing summary for one admission report.
+///
+/// Kept separate from transport so the wording is asserted directly rather than
+/// through a daemon round trip.
+pub fn summary_lines(report: &AdmitReport) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    if !report.admitted {
+        // Cause first: the operator needs the reason before the counters, and
+        // the counters below describe a tree the pass did not change.
+        let cause = report
+            .failure
+            .as_deref()
+            .or(report.reconcile.last_admission_error.as_deref())
+            .unwrap_or("no cause recorded");
+        lines.push(format!("Complete exact-tree admission failed: {cause}"));
+        lines.push(format!(
+            "Graph authority is unchanged: {} tracked artifacts, {} entities.",
+            report.tracked_before, report.entities_before
+        ));
+        return lines;
+    }
+
+    let tracked_delta = report.tracked_after as i64 - report.tracked_before as i64;
+    let entity_delta = report.entities_after as i64 - report.entities_before as i64;
+    if tracked_delta == 0 && entity_delta == 0 {
+        lines.push(format!(
+            "Admitted the complete exact tree; nothing changed. {} tracked artifacts, {} entities.",
+            report.tracked_after, report.entities_after
+        ));
+    } else {
+        lines.push(format!(
+            "Admitted the complete exact tree: {} tracked artifacts ({tracked_delta:+}), {} \
+             entities ({entity_delta:+}).",
+            report.tracked_after, report.entities_after
+        ));
+    }
+
+    // An admission adds graph objects; embedding them is the pass that follows.
+    // Saying so is the difference between an operator waiting for retrieval to
+    // improve and an operator concluding the admission did not work.
+    if report.embeddings_total > report.embeddings_indexed {
+        lines.push(format!(
+            "Embeddings: {} of {} indexed; the remainder is queued for the background embed pass.",
+            report.embeddings_indexed, report.embeddings_total
+        ));
+    } else if report.embeddings_total > 0 {
+        lines.push(format!(
+            "Embeddings: {} of {} indexed.",
+            report.embeddings_indexed, report.embeddings_total
+        ));
+    }
+
+    // The probes are the reason this command reports an outcome at all rather
+    // than exiting zero on a successful request, so a degraded reconcile state
+    // is printed even on a pass that itself succeeded.
+    for reason in report.reconcile.degraded_reasons() {
+        lines.push(format!("Attention: {reason}"));
+    }
+
+    lines
+}
+
+pub async fn run() -> Result<()> {
+    let cwd = std::env::current_dir().context("resolve current directory")?;
+    let layout = crate::commands::require_repository_layout_at(&cwd)?;
+    let base_url = crate::daemon_client::resolve_daemon_url(&layout)
+        .await?
+        .ok_or_else(|| {
+            crate::daemon_client::daemon_required_error(
+                "admitting the complete exact tree",
+                &layout,
+            )
+        })?;
+    // Explicit authority with no session header: this publishes against HEAD
+    // authority, so an ambient `KIN_SESSION_ID` inherited from a surrounding
+    // agent session would scope the request to a workspace it must not touch.
+    // The lease taken below is a liveness hold, not a scope.
+    let client = crate::daemon_client::DaemonClient::from_base_url_with_explicit_authority(
+        base_url,
+        crate::daemon_client::resolve_daemon_auth_token_for_layout(&layout),
+        None,
+    )?;
+
+    // Hold a session for the pass. A daemon with no registered session idles
+    // out on its own timer, and a complete exact-tree admission on a large
+    // store outlives that window, so without this the command's own request can
+    // be killed by the daemon it is talking to.
+    let session_id = client
+        .start_session(
+            ADMIT_SESSION_VENDOR,
+            ADMIT_SESSION_CLIENT,
+            &cwd,
+            std::process::id(),
+            kin_model::session::SessionCapabilities::default(),
+        )
+        .await
+        .context("register the daemon session that keeps this admission alive")?;
+
+    let outcome = client
+        .admit(&AdmitRequest {
+            operation_id: OperationId::new(),
+            actor: AuthorId::new(kin_core::whoami()),
+        })
+        .await;
+
+    // Release the lease on every path. A leaked lease keeps the daemon awake
+    // indefinitely, which is the same defect as the one this command fixes
+    // pointed the other way.
+    if let Err(error) = client.end_session(&session_id).await {
+        tracing::warn!(
+            error = %error,
+            session = %session_id,
+            "failed to release the admission session lease; it will expire on its idle timeout"
+        );
+    }
+
+    let response = outcome?;
+    for line in &response.lines {
+        println!("{line}");
+    }
+    match response.report.as_ref() {
+        Some(report) if !report.admitted => {
+            let cause = report
+                .failure
+                .as_deref()
+                .or(report.reconcile.last_admission_error.as_deref())
+                .unwrap_or("no cause recorded");
+            Err(anyhow::anyhow!(
+                "complete exact-tree admission failed: {cause}"
+            ))
+        }
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(admitted: bool) -> AdmitReport {
+        AdmitReport {
+            schema: ADMIT_SCHEMA.to_string(),
+            repository_id: RepositoryId::new("admit-summary").unwrap(),
+            tracked_before: 31,
+            tracked_after: 4210,
+            entities_before: 0,
+            entities_after: 9977,
+            embeddings_indexed: 49,
+            embeddings_total: 14187,
+            reconcile: ReconcileHealth::default(),
+            admitted,
+            failure: (!admitted).then(|| "host entry changed after exact-tree admission".to_string()),
+        }
+    }
+
+    #[test]
+    fn a_successful_admission_names_both_sides_of_the_transition() {
+        let text = summary_lines(&report(true)).join("\n");
+        assert!(text.contains("4210 tracked artifacts (+4179)"), "{text}");
+        assert!(text.contains("9977 entities (+9977)"), "{text}");
+        assert!(!text.contains("failed"), "{text}");
+    }
+
+    /// The counters describe a tree the failed pass did not change, so the cause
+    /// has to lead and the counters have to say they are unchanged.
+    #[test]
+    fn a_failed_admission_leads_with_its_cause_and_refuses_to_claim_a_change() {
+        let text = summary_lines(&report(false)).join("\n");
+        let first = text.lines().next().unwrap_or_default();
+        assert!(
+            first.starts_with("Complete exact-tree admission failed: host entry changed"),
+            "{text}"
+        );
+        assert!(text.contains("Graph authority is unchanged"), "{text}");
+        assert!(!text.contains("4210"), "{text}");
+    }
+
+    /// A pass that ran and admitted nothing is a real answer, and it must not
+    /// read like a pass that could not run.
+    #[test]
+    fn an_admission_that_changed_nothing_says_so_without_reading_as_a_failure() {
+        let mut settled = report(true);
+        settled.tracked_before = 4210;
+        settled.entities_before = 9977;
+        settled.embeddings_indexed = 14187;
+        let text = summary_lines(&settled).join("\n");
+        assert!(text.contains("nothing changed"), "{text}");
+        assert!(!text.contains("failed"), "{text}");
+        assert!(text.contains("14187 of 14187 indexed"), "{text}");
+    }
+
+    /// The request succeeding is not the outcome. A degraded reconcile state is
+    /// reported even when this pass itself admitted cleanly, because that is the
+    /// condition the probes exist to publish.
+    #[test]
+    fn a_degraded_reconcile_state_is_reported_on_an_otherwise_clean_pass() {
+        let mut degraded = report(true);
+        degraded.reconcile.skipped_events = 4;
+        degraded.reconcile.last_error = Some("parse failed".to_string());
+        degraded.reconcile.last_error_age_seconds = Some(12);
+        let text = summary_lines(&degraded).join("\n");
+        assert!(text.contains("Attention:"), "{text}");
+        assert!(text.contains("4 reconcile event(s) errored"), "{text}");
+    }
+
+    /// Unembedded objects after an admission are the expected steady state, and
+    /// an operator who is not told so reads the store as still broken.
+    #[test]
+    fn pending_embedding_work_is_named_as_queued_rather_than_missing() {
+        let text = summary_lines(&report(true)).join("\n");
+        assert!(
+            text.contains("49 of 14187 indexed; the remainder is queued"),
+            "{text}"
+        );
+    }
+}

--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -259,7 +259,8 @@ mod tests {
             embeddings_total: 14187,
             reconcile: ReconcileHealth::default(),
             admitted,
-            failure: (!admitted).then(|| "host entry changed after exact-tree admission".to_string()),
+            failure: (!admitted)
+                .then(|| "host entry changed after exact-tree admission".to_string()),
         }
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -266,6 +266,44 @@ pub enum LocateMatchKind {
     TextFallback,
 }
 
+/// Which id space a located hit's identifier belongs to.
+///
+/// The retrieval spine is keyed by `kin_model::RetrievalKey`, which spans four
+/// variants across two id spaces: entities and their revisions on one side,
+/// artifacts and their revisions on the other. `EntityId` and `ArtifactId` are
+/// both bare UUID newtypes, and an artifact hit that carries a path instead is
+/// still just a string, so nothing about a rendered id says which space it came
+/// from. A consumer therefore cannot tell an id it may pass to
+/// `get_entity_source`, `get_context_pack`, or `graph_neighborhood` from one
+/// those tools will reject, and it finds out by making the call and being
+/// refused.
+///
+/// This states it up front. It never affects ranking or ordering, and it is a
+/// fact about the hit rather than about the query, which is the distinction
+/// [`LocateMatchKind`] draws on the other axis.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LocateIdSpace {
+    /// The hit's `entity_id` names a live entity in the graph. Every
+    /// id-consuming graph tool resolves it.
+    Entity,
+    /// The hit names an artifact-level embedding: a tracked file with no parsed
+    /// entities. It carries `artifact_path` and deliberately carries no
+    /// `entity_id`, because there is no entity id to carry and a field named
+    /// one holding a path is precisely how a dead id reaches an agent.
+    Artifact,
+}
+
+impl LocateIdSpace {
+    /// The serialized token, so callers can assert against one spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Entity => "entity",
+            Self::Artifact => "artifact",
+        }
+    }
+}
+
 /// Whether a query token IS this entity's name (or its last dotted segment).
 ///
 /// The single definition of "the query named this symbol". `kin-daemon`'s

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+pub mod admit;
 pub mod approvals;
 pub mod assistant;
 pub mod assistant_adapter;

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -361,7 +361,8 @@ impl ReconcileHealth {
             };
             notices.push(format!(
                 "{} host path(s) observed but not tracked{sample}. Watching a file never enlarges \
-                 the repository, so these stay unqueryable until a commit admits them.",
+                 the repository, so these stay unqueryable until a commit admits them or kin \
+                 admit does it on demand.",
                 self.untracked_path_count
             ));
         }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -442,6 +442,25 @@ fn daemon_client_headers(
     Ok(headers)
 }
 
+/// What one admission dispatch established.
+///
+/// The daemon runs a complete exact-tree admission in a task of its own, so a
+/// request that goes unanswered says nothing about the pass: it is still
+/// running, and a later request joins it rather than starting a second one.
+/// Collapsing that into an ordinary transport error would let a caller read "no
+/// answer" as "nothing happened", which is the one reading that is never true
+/// here.
+pub enum AdmitDispatch {
+    /// The daemon answered with a report. Terminal, whatever the report says:
+    /// a refused admission is an answer and carries its cause.
+    Answered(crate::commands::admit::AdmitResponse),
+    /// The daemon refused the request itself, so no pass was started by it.
+    Refused(anyhow::Error),
+    /// Nothing usable came back. The pass may be running, and its outcome is
+    /// not established either way.
+    Unanswered(anyhow::Error),
+}
+
 impl DaemonClient {
     pub fn from_base_url(base_url: impl Into<String>) -> Result<Self> {
         Self::from_base_url_with_token(base_url, resolve_daemon_auth_token())
@@ -1467,16 +1486,84 @@ impl DaemonClient {
 
     /// Request one complete exact-tree admission.
     ///
-    /// Idempotent by construction rather than by convention: the pass observes
-    /// the whole working directory and publishes the difference, so a retried
-    /// request re-observes the tree the first one already admitted and finds
-    /// nothing to do. That is what makes it safe on the shared retrying poster.
-    pub async fn admit(
-        &self,
-        request: &crate::commands::admit::AdmitRequest,
-    ) -> Result<crate::commands::admit::AdmitResponse> {
-        self.post_idempotent_json("/commands/admit", request, "admit")
+    /// Deliberately not on the shared retrying poster. That poster retries a
+    /// transport failure with the same payload, and here the first attempt may
+    /// have left a pass running that already published the tree: the retry then
+    /// observes a tree with nothing to do, and the fast empty-delta answer it
+    /// gets back reports a complete admission for a pass whose enrichment never
+    /// ran. One dispatch keeps the two facts apart, and the caller waits by
+    /// asking again on purpose rather than by being retried silently.
+    pub async fn admit(&self, request: &crate::commands::admit::AdmitRequest) -> AdmitDispatch {
+        let url = format!("{}/commands/admit", self.base_url.trim_end_matches('/'));
+        let payload = match serde_json::to_vec(request) {
+            Ok(payload) => payload,
+            Err(error) => {
+                return AdmitDispatch::Refused(
+                    anyhow::Error::new(error).context("encode the admission request"),
+                )
+            }
+        };
+        let response = match self
+            .one_dispatch_client
+            .post(&url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(payload)
+            .send()
             .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return AdmitDispatch::Unanswered(
+                    anyhow::Error::new(error)
+                        .context(daemon_send_failure_message(&self.base_url, "admit")),
+                )
+            }
+        };
+        if let Err(error) = check_response_build_match(response.headers()) {
+            return AdmitDispatch::Refused(error);
+        }
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return AdmitDispatch::Refused(daemon_http_error(
+                &self.base_url,
+                "admit",
+                status.as_u16(),
+                &body,
+            ));
+        }
+        let body = match response.bytes().await {
+            Ok(body) => body,
+            Err(error) => {
+                return AdmitDispatch::Unanswered(
+                    anyhow::Error::new(error).context("read the admission response body"),
+                )
+            }
+        };
+        match serde_json::from_slice(&body) {
+            Ok(decoded) => AdmitDispatch::Answered(decoded),
+            Err(error) => AdmitDispatch::Unanswered(
+                anyhow::Error::new(error).context("decode the admission response"),
+            ),
+        }
+    }
+
+    /// Whether the daemon is answering at all, on a budget short enough to be
+    /// asked while another request is outstanding.
+    ///
+    /// A command waiting on work the daemon is doing has to tell "still
+    /// running" from "gone", and the request it is waiting on cannot answer
+    /// that: both look like nothing coming back. Deliberately a bool, because
+    /// the only thing it establishes is reachability, and a daemon that is
+    /// reachable has said nothing about the work.
+    pub async fn is_reachable(&self) -> bool {
+        self.one_dispatch_client
+            .get(format!("{}/health", self.base_url.trim_end_matches('/')))
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map(|response| response.status().is_success())
+            .unwrap_or(false)
     }
 
     pub async fn rollback(

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1465,6 +1465,20 @@ impl DaemonClient {
             .await
     }
 
+    /// Request one complete exact-tree admission.
+    ///
+    /// Idempotent by construction rather than by convention: the pass observes
+    /// the whole working directory and publishes the difference, so a retried
+    /// request re-observes the tree the first one already admitted and finds
+    /// nothing to do. That is what makes it safe on the shared retrying poster.
+    pub async fn admit(
+        &self,
+        request: &crate::commands::admit::AdmitRequest,
+    ) -> Result<crate::commands::admit::AdmitResponse> {
+        self.post_idempotent_json("/commands/admit", request, "admit")
+            .await
+    }
+
     pub async fn rollback(
         &self,
         request: &crate::commands::rollback::RollbackRequest,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -915,6 +915,13 @@ enum Command {
         #[arg(long)]
         confirm_mass_deletion: bool,
     },
+    /// Admit the complete exact working tree into graph authority now
+    ///
+    /// The daemon admits a complete tree on startup, on commit, and on what its
+    /// watcher observes. This is the trigger for the case none of those covers:
+    /// a graph that fell behind its working tree and is waiting for churn that
+    /// is not coming.
+    Admit,
     /// Admit one exact disposable-session observation into repository-v6 authority
     Reconcile {
         /// Session ID (defaults to most recent session)
@@ -3140,6 +3147,10 @@ fn main() -> Result<()> {
                 } => {
                     commands::capabilities::require_ready("purge-ignored")?;
                     commands::purge_ignored::run(confirm, confirm_mass_deletion).await
+                }
+                Command::Admit => {
+                    commands::capabilities::require_ready("admit")?;
+                    commands::admit::run().await
                 }
                 Command::Reconcile {
                     session,

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,14 +40,14 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["all_declared_command_surfaces_enabled"], true);
-    assert_eq!(report["enabled_commands"], 34);
+    assert_eq!(report["enabled_commands"], 35);
     assert_eq!(report["full_git_replacement_ready"], false);
     // Exact counts, so a silent re-seal cannot pass. They are also the reason
     // two lanes must never flip a gate in the same wave: both bumps merge
     // without conflict and main goes red with every pull request green.
     // Recount from the merged fixture rather than from either branch.
-    assert_eq!(report["ready_commands"], 33);
-    assert_eq!(report["command_total"], 34);
+    assert_eq!(report["ready_commands"], 34);
+    assert_eq!(report["command_total"], 35);
 
     let commands = report["commands"]
         .as_array()

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -386,6 +386,28 @@
       "note": "The session scanner performs retained-root double observation and authority-root CAS, and its observation now owns the retained no-follow directory capability it was taken through. Every field is private, so the observation cannot be built outside the scanner, and planning re-proves the retained capability before anything is planned against it."
     },
     {
+      "command": "admit",
+      "status": "ready",
+      "exposure": "enabled",
+      "authority": "repository-v6 authority transition published through the daemon's own complete exact-tree admission seam",
+      "required_for_bounded_dogfood": false,
+      "acceptance_spec": [
+        "run the same complete exact-tree admission the watch loop and commit run, rather than a second admission implementation that could admit differently",
+        "hold a registered daemon session for the duration so the idle window cannot end the pass in flight, and release it on every exit path",
+        "report the outcome from the reconcile probes rather than from the request succeeding, because a pass can fail inside a request that returns cleanly",
+        "exit nonzero on a failed pass, leading with the recorded cause and stating that graph authority is unchanged"
+      ],
+      "evidence_tests": [
+        "kin_cli::commands::admit::tests::a_successful_admission_names_both_sides_of_the_transition",
+        "kin_cli::commands::admit::tests::a_failed_admission_leads_with_its_cause_and_refuses_to_claim_a_change",
+        "kin_cli::commands::admit::tests::an_admission_that_changed_nothing_says_so_without_reading_as_a_failure",
+        "kin_daemon::api::tests::admit_admits_a_complete_tree_no_watcher_event_ever_named",
+        "kin_daemon::api::tests::admit_records_its_pass_on_the_probes_the_health_surfaces_read",
+        "kin_daemon::api::tests::a_cli_session_suppresses_the_idle_shutdown_that_would_end_an_admission"
+      ],
+      "note": "The daemon admits a complete exact tree on startup, on commit, and on what its watcher observed, and none of those is a trigger an operator can pull, so a graph that fell behind its working tree waits for churn that may not come while a quiet daemon idles out first. This command is that trigger. It runs the daemon's own admission seam, so it inherits the same completion proof, authority compare-and-swap, and mass-deletion guard, and it carries no mass-deletion override of its own because the guard's override is read from the daemon's environment and a second control over one guard is two rules that can disagree."
+    },
+    {
       "command": "purge-ignored",
       "status": "ready",
       "exposure": "enabled",

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -403,7 +403,10 @@
         "kin_cli::commands::admit::tests::an_admission_that_changed_nothing_says_so_without_reading_as_a_failure",
         "kin_daemon::api::tests::admit_admits_a_complete_tree_no_watcher_event_ever_named",
         "kin_daemon::api::tests::admit_records_its_pass_on_the_probes_the_health_surfaces_read",
-        "kin_daemon::api::tests::a_cli_session_suppresses_the_idle_shutdown_that_would_end_an_admission"
+        "kin_daemon::api::tests::a_cli_session_suppresses_the_idle_shutdown_that_would_end_an_admission",
+        "kin_daemon::api::tests::a_live_entity_hit_keeps_its_entity_id_and_declares_the_entity_id_space",
+        "kin_daemon::api::tests::an_artifact_hit_carries_no_entity_id_and_names_the_tool_that_reads_it",
+        "kin_daemon::api::tests::a_retired_entity_key_is_dropped_rather_than_served_as_a_dead_id"
       ],
       "note": "The daemon admits a complete exact tree on startup, on commit, and on what its watcher observed, and none of those is a trigger an operator can pull, so a graph that fell behind its working tree waits for churn that may not come while a quiet daemon idles out first. This command is that trigger. It runs the daemon's own admission seam, so it inherits the same completion proof, authority compare-and-swap, and mass-deletion guard, and it carries no mass-deletion override of its own because the guard's override is read from the daemon's environment and a second control over one guard is two rules that can disagree."
     },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6885,7 +6885,11 @@ fn build_semantic_locate_result(
             continue;
         };
         let LocateHitIdentity {
-            name, file, kind, signature, ..
+            name,
+            file,
+            kind,
+            signature,
+            ..
         } = identity.clone();
         let dedupe_id = identity.dedupe_key();
 
@@ -18400,10 +18404,7 @@ mod tests {
         );
         assert_eq!(hit["artifact_path"], json!("docs/design.md"));
         assert_eq!(hit["resolves_with"], json!("kin_artifact_read"));
-        assert!(hit["note"]
-            .as_str()
-            .unwrap()
-            .contains("get_entity_source"));
+        assert!(hit["note"].as_str().unwrap().contains("get_entity_source"));
     }
 
     /// The second dead-id path, and the one that produced the ticket's title.
@@ -18418,8 +18419,11 @@ mod tests {
     fn a_retired_entity_key_is_dropped_rather_than_served_as_a_dead_id() {
         let retired = test_entity("deleted_symbol", "src/gone.rs");
         assert!(
-            locate_hit_identity(&kin_db::ResolvedRetrievalItem::Entity(retired.clone()), false)
-                .is_none(),
+            locate_hit_identity(
+                &kin_db::ResolvedRetrievalItem::Entity(retired.clone()),
+                false
+            )
+            .is_none(),
             "an id the graph no longer holds must not reach a row"
         );
         // Falsification: the same item with liveness restored IS served, so the

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3954,11 +3954,6 @@ async fn command_tag(
     Ok(Json(response))
 }
 
-/// POST /commands/purge-ignored — retire tracked paths that ignore rules cover.
-///
-/// Reports without mutating unless the request confirms. The coordination gate
-/// is held for both, so the watch loop cannot admit a competing observation
-/// between the tracked set this reports and the transition it publishes.
 /// POST /commands/admit — run one complete exact-tree admission on demand.
 ///
 /// The trigger the daemon otherwise does not have. Its ambient admissions are
@@ -3967,6 +3962,10 @@ async fn command_tag(
 /// daemon idles out before that happens, which is why the caller is expected to
 /// hold a registered session across this request: any session whose vendor is
 /// not `kin-daemon` suppresses idle shutdown for as long as it is held.
+///
+/// The pass this starts is not this request. It runs detached, so hanging up
+/// stops the waiting rather than the admission, and a second request joins the
+/// running pass instead of starting one.
 async fn command_admit(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
@@ -3994,6 +3993,9 @@ async fn command_admit(
                 .to_string(),
         ));
     }
+    if let Some(condition) = admission_seam_would_skip(&state) {
+        return Err(condition);
+    }
 
     // No coordination gate here: the admission seam takes it, and the mutex is
     // not reentrant.
@@ -4003,6 +4005,55 @@ async fn command_admit(
     Ok(Json(response))
 }
 
+/// The refusal for a daemon whose admission seam would return without running,
+/// or `None` where a requested pass is real work.
+///
+/// The seam skips silently in two conditions, and a silent skip is
+/// indistinguishable from a pass that ran and found nothing settled: filesystem
+/// reconcile disabled, and a working directory that is a bare Git repository
+/// with no working copy to admit. Answering either with a report would stamp a
+/// successful admission on the reconcile probes for a pass that never happened,
+/// and every health surface would then say a recent admission succeeded on a
+/// store whose graph is still behind. Commit and stash refuse the disabled
+/// condition ahead of the same seam; this refuses both.
+///
+/// The bare-repository question is asked here the way
+/// `loop_runner::is_bare_repository` asks it, and the two have to stay in step:
+/// a divergence would either refuse a store the seam would have admitted or
+/// admit a skip as a success again.
+fn admission_seam_would_skip(state: &DaemonState) -> Option<(StatusCode, String)> {
+    let working_dir = state.layout.working_dir();
+    if state.filesystem_reconcile_disabled() {
+        return Some(filesystem_ingest_disabled_response(
+            "/commands/admit",
+            &working_dir.display().to_string(),
+        ));
+    }
+    let bare = working_dir.join("config").is_file()
+        && working_dir.join("objects").is_dir()
+        && working_dir.join("refs").is_dir()
+        && !working_dir.join(".git").exists();
+    if bare {
+        return Some((
+            StatusCode::CONFLICT,
+            json!({
+                "error": "bare_repository_has_no_working_copy",
+                "endpoint": "/commands/admit",
+                "path": working_dir.display().to_string(),
+                "mutation_applied": false,
+                "authority": "repository_v6",
+            })
+            .to_string(),
+        ));
+    }
+    None
+}
+
+/// POST /commands/purge-ignored — retire tracked paths that ignore rules cover.
+///
+/// Reports without mutating unless the request confirms. The coordination gate
+/// is held for both, so the watch loop cannot admit a competing observation
+/// between the tracked set this reports and the transition it publishes.
 async fn command_purge_ignored(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
@@ -18310,23 +18361,21 @@ mod tests {
             .collect()
     }
 
+    fn admit_request() -> Request<Body> {
+        Request::post("/commands/admit")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "operation_id": kin_model::OperationId::new(),
+                    "actor": AuthorId::new("admit-acceptance")
+                })
+                .to_string(),
+            ))
+            .unwrap()
+    }
+
     async fn admit_through_api(app: &axum::Router) -> (StatusCode, serde_json::Value) {
-        let response = app
-            .clone()
-            .oneshot(
-                Request::post("/commands/admit")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        json!({
-                            "operation_id": kin_model::OperationId::new(),
-                            "actor": AuthorId::new("admit-acceptance")
-                        })
-                        .to_string(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let response = app.clone().oneshot(admit_request()).await.unwrap();
         let status = response.status();
         let body = axum::body::to_bytes(response.into_body(), 256 * 1024)
             .await
@@ -18510,6 +18559,175 @@ mod tests {
         assert_eq!(
             replay["report"]["tracked_before"],
             replay["report"]["tracked_after"]
+        );
+    }
+
+    /// A request that hangs up mid-pass must never become a retry that reports a
+    /// complete admission.
+    ///
+    /// The seam publishes repository authority before it enriches and has one
+    /// await between the two, so a client timeout could cancel the pass exactly
+    /// there, leaving the tree admitted with nothing parsed for it. Nothing
+    /// re-enriches a file that did not change, so the next request observed a
+    /// settled tree, found no deltas, and answered with a complete admission
+    /// that had skipped every entity in the backlog.
+    ///
+    /// This drives that sequence: the pass is parked at its one await, the
+    /// request waiting on it is dropped, and the attempt that follows has to
+    /// report the real transition rather than an empty one.
+    #[tokio::test]
+    async fn a_client_timeout_mid_pass_never_lets_a_retry_report_a_complete_admission() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        install_working_copy_file(
+            &state,
+            "src/admitted.rs",
+            b"pub fn admitted() -> u8 {\n    7\n}\n",
+            false,
+        );
+
+        // Precondition: nothing is admitted and nothing is enriched, so neither
+        // half of the assertion below can pass on the fixture.
+        assert!(tracked_paths(&state).is_empty(), "the fixture pre-admitted");
+        assert_eq!(state.graph.entity_count(), 0);
+
+        // The seam's single await is the reconciler write lock, so holding it
+        // parks the pass precisely where a hang-up used to cancel it.
+        let held = state.reconciler.write().await;
+
+        let mut abandoned = Box::pin(crate::repository_admit::execute(&state));
+        let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+        assert!(
+            std::future::Future::poll(abandoned.as_mut(), &mut context).is_pending(),
+            "the request must be waiting on a pass rather than running one"
+        );
+        // The client hung up: an HTTP timeout, or an interrupt.
+        drop(abandoned);
+
+        let retry = tokio::spawn({
+            let state = Arc::clone(&state);
+            async move { crate::repository_admit::execute(&state).await }
+        });
+        // Let the abandoned pass and the retry both reach the lock this test
+        // holds before releasing it.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        drop(held);
+
+        let response = retry.await.unwrap().expect("the pass reported an outcome");
+        let report = response.report.expect("a reported pass carries its report");
+        assert!(report.admitted, "{:?}", report.failure);
+        assert!(
+            tracked_paths(&state).contains("src/admitted.rs"),
+            "the abandoned request took its own admission down with it"
+        );
+        assert!(
+            report.entities_after > 0,
+            "an admission whose enrichment was skipped read as complete: {report:?}"
+        );
+        assert!(
+            response.mutated,
+            "the pass moved the graph and the report denied it: {report:?}"
+        );
+    }
+
+    /// A daemon whose admission seam would decline to run has to refuse, not
+    /// report.
+    ///
+    /// The seam returns without running when filesystem reconcile is disabled,
+    /// and that silent skip is indistinguishable from a pass that ran and found
+    /// a settled tree. Answering it with a report would stamp a successful
+    /// admission on the probes every health surface reads, on a daemon where no
+    /// admission can happen at all, while the locate degradation added beside
+    /// this command tells the operator to run exactly this.
+    #[tokio::test]
+    async fn an_admission_refuses_on_a_daemon_whose_seam_would_silently_skip() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        install_working_copy_file(&state, "docs/notes.md", b"notes\n", false);
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(admit_request())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let refusal: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(refusal["error"], json!("filesystem_admission_disabled"));
+        assert_eq!(refusal["mutation_applied"], json!(false));
+
+        // The refusal has to leave the health surfaces telling the truth: no
+        // admission succeeded here, because none ran.
+        let probes = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert!(
+            probes.last_admission_success_age_seconds.is_none(),
+            "a refused request stamped a successful admission on the probes"
+        );
+        assert!(tracked_paths(&state).is_empty());
+    }
+
+    /// The seam's other silent skip. A bare Git repository has no working copy
+    /// to admit, so the pass returns without running, and the refusal is what
+    /// keeps that from reading as an admission that succeeded.
+    ///
+    /// The predicate is asked here rather than shared with the seam, so this
+    /// pins both directions: an ordinary working directory is admitted, and one
+    /// carrying a bare repository's own layout is refused.
+    #[tokio::test]
+    async fn an_admission_refuses_on_a_bare_repository_the_seam_would_skip() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            admission_seam_would_skip(&state).is_none(),
+            "the fixture already refuses, so this cannot discriminate"
+        );
+
+        let working_dir = state.layout.working_dir().to_path_buf();
+        std::fs::write(working_dir.join("config"), b"[core]\n\tbare = true\n").unwrap();
+        std::fs::create_dir_all(working_dir.join("objects")).unwrap();
+        std::fs::create_dir_all(working_dir.join("refs")).unwrap();
+        let git = working_dir.join(".git");
+        if git.is_dir() {
+            std::fs::remove_dir_all(&git).unwrap();
+        } else if git.exists() {
+            std::fs::remove_file(&git).unwrap();
+        }
+
+        let response = router(Arc::clone(&state))
+            .oneshot(admit_request())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let refusal: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            refusal["error"],
+            json!("bare_repository_has_no_working_copy")
+        );
+
+        let probes = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert!(
+            probes.last_admission_success_age_seconds.is_none(),
+            "a refused request stamped a successful admission on the probes"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1468,6 +1468,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/resolve", post(command_resolve))
         .route("/commands/drift", post(command_drift))
         .route("/commands/tag", post(command_tag))
+        .route("/commands/admit", post(command_admit))
         .route("/commands/purge-ignored", post(command_purge_ignored))
         .route("/commands/rollback", post(command_rollback))
         .route("/commands/checkout", post(command_checkout))
@@ -3958,6 +3959,50 @@ async fn command_tag(
 /// Reports without mutating unless the request confirms. The coordination gate
 /// is held for both, so the watch loop cannot admit a competing observation
 /// between the tracked set this reports and the transition it publishes.
+/// POST /commands/admit — run one complete exact-tree admission on demand.
+///
+/// The trigger the daemon otherwise does not have. Its ambient admissions are
+/// driven by startup, by commit, and by whatever the watcher observed, so a
+/// graph that fell behind its working tree waits for churn to arrive. A quiet
+/// daemon idles out before that happens, which is why the caller is expected to
+/// hold a registered session across this request: any session whose vendor is
+/// not `kin-daemon` suppresses idle shutdown for as long as it is held.
+async fn command_admit(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(_request): Json<kin_cli::commands::admit::AdmitRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if !state
+        .is_initialized
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "daemon not fully initialized".to_string(),
+        ));
+    }
+    if state.storage_backend.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "local exact-tree admission is unavailable for hosted snapshot authority".to_string(),
+        ));
+    }
+    if extract_session_id_from_headers(&headers)?.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "admission publishes against HEAD authority; run it without ambient session scope"
+                .to_string(),
+        ));
+    }
+
+    // No coordination gate here: the admission seam takes it, and the mutex is
+    // not reentrant.
+    let response = crate::repository_admit::execute(&state)
+        .await
+        .map_err(|error| (StatusCode::CONFLICT, error.to_string()))?;
+    Ok(Json(response))
+}
+
 async fn command_purge_ignored(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
@@ -6702,23 +6747,51 @@ fn build_semantic_locate_result(
     // about test code (so Test-role hits are not treated as demoted).
     let rerank_active = semloc_rerank_enabled();
     let is_test_query = semloc_query_is_test_related(&query);
+    // Sidecar keys that named nothing this graph still holds. Counted rather
+    // than passed over, because a ranking that quietly drops most of its
+    // candidates and a ranking that genuinely found little look identical from
+    // the outside, and the difference is the whole diagnosis.
+    let mut unresolved_keys = 0usize;
+    let mut retired_entity_keys = 0usize;
     for (key, distance) in raw {
         if rows.len() >= max_rows {
             break;
         }
         let Some(item) = graph.resolve_retrieval_key(&key) else {
+            unresolved_keys += 1;
             continue;
         };
         // Entity-centric projection: the ENTITY (kind + name + signature) is the
         // result; the file is demoted to provenance.
-        let (entity_id, name, file, kind, signature) = match &item {
-            kin_db::ResolvedRetrievalItem::Entity(entity) => (
-                entity.id.to_string(),
-                entity.name.clone(),
-                entity.file_origin.as_ref().map(|origin| origin.0.clone()),
-                Some(format!("{:?}", entity.kind).to_lowercase()),
-                Some(entity.signature.clone()).filter(|sig| !sig.is_empty()),
-            ),
+        let (id_space, entity_id, name, file, kind, signature) = match &item {
+            kin_db::ResolvedRetrievalItem::Entity(entity) => {
+                // Resolution is not liveness. An `EntityRevision` key resolves
+                // against immutable revision history, and retiring an entity
+                // deliberately leaves that history behind, so the head revision
+                // of a deleted entity still resolves to an `Entity` whose id
+                // names nothing the graph holds. Every id-consuming tool then
+                // refuses that id, which is the whole reported defect. The
+                // snippet projection below already dropped these, but only when
+                // snippets were on; under `include_snippet: false` or file
+                // granularity nothing filtered them at all.
+                if graph
+                    .get_entity(&entity.id)
+                    .ok()
+                    .flatten()
+                    .is_none()
+                {
+                    retired_entity_keys += 1;
+                    continue;
+                }
+                (
+                    kin_cli::commands::locate::LocateIdSpace::Entity,
+                    Some(entity.id.to_string()),
+                    entity.name.clone(),
+                    entity.file_origin.as_ref().map(|origin| origin.0.clone()),
+                    Some(format!("{:?}", entity.kind).to_lowercase()),
+                    Some(entity.signature.clone()).filter(|sig| !sig.is_empty()),
+                )
+            }
             other => {
                 let file = other.file_path().map(|path| path.0.clone());
                 let name = file
@@ -6730,10 +6803,25 @@ fn build_semantic_locate_result(
                     })
                     .unwrap_or_default()
                     .to_string();
-                let id = file.clone().unwrap_or_else(|| name.clone());
-                (id, name, file, None, None)
+                // Deliberately no entity id. This hit is an artifact-level
+                // embedding: a tracked file the parsers produced no entities
+                // for. It previously carried its own path under `entity_id`,
+                // which reads as an actionable handle and is refused by every
+                // tool that takes one.
+                (
+                    kin_cli::commands::locate::LocateIdSpace::Artifact,
+                    None,
+                    name,
+                    file,
+                    None,
+                    None,
+                )
             }
         };
+        // Dedupe still needs one stable string per hit. For an artifact that is
+        // its path, which is what made the old code put a path in `entity_id`
+        // in the first place; the two uses are now separate.
+        let dedupe_id = entity_id.clone().or_else(|| file.clone()).unwrap_or_else(|| name.clone());
 
         if file_granularity {
             match &file {
@@ -6745,7 +6833,7 @@ fn build_semantic_locate_result(
                 // File granularity requires a file path; skip pathless hits.
                 None => continue,
             }
-        } else if !seen_entities.insert(entity_id.clone()) {
+        } else if !seen_entities.insert(dedupe_id.clone()) {
             // Collapse the two index keys per entity (`Entity(E)` +
             // `EntityRevision(head)`) into a single result. `raw` is rank-ordered
             // by distance, so the first occurrence of an entity is its best hit.
@@ -6807,7 +6895,7 @@ fn build_semantic_locate_result(
         let match_evidence =
             cosine_match_evidence(&query, &name, role, rerank_active, is_test_query);
         let mut hit = json!({
-            "entity_id": entity_id,
+            "id_space": id_space.as_str(),
             "kind": kind,
             "name": name,
             "signature": signature,
@@ -6815,6 +6903,26 @@ fn build_semantic_locate_result(
             "provenance": { "file": file },
             "match_evidence": match_evidence,
         });
+        match entity_id {
+            // An entity hit is unchanged: same key, same graph entity id, and
+            // every id-consuming tool resolves it.
+            Some(entity_id) => {
+                hit["entity_id"] = json!(entity_id);
+            }
+            // An artifact hit states what it is and what reads it. Omitting
+            // `entity_id` is the point: the field existed, held a path, and was
+            // refused by every tool that accepts one, so an agent could only
+            // discover the hit was not act-on-able by acting on it.
+            None => {
+                hit["artifact_path"] = json!(file);
+                hit["resolves_with"] = json!("kin_artifact_read");
+                hit["note"] = json!(
+                    "artifact-level embedding: a tracked file with no parsed entities. It has no \
+                     entity id, so get_entity_source, get_context_pack, and graph_neighborhood \
+                     cannot take this hit; read it with kin_artifact_read."
+                );
+            }
+        }
         if let Some(span) = span {
             let (start_line, end_line) = kin_mcp::handlers::common::presentation_span_lines(span);
             hit["start_line"] = json!(start_line);
@@ -6824,6 +6932,43 @@ fn build_semantic_locate_result(
             hit["snippet"] = json!(snippet);
         }
         rows.push(hit);
+    }
+
+    // Report the sidecar/graph gap rather than serving a short page as if the
+    // index had simply ranked little. A store whose graph fell behind its
+    // embeddings answers every query this way, and without this the only
+    // symptom is an empty result that looks like an honest negative.
+    if unresolved_keys > 0 {
+        kin_cli::commands::locate::record_degradation(
+            &mut degradations,
+            kin_cli::commands::locate::RetrievalDegradation {
+                component: "vector_sidecar".to_string(),
+                reason: "keys_not_in_graph".to_string(),
+                detail: format!(
+                    "{unresolved_keys} ranked vector key(s) named no object this graph holds, so \
+                     they were dropped from the ranking"
+                ),
+                remediation: "run 'kin admit' to admit the complete exact tree, then let the \
+                              embed pass re-index"
+                    .to_string(),
+            },
+        );
+    }
+    if retired_entity_keys > 0 {
+        kin_cli::commands::locate::record_degradation(
+            &mut degradations,
+            kin_cli::commands::locate::RetrievalDegradation {
+                component: "vector_sidecar".to_string(),
+                reason: "retired_entity_keys".to_string(),
+                detail: format!(
+                    "{retired_entity_keys} ranked vector key(s) resolved through revision history \
+                     to entities the graph no longer holds, so they were dropped rather than \
+                     served as ids no graph tool can take"
+                ),
+                remediation: "run 'kin embed' to re-index this graph's current entities"
+                    .to_string(),
+            },
+        );
     }
 
     // Cache the full ranking under the paging key, then return page 0.
@@ -6922,6 +7067,17 @@ fn fused_semantic_locate_payload(
                 map.insert(
                     "match_evidence".to_string(),
                     fused_match_evidence(query, entity),
+                );
+                // Constant-true here, and stated anyway. The fused pipeline
+                // re-projects its page from live graph entities, so a hit on
+                // this arm cannot be artifact-level or retired. A caller that
+                // reads `id_space` should not have to know which arm answered
+                // to know whether the field is present, and a label that
+                // appears on one arm only is a label a consumer learns to
+                // ignore.
+                map.insert(
+                    "id_space".to_string(),
+                    json!(kin_cli::commands::locate::LocateIdSpace::Entity.as_str()),
                 );
                 // The two `semantic_locate` arms carried the same graph-owned
                 // excerpt under different names: the cosine arm called it

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6572,6 +6572,114 @@ fn semantic_locate_payload(
     }
 }
 
+/// The identity half of one `semantic_locate` row: which id space the hit
+/// belongs to, and the fields that follow from that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocateHitIdentity {
+    id_space: kin_cli::commands::locate::LocateIdSpace,
+    /// `Some` only for a live entity hit. An artifact hit has no entity id, and
+    /// this being `None` rather than a path is the whole contract.
+    entity_id: Option<String>,
+    name: String,
+    file: Option<String>,
+    kind: Option<String>,
+    signature: Option<String>,
+}
+
+impl LocateHitIdentity {
+    /// The stable string this hit dedupes on.
+    ///
+    /// Entity granularity collapses the two index keys per entity into one row,
+    /// and an artifact has no entity id to collapse on, so it falls back to its
+    /// path. Keeping this separate from `entity_id` is the fix: conflating the
+    /// two is what put a path in a field named `entity_id`.
+    fn dedupe_key(&self) -> String {
+        self.entity_id
+            .clone()
+            .or_else(|| self.file.clone())
+            .unwrap_or_else(|| self.name.clone())
+    }
+}
+
+/// Classify one resolved retrieval item into the row identity it should carry,
+/// or `None` when the hit must be dropped rather than served.
+///
+/// `entity_is_live` is passed in rather than looked up here because liveness is
+/// a graph question and this is a shaping decision; separating them is what
+/// lets the shaping be asserted directly instead of through a query that needs
+/// a live embedder.
+///
+/// Resolution is not liveness. A `RetrievalKey::EntityRevision` resolves
+/// against immutable revision history, and retiring an entity deliberately
+/// leaves that history in place, so the head revision of a deleted entity still
+/// resolves to an `Entity` whose id names nothing the graph holds. Serving that
+/// id is the reported defect: every id-consuming tool refuses it, and the
+/// caller can only discover that by calling one.
+fn locate_hit_identity(
+    item: &kin_db::ResolvedRetrievalItem,
+    entity_is_live: bool,
+) -> Option<LocateHitIdentity> {
+    match item {
+        kin_db::ResolvedRetrievalItem::Entity(entity) => {
+            if !entity_is_live {
+                return None;
+            }
+            Some(LocateHitIdentity {
+                id_space: kin_cli::commands::locate::LocateIdSpace::Entity,
+                entity_id: Some(entity.id.to_string()),
+                name: entity.name.clone(),
+                file: entity.file_origin.as_ref().map(|origin| origin.0.clone()),
+                kind: Some(format!("{:?}", entity.kind).to_lowercase()),
+                signature: Some(entity.signature.clone()).filter(|sig| !sig.is_empty()),
+            })
+        }
+        other => {
+            let file = other.file_path().map(|path| path.0.clone());
+            let name = file
+                .as_deref()
+                .and_then(|path| {
+                    FsPath::new(path)
+                        .file_name()
+                        .and_then(|component| component.to_str())
+                })
+                .unwrap_or_default()
+                .to_string();
+            Some(LocateHitIdentity {
+                id_space: kin_cli::commands::locate::LocateIdSpace::Artifact,
+                entity_id: None,
+                name,
+                file,
+                kind: None,
+                signature: None,
+            })
+        }
+    }
+}
+
+/// Write one row's identity fields, stating the id space either way.
+///
+/// An entity hit is unchanged. An artifact hit says what it is, carries its
+/// path under a field named for what it holds, and names the tool that reads
+/// it. The old shape put the path under `entity_id`, which reads as an
+/// actionable handle and is refused by every tool that takes one.
+fn write_locate_hit_identity(hit: &mut serde_json::Value, identity: &LocateHitIdentity) {
+    hit["id_space"] = json!(identity.id_space.as_str());
+    match &identity.entity_id {
+        Some(entity_id) => {
+            hit["entity_id"] = json!(entity_id);
+        }
+        None => {
+            hit["artifact_path"] = json!(identity.file);
+            hit["resolves_with"] = json!("kin_artifact_read");
+            hit["note"] = json!(
+                "artifact-level embedding: a tracked file with no parsed entities. It has no \
+                 entity id, so get_entity_source, get_context_pack, and graph_neighborhood \
+                 cannot take this hit; read it with kin_artifact_read."
+            );
+        }
+    }
+}
+
 fn build_semantic_locate_result(
     state: &DaemonState,
     graph: &kin_db::InMemoryGraph,
@@ -6762,66 +6870,24 @@ fn build_semantic_locate_result(
             continue;
         };
         // Entity-centric projection: the ENTITY (kind + name + signature) is the
-        // result; the file is demoted to provenance.
-        let (id_space, entity_id, name, file, kind, signature) = match &item {
+        // result; the file is demoted to provenance. The snippet projection
+        // below already dropped retired entities, but only when snippets were
+        // on; under `include_snippet: false` or file granularity nothing
+        // filtered them at all.
+        let entity_is_live = match &item {
             kin_db::ResolvedRetrievalItem::Entity(entity) => {
-                // Resolution is not liveness. An `EntityRevision` key resolves
-                // against immutable revision history, and retiring an entity
-                // deliberately leaves that history behind, so the head revision
-                // of a deleted entity still resolves to an `Entity` whose id
-                // names nothing the graph holds. Every id-consuming tool then
-                // refuses that id, which is the whole reported defect. The
-                // snippet projection below already dropped these, but only when
-                // snippets were on; under `include_snippet: false` or file
-                // granularity nothing filtered them at all.
-                if graph
-                    .get_entity(&entity.id)
-                    .ok()
-                    .flatten()
-                    .is_none()
-                {
-                    retired_entity_keys += 1;
-                    continue;
-                }
-                (
-                    kin_cli::commands::locate::LocateIdSpace::Entity,
-                    Some(entity.id.to_string()),
-                    entity.name.clone(),
-                    entity.file_origin.as_ref().map(|origin| origin.0.clone()),
-                    Some(format!("{:?}", entity.kind).to_lowercase()),
-                    Some(entity.signature.clone()).filter(|sig| !sig.is_empty()),
-                )
+                graph.get_entity(&entity.id).ok().flatten().is_some()
             }
-            other => {
-                let file = other.file_path().map(|path| path.0.clone());
-                let name = file
-                    .as_deref()
-                    .and_then(|path| {
-                        FsPath::new(path)
-                            .file_name()
-                            .and_then(|component| component.to_str())
-                    })
-                    .unwrap_or_default()
-                    .to_string();
-                // Deliberately no entity id. This hit is an artifact-level
-                // embedding: a tracked file the parsers produced no entities
-                // for. It previously carried its own path under `entity_id`,
-                // which reads as an actionable handle and is refused by every
-                // tool that takes one.
-                (
-                    kin_cli::commands::locate::LocateIdSpace::Artifact,
-                    None,
-                    name,
-                    file,
-                    None,
-                    None,
-                )
-            }
+            _ => false,
         };
-        // Dedupe still needs one stable string per hit. For an artifact that is
-        // its path, which is what made the old code put a path in `entity_id`
-        // in the first place; the two uses are now separate.
-        let dedupe_id = entity_id.clone().or_else(|| file.clone()).unwrap_or_else(|| name.clone());
+        let Some(identity) = locate_hit_identity(&item, entity_is_live) else {
+            retired_entity_keys += 1;
+            continue;
+        };
+        let LocateHitIdentity {
+            name, file, kind, signature, ..
+        } = identity.clone();
+        let dedupe_id = identity.dedupe_key();
 
         if file_granularity {
             match &file {
@@ -6895,7 +6961,6 @@ fn build_semantic_locate_result(
         let match_evidence =
             cosine_match_evidence(&query, &name, role, rerank_active, is_test_query);
         let mut hit = json!({
-            "id_space": id_space.as_str(),
             "kind": kind,
             "name": name,
             "signature": signature,
@@ -6903,26 +6968,7 @@ fn build_semantic_locate_result(
             "provenance": { "file": file },
             "match_evidence": match_evidence,
         });
-        match entity_id {
-            // An entity hit is unchanged: same key, same graph entity id, and
-            // every id-consuming tool resolves it.
-            Some(entity_id) => {
-                hit["entity_id"] = json!(entity_id);
-            }
-            // An artifact hit states what it is and what reads it. Omitting
-            // `entity_id` is the point: the field existed, held a path, and was
-            // refused by every tool that accepts one, so an agent could only
-            // discover the hit was not act-on-able by acting on it.
-            None => {
-                hit["artifact_path"] = json!(file);
-                hit["resolves_with"] = json!("kin_artifact_read");
-                hit["note"] = json!(
-                    "artifact-level embedding: a tracked file with no parsed entities. It has no \
-                     entity id, so get_entity_source, get_context_pack, and graph_neighborhood \
-                     cannot take this hit; read it with kin_artifact_read."
-                );
-            }
-        }
+        write_locate_hit_identity(&mut hit, &identity);
         if let Some(span) = span {
             let (start_line, end_line) = kin_mcp::handlers::common::presentation_span_lines(span);
             hit["start_line"] = json!(start_line);
@@ -18258,6 +18304,317 @@ mod tests {
             .artifacts_by_path()
             .map(|artifact| artifact.path.to_string())
             .collect()
+    }
+
+    async fn admit_through_api(app: &axum::Router) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/commands/admit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "actor": AuthorId::new("admit-acceptance")
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    /// Every hit `semantic_locate` serves on a code store, unchanged.
+    ///
+    /// The healthy path is the thing a labeling change is most likely to break,
+    /// so it is pinned first: a live entity still carries its graph entity id
+    /// under `entity_id`, and now says which id space that is.
+    #[test]
+    fn a_live_entity_hit_keeps_its_entity_id_and_declares_the_entity_id_space() {
+        let entity = test_entity("resolve_retrieval_key", "src/engine/graph.rs");
+        let identity =
+            locate_hit_identity(&kin_db::ResolvedRetrievalItem::Entity(entity.clone()), true)
+                .expect("a live entity hit must be served");
+
+        assert_eq!(
+            identity.id_space,
+            kin_cli::commands::locate::LocateIdSpace::Entity
+        );
+        assert_eq!(identity.entity_id.as_deref(), Some(&*entity.id.to_string()));
+        assert_eq!(identity.file.as_deref(), Some("src/engine/graph.rs"));
+        assert_eq!(identity.kind.as_deref(), Some("function"));
+
+        let mut hit = json!({ "name": identity.name });
+        write_locate_hit_identity(&mut hit, &identity);
+        assert_eq!(hit["id_space"], json!("entity"));
+        assert_eq!(hit["entity_id"], json!(entity.id.to_string()));
+        assert!(
+            hit.get("artifact_path").is_none(),
+            "an entity hit must not carry artifact fields: {hit}"
+        );
+    }
+
+    /// The reported defect, on the artifact-only store shape.
+    ///
+    /// An artifact-level embedding is a tracked file the parsers produced no
+    /// entities for. It used to be served with its own path in a field named
+    /// `entity_id`, which every id-consuming tool refuses, so an agent could
+    /// only discover the id was dead by spending a call on it.
+    #[test]
+    fn an_artifact_hit_carries_no_entity_id_and_names_the_tool_that_reads_it() {
+        let artifact = kin_db::ResolvedRetrievalItem::OpaqueArtifact(kin_model::OpaqueArtifact {
+            file_id: kin_model::FilePathId::new("docs/design.md"),
+            content_hash: Hash256::from_bytes([0x07; 32]),
+            mime_type: Some("text/markdown".to_string()),
+            text_preview: None,
+        });
+        let identity =
+            locate_hit_identity(&artifact, false).expect("an artifact hit must still be served");
+
+        assert_eq!(
+            identity.id_space,
+            kin_cli::commands::locate::LocateIdSpace::Artifact
+        );
+        assert_eq!(
+            identity.entity_id, None,
+            "an artifact hit has no entity id, and a path in that field is the defect"
+        );
+        assert_eq!(identity.name, "design.md");
+        assert_eq!(identity.file.as_deref(), Some("docs/design.md"));
+        // It still dedupes, on its path rather than on an id it does not have.
+        assert_eq!(identity.dedupe_key(), "docs/design.md");
+
+        let mut hit = json!({ "name": identity.name });
+        write_locate_hit_identity(&mut hit, &identity);
+        assert_eq!(hit["id_space"], json!("artifact"));
+        assert!(
+            hit.get("entity_id").is_none(),
+            "the dead id must be absent, not merely labelled: {hit}"
+        );
+        assert_eq!(hit["artifact_path"], json!("docs/design.md"));
+        assert_eq!(hit["resolves_with"], json!("kin_artifact_read"));
+        assert!(hit["note"]
+            .as_str()
+            .unwrap()
+            .contains("get_entity_source"));
+    }
+
+    /// The second dead-id path, and the one that produced the ticket's title.
+    ///
+    /// A `RetrievalKey::EntityRevision` resolves through immutable revision
+    /// history, and retiring an entity deliberately leaves that history in
+    /// place, so a deleted entity's head revision still resolves to an `Entity`
+    /// whose id names nothing the graph holds. That id is entity-SHAPED — a
+    /// bare UUID — so no consumer can tell it from a live one. It must be
+    /// dropped rather than served under any label.
+    #[test]
+    fn a_retired_entity_key_is_dropped_rather_than_served_as_a_dead_id() {
+        let retired = test_entity("deleted_symbol", "src/gone.rs");
+        assert!(
+            locate_hit_identity(&kin_db::ResolvedRetrievalItem::Entity(retired.clone()), false)
+                .is_none(),
+            "an id the graph no longer holds must not reach a row"
+        );
+        // Falsification: the same item with liveness restored IS served, so the
+        // assertion above is about liveness and not about the fixture.
+        assert!(
+            locate_hit_identity(&kin_db::ResolvedRetrievalItem::Entity(retired), true).is_some()
+        );
+    }
+
+    /// The two id spaces are distinguishable in the output, which is the whole
+    /// point: `EntityId` and `ArtifactId` are both bare UUID newtypes, so
+    /// nothing about a rendered id says which space produced it.
+    #[test]
+    fn the_two_id_spaces_serialize_to_distinct_stable_tokens() {
+        assert_eq!(
+            kin_cli::commands::locate::LocateIdSpace::Entity.as_str(),
+            "entity"
+        );
+        assert_eq!(
+            kin_cli::commands::locate::LocateIdSpace::Artifact.as_str(),
+            "artifact"
+        );
+        assert_eq!(
+            serde_json::to_value(kin_cli::commands::locate::LocateIdSpace::Artifact).unwrap(),
+            json!("artifact"),
+            "the enum and the emitted token must be one spelling"
+        );
+    }
+
+    /// The gap `kin admit` exists to close: a working tree the daemon holds no
+    /// watcher event for, and therefore never admits on its own.
+    ///
+    /// The files are written to disk only. Nothing admits them, which is
+    /// precisely the state a store lands in when ingest was interrupted or when
+    /// a rule change made previously-excluded content admissible, and the
+    /// daemon has been quiet since.
+    #[tokio::test]
+    async fn admit_admits_a_complete_tree_no_watcher_event_ever_named() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        for (path, content) in [
+            ("docs/design.md", &b"# design\n"[..]),
+            (".github/workflows/ci.yml", &b"name: ci\n"[..]),
+            ("scripts/deploy.sh", &b"#!/bin/sh\necho deploy\n"[..]),
+        ] {
+            install_working_copy_file(&state, path, content, false);
+        }
+
+        // Precondition, so a pass that admitted nothing cannot read as success:
+        // none of this is tracked yet.
+        let before = tracked_paths(&state);
+        assert!(
+            !before.contains("docs/design.md"),
+            "the fixture admitted the tree before the command ran: {before:?}"
+        );
+
+        let app = router(Arc::clone(&state));
+        let (_, response) = admit_through_api(&app).await;
+
+        assert_eq!(response["report"]["admitted"], json!(true));
+        assert_eq!(response["mutated"], json!(true));
+        let after = tracked_paths(&state);
+        for path in [
+            "docs/design.md",
+            ".github/workflows/ci.yml",
+            "scripts/deploy.sh",
+        ] {
+            assert!(after.contains(path), "{path} was not admitted: {after:?}");
+        }
+        assert_eq!(
+            response["report"]["tracked_before"],
+            json!(before.len()),
+            "the report must name the tree it started from"
+        );
+        assert_eq!(response["report"]["tracked_after"], json!(after.len()));
+
+        // A second pass observes the same tree and has nothing to do. This is
+        // what makes the route safe on the retrying poster the CLI uses.
+        let (_, replay) = admit_through_api(&app).await;
+        assert_eq!(replay["report"]["admitted"], json!(true));
+        assert_eq!(replay["mutated"], json!(false));
+        assert_eq!(
+            replay["report"]["tracked_before"],
+            replay["report"]["tracked_after"]
+        );
+    }
+
+    /// A requested admission has to reach the probes the health surfaces read.
+    ///
+    /// `kin graph status` and `/health` both answer from `ReconcileHealth`, so
+    /// an operator's own recovery pass being the one admission those surfaces
+    /// cannot see would reproduce the blindness the probes were added to fix.
+    #[tokio::test]
+    async fn admit_records_its_pass_on_the_probes_the_health_surfaces_read() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        install_working_copy_file(&state, "docs/notes.md", b"notes\n", false);
+
+        // Precondition: nothing has recorded a successful admission yet, so the
+        // assertion below cannot pass on a pre-existing mark.
+        let before = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert!(
+            before.last_admission_success_age_seconds.is_none(),
+            "the fixture recorded an admission before the command ran"
+        );
+
+        let app = router(Arc::clone(&state));
+        let (_, response) = admit_through_api(&app).await;
+        assert_eq!(response["report"]["admitted"], json!(true));
+        assert!(
+            response["report"]["reconcile"]["last_admission_success_age_seconds"].is_number(),
+            "the response must carry the probe reading: {response}"
+        );
+
+        let after = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert!(
+            after.last_admission_success_age_seconds.is_some(),
+            "the pass did not reach the probes the health surfaces read"
+        );
+        assert_eq!(after.admission_failure_streak, 0);
+    }
+
+    /// The idle window is what would otherwise end a long pass, so the lease the
+    /// CLI takes has to be the thing that suppresses it.
+    ///
+    /// `kin admit` registers a session before its request and releases it after.
+    /// This pins the daemon-side half of that contract: a CLI-vendored session
+    /// makes the daemon ineligible for idle shutdown, and ending it restores
+    /// eligibility so the lease cannot keep a daemon awake forever.
+    #[tokio::test]
+    async fn a_cli_session_suppresses_the_idle_shutdown_that_would_end_an_admission() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            !state.has_external_sessions(),
+            "the fixture already held a session, so this cannot discriminate"
+        );
+
+        let app = router(Arc::clone(&state));
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/session")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "vendor": kin_cli::commands::admit::ADMIT_SESSION_VENDOR,
+                            "client_name": kin_cli::commands::admit::ADMIT_SESSION_CLIENT,
+                            "transport": "cli",
+                            "pid": std::process::id(),
+                            "cwd": state.layout.working_dir().display().to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let started: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let session_id = started["session_id"].as_str().unwrap().to_string();
+
+        assert!(
+            state.has_external_sessions(),
+            "a kin-cli session must pin the daemon against idle shutdown"
+        );
+
+        let response = app
+            .oneshot(
+                Request::delete(format!("/session/{session_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            !state.has_external_sessions(),
+            "releasing the lease must restore idle eligibility"
+        );
     }
 
     /// A default exclude alone retires nothing, because ignore rules never hide

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4017,10 +4017,9 @@ async fn command_admit(
 /// store whose graph is still behind. Commit and stash refuse the disabled
 /// condition ahead of the same seam; this refuses both.
 ///
-/// The bare-repository question is asked here the way
-/// `loop_runner::is_bare_repository` asks it, and the two have to stay in step:
-/// a divergence would either refuse a store the seam would have admitted or
-/// admit a skip as a success again.
+/// The bare-repository question is the seam's own predicate rather than a copy
+/// of it, so the two cannot drift: a divergence would either refuse a store the
+/// seam would have admitted or admit a skip as a success again.
 fn admission_seam_would_skip(state: &DaemonState) -> Option<(StatusCode, String)> {
     let working_dir = state.layout.working_dir();
     if state.filesystem_reconcile_disabled() {
@@ -4029,11 +4028,7 @@ fn admission_seam_would_skip(state: &DaemonState) -> Option<(StatusCode, String)
             &working_dir.display().to_string(),
         ));
     }
-    let bare = working_dir.join("config").is_file()
-        && working_dir.join("objects").is_dir()
-        && working_dir.join("refs").is_dir()
-        && !working_dir.join(".git").exists();
-    if bare {
+    if crate::loop_runner::is_bare_repository(working_dir) {
         return Some((
             StatusCode::CONFLICT,
             json!({

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -124,6 +124,7 @@ mod local_repository_authority;
 pub mod loop_runner;
 mod mcp_commit;
 pub mod replica_adoption;
+mod repository_admit;
 mod repository_branch;
 mod repository_checkout;
 pub mod repository_commit;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -76,15 +76,14 @@ impl Default for LoopConfig {
     }
 }
 
-/// Run the reconciliation loop until the cancellation token fires.
+/// Whether `dir` is a bare Git repository, which holds no working copy to
+/// reconcile or admit.
 ///
-/// This is the main loop of the daemon. It:
-/// 1. Watches the working directory for file changes (via `notify`)
-/// 2. Drains batches of events
-/// 3. For each event, runs the reconciler (file -> overlay)
-/// 4. Projects overlay mutations back to files (overlay -> file)
-///
-fn is_bare_repository(dir: &std::path::Path) -> bool {
+/// Crate-visible because the on-demand admission seam refuses the same
+/// condition. A second copy of the predicate would be a second set of rules to
+/// keep in step, and a divergence there would either refuse a store the seam
+/// would have admitted or report a skipped pass as a completed one.
+pub(crate) fn is_bare_repository(dir: &std::path::Path) -> bool {
     dir.join("config").is_file()
         && dir.join("objects").is_dir()
         && dir.join("refs").is_dir()

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Daemon-owned on-demand trigger for one complete exact-tree admission.
+//!
+//! This module runs no admission of its own. It calls the same
+//! [`crate::loop_runner::sync_filesystem_with_graph`] seam the watch loop and
+//! `/commands/commit` already use, so a requested pass inherits the same
+//! completion proof, authority compare-and-swap, mass-deletion guard, and
+//! enrichment ordering as an ambient one. A second implementation would be a
+//! second set of rules to keep in step, and the one thing a recovery path must
+//! not do is admit differently from the loop it is recovering.
+//!
+//! What it adds is an answer. The pass itself returns `()`, and a store's
+//! operator needs to know whether it moved anything and whether it worked, so
+//! the graph is measured on both sides of the call and the reconcile probes are
+//! read afterwards. Those two facts are different: a pass can succeed and admit
+//! nothing, which is the settled case, and a pass can fail while the request
+//! that carried it returns cleanly, which is the case the probes exist to
+//! publish.
+
+use anyhow::Result;
+use kin_cli::commands::admit::{summary_lines, AdmitReport, AdmitResponse, ADMIT_SCHEMA};
+use std::time::Instant;
+
+use crate::state::DaemonState;
+
+/// One observation of the graph counts an admission can change.
+struct GraphCensus {
+    tracked: usize,
+    entities: usize,
+}
+
+fn census(state: &DaemonState) -> GraphCensus {
+    GraphCensus {
+        tracked: state.graph.resolved_tree().len(),
+        entities: state.graph.entity_count(),
+    }
+}
+
+/// Run one complete exact-tree admission and report what it did.
+///
+/// Never returns `Err` for a failed admission. A refused pass is an outcome the
+/// operator has to see the counters and the cause for, and turning it into a
+/// transport-level error would strip both and leave `kin admit` printing an
+/// HTTP status. The CLI exits nonzero off `AdmitReport::admitted` instead.
+/// Transport, initialization, and authority problems still refuse at the
+/// handler, because those mean no pass ran at all.
+pub(crate) async fn execute(state: &DaemonState) -> Result<AdmitResponse> {
+    let repository_id =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?
+            .repository_id()
+            .clone();
+    let before = census(state);
+
+    // The same seam `/commands/commit` calls. It takes the coordination gate
+    // itself, so this handler must not already hold it.
+    let outcome = crate::loop_runner::sync_filesystem_with_graph(state).await;
+
+    // Record the outcome on the same probes the ambient loop records to. A pass
+    // requested here is a complete exact-tree admission by every measure that
+    // matters to a reader of `kin graph status` or `/health`, and leaving it out
+    // would make an operator's own recovery attempt the one admission the
+    // health surfaces cannot see.
+    let now = Instant::now();
+    let probes = state.background_work.reconcile();
+    let failure = match &outcome {
+        Ok(()) => {
+            probes.record_admission_success(now);
+            None
+        }
+        Err(error) => {
+            let cause = crate::error::cause_first(&anyhow::anyhow!(error.to_string()));
+            probes.record_admission_failure(&cause, now);
+            Some(annotate_admission_failure(cause))
+        }
+    };
+
+    let after = census(state);
+    let embeddings = state.graph.embedding_status();
+    let mut report = AdmitReport {
+        schema: ADMIT_SCHEMA.to_string(),
+        repository_id,
+        tracked_before: before.tracked,
+        tracked_after: after.tracked,
+        entities_before: before.entities,
+        entities_after: after.entities,
+        embeddings_indexed: embeddings.indexed,
+        embeddings_total: embeddings.total,
+        reconcile: probes.report(now),
+        admitted: failure.is_none(),
+        failure,
+    };
+    // A failed pass publishes nothing, so the two sides of the census describe
+    // one unchanged tree. Saying so outright keeps the summary from reading a
+    // concurrent tick's work as this pass's.
+    if !report.admitted {
+        report.tracked_after = report.tracked_before;
+        report.entities_after = report.entities_before;
+    }
+
+    let lines = summary_lines(&report);
+    let mutated = report.admitted
+        && (report.tracked_after != report.tracked_before
+            || report.entities_after != report.entities_before);
+    Ok(AdmitResponse {
+        lines,
+        mutated,
+        report: Some(report),
+    })
+}
+
+/// The mass-deletion refusal names an environment variable, and the variable is
+/// read by the daemon rather than by the process the operator just typed into.
+///
+/// Without this, the obvious next move is `KIN_ALLOW_MASS_DELETION=1 kin admit`,
+/// which sets it on the CLI, changes nothing, and refuses identically. An
+/// operator who tries that twice concludes the override is broken.
+fn annotate_admission_failure(cause: String) -> String {
+    if cause.contains("KIN_ALLOW_MASS_DELETION") {
+        format!(
+            "{cause}. That variable is read by the daemon process, not by this command, so set it \
+             where the daemon starts: stop it with `kin daemon stop`, then re-run with \
+             KIN_ALLOW_MASS_DELETION=1 exported so the daemon it starts inherits it"
+        )
+    } else {
+        cause
+    }
+}

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -11,19 +11,104 @@
 //! second set of rules to keep in step, and the one thing a recovery path must
 //! not do is admit differently from the loop it is recovering.
 //!
-//! What it adds is an answer. The pass itself returns `()`, and a store's
-//! operator needs to know whether it moved anything and whether it worked, so
-//! the graph is measured on both sides of the call and the reconcile probes are
-//! read afterwards. Those two facts are different: a pass can succeed and admit
-//! nothing, which is the settled case, and a pass can fail while the request
-//! that carried it returns cleanly, which is the case the probes exist to
-//! publish.
+//! What it adds is an answer, and a pass that outlives the request asking for
+//! it. The pass itself returns `()`, and a store's operator needs to know
+//! whether it moved anything and whether it worked, so the graph is measured on
+//! both sides of the call and the reconcile probes are read afterwards. Those
+//! two facts are different: a pass can succeed and admit nothing, which is the
+//! settled case, and a pass can fail while the request that carried it returns
+//! cleanly, which is the case the probes exist to publish.
 
 use anyhow::Result;
-use kin_cli::commands::admit::{summary_lines, AdmitReport, AdmitResponse, ADMIT_SCHEMA};
+use kin_cli::commands::admit::{
+    census_moved, summary_lines, AdmitReport, AdmitResponse, ADMIT_SCHEMA,
+};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
 
 use crate::state::DaemonState;
+
+/// The complete exact-tree admission this daemon currently has in flight.
+///
+/// The pass runs in a task of its own rather than inside the request that asked
+/// for it, because a request can be dropped and this pass must not be. The seam
+/// publishes repository authority BEFORE it enriches and its one await sits
+/// between the two, so a client that hangs up mid-pass (an HTTP timeout, an
+/// interrupt) would otherwise leave the tree admitted with nothing parsed for
+/// it, and nothing re-enriches a file that did not change. A detached pass has
+/// no such midpoint: it finishes, or it dies with the daemon and reports
+/// nothing.
+///
+/// The slot is also what makes a second request safe. Attaching it to the
+/// running pass is the difference between reporting that pass's real transition
+/// and re-observing an already-published tree, finding no deltas, and calling
+/// that a complete admission.
+///
+/// What an attached request gets is the running pass's transition, and that
+/// pass observed the tree when it started. A request that arrives afterwards
+/// and needs the tree as of its own arrival asks again once this one reports;
+/// the answer it gets meanwhile is true about the pass it names.
+#[derive(Default)]
+pub(crate) struct AdmissionRuns {
+    inner: Mutex<Option<InFlightAdmission>>,
+}
+
+struct InFlightAdmission {
+    outcome: tokio::sync::watch::Receiver<AdmissionRunState>,
+}
+
+#[derive(Clone)]
+enum AdmissionRunState {
+    Running,
+    /// The pass ended and this is what it did. Shared rather than recomputed,
+    /// so every caller waiting on one pass reports one outcome.
+    Finished(Arc<Result<AdmitResponse, String>>),
+}
+
+/// The right to run a pass, or a seat at the one already running.
+enum AdmissionClaim {
+    Started(
+        tokio::sync::watch::Sender<AdmissionRunState>,
+        tokio::sync::watch::Receiver<AdmissionRunState>,
+    ),
+    Attached(tokio::sync::watch::Receiver<AdmissionRunState>),
+}
+
+impl AdmissionRuns {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<InFlightAdmission>> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn claim(&self) -> AdmissionClaim {
+        let mut slot = self.lock();
+        if let Some(running) = slot.as_ref() {
+            return AdmissionClaim::Attached(running.outcome.clone());
+        }
+        let (sender, receiver) = tokio::sync::watch::channel(AdmissionRunState::Running);
+        *slot = Some(InFlightAdmission {
+            outcome: receiver.clone(),
+        });
+        AdmissionClaim::Started(sender, receiver)
+    }
+
+    fn release(&self) {
+        *self.lock() = None;
+    }
+}
+
+/// Clears the in-flight slot when the pass ends, however it ends.
+///
+/// A pass that panics has to leave the slot empty, or the daemon spends the
+/// rest of its life attaching callers to a run that will never report.
+struct RunningPass {
+    state: Arc<DaemonState>,
+}
+
+impl Drop for RunningPass {
+    fn drop(&mut self) {
+        self.state.admission_runs.release();
+    }
+}
 
 /// One observation of the graph counts an admission can change.
 struct GraphCensus {
@@ -38,7 +123,8 @@ fn census(state: &DaemonState) -> GraphCensus {
     }
 }
 
-/// Run one complete exact-tree admission and report what it did.
+/// Run one complete exact-tree admission and report what it did, or report what
+/// the pass already running is doing.
 ///
 /// Never returns `Err` for a failed admission. A refused pass is an outcome the
 /// operator has to see the counters and the cause for, and turning it into a
@@ -46,7 +132,49 @@ fn census(state: &DaemonState) -> GraphCensus {
 /// HTTP status. The CLI exits nonzero off `AdmitReport::admitted` instead.
 /// Transport, initialization, and authority problems still refuse at the
 /// handler, because those mean no pass ran at all.
-pub(crate) async fn execute(state: &DaemonState) -> Result<AdmitResponse> {
+///
+/// `Err` is reserved for the two cases where no outcome was established: the
+/// repository authority context could not be resolved, and the pass stopped
+/// without reporting. Neither may read as success.
+pub(crate) async fn execute(state: &Arc<DaemonState>) -> Result<AdmitResponse> {
+    let mut outcome = match state.admission_runs.claim() {
+        AdmissionClaim::Attached(outcome) => outcome,
+        AdmissionClaim::Started(sender, outcome) => {
+            let owned = Arc::clone(state);
+            tokio::spawn(async move {
+                // Dropped after the send, and during an unwind if the pass
+                // panics, so the slot never outlives the run it names.
+                let _running = RunningPass {
+                    state: Arc::clone(&owned),
+                };
+                let finished = run_pass(&owned).await.map_err(|error| error.to_string());
+                let _ = sender.send(AdmissionRunState::Finished(Arc::new(finished)));
+            });
+            outcome
+        }
+    };
+
+    loop {
+        if let AdmissionRunState::Finished(finished) = outcome.borrow_and_update().clone() {
+            return match finished.as_ref() {
+                Ok(response) => Ok(response.clone()),
+                Err(error) => Err(anyhow::anyhow!(error.clone())),
+            };
+        }
+        if outcome.changed().await.is_err() {
+            // The task carrying the pass ended without publishing an outcome,
+            // which is a panic or a daemon shutdown. What the pass managed to
+            // publish before that is unknown from here, and the one answer that
+            // must never be given is a successful one.
+            return Err(anyhow::anyhow!(
+                "the complete exact-tree admission stopped without reporting an outcome; read \
+                 `kin graph status` for the state it left behind"
+            ));
+        }
+    }
+}
+
+async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
     let repository_id =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?
             .repository_id()
@@ -54,14 +182,16 @@ pub(crate) async fn execute(state: &DaemonState) -> Result<AdmitResponse> {
     let before = census(state);
 
     // The same seam `/commands/commit` calls. It takes the coordination gate
-    // itself, so this handler must not already hold it.
+    // itself, so this must not already hold it.
     let outcome = crate::loop_runner::sync_filesystem_with_graph(state).await;
 
     // Record the outcome on the same probes the ambient loop records to. A pass
     // requested here is a complete exact-tree admission by every measure that
     // matters to a reader of `kin graph status` or `/health`, and leaving it out
     // would make an operator's own recovery attempt the one admission the
-    // health surfaces cannot see.
+    // health surfaces cannot see. Recording from the pass rather than from the
+    // request also means a caller that hung up mid-pass still leaves the
+    // outcome on the surfaces that answer for the store.
     let now = Instant::now();
     let probes = state.background_work.reconcile();
     let failure = match &outcome {
@@ -76,9 +206,15 @@ pub(crate) async fn execute(state: &DaemonState) -> Result<AdmitResponse> {
         }
     };
 
+    // The census is reported as measured on both sides, whatever the outcome.
+    // The seam publishes repository authority before it enriches, so a pass that
+    // fails afterwards has already moved the tree; rewriting the after side to
+    // match the before side would report that move as if it had never happened,
+    // on exactly the path where an operator most needs to know it did.
+    // `summary_lines` derives its wording from the two sides instead.
     let after = census(state);
     let embeddings = state.graph.embedding_status();
-    let mut report = AdmitReport {
+    let report = AdmitReport {
         schema: ADMIT_SCHEMA.to_string(),
         repository_id,
         tracked_before: before.tracked,
@@ -91,18 +227,9 @@ pub(crate) async fn execute(state: &DaemonState) -> Result<AdmitResponse> {
         admitted: failure.is_none(),
         failure,
     };
-    // A failed pass publishes nothing, so the two sides of the census describe
-    // one unchanged tree. Saying so outright keeps the summary from reading a
-    // concurrent tick's work as this pass's.
-    if !report.admitted {
-        report.tracked_after = report.tracked_before;
-        report.entities_after = report.entities_before;
-    }
 
     let lines = summary_lines(&report);
-    let mutated = report.admitted
-        && (report.tracked_after != report.tracked_before
-            || report.entities_after != report.entities_before);
+    let mutated = census_moved(&report);
     Ok(AdmitResponse {
         lines,
         mutated,

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1280,6 +1280,11 @@ pub struct DaemonState {
     /// process on a user's box, so nothing outside it can notice a wedged pass;
     /// this is where that noticing lives.
     pub background_work: Arc<crate::background_work::BackgroundWorkSupervisor>,
+    /// The requested complete exact-tree admission this daemon currently has in
+    /// flight, if any. Such a pass runs detached from the request that asked for
+    /// it, so it needs a home that outlives that request, and a second request
+    /// needs somewhere to find it rather than starting a competing pass.
+    pub(crate) admission_runs: crate::repository_admit::AdmissionRuns,
     /// Why the views this daemon derives from repository authority stopped
     /// matching it, or `None` when they match.
     ///
@@ -2223,6 +2228,7 @@ impl DaemonState {
             spine_initialization: Mutex::new(()),
             spine_warming: AtomicBool::new(false),
             background_work: Arc::new(crate::background_work::BackgroundWorkSupervisor::default()),
+            admission_runs: crate::repository_admit::AdmissionRuns::default(),
             #[cfg(test)]
             spine_initialization_test_hook: Mutex::new(None),
             #[cfg(all(test, feature = "embeddings"))]
@@ -2440,6 +2446,7 @@ impl DaemonState {
             spine_initialization: Mutex::new(()),
             spine_warming: AtomicBool::new(false),
             background_work: Arc::new(crate::background_work::BackgroundWorkSupervisor::default()),
+            admission_runs: crate::repository_admit::AdmissionRuns::default(),
             #[cfg(test)]
             spine_initialization_test_hook: Mutex::new(None),
             #[cfg(all(test, feature = "embeddings"))]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -114,7 +114,14 @@ returns its best candidates: each hit carries `match_kind` (`name` when a query 
 that entity's name, else `semantic` or `text_fallback`), and the response carries \
 `all_fallback: true` when NOT ONE returned entity was named by the query. Asking for a \
 symbol that does not exist yields a full, confident-looking page with `all_fallback` set \
-— treat that as \"this symbol was not found\" rather than as the answer.";
+— treat that as \"this symbol was not found\" rather than as the answer. Every hit also \
+states which id space it belongs to, because the retrieval index spans two and their ids \
+look alike. `id_space: \"entity\"` means the hit carries an `entity_id` that resolves in \
+the graph, so get_entity_source, get_context_pack, graph_neighborhood, and find_references \
+all take it. `id_space: \"artifact\"` means the hit is an artifact-level embedding — a \
+tracked file the parsers produced no entities for — so it carries `artifact_path` and NO \
+`entity_id`, and those tools will refuse it; read it with kin_artifact_read instead. Do \
+not synthesize an entity id from an artifact hit's path.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///


### PR DESCRIPTION
A store whose graph has fallen behind its working tree has had no way to recover on demand. The daemon admits a complete exact tree on startup, on commit, and on whatever its watcher observed, and none of those is a trigger an operator can pull, so recovery waits for an organic churn burst while a quiet daemon idles out first. `kin admit` is that trigger. It runs the daemon's own admission seam rather than a second copy of it, so a requested pass inherits the same completion proof, authority compare-and-swap, mass-deletion guard, and enrichment ordering as every ambient one. No admission internals change. The untracked-paths disclosure that `kin graph status` and `/health` print now names this command as the on-demand remedy beside a commit, so the surface explaining why a new file is not queryable also says what to do about it.

The command has to survive the very condition it repairs. A daemon holding no registered session idles out while a long first pass is still running, and an admission killed at its midpoint is exactly the failure being fixed, so the CLI registers a session for the duration and releases it on every exit path. The outcome is then read back from the reconcile probes rather than inferred from the request returning cleanly, because a pass that ran and admitted nothing is a different answer from a pass that failed inside a successful request. A failed pass exits nonzero and leads with the recorded cause, stating that graph authority is unchanged.

There is deliberately no mass-deletion confirmation of its own here. That guard is evaluated inside the shared pass and its override is read from the daemon's environment, so a flag on this command would be a second control over one guard reaching it by a different route, and two controls over one guard are two rules that can come to disagree. A refused admission reports the guard's own counts instead, and now adds the one thing the message was missing: the variable belongs to the daemon process, so setting it on the command that just failed changes nothing. The refusal for a bare working directory asks the reconcile loop's own predicate for the same reason, rather than keeping a second copy of it on a runtime authority path.

The other half is the retrieval contract. The vector spine is keyed by `RetrievalKey`, which spans two id spaces, and `EntityId` and `ArtifactId` are both bare UUID newtypes, so nothing about a rendered id says which space produced it. The cosine `semantic_locate` arm was serving two kinds of unusable identifier under the field name `entity_id`. An artifact-level hit, meaning a tracked file the parsers produced no entities for, was given its own path as an id. A hit resolved through `RetrievalKey::EntityRevision` was given a live-looking UUID even after its entity had been retired, because resolution walks immutable revision history rather than live state, and retiring an entity deliberately leaves that history in place. Both are refused by `get_entity_source`, `get_context_pack`, and `graph_neighborhood`, so a caller could only discover the id was dead by spending a call on it.

Every hit now states its id space. An entity hit is unchanged and reports `id_space: "entity"`. An artifact hit reports `id_space: "artifact"` and carries `artifact_path`, a field named for what it actually holds, alongside the name of the tool that does read it. It carries no `entity_id` at all, because a field named for an entity holding a path is the defect rather than a cosmetic problem. A hit whose entity the graph no longer holds is dropped instead of being served under any label. That also closes the case the snippet projection used to mask only when snippets were on, since nothing filtered it before under `include_snippet: false` or when results roll up to files. Dropped candidates are counted and reported as retrieval degradations, so a short page on a store whose sidecar and graph have drifted apart is attributable rather than reading as an honest negative. The fused arm reports the same field, where it is constant by construction, so a consumer never has to know which pipeline answered to know whether the label is there. The tool description states the contract and tells an agent not to synthesize an entity id from an artifact path.

Verification: `cargo fmt --check`, clippy under the ci.yml allowlist with `-D warnings`, and `kin-dev local-test kin` on this branch, 5345 passed and 11 skipped with no lock contamination. New tests cover both halves. The shaping decision is extracted so it can be asserted directly rather than through a query needing a live embedder. The retired-entity test checks both directions, which makes it a test about liveness rather than about its fixture. Scratch stores were driven end to end with binaries built from this branch. An artifact-only store of docs, workflows, and a shell script admitted four artifacts and zero entities. A code-bearing store admitted two artifacts and five entities. Both exited zero, and a replayed request correctly reported that nothing changed.

Findings worth separate tickets came out of that run and are not addressed here. Files written into a repository with a live daemon were still unadmitted after twenty-five seconds, which is the ambient gap this command works around rather than fixes. A YAML file's structured-artifact facet also disagrees with exact repository content identity, and the released 0.5.15 binary reproduces that through `kin commit`, so it predates this change and is reachable without it.

Closes FIR-2132
