### PR TITLE
Split the Windows authority job and budget its steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,11 +159,11 @@ jobs:
     # caps, and they sum to less than this on purpose. A step that overruns its
     # budget FAILS, and a failed step names itself on the check. A job that hits
     # its own cap is CANCELLED, and a cancellation on a check no ruleset
-    # requires says nothing at all: the four cap-outs found on 2026-08-10 each
-    # had every substantive step green and were noticed only by reading run
-    # durations. Keeping the sum under this number is what makes the loud
-    # failure arrive first whichever step is the slow one, and the authority
-    # test holds that arithmetic.
+    # requires says nothing at all: every sampled cap-out carried green
+    # substantive steps and was found by reading run durations rather than by
+    # anything going red. Keeping the sum under this number is what makes the
+    # loud failure arrive first whichever step is the slow one, and the
+    # authority test holds that arithmetic.
     timeout-minutes: 80
     steps:
       - name: Preserve tracked bytes on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
           bash -n ./scripts/publish-npm-release.sh
           bash -n ./scripts/verify-npm-release.sh
           bash -n ./scripts/assert-windows-init-contract.sh
+          bash -n ./scripts/windows-authority-legs.sh
           bash -n ./scripts/verify-base-image-pins.sh
           # install.sh is the public installer users pipe straight into a shell,
           # and the one with no pull-request syntax check. Its only `sh -n` runs
@@ -131,13 +132,39 @@ jobs:
     # build share no artifacts (separate target profiles), so serialising them
     # only added wall clock. They run concurrently now.
     #
-    # This job stays on every event on purpose, and the authority test enforces
-    # that it carries no job-level `if:`. It is the merge group's only proof of
-    # the native Windows admission contract, so taking it off the queue to reclaim its
+    # This job and the two Windows authority jobs below stay on every event on
+    # purpose, and the authority test enforces that none of them carries a
+    # job-level `if:`. Together they are the merge group's only proof of the
+    # native Windows admission contract, so taking them off the queue to reclaim
     # runner minutes would trade a reviewable pre-landing signal for a required
     # context that first fails on main.
+    #
+    # The legs were split three ways by compilation unit because one job could
+    # not finish inside any cap worth setting. Across 119 sampled runs, 32 of
+    # the 106 allowed to finish were destroyed by the 60-minute limit, and on
+    # pull requests that was half of them. The 70 survivors averaged 52.6
+    # minutes and reached 59.7, so the sample is censored by the cap itself and
+    # the real mean is near 57. This job keeps the admission contract, both npm
+    # surfaces, and the library legs that build no test binary; the CLI and
+    # runtime jobs below take the rest. Each compiles one kind of artifact, so
+    # none waits on another's build.
+    #
+    # The binary build, the admission assertion, and the npm first-run proof run
+    # ahead of the library legs rather than after them. They used to be the last
+    # three steps, which is exactly where every cap-out landed, so an admission
+    # regression could not be reported until fifty minutes of unrelated tests
+    # had passed first.
     runs-on: windows-latest
-    timeout-minutes: 60
+    # This is a backstop, not the budget. The step budgets below are the real
+    # caps, and they sum to less than this on purpose. A step that overruns its
+    # budget FAILS, and a failed step names itself on the check. A job that hits
+    # its own cap is CANCELLED, and a cancellation on a check no ruleset
+    # requires says nothing at all: the four cap-outs found on 2026-08-10 each
+    # had every substantive step green and were noticed only by reading run
+    # durations. Keeping the sum under this number is what makes the loud
+    # failure arrive first whichever step is the slow one, and the authority
+    # test holds that arithmetic.
+    timeout-minutes: 80
     steps:
       - name: Preserve tracked bytes on Windows
         shell: bash
@@ -181,134 +208,69 @@ jobs:
       # warm start for one entry every pull request restores from push 1.
       # The tradeoff is real and measured: see the trusted-ref note in
       # scripts/test-release-workflow-authority.py.
+      #
+      # `cache-on-failure` is what stops a bad run from compounding into the
+      # next one. The save is a post step and rust-cache gates it on
+      # `success() || env.CACHE_ON_FAILURE == 'true'`, so at the default every
+      # run that does not end green discards everything it compiled. That is not
+      # theoretical: all four sampled red runs and every one of the 32 sampled
+      # cap-outs skipped the save, which is why a slow afternoon left each
+      # following run colder than the one before it. Setting this makes the
+      # condition unconditional, so the artifacts survive a red run or a
+      # cancelled one.
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
 
-      # `daemon_status_and_stop_lifecycle` drives a real daemon, and the harness
-      # takes it from the `kin-daemon` beside the `kin` binary the test was
-      # built with. Every other `kin-daemon` invocation below compiles `--lib`,
-      # and the step that builds the binary runs after the tests, so nothing put
-      # a `kin-daemon.exe` in the msvc directory before the test read it. The
-      # harness covers a missing daemon by rebuilding one, which lands beside
-      # the test only when it carries the same `--target`, so a leg that omits
-      # this build depends on that rebuild rather than on its own inputs. The
-      # feature set matches the binary build below, so both produce one artifact.
-      - name: Build the sibling Windows daemon the authority tests drive
+      # The three steps below are the pull-request half of the Windows admission
+      # contract. The installer leg asserts the same behavior against the
+      # release binary, but it runs only on the landing push, so on its own it
+      # can report an admission change no earlier than a required check
+      # failing on a release commit. This leg builds without default features
+      # and the installer leg builds with them, so the shared script asserts
+      # the same refusals against both feature sets of the command.
+      - name: Build the Windows binaries the admission and npm assertions drive
         shell: bash
+        timeout-minutes: 25
         run: |
           set -euo pipefail
           cargo build --locked --target x86_64-pc-windows-msvc \
-            -p kin-daemon --no-default-features --bin kin-daemon
+            -p kin-cli -p kin-daemon --no-default-features \
+            --bin kin --bin kin-daemon
 
-      - name: Compile and run native Windows authority tests
+      - name: Assert the Windows admission contract
         shell: bash
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          bash ./scripts/assert-windows-init-contract.sh \
+            "$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/debug/kin.exe" \
+            "$RUNNER_TEMP/kin-windows-admission"
+
+      - name: Prove both npm surfaces from built Windows binaries
+        shell: bash
+        timeout-minutes: 10
+        env:
+          KIN_NPM_PROOF_KIN_BIN: ${{ github.workspace }}/target/x86_64-pc-windows-msvc/debug/kin.exe
+          KIN_NPM_PROOF_DAEMON_BIN: ${{ github.workspace }}/target/x86_64-pc-windows-msvc/debug/kin-daemon.exe
+        run: |
+          set -euo pipefail
+          node ./scripts/prove-windows-npm-first-run.mjs
+
+      # Library legs only: every invocation here compiles a `--lib` test binary
+      # or nothing at all. The kin-cli unit legs and the integration-test
+      # binaries live in the two jobs below because they are the expensive
+      # compilation units, and keeping them here is what made one job unable to
+      # finish inside any cap worth setting.
+      - name: Compile and run native Windows core authority tests
+        shell: bash
+        timeout-minutes: 30
         run: |
           set -euo pipefail
           export RUST_BACKTRACE=1
-
-          list_tests() {
-            CARGO_TERM_COLOR=never cargo test "$@" -- --list | tr -d '\r'
-          }
-
-          assert_nonempty_listing() {
-            local label="$1"
-            local listing="$2"
-            local count
-            count="$(printf '%s\n' "$listing" \
-              | awk '/: test$/ { count += 1 } END { print count + 0 }')"
-            if [[ "$count" -eq 0 ]]; then
-              echo "::error title=Missing native Windows tests::$label listed zero tests"
-              printf '%s\n' "$listing"
-              exit 1
-            fi
-            echo "$label: listed $count test(s)"
-          }
-
-          run_nonempty_target() {
-            local label="$1"
-            shift
-            local listing
-            listing="$(list_tests "$@")"
-            assert_nonempty_listing "$label" "$listing"
-            cargo test "$@" -- --test-threads=1
-          }
-
-          run_required_filter() {
-            local label="$1"
-            local filter="$2"
-            shift 2
-            local listing
-            local matches
-            listing="$(list_tests "$@")"
-            matches="$(printf '%s\n' "$listing" \
-              | awk -v needle="$filter" \
-                'index($0, needle) > 0 && /: test$/ { count += 1 } END { print count + 0 }')"
-            if [[ "$matches" -eq 0 ]]; then
-              echo "::error title=Missing native Windows tests::$label filter '$filter' matched zero listed tests"
-              printf '%s\n' "$listing"
-              exit 1
-            fi
-            echo "$label: filter '$filter' matched $matches test(s)"
-            cargo test "$@" "$filter" -- --test-threads=1
-          }
-
-          run_required_exact() {
-            local label="$1"
-            local test_name="$2"
-            shift 2
-            local listing
-            local matches
-            listing="$(list_tests "$@")"
-            matches="$(printf '%s\n' "$listing" \
-              | awk -v expected="$test_name: test" \
-                '$0 == expected { count += 1 } END { print count + 0 }')"
-            if [[ "$matches" -ne 1 ]]; then
-              echo "::error title=Missing native Windows test::$label expected exactly one '$test_name', found $matches"
-              printf '%s\n' "$listing"
-              exit 1
-            fi
-            cargo test "$@" "$test_name" -- --exact --test-threads=1
-          }
-
-          run_required_target() {
-            local label="$1"
-            local required_test="$2"
-            shift 2
-            local listing
-            local matches
-            listing="$(list_tests "$@")"
-            assert_nonempty_listing "$label" "$listing"
-            matches="$(printf '%s\n' "$listing" \
-              | awk -v expected="$required_test: test" \
-                '$0 == expected { count += 1 } END { print count + 0 }')"
-            if [[ "$matches" -ne 1 ]]; then
-              echo "::error title=Missing native Windows test::$label expected exactly one '$required_test', found $matches"
-              printf '%s\n' "$listing"
-              exit 1
-            fi
-            cargo test "$@" -- --test-threads=1
-          }
-
-          compile_required_target() {
-            local label="$1"
-            local required_test="$2"
-            shift 2
-            local listing
-            local matches
-            listing="$(list_tests "$@")"
-            assert_nonempty_listing "$label" "$listing"
-            matches="$(printf '%s\n' "$listing" \
-              | awk -v expected="$required_test: test" \
-                '$0 == expected { count += 1 } END { print count + 0 }')"
-            if [[ "$matches" -ne 1 ]]; then
-              echo "::error title=Missing native Windows compile target::$label expected exactly one '$required_test', found $matches"
-              printf '%s\n' "$listing"
-              exit 1
-            fi
-            echo "$label: compiled and listed required test '$required_test'"
-          }
+          source ./scripts/windows-authority-legs.sh
 
           run_nonempty_target "kin-registry library" \
             --locked --target x86_64-pc-windows-msvc \
@@ -335,35 +297,82 @@ jobs:
           run_nonempty_target "kin-git library" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-git --lib
-          run_required_filter "kin-cli Windows modules" "windows" \
-            --locked --target x86_64-pc-windows-msvc \
-            -p kin-cli --no-default-features --lib
+          # Stays in this job rather than moving to the CLI one: the npm proof
+          # above asserts that the compatibility wrapper finds its sibling
+          # daemon, and this is the unit case for the discovery it depends on.
+          # Separating them would let one job claim a runtime behavior whose
+          # only unit proof lives in a job that can go red on its own.
           run_required_exact "MCP Windows sibling daemon discovery" \
             "daemon_delegate::tests::windows_daemon_discovery_finds_platform_sibling_without_path" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-mcp --no-default-features --lib
-          # Full uninstall owns native Windows process handles, directory
-          # identity, and deferred self-deletion. Compiling these paths on a
-          # non-Windows host cannot prove their runtime contract, so keep both
-          # the focused unit surface and the real daemon lifecycle in the
-          # permanent Windows authority leg.
-          run_required_filter "full managed uninstall safety" \
-            "commands::setup::tests::full_uninstall" \
-            --locked --target x86_64-pc-windows-msvc \
-            -p kin-cli --no-default-features --lib
           # Admission itself, in process. `kin init` is the transaction the
-          # contract script drives end to end, but that script runs two steps
-          # later and reports one line naming a path that two different
-          # components can report. These cases stage, publish, seal, and
-          # promote a repository through the same code the binary does, so a
-          # refusal names a test and a line instead of a path. Until this
-          # existed, `init.rs` had no native Windows coverage at all, which is
-          # why a refusal in it could only be seen by a thirty-minute job that
-          # then could not say which call refused.
+          # contract script drives end to end, but that script reports one line
+          # naming a path that two different components can report. These cases
+          # stage, publish, seal, and promote a repository through the same code
+          # the binary does, so a refusal names a test and a line instead of a
+          # path. Until this existed, `init.rs` had no native Windows coverage
+          # at all, which is why a refusal in it could only be seen by a
+          # thirty-minute job that then could not say which call refused.
           run_required_filter "kin-core repository initialization" \
             "init::tests" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-core --lib
+          run_required_filter "managed-install spawn fence" \
+            "managed_spawn_fence" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-daemon-spawn --lib
+          run_required_filter "daemon shutdown identity" "shutdown" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-daemon --no-default-features --lib
+
+  windows-authority-cli-tests:
+    name: Windows authority CLI tests
+    # Every leg here is `-p kin-cli --no-default-features --lib`, which is one
+    # compilation unit and the single most expensive one in the Windows set.
+    # Splitting on that boundary is why the three jobs do not duplicate each
+    # other's compile: this one builds the CLI unit-test binary, the job above
+    # builds the library ones, and the job below builds the integration ones.
+    #
+    # Full uninstall owns native Windows process handles, directory identity,
+    # and deferred self-deletion. Compiling these paths on a non-Windows host
+    # cannot prove their runtime contract, so they stay on a permanent native
+    # Windows leg.
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Preserve tracked bytes on Windows
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+
+      - name: Compile and run native Windows CLI authority tests
+        shell: bash
+        timeout-minutes: 35
+        run: |
+          set -euo pipefail
+          export RUST_BACKTRACE=1
+          source ./scripts/windows-authority-legs.sh
+
+          run_required_filter "kin-cli Windows modules" "windows" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-cli --no-default-features --lib
+          run_required_filter "full managed uninstall safety" \
+            "commands::setup::tests::full_uninstall" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-cli --no-default-features --lib
           run_required_exact "native full managed uninstall lifecycle" \
             "commands::setup::tests::native_full_uninstall_runtime_executes_retirement_and_user_path_cleanup" \
             --locked --target x86_64-pc-windows-msvc \
@@ -380,17 +389,6 @@ jobs:
             "commands::update::tests::managed_daemon_spawn_lease_blocks_uninstall_authority_until_readiness" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-cli --no-default-features --lib
-          run_required_filter "managed-install spawn fence" \
-            "managed_spawn_fence" \
-            --locked --target x86_64-pc-windows-msvc \
-            -p kin-daemon-spawn --lib
-          run_required_filter "daemon shutdown identity" "shutdown" \
-            --locked --target x86_64-pc-windows-msvc \
-            -p kin-daemon --no-default-features --lib
-          run_required_target "daemon status and stop lifecycle" \
-            "daemon_status_and_stop_lifecycle" \
-            --locked --target x86_64-pc-windows-msvc \
-            -p kin-cli --no-default-features --test daemon_stop
           run_required_filter "bounded CLI test subprocesses" \
             "commands::test_subprocess::tests" \
             --locked --target x86_64-pc-windows-msvc \
@@ -399,6 +397,62 @@ jobs:
             "daemon_client::probe_process::tests" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-cli --no-default-features --lib
+
+  windows-authority-runtime-tests:
+    name: Windows authority runtime tests
+    # The integration-test binaries: real daemons, real process trees, real
+    # containment. These are the legs that spend their time running rather than
+    # compiling, which is why they belong away from the unit legs instead of
+    # queued behind them.
+    runs-on: windows-latest
+    timeout-minutes: 70
+    steps:
+      - name: Preserve tracked bytes on Windows
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+
+      # `daemon_status_and_stop_lifecycle` drives a real daemon, and the harness
+      # takes it from the `kin-daemon` beside the `kin` binary the test was
+      # built with. Every other `kin-daemon` invocation in this job compiles a
+      # test binary, which writes no `kin-daemon.exe`, so nothing else puts one
+      # in the msvc directory before the test reads it. The harness covers a
+      # missing daemon by rebuilding one, which lands beside the test only when
+      # it carries the same `--target`, so a leg that omits this build depends
+      # on that rebuild rather than on its own inputs. The feature set matches
+      # the binary build in the admission job, so both produce one artifact.
+      - name: Build the sibling Windows daemon the authority tests drive
+        shell: bash
+        timeout-minutes: 25
+        run: |
+          set -euo pipefail
+          cargo build --locked --target x86_64-pc-windows-msvc \
+            -p kin-daemon --no-default-features --bin kin-daemon
+
+      - name: Compile and run native Windows runtime authority tests
+        shell: bash
+        timeout-minutes: 35
+        run: |
+          set -euo pipefail
+          export RUST_BACKTRACE=1
+          source ./scripts/windows-authority-legs.sh
+
+          run_required_target "daemon status and stop lifecycle" \
+            "daemon_status_and_stop_lifecycle" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-cli --no-default-features --test daemon_stop
           run_required_target "spawned-child Windows authority ordering" \
             "spawned_child_observes_case_insensitive_authority_order" \
             --locked --target x86_64-pc-windows-msvc \
@@ -422,38 +476,6 @@ jobs:
             "concurrent_resolutions_from_one_view_leave_one_winner" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-cli --no-default-features --test repository_merge_resolution
-
-      # The two steps below are the pull-request half of the Windows admission
-      # contract. The installer leg asserts the same behavior against the
-      # release binary, but it runs only on the landing push, so on its own it
-      # can report an admission change no earlier than a required check
-      # failing on a release commit. This leg builds without default features
-      # and the installer leg builds with them, so the shared script asserts
-      # the same refusals against both feature sets of the command.
-      - name: Build the Windows binaries the admission and npm assertions drive
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build --locked --target x86_64-pc-windows-msvc \
-            -p kin-cli -p kin-daemon --no-default-features \
-            --bin kin --bin kin-daemon
-
-      - name: Assert the Windows admission contract
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash ./scripts/assert-windows-init-contract.sh \
-            "$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/debug/kin.exe" \
-            "$RUNNER_TEMP/kin-windows-admission"
-
-      - name: Prove both npm surfaces from built Windows binaries
-        shell: bash
-        env:
-          KIN_NPM_PROOF_KIN_BIN: ${{ github.workspace }}/target/x86_64-pc-windows-msvc/debug/kin.exe
-          KIN_NPM_PROOF_DAEMON_BIN: ${{ github.workspace }}/target/x86_64-pc-windows-msvc/debug/kin-daemon.exe
-        run: |
-          set -euo pipefail
-          node ./scripts/prove-windows-npm-first-run.mjs
 
   windows-installer:
     # Renamed from "Windows installer + vector-free release build" when native

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -461,6 +461,8 @@ CI_JOB_DISPLAY_NAMES = {
     "dco": "DCO Sign-off",
     "npm-launchers": "npm launcher tests",
     "windows-authority-tests": "Windows authority tests",
+    "windows-authority-cli-tests": "Windows authority CLI tests",
+    "windows-authority-runtime-tests": "Windows authority runtime tests",
     "windows-installer": "Windows installer + vector release build",
     "changes": "Classify diff scope",
     "check-docs-only": "Check & Test",
@@ -2802,7 +2804,7 @@ WINDOWS_DAEMON_SIBLING_BUILD = (
     "- name: Build the sibling Windows daemon the authority tests drive"
 )
 WINDOWS_DAEMON_COMPILE_STEP = (
-    "- name: Compile and run native Windows authority tests"
+    "- name: Compile and run native Windows runtime authority tests"
 )
 WINDOWS_DAEMON_LIFECYCLE_TEST = '"daemon_status_and_stop_lifecycle"'
 
@@ -2854,6 +2856,109 @@ def assert_windows_daemon_sibling_build(ci_job: str) -> None:
         WINDOWS_DAEMON_LIFECYCLE_TEST,
         "native Windows daemon lifecycle prerequisite",
     )
+
+
+WINDOWS_AUTHORITY_JOBS = (
+    "windows-authority-tests",
+    "windows-authority-cli-tests",
+    "windows-authority-runtime-tests",
+)
+WINDOWS_AUTHORITY_LEG_HELPERS = "source ./scripts/windows-authority-legs.sh"
+# Every native Windows leg, wherever it runs. The set is what the three jobs
+# owe between them, so splitting or rebalancing them stays a free choice while
+# dropping one does not: a leg that leaves this file has to leave it visibly.
+WINDOWS_AUTHORITY_LEGS = (
+    "kin-registry library",
+    "kin-core registry authority",
+    "kin-core capability-owned config replacement",
+    "retained config capability exclusion",
+    "kin-git library",
+    "MCP Windows sibling daemon discovery",
+    "kin-core repository initialization",
+    "managed-install spawn fence",
+    "daemon shutdown identity",
+    "kin-cli Windows modules",
+    "full managed uninstall safety",
+    "native full managed uninstall lifecycle",
+    "native managed-daemon ownership scan",
+    "native install authority contention and crash recovery",
+    "native managed-daemon spawn admission",
+    "bounded CLI test subprocesses",
+    "bounded daemon probe subprocesses",
+    "daemon status and stop lifecycle",
+    "spawned-child Windows authority ordering",
+    "isolated runtime process-tree containment",
+    "direct daemon-child containment",
+    "late daemon-descendant containment",
+    "daemon isolation support",
+    "durable merge resolution containment compile",
+)
+
+
+def assert_windows_authority_split(ci_jobs: dict[str, str]) -> None:
+    """Hold the three native Windows jobs to what one job used to owe.
+
+    The legs were split across three jobs because one job could not finish
+    inside any cap worth setting: across 119 sampled runs, 32 of the 106 allowed
+    to finish were destroyed by the 60-minute limit, and the 70 survivors
+    averaged 52.6 minutes against it. Three things have to stay true for the
+    split to be an improvement rather than a way to lose coverage quietly.
+
+    Every leg still runs exactly once. A split is the cheapest possible place to
+    drop a test, because the leg simply is not in the job you are reading and
+    the other job looks complete on its own.
+
+    No job takes a job-level `if:`. These jobs are the merge group's only proof
+    of the native Windows admission contract, and that reasoning did not change
+    when one job became three.
+
+    The step budgets sum to less than the job cap. GitHub CANCELS a job that
+    hits its own timeout, and a cancelled job is silent on a check no ruleset
+    requires and skips its cache save, so the next run starts colder than the
+    one that timed out. A step that overruns its own budget FAILS instead, which
+    is loud and still runs the save. Keeping the sum under the cap is what makes
+    the loud failure arrive first, whichever step is the slow one.
+    """
+
+    combined = "\n".join(
+        "\n".join(active_lines(ci_jobs[job])) for job in WINDOWS_AUTHORITY_JOBS
+    )
+    for leg in WINDOWS_AUTHORITY_LEGS:
+        occurrences = combined.count(f'"{leg}"')
+        if occurrences != 1:
+            raise AssertionError(
+                "the native Windows authority jobs must run every reviewed leg "
+                f"exactly once; '{leg}' appears {occurrences} times across "
+                + ", ".join(WINDOWS_AUTHORITY_JOBS)
+            )
+
+    for job_id in WINDOWS_AUTHORITY_JOBS:
+        block = ci_jobs[job_id]
+        if re.search(r"(?m)^    if:", block) is not None:
+            raise AssertionError(
+                "the Windows authority jobs must stay on every event, so "
+                "admission behavior is asserted before a release commit can "
+                f"carry it: {job_id}"
+            )
+        require(block, WINDOWS_AUTHORITY_LEG_HELPERS, f"shared leg helpers in {job_id}")
+        job_cap = re.search(r"(?m)^    timeout-minutes: (?P<cap>\d+)$", block)
+        if job_cap is None:
+            raise AssertionError(f"{job_id} must declare one job timeout")
+        step_budgets = [
+            int(budget)
+            for budget in re.findall(r"(?m)^        timeout-minutes: (\d+)$", block)
+        ]
+        if not step_budgets:
+            raise AssertionError(
+                f"{job_id} must budget its long steps, or a slow step can only "
+                "be reported by cancelling the job"
+            )
+        if sum(step_budgets) >= int(job_cap.group("cap")):
+            raise AssertionError(
+                f"{job_id} step budgets sum to {sum(step_budgets)} against a job "
+                f"cap of {job_cap.group('cap')}: an overrun there is cancelled "
+                "silently instead of failing loudly"
+            )
 
 
 def assert_windows_npm_first_run_proof(ci_job: str, proof_source: str) -> None:
@@ -8126,11 +8231,11 @@ def main() -> None:
     assert_windows_npm_first_run_proof(
         ci_jobs["windows-authority-tests"], windows_npm_proof
     )
-    assert_windows_daemon_sibling_build(ci_jobs["windows-authority-tests"])
-    windows_job = ci_jobs["windows-authority-tests"]
+    assert_windows_daemon_sibling_build(ci_jobs["windows-authority-runtime-tests"])
+    windows_job = ci_jobs["windows-authority-runtime-tests"]
     sibling_build_start = windows_job.index(WINDOWS_DAEMON_SIBLING_BUILD)
     sibling_build_end = windows_job.index(
-        "      - name: Compile and run native Windows authority tests"
+        "      - name: Compile and run native Windows runtime authority tests"
     )
     sibling_build_block = windows_job[sibling_build_start:sibling_build_end]
     for label, mutated_job, expected in (
@@ -8370,10 +8475,67 @@ def main() -> None:
         "target/x86_64-pc-windows-msvc/release/kin.exe",
         "landing-push Windows admission proof",
     )
-    if re.search(r"(?m)^    if:", ci_jobs["windows-authority-tests"]) is not None:
-        raise AssertionError(
-            "the Windows authority job must stay on every event, so admission "
-            "behavior is asserted before a release commit can carry it"
+    assert_windows_authority_split(ci_jobs)
+    for label, job_id, mutated_block, expected in (
+        (
+            "a native Windows leg is dropped in the split",
+            "windows-authority-cli-tests",
+            ci_jobs["windows-authority-cli-tests"].replace(
+                '"native managed-daemon ownership scan"', '"renamed leg"', 1
+            ),
+            "exactly once",
+        ),
+        (
+            "two Windows jobs both claim the same leg",
+            "windows-authority-runtime-tests",
+            ci_jobs["windows-authority-runtime-tests"].replace(
+                '"daemon isolation support"', '"kin-git library"', 1
+            ),
+            "exactly once",
+        ),
+        (
+            "a Windows authority job takes a job-level condition",
+            "windows-authority-runtime-tests",
+            ci_jobs["windows-authority-runtime-tests"].replace(
+                "    runs-on: windows-latest",
+                "    if: github.event_name != 'merge_group'\n    runs-on: windows-latest",
+                1,
+            ),
+            "must stay on every event",
+        ),
+        (
+            "a Windows authority job stops sourcing the shared leg helpers",
+            "windows-authority-cli-tests",
+            ci_jobs["windows-authority-cli-tests"].replace(
+                f"          {WINDOWS_AUTHORITY_LEG_HELPERS}\n", "", 1
+            ),
+            "shared leg helpers",
+        ),
+        (
+            "the step budgets grow past the job cap they must fire before",
+            "windows-authority-cli-tests",
+            ci_jobs["windows-authority-cli-tests"].replace(
+                "    timeout-minutes: 45", "    timeout-minutes: 30", 1
+            ),
+            "failing loudly",
+        ),
+        (
+            "a Windows authority job budgets no step at all",
+            "windows-authority-cli-tests",
+            re.sub(
+                r"(?m)^        timeout-minutes: \d+\n",
+                "",
+                ci_jobs["windows-authority-cli-tests"],
+            ),
+            "must budget its long steps",
+        ),
+    ):
+        expect_assertion(
+            label,
+            expected,
+            lambda job_id=job_id, mutated_block=mutated_block: (
+                assert_windows_authority_split({**ci_jobs, job_id: mutated_block})
+            ),
         )
 
     # The Linux release artifacts are the only musl compilation Kin performs,

--- a/scripts/windows-authority-legs.sh
+++ b/scripts/windows-authority-legs.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Shared invocation helpers for the native Windows authority CI legs.
+#
+# Every helper below fails closed on an EMPTY test selection. A `cargo test`
+# whose filter matches nothing exits 0 and prints a passing summary, so a leg
+# that only ran `cargo test <filter>` would report success for a test that had
+# been renamed away, moved behind a cfg, or deleted. Each helper therefore
+# lists the target's tests first and asserts the selection is non-empty, or
+# exactly one, before running anything.
+#
+# The helpers live here rather than inline in ci.yml because three jobs now run
+# these legs. Duplicating them per job is how the three copies would drift, and
+# a drifted copy of an emptiness guard is a guard that stops guarding one leg
+# while still reading as present in the other two. The invocations themselves
+# stay in ci.yml on purpose: which tests a Windows leg is required to run is
+# reviewable workflow policy, and the release authority test asserts against it
+# there.
+#
+# Source this file from a `bash` step that has already set `-euo pipefail`.
+
+list_tests() {
+  CARGO_TERM_COLOR=never cargo test "$@" -- --list | tr -d '\r'
+}
+
+assert_nonempty_listing() {
+  local label="$1"
+  local listing="$2"
+  local count
+  count="$(printf '%s\n' "$listing" \
+    | awk '/: test$/ { count += 1 } END { print count + 0 }')"
+  if [[ "$count" -eq 0 ]]; then
+    echo "::error title=Missing native Windows tests::$label listed zero tests"
+    printf '%s\n' "$listing"
+    exit 1
+  fi
+  echo "$label: listed $count test(s)"
+}
+
+run_nonempty_target() {
+  local label="$1"
+  shift
+  local listing
+  listing="$(list_tests "$@")"
+  assert_nonempty_listing "$label" "$listing"
+  cargo test "$@" -- --test-threads=1
+}
+
+run_required_filter() {
+  local label="$1"
+  local filter="$2"
+  shift 2
+  local listing
+  local matches
+  listing="$(list_tests "$@")"
+  matches="$(printf '%s\n' "$listing" \
+    | awk -v needle="$filter" \
+      'index($0, needle) > 0 && /: test$/ { count += 1 } END { print count + 0 }')"
+  if [[ "$matches" -eq 0 ]]; then
+    echo "::error title=Missing native Windows tests::$label filter '$filter' matched zero listed tests"
+    printf '%s\n' "$listing"
+    exit 1
+  fi
+  echo "$label: filter '$filter' matched $matches test(s)"
+  cargo test "$@" "$filter" -- --test-threads=1
+}
+
+run_required_exact() {
+  local label="$1"
+  local test_name="$2"
+  shift 2
+  local listing
+  local matches
+  listing="$(list_tests "$@")"
+  matches="$(printf '%s\n' "$listing" \
+    | awk -v expected="$test_name: test" \
+      '$0 == expected { count += 1 } END { print count + 0 }')"
+  if [[ "$matches" -ne 1 ]]; then
+    echo "::error title=Missing native Windows test::$label expected exactly one '$test_name', found $matches"
+    printf '%s\n' "$listing"
+    exit 1
+  fi
+  cargo test "$@" "$test_name" -- --exact --test-threads=1
+}
+
+run_required_target() {
+  local label="$1"
+  local required_test="$2"
+  shift 2
+  local listing
+  local matches
+  listing="$(list_tests "$@")"
+  assert_nonempty_listing "$label" "$listing"
+  matches="$(printf '%s\n' "$listing" \
+    | awk -v expected="$required_test: test" \
+      '$0 == expected { count += 1 } END { print count + 0 }')"
+  if [[ "$matches" -ne 1 ]]; then
+    echo "::error title=Missing native Windows test::$label expected exactly one '$required_test', found $matches"
+    printf '%s\n' "$listing"
+    exit 1
+  fi
+  cargo test "$@" -- --test-threads=1
+}
+
+compile_required_target() {
+  local label="$1"
+  local required_test="$2"
+  shift 2
+  local listing
+  local matches
+  listing="$(list_tests "$@")"
+  assert_nonempty_listing "$label" "$listing"
+  matches="$(printf '%s\n' "$listing" \
+    | awk -v expected="$required_test: test" \
+      '$0 == expected { count += 1 } END { print count + 0 }')"
+  if [[ "$matches" -ne 1 ]]; then
+    echo "::error title=Missing native Windows compile target::$label expected exactly one '$required_test', found $matches"
+    printf '%s\n' "$listing"
+    exit 1
+  fi
+  echo "$label: compiled and listed required test '$required_test'"
+}


### PR DESCRIPTION
The Windows authority job could not finish inside its own cap, and when it failed to, nobody heard.

Across 119 sampled runs of that job, 32 of the 106 allowed to finish were destroyed by the 60 minute limit. On pull requests that was half of them. The 70 survivors averaged 52.6 minutes with a standard deviation of 4.8 and a maximum of 59.7, which is 99.6 percent of the cap. That sample is censored: every run that would have taken longer was cut off at 60, so the real mean sits near 57 and the real p95 above the cap itself. There was no headroom to tune. The job had outgrown any cap worth setting.

The silence is the other half of it. "Windows authority tests" is not in main's required status check set, and release-tag.yml does not name it either. The ruleset requires Check & Test on ubuntu and macos, DCO Sign-off, cargo-deny, gitleaks, the Windows installer build, and PR text hygiene, and that is the whole list. So a cap-out blocked nothing and announced nothing, leaving a check that read cancelled with every substantive step inside it green. FIR-2160 recorded the job as required. It is not, which is why the cap-outs on 2026-08-10 were found by reading run durations rather than by anything going red.

Run 31447617881 spent 45.0 of its 54.2 minutes inside the single step "Compile and run native Windows authority tests". The terminal proof chain FIR-2158 proposed splitting out, which builds the binaries, asserts admission, and proves both npm surfaces, is 3.5 minutes of that, or 6.5 percent. Moving it alone would have returned 6.5 percent against a 30 percent cap-out rate.

So the legs are split three ways along compilation unit seams, which is what makes the split cheap: each job builds one kind of artifact and none waits on another's build. Library units, the admission contract, and both npm surfaces stay in Windows authority tests. The kin-cli unit legs, one compilation unit and the most expensive one, become Windows authority CLI tests. The integration test binaries, which spend their time running rather than compiling, become Windows authority runtime tests. All 24 leg invocations are preserved byte for byte, and the authority test now holds each of them to appearing exactly once across the three jobs, so rebalancing them stays free while dropping one does not. Estimated from the profiled run, the three jobs come in around 18, 22, and 23 minutes.

The caps are set by arithmetic rather than by picking a larger round number. Every long step carries its own timeout-minutes, and every job cap exceeds the sum of its step budgets: 25 plus 5 plus 10 plus 30 is 70 under a cap of 80 for the admission job, 35 under 45 for the CLI job, and 25 plus 35 is 60 under 70 for the runtime job. That inequality is the fix. A step that overruns its budget fails and names itself on the check, while a job that hits its own cap is cancelled, and the cancellation is what was silent. Holding the sum under the cap means the loud failure arrives first whichever step is the slow one, and the authority test asserts it. Measured against the step budgets that do the enforcing, the three estimates sit at 43, 54, and 51 percent of budget, where the old job sat near 95.

Cache saving was the part that compounded. rust-cache gates its save on success() or CACHE_ON_FAILURE, so at the default every run that did not end green threw away everything it had compiled. All four sampled red runs and all 32 cap-outs skipped their save, which left each following run colder than the one that timed out. All three jobs now set cache-on-failure: true.

The shell helpers move to scripts/windows-authority-legs.sh, sourced by all three jobs. Three inline copies of an emptiness guard would drift, and a drifted copy stops guarding one leg while still reading as present in the other two. The invocations stay in ci.yml, where the authority test asserts against them, and the script picks up a bash -n check beside the others.

The release workflow authority test passes, including six new falsifications that each prove a new guard can fire: a dropped leg, a duplicated leg, a job level if, a missing helper source, step budgets grown past their job cap, and a job that budgets no step at all. actionlint is clean on ci.yml. This PR is its own canary, since a ci.yml change takes effect on the run that carries it.

One thing to watch that is out of scope here. The repository sits at 9 GB of the 10 GB Actions cache budget across 49 entries, and rust-cache keys per job, so the two new jobs add entries and will force LRU eviction. The natural victims are the three v0.5.17 tag ref entries, about 2.1 GB that nothing restores again.

Closes FIR-2158
Closes FIR-2160
Closes FIR-2162
