### PR TITLE
Account for Windows binary suffixes in the installer post-extract path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,13 @@ jobs:
           # is not evidence that it can.
           python3 ./scripts/verify-installer-release-assets.py
           python3 ./scripts/falsify-installer-release-assets.py
+          # Resolving the archive name is only half an install. Once it lands,
+          # the installer names the binaries inside it, and those names carry a
+          # platform suffix the installer did not account for, so a complete
+          # Windows archive aborted the install after the download had already
+          # been fetched and verified.
+          python3 ./scripts/verify-installer-archive-binaries.py
+          python3 ./scripts/falsify-installer-archive-binaries.py
           python3 ./scripts/test-npm-automatic-release.py
           python3 ./scripts/test-verify-npm-release.py
           node --test \

--- a/scripts/falsify-installer-archive-binaries.py
+++ b/scripts/falsify-installer-archive-binaries.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Prove the archive binary guard can fail, one poisoned tree at a time.
+
+A guard nobody has watched fail is not evidence. Each probe below plants exactly
+one disagreement between the binary names `scripts/install.sh` uses after
+extracting an archive and the names the release actually packs into it, and
+requires `scripts/verify-installer-archive-binaries.py` to fail.
+
+The first probe reproduces the defect itself: the mandatory-daemon assertion
+naming a bare `kin-daemon` inside a Windows archive that carries
+`kin-daemon.exe`, which aborted the install after the download had already been
+fetched and verified.
+
+The last two probes are about the guard's own honesty rather than about a
+mismatched name. A guard that cannot read what the installer asks for, or that
+cannot read the release's own record of which binaries are mandatory, must say
+so rather than derive nothing and report success.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+GUARD = "scripts/verify-installer-archive-binaries.py"
+COPIED = (
+    "scripts/install.sh",
+    GUARD,
+    ".github/workflows/release.yml",
+)
+
+
+class FalsificationError(RuntimeError):
+    """The guard did not fail where it must, so it proves nothing."""
+
+
+def probe_tree(destination: Path) -> Path:
+    for relative in COPIED:
+        source = ROOT / relative
+        if not source.is_file():
+            raise FalsificationError(f"cannot build a probe tree without {relative}")
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    return destination
+
+
+def poison(tree: Path, relative: str, old: str, new: str) -> None:
+    """Plant one mutation at an anchor that appears exactly once.
+
+    Requiring uniqueness is what stops a probe from mutating a line the guard
+    never reads, leaving the guard correctly green while the probe reports that
+    it proved something.
+    """
+    path = tree / relative
+    source = path.read_text(encoding="utf-8")
+    found = source.count(old)
+    if found != 1:
+        raise FalsificationError(
+            f"probe could not plant its mutation: {relative} contains {found} "
+            f"occurrences of {old!r}, expected exactly one"
+        )
+    path.write_text(source.replace(old, new, 1), encoding="utf-8")
+
+
+def run_guard(tree: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(tree / GUARD)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def expect_failure(label: str, expected: str, mutate: Callable[[Path], None]) -> str:
+    with tempfile.TemporaryDirectory() as temp:
+        tree = probe_tree(Path(temp))
+        mutate(tree)
+        result = run_guard(tree)
+    if result.returncode == 0:
+        raise FalsificationError(
+            f"{label}: the guard passed a tree it must reject.\n"
+            f"        {result.stdout.strip()}"
+        )
+    output = f"{result.stdout}\n{result.stderr}"
+    if expected not in output:
+        raise FalsificationError(
+            f"{label}: the guard failed, but not for the planted reason.\n"
+            f"        expected to see {expected!r}\n"
+            f"        got: {output.strip()}"
+        )
+    return f"{label}: rejected, naming {expected!r}"
+
+
+PROBES: tuple[tuple[str, str, Callable[[Path], None]], ...] = (
+    (
+        "the shipped defect: mandatory daemon named without its suffix",
+        "install.sh failed against a complete kin-windows-x86_64 archive",
+        lambda tree: poison(
+            tree,
+            "scripts/install.sh",
+            'if [ ! -f "$EXTRACT_DIR/kin-daemon$BIN_EXT" ]; then',
+            'if [ ! -f "$EXTRACT_DIR/kin-daemon" ]; then',
+        ),
+    ),
+    (
+        "the suffix derivation neutered for windows",
+        "install.sh failed against a complete kin-windows-x86_64 archive",
+        lambda tree: poison(
+            tree,
+            "scripts/install.sh",
+            'windows) BIN_EXT=".exe" ;;',
+            'windows) BIN_EXT="" ;;',
+        ),
+    ),
+    (
+        "binaries installed under names the archive never carried",
+        "kin-windows-x86_64",
+        lambda tree: poison(
+            tree,
+            "scripts/install.sh",
+            'mv "$EXTRACT_DIR/$bin$BIN_EXT" "$KIN_BIN/$bin$BIN_EXT"',
+            'mv "$EXTRACT_DIR/$bin$BIN_EXT" "$KIN_BIN/$bin"',
+        ),
+    ),
+    (
+        "the release leg packaging a daemon the installer cannot name",
+        "unaccounted for",
+        lambda tree: poison(
+            tree,
+            ".github/workflows/release.yml",
+            'Copy-Item "target/$env:TARGET/release/kin-daemon.exe" "$env:ARTIFACT/" -ErrorAction Stop',
+            'Copy-Item "target/$env:TARGET/release/kin-daemon" "$env:ARTIFACT/" -ErrorAction Stop',
+        ),
+    ),
+    (
+        "an installer that no longer names what it downloads",
+        "cannot read what it asks for",
+        lambda tree: poison(
+            tree,
+            "scripts/install.sh",
+            'info "Downloading $ARCHIVE..."',
+            'info "Fetching $ARCHIVE"',
+        ),
+    ),
+    (
+        "one of the release's mandatory binary records made unreadable",
+        "can be read",
+        lambda tree: poison(
+            tree,
+            ".github/workflows/release.yml",
+            '            target.includes("-windows-")\n'
+            '              ? ["kin.exe", "kin-daemon.exe"]',
+            '            target.includes("-windows-")\n'
+            "              ? windowsAuthorityNames()",
+        ),
+    ),
+)
+
+
+def main() -> int:
+    lines: list[str] = []
+    try:
+        for label, expected, mutate in PROBES:
+            lines.append(expect_failure(label, expected, mutate))
+    except FalsificationError as error:
+        print(f"archive binary guard falsification FAILED\n  {error}", file=sys.stderr)
+        return 1
+
+    print(f"archive binary guard rejected all {len(PROBES)} poisoned trees:")
+    for line in lines:
+        print(f"  {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,6 +68,16 @@ OS="$(detect_os)"
 ARCH="$(detect_arch)"
 TARGET="${OS}-${ARCH}"
 
+# Windows release archives carry `.exe`-suffixed binaries; every other platform
+# ships bare names. Derive the suffix once from the detected OS and apply it
+# everywhere a binary is named after extraction. Naming a bare `kin-daemon`
+# under a Windows archive aborted the install after the download had already
+# been fetched and verified, which is a worse failure than the 404 it replaced.
+case "$OS" in
+    windows) BIN_EXT=".exe" ;;
+    *)       BIN_EXT="" ;;
+esac
+
 printf '\n'
 printf '  \033[1;36mKin Installer\033[0m\n'
 printf '  Semantic development environment\n'
@@ -90,8 +100,8 @@ fi
 # ── Detect an existing install (reinstall / upgrade) ──────────────────
 
 PREVIOUS_VERSION=""
-if [ -x "$KIN_BIN/kin" ]; then
-    PREVIOUS_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $2}')
+if [ -x "$KIN_BIN/kin$BIN_EXT" ]; then
+    PREVIOUS_VERSION=$("$KIN_BIN/kin$BIN_EXT" --version 2>/dev/null | awk '{print $2}')
     if [ -n "$PREVIOUS_VERSION" ]; then
         info "Existing install found: kin $PREVIOUS_VERSION (will be replaced)"
     else
@@ -234,8 +244,8 @@ fi
 # require it. Assert it is present in the extracted archive BEFORE moving
 # anything, so a daemon-less archive (e.g. a stale build) aborts cleanly instead
 # of leaving a half-installed, daemon-less environment.
-if [ ! -f "$EXTRACT_DIR/kin-daemon" ]; then
-    err "kin-daemon missing from the downloaded archive."
+if [ ! -f "$EXTRACT_DIR/kin-daemon$BIN_EXT" ]; then
+    err "kin-daemon$BIN_EXT missing from the downloaded archive."
     err "kin status/search and the MCP server require it. Refusing a daemon-less install. Aborting."
     exit 1
 fi
@@ -283,13 +293,13 @@ fi
 # `kin doctor` and `kin update`. Run its content-free check before replacing
 # any installed binary. Unsafe existing state is never silently chmodded or
 # overwritten; the operator must explicitly repair it and rerun the installer.
-chmod +x "$EXTRACT_DIR/kin"
+chmod +x "$EXTRACT_DIR/kin$BIN_EXT"
 if is_truthy "${KIN_REGISTRY_REPAIR:-}"; then
     REGISTRY_AUTHORITY_STATUS=0
-    "$EXTRACT_DIR/kin" registry authority --fix --initialize || REGISTRY_AUTHORITY_STATUS=$?
+    "$EXTRACT_DIR/kin$BIN_EXT" registry authority --fix --initialize || REGISTRY_AUTHORITY_STATUS=$?
 else
     REGISTRY_AUTHORITY_STATUS=0
-    "$EXTRACT_DIR/kin" registry authority --initialize || REGISTRY_AUTHORITY_STATUS=$?
+    "$EXTRACT_DIR/kin$BIN_EXT" registry authority --initialize || REGISTRY_AUTHORITY_STATUS=$?
 fi
 if [ "$REGISTRY_AUTHORITY_STATUS" -ne 0 ]; then
     err "Unsafe local registry authority blocks installation."
@@ -302,9 +312,9 @@ fi
 # optional filesystem-projection client.
 HAVE_VFS=0
 for bin in kin kin-daemon kin-vfs; do
-    if [ -f "$EXTRACT_DIR/$bin" ]; then
-        mv "$EXTRACT_DIR/$bin" "$KIN_BIN/$bin"
-        chmod +x "$KIN_BIN/$bin"
+    if [ -f "$EXTRACT_DIR/$bin$BIN_EXT" ]; then
+        mv "$EXTRACT_DIR/$bin$BIN_EXT" "$KIN_BIN/$bin$BIN_EXT"
+        chmod +x "$KIN_BIN/$bin$BIN_EXT"
         [ "$bin" = "kin-vfs" ] && HAVE_VFS=1
     fi
 done
@@ -312,7 +322,7 @@ done
 # Move the projection shim library if the archive bundled it (Linux .so /
 # macOS .dylib). It is consumed by the shell hooks via $KIN_DIR/lib.
 HAVE_SHIM=0
-for lib in libkin_vfs_shim.so libkin_vfs_shim.dylib; do
+for lib in libkin_vfs_shim.so libkin_vfs_shim.dylib kin_vfs_shim.dll; do
     if [ -f "$EXTRACT_DIR/$lib" ]; then
         mv "$EXTRACT_DIR/$lib" "$KIN_LIB/$lib"
         HAVE_SHIM=1
@@ -355,12 +365,13 @@ if [ "$HAVE_VFS" = "1" ] && [ "$HAVE_SHIM" = "1" ]; then
     # while today's kin-vfs and shim are glibc-linked. Test the installed CLI
     # before claiming the optional projection is usable, and do not leave a
     # command behind that the host loader cannot execute.
-    if "$KIN_BIN/kin-vfs" --help >/dev/null 2>&1; then
+    if "$KIN_BIN/kin-vfs$BIN_EXT" --help >/dev/null 2>&1; then
         ok "Filesystem projection installed (kin-vfs + shim)"
     else
-        rm -f "$KIN_BIN/kin-vfs" \
+        rm -f "$KIN_BIN/kin-vfs$BIN_EXT" \
             "$KIN_LIB/libkin_vfs_shim.so" \
-            "$KIN_LIB/libkin_vfs_shim.dylib"
+            "$KIN_LIB/libkin_vfs_shim.dylib" \
+            "$KIN_LIB/kin_vfs_shim.dll"
         info "Filesystem projection is unavailable on this platform; core CLI and daemon are fully functional without it."
     fi
 else
@@ -390,7 +401,12 @@ case "$OS" in
             add_to_path "$HOME/.bashrc"
         fi
         ;;
-    linux)
+    linux|windows)
+        # The windows arm is reached from the MSYS, MINGW, and Cygwin shells,
+        # whose startup files are the same ones Linux uses. It could not run at
+        # all until the post-extract path above stopped aborting on those hosts,
+        # so a Windows install that got this far previously left the CLI off
+        # PATH with nothing said about it.
         if [ -f "$HOME/.bashrc" ]; then
             add_to_path "$HOME/.bashrc"
         fi
@@ -404,8 +420,8 @@ esac
 
 export PATH="$KIN_BIN:$PATH"
 
-if has_cmd "$KIN_BIN/kin"; then
-    INSTALLED_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $2}')
+if has_cmd "$KIN_BIN/kin$BIN_EXT"; then
+    INSTALLED_VERSION=$("$KIN_BIN/kin$BIN_EXT" --version 2>/dev/null | awk '{print $2}')
     if [ -n "$PREVIOUS_VERSION" ] && [ -n "$INSTALLED_VERSION" ] && [ "$PREVIOUS_VERSION" != "$INSTALLED_VERSION" ]; then
         ok "kin upgraded: $PREVIOUS_VERSION → $INSTALLED_VERSION"
     else
@@ -432,7 +448,7 @@ else
     # Reopen /dev/tty so the interactive wizard can read keyboard input.
     if [ -t 0 ]; then
         # Already in a TTY — run directly
-        "$KIN_BIN/kin" setup
+        "$KIN_BIN/kin$BIN_EXT" setup
     elif [ -e /dev/tty ] && ( : < /dev/tty ) 2>/dev/null; then
         # Piped but a usable controlling TTY is available — read keyboard input
         # from it. The `( : < /dev/tty )` probe confirms the device can actually
@@ -442,11 +458,11 @@ else
         # a redirection failure on the `:` special built-in exits its shell, so
         # in a bare brace group it would terminate the whole non-interactive
         # installer (POSIX dash) before the fallback below can run.
-        "$KIN_BIN/kin" setup < /dev/tty
+        "$KIN_BIN/kin$BIN_EXT" setup < /dev/tty
     else
         # No usable TTY (CI, Docker, piped without a controlling terminal) —
         # run non-interactive so the install never exits non-zero here.
-        "$KIN_BIN/kin" setup --no-interactive
+        "$KIN_BIN/kin$BIN_EXT" setup --no-interactive
     fi
     set -e
 fi

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -63,6 +63,10 @@ INSTALLER_ASSET_GUARD = ROOT / "scripts" / "verify-installer-release-assets.py"
 INSTALLER_ASSET_GUARD_POLICY = "scripts/verify-installer-release-assets.py"
 INSTALLER_ASSET_FALSIFIER = ROOT / "scripts" / "falsify-installer-release-assets.py"
 INSTALLER_ASSET_FALSIFIER_POLICY = "scripts/falsify-installer-release-assets.py"
+INSTALLER_BINARY_GUARD = ROOT / "scripts" / "verify-installer-archive-binaries.py"
+INSTALLER_BINARY_GUARD_POLICY = "scripts/verify-installer-archive-binaries.py"
+INSTALLER_BINARY_FALSIFIER = ROOT / "scripts" / "falsify-installer-archive-binaries.py"
+INSTALLER_BINARY_FALSIFIER_POLICY = "scripts/falsify-installer-archive-binaries.py"
 TRUSTED_POLICY_PREFIX = "refs/remotes/origin/main:"
 TAG_LISTING_FORMAT = (
     "--format='%(refname:strip=2) "
@@ -3255,6 +3259,50 @@ def assert_installer_asset_guard_wired(ci: str, release: str) -> None:
             f"release.yml must run {INSTALLER_ASSET_GUARD_POLICY} against the "
             "staged assets; the workflow's intent is not the same evidence as "
             "the bytes about to be uploaded"
+        )
+
+
+def assert_installer_archive_binary_guard_wired(ci: str) -> None:
+    """Keep the check that the installer names binaries the archive carries.
+
+    Resolving the right archive name is only half an install. Once the download
+    lands, the installer names the binaries inside it, and a Windows archive
+    carries `.exe`-suffixed names. The installer named the bare form on every
+    platform, so its mandatory-daemon assertion failed against an archive that
+    was present, complete, and checksum-verified, aborting after the user had
+    already waited for the download.
+
+    This guard reads source rather than staged bytes, so it belongs on pull
+    requests alone. The falsifier runs beside it because a guard nobody has
+    watched fail is not evidence that it can.
+    """
+
+    for path, policy in (
+        (INSTALLER_BINARY_GUARD, INSTALLER_BINARY_GUARD_POLICY),
+        (INSTALLER_BINARY_FALSIFIER, INSTALLER_BINARY_FALSIFIER_POLICY),
+    ):
+        if not path.is_file():
+            raise AssertionError(
+                f"{policy} is missing; the installer could name a binary the "
+                "release archive does not carry and nothing would notice"
+            )
+
+    # Match whole invocations rather than searching for the path, which a
+    # commented-out line would still satisfy.
+    ci_lines = {line.strip() for line in ci.splitlines()}
+    missing = sorted(
+        command
+        for command in (
+            f"python3 ./{INSTALLER_BINARY_GUARD_POLICY}",
+            f"python3 ./{INSTALLER_BINARY_FALSIFIER_POLICY}",
+        )
+        if command not in ci_lines
+    )
+    if missing:
+        raise AssertionError(
+            "ci.yml must run " + " and ".join(missing) + "; without both, the "
+            "installer can abort on a complete archive and no pull request "
+            "would go red"
         )
 
 
@@ -6639,7 +6687,7 @@ def main() -> None:
 
     require(
         install_sh,
-        '"$EXTRACT_DIR/kin" registry authority --initialize',
+        '"$EXTRACT_DIR/kin$BIN_EXT" registry authority --initialize',
         "content-free Unix installer registry-authority initialization",
     )
     require(
@@ -9200,6 +9248,21 @@ def main() -> None:
         lambda: assert_installer_asset_guard_wired(
             ci_workflow,
             release.replace(f"./{INSTALLER_ASSET_GUARD_POLICY} --assets-dir .", "true"),
+        ),
+    )
+    assert_installer_archive_binary_guard_wired(ci_workflow)
+    expect_assertion(
+        "ci.yml drops the guard that installer binary names match the archive",
+        "ci.yml must run",
+        lambda: assert_installer_archive_binary_guard_wired(
+            ci_workflow.replace(INSTALLER_BINARY_GUARD_POLICY, "scripts/absent.py")
+        ),
+    )
+    expect_assertion(
+        "ci.yml keeps the binary-name guard but drops its falsification",
+        "ci.yml must run",
+        lambda: assert_installer_archive_binary_guard_wired(
+            ci_workflow.replace(INSTALLER_BINARY_FALSIFIER_POLICY, "scripts/absent.py")
         ),
     )
     expect_assertion(

--- a/scripts/verify-installer-archive-binaries.py
+++ b/scripts/verify-installer-archive-binaries.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Fail when the installer names binaries the release archive does not carry.
+
+Resolving the right archive name is only half of an install. Once the download
+lands, `scripts/install.sh` names the binaries inside it, and those names carry
+a platform suffix: a Windows release archive holds `kin.exe` and
+`kin-daemon.exe`, every other leg holds bare names. The installer named the bare
+form on every platform, so the mandatory-daemon assertion failed against a
+Windows archive that was present, complete, and checksum-verified. That abort
+lands after the user has already waited for the download, which is a worse first
+run than the 404 that preceded it.
+
+Nothing here is restated. The member names come from the release workflow's own
+packaging steps, honouring each matrix row's shim name and its `skip_vfs` key,
+and the mandatory subset comes from the provenance manifest's own authority
+list. Each host identity is mapped to its artifact by running `install.sh`
+against a stubbed `uname` and reading the name it asks to download. A fixture
+archive is then built with exactly those members and the real installer is run
+against it end to end, so the post-extract path is exercised per platform rather
+than described. The assertion is that the binaries the installer ends up with
+are the ones the archive actually contained, suffixes included.
+
+Anchored patterns fail rather than skip when the workflow moves. A guard that
+derived nothing would pass forever.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+PROBE_VERSION = "0.0.0-archive-binary-probe"
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+DOWNLOAD_LINE = re.compile(r"Downloading (?P<asset>\S+)\.\.\.")
+
+# One matrix row per release leg. Rows are recognised by their artifact key, so
+# an unrelated matrix elsewhere in the workflow cannot be mistaken for one.
+MATRIX_MARKER = re.compile(r"^(?P<indent>\s+)- os: (?P<os>\S+)\s*$")
+ROW_KEY = re.compile(r"^\s+(?P<key>\w+): (?P<value>.*?)\s*$")
+
+# The two packaging steps, each naming the components it copies into the
+# archive root. The Windows leg marks optional components with
+# `-ErrorAction SilentlyContinue`; the Unix leg has no optional copies.
+UNIX_COPY = re.compile(
+    r'^\s+cp "(?:target/\$\{TARGET\}|kin-vfs/target/\$\{VFS_TARGET\})'
+    r'/release/(?P<name>[^"]+)" "\$ARTIFACT/"\s*$',
+    re.M,
+)
+WINDOWS_COPY = re.compile(
+    r'^\s+Copy-Item "(?:target/\$env:TARGET|kin-vfs/target/\$env:TARGET)'
+    r'/release/(?P<name>[^"]+)" "\$env:ARTIFACT/"(?P<tail>.*?)\s*$',
+    re.M,
+)
+
+# The release's own declaration of which binaries are mandatory per leg. It is
+# declared in more than one place, so every declaration must be readable and all
+# of them must agree. Reading only the first would let a second declaration drift
+# or become unreadable without anything noticing.
+AUTHORITY_DECLARATION = re.compile(r"authorityNames = new Set\(")
+AUTHORITY_NAMES = re.compile(
+    r'target\.includes\("-windows-"\)\s*\n'
+    r'\s*\? \[(?P<windows>[^\]]+)\]\s*\n'
+    r'\s*: \[(?P<unix>[^\]]+)\]',
+    re.M,
+)
+
+# Host identities, not answers. Each row says only "a machine reporting this
+# runs the installer"; which artifact it receives and which binaries that
+# artifact carries are both derived below.
+HOSTS: tuple[tuple[str, str, str], ...] = (
+    ("linux x86_64", "Linux", "x86_64"),
+    ("linux aarch64", "Linux", "aarch64"),
+    ("macos x86_64", "Darwin", "x86_64"),
+    ("macos aarch64", "Darwin", "arm64"),
+    ("windows x86_64 (Git Bash)", "MINGW64_NT-10.0-22631", "x86_64"),
+    ("windows x86_64 (MSYS)", "MSYS_NT-10.0-22631", "x86_64"),
+    ("windows x86_64 (Cygwin)", "CYGWIN_NT-10.0-22631", "amd64"),
+)
+
+
+class GuardError(RuntimeError):
+    """The installer and the release archive disagree about a binary name."""
+
+
+@dataclass(frozen=True)
+class Leg:
+    """One release leg: the artifact it publishes and what it packs into it."""
+
+    artifact: str
+    windows: bool
+    binaries: tuple[str, ...]
+    shim: str | None
+    notifier: bool
+
+
+def executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def read_workflow() -> str:
+    if not RELEASE_WORKFLOW.is_file():
+        raise GuardError(f"cannot derive release contents without {RELEASE_WORKFLOW}")
+    return RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+
+def matrix_rows(workflow: str) -> dict[str, dict[str, str]]:
+    """Every release leg keyed by artifact, with the keys that shape its archive.
+
+    Read line by line rather than by one block pattern. Comment lines sit
+    between matrix rows, and a block pattern that stopped at the next `- os:`
+    silently dropped the row behind the first comment, which cost a real leg its
+    coverage while the guard still reported a result.
+    """
+    rows: dict[str, dict[str, str]] = {}
+    lines = workflow.splitlines()
+    index = 0
+    while index < len(lines):
+        marker = MATRIX_MARKER.match(lines[index])
+        if marker is None:
+            index += 1
+            continue
+        indent = len(marker.group("indent"))
+        keys = {"os": marker.group("os")}
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                if len(line) - len(line.lstrip()) <= indent:
+                    break
+                pair = ROW_KEY.match(line)
+                if pair:
+                    keys[pair.group("key")] = pair.group("value")
+            index += 1
+        artifact = keys.get("artifact", "")
+        if artifact.startswith("kin-"):
+            rows[artifact] = keys
+    if not rows:
+        raise GuardError(
+            "no release matrix rows found; the workflow's matrix shape moved and "
+            "this guard would otherwise derive nothing and pass"
+        )
+    return rows
+
+
+def authority_binaries(workflow: str) -> tuple[frozenset[str], frozenset[str]]:
+    """The mandatory binary names the release records per leg."""
+
+    def names(raw: str) -> frozenset[str]:
+        found = frozenset(re.findall(r'"([^"]+)"', raw))
+        if not found:
+            raise GuardError(f"empty authority name list: {raw!r}")
+        return found
+
+    declared = len(AUTHORITY_DECLARATION.findall(workflow))
+    matches = AUTHORITY_NAMES.findall(workflow)
+    if not declared or not matches:
+        raise GuardError(
+            "release provenance authority names not found; without them this "
+            "guard cannot say which binaries an archive must carry"
+        )
+    if len(matches) != declared:
+        raise GuardError(
+            f"the release declares {declared} mandatory-binary authority lists "
+            f"but only {len(matches)} can be read; an unreadable list would let "
+            "this guard derive its answer from a partial record"
+        )
+    windows = {names(pair[0]) for pair in matches}
+    unix = {names(pair[1]) for pair in matches}
+    if len(windows) != 1 or len(unix) != 1:
+        raise GuardError(
+            "the release's mandatory-binary authority lists disagree with each "
+            f"other: windows {sorted(windows)}, unix {sorted(unix)}"
+        )
+    return windows.pop(), unix.pop()
+
+
+def packaged_components(workflow: str, row: dict[str, str]) -> tuple[list[str], bool]:
+    """The component names one leg copies into its archive root.
+
+    Optional copies are dropped when the row does not build them. The Windows
+    row carries `skip_vfs`, so its silently-tolerated projection copies produce
+    nothing and the published archive holds the two mandatory binaries alone.
+    """
+    windows = row.get("os", "").startswith("windows")
+    pattern = WINDOWS_COPY if windows else UNIX_COPY
+    matches = list(pattern.finditer(workflow))
+    if not matches:
+        raise GuardError(
+            f"no packaging copies found for {row.get('artifact')}; the packaging "
+            "step moved and this guard would derive an empty archive"
+        )
+
+    skip_vfs = row.get("skip_vfs", "false") == "true"
+    components: list[str] = []
+    for match in matches:
+        name = match.group("name")
+        if name in {"${SHIM_NAME}", "$env:SHIM_NAME"}:
+            shim = row.get("shim_name")
+            if not shim:
+                raise GuardError(f"matrix row {row.get('artifact')} names no shim")
+            name = shim
+        projection = name.startswith("kin-vfs") or "shim" in name
+        if projection and skip_vfs:
+            continue
+        components.append(name)
+    return components, windows
+
+
+def legs(workflow: str) -> dict[str, Leg]:
+    windows_authority, unix_authority = authority_binaries(workflow)
+    resolved: dict[str, Leg] = {}
+    for artifact, row in matrix_rows(workflow).items():
+        components, windows = packaged_components(workflow, row)
+        authority = windows_authority if windows else unix_authority
+        missing = authority - set(components)
+        if missing:
+            raise GuardError(
+                f"{artifact} packages {sorted(components)} but the release records "
+                f"{sorted(authority)} as mandatory; {sorted(missing)} is unaccounted for"
+            )
+        shim = next((name for name in components if "shim" in name), None)
+        binaries = tuple(name for name in components if name != shim)
+        resolved[artifact] = Leg(
+            artifact=artifact,
+            windows=windows,
+            binaries=binaries,
+            shim=shim,
+            notifier=artifact.startswith("kin-macos-"),
+        )
+    return resolved
+
+
+def uname_stub(directory: Path, uname_s: str, uname_m: str) -> Path:
+    fake_bin = directory / "fake-bin"
+    fake_bin.mkdir(exist_ok=True)
+    executable(
+        fake_bin / "uname",
+        "#!/bin/sh\n"
+        'case "${1:-}" in\n'
+        f"  -s) printf '{uname_s}\\n' ;;\n"
+        f"  -m) printf '{uname_m}\\n' ;;\n"
+        "  *) exit 2 ;;\n"
+        "esac\n",
+    )
+    return fake_bin
+
+
+def installer_env(root: Path, fake_bin: Path, releases: Path, home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env.get('PATH', '')}",
+            "HOME": str(home),
+            "KIN_HOME": str(home / ".kin"),
+            "KIN_BASE_URL": releases.as_uri(),
+            "KIN_VERSION": PROBE_VERSION,
+            "KIN_NO_SETUP": "1",
+            "SHELL": "/bin/sh",
+        }
+    )
+    env.pop("KIN_DIR", None)
+    return env
+
+
+def requested_asset(uname_s: str, uname_m: str) -> str:
+    """Ask install.sh which artifact this host is served.
+
+    The release directory is empty on purpose: the installer prints the name it
+    wants before it fails to fetch it, which is all this needs and keeps the
+    probe off the network.
+    """
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        fake_bin = uname_stub(root, uname_s, uname_m)
+        releases = root / "releases"
+        releases.mkdir()
+        home = root / "home"
+        home.mkdir()
+        result = subprocess.run(
+            ["sh", str(INSTALL_SH)],
+            env=installer_env(root, fake_bin, releases, home),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    for line in ANSI.sub("", result.stdout).splitlines():
+        match = DOWNLOAD_LINE.search(line)
+        if match:
+            asset = match.group("asset")
+            for suffix in (".tar.gz", ".zip"):
+                if asset.endswith(suffix):
+                    return asset[: -len(suffix)]
+            raise GuardError(f"installer asked for an unrecognised archive: {asset}")
+    raise GuardError(
+        f"install.sh named no download on a {uname_s}/{uname_m} host; the probe "
+        "cannot read what it asks for and must not pass silently"
+    )
+
+
+def build_archive(directory: Path, leg: Leg) -> Path:
+    """A fixture carrying exactly the members this leg publishes."""
+    archive_root = directory / leg.artifact
+    archive_root.mkdir()
+    for name in leg.binaries:
+        if name.startswith("kin.") or name == "kin":
+            body = "#!/bin/sh\nprintf 'kin 9.9.9\\n'\n"
+        else:
+            body = "#!/bin/sh\nexit 0\n"
+        executable(archive_root / name, body)
+    if leg.shim:
+        (archive_root / leg.shim).write_bytes(b"fixture shim")
+    if leg.notifier:
+        contents = archive_root / "KinNotifier.app" / "Contents"
+        (contents / "MacOS").mkdir(parents=True)
+        executable(contents / "MacOS" / "KinNotifier", "#!/bin/sh\nexit 0\n")
+        (contents / "Info.plist").write_text("<plist>fixture</plist>", encoding="utf-8")
+
+    releases = directory / "download" / f"v{PROBE_VERSION}"
+    releases.mkdir(parents=True)
+    archive = releases / f"{leg.artifact}.tar.gz"
+    with tarfile.open(archive, "w:gz") as bundle:
+        bundle.dereference = False
+        bundle.add(archive_root, arcname=archive_root.name)
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    archive.with_suffix(archive.suffix + ".sha256").write_text(
+        f"{digest}  {archive.name}\n", encoding="utf-8"
+    )
+    return archive
+
+
+def check_host(label: str, uname_s: str, uname_m: str, resolved: dict[str, Leg]) -> str:
+    artifact = requested_asset(uname_s, uname_m)
+    leg = resolved.get(artifact)
+    if leg is None:
+        raise GuardError(
+            f"{label}: install.sh downloads {artifact}, which no release leg "
+            "publishes; a platform cannot be served an archive nobody builds"
+        )
+
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        fake_bin = uname_stub(root, uname_s, uname_m)
+        build_archive(root, leg)
+        home = root / "home"
+        home.mkdir()
+        kin_home = home / ".kin"
+        result = subprocess.run(
+            ["sh", str(INSTALL_SH)],
+            env=installer_env(root, fake_bin, root, home),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise GuardError(
+                f"{label}: install.sh failed against a complete {artifact} archive "
+                f"carrying {sorted(leg.binaries)}.\n"
+                f"        exit {result.returncode}\n"
+                f"        {ANSI.sub('', result.stderr).strip()}"
+            )
+        installed = sorted(p.name for p in (kin_home / "bin").iterdir()) if (
+            kin_home / "bin"
+        ).is_dir() else []
+        expected = sorted(leg.binaries)
+        if installed != expected:
+            raise GuardError(
+                f"{label}: {artifact} carries {expected} but the install left "
+                f"{installed} in bin; the installer names binaries the archive "
+                "does not contain"
+            )
+        if leg.shim:
+            shim_path = kin_home / "lib" / leg.shim
+            if not shim_path.is_file():
+                raise GuardError(
+                    f"{label}: {artifact} carries {leg.shim} but it was not installed"
+                )
+    return f"{label}: {artifact} -> {', '.join(expected)}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    if not INSTALL_SH.is_file():
+        print(f"cannot verify without {INSTALL_SH}", file=sys.stderr)
+        return 1
+    try:
+        resolved = legs(read_workflow())
+        lines = [check_host(*host, resolved) for host in HOSTS]
+    except GuardError as error:
+        print(f"installer archive binary guard FAILED\n  {error}", file=sys.stderr)
+        return 1
+
+    print("installer archive binaries agree with what the release packages:")
+    for line in lines:
+        print(f"  {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The installer resolves the right archive for a Windows host and then cannot use it. Once the download completes and its checksum verifies, `install.sh` names the binaries inside the archive by their bare names. A Windows release archive carries `kin.exe` and `kin-daemon.exe`, so the mandatory-daemon assertion looked for `kin-daemon` inside an archive holding `kin-daemon.exe` and aborted with "kin-daemon missing from the downloaded archive". That abort comes after the user has already waited for the download, which is a worse first run than the 404 #738 replaced.

The suffix is now derived once from the detected OS and applied at every site that names a binary after extraction. That covers the existing-install version probe, the mandatory-daemon assertion, the chmod and registry-authority call on the staged CLI, the binary move loop, the optional projection probe with its cleanup, the post-install verification, and all three `kin setup` invocations. The projection shim list gains the Windows dll name so the same loop covers it if that leg ever builds one. The PATH arm gains `windows` beside `linux`, since those shells read the same startup files and the arm could not run at all while the post-extract path aborted first, so a Windows install that got past the download previously left the CLI off PATH with nothing said about it.

Then the check that was missing. `scripts/verify-installer-archive-binaries.py` derives each leg's member names from the release workflow's own packaging steps, honoring each matrix row's shim name and its `skip_vfs` key, and takes the mandatory subset from the provenance manifest's authority list. Every declaration of that list must be readable and they must agree, so a second declaration cannot drift or go unreadable while the guard reads only the first. Each host identity is mapped to its artifact by running `install.sh` against a stubbed `uname` and reading the name it asks to download. A fixture carrying exactly those members is then built and the real installer is run against it end to end. The assertion is that the binaries the install leaves behind are the ones the archive contained, suffixes included. The derived Windows member set is `kin.exe` and `kin-daemon.exe`, which matches the published `kin-windows-x86_64.zip` for v0.5.17 name for name.

The matrix is read line by line rather than by one block pattern. A pattern that stopped at the next row silently dropped the leg sitting behind the first comment, which cost a real platform its coverage while the guard still reported a result.

`scripts/falsify-installer-archive-binaries.py` runs beside it through six poisoned trees, because a guard nobody has watched fail is not evidence that it can. It covers the defect itself, the suffix derivation neutered, binaries installed under names the archive never carried, a release leg packaging a daemon the installer cannot name, an installer that stops naming what it downloads, and one of the release's mandatory-binary records made unreadable. The last two are about the guard's own honesty rather than a mismatched name, since a guard that derives nothing must say so rather than report success.

Verified locally. The guard fails against the pre-fix installer on all three Windows host identities and reports the exact abort this ticket names. It passes on this branch. The release authority suite holds both scripts wired into CI so neither can be dropped quietly, and its pin on the installer's registry-authority call moves to the suffixed path that call now names.

Closes FIR-2189
