### PR TITLE
Qualify fused and unnamed semantic_locate pages with the negative envelope

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12154,6 +12154,104 @@ mod tests {
         serde_json::to_value(result).unwrap()
     }
 
+    /// The JSON body the fused arm actually puts on the wire, parsed out of the
+    /// tool result's text block.
+    fn fused_locate_body(
+        result: kin_cli::commands::locate::LocateResult,
+        query: &str,
+    ) -> serde_json::Value {
+        let tool = fused_semantic_locate_payload(result, query, false);
+        serde_json::from_str(
+            tool_result_json(&tool)["content"][0]["text"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn fused_locate_entity(name: &str) -> kin_cli::commands::locate::LocateEntity {
+        kin_cli::commands::locate::LocateEntity {
+            entity_id: "00000000-0000-0000-0000-0000000000aa".into(),
+            kind: "function".into(),
+            name: name.into(),
+            signature: String::new(),
+            score: 0.4,
+            definition: true,
+            span: None,
+            body: None,
+            match_kind: None,
+            provenance: kin_cli::commands::locate::LocateProvenance {
+                file: Some("src/lib.rs".into()),
+                origin: String::new(),
+                cosine: None,
+            },
+            matched_queries: Vec::new(),
+        }
+    }
+
+    /// FIR-2170, asserted against the serializer rather than a hand-written
+    /// payload. `LocateResult` skips `entities` when the vector is empty, so an
+    /// empty fused page reaches the negative machinery carrying `files` and no
+    /// `entities` key at all — the shape that has to be recognized, and the one
+    /// a fixture written from the struct definition would miss.
+    #[test]
+    fn empty_fused_locate_body_is_qualified_by_the_negative_contract() {
+        let body = fused_locate_body(
+            kin_cli::commands::locate::LocateResult::default(),
+            "where does the daemon start",
+        );
+        assert!(
+            body.get("entities").is_none(),
+            "an empty fused page omits `entities` entirely: {body}"
+        );
+        assert_eq!(body["files"], json!([]));
+        let negative =
+            kin_mcp::negative::negative_for("semantic_locate", &body, &kin_mcp::Envelope::daemon())
+                .expect("an empty fused page must carry a negative");
+        assert_eq!(negative["kind"], json!("no_ranked_match"));
+        assert_eq!(negative["result_count"], json!(0));
+    }
+
+    /// FIR-2178 on the same serialized shape: a full page for a symbol the
+    /// ranking never names is qualified, and every row it served is still
+    /// counted, because the contract reports and never filters.
+    #[test]
+    fn unnamed_fused_locate_body_is_qualified_without_dropping_rows() {
+        let result = kin_cli::commands::locate::LocateResult {
+            entities: vec![fused_locate_entity("neighbor_one")],
+            all_fallback: true,
+            total_ranked: 9,
+            ..Default::default()
+        };
+        let body = fused_locate_body(result, "zzqqxx_nonexistent_symbol_9f3a");
+        assert_eq!(body["all_fallback"], json!(true));
+        let negative =
+            kin_mcp::negative::negative_for("semantic_locate", &body, &kin_mcp::Envelope::daemon())
+                .expect("a ranking that names nothing must be qualified");
+        assert_eq!(negative["kind"], json!("no_named_match"));
+        assert_eq!(negative["interpretation"], json!("unnamed_ranking"));
+        assert_eq!(negative["result_count"], json!(1));
+        assert_eq!(body["entities"].as_array().map(Vec::len), Some(1));
+    }
+
+    /// The control: a page holding the symbol the query named is not qualified
+    /// at all, so the label keeps meaning something.
+    #[test]
+    fn named_fused_locate_body_carries_no_negative() {
+        let result = kin_cli::commands::locate::LocateResult {
+            entities: vec![fused_locate_entity("run_fused_locate_for_state")],
+            total_ranked: 4,
+            ..Default::default()
+        };
+        let body = fused_locate_body(result, "run_fused_locate_for_state");
+        assert!(kin_mcp::negative::negative_for(
+            "semantic_locate",
+            &body,
+            &kin_mcp::Envelope::daemon()
+        )
+        .is_none());
+    }
+
     #[test]
     fn entity_source_tool_result_not_found_surfaces_error_not_missing_source() {
         use kin_cli::commands::graph::EntitySourceOutcome;

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -179,7 +179,10 @@ fn collection_len(payload: &Value, field: &str) -> Option<usize> {
 /// that an absence would certify a gap the ranking did not report.
 fn locate_result_count(payload: &Value) -> Option<usize> {
     if payload.get("routing").and_then(Value::as_str) == Some("fused-v1") {
-        let files = payload.get("files").and_then(Value::as_array).map(Vec::len)?;
+        let files = payload
+            .get("files")
+            .and_then(Value::as_array)
+            .map(Vec::len)?;
         let entities = payload
             .get("entities")
             .and_then(Value::as_array)
@@ -1808,8 +1811,12 @@ mod tests {
         // qualification at all — an honest-looking negative that had qualified
         // nothing.
         let payload = empty_fused_locate_page("where does the daemon start");
-        let negative =
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
         assert_eq!(negative["kind"], json!("no_ranked_match"));
         assert_eq!(negative["result_count"], json!(0));
         assert_eq!(negative["interpretation"], json!("absent_as_indexed"));
@@ -1826,8 +1833,12 @@ mod tests {
             "total_ranked": 0,
             "results": [],
         });
-        let negative =
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
         assert_eq!(negative["kind"], json!("no_ranked_match"));
         assert_eq!(negative["result_count"], json!(0));
     }
@@ -1838,9 +1849,12 @@ mod tests {
         let mut payload = empty_fused_locate_page("run_fused_locate_for_state");
         payload["entities"] = json!([fused_locate_hit("run_fused_locate_for_state")]);
         payload["total_ranked"] = json!(1);
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1849,9 +1863,12 @@ mod tests {
         // ranking never reported.
         let mut payload = empty_fused_locate_page("where does the daemon start");
         payload["files"] = json!([{ "path": "src/lib.rs", "score": 0.5 }]);
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1859,9 +1876,12 @@ mod tests {
         // Absence is never guessed: without `results` and without the `files`
         // that proves a fused page, emptiness is unknown, not zero.
         let payload = json!({ "query": "x", "routing": "fused-v1", "page": 0 });
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1875,8 +1895,12 @@ mod tests {
             .collect::<Vec<_>>());
         payload["total_ranked"] = json!(9);
         payload["all_fallback"] = json!(true);
-        let negative =
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
         assert_eq!(negative["kind"], json!("no_named_match"));
         assert_eq!(negative["interpretation"], json!("unnamed_ranking"));
         // Qualification, never filtering: every row served is still counted.
@@ -1894,9 +1918,12 @@ mod tests {
         let mut payload = empty_fused_locate_page("run_fused_locate_for_state");
         payload["entities"] = json!([fused_locate_hit("run_fused_locate_for_state")]);
         payload["total_ranked"] = json!(4);
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1908,9 +1935,12 @@ mod tests {
         payload["entities"] = json!([fused_locate_hit("submit_to_queue")]);
         payload["total_ranked"] = json!(3);
         payload["all_fallback"] = json!(true);
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1925,8 +1955,12 @@ mod tests {
                 cosine_locate_hit("neighbor_two", "partial"),
             ],
         });
-        let negative =
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        let negative = negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
         assert_eq!(negative["kind"], json!("no_named_match"));
         assert_eq!(negative["result_count"], json!(2));
     }
@@ -1943,9 +1977,12 @@ mod tests {
                 cosine_locate_hit("neighbor_two", "none"),
             ],
         });
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1959,9 +1996,12 @@ mod tests {
             "total_ranked": 9,
             "results": [cosine_locate_hit("neighbor_one", "none")],
         });
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1973,9 +2013,12 @@ mod tests {
             "total_ranked": 1,
             "results": [{ "name": "neighbor_one", "score": 0.2 }],
         });
-        assert!(
-            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
-        );
+        assert!(negative_for(
+            "semantic_locate",
+            &payload,
+            &semantic_authoritative_envelope()
+        )
+        .is_none());
     }
 
     #[test]
@@ -1985,7 +2028,9 @@ mod tests {
         assert!(query_names_a_symbol("LocateResult"));
         assert!(query_names_a_symbol("kin_mcp::negative"));
         assert!(query_names_a_symbol("AGENTS.md"));
-        assert!(!query_names_a_symbol("merge queue captain lane arbitration"));
+        assert!(!query_names_a_symbol(
+            "merge queue captain lane arbitration"
+        ));
         assert!(!query_names_a_symbol("Checks That Cannot Fail"));
         assert!(!query_names_a_symbol("graph-native repo substrate"));
         assert!(!query_names_a_symbol(""));

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -71,7 +71,9 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
             class: NegativeClass::Semantic,
         },
         // Daemon-only: offline returns an error (no payload), so this fires only
-        // on the daemon path, where the payload carries `results`.
+        // on the daemon path. `field` is the cosine arm's collection; the fused
+        // arm answers under a different key and is resolved by
+        // [`locate_result_count`], which this spec defers to.
         "semantic_locate" => RetrievalSpec {
             field: "results",
             kind: "no_ranked_match",
@@ -153,6 +155,106 @@ fn collection_len(payload: &Value, field: &str) -> Option<usize> {
     } else {
         payload.get(field).and_then(Value::as_array).map(Vec::len)
     }
+}
+
+/// Rows a `semantic_locate` page actually returned, whichever arm answered.
+///
+/// The two arms publish their hits under different keys, and the negative
+/// contract used to be written against the cosine arm's alone. The fused arm
+/// serializes a `LocateResult`, whose `entities` field is skipped when empty, so
+/// the exact page that most needs qualifying — a fused answer with nothing in it
+/// — carried neither an `entities` key nor a `results` one. [`collection_len`]
+/// therefore returned `None` and the whole payload was skipped, leaving an empty
+/// fused page reading as a bare, unqualified negative on the arm that serves
+/// every code-bearing store by default.
+///
+/// `files` is the discriminator rather than `entities`: `LocateResult`
+/// serializes it unconditionally, so its presence as an array is what proves a
+/// fused locate payload is in hand and an absent `entities` means "empty" rather
+/// than "not this shape". Absence is still never guessed — a payload carrying
+/// neither key returns `None` exactly as before.
+///
+/// Both surfaces count toward the total because both are answers: a store whose
+/// files rank but whose entities do not project has returned rows, and calling
+/// that an absence would certify a gap the ranking did not report.
+fn locate_result_count(payload: &Value) -> Option<usize> {
+    if payload.get("routing").and_then(Value::as_str) == Some("fused-v1") {
+        let files = payload.get("files").and_then(Value::as_array).map(Vec::len)?;
+        let entities = payload
+            .get("entities")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        return Some(files + entities);
+    }
+    collection_len(payload, "results")
+}
+
+/// True when a query token is identifier-shaped: the caller named a symbol
+/// rather than describing one in prose.
+///
+/// Deliberately narrower than the `is_symbolic_search_term` rule `kin-cli` uses
+/// to distill retrieval variants, and deliberately a separate copy: this one
+/// gates a claim in the response, never a ranking input, so it must not be able
+/// to drift into retrieval by being shared with it. Hyphens are excluded because
+/// ordinary prose hyphenates, and a rule that reads `graph-native` as a symbol
+/// name would qualify half of all English queries.
+fn query_names_a_symbol(query: &str) -> bool {
+    query.split_whitespace().any(|token| {
+        let core = token.trim_matches(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'));
+        core.len() >= 3
+            && (core.contains('_')
+                || core.contains("::")
+                || core.contains('.')
+                || core.chars().filter(|ch| ch.is_ascii_uppercase()).count() >= 2)
+    })
+}
+
+/// True when the query named a symbol and nothing in the ranking carries that
+/// name — a populated page that is not the answer it looks like.
+///
+/// Cosine ranking always returns its best candidates, so a query for a symbol
+/// that exists nowhere comes back as a full page of confidently-scored hits that
+/// is indistinguishable, field for field, from a page that found the symbol. The
+/// scores cannot separate them: they are ranks within a result set, not evidence
+/// that anything matched.
+///
+/// The verdict is read from what each arm already publishes about its FULL
+/// ranking, never from the page alone, because a page is a window: an exact name
+/// match sitting on page two would otherwise be reported as absent from the
+/// whole ranking.
+///
+/// - Fused arm: `all_fallback` is computed over the full ranking before paging
+///   and means precisely this, so it is used verbatim.
+/// - Cosine arm: every row's `match_evidence.name_match` is inspected, and only
+///   when the page holds the entire ranking. A row that reports no
+///   `match_evidence` at all leaves the question unanswered, so nothing is
+///   qualified — the same refusal to guess the rest of the module makes.
+fn locate_ranking_names_nothing(payload: &Value) -> bool {
+    if !payload
+        .get("query")
+        .and_then(Value::as_str)
+        .is_some_and(query_names_a_symbol)
+    {
+        return false;
+    }
+    if payload.get("routing").and_then(Value::as_str) == Some("fused-v1") {
+        return payload.get("all_fallback").and_then(Value::as_bool) == Some(true);
+    }
+    let Some(rows) = payload.get("results").and_then(Value::as_array) else {
+        return false;
+    };
+    let whole_ranking = payload
+        .get("total_ranked")
+        .and_then(Value::as_u64)
+        .is_some_and(|total| total <= rows.len() as u64);
+    whole_ranking
+        && !rows.is_empty()
+        && rows.iter().all(|row| {
+            row.get("match_evidence")
+                .and_then(|evidence| evidence.get("name_match"))
+                .and_then(Value::as_str)
+                .is_some_and(|name_match| name_match != "exact")
+        })
 }
 
 /// Render the envelope's embedding coverage as a compact, agent-readable object
@@ -339,6 +441,19 @@ fn absence_consequence(always: bool, trustworthy: bool) -> &'static str {
     }
 }
 
+/// The consequence sentence for a locate page that ranked hits but none the
+/// query named. Distinct from [`absence_consequence`], which speaks about an
+/// empty result: here the rows are real and stay ranked, and what is absent is
+/// the NAME, so the advice has to separate "these are neighbors" from "the
+/// symbol does not exist" instead of collapsing them into one verdict.
+fn unnamed_ranking_consequence(trustworthy: bool) -> &'static str {
+    if trustworthy {
+        "These hits are neighbors, not the symbol: no ranked entity carries the name the query asked for, and on a complete graph that means no entity carries it at all. Do not treat the top hit as the requested symbol."
+    } else {
+        "These hits are neighbors, not the symbol: no ranked entity carries the name the query asked for. The name's absence is NOT authoritative — it may simply not be indexed yet — so do not conclude the symbol does not exist. Re-check after embedding is complete and the daemon is healthy."
+    }
+}
+
 /// The kind the payload reports for its focal entity, whichever shape carries
 /// it: `find_references` nests the focal under `focal_entity`, `trace_data_flow`
 /// reports it flat as `focal_kind`.
@@ -496,8 +611,18 @@ fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
 /// beside the existing payload keys, never replacing them.
 pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<Value> {
     let spec = spec_for(tool)?;
-    let count = collection_len(payload, spec.field)?;
-    if count != 0 && !spec.always {
+    let count = if tool == "semantic_locate" {
+        locate_result_count(payload)?
+    } else {
+        collection_len(payload, spec.field)?
+    };
+    // A locate page has a second way of being a negative: it came back full, and
+    // not one hit is the symbol the query named. Qualifying that page is the
+    // whole point — the rows are real neighbors and stay exactly as ranked, so
+    // this reports rather than filters, and a weak-but-real hit is never dropped
+    // to hide a wrong one.
+    let ranking_names_nothing = tool == "semantic_locate" && locate_ranking_names_nothing(payload);
+    if count != 0 && !spec.always && !ranking_names_nothing {
         return None;
     }
 
@@ -544,6 +669,11 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // the traversal never reached.
     let mut kind = spec.kind;
     let mut subject = spec.subject;
+    if ranking_names_nothing {
+        kind = "no_named_match";
+        subject = "the query named a symbol and no ranked entity carries that name; \
+                   every hit was surfaced by content or embedding similarity";
+    }
     if tool == "graph_neighborhood" {
         // The emitted edge array is capped by the caller's `limit`, and a
         // `limit` of zero empties it while the walk still found neighbors. The
@@ -616,10 +746,17 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         }
     }
 
-    let interpretation = if spec.always {
+    let interpretation = if ranking_names_nothing {
+        "unnamed_ranking"
+    } else if spec.always {
         "qualified_verdicts"
     } else {
         "absent_as_indexed"
+    };
+    let consequence = if ranking_names_nothing {
+        unnamed_ranking_consequence(trustworthy)
+    } else {
+        absence_consequence(spec.always, trustworthy)
     };
 
     let mut negative = Map::new();
@@ -648,11 +785,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     );
     negative.insert(
         "advice".to_string(),
-        json!(build_advice(
-            subject,
-            absence_consequence(spec.always, trustworthy),
-            envelope
-        )),
+        json!(build_advice(subject, consequence, envelope)),
     );
     Some(Value::Object(negative))
 }
@@ -1624,5 +1757,237 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("structural_authoritative"));
+    }
+
+    /// An empty fused `semantic_locate` page exactly as the daemon serializes
+    /// it: `LocateResult` skips `entities` when the vector is empty, so the key
+    /// is ABSENT rather than an empty array, and `files` is the only collection
+    /// on the wire.
+    fn empty_fused_locate_page(query: &str) -> Value {
+        json!({
+            "query": query,
+            "granularity": "entity",
+            "routing": "fused-v1",
+            "page": 0,
+            "files": [],
+        })
+    }
+
+    fn fused_locate_hit(name: &str) -> Value {
+        json!({
+            "entity_id": "00000000-0000-0000-0000-0000000000aa",
+            "kind": "function",
+            "name": name,
+            "score": 0.42,
+            "definition": true,
+            "provenance": { "file": "src/lib.rs" },
+        })
+    }
+
+    fn cosine_locate_hit(name: &str, name_match: &str) -> Value {
+        json!({
+            "kind": "function",
+            "name": name,
+            "score": 0.31,
+            "id_space": "entity",
+            "entity_id": "00000000-0000-0000-0000-0000000000bb",
+            "provenance": { "file": "src/lib.rs" },
+            "match_evidence": {
+                "ranker": "cosine-v0",
+                "score_source": "vector_cosine",
+                "name_match": name_match,
+                "reranked": false,
+            },
+        })
+    }
+
+    #[test]
+    fn empty_fused_locate_page_carries_the_negative() {
+        // FIR-2170: the fused arm is the default for code-bearing stores, and
+        // its empty page used to reach an agent as a bare `files: []` with no
+        // qualification at all — an honest-looking negative that had qualified
+        // nothing.
+        let payload = empty_fused_locate_page("where does the daemon start");
+        let negative =
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        assert_eq!(negative["kind"], json!("no_ranked_match"));
+        assert_eq!(negative["result_count"], json!(0));
+        assert_eq!(negative["interpretation"], json!("absent_as_indexed"));
+        assert_eq!(negative["trust"], json!("authoritative"));
+    }
+
+    #[test]
+    fn empty_cosine_locate_page_keeps_its_negative() {
+        // The control the fix must not break: the arm that already qualified.
+        let payload = json!({
+            "query": "where does the daemon start",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 0,
+            "results": [],
+        });
+        let negative =
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        assert_eq!(negative["kind"], json!("no_ranked_match"));
+        assert_eq!(negative["result_count"], json!(0));
+    }
+
+    #[test]
+    fn populated_fused_locate_page_carries_no_negative() {
+        // The other control: a page that answered is not qualified at all.
+        let mut payload = empty_fused_locate_page("run_fused_locate_for_state");
+        payload["entities"] = json!([fused_locate_hit("run_fused_locate_for_state")]);
+        payload["total_ranked"] = json!(1);
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn fused_page_with_ranked_files_but_no_entities_is_not_an_absence() {
+        // Rows came back. Calling that an absence would certify a gap the
+        // ranking never reported.
+        let mut payload = empty_fused_locate_page("where does the daemon start");
+        payload["files"] = json!([{ "path": "src/lib.rs", "score": 0.5 }]);
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn locate_payload_carrying_neither_collection_yields_no_negative() {
+        // Absence is never guessed: without `results` and without the `files`
+        // that proves a fused page, emptiness is unknown, not zero.
+        let payload = json!({ "query": "x", "routing": "fused-v1", "page": 0 });
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn fabricated_symbol_gets_a_full_fused_page_qualified_as_unnamed() {
+        // FIR-2178: five confidently-scored hits for a symbol that exists
+        // nowhere. The page is real and stays whole; what it is NOT is the
+        // symbol that was asked for, and that is now stated.
+        let mut payload = empty_fused_locate_page("zzqqxx_nonexistent_symbol_9f3a");
+        payload["entities"] = json!((0..5)
+            .map(|index| fused_locate_hit(&format!("neighbor_{index}")))
+            .collect::<Vec<_>>());
+        payload["total_ranked"] = json!(9);
+        payload["all_fallback"] = json!(true);
+        let negative =
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        assert_eq!(negative["kind"], json!("no_named_match"));
+        assert_eq!(negative["interpretation"], json!("unnamed_ranking"));
+        // Qualification, never filtering: every row served is still counted.
+        assert_eq!(negative["result_count"], json!(5));
+        assert!(negative["advice"]
+            .as_str()
+            .unwrap()
+            .contains("neighbors, not the symbol"));
+    }
+
+    #[test]
+    fn real_symbol_page_stays_unqualified() {
+        // The control that keeps the qualifier meaningful: a query naming a
+        // symbol the ranking holds gets no negative at all.
+        let mut payload = empty_fused_locate_page("run_fused_locate_for_state");
+        payload["entities"] = json!([fused_locate_hit("run_fused_locate_for_state")]);
+        payload["total_ranked"] = json!(4);
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn prose_query_over_fallback_hits_is_not_qualified_as_unnamed() {
+        // `all_fallback` fires on natural-language queries whose top hits are
+        // correct, so it cannot be the whole rule. A qualifier that fired there
+        // too is one an agent learns to ignore.
+        let mut payload = empty_fused_locate_page("merge queue captain lane arbitration");
+        payload["entities"] = json!([fused_locate_hit("submit_to_queue")]);
+        payload["total_ranked"] = json!(3);
+        payload["all_fallback"] = json!(true);
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn cosine_page_naming_nothing_is_qualified() {
+        let payload = json!({
+            "query": "zzqqxx_nonexistent_symbol_9f3a",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 2,
+            "results": [
+                cosine_locate_hit("neighbor_one", "none"),
+                cosine_locate_hit("neighbor_two", "partial"),
+            ],
+        });
+        let negative =
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).unwrap();
+        assert_eq!(negative["kind"], json!("no_named_match"));
+        assert_eq!(negative["result_count"], json!(2));
+    }
+
+    #[test]
+    fn cosine_page_holding_an_exact_name_match_is_not_qualified() {
+        let payload = json!({
+            "query": "locate_result_count",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 2,
+            "results": [
+                cosine_locate_hit("locate_result_count", "exact"),
+                cosine_locate_hit("neighbor_two", "none"),
+            ],
+        });
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn cosine_page_shorter_than_its_ranking_is_not_qualified() {
+        // A page is a window. An exact name match on page two must not be
+        // reported as absent from the whole ranking.
+        let payload = json!({
+            "query": "zzqqxx_nonexistent_symbol_9f3a",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 9,
+            "results": [cosine_locate_hit("neighbor_one", "none")],
+        });
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn cosine_row_without_match_evidence_leaves_the_page_unqualified() {
+        let payload = json!({
+            "query": "zzqqxx_nonexistent_symbol_9f3a",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 1,
+            "results": [{ "name": "neighbor_one", "score": 0.2 }],
+        });
+        assert!(
+            negative_for("semantic_locate", &payload, &semantic_authoritative_envelope()).is_none()
+        );
+    }
+
+    #[test]
+    fn symbol_shape_rule_separates_identifiers_from_prose() {
+        assert!(query_names_a_symbol("zzqqxx_nonexistent_symbol_9f3a"));
+        assert!(query_names_a_symbol("where is semantic_locate defined"));
+        assert!(query_names_a_symbol("LocateResult"));
+        assert!(query_names_a_symbol("kin_mcp::negative"));
+        assert!(query_names_a_symbol("AGENTS.md"));
+        assert!(!query_names_a_symbol("merge queue captain lane arbitration"));
+        assert!(!query_names_a_symbol("Checks That Cannot Fail"));
+        assert!(!query_names_a_symbol("graph-native repo substrate"));
+        assert!(!query_names_a_symbol(""));
     }
 }


### PR DESCRIPTION
`semantic_locate` has two arms and the negative contract only ever covered one of them.

The registry entry named `results` as the tool's result collection, which is the cosine arm's key. The fused arm serializes a `LocateResult`, and that struct skips `entities` when the vector is empty. So the exact page that most needed qualifying, a fused answer with nothing in it, arrived carrying neither key: `collection_len` returned `None`, `negative_for` skipped the payload whole, and an empty page reached the agent as a bare result with no freshness, no coverage, and no verdict. That is the arm serving every code-bearing store by default, so the honesty envelope was absent exactly where it was load-bearing. Worth noting the shape, because it is not the one the struct definition suggests: `entities` is absent rather than empty, so a fixture built from the type would have passed on both sides of the bug.

The collection is now resolved per arm. `files` is the discriminator rather than `entities`, since `LocateResult` serializes it unconditionally, so its presence as an array is what proves a fused payload is in hand and lets an absent `entities` mean empty instead of unknown. A payload carrying neither key still yields no negative, because absence is never guessed. Both surfaces count toward the total: a store whose files rank but whose entities do not project has returned rows, and calling that an absence would certify a gap the ranking never reported.

The second half is the page that comes back full and still is not an answer. Cosine ranking always returns its best candidates, so a query for a symbol that exists nowhere produces a page of confidently scored hits that is field for field indistinguishable from a page that found it. The scores cannot separate them, because they are ranks within a result set rather than evidence that anything matched. Such a page is now qualified as `no_named_match` when the query carries an identifier-shaped token and the full ranking names nothing.

Two things keep that qualifier honest. It reads the full ranking, never the page: the fused arm's `all_fallback` is already computed over the whole ranking before paging, and the cosine arm's per-row `match_evidence.name_match` is consulted only when the page holds the entire ranking, so an exact match sitting on page two is never reported as absent. And it reports rather than filters. Every row stays ranked and counted, so a weak-but-real hit is never dropped to hide a wrong one.

`all_fallback` alone could not be the rule. It also fires on prose queries whose top hits are correct, and a qualifier that fires there is one an agent learns to ignore, so the identifier-shape gate is what makes the claim precise: the query named a symbol, and this ranking does not contain it. The shape rule is deliberately a separate, narrower copy of the one retrieval uses to distill query variants, because it gates a claim in the response and must not be able to drift into ranking by being shared with it.

Fourteen tests cover both halves, each paired with the control that must not change: an empty cosine page keeps its negative, a populated page carrying the named symbol gets none, a fused page whose files rank but whose entities do not project is not an absence, a payload with neither collection stays unqualified, a prose query over fallback hits is not flagged, a cosine page shorter than its ranking is not flagged, and a row without `match_evidence` leaves the page alone. Three of them build the payload through `fused_semantic_locate_payload` itself rather than by hand, so the empty page under test is byte-identical to the one an agent receives.

Reverting the two fix hunks fails five tests across the workspace, the three negative-contract tests in kin-mcp and the two serializer-driven checks in the daemon api suite, all on the symptom of no negative being synthesized, with every control still passing.

Closes FIR-2170
Closes FIR-2178

