### PR TITLE
Publish a Windows tarball and guard installer asset names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
           python3 ./scripts/test-release-workflow-authority.py
           python3 ./scripts/test_install_optional_vfs.py
           python3 ./scripts/test_installer_parity.py
+          # Every install surface builds a release asset name; the release
+          # publishes a fixed list of them. Nothing compared the two lists, and
+          # a Windows disagreement 404'd through every release to date. The
+          # falsifier runs beside the guard because a guard nobody has seen fail
+          # is not evidence that it can.
+          python3 ./scripts/verify-installer-release-assets.py
+          python3 ./scripts/falsify-installer-release-assets.py
           python3 ./scripts/test-npm-automatic-release.py
           python3 ./scripts/test-verify-npm-release.py
           node --test \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -943,7 +943,7 @@ jobs:
           # the zip. The zip stays the primary archive: the PowerShell
           # installer, the npm launcher, and `kin update` all resolve Windows by
           # that name, and anything already depending on it keeps working.
-          tar -czf "$env:ARTIFACT.tar.gz" $env:ARTIFACT
+          tar -czf "$env:ARTIFACT.tar.gz" "$env:ARTIFACT"
           if ($LASTEXITCODE -ne 0) {
             Write-Error "tar failed to package $env:ARTIFACT.tar.gz"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -934,9 +934,60 @@ jobs:
             Write-Error "kin-daemon.exe missing from $env:ARTIFACT.zip — refusing to publish a daemon-less archive"
             exit 1
           }
-          $ArchivePath = "$env:ARTIFACT.zip"
-          $Hash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
-          "$Hash  $ArchivePath" | Set-Content -Encoding ascii "$ArchivePath.sha256"
+          # The POSIX installer builds one archive name for every platform it
+          # detects, "kin-<os>-<arch>.tar.gz", and it detects windows from the
+          # MSYS, MINGW, and CYGWIN uname strings. Piping the documented curl
+          # command into a shell on Windows therefore asked for a tarball this
+          # leg never produced, and every release to date answered that request
+          # with a 404. Publish the same components under that exact name beside
+          # the zip. The zip stays the primary archive: the PowerShell
+          # installer, the npm launcher, and `kin update` all resolve Windows by
+          # that name, and anything already depending on it keeps working.
+          tar -czf "$env:ARTIFACT.tar.gz" $env:ARTIFACT
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "tar failed to package $env:ARTIFACT.tar.gz"
+            exit 1
+          }
+          $members = @(tar -tzf "$env:ARTIFACT.tar.gz")
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "tar failed to list $env:ARTIFACT.tar.gz"
+            exit 1
+          }
+          $members = @($members | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+          # The Unix legs wrap their contents in a single "<artifact>/" root and
+          # the release shape rules refuse a member carrying a backslash, so
+          # assert both here rather than discovering a Windows path separator in
+          # the publish job after the archive is already built.
+          $prefix = "$env:ARTIFACT/"
+          foreach ($member in $members) {
+            if ($member.Contains("\")) {
+              Write-Error "$env:ARTIFACT.tar.gz member '$member' uses a Windows path separator"
+              exit 1
+            }
+            if (-not $member.StartsWith($prefix)) {
+              Write-Error "$env:ARTIFACT.tar.gz member '$member' is not under $prefix"
+              exit 1
+            }
+          }
+          $TarNames = @(
+            $members |
+              Where-Object { -not $_.EndsWith("/") } |
+              ForEach-Object { $_.Substring($prefix.Length) } |
+              Sort-Object
+          )
+          $ZipNames = @($entries | Sort-Object)
+          if (Compare-Object -ReferenceObject $ZipNames -DifferenceObject $TarNames) {
+            Write-Error "$env:ARTIFACT.tar.gz and $env:ARTIFACT.zip do not carry the same components"
+            exit 1
+          }
+          if ($TarNames -notcontains "kin-daemon.exe") {
+            Write-Error "kin-daemon.exe missing from $env:ARTIFACT.tar.gz"
+            exit 1
+          }
+          foreach ($ArchivePath in @("$env:ARTIFACT.zip", "$env:ARTIFACT.tar.gz")) {
+            $Hash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
+            "$Hash  $ArchivePath" | Set-Content -Encoding ascii "$ArchivePath.sha256"
+          }
         env:
           TARGET: ${{ matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}
@@ -991,11 +1042,29 @@ jobs:
             throw new Error("embedded build provenance does not match the tagged Kin source and Cargo.lock");
           }
 
-          const archives = [`${artifact}.tar.gz`, `${artifact}.zip`].filter((file) => fs.existsSync(file));
-          if (archives.length !== 1) {
-            throw new Error(`expected exactly one final archive for ${artifact}, found ${archives.join(", ") || "none"}`);
+          // Windows publishes two containers of the same components: the zip
+          // every Windows resolver already asks for, and the tarball the POSIX
+          // installer builds its name from. The zip stays the manifest's
+          // primary archive because `kin update` and the public install proof
+          // both find the platform record by that exact name; the tarball is
+          // inventoried beside it so its bytes are covered by the same
+          // provenance rather than published unaccounted for.
+          const windowsTarget = target.includes("-windows-");
+          const primaryArchive = windowsTarget ? `${artifact}.zip` : `${artifact}.tar.gz`;
+          const additionalArchiveNames = windowsTarget ? [`${artifact}.tar.gz`] : [];
+          const expectedArchives = [primaryArchive, ...additionalArchiveNames].sort();
+          const archives = [`${artifact}.tar.gz`, `${artifact}.zip`]
+            .filter((file) => fs.existsSync(file))
+            .sort();
+          if (JSON.stringify(archives) !== JSON.stringify(expectedArchives)) {
+            throw new Error(`expected final archives ${expectedArchives.join(", ")} for ${artifact}, found ${archives.join(", ") || "none"}`);
           }
-          const archive = archives[0];
+          const archive = primaryArchive;
+          const archiveRecord = (name) => ({
+            name,
+            sha256: sha256(name),
+            size_bytes: fs.statSync(name).size,
+          });
           // The content inventory covers the archive's component files. The macOS
           // notification bundle is a sealed directory rather than a component, so
           // it is classified and shape-checked here but stays out of the manifest:
@@ -1059,11 +1128,10 @@ jobs:
               dirty: false,
               cargo_lock_sha256: vfsLockSha,
             },
-            archive: {
-              name: archive,
-              sha256: sha256(archive),
-              size_bytes: fs.statSync(archive).size,
-            },
+            archive: archiveRecord(archive),
+            ...(additionalArchiveNames.length
+              ? { additional_archives: additionalArchiveNames.map(archiveRecord) }
+              : {}),
             archive_contents: contents,
             workflow: {
               repository: process.env.GITHUB_REPOSITORY,
@@ -1262,6 +1330,7 @@ jobs:
             kin-macos-x86_64.tar.gz
             kin-macos-aarch64.tar.gz
             kin-windows-x86_64.zip
+            kin-windows-x86_64.tar.gz
           )
           for asset in "${assets[@]}"; do
             test -s "$asset"
@@ -1274,6 +1343,15 @@ jobs:
             test -s "$artifact.provenance.json"
           done
           test -s checksums-sha256.txt
+
+      # The inventory above asserts the assets this workflow means to publish.
+      # This asserts the other direction, which is the one that shipped broken:
+      # every asset name a public installer builds for a supported platform has
+      # to be among the bytes staged here. It derives those names by running the
+      # installers rather than by restating them, so a list that quietly stops
+      # matching an installer fails the release instead of a user's install.
+      - name: Verify every installer asset name is published
+        run: python3 ./scripts/verify-installer-release-assets.py --assets-dir .
 
       - name: Verify and aggregate release provenance
         env:
@@ -1299,6 +1377,31 @@ jobs:
             childProcess.execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
           const fail = (condition, message) => {
             if (!condition) throw new Error(message);
+          };
+          // Judge an archive's declared member paths before extracting it. A
+          // member that escapes the extraction root has already been written
+          // somewhere else by the time the extracted tree can be inspected.
+          // Every published container goes through here, so a second container
+          // of the same components is judged by the same rules as the first.
+          const extractArchive = (archiveName, spec) => {
+            const listing = archiveName.endsWith(".zip")
+              ? childProcess.execFileSync("unzip", ["-Z1", archiveName], { encoding: "utf8" })
+              : childProcess.execFileSync("tar", ["-tzf", archiveName], { encoding: "utf8" });
+            assertReleaseArchiveMemberPaths(
+              listing.split("\n").filter((member) => member !== ""),
+              { artifact: spec.artifact, target: spec.target }
+            );
+            const extractRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${spec.artifact}-`));
+            if (archiveName.endsWith(".zip")) {
+              childProcess.execFileSync("unzip", ["-q", archiveName, "-d", extractRoot]);
+            } else {
+              childProcess.execFileSync("tar", ["-xzf", archiveName, "-C", extractRoot]);
+            }
+            const nested = path.join(extractRoot, spec.artifact);
+            return {
+              extractRoot,
+              contentRoot: fs.existsSync(nested) ? nested : extractRoot,
+            };
           };
           const specs = [
             {
@@ -1332,6 +1435,11 @@ jobs:
             {
               artifact: "kin-windows-x86_64",
               archive: "kin-windows-x86_64.zip",
+              // The POSIX installer asks Windows for this tarball by name. It
+              // carries the same components as the zip and is verified against
+              // the same content records below, so the two containers cannot
+              // drift into shipping different bytes under one release.
+              additionalArchives: ["kin-windows-x86_64.tar.gz"],
               target: "x86_64-pc-windows-msvc",
               vfsTarget: "x86_64-pc-windows-msvc",
               required: ["kin.exe", "kin-daemon.exe"],
@@ -1371,6 +1479,18 @@ jobs:
               `${manifestPath} archive hash does not match the final archive`);
             fail(manifest.archive?.size_bytes === fs.statSync(spec.archive).size,
               `${manifestPath} archive size does not match the final archive`);
+            const additionalArchives = manifest.additional_archives ?? [];
+            fail(
+              JSON.stringify(additionalArchives.map((entry) => entry.name)) ===
+                JSON.stringify(spec.additionalArchives ?? []),
+              `${manifestPath} does not declare exactly the additional archives ${(spec.additionalArchives ?? []).join(", ") || "(none)"}`);
+            for (const entry of additionalArchives) {
+              fail(fs.existsSync(entry.name), `${entry.name} is declared but was not published`);
+              fail(entry.sha256 === sha256(entry.name),
+                `${manifestPath} hash does not match the final ${entry.name}`);
+              fail(entry.size_bytes === fs.statSync(entry.name).size,
+                `${manifestPath} size does not match the final ${entry.name}`);
+            }
             fail(Array.isArray(manifest.archive_contents), `${manifestPath} has no archive content hashes`);
             fail(manifest.workflow?.repository === process.env.GITHUB_REPOSITORY,
               `${manifestPath} repository identity does not match this run`);
@@ -1398,25 +1518,8 @@ jobs:
                 manifestAttempt <= currentAttempt,
               `${manifestPath} run attempt ${manifest.workflow?.run_attempt} is not an attempt of this run (current attempt ${process.env.GITHUB_RUN_ATTEMPT})`);
 
-            // Judge the archive's declared member paths before extracting it. A
-            // member that escapes the extraction root has already been written
-            // somewhere else by the time the extracted tree can be inspected.
-            const listing = spec.archive.endsWith(".zip")
-              ? childProcess.execFileSync("unzip", ["-Z1", spec.archive], { encoding: "utf8" })
-              : childProcess.execFileSync("tar", ["-tzf", spec.archive], { encoding: "utf8" });
-            assertReleaseArchiveMemberPaths(
-              listing.split("\n").filter((member) => member !== ""),
-              { artifact: spec.artifact, target: spec.target }
-            );
-            const extractRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${spec.artifact}-`));
+            const { extractRoot, contentRoot } = extractArchive(spec.archive, spec);
             try {
-              if (spec.archive.endsWith(".zip")) {
-                childProcess.execFileSync("unzip", ["-q", spec.archive, "-d", extractRoot]);
-              } else {
-                childProcess.execFileSync("tar", ["-xzf", spec.archive, "-C", extractRoot]);
-              }
-              const nested = path.join(extractRoot, spec.artifact);
-              const contentRoot = fs.existsSync(nested) ? nested : extractRoot;
               // Component files carry per-file provenance; the macOS notification
               // bundle is admitted as a sealed directory and is inventoried by the
               // archive digest instead. Everything else is refused.
@@ -1466,6 +1569,27 @@ jobs:
                 `${spec.archive} is missing a static build-identity authority`);
               fail(graphVersions.size === 1,
                 `${spec.archive} CLI and daemon graph snapshot identities disagree`);
+              // A second container is only honest if it carries the first one's
+              // bytes. Compare the extracted components name for name and hash
+              // for hash against the records already proven above, so a Windows
+              // tarball built from a stale or partial directory fails the
+              // release instead of installing something the zip never shipped.
+              for (const entry of additionalArchives) {
+                const extra = extractArchive(entry.name, spec);
+                try {
+                  const extraNames = classifyReleaseArchiveRoot(extra.contentRoot, {
+                    target: spec.target,
+                  }).files;
+                  fail(JSON.stringify(extraNames) === JSON.stringify(manifestNames),
+                    `${entry.name} does not carry the same components as ${spec.archive}`);
+                  for (const name of extraNames) {
+                    fail(sha256(path.join(extra.contentRoot, name)) === records.get(name)?.sha256,
+                      `${entry.name} ${name} bytes differ from ${spec.archive}`);
+                  }
+                } finally {
+                  fs.rmSync(extra.extractRoot, { recursive: true, force: true });
+                }
+              }
             } finally {
               fs.rmSync(extractRoot, { recursive: true, force: true });
             }
@@ -1537,6 +1661,7 @@ jobs:
             kin-macos-x86_64.tar.gz
             kin-macos-aarch64.tar.gz
             kin-windows-x86_64.zip
+            kin-windows-x86_64.tar.gz
             release-provenance.json
 
       - name: Create GitHub Release
@@ -1564,6 +1689,8 @@ jobs:
             kin-macos-aarch64.tar.gz.sha256
             kin-windows-x86_64.zip
             kin-windows-x86_64.zip.sha256
+            kin-windows-x86_64.tar.gz
+            kin-windows-x86_64.tar.gz.sha256
             checksums-sha256.txt
             kin-linux-x86_64.provenance.json
             kin-linux-aarch64.provenance.json

--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ coordination metadata rather than claiming zero residual bytes.
 For manual installation, each archive and its `.sha256` file is published under
 `https://github.com/firelock-ai/kin/releases/latest/download/`. The moving asset
 names are `kin-macos-aarch64`, `kin-macos-x86_64`, `kin-linux-aarch64`,
-`kin-linux-x86_64`, and `kin-windows-x86_64`; use the Unix `.tar.gz` or Windows
-`.zip` suffix shown on the latest release page.
+`kin-linux-x86_64`, and `kin-windows-x86_64`; use the `.tar.gz` suffix shown on
+the latest release page. Windows also publishes `kin-windows-x86_64.zip`, which
+is what the PowerShell installer and the npm launcher fetch.
 
 The npm entry point resolves the same public release channel:
 

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -25,6 +25,14 @@ per-artifact SHA-256 file:
 | macOS x86_64 | `kin-macos-x86_64.tar.gz` | `.tar.gz.sha256` |
 | macOS aarch64 | `kin-macos-aarch64.tar.gz` | `.tar.gz.sha256` |
 | Windows x86_64 | `kin-windows-x86_64.zip` | `.zip.sha256` |
+| Windows x86_64 | `kin-windows-x86_64.tar.gz` | `.tar.gz.sha256` |
+
+Windows ships the same components in two containers. The zip is the name the
+PowerShell installer, the npm launcher, and `kin update` resolve; the tarball is
+the name the POSIX installer builds on every platform it supports, including the
+MSYS, MINGW, and CYGWIN shells, so piping the documented curl command into a
+shell on Windows resolves instead of 404ing. Both are checksummed, attested, and
+verified against one content inventory, so they cannot ship different bytes.
 
 A convenience `checksums-sha256.txt` aggregating every per-artifact file is also
 attached to the release, but the installer verifies against the per-artifact

--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -22,7 +22,8 @@ Two parts of Kin are built around Unix runtime mechanics:
   `kin init` admits a Git repository on native Windows and publishes graph
   authority, and graph, lexical, and daemon-backed queries answer from it.
 - **Semantic vector search** ships enabled on every published platform. The
-  native Windows CLI artifact (`kin-windows-x86_64.zip`) is built with the same
+  native Windows CLI artifact (`kin-windows-x86_64.zip`, published as
+  `kin-windows-x86_64.tar.gz` as well) is built with the same
   default feature set as Linux and macOS, so semantic search and embedding are
   compiled in rather than stripped. Embedding runs on the portable CPU backend;
   the Metal GPU backend is macOS-only and is not part of any Windows build.

--- a/scripts/falsify-installer-release-assets.py
+++ b/scripts/falsify-installer-release-assets.py
@@ -57,11 +57,21 @@ def probe_tree(destination: Path) -> Path:
 
 
 def poison(tree: Path, relative: str, old: str, new: str) -> None:
+    """Plant one mutation at an anchor that appears exactly once.
+
+    Requiring uniqueness is not pedantry. The near-miss probe first landed on
+    the attestation list because the bare asset name appears in several lists,
+    which left the list under test untouched and the guard correctly green, so
+    the probe proved nothing while reporting that it had.
+    """
+
     path = tree / relative
     source = path.read_text(encoding="utf-8")
-    if source.count(old) < 1:
+    found = source.count(old)
+    if found != 1:
         raise FalsificationError(
-            f"probe could not plant its mutation: {relative} does not contain {old!r}"
+            f"probe could not plant its mutation: {relative} contains {found} "
+            f"occurrences of {old!r}, expected exactly one"
         )
     path.write_text(source.replace(old, new, 1), encoding="utf-8")
 

--- a/scripts/falsify-installer-release-assets.py
+++ b/scripts/falsify-installer-release-assets.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove the installer asset guard can fail, one poisoned tree at a time.
+
+A guard that passes before and after a fix is not evidence. Each probe below
+plants exactly one disagreement between what an install surface asks a release
+for and what that release publishes, and requires
+`scripts/verify-installer-release-assets.py` to fail and to name the asset it
+could not find. The first probe reproduces the defect that shipped through every
+release to date: the Windows leg published only a `.zip` while the POSIX
+installer asked every platform, Windows included, for a `.tar.gz`.
+
+The last two probes are about the guard's own honesty rather than about a
+missing asset: a new release platform must not arrive unguarded, and a probe
+that cannot read what the installer asks for must say so instead of deriving
+nothing and passing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+GUARD = "scripts/verify-installer-release-assets.py"
+COPIED = (
+    "scripts/install.sh",
+    "scripts/install.ps1",
+    GUARD,
+    "packages/kin/lib/provision.mjs",
+    "packages/kin/lib/resolve.mjs",
+    ".github/workflows/release.yml",
+)
+
+
+class FalsificationError(RuntimeError):
+    """The guard did not fail where it must, so it proves nothing."""
+
+
+def probe_tree(destination: Path) -> Path:
+    for relative in COPIED:
+        source = ROOT / relative
+        if not source.is_file():
+            raise FalsificationError(f"cannot build a probe tree without {relative}")
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    return destination
+
+
+def poison(tree: Path, relative: str, old: str, new: str) -> None:
+    path = tree / relative
+    source = path.read_text(encoding="utf-8")
+    if source.count(old) < 1:
+        raise FalsificationError(
+            f"probe could not plant its mutation: {relative} does not contain {old!r}"
+        )
+    path.write_text(source.replace(old, new, 1), encoding="utf-8")
+
+
+def run_guard(tree: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(tree / GUARD), *args],
+        capture_output=True,
+        text=True,
+        timeout=900,
+        check=False,
+    )
+
+
+def expect_failure(label: str, tree: Path, wanted: str, *args: str) -> None:
+    completed = run_guard(tree, *args)
+    output = completed.stdout + completed.stderr
+    if completed.returncode == 0:
+        raise FalsificationError(
+            f"falsification failed: {label} did not fail the guard.\n{output}"
+        )
+    if wanted not in output:
+        raise FalsificationError(
+            f"falsification failed: {label} failed but never named {wanted!r}.\n{output}"
+        )
+    print(f"  ok: {label}")
+
+
+def expect_success(label: str, tree: Path, *args: str) -> None:
+    completed = run_guard(tree, *args)
+    output = completed.stdout + completed.stderr
+    if completed.returncode != 0:
+        raise FalsificationError(
+            f"falsification failed: {label} should pass the guard.\n{output}"
+        )
+    print(f"  ok: {label}")
+
+
+def published_assets(tree: Path) -> list[str]:
+    """Read the probe tree's own published file list through the guard's parser."""
+    spec = importlib.util.spec_from_file_location("probe_guard", tree / GUARD)
+    if spec is None or spec.loader is None:
+        raise FalsificationError("could not load the probe tree's guard module")
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution: the guard's dataclasses resolve their own
+    # module out of sys.modules while the class body is being processed.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    workflow = (tree / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    return module.workflow_step_block(workflow, module.RELEASE_STEP, module.RELEASE_FILES_KEY)
+
+
+def unmodified_tree_passes(tree: Path) -> None:
+    expect_success("an unmodified tree passes (positive control)", tree)
+
+
+def windows_tarball_unpublished(tree: Path) -> None:
+    # The exact state every release shipped in: the POSIX installer asks Windows
+    # for a tarball and the release publishes only the zip.
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.tar.gz\n            kin-windows-x86_64.tar.gz.sha256\n",
+        "",
+    )
+    expect_failure(
+        "the Windows tarball is not published", tree, "kin-windows-x86_64.tar.gz"
+    )
+
+
+def windows_tarball_arch_token_near_miss(tree: Path) -> None:
+    # A near miss on the architecture token 404s exactly like an absent asset
+    # while every other check still sees a Windows tarball being published. The
+    # publish list is anchored through its checksum sidecar, because the same
+    # bare file name also appears in the attestation subjects and a mutation
+    # planted there would leave the list under test untouched.
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.tar.gz\n            kin-windows-x86_64.tar.gz.sha256\n",
+        "            kin-windows-amd64.tar.gz\n            kin-windows-amd64.tar.gz.sha256\n",
+    )
+    expect_failure(
+        "the published Windows tarball carries the wrong arch token",
+        tree,
+        "kin-windows-x86_64.tar.gz",
+    )
+
+
+def windows_tarball_unattested(tree: Path) -> None:
+    # Published but absent from the attestation subjects: the download resolves
+    # and then fails verification, which reads to a user like a broken asset.
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.zip\n            kin-windows-x86_64.tar.gz\n            release-provenance.json\n",
+        "            kin-windows-x86_64.zip\n            release-provenance.json\n",
+    )
+    expect_failure(
+        "the Windows tarball is published but not attested",
+        tree,
+        "the release attestation subject list",
+    )
+
+
+def windows_tarball_uninventoried(tree: Path) -> None:
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.zip\n            kin-windows-x86_64.tar.gz\n          )\n",
+        "            kin-windows-x86_64.zip\n          )\n",
+    )
+    expect_failure(
+        "the Windows tarball is published but not inventoried",
+        tree,
+        "the release asset inventory",
+    )
+
+
+def windows_zip_unpublished(tree: Path) -> None:
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.zip\n            kin-windows-x86_64.zip.sha256\n",
+        "",
+    )
+    expect_failure("the Windows zip is not published", tree, "kin-windows-x86_64.zip")
+
+
+def installer_extension_drift(tree: Path) -> None:
+    # The names must be read out of the installer rather than restated here: a
+    # changed extension has to show up as a changed requirement.
+    poison(tree, "scripts/install.sh", 'ARCHIVE="kin-${TARGET}.tar.gz"', 'ARCHIVE="kin-${TARGET}.tgz"')
+    expect_failure(
+        "the POSIX installer asks for a different extension",
+        tree,
+        "kin-linux-x86_64.tgz",
+    )
+
+
+def unguarded_release_platform(tree: Path) -> None:
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            artifact: kin-windows-x86_64\n",
+        "            artifact: kin-windows-aarch64\n",
+    )
+    expect_failure(
+        "a release platform has no guarded install surface",
+        tree,
+        "kin-windows-aarch64",
+    )
+
+
+def unreadable_installer_probe(tree: Path) -> None:
+    # If the probe cannot read what the installer asks for, it must report that
+    # rather than deriving nothing and reporting agreement.
+    poison(tree, "scripts/install.sh", 'info "Downloading $ARCHIVE..."', "true")
+    expect_failure(
+        "the probe cannot read what the installer downloads",
+        tree,
+        "expected exactly one",
+    )
+
+
+def staged_release_assets(tree: Path) -> None:
+    # The mode the release itself runs in: check the bytes about to be uploaded,
+    # not the workflow's intent.
+    staged = tree / "staged-assets"
+    staged.mkdir()
+    names = published_assets(tree)
+    for name in names:
+        (staged / name).write_text("probe\n", encoding="utf-8")
+    expect_success(
+        "staged release assets carrying every requested name pass",
+        tree,
+        "--assets-dir",
+        str(staged),
+    )
+    (staged / "kin-windows-x86_64.tar.gz").unlink()
+    expect_failure(
+        "staged release assets missing the Windows tarball fail",
+        tree,
+        "kin-windows-x86_64.tar.gz",
+        "--assets-dir",
+        str(staged),
+    )
+
+
+PROBES: tuple[tuple[str, Callable[[Path], None]], ...] = (
+    ("positive control", unmodified_tree_passes),
+    ("windows tarball unpublished", windows_tarball_unpublished),
+    ("windows tarball arch token near miss", windows_tarball_arch_token_near_miss),
+    ("windows tarball unattested", windows_tarball_unattested),
+    ("windows tarball uninventoried", windows_tarball_uninventoried),
+    ("windows zip unpublished", windows_zip_unpublished),
+    ("installer extension drift", installer_extension_drift),
+    ("unguarded release platform", unguarded_release_platform),
+    ("unreadable installer probe", unreadable_installer_probe),
+    ("staged release assets", staged_release_assets),
+)
+
+
+def main() -> int:
+    for index, (label, probe) in enumerate(PROBES, start=1):
+        print(f"[{index}/{len(PROBES)}] {label}")
+        with tempfile.TemporaryDirectory() as temp:
+            tree = probe_tree(Path(temp))
+            try:
+                probe(tree)
+            except FalsificationError as error:
+                print(f"::error::{error}", file=sys.stderr)
+                return 1
+    print(f"installer asset guard falsified through {len(PROBES)} probes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/falsify-installer-release-assets.py
+++ b/scripts/falsify-installer-release-assets.py
@@ -76,6 +76,12 @@ def poison(tree: Path, relative: str, old: str, new: str) -> None:
     path.write_text(source.replace(old, new, 1), encoding="utf-8")
 
 
+def append(tree: Path, relative: str, text: str) -> None:
+    """Add a decoy at the end of a file, leaving the real content in place."""
+    path = tree / relative
+    path.write_text(path.read_text(encoding="utf-8") + text, encoding="utf-8")
+
+
 def run_guard(tree: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(tree / GUARD), *args],
@@ -237,6 +243,121 @@ def unreadable_installer_probe(tree: Path) -> None:
     )
 
 
+DECOY_PUBLISH_JOB = """
+  decoy-publisher:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload something unrelated
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: |
+            kin-linux-x86_64.tar.gz
+            kin-linux-aarch64.tar.gz
+            kin-macos-x86_64.tar.gz
+            kin-macos-aarch64.tar.gz
+            kin-windows-x86_64.zip
+            kin-windows-x86_64.tar.gz
+"""
+
+DECOY_INVENTORY_JOB = """
+  decoy-inventory:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check something unrelated
+        run: |
+          set -euo pipefail
+          assets=(
+            kin-linux-x86_64.tar.gz
+            kin-linux-aarch64.tar.gz
+            kin-macos-x86_64.tar.gz
+            kin-macos-aarch64.tar.gz
+            kin-windows-x86_64.zip
+            kin-windows-x86_64.tar.gz
+          )
+          echo "${assets[@]}"
+"""
+
+
+def decoy_publish_list_elsewhere(tree: Path) -> None:
+    """A later job's identical key must not answer for this step's list.
+
+    `files: |` is generic, and this workflow already reuses `assets=(` and
+    `subject-path:` in its promotion job, so a reformat of the real key is an
+    ordinary edit rather than an exotic one. Reformat it, plant a complete list
+    under the same key in an unrelated job, and genuinely drop the Windows
+    tarball from the real list. A search that runs past the end of its own step
+    reads the decoy, answers that everything is published, and exits clean.
+    """
+
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.tar.gz\n            kin-windows-x86_64.tar.gz.sha256\n",
+        "",
+    )
+    poison(tree, ".github/workflows/release.yml", "          files: |\n", "          files:  |\n")
+    append(tree, ".github/workflows/release.yml", DECOY_PUBLISH_JOB)
+    expect_failure(
+        "a later job's file list cannot answer for the release upload step",
+        tree,
+        "carries 0 'files: |' blocks",
+    )
+
+
+def decoy_inventory_elsewhere(tree: Path) -> None:
+    poison(
+        tree,
+        ".github/workflows/release.yml",
+        "            kin-windows-x86_64.zip\n            kin-windows-x86_64.tar.gz\n          )\n",
+        "            kin-windows-x86_64.zip\n          )\n",
+    )
+    poison(tree, ".github/workflows/release.yml", "          assets=(\n", "          assets=( \n")
+    append(tree, ".github/workflows/release.yml", DECOY_INVENTORY_JOB)
+    expect_failure(
+        "a later job's asset array cannot answer for the inventory step",
+        tree,
+        "declares 0 asset lists",
+    )
+
+
+def duplicated_release_step(tree: Path) -> None:
+    # Hardening rather than a fixed regression: a duplicated step name resolved
+    # to whichever copy came first, which is a coin flip about which list the
+    # guard read. Refuse instead of picking.
+    append(tree, ".github/workflows/release.yml", DECOY_PUBLISH_JOB.replace(
+        "      - name: Upload something unrelated",
+        "      - name: Create GitHub Release",
+    ))
+    expect_failure(
+        "two steps claiming the release upload name are refused",
+        tree,
+        "names the step 'Create GitHub Release' 2 times",
+    )
+    # The message has to name the step a reader can find, not the raw anchor.
+    completed = run_guard(tree)
+    if "- name:" in (completed.stdout + completed.stderr):
+        raise FalsificationError(
+            "the duplicate-step failure quotes its raw YAML anchor instead of the step name"
+        )
+
+
+def ambiguous_powershell_arch_mapping(tree: Path) -> None:
+    # A block comment that looks like the live mapping. `search` would take the
+    # first match and derive the Windows asset name from text PowerShell never
+    # runs, so the mapping has to be unique or refused.
+    poison(
+        tree,
+        "scripts/install.ps1",
+        "function Resolve-KinWindowsArchiveArchitecture",
+        '<#\n    "AMD64" { return "itanium" }\n#>\nfunction Resolve-KinWindowsArchiveArchitecture',
+    )
+    expect_failure(
+        "install.ps1 maps AMD64 more than once",
+        tree,
+        "maps an AMD64 process architecture 2 times",
+    )
+
+
 def staged_release_assets(tree: Path) -> None:
     # The mode the release itself runs in: check the bytes about to be uploaded,
     # not the workflow's intent.
@@ -271,6 +392,10 @@ PROBES: tuple[tuple[str, Callable[[Path], None]], ...] = (
     ("installer extension drift", installer_extension_drift),
     ("unguarded release platform", unguarded_release_platform),
     ("unreadable installer probe", unreadable_installer_probe),
+    ("decoy publish list in a later job", decoy_publish_list_elsewhere),
+    ("decoy asset inventory in a later job", decoy_inventory_elsewhere),
+    ("duplicated release upload step", duplicated_release_step),
+    ("ambiguous PowerShell arch mapping", ambiguous_powershell_arch_mapping),
     ("staged release assets", staged_release_assets),
 )
 

--- a/scripts/test-install-checksum.py
+++ b/scripts/test-install-checksum.py
@@ -130,8 +130,12 @@ def check_product_wiring() -> None:
             "through Start-Process rather than session-wide $LASTEXITCODE"
         )
 
+    # Both Windows containers get the same filename-bound sidecar. Binding the
+    # hash to the archive's own name is what lets install.ps1 refuse a checksum
+    # file that names a different archive, so a second published container that
+    # skipped this line would ship a sidecar nothing could match.
     release_requirements = (
-        '$ArchivePath = "$env:ARTIFACT.zip"',
+        'foreach ($ArchivePath in @("$env:ARTIFACT.zip", "$env:ARTIFACT.tar.gz")) {',
         "$Hash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()",
         '"$Hash  $ArchivePath" | Set-Content -Encoding ascii "$ArchivePath.sha256"',
     )

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -59,6 +59,10 @@ ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
 TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
 ASSERTION_REACHABILITY = ROOT / "scripts" / "test-assertion-reachability.py"
 ASSERTION_REACHABILITY_POLICY = "scripts/test-assertion-reachability.py"
+INSTALLER_ASSET_GUARD = ROOT / "scripts" / "verify-installer-release-assets.py"
+INSTALLER_ASSET_GUARD_POLICY = "scripts/verify-installer-release-assets.py"
+INSTALLER_ASSET_FALSIFIER = ROOT / "scripts" / "falsify-installer-release-assets.py"
+INSTALLER_ASSET_FALSIFIER_POLICY = "scripts/falsify-installer-release-assets.py"
 TRUSTED_POLICY_PREFIX = "refs/remotes/origin/main:"
 TAG_LISTING_FORMAT = (
     "--format='%(refname:strip=2) "
@@ -3198,6 +3202,59 @@ def assert_assertion_reachability_gate_wired(workflow: str) -> None:
         raise AssertionError(
             f"{ASSERTION_REACHABILITY_POLICY} is missing; the release gates "
             "would no longer prove their own checks run"
+        )
+
+
+def assert_installer_asset_guard_wired(ci: str, release: str) -> None:
+    """Keep the check that every installer asset name is one the release ships.
+
+    Each install surface builds a release asset name out of the platform it
+    detects, and the release publishes a fixed list of names. Nothing compared
+    the two lists, so a disagreement rode every release to date: the POSIX
+    installer asks `windows` for a `.tar.gz`, mapping the MSYS, MINGW, and
+    CYGWIN shells onto it, while the Windows leg published only a `.zip`. The
+    documented curl command 404'd there and every check stayed green.
+
+    The guard runs on pull requests against the workflow's own asset lists and
+    again inside the release against the bytes staged for upload. The falsifier
+    runs beside it because a guard nobody has watched fail is not evidence that
+    it can, and this defect is exactly what a check that cannot fail looks like.
+    """
+
+    for path, policy in (
+        (INSTALLER_ASSET_GUARD, INSTALLER_ASSET_GUARD_POLICY),
+        (INSTALLER_ASSET_FALSIFIER, INSTALLER_ASSET_FALSIFIER_POLICY),
+    ):
+        if not path.is_file():
+            raise AssertionError(
+                f"{policy} is missing; an installer could ask a release for an "
+                "asset it does not publish and nothing would notice"
+            )
+
+    # Match whole invocations rather than searching for the path, which a
+    # commented-out line would still satisfy.
+    ci_lines = {line.strip() for line in ci.splitlines()}
+    missing = sorted(
+        command
+        for command in (
+            f"python3 ./{INSTALLER_ASSET_GUARD_POLICY}",
+            f"python3 ./{INSTALLER_ASSET_FALSIFIER_POLICY}",
+        )
+        if command not in ci_lines
+    )
+    if missing:
+        raise AssertionError(
+            "ci.yml must run " + " and ".join(missing) + "; without both, an "
+            "installer asset name can stop being published and no pull request "
+            "would go red"
+        )
+
+    release_command = f"run: python3 ./{INSTALLER_ASSET_GUARD_POLICY} --assets-dir ."
+    if release_command not in {line.strip() for line in release.splitlines()}:
+        raise AssertionError(
+            f"release.yml must run {INSTALLER_ASSET_GUARD_POLICY} against the "
+            "staged assets; the workflow's intent is not the same evidence as "
+            "the bytes about to be uploaded"
         )
 
 
@@ -9014,6 +9071,7 @@ def main() -> None:
         "kin-macos-x86_64.tar.gz",
         "kin-macos-aarch64.tar.gz",
         "kin-windows-x86_64.zip",
+        "kin-windows-x86_64.tar.gz",
         "release-provenance.json",
         "Fail closed",
     ):
@@ -9119,6 +9177,31 @@ def main() -> None:
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(ci_workflow)
     assert_assertion_reachability_gate_wired(ci_workflow)
+    assert_installer_asset_guard_wired(ci_workflow, release)
+    expect_assertion(
+        "ci.yml drops the guard that installer asset names are published",
+        "ci.yml must run",
+        lambda: assert_installer_asset_guard_wired(
+            ci_workflow.replace(INSTALLER_ASSET_GUARD_POLICY, "scripts/absent.py"),
+            release,
+        ),
+    )
+    expect_assertion(
+        "ci.yml keeps the guard but drops its falsification",
+        "ci.yml must run",
+        lambda: assert_installer_asset_guard_wired(
+            ci_workflow.replace(INSTALLER_ASSET_FALSIFIER_POLICY, "scripts/absent.py"),
+            release,
+        ),
+    )
+    expect_assertion(
+        "the release stops checking installer asset names against its own assets",
+        "must run",
+        lambda: assert_installer_asset_guard_wired(
+            ci_workflow,
+            release.replace(f"./{INSTALLER_ASSET_GUARD_POLICY} --assets-dir .", "true"),
+        ),
+    )
     expect_assertion(
         "ci.yml drops the step that proves every assertion still runs",
         "ci.yml must run",

--- a/scripts/verify-installer-release-assets.py
+++ b/scripts/verify-installer-release-assets.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Fail when a public installer asks a release for an asset it does not publish.
+
+Every install surface builds a release asset name from the platform it detects,
+and the release publishes a fixed list of asset names. Nothing compared the two
+lists, so a disagreement shipped through every release to date: the POSIX
+installer builds `kin-<os>-<arch>.tar.gz` on every platform it supports,
+including the MSYS, MINGW, and CYGWIN shells it maps to `windows`, while the
+Windows leg published only a `.zip`. Piping the documented curl command into a
+shell on Windows therefore 404'd.
+
+The names checked here are DERIVED from the installers rather than restated.
+`scripts/install.sh` is executed once per platform against a stubbed `uname` and
+asked what it would download; `packages/kin/lib/provision.mjs` exports the pure
+function the npm launcher resolves with and is called directly; `install.ps1`
+carries its construction in two literal assignments that are parsed under
+anchored patterns that fail rather than skip when the source moves. A guard that
+restated the expected names would agree with itself forever.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
+NPM_PROVISION = ROOT / "packages" / "kin" / "lib" / "provision.mjs"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+# Any pinned version keeps the probe off the network: the installer resolves
+# `latest` through a redirect only when KIN_VERSION is unset.
+PROBE_VERSION = "0.0.0-asset-name-probe"
+
+ASSET_NAME = re.compile(r"^kin-[a-z0-9_]+-[a-z0-9_]+\.(?:tar\.gz|zip)$")
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+DOWNLOAD_LINE = re.compile(r"Downloading (\S+)\.\.\.")
+MATRIX_ARTIFACT = re.compile(r"^\s+artifact: (kin-[a-z0-9_]+-[a-z0-9_]+)\s*$", re.M)
+PS1_TARGET = re.compile(r'^\$Target = "windows-\$Arch"\s*$', re.M)
+PS1_ARCHIVE = re.compile(r'^\$Archive = "kin-\$Target\.(?P<ext>[A-Za-z0-9.]+)"\s*$', re.M)
+PS1_ARCH = re.compile(r'^\s*"AMD64" \{ return "(?P<arch>[A-Za-z0-9_]+)" \}\s*$', re.M)
+
+RELEASE_STEP = "      - name: Create GitHub Release"
+RELEASE_FILES_KEY = "          files: |"
+ATTEST_STEP = "      - name: Attest final release archives and provenance"
+ATTEST_SUBJECT_KEY = "          subject-path: |"
+INVENTORY_STEP = "      - name: Verify complete release asset inventory"
+INVENTORY_ASSETS = re.compile(r"^\s+assets=\(\n(?P<body>(?:\s+\S+\n)+?)\s*\)\s*$", re.M)
+
+
+class GuardError(RuntimeError):
+    """The installer surface and the published release assets disagree."""
+
+
+@dataclass(frozen=True)
+class Platform:
+    """One host identity, and the release artifact a user on it must receive."""
+
+    label: str
+    artifact: str
+    uname_s: str = ""
+    uname_m: str = ""
+    node: tuple[str, str] | None = None
+    powershell: bool = False
+
+
+# Host identities, not answers. Each row says "a user whose machine reports this
+# is served this artifact"; what name the installers build from that identity is
+# derived below and is exactly what this guard exists to check.
+PLATFORMS: tuple[Platform, ...] = (
+    Platform("linux x86_64", "kin-linux-x86_64", "Linux", "x86_64", ("linux", "x64")),
+    Platform("linux aarch64", "kin-linux-aarch64", "Linux", "aarch64", ("linux", "arm64")),
+    Platform("macos x86_64", "kin-macos-x86_64", "Darwin", "x86_64", ("darwin", "x64")),
+    Platform("macos aarch64", "kin-macos-aarch64", "Darwin", "arm64", ("darwin", "arm64")),
+    # The three shells whose uname the installer maps to `windows`. All three
+    # reach the same published artifact, and all three 404'd before the Windows
+    # leg published a tarball.
+    Platform(
+        "windows x86_64 (Git Bash)",
+        "kin-windows-x86_64",
+        "MINGW64_NT-10.0-22631",
+        "x86_64",
+        ("win32", "x64"),
+        powershell=True,
+    ),
+    Platform("windows x86_64 (MSYS)", "kin-windows-x86_64", "MSYS_NT-10.0-22631", "x86_64"),
+    Platform("windows x86_64 (Cygwin)", "kin-windows-x86_64", "CYGWIN_NT-10.0-22631", "amd64"),
+)
+
+
+@dataclass
+class Requirement:
+    """One asset name an install surface builds, and who builds it."""
+
+    asset: str
+    surfaces: list[str] = field(default_factory=list)
+
+
+def executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def posix_installer_asset(install_sh: Path, platform: Platform) -> str:
+    """Ask install.sh itself what it downloads on this platform."""
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir()
+        executable(
+            fake_bin / "uname",
+            "#!/bin/sh\n"
+            'case "${1:-}" in\n'
+            f"  -s) printf '{platform.uname_s}\\n' ;;\n"
+            f"  -m) printf '{platform.uname_m}\\n' ;;\n"
+            "  *) exit 2 ;;\n"
+            "esac\n",
+        )
+        # An empty release directory: the installer prints the name it wants and
+        # then fails to fetch it, which is all this probe needs and keeps the
+        # run local.
+        releases = root / "releases"
+        releases.mkdir()
+        home = root / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{fake_bin}{os.pathsep}{env.get('PATH', '')}",
+                "HOME": str(home),
+                "KIN_HOME": str(home / ".kin"),
+                "KIN_BASE_URL": releases.as_uri(),
+                "KIN_VERSION": PROBE_VERSION,
+                "KIN_NO_SETUP": "1",
+            }
+        )
+        env.pop("KIN_DIR", None)
+        completed = subprocess.run(
+            ["sh", str(install_sh)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+    output = ANSI.sub("", completed.stdout + completed.stderr)
+    names = DOWNLOAD_LINE.findall(output)
+    if len(names) != 1:
+        raise GuardError(
+            f"{install_sh.name} named {len(names)} archives on {platform.label} "
+            f"(expected exactly one). The probe could not read what the installer "
+            f"asks for, so it proves nothing. Output:\n{output}"
+        )
+    return names[0]
+
+
+def npm_launcher_asset(provision: Path, node_platform: str, node_arch: str) -> str:
+    """Call the npm launcher's own artifactName() for this platform."""
+    node = shutil.which("node")
+    if node is None:
+        raise GuardError("node is required to evaluate the npm launcher asset table")
+    driver = (
+        "const { pathToFileURL } = await import('node:url');"
+        "const mod = await import(pathToFileURL(process.argv[1]).href);"
+        "process.stdout.write(mod.artifactName(process.argv[2], process.argv[3]));"
+    )
+    completed = subprocess.run(
+        [node, "--input-type=module", "-e", driver, str(provision), node_platform, node_arch],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise GuardError(
+            f"npm launcher artifactName({node_platform}, {node_arch}) failed:\n"
+            f"{completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def powershell_installer_asset(install_ps1: Path) -> str:
+    """Read install.ps1's archive construction out of its own source."""
+    source = install_ps1.read_text(encoding="utf-8")
+    if len(PS1_TARGET.findall(source)) != 1:
+        raise GuardError(
+            f"{install_ps1.name} no longer builds its target as `windows-$Arch`; "
+            "this guard cannot derive the asset name it requests"
+        )
+    archive = PS1_ARCHIVE.search(source)
+    if archive is None or len(PS1_ARCHIVE.findall(source)) != 1:
+        raise GuardError(
+            f"{install_ps1.name} no longer builds its archive as `kin-$Target.<ext>`; "
+            "this guard cannot derive the asset name it requests"
+        )
+    arch = PS1_ARCH.search(source)
+    if arch is None:
+        raise GuardError(
+            f"{install_ps1.name} no longer maps an AMD64 process architecture; "
+            "this guard cannot derive the asset name it requests"
+        )
+    return f"kin-windows-{arch.group('arch')}.{archive.group('ext')}"
+
+
+def workflow_step_block(workflow: str, step: str, key: str) -> list[str]:
+    """The indented block under `key` inside the named workflow step."""
+    lines = workflow.splitlines()
+    try:
+        start = lines.index(step)
+    except ValueError as error:
+        raise GuardError(f"release workflow has no step {step.strip()!r}") from error
+    try:
+        key_index = lines.index(key, start)
+    except ValueError as error:
+        raise GuardError(
+            f"release workflow step {step.strip()!r} has no {key.strip()!r} block"
+        ) from error
+    indent = len(key) - len(key.lstrip()) + 2
+    block: list[str] = []
+    for line in lines[key_index + 1 :]:
+        if not line.strip():
+            break
+        if len(line) - len(line.lstrip()) < indent:
+            break
+        block.append(line.strip())
+    if not block:
+        raise GuardError(
+            f"release workflow step {step.strip()!r} publishes an empty {key.strip()!r} block"
+        )
+    return block
+
+
+def inventory_assets(workflow_source: str) -> set[str]:
+    """The asset list the publish job asserts is complete before it uploads."""
+    if INVENTORY_STEP not in workflow_source:
+        raise GuardError(f"release workflow has no step {INVENTORY_STEP.strip()!r}")
+    tail = workflow_source[workflow_source.index(INVENTORY_STEP) :]
+    match = INVENTORY_ASSETS.search(tail)
+    if match is None:
+        raise GuardError("release workflow's asset inventory declares no asset list")
+    return {line.strip() for line in match.group("body").splitlines() if line.strip()}
+
+
+def asset_sources(assets_dir: Path | None, workflow_source: str) -> list[tuple[str, set[str]]]:
+    """Every list a published asset has to appear in, with a name for each.
+
+    An archive that exists but is missing from the checksum inventory or the
+    attestation subjects fails verification downstream in a way that reads to a
+    user like a broken download, so all three lists are judged together rather
+    than trusting the upload list alone.
+    """
+    sources = [
+        (
+            "the release workflow's published file list",
+            set(workflow_step_block(workflow_source, RELEASE_STEP, RELEASE_FILES_KEY)),
+        ),
+        (
+            "the release attestation subject list",
+            set(workflow_step_block(workflow_source, ATTEST_STEP, ATTEST_SUBJECT_KEY)),
+        ),
+        ("the release asset inventory", inventory_assets(workflow_source)),
+    ]
+    if assets_dir is not None:
+        sources.append(
+            (
+                f"the assets staged in {assets_dir}",
+                {entry.name for entry in assets_dir.iterdir() if entry.is_file()},
+            )
+        )
+    return sources
+
+
+def guarded_platform_artifacts(workflow_source: str) -> None:
+    """Every artifact the release builds must have a platform row here."""
+    matrix = set(MATRIX_ARTIFACT.findall(workflow_source))
+    if not matrix:
+        raise GuardError("could not read the release build matrix's artifact names")
+    guarded = {platform.artifact for platform in PLATFORMS}
+    unguarded = sorted(matrix - guarded)
+    if unguarded:
+        raise GuardError(
+            "the release builds artifacts no platform row covers, so no installer "
+            f"name is checked for them: {', '.join(unguarded)}"
+        )
+    stale = sorted(guarded - matrix)
+    if stale:
+        raise GuardError(
+            "platform rows name artifacts the release no longer builds: "
+            f"{', '.join(stale)}"
+        )
+
+
+def required_assets() -> dict[str, Requirement]:
+    required: dict[str, Requirement] = {}
+
+    def record(asset: str, surface: str) -> None:
+        if not ASSET_NAME.fullmatch(asset):
+            raise GuardError(f"{surface} built an implausible asset name {asset!r}")
+        required.setdefault(asset, Requirement(asset)).surfaces.append(surface)
+
+    for platform in PLATFORMS:
+        if platform.uname_s:
+            record(
+                posix_installer_asset(INSTALL_SH, platform),
+                f"scripts/install.sh on {platform.label}",
+            )
+        if platform.node is not None:
+            record(
+                npm_launcher_asset(NPM_PROVISION, *platform.node),
+                f"packages/kin/lib/provision.mjs on {platform.label}",
+            )
+        if platform.powershell:
+            record(
+                powershell_installer_asset(INSTALL_PS1),
+                f"scripts/install.ps1 on {platform.label}",
+            )
+    if not required:
+        raise GuardError("no installer asset names were derived; the check is vacuous")
+    return required
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--assets-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Check against the assets staged in this directory (the release "
+            "being published). Defaults to the release workflow's published "
+            "file list, which is what a pull request can check."
+        ),
+    )
+    args = parser.parse_args()
+
+    workflow_source = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    try:
+        guarded_platform_artifacts(workflow_source)
+        required = required_assets()
+        sources = asset_sources(args.assets_dir, workflow_source)
+    except GuardError as error:
+        print(f"installer asset guard: {error}", file=sys.stderr)
+        return 1
+
+    failed = False
+    for label, names in sources:
+        if not names:
+            print(f"installer asset guard: {label} is empty", file=sys.stderr)
+            return 1
+        for name in sorted(required):
+            if name in names:
+                continue
+            failed = True
+            print(
+                f"::error::{name} is requested by {', '.join(required[name].surfaces)} "
+                f"but is absent from {label}. That install path resolves to a 404.",
+                file=sys.stderr,
+            )
+    if failed:
+        return 1
+
+    for name in sorted(required):
+        print(f"  ok: {name} <- {', '.join(required[name].surfaces)}")
+    print(
+        f"installer asset guard: {len(required)} requested assets all present in "
+        f"{len(sources)} release asset lists"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-installer-release-assets.py
+++ b/scripts/verify-installer-release-assets.py
@@ -317,15 +317,18 @@ def required_assets() -> dict[str, Requirement]:
                 posix_installer_asset(INSTALL_SH, platform),
                 f"scripts/install.sh on {platform.label}",
             )
+        # The npm launcher and the PowerShell installer detect their platform
+        # from the running process rather than from uname, so they are reported
+        # against the artifact they resolve instead of against a shell name.
         if platform.node is not None:
             record(
                 npm_launcher_asset(NPM_PROVISION, *platform.node),
-                f"packages/kin/lib/provision.mjs on {platform.label}",
+                f"packages/kin/lib/provision.mjs for {platform.artifact}",
             )
         if platform.powershell:
             record(
                 powershell_installer_asset(INSTALL_PS1),
-                f"scripts/install.ps1 on {platform.label}",
+                f"scripts/install.ps1 for {platform.artifact}",
             )
     if not required:
         raise GuardError("no installer asset names were derived; the check is vacuous")

--- a/scripts/verify-installer-release-assets.py
+++ b/scripts/verify-installer-release-assets.py
@@ -206,28 +206,72 @@ def powershell_installer_asset(install_ps1: Path) -> str:
             f"{install_ps1.name} no longer builds its archive as `kin-$Target.<ext>`; "
             "this guard cannot derive the asset name it requests"
         )
-    arch = PS1_ARCH.search(source)
-    if arch is None:
+    # Exactly one, like its two siblings above. A bare `search` takes the first
+    # match anywhere in the file, so a line inside a block comment that happens
+    # to look like the mapping would be read as the mapping, and the guard would
+    # derive its Windows asset name from text PowerShell never executes.
+    arch_matches = PS1_ARCH.findall(source)
+    if len(arch_matches) != 1:
         raise GuardError(
-            f"{install_ps1.name} no longer maps an AMD64 process architecture; "
-            "this guard cannot derive the asset name it requests"
+            f"{install_ps1.name} maps an AMD64 process architecture "
+            f"{len(arch_matches)} times, expected exactly one; this guard cannot "
+            "tell which mapping the installer would resolve"
         )
-    return f"kin-windows-{arch.group('arch')}.{archive.group('ext')}"
+    return f"kin-windows-{arch_matches[0]}.{archive.group('ext')}"
+
+
+def step_label(step: str) -> str:
+    """A step anchor as its name alone, for readable failures."""
+    return step.strip().removeprefix("- name: ")
+
+
+def workflow_step_lines(workflow: str, step: str) -> list[str]:
+    """The lines belonging to one workflow step, and nothing past its end.
+
+    `files: |`, `subject-path: |`, and `assets=(` are generic, reusable keys,
+    and `release.yml` already carries a second `assets=(` and a second
+    `subject-path:` in its promotion job. A forward search that is not bounded
+    to the step it started in therefore does not fail when its own key drifts by
+    a byte; it falls through to an unrelated job's identical key and answers
+    from the wrong list, which is a check reporting success about something it
+    never read.
+
+    A step's extent ends at the next sibling step or at the first line that
+    dedents out of it. A step name that appears more than once is refused rather
+    than resolved to whichever copy came first.
+    """
+
+    lines = workflow.splitlines()
+    occurrences = [index for index, line in enumerate(lines) if line == step]
+    if len(occurrences) != 1:
+        raise GuardError(
+            f"release workflow names the step {step_label(step)!r} {len(occurrences)} "
+            "times, expected exactly one"
+        )
+    start = occurrences[0]
+    indent = len(step) - len(step.lstrip())
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        current = len(line) - len(line.lstrip())
+        if current < indent or (current == indent and line.lstrip().startswith("- ")):
+            end = index
+            break
+    return lines[start:end]
 
 
 def workflow_step_block(workflow: str, step: str, key: str) -> list[str]:
-    """The indented block under `key` inside the named workflow step."""
-    lines = workflow.splitlines()
-    try:
-        start = lines.index(step)
-    except ValueError as error:
-        raise GuardError(f"release workflow has no step {step.strip()!r}") from error
-    try:
-        key_index = lines.index(key, start)
-    except ValueError as error:
+    """The indented block under `key`, read only from inside the named step."""
+    lines = workflow_step_lines(workflow, step)
+    occurrences = [index for index, line in enumerate(lines) if line == key]
+    if len(occurrences) != 1:
         raise GuardError(
-            f"release workflow step {step.strip()!r} has no {key.strip()!r} block"
-        ) from error
+            f"release workflow step {step_label(step)!r} carries {len(occurrences)} "
+            f"{key.strip()!r} blocks, expected exactly one"
+        )
+    key_index = occurrences[0]
     indent = len(key) - len(key.lstrip()) + 2
     block: list[str] = []
     for line in lines[key_index + 1 :]:
@@ -238,20 +282,28 @@ def workflow_step_block(workflow: str, step: str, key: str) -> list[str]:
         block.append(line.strip())
     if not block:
         raise GuardError(
-            f"release workflow step {step.strip()!r} publishes an empty {key.strip()!r} block"
+            f"release workflow step {step_label(step)!r} publishes an empty {key.strip()!r} block"
         )
     return block
 
 
 def inventory_assets(workflow_source: str) -> set[str]:
-    """The asset list the publish job asserts is complete before it uploads."""
-    if INVENTORY_STEP not in workflow_source:
-        raise GuardError(f"release workflow has no step {INVENTORY_STEP.strip()!r}")
-    tail = workflow_source[workflow_source.index(INVENTORY_STEP) :]
-    match = INVENTORY_ASSETS.search(tail)
-    if match is None:
-        raise GuardError("release workflow's asset inventory declares no asset list")
-    return {line.strip() for line in match.group("body").splitlines() if line.strip()}
+    """The asset list the publish job asserts is complete before it uploads.
+
+    Bounded to its own step for the same reason as `workflow_step_block`: the
+    promotion job further down this workflow opens its own `assets=(` array, and
+    an unbounded search would answer with that one the moment this step's array
+    stopped matching.
+    """
+
+    step_source = "\n".join(workflow_step_lines(workflow_source, INVENTORY_STEP))
+    bodies = INVENTORY_ASSETS.findall(step_source)
+    if len(bodies) != 1:
+        raise GuardError(
+            f"release workflow's asset inventory declares {len(bodies)} asset "
+            "lists, expected exactly one"
+        )
+    return {line.strip() for line in bodies[0].splitlines() if line.strip()}
 
 
 def asset_sources(assets_dir: Path | None, workflow_source: str) -> list[tuple[str, set[str]]]:


### PR DESCRIPTION
The POSIX installer builds one archive name for every platform it detects, `kin-<os>-<arch>.tar.gz`, and it maps the MSYS, MINGW, and CYGWIN uname strings to `windows`. The Windows release leg packaged only a zip, so piping the documented curl command into a shell on Windows asked for `kin-windows-x86_64.tar.gz` and got a 404 on every release to date. The two names never agreed and nothing compared them:

- `scripts/install.sh` line 133: `ARCHIVE="kin-${TARGET}.tar.gz"`, with no `.zip` branch and `TARGET` set to `windows-x86_64` on those shells.
- `.github/workflows/release.yml` Package (Windows): `Compress-Archive -Path "$env:ARTIFACT/*" -DestinationPath "$env:ARTIFACT.zip"`, and nothing else.

The Windows leg now packages the same components as a tarball beside the zip, publishing it through the checksum inventory, the attestation subjects, and the release upload list. The zip stays the primary archive because the PowerShell installer, the npm launcher, and `kin update` all resolve Windows by that name, and anything already depending on it keeps working. Both containers are verified against one content inventory at publish time, so they cannot ship different bytes under a single release. The packaging step asserts the tarball's member set equals the zip's, that every member sits under the `kin-windows-x86_64/` root the Unix legs use, and that no member carries a Windows path separator. Both sidecars are written through one loop that binds each hash to its own archive filename, and the installer checksum gate now pins that loop rather than the single zip line it used to pin, so a second container cannot ship a sidecar nothing can match.

Then the check that was missing. `scripts/verify-installer-release-assets.py` derives the asset name every install surface builds and fails when a derived name is absent from any release asset list. The names are derived rather than restated: `install.sh` is executed against a stubbed `uname` and asked what it downloads, the npm launcher's own `artifactName` is called, and `install.ps1` is read under anchored patterns that fail rather than skip when its source moves. A release platform with no guarded install surface fails too, so a new platform cannot arrive unguarded. The guard runs on pull requests against the workflow's lists and inside the release against the bytes staged for upload.

`scripts/falsify-installer-release-assets.py` runs beside it through ten poisoned trees, because a guard nobody has watched fail is not evidence that it can fail. It covers the exact pre-fix state, an architecture-token near miss that would 404 identically, published-but-unattested and published-but-uninventoried, an installer that changes its extension, a release platform with no guarded surface, and a probe that cannot read what the installer asks for. The release authority suite holds both scripts wired into CI and into the release, so neither can be dropped quietly.

Verified locally: the guard fails against `origin/main` naming `kin-windows-x86_64.tar.gz` on all three asset lists, and passes on this branch. A tarball packaged the way this change packages it is accepted by the release's own `assertReleaseArchiveMemberPaths` and `classifyReleaseArchiveRoot` rules under the Windows target, and `install.sh` run as a MINGW host against a local release carrying it resolves the download and verifies its checksum.

Closes FIR-2175
