### PR TITLE
Admit observed new files into the workspace as they are written

### DIFF
--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -260,20 +260,32 @@ pub struct ReconcileHealth {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backlog_age_seconds: Option<u64>,
     /// Host paths the most recent complete scan observed that repository
-    /// authority does not track.
+    /// authority does not track and no observation covered.
     ///
-    /// Ambient observation revises graph-owned history but never enlarges it, so
-    /// a path the workspace has never tracked stays untracked until an explicit
-    /// seam admits it. That is deliberate, and it is also the exact reason a
-    /// freshly written file is not queryable. Reported so the answer to "why is
-    /// my new file missing" is on the status surface instead of inferable only
-    /// from the loop's source.
+    /// Watching a working copy admits new non-ignored files into the workspace,
+    /// so a path that stays untracked is one nothing observed arriving: the
+    /// daemon was down when it appeared, or its notification never came. No
+    /// later ambient tick picks it up on its own, which is exactly why it is
+    /// reported rather than left for a reader to infer from the loop's source.
     #[serde(default)]
     pub untracked_path_count: u64,
     /// A bounded sample of `untracked_path_count`, so the notice names paths a
     /// reader can act on without a large working copy flooding the surface.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub untracked_paths_sample: Vec<String>,
+    /// Untracked host entries the effective ignore rules excluded from the most
+    /// recent walk.
+    ///
+    /// A count, never a list. An excluded directory is counted once and never
+    /// descended into, so this stays small enough to read, and it is the only
+    /// signal that separates "nothing has taken your file yet" from "the rules
+    /// exclude it and nothing ever will".
+    #[serde(default)]
+    pub ignored_path_count: u64,
+    /// Untracked host leaves outside Kin's regular-file and symbolic-link tree,
+    /// which no admission can represent.
+    #[serde(default)]
+    pub unsupported_path_count: u64,
 }
 
 impl ReconcileHealth {
@@ -343,6 +355,12 @@ impl ReconcileHealth {
     /// reader to ignore the field. It still has to be said: a path the loop
     /// declines to admit is a path whose entities never appear, and silence
     /// there is what made a deliberate refusal look like a stuck daemon.
+    ///
+    /// The two notices answer the same reader's question from opposite sides. A
+    /// file that is missing because nothing observed it arriving is recoverable
+    /// and gets named outright; a file that is missing because the rules exclude
+    /// it is not, and the count is what tells the reader to go and read the
+    /// rules instead of waiting.
     pub fn notices(&self) -> Vec<String> {
         let mut notices = Vec::new();
         if self.untracked_path_count > 0 {
@@ -360,10 +378,32 @@ impl ReconcileHealth {
                 }
             };
             notices.push(format!(
-                "{} host path(s) observed but not tracked{sample}. Watching a file never enlarges \
-                 the repository, so these stay unqueryable until a commit admits them or kin \
-                 admit does it on demand.",
+                "{} host path(s) observed but not tracked{sample}. Watching a working copy admits \
+                 new non-ignored files, so nothing observed these arriving and no later tick picks \
+                 them up on its own; kin admit takes them now, and the next commit takes them \
+                 anyway.",
                 self.untracked_path_count
+            ));
+        }
+        if self.ignored_path_count > 0 || self.unsupported_path_count > 0 {
+            let mut excluded = Vec::new();
+            if self.ignored_path_count > 0 {
+                excluded.push(format!(
+                    "{} excluded by the ignore rules",
+                    self.ignored_path_count
+                ));
+            }
+            if self.unsupported_path_count > 0 {
+                excluded.push(format!(
+                    "{} outside Kin's file and symbolic-link tree",
+                    self.unsupported_path_count
+                ));
+            }
+            notices.push(format!(
+                "The last complete walk left host content unobserved: {}. Nothing admits these, so \
+                 a file missing from here is missing on purpose; check .kinignore before waiting \
+                 on it.",
+                excluded.join(", ")
             ));
         }
         notices
@@ -738,6 +778,49 @@ mod tests {
             ReconcileHealth::default().notices().is_empty(),
             "a working copy with nothing untracked says nothing"
         );
+    }
+
+    /// Excluded content is announced as a count and never as a list.
+    ///
+    /// It answers a different question from the untracked notice. A path nothing
+    /// observed is recoverable and gets named; a path the rules exclude is not
+    /// coming however long anyone waits, and the only useful answer is how much
+    /// is being left out and where the decision lives. Listing it instead would
+    /// put every derived file in the working copy on a surface whose job is to
+    /// name the one file a reader is looking for.
+    #[test]
+    fn excluded_host_content_is_announced_as_a_count_without_degrading_the_daemon() {
+        let health = ReconcileHealth {
+            ignored_path_count: 3,
+            unsupported_path_count: 1,
+            ..Default::default()
+        };
+        assert!(!health.degraded(), "{:?}", health.degraded_reasons());
+        let notices = health.notices();
+        assert_eq!(notices.len(), 1, "{notices:?}");
+        let notice = &notices[0];
+        assert!(
+            notice.contains('3') && notice.contains("ignore rules"),
+            "the excluded count and its cause must both be named: {notice}"
+        );
+        assert!(
+            notice.contains('1') && notice.contains("symbolic-link"),
+            "content Kin cannot represent is a separate cause: {notice}"
+        );
+        assert!(
+            notice.contains(".kinignore"),
+            "the reader needs the file that decides this: {notice}"
+        );
+
+        // The two notices are independent: a repository can be missing a file
+        // for either reason, and a reader gets whichever answer is true.
+        let both = ReconcileHealth {
+            untracked_path_count: 1,
+            untracked_paths_sample: vec!["src/new.rs".to_string()],
+            ignored_path_count: 2,
+            ..Default::default()
+        };
+        assert_eq!(both.notices().len(), 2, "{:?}", both.notices());
     }
 
     #[test]

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -89,6 +89,35 @@ fn open_authority(
     (repository_id, manager)
 }
 
+/// Wait until the workspace tree is level with its base, or give up.
+///
+/// A watcher that admits observed host content leaves the workspace ahead of
+/// its base for as long as it takes the loop to drain a tick, and several
+/// repository transitions refuse over exactly that state. Polling authority is
+/// how a test asks "has the loop finished" without asserting on a clock.
+fn wait_for_level_workspace(layout: &kin_core::KinLayout, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    loop {
+        let (_, manager) = open_authority(layout);
+        let level = {
+            let lease = manager.read_authority();
+            lease
+                .metadata()
+                .workspaces
+                .first()
+                .map(|workspace| workspace.base_tree_hash == Some(workspace.tree_hash))
+                .unwrap_or(false)
+        };
+        if level {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
 fn run_git(path: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
@@ -1067,6 +1096,28 @@ fn branch_switch_preserves_graph_only_gitlinks_without_traversing_nested_checkou
         [0_u8, 0xff, 0x44]
     );
     assert_workspace_has_no_path(&open_authority(&layout).1, b"vendor/dependency");
+
+    // Let the watcher finish with the events these switches produced before
+    // asking for another one. A switch refuses over a workspace holding content
+    // ahead of its base, and admitting observed host content is what the
+    // watcher now does, so a second switch issued while the loop is still
+    // draining is racing the product rather than testing it.
+    //
+    // The wait is bounded and its failure is specific. If the loop settles and
+    // the workspace is still ahead of its base, that is the one corner this
+    // pairing has: events beneath a graph-only member are dropped against the
+    // tree as it stands when they are drained, so events that outlive the
+    // member's removal are no longer recognised as belonging to an independent
+    // checkout, and the content underneath it is admitted like any other new
+    // file. The message says so rather than leaving a later reader to rediscover
+    // it from a timeout.
+    let settled = wait_for_level_workspace(&layout, Duration::from_secs(30));
+    assert!(
+        settled,
+        "the workspace never came level with its base. Host content beneath the removed Gitlink \
+         was admitted as ordinary new content, which happens when its watcher events are drained \
+         after the member is gone rather than while it is still there"
+    );
 
     let add_retained = run_kin(&runtime, &repo, &["branch", "switch", "gitlink-a"]);
     assert!(

--- a/crates/kin-cli/tests/repository_drift.rs
+++ b/crates/kin-cli/tests/repository_drift.rs
@@ -107,8 +107,18 @@ fn drift_paths(report: &Value) -> Vec<String> {
         .collect()
 }
 
+/// Host content the graph does not own has no bearing on a drift answer.
+///
+/// The content used here is content the rules exclude, which is now the whole
+/// of that population: a watcher admits an ordinary new file into the workspace
+/// shortly after it is written, so writing one and asserting the graph ignored
+/// it would be asserting against the product rather than against a raw
+/// filesystem walk, and it would race the watcher besides. Excluded content
+/// never enters a walk at all, so it is the deterministic form of the same
+/// question, and the same question is still worth asking: a drift report that
+/// grows here is answering from the host instead of from graph truth.
 #[test]
-fn drift_reads_graph_truth_and_never_answers_from_untracked_host_files() {
+fn drift_reads_graph_truth_and_never_answers_from_excluded_host_files() {
     let root = tempdir().expect("temp root");
     let repo = root.path().join("repo");
     initialize_git_repo(&repo);
@@ -135,15 +145,17 @@ fn drift_reads_graph_truth_and_never_answers_from_untracked_host_files() {
         "compared entries cannot exceed tracked artifacts"
     );
 
-    // Untracked host content is not graph-owned, so it cannot drift. A drift
-    // report that grows here is answering from a raw filesystem walk.
-    fs::write(repo.join("untracked.rs"), b"pub fn ghost() {}\n").expect("write untracked source");
-    fs::create_dir_all(repo.join("scratch")).expect("create untracked directory");
-    fs::write(repo.join("scratch/notes.txt"), b"scratch\n").expect("write untracked note");
+    // Excluded host content is not graph-owned, so it cannot drift. A drift
+    // report that grows here is answering from a raw filesystem walk. `target`
+    // is excluded by the built-in rules, so nothing admits this however long
+    // the watcher runs.
+    fs::create_dir_all(repo.join("target")).expect("create excluded directory");
+    fs::write(repo.join("target/ghost.rs"), b"pub fn ghost() {}\n").expect("write excluded source");
+    fs::write(repo.join("target/notes.txt"), b"scratch\n").expect("write excluded note");
     let with_untracked = drift_report(&runtime, &repo);
     assert_eq!(
         with_untracked["clean"], true,
-        "untracked host files must never be reported as drift"
+        "excluded host files must never be reported as drift"
     );
     assert_eq!(with_untracked["drift_count"], 0);
     assert_eq!(

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -586,10 +586,30 @@ struct ReconcileProbesInner {
     /// unbroken backlog rather than of the oldest one this daemon ever saw.
     backlog_since: Option<Instant>,
     /// How many host paths the most recent complete scan observed that
-    /// repository authority does not track.
+    /// repository authority does not track and no observation covered.
     untracked_path_count: u64,
     /// A bounded sample of those paths.
     untracked_paths_sample: Vec<String>,
+    /// What the most recent complete walk deliberately did not observe.
+    excluded: ExcludedHostContent,
+}
+
+/// Host content one complete walk declined to observe at all.
+///
+/// Separate from the untracked count because the two answer different
+/// questions. An untracked path is admissible content nothing has taken yet;
+/// these are paths the product will not index however long a reader waits, so
+/// the honest answer to "where is my file" is different in each case.
+///
+/// Counts only, never lists. An excluded directory is counted once and never
+/// descended into, so these stay small enough to read, and a surface that
+/// enumerated every derived file would have stopped being a notice.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExcludedHostContent {
+    /// Untracked entries the effective ignore rules excluded.
+    pub ignored: u64,
+    /// Untracked leaves outside Kin's regular-file and symbolic-link tree.
+    pub unsupported: u64,
 }
 
 /// How many untracked paths a disclosure names outright.
@@ -646,7 +666,12 @@ impl ReconcileProbes {
         }
     }
 
-    /// What one complete scan saw on the host that authority does not track.
+    /// What one complete scan saw on the host that it did not admit.
+    ///
+    /// `paths` are admissible content authority does not carry and this pass did
+    /// not take; `excluded` is what the same walk declined to observe at all.
+    /// Both come from one scan and are recorded together so the two halves of
+    /// "why is my file missing" can never describe different moments.
     ///
     /// Replaces the previous record rather than accumulating. The scan behind it
     /// is complete, so its answer is the current truth about the working copy,
@@ -655,6 +680,7 @@ impl ReconcileProbes {
     pub fn record_untracked_observation<T: std::fmt::Display>(
         &self,
         paths: impl IntoIterator<Item = T>,
+        excluded: ExcludedHostContent,
     ) {
         let mut count: u64 = 0;
         let mut sample = Vec::new();
@@ -667,6 +693,7 @@ impl ReconcileProbes {
         let mut inner = self.lock();
         inner.untracked_path_count = count;
         inner.untracked_paths_sample = sample;
+        inner.excluded = excluded;
     }
 
     /// The disclosure surfaces' view of all of it.
@@ -697,6 +724,8 @@ impl ReconcileProbes {
                 .map(|since| now.saturating_duration_since(since).as_secs()),
             untracked_path_count: inner.untracked_path_count,
             untracked_paths_sample: inner.untracked_paths_sample.clone(),
+            ignored_path_count: inner.excluded.ignored,
+            unsupported_path_count: inner.excluded.unsupported,
         }
     }
 }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -426,6 +426,20 @@ pub(crate) fn current_authority_roots(state: &DaemonState) -> Result<kin_model::
     Ok(roots)
 }
 
+/// What one complete walk declined to observe, taken from its own diagnostics.
+///
+/// Read off the scan rather than recomputed, so the counts a surface prints and
+/// the walk that produced them can never describe different working copies.
+fn excluded_host_content(
+    scan: &kin_index::CompleteRepositoryScan,
+) -> crate::background_work::ExcludedHostContent {
+    let diagnostics = scan.diagnostics();
+    crate::background_work::ExcludedHostContent {
+        ignored: diagnostics.ignored_untracked_entries as u64,
+        unsupported: diagnostics.unsupported_untracked_entries as u64,
+    }
+}
+
 /// Report whether one repository path was named by an observation, either
 /// exactly or as a descendant of an observed directory.
 fn observation_covers_path(observed: &BTreeSet<RepoPath>, path: &RepoPath) -> bool {
@@ -444,14 +458,28 @@ fn observation_covers_path(observed: &BTreeSet<RepoPath>, path: &RepoPath) -> bo
 /// seam such as `/commands/commit`: everything the working copy holds crosses
 /// the compare-and-swap, including paths the workspace has never tracked.
 ///
-/// `Some(paths)` is the ambient watcher path and is bounded twice. Only the
-/// observed paths and their descendants may move, so one unrelated host event
-/// cannot sweep the rest of the working copy into repository authority. And
-/// only members the workspace already tracks may move at all, so ambient
-/// observation revises graph-owned history but never enlarges it: a host path
-/// the repository has never tracked becomes repository truth when a person
-/// commits it, not because a watcher noticed it. That is what keeps untracked
-/// host content from dirtying a workspace or gating a transition.
+/// `Some(paths)` is the ambient watcher path, and it is bounded to what the
+/// host was observed doing. Only the observed paths and their descendants may
+/// move, so one unrelated host event cannot sweep the rest of the working copy
+/// in and a single `touch` never costs a complete import. Within that bound an
+/// observed path moves whether or not the workspace already tracks it: a file
+/// becomes queryable because someone wrote it, not because someone remembered
+/// to run a command afterwards.
+///
+/// What this enlarges is the workspace tree, and only the workspace tree. The
+/// publication underneath advances the workspace generation while leaving its
+/// head, base target, and base tree hash exactly as they were, so ambient
+/// observation moves pending content and never repository history. The commit
+/// that later publishes that content is where authorship attaches, and it names
+/// what it carried rather than claiming its author wrote it.
+///
+/// This is a deliberate replacement for an earlier rule under which ambient
+/// observation revised graph-owned history but never enlarged it, so a newly
+/// written file stayed invisible until someone committed it. That rule cost
+/// more than it protected. The transactional write path stages edits against
+/// entities and relations that already exist and cannot create a file at a new
+/// path at all, which left this the only route by which an agent-authored file
+/// could become queryable.
 ///
 /// The scan itself stays complete either way, so a rename keeps one stable
 /// artifact identity even when its two halves arrive in different notification
@@ -531,24 +559,33 @@ fn exact_tree_admission(
             }
             observed.insert(artifact.path.clone(), artifact.entry);
         }
-        // Everything the walk met that authority does not carry is about to be
-        // dropped, because ambient observation may revise graph-owned history
-        // but never enlarge it. Publish the count and a sample before dropping
-        // them: this refusal is why a freshly written file is not queryable, and
-        // a surface that reports only what the loop admitted cannot say so. The
-        // scan behind this is complete, so it replaces the previous answer
-        // instead of adding to it, and the explicit seam below replaces it again
-        // as soon as a commit admits what was declined.
+        // What the walk met and authority does not carry divides in two here. A
+        // path this observation covers is admitted, which is what makes a file
+        // queryable from the act of writing it. The rest is dropped: an event
+        // about one path is no evidence about the others, and admitting them
+        // anyway would make one host notification pay for a complete import of
+        // whatever else happens to be lying in the working copy.
+        //
+        // The dropped set is exactly what the surfaces report, and it is
+        // recoverable rather than refused. Nothing observed those paths
+        // arriving, so no later ambient tick reaches them on its own and only an
+        // explicit pass will. The scan behind this is complete, so each pass
+        // replaces the previous answer instead of adding to it, and the explicit
+        // seam below replaces it again the moment one takes what was left.
         state
             .background_work
             .reconcile()
             .record_untracked_observation(
-                observed
-                    .entries()
-                    .keys()
-                    .filter(|path| previous.artifact_id_at_path(path).is_none()),
+                observed.entries().keys().filter(|path| {
+                    previous.artifact_id_at_path(path).is_none()
+                        && !observation_covers_path(observation, path)
+                }),
+                excluded_host_content(&scan),
             );
-        observed.retain(|path, _| previous.artifact_id_at_path(path).is_some());
+        observed.retain(|path, _| {
+            previous.artifact_id_at_path(path).is_some()
+                || observation_covers_path(observation, path)
+        });
     }
     // A bounded tick re-inserts every tracked path its observation did not
     // cover, which would restore the paths the rules just retracted. Editing
@@ -639,10 +676,17 @@ fn exact_tree_admission(
         // arrives, and the surfaces would keep naming a path this admission
         // just made queryable. It is recorded after publication, not before, so
         // a refused observation leaves a still-true record standing.
+        //
+        // What the walk declined to observe is still declined, and this pass
+        // measured it as recently as any ambient one, so it is republished
+        // rather than cleared.
         state
             .background_work
             .reconcile()
-            .record_untracked_observation(std::iter::empty::<&RepoPath>());
+            .record_untracked_observation(
+                std::iter::empty::<&RepoPath>(),
+                excluded_host_content(&scan),
+            );
     }
 
     Ok(ExactTreeAdmission {
@@ -719,13 +763,14 @@ fn admit_file_event_with_exact_tree(
 
     let file_type = metadata.file_type();
     if !tracked && (file_type.is_file() || file_type.is_symlink()) {
-        // Admissible host content at a path repository authority does not carry.
-        // Ambient observation revises graph-owned history and never enlarges it,
-        // so the complete admission that just ran deliberately refused to plan
-        // this path in. Enriching it anyway is not available either: the
-        // revalidation below compares host bytes against the tree entry authority
-        // holds, and authority holds none, so this path can only ever fail that
-        // comparison.
+        // Admissible host content the complete admission that just ran did not
+        // carry. An observed new path is admitted by that pass and reaches here
+        // tracked, so what is left is content the walk never met: a file created
+        // after its own directory was walked, or one whose notification arrived
+        // without it. Enriching it is not available either, because the
+        // revalidation below compares host bytes against the tree entry
+        // authority holds and authority holds none, so this path can only ever
+        // fail that comparison.
         //
         // It is declined here rather than deferred because a deferral would be a
         // promise the loop cannot keep. Every retry costs one complete exact-tree
@@ -734,7 +779,7 @@ fn admit_file_event_with_exact_tree(
         // as long as the daemon lives, reconciliation_status never returns to
         // idle, backlog_age climbs without bound, and the store spends a core
         // rescanning itself while admitting nothing. Declining once, out loud, is
-        // the fix.
+        // what keeps that shut.
         return Ok(AdmittedFileEvent::Untracked { repo_path });
     }
     let (content, blob_hash, entry, is_symlink) = if file_type.is_symlink() {
@@ -2389,47 +2434,234 @@ mod tests {
     /// backlog age climbed without bound, and a flagship store spent a core
     /// rescanning itself for as long as the daemon lived.
     #[test]
-    fn an_ambient_event_declines_untracked_host_content_and_says_so() {
+    fn an_ambient_event_admits_new_host_content_it_observed() {
         let repo = tempfile::tempdir().unwrap();
         let state = open_test_state(&repo);
-        let untracked = repo.path().join("brand_new.rs");
-        std::fs::write(&untracked, b"pub fn brand_new() -> u32 { 2152 }\n").unwrap();
+        let written = repo.path().join("brand_new.rs");
+        std::fs::write(&written, b"pub fn brand_new() -> u32 { 1 }\n").unwrap();
 
-        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(untracked)).unwrap();
-        let AdmittedFileEvent::Untracked { repo_path } = admitted else {
-            panic!("untracked host content must be declined, not admitted: {admitted:?}");
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(written)).unwrap();
+        let AdmittedFileEvent::Regular { tree_changed, .. } = admitted else {
+            panic!("an observed new file must be admitted, not declined: {admitted:?}");
         };
-        assert_eq!(repo_path, test_repo_path("brand_new.rs"));
         assert!(
-            tree_entry(&state, "brand_new.rs").is_none(),
-            "a declined path must not enter repository authority"
+            tree_changed,
+            "the admission that carried this path must be reported as having moved the tree"
+        );
+        assert!(
+            tree_entry(&state, "brand_new.rs").is_some(),
+            "writing a file is what makes it queryable; no command should be needed"
         );
 
-        // The surfaces have to be able to answer why the file is not queryable.
-        // Silence here is what made a deliberate refusal read as a wedged loop.
+        // Nothing is left for a surface to explain: the file a reader would
+        // have gone looking for is in the tree.
         let report = state
             .background_work
             .reconcile()
             .report(std::time::Instant::now());
-        assert_eq!(report.untracked_path_count, 1);
-        assert_eq!(report.untracked_paths_sample, vec!["brand_new.rs"]);
+        assert_eq!(report.untracked_path_count, 0);
+        assert!(report.untracked_paths_sample.is_empty());
+        assert!(!report.degraded(), "{:?}", report.degraded_reasons());
+        assert!(
+            !report
+                .notices()
+                .iter()
+                .any(|notice| notice.contains("brand_new.rs")),
+            "no surface may call an admitted path untracked: {:?}",
+            report.notices()
+        );
+    }
+
+    /// The delta bound, and the test that fails if anyone widens the predicate.
+    ///
+    /// Admission follows the observation, not the walk. Both files are equally
+    /// admissible and the complete scan met both, so the only thing separating
+    /// them is that a watcher saw one of them. Widening the ambient predicate to
+    /// take everything the walk met would make one host notification pay for a
+    /// complete import of the working copy, which is the cost this bound exists
+    /// to refuse. If this test ever fails on the second file being admitted,
+    /// that is the regression and not a stale assertion.
+    #[test]
+    fn an_ambient_event_admits_only_what_its_observation_covers() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let observed = repo.path().join("observed.rs");
+        std::fs::write(&observed, b"pub fn observed() -> u32 { 1 }\n").unwrap();
+        std::fs::write(
+            repo.path().join("unobserved.rs"),
+            b"pub fn unobserved() -> u32 { 2 }\n",
+        )
+        .unwrap();
+
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(observed)).unwrap();
+        assert!(
+            matches!(admitted, AdmittedFileEvent::Regular { .. }),
+            "the observed file is admitted: {admitted:?}"
+        );
+        assert!(tree_entry(&state, "observed.rs").is_some());
+        assert!(
+            tree_entry(&state, "unobserved.rs").is_none(),
+            "one event is no evidence about a path nothing observed"
+        );
+
+        let report = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(
+            report.untracked_path_count, 1,
+            "exactly the file no observation covered is reported"
+        );
+        assert_eq!(report.untracked_paths_sample, vec!["unobserved.rs"]);
+        assert!(
+            report
+                .notices()
+                .iter()
+                .any(|notice| notice.contains("unobserved.rs") && notice.contains("kin admit")),
+            "the notice must name the path and the command that recovers it: {:?}",
+            report.notices()
+        );
+    }
+
+    /// The livelock signature stays dead, in the counters that carried it.
+    ///
+    /// The earlier spin was a closed loop: an unadmitted path failed the host
+    /// revalidation, the loop deferred it, and every retry bought another
+    /// complete admission over the whole working copy that reached the identical
+    /// refusal. Admission breaks it at the first link, so this asserts the link
+    /// is broken rather than that the symptom is absent. A second tick over the
+    /// same observation plans nothing, and the revalidation `run_loop` defers on
+    /// now succeeds.
+    #[test]
+    fn a_second_ambient_tick_for_an_admitted_path_plans_nothing() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let path = repo.path().join("brand_new.rs");
+        std::fs::write(&path, b"pub fn brand_new() -> u32 { 1 }\n").unwrap();
+        let repo_path = test_repo_path("brand_new.rs");
+        let observation = std::iter::once(repo_path.clone()).collect::<BTreeSet<_>>();
+
+        let first = exact_tree_admission(&state, Some(&observation)).unwrap();
+        assert!(
+            first.changed_paths.contains(&repo_path),
+            "the first tick admits the observed path"
+        );
+
+        let second = exact_tree_admission(&state, Some(&observation)).unwrap();
+        assert!(
+            second.deltas.is_empty() && second.changed_paths.is_empty(),
+            "a settled path must plan nothing on the next tick: {:?}",
+            second.deltas
+        );
+
+        // `run_loop` defers precisely when this returns false, which is the step
+        // that opened the retry ladder.
+        assert!(
+            host_entry_matches_graph(&state, &path, &repo_path).unwrap(),
+            "an admitted path must revalidate, so no event for it can be deferred"
+        );
+
+        let report = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(report.untracked_path_count, 0);
+        assert_eq!(report.admission_failures, 0);
+        assert!(!report.degraded(), "{:?}", report.degraded_reasons());
+    }
+
+    /// The rules still decide, and they decide once.
+    ///
+    /// Excluded content is not in the walk at all, so admitting observed paths
+    /// cannot reach it however the watcher behaves. The verdict stays terminal,
+    /// nothing enters the tree, and the excluded content is disclosed as a count
+    /// rather than as a list of every derived file in the working copy.
+    #[test]
+    fn an_ignored_new_path_is_still_declined_once() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        // The rule file is itself new host content, and writing it is what puts
+        // it in force. It is admitted like any other observed file, which is why
+        // the ambient event for it comes first.
+        let rules = repo.path().join(".kinignore");
+        std::fs::write(&rules, b"secrets\n").unwrap();
+        admit_file_event_ambient(&state, &FileEvent::Changed(rules)).unwrap();
+        assert!(
+            tree_entry(&state, ".kinignore").is_some(),
+            "a rule file is repository content and is admitted like any other"
+        );
+
+        std::fs::create_dir(repo.path().join("secrets")).unwrap();
+        let ignored = repo.path().join("secrets/key.rs");
+        std::fs::write(&ignored, b"pub fn key() -> u32 { 1 }\n").unwrap();
+
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(ignored)).unwrap();
+        assert!(
+            matches!(admitted, AdmittedFileEvent::Ignored),
+            "an excluded path is declined, not admitted: {admitted:?}"
+        );
+        assert!(tree_entry(&state, "secrets/key.rs").is_none());
+
+        let report = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(
+            report.untracked_path_count, 0,
+            "excluded content is not admissible content waiting for a pass"
+        );
+        assert!(
+            report.ignored_path_count > 0,
+            "the walk must say it left content unobserved: {report:?}"
+        );
         assert!(
             !report.degraded(),
-            "untracked content is the ordinary state of a working copy and must not degrade the daemon"
+            "ignoring content is a rule taking effect, not a fault: {:?}",
+            report.degraded_reasons()
         );
         assert!(
             report
                 .notices()
                 .iter()
-                .any(|notice| notice.contains("brand_new.rs")),
-            "the notice must name the path a reader is looking for: {:?}",
+                .any(|notice| notice.contains("ignore rules") && notice.contains(".kinignore")),
+            "the notice must send the reader to the rules: {:?}",
             report.notices()
         );
     }
 
-    /// Falsification: the identical file reaches the opposite verdict through an
-    /// explicit admission seam, so the decline above is about how the event
-    /// arrived and not about the file.
+    /// The verdict that remains after observed paths are admitted: admissible
+    /// content the complete walk never met, such as a file created after its own
+    /// directory was walked. It is still terminal, because a deferral would
+    /// reopen the ladder that never converged.
+    #[test]
+    fn content_the_walk_never_met_is_still_declined_terminally() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let missed = repo.path().join("raced.rs");
+
+        // The admission runs against a working copy that does not hold the file,
+        // exactly as a walk that finished before the file landed would have.
+        let observation = BTreeSet::new();
+        let admission = exact_tree_admission(&state, Some(&observation)).unwrap();
+        std::fs::write(&missed, b"pub fn raced() -> u32 { 1 }\n").unwrap();
+
+        let admitted = admit_file_event_with_exact_tree(
+            &state,
+            &FileEvent::Changed(missed),
+            &admission.changed_paths,
+        )
+        .unwrap();
+        let AdmittedFileEvent::Untracked { repo_path } = admitted else {
+            panic!("content no admission carried must be declined: {admitted:?}");
+        };
+        assert_eq!(repo_path, test_repo_path("raced.rs"));
+        assert!(tree_entry(&state, "raced.rs").is_none());
+    }
+
+    /// The explicit seam is bounded by nothing, which is what makes it the
+    /// recovery surface. It admits a path the working copy holds whether or not
+    /// anything ever observed that path arriving, so a store whose watcher
+    /// missed a file is one command away from carrying it.
     #[test]
     fn an_explicit_seam_still_admits_the_same_untracked_path() {
         let repo = tempfile::tempdir().unwrap();
@@ -2457,23 +2689,28 @@ mod tests {
     fn admitting_a_declined_path_clears_its_disclosure_without_another_host_event() {
         let repo = tempfile::tempdir().unwrap();
         let state = open_test_state(&repo);
-        let path = repo.path().join("brand_new.rs");
-        std::fs::write(&path, b"pub fn brand_new() -> u32 { 2152 }\n").unwrap();
+        let observed = repo.path().join("observed.rs");
+        std::fs::write(&observed, b"pub fn observed() -> u32 { 1 }\n").unwrap();
+        std::fs::write(
+            repo.path().join("unobserved.rs"),
+            b"pub fn unobserved() -> u32 { 2 }\n",
+        )
+        .unwrap();
 
-        admit_file_event_ambient(&state, &FileEvent::Changed(path)).unwrap();
+        admit_file_event_ambient(&state, &FileEvent::Changed(observed)).unwrap();
         let declined = state
             .background_work
             .reconcile()
             .report(std::time::Instant::now());
         assert_eq!(declined.untracked_path_count, 1);
-        assert_eq!(declined.untracked_paths_sample, vec!["brand_new.rs"]);
+        assert_eq!(declined.untracked_paths_sample, vec!["unobserved.rs"]);
 
         // The commit seam, and nothing after it: no watcher event is delivered,
         // which is exactly the quiescent working copy the stale record survived
         // on.
         exact_tree_admission(&state, None).unwrap();
         assert!(
-            tree_entry(&state, "brand_new.rs").is_some(),
+            tree_entry(&state, "unobserved.rs").is_some(),
             "the seam must admit the path this disclosure was about"
         );
 
@@ -2490,7 +2727,7 @@ mod tests {
             !admitted
                 .notices()
                 .iter()
-                .any(|notice| notice.contains("brand_new.rs")),
+                .any(|notice| notice.contains("unobserved.rs")),
             "no surface may keep calling an admitted path untracked: {:?}",
             admitted.notices()
         );

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -867,6 +867,18 @@ fn admit_file_event_ambient(state: &DaemonState, event: &FileEvent) -> Result<Ad
     admit_file_event_with_exact_tree(state, event, &admission.changed_paths)
 }
 
+/// Run one ambient watcher tick over a single host path and keep only what it
+/// left behind.
+///
+/// For tests in other modules that need the state a watcher produces rather
+/// than the verdict it reached, so the pending content a commit folds can come
+/// from the real path instead of from a delta assembled to resemble it.
+#[cfg(test)]
+pub(crate) fn admit_one_ambient_host_event(state: &DaemonState, path: PathBuf) -> Result<()> {
+    admit_file_event_ambient(state, &FileEvent::Changed(path))?;
+    Ok(())
+}
+
 fn clear_incompatible_facets(
     state: &DaemonState,
     file_id: &FilePathId,

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -5243,6 +5243,81 @@ mod tests {
         );
     }
 
+    /// The closing arm: a file nothing did but write is carried by the next
+    /// commit and named as carried.
+    ///
+    /// The pending content here comes from the real watcher path rather than
+    /// from a delta assembled to look like one, because the composition is the
+    /// claim. Writing the file is the whole of the user's action: ambient
+    /// admission puts it in the workspace tree without moving the base, and the
+    /// commit that follows publishes it while stating plainly that its author
+    /// did not write it. Either half alone is defensible and useless; a file
+    /// that becomes queryable and then gets published as somebody's work is
+    /// worse than one that never appeared.
+    #[test]
+    fn a_commit_declares_a_watcher_admitted_file_as_carried() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+
+        // Nothing here but a write and the notification it produces.
+        let written = state.layout.working_dir().join("src/brand_new.rs");
+        std::fs::write(&written, b"pub fn brand_new() -> u8 { 1 }\n").unwrap();
+        crate::loop_runner::admit_one_ambient_host_event(&state, written).unwrap();
+        assert!(
+            state
+                .graph
+                .resolved_tree()
+                .artifact_at_path(&RepoPath::from_utf8("src/brand_new.rs").unwrap())
+                .is_some(),
+            "the watcher pass must have admitted the new file before the commit sees it"
+        );
+
+        let sessions = test_sessions();
+        let (_, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a workspace carrying a watcher-admitted file must still commit: {}",
+            result_text(&result)
+        );
+
+        let reply = commit_reply(&result);
+        assert_eq!(
+            reply["staged_operation_files"],
+            serde_json::json!(["src/lib.rs"]),
+            "the reply must keep the operations' own file separate: {reply:#}"
+        );
+        assert_eq!(
+            reply["carried_pending_files"],
+            serde_json::json!(["src/brand_new.rs"]),
+            "a file the watcher admitted is carried, not authored: {reply:#}"
+        );
+
+        let change_id = reply["change_id"].as_str().unwrap().to_string();
+        let change = state
+            .graph
+            .get_entity_history(&entity.id)
+            .unwrap()
+            .into_iter()
+            .find(|change| change.id.to_string() == change_id)
+            .expect("the published change is reachable from the entity the operation wrote");
+        assert!(
+            change.message.contains("src/brand_new.rs"),
+            "the permanent record must name what it carried: {}",
+            change.message
+        );
+        assert!(
+            !workspace_is_dirty(&state),
+            "the commit must leave the workspace level with its base"
+        );
+    }
+
     /// A workspace with nothing pending answers exactly as it did before the
     /// fold existed.
     ///


### PR DESCRIPTION
A file a person or an agent writes now becomes queryable because it was written. The ambient watcher pass admits any path its observation covers, whether or not the workspace already tracks it, so a new file joins the graph the way an edit to a tracked file already did, with nothing to remember and no command to run.

The founder ruled this on 2026-08-10, and it deliberately supersedes an invariant documented on `exact_tree_admission` itself: that ambient observation revises graph-owned history but never enlarges it. That rule was defensible and it cost more than it protected. The transactional write path stages edits against entities and relations that already exist and cannot create a file at a new path at all, which left ambient observation as the only route by which an agent-authored file could ever become queryable. The doc has been rewritten rather than annotated, because a file asserting two contradictory contracts is how the next reader gets it wrong.

What the watcher enlarges is the workspace tree, and only the workspace tree. The publication underneath advances the workspace generation while leaving head, base target, and base tree hash exactly as they were, so pending content moves and repository history does not. Authorship still attaches at an explicit seam, and the commit that publishes this content names it as carried rather than presenting it as the author's work, which the fold-and-declare path already did and which a new test now drives end to end from the real watcher pass through a real commit.

The observation bound stays, and it is what keeps the cost honest. One host notification admits what that notification was about and never the rest of the working copy, so a single write never pays for a complete import. Content that arrived with nothing watching is reported rather than taken, and `kin admit` is still the surface that recovers it in bulk.

This also removes per-tick work rather than adding it. Because an untracked path never matches the entry authority carries, every untracked file in a working copy used to be read a second time and blob-written on every ambient tick before being discarded. Admission ends that: the path matches on every later tick and stops being re-read at all, which is a real improvement on any dirty working copy.

The livelock the decline-once change closed cannot return through this. Its first link was the revalidation comparing host bytes against a tree entry authority did not hold; admission supplies that entry, so the comparison succeeds and no deferral is possible. The `Untracked` verdict is kept and stays terminal for the case that can still reach it, admissible content the complete walk never met. A test asserts the second tick over an admitted path plans nothing, that the revalidation succeeds, and that the counters stay at zero.

Ignore and retraction needed no change, and the reason is worth stating. Excluded content never enters the walk, so nothing here can admit it. A rule written later retracts an ambiently admitted path precisely because it is tracked identity by then. The mass-deletion guard counts removals only and is untouched.

The disclosure narrows to what the loop actually leaves behind. The untracked count now names only paths that are admissible, untracked, and covered by no observation, which is the recovery set and which goes to zero in steady state, and its notice no longer claims that watching a file never enlarges the repository. Beside it, the counts of content the walk declined to observe are published from the scan's own diagnostics, as counts and never as lists, so a reader whose file is missing because the rules exclude it is sent to `.kinignore` instead of waiting for a pass that is not coming.

The projection tests that asked their question by writing an ordinary new file and expecting the graph to ignore it are now asserting against the product, so both were rewritten. The drift test asks with excluded content instead, which is deterministic and is the whole of the population that is still never admitted. The branch test waits for the workspace to come level with its base before asking for another switch, and its failure message names the one corner this pairing has: watcher events beneath a graph-only member are dropped against the tree as it stands when they are drained, so events that outlive the member's removal stop being recognised as belonging to an independent checkout and the content under it is admitted like any other new file. That corner is disclosed here rather than fixed, because the principled remedy is for the walk to decline to descend into a directory carrying its own `.git`, which would change the explicit seams too and deserves its own decision.

Verified on a scratch store with these binaries: four new files written into a settled repository with no command at all were tracked within five seconds, `kin locate` resolved a symbol that exists only in a new file, the reconcile probes reported nothing untracked and no backlog with the last admission ageing rather than being restamped, and `kin admit` against the same live daemon answered that nothing changed. The full workspace gate runs 5361 tests green, clippy matches the CI allowlist under `-D warnings`, and the zero-file-search guard passes and was falsified once to prove it can still fail.

Closes FIR-2168
