### PR TITLE
Make the MCP write path land in one pass and answer truthfully when it already has

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7283,6 +7283,19 @@ async fn mcp_tools_call(
                 "missing required parameter: entity_id".to_string(),
             )));
         };
+        // A blank id is a caller bug, not a query, and it must fail closed like
+        // the missing one above. Resolution parses no uuid from it and falls
+        // through to ranked name selection, where an empty query still ranks
+        // every entity and returns whichever sorts best: the tool answers an
+        // arbitrary entity's body and reports success, so the caller cannot
+        // tell the accident from a real hit.
+        if entity_id.trim().is_empty() {
+            return Ok(Json(kin_mcp::ToolCallResult::error(
+                "invalid parameter: entity_id must not be empty; pass an entity uuid or its exact \
+                 name"
+                    .to_string(),
+            )));
+        }
         let repository_authority = match require_mcp_command_repository_authority(&state) {
             Ok(authority) => authority,
             Err(error) => return Ok(Json(kin_mcp::ToolCallResult::error(error.to_string()))),

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -203,28 +203,45 @@ pub(crate) fn require_fresh_daemon_workspace(
 }
 
 /// Describe the first authority-owned entity or relation the daemon graph has
-/// dropped or rewritten, or `None` when authority is still fully retained.
+/// dropped, or `None` when authority is still fully retained.
 ///
-/// A derived view may hold more than authority owns. It may never hold less,
-/// and it may never hold a different value under an identity authority already
-/// published: either would mean the daemon is answering from something other
-/// than graph truth.
+/// A derived view may hold more than authority owns, and it may hold a richer
+/// value for something authority owns. It may never hold less: a dropped entity
+/// or relation means the daemon is answering from something other than graph
+/// truth, and no derived writer produces that.
+///
+/// A rewrite is deliberately not divergence. Parser reconciliation and the
+/// asynchronous LSP enrichment worker publish semantic facets onto existing
+/// authority-owned entities continuously and outside the coordination gate, so
+/// treating a rewritten value as divergence refuses every commit that follows
+/// any enrichment tick. That is the same unachievable invariant the equality
+/// check above was removed for, reintroduced one level down at entity
+/// granularity, and it fails the same way: a caller told to "re-send this
+/// commit unchanged once the daemon is reading current repository authority"
+/// races the worker and loses again, naming a different rewritten entity each
+/// attempt, until the daemon is recycled.
+///
+/// Tolerating the rewrite is safe because a derived lead cannot reach
+/// publication. [`crate::mcp_commit`] builds its prospective graph from the
+/// authority workspace snapshot and applies only the staged operations, so what
+/// the live graph holds never enters the committed change. Staleness, the
+/// failure this check is sometimes assumed to catch, is caught before it by the
+/// generation binding above: a daemon that missed an authority move fails there
+/// with both generations named. After the commit the live graph is corrected
+/// onto authority and verified, which is where a genuinely corrupt derived
+/// value is caught.
 fn authority_semantics_divergence(
     live: &kin_db::GraphSnapshot,
     authority: &kin_db::GraphSnapshot,
 ) -> Option<String> {
-    for (entity_id, entity) in &authority.entities {
-        match live.entities.get(entity_id) {
-            Some(live_entity) if live_entity == entity => {}
-            Some(_) => return Some(format!("entity {entity_id} was rewritten")),
-            None => return Some(format!("entity {entity_id} is missing")),
+    for entity_id in authority.entities.keys() {
+        if !live.entities.contains_key(entity_id) {
+            return Some(format!("entity {entity_id} is missing"));
         }
     }
-    for (relation_id, relation) in &authority.relations {
-        match live.relations.get(relation_id) {
-            Some(live_relation) if live_relation == relation => {}
-            Some(_) => return Some(format!("relation {relation_id} was rewritten")),
-            None => return Some(format!("relation {relation_id} is missing")),
+    for relation_id in authority.relations.keys() {
+        if !live.relations.contains_key(relation_id) {
+            return Some(format!("relation {relation_id} is missing"));
         }
     }
     None

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -78,9 +78,19 @@ fn commit_exact_transaction_inner(
         .ok_or_else(|| "missing required parameter: transaction_id".to_string())?
         .to_string();
 
-    let mut transaction = sessions
-        .get_transaction(&transaction_id)
-        .ok_or_else(|| format!("Transaction not found: {transaction_id}"))?;
+    let Some(mut transaction) = sessions.get_transaction(&transaction_id) else {
+        // A missing record is not proof the work never happened. A successful
+        // commit evicts its own transaction, and a client whose per-attempt
+        // HTTP budget expired during a long apply retries straight into that
+        // gap: the retry blocks on the coordination gate, the first attempt
+        // finishes and evicts, and the retry then reads a registry that no
+        // longer holds what it just applied. Answering "not found" there
+        // reports failure over a commit whose file, entity, and provenance
+        // all landed, which is a double-apply generator, because any correct
+        // agent retries a failure. Repository authority still holds the
+        // receipt for this caller-stable operation id, so ask it.
+        return replay_applied_commit(state, &transaction_id, coordination);
+    };
 
     // Operations handed to the commit call itself stage and publish in one
     // step. Once the transaction is fenced they are read as a restatement of
@@ -1188,6 +1198,68 @@ fn apply_relation_operations(
             .map_err(|error| format!("apply prospective relation operation: {error}"))?;
     }
     Ok(())
+}
+
+/// Answer a commit whose transaction record is gone by asking repository
+/// authority whether that transaction already landed.
+///
+/// The record is deliberately evicted once a commit succeeds, so its absence
+/// carries no information on its own: it is the state left behind by success
+/// and the state left behind by an id that never existed. Repository authority
+/// separates them, because the receipt is keyed by the same caller-stable
+/// operation id the transaction id derives from and it is published in the same
+/// atomic successor as the authority it moved. A receipt therefore proves the
+/// work applied, and its absence proves it did not.
+///
+/// Nothing here re-applies or re-installs anything. The reply is derived
+/// entirely from the persisted receipt, so a caller that retries an
+/// already-applied commit any number of times gets the same answer and moves
+/// authority exactly once.
+fn replay_applied_commit(
+    state: &Arc<DaemonState>,
+    transaction_id: &str,
+    coordination: Option<&kin_mcp::CoordinationWritePreflight>,
+) -> Result<kin_mcp::ToolCallResult, String> {
+    let Ok(operation_uuid) = uuid::Uuid::parse_str(transaction_id) else {
+        // Not a transaction id this daemon could ever have minted, so there is
+        // no receipt to look for and nothing to be idempotent about.
+        return Err(format!("Transaction not found: {transaction_id}"));
+    };
+    let authority_context = authority_context(state)?;
+    let Some(recovered) =
+        recover_native_commit(&authority_context, OperationId::from_uuid(operation_uuid))
+            .map_err(|error| format!("recover exact MCP repository receipt: {error}"))?
+    else {
+        return Err(format!(
+            "Transaction not found: {transaction_id}. Repository authority holds no receipt for \
+             it either, so nothing was published under this id and re-sending this commit cannot \
+             succeed. Begin a new transaction with kin_transaction_begin and stage the operations \
+             again."
+        ));
+    };
+
+    let modified_files = changed_file_ids(&recovered.change)?;
+    let result = serde_json::json!({
+        "transaction_id": transaction_id,
+        "state": "committed",
+        "status": "committed",
+        "already_applied": true,
+        "empty": false,
+        "entity_deltas": recovered.entity_count,
+        "relation_deltas": recovered.relation_count,
+        "change_id": recovered.change.id.to_string(),
+        "repository_generation": recovered.receipt.generation,
+        "repository_operation_id": recovered.receipt.operation_id.to_string(),
+        "new_root_hash": hex::encode(state.graph.compute_root_hash()),
+        "modified_files": modified_files.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        "collision_warnings": [],
+        "conflicts": [],
+        "semantic_authority": "reparsed_exact_repository_bytes",
+        "coordination": coordination,
+    });
+    let json = serde_json::to_string_pretty(&result)
+        .map_err(|error| format!("serialize replayed exact MCP commit response: {error}"))?;
+    Ok(kin_mcp::ToolCallResult::text(json))
 }
 
 fn finalize_committed_transaction(

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -4481,6 +4481,213 @@ mod tests {
         relation
     }
 
+    /// Rewrite one authority-owned entity in the live graph the way parser
+    /// reconciliation does: in place, under the graph-authority epoch alone,
+    /// holding neither the coordination gate nor the persistence lock.
+    fn rewrite_authority_entity_in_live_graph(state: &Arc<DaemonState>, entity: &Entity) -> Entity {
+        use kin_model::EntityStore;
+        let mut rewritten = entity.clone();
+        rewritten.doc_summary = Some("derived summary the enrichment worker computed".to_string());
+        let guard = state.begin_graph_authority_mutation();
+        state.graph.upsert_entity(&rewritten).unwrap();
+        state.bump_version();
+        drop(guard);
+        rewritten
+    }
+
+    /// A derived REWRITE of an authority-owned entity must not refuse a commit.
+    ///
+    /// Parser reconciliation and the LSP worker rewrite existing entities
+    /// continuously and outside the coordination gate, so refusing on a rewrite
+    /// refuses every commit that follows any tick, naming a different entity
+    /// each attempt. The instruction such a refusal carries, to re-send once the
+    /// daemon reads current authority, can then never converge: the worker wins
+    /// the race every time and only a daemon recycle clears it.
+    #[test]
+    fn a_commit_after_a_derived_entity_rewrite_is_not_refused() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let rewritten = rewrite_authority_entity_in_live_graph(&state, &entity);
+        assert!(
+            !semantic_workspace_matches(state.graph.as_ref(), &before.graph),
+            "the rewrite must put the live graph out of step with authority, or this test proves \
+             nothing about the refusal it exists to falsify"
+        );
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a commit issued after a derived entity rewrite must not be refused: {}",
+            result_text(&result)
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(after.roots.generation, before.roots.generation + 1);
+        assert_eq!(
+            after
+                .graph
+                .to_snapshot()
+                .entities
+                .get(&entity.id)
+                .expect("the entity must survive the commit")
+                .doc_summary,
+            None,
+            "the derived summary must not be absorbed into the published change"
+        );
+        assert_ne!(
+            rewritten.doc_summary, None,
+            "the fixture must actually have written a derived value"
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n"
+        );
+    }
+
+    /// Losing an entity authority owns is still divergence: a derived view may
+    /// hold more than authority, and may hold a richer value for what authority
+    /// owns, but it may never hold less.
+    #[test]
+    fn a_commit_is_refused_when_the_live_graph_has_dropped_an_authority_entity() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\npub fn other() -> u8 { 3 }\n",
+            "value",
+        );
+        let dropped = load_native_commit_base(&state.layout)
+            .unwrap()
+            .graph
+            .to_snapshot()
+            .entities
+            .into_values()
+            .find(|candidate| candidate.id != entity.id)
+            .expect("the fixture must own a second entity to drop");
+        let guard = state.begin_graph_authority_mutation();
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: vec![EntityDelta::Removed { old: dropped }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        state.bump_version();
+        drop(guard);
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "a commit must be refused while the daemon holds less than authority owns"
+        );
+        assert!(
+            result_text(&result).contains("is missing"),
+            "the refusal must name the loss: {}",
+            result_text(&result)
+        );
+    }
+
+    /// A retry of a commit whose record is gone must be answered from the
+    /// repository receipt, not reported as a missing transaction.
+    ///
+    /// A successful commit evicts its own record, and a client whose per-attempt
+    /// budget expired during a long apply retries straight into that gap. The
+    /// old answer, `Transaction not found`, reported failure over a commit whose
+    /// file, entity, and provenance had all landed, which is a double-apply
+    /// generator because any correct agent retries a failure.
+    #[test]
+    fn a_retry_of_an_evicted_committed_transaction_answers_from_the_receipt() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let first = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(first.is_error, Some(true), "{}", result_text(&first));
+        let first_body: serde_json::Value = serde_json::from_str(result_text(&first)).unwrap();
+        let generation_after_first = load_native_commit_base(&state.layout)
+            .unwrap()
+            .roots
+            .generation;
+
+        // Exactly what a successful commit leaves behind for the next attempt:
+        // the durable store and the live registry both forget the transaction.
+        state
+            .mcp_transactions
+            .lock()
+            .unwrap()
+            .remove(&transaction_id);
+        let retry_sessions = test_sessions();
+        assert!(
+            retry_sessions.get_transaction(&transaction_id).is_none(),
+            "the fixture must reproduce the evicted-record state the retry actually meets"
+        );
+
+        let retry = commit_exact_transaction(&state, &retry_sessions, &arguments, None);
+        assert_ne!(
+            retry.is_error,
+            Some(true),
+            "a retry of an applied commit must not report failure: {}",
+            result_text(&retry)
+        );
+        let retry_body: serde_json::Value = serde_json::from_str(result_text(&retry)).unwrap();
+        assert_eq!(retry_body["status"], "committed");
+        assert_eq!(retry_body["already_applied"], true);
+        assert_eq!(retry_body["change_id"], first_body["change_id"]);
+        assert_eq!(
+            load_native_commit_base(&state.layout)
+                .unwrap()
+                .roots
+                .generation,
+            generation_after_first,
+            "answering the retry must not publish a second repository generation"
+        );
+    }
+
+    /// An id that never named a transaction still fails closed, and says it
+    /// checked repository authority too, so the caller can tell "already landed"
+    /// apart from "nothing was ever published under this id".
+    #[test]
+    fn a_commit_for_an_unknown_transaction_id_still_fails_closed() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let arguments = HashMap::from([(
+            "transaction_id".to_string(),
+            serde_json::json!(uuid::Uuid::new_v4().to_string()),
+        )]);
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(result.is_error, Some(true));
+        let message = result_text(&result);
+        assert!(message.contains("Transaction not found"), "{message}");
+        assert!(
+            message.contains("holds no receipt"),
+            "the refusal must say authority was consulted as well: {message}"
+        );
+    }
+
     /// The same acceptance as the enrichment-tick case, in the exact shape the
     /// LSP worker writes: relations only, on entities authority already owns.
     #[test]

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -2669,6 +2669,55 @@ mod tests {
         }
     }
 
+    /// Product mode must teach the whole operation schema on a decode failure,
+    /// exactly as the in-process handler does. This path used to decode by hand
+    /// and answer with whichever single field serde stopped on, so a caller
+    /// improvising the shape against a real daemon learned one field per
+    /// attempt and never saw the contract it was failing.
+    #[test]
+    fn delegate_stage_decode_failure_names_the_whole_operation_schema() {
+        let mut args = HashMap::new();
+        args.insert("transaction_id".into(), serde_json::json!("tx-1"));
+        args.insert(
+            "operations".into(),
+            serde_json::json!([{ "target": "Foo::bar", "content": "new source" }]),
+        );
+        let err = validate_stage_arguments(&args).unwrap_err();
+        for expected in [
+            "each element of `operations` is one of",
+            "an entity source edit",
+            "`verb` (string, REQUIRED)",
+            "`target` (string, REQUIRED)",
+            "`description` (string, REQUIRED)",
+            "`body` (string, optional)",
+            "`payload` (object, optional)",
+            "create/add/upsert/insert, update/modify, or delete/remove",
+        ] {
+            assert!(err.contains(expected), "refusal omits {expected:?}: {err}");
+        }
+    }
+
+    /// The key a caller reaches for before it reaches for `body` is named in
+    /// the refusal rather than dropped, because silently discarding it commits
+    /// nothing while reporting success.
+    #[test]
+    fn delegate_stage_names_an_unknown_source_field_rather_than_dropping_it() {
+        let mut args = HashMap::new();
+        args.insert("transaction_id".into(), serde_json::json!("tx-1"));
+        args.insert(
+            "operations".into(),
+            serde_json::json!([{
+                "verb": "update",
+                "target": "Foo::bar",
+                "description": "why",
+                "new_body": "new source",
+            }]),
+        );
+        let err = validate_stage_arguments(&args).unwrap_err();
+        assert!(err.contains("'new_body'"), "{err}");
+        assert!(err.contains("New source text goes in `body`"), "{err}");
+    }
+
     #[test]
     fn delegate_stage_rejects_relation_modify() {
         let args = stage_args(vec![stage_op("modify", Some(stage_relation()))]);

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1400,13 +1400,19 @@ pub async fn forward_tool_call(
 /// argument map. A missing `operations` field is left for the daemon to report
 /// (so the missing-parameter message stays authoritative); a malformed array or
 /// a payload that would be silently dropped at commit fails loud here.
+///
+/// Decoding goes through [`crate::session::parse_staged_operations`] rather
+/// than serde directly. Product mode reaches this function and the in-process
+/// handler reaches that one, so decoding here by hand gave the two modes
+/// different refusals for the identical input: in-process named the whole
+/// operation schema and product mode answered with whichever single field
+/// serde stopped on. A caller improvising the shape against a real daemon
+/// learned one field per attempt and never saw the contract.
 fn validate_stage_arguments(arguments: &HashMap<String, serde_json::Value>) -> Result<(), String> {
     let Some(operations_val) = arguments.get("operations") else {
         return Ok(());
     };
-    let operations: Vec<crate::session::McpMutationOperation> =
-        serde_json::from_value(operations_val.clone())
-            .map_err(|e| format!("invalid operations array: {e}"))?;
+    let operations = crate::session::parse_staged_operations(operations_val)?;
     crate::session::validate_staged_operations(&operations)
 }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -341,6 +341,16 @@ pub fn parse_batch_source_args(
             MAX_BULK_SOURCE_ENTITIES
         )));
     }
+    // A blank entry is a caller bug, not a query. It matches no uuid, so
+    // resolution falls through to ranked name selection, and ranking an empty
+    // query returns whichever entity sorts first: the row would carry an
+    // arbitrary entity's body under the caller's empty id. Refuse the batch
+    // rather than answer one of its rows with something nobody asked for.
+    if let Some(index) = entity_ids.iter().position(|id| id.trim().is_empty()) {
+        return Err(McpError::InvalidParams(format!(
+            "entity_ids[{index}] is empty; every entry must be an entity uuid or its exact name"
+        )));
+    }
     // `token_budget` stays optional (None = unbounded); the others default to
     // the single-tool body bounds so an unclamped batch matches get_entity_source.
     let token_budget = args

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -780,7 +780,13 @@ with the unknown field named, never accepted with the source dropped. A refusal 
 one-line JSON object carrying schema, code, and the operations it names, so you can branch on the \
 code instead of reading the sentence. On success the change is attributed to the calling session: \
 its vendor and client name become the change author and a queryable audit record, so \
-kin_provenance_query, kin history, and kin blame all name the agent that wrote it.";
+kin_provenance_query, kin history, and kin blame all name the agent that wrote it. Re-sending a \
+commit that already landed is safe and is answered, not refused: the reply carries \
+already_applied true beside the original change_id, repository_generation, and modified_files, and \
+publishes nothing further. That answer is derived from the repository receipt rather than from any \
+in-memory record, so it survives the transaction being forgotten and stays correct however many \
+times it is retried. It omits ops_applied, which only the staged record could name. A commit that \
+never landed under this id still fails closed and says authority was consulted too.";
 
 fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
     if !scopes.contains(&scope) {

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -419,8 +419,14 @@ pub fn uncommittable_reason(op: &McpMutationOperation) -> Option<String> {
     }
 }
 
-/// The accepted `operations` element shapes, spelled out for a caller that has
+/// The complete `operations` element schema, spelled out for a caller that has
 /// to construct them without reading Kin's Rust types.
+///
+/// Every refusal from [`parse_staged_operations`] carries this whole text
+/// rather than the single field serde stopped on. A caller improvising the
+/// shape learns one missing field per attempt from a raw decode error, so it
+/// discovers the contract by looping on retries; naming the full schema once
+/// ends the loop on the first refusal.
 pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one of:\n  \
      - an entity source edit: {\"verb\": \"update\", \"target\": \"<entity uuid or exact name>\", \
      \"body\": \"<the entity's full new source text>\", \"description\": \"<why>\"}\n  \
@@ -430,7 +436,22 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
      - a relation edit: {\"verb\": \"create\"|\"delete\", \"target\": \"\", \
      \"payload\": {\"Relation\": {\"from\": \"<uuid>\", \"to\": \"<uuid>\", \"kind\": \"<relation kind>\"}}, \
      \"description\": \"<why>\"}\n\
-     Prefer the first shape: it needs only a target and the new source text";
+     Prefer the first shape: it needs only a target and the new source text.\n\
+     Every field of an operation, and nothing else is accepted:\n  \
+     - `verb` (string, REQUIRED): one of create/add/upsert/insert, update/modify, or \
+     delete/remove. Compared case-insensitively after trimming.\n  \
+     - `target` (string, REQUIRED): the entity this operation acts on, as either its uuid or \
+     its exact name. Empty string for relation payloads, which identify themselves by their \
+     endpoints and kind.\n  \
+     - `description` (string, REQUIRED): why this operation is being made.\n  \
+     - `body` (string, optional): the entity's complete new source text, never a fragment or a \
+     diff. New source text is carried by this field and no other; a key like `content`, \
+     `source`, or `new_body` is refused rather than accepted with the source dropped.\n  \
+     - `payload` (object, optional): omit it for a source edit. Otherwise exactly one of \
+     {\"Entity\": {<entity object>}}, {\"Relation\": {\"from\": \"<uuid>\", \"to\": \"<uuid>\", \
+     \"kind\": \"<relation kind>\"}}, or {\"Blob\": [<bytes>]}. Relation payloads accept only \
+     create/add/upsert/insert or delete/remove, and blob payloads are not committable through \
+     transactions yet";
 
 /// Every field an operation is allowed to carry.
 ///


### PR DESCRIPTION
The first end-to-end dogfood of the MCP transactional write path hit four sequential walls on a store whose only distinguishing feature was that someone had used it. Three of them are fixed here, along with a fifth defect found on the way. The fourth is a design question and is called out below rather than guessed at.

Every claim in this description was reproduced on a scratch clone of kin-db with 3158 entities, driven over the real MCP stdio path with embeddings disabled, first on v0.5.16 binaries to prove each defect and then on binaries built from this branch to prove each fix.

Staging a wrong-shaped operation used to answer with whichever single field serde stopped on. The verbatim refusal was "invalid operations array: missing field `verb`". A caller writing the shape by hand cannot act on that, so it discovers the contract one field per attempt and burns a round trip on each. The cause was that product mode decoded the operations array itself instead of going through the parser the in-process handler uses, and only that parser carried the schema text. Product mode now uses it. The schema it carries has also been widened from a list of example shapes into the whole contract, naming every field along with its type, its allowed values, and whether it is required. The refusal that used to name one missing field now names the entire operation.

A commit whose apply had plainly succeeded could still answer "Transaction not found". A successful commit evicts its own transaction record, so the record's absence is the state left behind by success as much as by an id that never existed, and the commit path could not tell those apart. A client whose per-attempt budget expires during a long apply retries straight into that gap. The retry waits on the coordination gate while the first attempt finishes and evicts, and it then reads a registry that no longer holds what it just applied. Reporting failure there is a double-apply generator, because any correct agent retries a failure. Repository authority can separate the two cases, since the receipt is keyed by the same caller-stable operation id the transaction id derives from and is published in the same atomic successor as the authority it moved. A retry of an applied commit is now answered from that receipt, carrying already_applied beside the original change_id, generation, and modified_files, and publishing nothing further. An id that never landed still fails closed and says authority was consulted too. This is not hypothetical. In the acceptance run the very first commit took 124 seconds, and it was answered through this path because the client had already retried it.

The wall that made the write path unusable was a commit precondition requiring the daemon's live graph to hold every authority-owned entity byte-identically. Parser reconciliation and the LSP enrichment worker rewrite those entities continuously and outside the coordination gate, so every commit raced them and lost, naming a different rewritten entity each attempt. The refusal instructed the caller to re-send once the daemon was reading current repository authority, which could never happen. Only recycling the daemon cleared it, and the worker began winning again as soon as it ran. A derived rewrite is now tolerated while a derived loss still refuses, which is what the precondition is actually for. Running ahead of authority is allowed, and a derived view routinely does, carrying extra facets and richer values. Holding less than authority owns is not. Tolerating the rewrite cannot leak it into a change, because the prospective graph is built from the authority snapshot plus the staged operations and never reads the live graph, and staleness is still caught by the generation binding checked just before it. The file's own documentation already made this argument for the equality check one level up, which had been removed for exactly this reason. The same unachievable invariant had simply been reintroduced one level down, per entity instead of per graph.

Finally, get_entity_source with an empty entity_id returned an arbitrary entity's body and reported success. An empty string parses as no uuid, so resolution fell through to ranked name selection, and ranking an empty query still ranks every entity and returns whichever sorts best. It now fails closed like the missing parameter beside it, on both the single and the batch surface.

What is not fixed here is the clean-workspace requirement. A commit still refuses with "MCP repository commit requires a clean exact workspace" once anything has advanced the workspace tree, and the daemon's own admission path advances it on any working-file edit while publishing no change. So ordinary use reaches that state, and it does not clear itself. Reverting the file leaves the workspace dirty, and only a stash or a commit clears it. Fixing this changes what a commit publishes, because the workspace graph the planner loads already carries the pending tree as its resolved tree, so the pending content cannot be excluded from the change without the workspace correction reverting the user's uncommitted files. The choice is between publishing it as one change under the session actor and publishing it as two changes so the human's work keeps its own attribution. That deserves its own review and its own change, so it is deliberately not in this one.

Refs FIR-2154
