### PR TITLE
Scope daemon stop and the daemon census by KIN_HOME, with the supervisor machine-wide by contract

### DIFF
--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1115,6 +1115,19 @@ async fn stop_all(scope: StopScope, json: bool, quiet: bool) -> Result<()> {
     stop_all_inner(scope, json, quiet, None).await
 }
 
+/// Whether the current-repo fallback may stop `pid`. The fallback exists for a
+/// worker no supervisor knows about, so a pid already covered by a stop report
+/// is declined for the ordinary reason, and a pid the home partition skipped
+/// must be declined too: stopping it would undo the partition the sweep just
+/// disclosed, and the command's own output would contradict itself.
+fn fallback_may_stop(
+    pid: u32,
+    reported: impl IntoIterator<Item = u32>,
+    skipped: impl IntoIterator<Item = u32>,
+) -> bool {
+    !reported.into_iter().any(|p| p == pid) && !skipped.into_iter().any(|p| p == pid)
+}
+
 async fn stop_all_inner(
     scope: StopScope,
     json: bool,
@@ -1221,14 +1234,21 @@ async fn stop_all_inner(
     }
 
     // Also stop the current repo's worker if it is not registered with the
-    // supervisor (e.g. supervisor down but a worker process lingering).
+    // supervisor (e.g. supervisor down but a worker process lingering). The
+    // repo-local pid file is home-agnostic, so this fallback is where a scoped
+    // sweep could otherwise reach a daemon the partition skipped;
+    // `fallback_may_stop` is what keeps the disclosure and the kill agreeing.
     if let Ok(cwd) = std::env::current_dir() {
         if let Some(layout) = kin_core::KinLayout::discover(&cwd) {
             let kin_root = layout.root().to_path_buf();
             let (pid, _) = repo_daemon_recorded_endpoint(&kin_root);
             if let Some(pid) = pid {
-                let already = reports.iter().any(|r| r.pid == pid);
-                if !already && is_process_alive(pid) {
+                let may_stop = fallback_may_stop(
+                    pid,
+                    reports.iter().map(|r| r.pid),
+                    foreign.iter().map(|skipped| skipped.pid),
+                );
+                if may_stop && is_process_alive(pid) {
                     let working_dir = kin_root.parent().unwrap_or(&kin_root).to_path_buf();
                     let outcome = stop_worker_at(
                         &kin_root,
@@ -2309,6 +2329,54 @@ mod tests {
         assert!(
             foreign.is_empty(),
             "nothing skipped, so the shared supervisor has no other dependant"
+        );
+    }
+
+    /// The current-repo fallback must not undo the partition.
+    ///
+    /// That fallback exists for a worker no supervisor knows about, and it keys
+    /// on "this pid is not already in the reports". A skipped daemon is not in
+    /// the reports either, so keying on that alone would stop the daemon the
+    /// sweep had just named as another home's and print both facts about it.
+    #[test]
+    fn the_current_repo_fallback_skips_a_daemon_the_partition_excluded() {
+        let (targets, foreign) = partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Home);
+        let reported: Vec<u32> = targets.iter().map(|d| d.pid).collect();
+
+        // The foreign daemon happens to serve the repository the caller stands
+        // in, so the fallback would reach for it, and the reports cannot be
+        // what protects it: the partition excluded it from them.
+        let current_repo_pid = 202;
+        assert!(!reported.contains(&current_repo_pid));
+        assert!(
+            !fallback_may_stop(
+                current_repo_pid,
+                reported.iter().copied(),
+                foreign.iter().map(|skipped| skipped.pid),
+            ),
+            "a daemon named as skipped must not then be stopped by the fallback"
+        );
+
+        // The caller's own daemon is in the reports, so the fallback declines
+        // it for the ordinary reason.
+        assert!(
+            !fallback_may_stop(
+                101,
+                reported.iter().copied(),
+                foreign.iter().map(|skipped| skipped.pid),
+            ),
+            "an already-reported daemon is not the fallback's business"
+        );
+
+        // A worker neither reported nor skipped is exactly what the fallback
+        // exists for, so the guard must not over-prune it.
+        assert!(
+            fallback_may_stop(
+                999,
+                reported.iter().copied(),
+                foreign.iter().map(|skipped| skipped.pid),
+            ),
+            "an unknown lingering worker must remain stoppable"
         );
     }
 

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -25,13 +25,14 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::daemon_client::{
-    fetch_registered_daemons, is_port_open, is_process_alive, process_identity,
+    caller_home_id, fetch_registered_daemons, is_port_open, is_process_alive, process_identity,
     process_identity_is_current, read_endpoint_owner_record, read_supervisor_owner_record,
     remove_stale_daemon_files, remove_stale_supervisor_files, repo_daemon_owner_path,
     repo_daemon_pid_path, repo_daemon_port_path, repo_daemon_recorded_endpoint,
     retire_stopped_daemon_endpoint, supervisor_owner_path, supervisor_pid_path,
     supervisor_port_path, supervisor_recorded_endpoint, try_acquire_supervisor_startup_lock_in_dir,
-    PreservedDaemonEndpoint, ProcessIdentity, RegisteredRepoDaemon, SupervisorStartupLock,
+    DaemonHomeScope, PreservedDaemonEndpoint, ProcessIdentity, RegisteredRepoDaemon,
+    SupervisorStartupLock,
 };
 
 /// Liveness of a recorded daemon/supervisor endpoint. Pure classification of the
@@ -634,6 +635,12 @@ pub async fn status(json: bool) -> Result<()> {
     // stale local endpoint is visible even when the supervisor has pruned it.
     let current = current_repo_status();
 
+    // The supervisor is machine-wide, so this listing can span managed homes.
+    // Every entry is labelled with the home it belongs to and whether that is
+    // the caller's, which is what makes a pinned session able to see which
+    // daemons are its own.
+    let caller_home = caller_home_id();
+
     if json {
         let daemons_json: Vec<_> = daemons
             .iter()
@@ -651,17 +658,21 @@ pub async fn status(json: bool) -> Result<()> {
                     "graph_entity_count": d.graph_entity_count,
                     "last_heartbeat_at": d.last_heartbeat_at,
                     "state": state.label(),
+                    "kin_home": d.kin_home,
+                    "home_scope": home_scope_label(d.home_scope(&caller_home)),
                 })
             })
             .collect();
         let payload = serde_json::json!({
             "schema": "kin.daemon-status.v1",
+            "caller_kin_home": caller_home,
             "supervisor": {
                 "state": sup_state.label(),
                 "pid": sup_pid,
                 "port": sup_port,
                 "pid_file": supervisor_pid_path().display().to_string(),
                 "port_file": supervisor_port_path().display().to_string(),
+                "scope": "machine",
             },
             "repo_daemons": daemons_json,
             "current_repo": current.as_ref().map(|c| serde_json::json!({
@@ -691,9 +702,11 @@ pub async fn status(json: bool) -> Result<()> {
     }
     println!("  pid file:  {}", supervisor_pid_path().display());
     println!("  port file: {}", supervisor_port_path().display());
+    println!("  scope:     machine-wide (one per machine, not per KIN_HOME)");
     if sup_state.is_stale() {
         println!("  note: supervisor endpoint files are stale; run `kin daemon stop --all` to clear them");
     }
+    println!("  this KIN_HOME: {caller_home}");
 
     println!();
     if supervisor_url.is_none() {
@@ -726,6 +739,11 @@ pub async fn status(json: bool) -> Result<()> {
             );
             println!("    route:     {}", daemon.repo_id);
             println!("    endpoint:  {}", daemon.endpoint);
+            println!(
+                "    kin home:  {} ({})",
+                daemon.home_label(),
+                home_scope_label(daemon.home_scope(&caller_home))
+            );
             if !daemon.last_heartbeat_at.trim().is_empty() {
                 println!("    heartbeat: {}", daemon.last_heartbeat_at);
             }
@@ -779,13 +797,117 @@ fn current_repo_status() -> Option<CurrentRepoStatus> {
 
 // ── stop ────────────────────────────────────────────────────────────────────
 
+/// Which daemons a `--all` sweep is entitled to stop.
+///
+/// The supervisor is a machine-level singleton: its directory hangs off
+/// `registry_path()`, which resolves from the real home, while `KIN_HOME` moves
+/// only store and install state. One supervisor therefore holds daemons from
+/// several managed homes, and an unscoped `--all` reaches every one of them.
+/// That is how a pinned session stopped daemons it did not own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StopScope {
+    /// Only daemons recording the caller's managed home. The default, because
+    /// pinning `KIN_HOME` reads everywhere else as "bound to my own state".
+    Home,
+    /// Every daemon this supervisor knows about, whichever home it belongs to.
+    /// The operator gesture, and it names what it is taking down.
+    Machine,
+}
+
+impl StopScope {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Home => "home",
+            Self::Machine => "machine",
+        }
+    }
+}
+
 /// `kin daemon stop` — gracefully stop the current repo's worker daemon, or with
-/// `--all` every worker plus the supervisor (supervisor last).
-pub async fn stop(all: bool, json: bool) -> Result<()> {
+/// `--all` every worker under this managed home plus the supervisor (supervisor
+/// last). `--machine` widens the sweep to the whole box.
+pub async fn stop(all: bool, machine: bool, json: bool) -> Result<()> {
     if all {
-        stop_all(json, false).await
+        let scope = if machine {
+            StopScope::Machine
+        } else {
+            StopScope::Home
+        };
+        stop_all(scope, json, false).await
     } else {
         stop_current_repo(json).await
+    }
+}
+
+/// A registered daemon that does not belong to the caller's managed home.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ForeignDaemon {
+    label: String,
+    pid: u32,
+    /// The recorded home, or `unrecorded`.
+    home: String,
+    /// False when the daemon reported no home at all, which is a different
+    /// answer from reporting one that does not match.
+    recorded: bool,
+}
+
+impl ForeignDaemon {
+    fn description(&self) -> String {
+        if self.recorded {
+            format!("{} (pid {}, home {})", self.label, self.pid, self.home)
+        } else {
+            format!("{} (pid {}, home unrecorded)", self.label, self.pid)
+        }
+    }
+}
+
+/// Split a supervisor's registry into what this sweep will stop and what does
+/// not belong to the caller's home.
+///
+/// The second list is returned for both scopes and means different things:
+/// under [`StopScope::Home`] it is what was skipped, under
+/// [`StopScope::Machine`] it is what is being taken down on someone else's
+/// behalf. Either way it gets named, because a sweep that silently omits or
+/// silently includes a daemon is the failure this partition exists to end.
+pub(crate) fn partition_by_home(
+    daemons: Vec<RegisteredRepoDaemon>,
+    caller_home: &str,
+    scope: StopScope,
+) -> (Vec<RegisteredRepoDaemon>, Vec<ForeignDaemon>) {
+    let mut targets = Vec::new();
+    let mut foreign = Vec::new();
+
+    for daemon in daemons {
+        let relation = daemon.home_scope(caller_home);
+        if relation != DaemonHomeScope::Own {
+            foreign.push(ForeignDaemon {
+                label: daemon_label(&daemon),
+                pid: daemon.pid,
+                home: daemon.home_label().to_string(),
+                recorded: relation == DaemonHomeScope::Foreign,
+            });
+        }
+        if scope == StopScope::Machine || relation == DaemonHomeScope::Own {
+            targets.push(daemon);
+        }
+    }
+
+    (targets, foreign)
+}
+
+fn daemon_label(daemon: &RegisteredRepoDaemon) -> String {
+    if daemon.display_name.trim().is_empty() {
+        daemon.repo_id.clone()
+    } else {
+        daemon.display_name.clone()
+    }
+}
+
+fn home_scope_label(scope: DaemonHomeScope) -> &'static str {
+    match scope {
+        DaemonHomeScope::Own => "this KIN_HOME",
+        DaemonHomeScope::Foreign => "other KIN_HOME",
+        DaemonHomeScope::Unrecorded => "home unrecorded",
     }
 }
 
@@ -794,7 +916,10 @@ pub async fn stop(all: bool, json: bool) -> Result<()> {
 /// failures still propagate so it never removes binaries out from under a live
 /// daemon.
 pub(crate) async fn stop_all_quiet() -> Result<()> {
-    stop_all(false, true).await
+    // Machine scope on purpose: uninstall removes the binaries every daemon on
+    // this box is running from, so leaving another home's daemon alive would
+    // strand a live process on a deleted install.
+    stop_all(StopScope::Machine, true, true).await
 }
 
 /// Startup authority retained by full uninstall until the install root is
@@ -871,7 +996,7 @@ pub(crate) async fn stop_all_for_uninstall(install_root: &Path) -> Result<Uninst
             }
         }
     };
-    stop_all_inner(false, true, Some(install_root)).await?;
+    stop_all_inner(StopScope::Machine, false, true, Some(install_root)).await?;
     let fence = UninstallDaemonFence {
         _startup_authority: startup_authority,
     };
@@ -986,11 +1111,16 @@ async fn resolve_repo_worker_pid(kin_root: &Path, working_dir: &Path) -> Result<
         .map(|d| d.pid))
 }
 
-async fn stop_all(json: bool, quiet: bool) -> Result<()> {
-    stop_all_inner(json, quiet, None).await
+async fn stop_all(scope: StopScope, json: bool, quiet: bool) -> Result<()> {
+    stop_all_inner(scope, json, quiet, None).await
 }
 
-async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) -> Result<()> {
+async fn stop_all_inner(
+    scope: StopScope,
+    json: bool,
+    quiet: bool,
+    uninstall_root: Option<&Path>,
+) -> Result<()> {
     // One budget for the whole sweep. Each identity below waits only for what
     // is left of it, so this command's bound is the budget rather than the
     // budget multiplied by however many daemons happen to be running.
@@ -1063,12 +1193,16 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
         }
     }
 
+    // Full uninstall is machine-wide by construction: it must leave no process
+    // running before it removes the binaries, so it never partitions.
+    let (daemons, foreign) = if uninstall_root.is_some() {
+        (daemons, Vec::new())
+    } else {
+        partition_by_home(daemons, &caller_home_id(), scope)
+    };
+
     for daemon in daemons {
-        let label = if daemon.display_name.trim().is_empty() {
-            daemon.repo_id.clone()
-        } else {
-            daemon.display_name.clone()
-        };
+        let label = daemon_label(&daemon);
         let kin_root = Path::new(&daemon.repo_root).join(".kin");
         let outcome = stop_worker_at(
             &kin_root,
@@ -1115,9 +1249,15 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
         }
     }
 
+    // The supervisor is shared. Stopping it while daemons from other homes are
+    // still registered would take away the routing they depend on, which is the
+    // same boundary violation as stopping them outright. A home-scoped sweep
+    // that left anything behind therefore retains it and says so.
+    let supervisor_retained = scope == StopScope::Home && !foreign.is_empty();
+
     // The ordinary `kin daemon stop --all` path keeps the historical order:
     // workers first, supervisor last. Full uninstall already stopped it above.
-    if uninstall_root.is_none() {
+    if uninstall_root.is_none() && !supervisor_retained {
         if let (Some(pid), Some(identity)) = (sup_pid, supervisor_identity.as_ref()) {
             let outcome = stop_supervisor_identity(identity, remaining_budget(deadline));
             if outcome.is_success() {
@@ -1137,25 +1277,101 @@ async fn stop_all_inner(json: bool, quiet: bool, uninstall_root: Option<&Path>) 
         stop_install_owned_daemons(install_root, deadline, &mut reports)?;
     }
 
+    let disclosure = StopDisclosure {
+        scope: Some(scope),
+        foreign,
+        supervisor_retained,
+    };
+
     if reports.is_empty() {
         if quiet {
             // The absence of managed daemons is a successful precondition for
             // full uninstall and needs no nested command output.
         } else if json {
-            let payload = serde_json::json!({
+            let mut payload = serde_json::json!({
                 "schema": "kin.daemon-stop.v1",
-                "scope": "all",
+                "scope": scope.label(),
                 "stopped": [],
                 "all_stopped": true,
             });
+            disclosure.write_json(&mut payload);
             println!("{}", serde_json::to_string_pretty(&payload)?);
-        } else {
+        } else if disclosure.foreign.is_empty() {
             println!("No Kin daemons running.");
+        } else {
+            // Never "no daemons running": daemons ARE running, and this scope
+            // is simply not entitled to them. Collapsing the two is how a
+            // scoped sweep would start reading as an empty machine.
+            println!("No Kin daemons running under this KIN_HOME.");
+            disclosure.write_text();
         }
         return Ok(());
     }
 
-    finish_stop_with_output("all", &reports, json, quiet)
+    finish_stop_with_output(scope.label(), &reports, json, quiet, &disclosure)
+}
+
+/// What a sweep must say about daemons outside its scope.
+#[derive(Debug, Default)]
+pub(crate) struct StopDisclosure {
+    scope: Option<StopScope>,
+    foreign: Vec<ForeignDaemon>,
+    /// The supervisor was deliberately left running because other homes still
+    /// depend on it.
+    supervisor_retained: bool,
+}
+
+impl StopDisclosure {
+    fn write_json(&self, payload: &mut serde_json::Value) {
+        let Some(scope) = self.scope else {
+            return;
+        };
+        let listed: Vec<_> = self
+            .foreign
+            .iter()
+            .map(|d| {
+                serde_json::json!({
+                    "label": d.label,
+                    "pid": d.pid,
+                    "kin_home": d.home,
+                    "home_recorded": d.recorded,
+                })
+            })
+            .collect();
+        let key = match scope {
+            StopScope::Home => "skipped_other_homes",
+            StopScope::Machine => "stopped_other_homes",
+        };
+        payload[key] = serde_json::Value::Array(listed);
+        payload["supervisor_retained"] = serde_json::Value::Bool(self.supervisor_retained);
+    }
+
+    fn write_text(&self) {
+        let Some(scope) = self.scope else {
+            return;
+        };
+        if self.foreign.is_empty() {
+            return;
+        }
+        let lead = match scope {
+            StopScope::Home => "Skipped (other KIN_HOME)",
+            StopScope::Machine => "Also stopped (other KIN_HOME)",
+        };
+        println!("{lead}:");
+        for daemon in &self.foreign {
+            println!("  {}", daemon.description());
+        }
+        if scope == StopScope::Home {
+            println!(
+                "  KIN_HOME bounds store state; the supervisor is machine-wide. Use `kin daemon stop --all --machine` to stop these too."
+            );
+        }
+        if self.supervisor_retained {
+            println!(
+                "  Supervisor left running: it is shared with the daemons above."
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1398,7 +1614,7 @@ fn stop_install_owned_daemons(
 /// Emit the stop report and fail loud (nonzero exit) if any endpoint would not
 /// die, so scripts can trust the exit code.
 fn finish_stop(scope: &str, reports: &[StopReport], json: bool) -> Result<()> {
-    finish_stop_with_output(scope, reports, json, false)
+    finish_stop_with_output(scope, reports, json, false, &StopDisclosure::default())
 }
 
 fn finish_stop_with_output(
@@ -1406,6 +1622,7 @@ fn finish_stop_with_output(
     reports: &[StopReport],
     json: bool,
     quiet: bool,
+    disclosure: &StopDisclosure,
 ) -> Result<()> {
     let all_stopped = reports.iter().all(|r| r.outcome.is_success());
     // Reported separately from `all_stopped`, which stays a statement about
@@ -1436,13 +1653,14 @@ fn finish_stop_with_output(
                 entry
             })
             .collect();
-        let payload = serde_json::json!({
+        let mut payload = serde_json::json!({
             "schema": "kin.daemon-stop.v1",
             "scope": scope,
             "stopped": stopped,
             "all_stopped": all_stopped,
             "endpoints_retired": endpoints_retired,
         });
+        disclosure.write_json(&mut payload);
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
         for r in reports {
@@ -1471,7 +1689,10 @@ fn finish_stop_with_output(
                 );
             }
         }
+        disclosure.write_text();
         if all_stopped && endpoints_retired {
+            // "Targeted" is load-bearing now that a sweep can be scoped: the
+            // disclosure above names what was outside the target.
             println!("All targeted Kin daemons stopped.");
         }
     }
@@ -1537,6 +1758,7 @@ mod tests {
             &[stop_report(Some(preserved))],
             false,
             false,
+            &StopDisclosure::default(),
         )
         .expect_err("a published endpoint outliving a confirmed stop is a failure");
         let rendered = format!("{error:#}");
@@ -1548,7 +1770,13 @@ mod tests {
         // The falsification: the identical report with nothing preserved passes,
         // so the assertion above is about the survivor and not about the shape
         // of the report.
-        finish_stop_with_output("current-repo", &[stop_report(None)], false, false)
+        finish_stop_with_output(
+            "current-repo",
+            &[stop_report(None)],
+            false,
+            false,
+            &StopDisclosure::default(),
+        )
             .expect("a retired endpoint is a clean stop");
     }
 
@@ -1562,7 +1790,13 @@ mod tests {
             Path::new("/repo/.kin/daemon.pid"),
             "recorded owner pid 4242 never became affirmatively dead",
         );
-        finish_stop_with_output("all", &[stop_report(Some(preserved))], false, true)
+        finish_stop_with_output(
+            "all",
+            &[stop_report(Some(preserved))],
+            false,
+            true,
+            &StopDisclosure::default(),
+        )
             .expect("a leftover endpoint record does not keep an install alive");
     }
 
@@ -1954,5 +2188,159 @@ mod tests {
         let _ = reaper.join();
 
         assert_eq!(outcome, StopOutcome::Stopped);
+    }
+
+    fn registered(label: &str, pid: u32, kin_home: &str) -> RegisteredRepoDaemon {
+        RegisteredRepoDaemon {
+            repo_id: format!("local-{label}"),
+            display_name: label.to_string(),
+            instance_id: format!("pid-{pid}"),
+            repo_root: format!("/repos/{label}"),
+            pid,
+            port: 49152,
+            endpoint: "http://127.0.0.1:49152".to_string(),
+            graph_entity_count: None,
+            kin_home: kin_home.to_string(),
+            registered_at: None,
+            last_heartbeat_at: String::new(),
+        }
+    }
+
+    fn two_homes() -> Vec<RegisteredRepoDaemon> {
+        vec![
+            registered("mine", 101, "/homes/a/.kin"),
+            registered("theirs", 202, "/homes/b/.kin"),
+        ]
+    }
+
+    /// The FIR-2167 refusal: a pinned session sweeping `--all` reaches only its
+    /// own daemons, and the neighbour's survives.
+    #[test]
+    fn a_home_scoped_sweep_stops_only_its_own_daemons() {
+        let (targets, foreign) =
+            partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Home);
+
+        assert_eq!(
+            targets.iter().map(|d| d.pid).collect::<Vec<_>>(),
+            vec![101]
+        );
+        assert_eq!(foreign.len(), 1);
+        assert_eq!(foreign[0].pid, 202);
+        assert_eq!(foreign[0].home, "/homes/b/.kin");
+        assert!(foreign[0].recorded);
+    }
+
+    /// The same registry read from the other home reaches the other daemon.
+    /// Without this, a partition that simply always kept the first entry would
+    /// pass the test above.
+    #[test]
+    fn the_scoped_sweep_follows_the_callers_home() {
+        let (targets, foreign) =
+            partition_by_home(two_homes(), "/homes/b/.kin", StopScope::Home);
+
+        assert_eq!(
+            targets.iter().map(|d| d.pid).collect::<Vec<_>>(),
+            vec![202]
+        );
+        assert_eq!(foreign.len(), 1);
+        assert_eq!(foreign[0].pid, 101);
+    }
+
+    #[test]
+    fn a_machine_sweep_stops_both_and_names_the_foreign_one() {
+        let (targets, foreign) =
+            partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Machine);
+
+        assert_eq!(
+            targets.iter().map(|d| d.pid).collect::<Vec<_>>(),
+            vec![101, 202]
+        );
+        assert_eq!(foreign.len(), 1, "the sweep must disclose what it took down");
+        assert_eq!(foreign[0].pid, 202);
+    }
+
+    /// A daemon that recorded no home is excluded from a scoped sweep. Treating
+    /// an unknown as a match is exactly the assumption that made `--all`
+    /// machine-wide in the first place.
+    #[test]
+    fn an_unrecorded_home_is_not_treated_as_the_callers() {
+        let daemons = vec![registered("legacy", 303, "")];
+        let (targets, foreign) =
+            partition_by_home(daemons, "/homes/a/.kin", StopScope::Home);
+
+        assert!(targets.is_empty());
+        assert_eq!(foreign.len(), 1);
+        assert!(!foreign[0].recorded);
+        assert!(foreign[0].description().contains("home unrecorded"));
+    }
+
+    #[test]
+    fn a_machine_sweep_still_reaches_an_unrecorded_daemon() {
+        let daemons = vec![registered("legacy", 303, "")];
+        let (targets, _) = partition_by_home(daemons, "/homes/a/.kin", StopScope::Machine);
+        assert_eq!(targets.len(), 1);
+    }
+
+    #[test]
+    fn home_scope_distinguishes_own_foreign_and_unrecorded() {
+        assert_eq!(
+            registered("a", 1, "/homes/a/.kin").home_scope("/homes/a/.kin"),
+            DaemonHomeScope::Own
+        );
+        assert_eq!(
+            registered("b", 2, "/homes/b/.kin").home_scope("/homes/a/.kin"),
+            DaemonHomeScope::Foreign
+        );
+        assert_eq!(
+            registered("c", 3, "  ").home_scope("/homes/a/.kin"),
+            DaemonHomeScope::Unrecorded
+        );
+        assert_eq!(registered("c", 3, "").home_label(), "unrecorded");
+    }
+
+    /// The census must be able to say which daemons are the caller's, which is
+    /// the FIR-2180 visibility half of the contract.
+    #[test]
+    fn the_census_labels_every_home() {
+        let labels: Vec<_> = two_homes()
+            .iter()
+            .map(|d| home_scope_label(d.home_scope("/homes/a/.kin")))
+            .collect();
+        assert_eq!(labels, vec!["this KIN_HOME", "other KIN_HOME"]);
+    }
+
+    #[test]
+    fn a_scoped_sweep_that_skips_nothing_may_stop_the_supervisor() {
+        let daemons = vec![registered("mine", 101, "/homes/a/.kin")];
+        let (_, foreign) = partition_by_home(daemons, "/homes/a/.kin", StopScope::Home);
+        assert!(
+            foreign.is_empty(),
+            "nothing skipped, so the shared supervisor has no other dependant"
+        );
+    }
+
+    #[test]
+    fn the_disclosure_json_separates_skipped_from_stopped() {
+        let (_, foreign) = partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Home);
+        let skipped = StopDisclosure {
+            scope: Some(StopScope::Home),
+            foreign: foreign.clone(),
+            supervisor_retained: true,
+        };
+        let mut payload = serde_json::json!({});
+        skipped.write_json(&mut payload);
+        assert_eq!(payload["skipped_other_homes"][0]["pid"], 202);
+        assert_eq!(payload["supervisor_retained"], true);
+        assert!(payload.get("stopped_other_homes").is_none());
+
+        let taken = StopDisclosure {
+            scope: Some(StopScope::Machine),
+            foreign,
+            supervisor_retained: false,
+        };
+        let mut payload = serde_json::json!({});
+        taken.write_json(&mut payload);
+        assert_eq!(payload["stopped_other_homes"][0]["pid"], 202);
+        assert!(payload.get("skipped_other_homes").is_none());
     }
 }

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1367,9 +1367,7 @@ impl StopDisclosure {
             );
         }
         if self.supervisor_retained {
-            println!(
-                "  Supervisor left running: it is shared with the daemons above."
-            );
+            println!("  Supervisor left running: it is shared with the daemons above.");
         }
     }
 }
@@ -1777,7 +1775,7 @@ mod tests {
             false,
             &StopDisclosure::default(),
         )
-            .expect("a retired endpoint is a clean stop");
+        .expect("a retired endpoint is a clean stop");
     }
 
     /// Full uninstall's nested stop must not be blocked by a leftover pid file.
@@ -1797,7 +1795,7 @@ mod tests {
             true,
             &StopDisclosure::default(),
         )
-            .expect("a leftover endpoint record does not keep an install alive");
+        .expect("a leftover endpoint record does not keep an install alive");
     }
 
     #[cfg(windows)]
@@ -2217,13 +2215,9 @@ mod tests {
     /// own daemons, and the neighbour's survives.
     #[test]
     fn a_home_scoped_sweep_stops_only_its_own_daemons() {
-        let (targets, foreign) =
-            partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Home);
+        let (targets, foreign) = partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Home);
 
-        assert_eq!(
-            targets.iter().map(|d| d.pid).collect::<Vec<_>>(),
-            vec![101]
-        );
+        assert_eq!(targets.iter().map(|d| d.pid).collect::<Vec<_>>(), vec![101]);
         assert_eq!(foreign.len(), 1);
         assert_eq!(foreign[0].pid, 202);
         assert_eq!(foreign[0].home, "/homes/b/.kin");
@@ -2235,13 +2229,9 @@ mod tests {
     /// pass the test above.
     #[test]
     fn the_scoped_sweep_follows_the_callers_home() {
-        let (targets, foreign) =
-            partition_by_home(two_homes(), "/homes/b/.kin", StopScope::Home);
+        let (targets, foreign) = partition_by_home(two_homes(), "/homes/b/.kin", StopScope::Home);
 
-        assert_eq!(
-            targets.iter().map(|d| d.pid).collect::<Vec<_>>(),
-            vec![202]
-        );
+        assert_eq!(targets.iter().map(|d| d.pid).collect::<Vec<_>>(), vec![202]);
         assert_eq!(foreign.len(), 1);
         assert_eq!(foreign[0].pid, 101);
     }
@@ -2255,7 +2245,11 @@ mod tests {
             targets.iter().map(|d| d.pid).collect::<Vec<_>>(),
             vec![101, 202]
         );
-        assert_eq!(foreign.len(), 1, "the sweep must disclose what it took down");
+        assert_eq!(
+            foreign.len(),
+            1,
+            "the sweep must disclose what it took down"
+        );
         assert_eq!(foreign[0].pid, 202);
     }
 
@@ -2265,8 +2259,7 @@ mod tests {
     #[test]
     fn an_unrecorded_home_is_not_treated_as_the_callers() {
         let daemons = vec![registered("legacy", 303, "")];
-        let (targets, foreign) =
-            partition_by_home(daemons, "/homes/a/.kin", StopScope::Home);
+        let (targets, foreign) = partition_by_home(daemons, "/homes/a/.kin", StopScope::Home);
 
         assert!(targets.is_empty());
         assert_eq!(foreign.len(), 1);

--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -64,7 +64,7 @@ pub async fn run(yes: bool) -> Result<()> {
 
     // The daemon is the only long-lived writer allowed to observe this
     // workspace. Stop it before the final root comparison and namespace swap.
-    crate::commands::daemon::stop(false, false)
+    crate::commands::daemon::stop(false, false, false)
         .await
         .context("stop repository daemon before eject")?;
     drop(authority);

--- a/crates/kin-cli/src/commands/registry.rs
+++ b/crates/kin-cli/src/commands/registry.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use kin_core::registry::KinRegistry;
 use std::collections::HashSet;
 
-use crate::daemon_client::RegisteredRepoDaemon;
+use crate::daemon_client::{DaemonHomeScope, RegisteredRepoDaemon};
 
 use super::deps;
 
@@ -109,7 +109,12 @@ pub async fn daemons(json: bool) -> Result<()> {
         return Ok(());
     }
 
-    println!("Kin supervisor: {}", supervisor_url);
+    // One supervisor per machine, so this listing can span managed homes. Each
+    // entry states which home it belongs to and whether that is the caller's.
+    let caller_home = crate::daemon_client::caller_home_id();
+
+    println!("Kin supervisor: {} (machine-wide)", supervisor_url);
+    println!("This KIN_HOME:  {caller_home}");
     if daemons.is_empty() {
         println!("No repo daemons registered.");
         return Ok(());
@@ -138,6 +143,15 @@ pub async fn daemons(json: bool) -> Result<()> {
             println!("  instance: {}", daemon.instance_id);
         }
         println!("  endpoint: {}", daemon.endpoint);
+        println!(
+            "  kin home: {} ({})",
+            daemon.home_label(),
+            match daemon.home_scope(&caller_home) {
+                DaemonHomeScope::Own => "this KIN_HOME",
+                DaemonHomeScope::Foreign => "other KIN_HOME",
+                DaemonHomeScope::Unrecorded => "home unrecorded",
+            }
+        );
         println!("  heartbeat: {}", daemon.last_heartbeat_at);
     }
     Ok(())

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -174,10 +174,68 @@ pub struct RegisteredRepoDaemon {
     pub endpoint: String,
     #[serde(default)]
     pub graph_entity_count: Option<usize>,
+    /// The managed Kin home the daemon reported at registration, empty when it
+    /// is not recorded (an older daemon, or one the supervisor adopted rather
+    /// than received a registration from).
+    ///
+    /// The supervisor is machine-wide while `KIN_HOME` bounds store and install
+    /// state, so a single registry legitimately lists daemons from several
+    /// homes. This is what the census labels and what a home-scoped
+    /// `kin daemon stop --all` partitions on.
+    #[serde(default)]
+    pub kin_home: String,
     #[serde(default)]
     pub registered_at: Option<String>,
     #[serde(default)]
     pub last_heartbeat_at: String,
+}
+
+/// How a registered daemon's home relates to the caller's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonHomeScope {
+    /// The daemon recorded the same managed home the caller resolves.
+    Own,
+    /// The daemon recorded a different managed home.
+    Foreign,
+    /// No home was recorded, so the relationship cannot be established.
+    ///
+    /// Deliberately distinct from [`DaemonHomeScope::Foreign`]: both are
+    /// excluded from a home-scoped sweep, but only one of them can be reported
+    /// with a home to name.
+    Unrecorded,
+}
+
+impl RegisteredRepoDaemon {
+    /// Classify this daemon against a caller's resolved managed home.
+    ///
+    /// An unrecorded home is never treated as a match. Failing to stop a daemon
+    /// is visible and recoverable; stopping a neighbour's is neither.
+    pub fn home_scope(&self, caller_home_id: &str) -> DaemonHomeScope {
+        let recorded = self.kin_home.trim();
+        if recorded.is_empty() {
+            DaemonHomeScope::Unrecorded
+        } else if recorded == caller_home_id {
+            DaemonHomeScope::Own
+        } else {
+            DaemonHomeScope::Foreign
+        }
+    }
+
+    /// The recorded home to show an operator, or a stated absence.
+    pub fn home_label(&self) -> &str {
+        let recorded = self.kin_home.trim();
+        if recorded.is_empty() {
+            "unrecorded"
+        } else {
+            recorded
+        }
+    }
+}
+
+/// The managed Kin home this process resolves, in the string form recorded by
+/// registering daemons.
+pub fn caller_home_id() -> String {
+    kin_core::registry::managed_kin_home_id(&kin_core::registry::managed_kin_home())
 }
 
 /// Fetch the repo daemons registered with a running supervisor via `GET

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1931,9 +1931,17 @@ enum DaemonAction {
     },
     /// Gracefully stop the current repo's worker daemon (or every daemon with --all)
     Stop {
-        /// Stop every worker daemon and the supervisor (supervisor last)
+        /// Stop every worker daemon under this KIN_HOME, then the supervisor
+        ///
+        /// The supervisor is machine-wide, so it can hold daemons from other
+        /// managed homes. Those are skipped and named rather than stopped, and
+        /// the supervisor itself is left running while any of them remain. Use
+        /// --machine to stop every daemon on the box regardless of home.
         #[arg(long)]
         all: bool,
+        /// Widen --all to every daemon on this machine, whatever KIN_HOME it runs under
+        #[arg(long, requires = "all")]
+        machine: bool,
         /// Emit machine-readable JSON
         #[arg(long)]
         json: bool,
@@ -3230,7 +3238,9 @@ fn main() -> Result<()> {
                 },
                 Command::Daemon { action } => match action {
                     DaemonAction::Status { json } => commands::daemon::status(json).await,
-                    DaemonAction::Stop { all, json } => commands::daemon::stop(all, json).await,
+                    DaemonAction::Stop { all, machine, json } => {
+                        commands::daemon::stop(all, machine, json).await
+                    }
                 },
                 Command::Doctor {
                     fix,

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -143,7 +143,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     // ---- validation control ---------------------------------------------------
     EnvVarSpec { name: "KIN_ENV_VALIDATION", kind: Kind::OneOf(&["off", "warn", "strict"]), default: "warn", sensitivity: Sensitivity::Operational, summary: "startup env validation mode: off, warn (default), or strict" },
     // ---- install / setup root -------------------------------------------------
-    EnvVarSpec { name: "KIN_HOME", kind: Kind::Path, default: "~/.kin", sensitivity: Sensitivity::Operational, summary: "preferred root for the managed Kin install used by the launcher, setup, and shell hooks" },
+    EnvVarSpec { name: "KIN_HOME", kind: Kind::Path, default: "~/.kin", sensitivity: Sensitivity::Operational, summary: "preferred root for the managed Kin install used by the launcher, setup, and shell hooks; bounds install and store state, NOT the machine-wide daemon supervisor" },
     EnvVarSpec { name: "KIN_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "compatibility alias for the managed Kin install root; KIN_HOME wins when both are set" },
     EnvVarSpec { name: "KIN_VERSION", kind: Kind::Str, default: "latest", sensitivity: Sensitivity::Operational, summary: "release version selected by the shell and PowerShell installers" },
     EnvVarSpec { name: "KIN_BASE_URL", kind: Kind::Url, default: "GitHub Releases", sensitivity: Sensitivity::Operational, summary: "release mirror base URL used by the shell and PowerShell installers" },

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -2619,10 +2619,7 @@ mod tests {
     #[test]
     fn a_missing_home_keeps_its_literal_identity() {
         let missing = PathBuf::from("/definitely/not/present/.kin");
-        assert_eq!(
-            managed_kin_home_id(&missing),
-            missing.display().to_string()
-        );
+        assert_eq!(managed_kin_home_id(&missing), missing.display().to_string());
     }
 
     #[test]

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -1580,6 +1580,11 @@ fn write_registry_atomically(
 }
 
 /// `~/.kin/registry.toml` path (cross-platform).
+///
+/// This also fixes the supervisor directory, which is this path's parent. That
+/// makes the supervisor a machine-level singleton keyed on the real home (or an
+/// explicit `KIN_REGISTRY_PATH`), deliberately *not* on `KIN_HOME`: see
+/// [`managed_kin_home`] for the boundary each variable actually draws.
 pub fn registry_path() -> PathBuf {
     if let Some(path) = std::env::var_os("KIN_REGISTRY_PATH") {
         return PathBuf::from(path);
@@ -1590,6 +1595,71 @@ pub fn registry_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".kin")
         .join("registry.toml")
+}
+
+/// The managed Kin install root this process resolves: `KIN_HOME`, then the
+/// `KIN_DIR` compatibility alias, then `<home>/.kin`.
+///
+/// This is the boundary `KIN_HOME` genuinely draws. It bounds store and install
+/// state; it does not move the supervisor, whose directory comes from
+/// [`registry_path`] and therefore from the real home. One supervisor can
+/// consequently hold daemons launched under several managed homes, so every
+/// daemon records the value this returns and the census partitions on it.
+///
+/// Both the CLI and the daemon call this same function, so two processes that
+/// resolve independently agree by construction.
+pub fn managed_kin_home() -> PathBuf {
+    resolve_managed_kin_home(
+        cfg!(windows),
+        |key| std::env::var_os(key),
+        || directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+        || directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+    )
+}
+
+/// The policy behind [`managed_kin_home`], with the platform, the environment,
+/// and both OS home lookups taken as arguments.
+///
+/// The Windows arm is a runtime branch rather than a `#[cfg]` block so it is
+/// compiled and tested on every host, including the ones this fleet actually
+/// builds on.
+pub(crate) fn resolve_managed_kin_home(
+    windows: bool,
+    var_os: impl Fn(&str) -> Option<std::ffi::OsString>,
+    known_profile_root: impl FnOnce() -> Option<PathBuf>,
+    base_dirs_home: impl FnOnce() -> Option<PathBuf>,
+) -> PathBuf {
+    for key in ["KIN_HOME", "KIN_DIR"] {
+        if let Some(value) = var_os(key).filter(|value| !value.is_empty()) {
+            return PathBuf::from(value);
+        }
+    }
+
+    let home = if windows {
+        var_os("USERPROFILE")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .or_else(known_profile_root)
+            .or_else(base_dirs_home)
+    } else {
+        base_dirs_home()
+    };
+
+    home.unwrap_or_else(|| PathBuf::from(".")).join(".kin")
+}
+
+/// Stable string identity for a managed home, for comparison between processes
+/// that resolved it independently.
+///
+/// A home that does not exist yet cannot be canonicalized; its literal path is
+/// used instead. Two processes that disagree about whether it existed therefore
+/// compare as *different* homes, which is the safe direction: an unrecognized
+/// home is skipped and named rather than silently swept up.
+pub fn managed_kin_home_id(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
 }
 
 #[cfg(test)]
@@ -2467,5 +2537,100 @@ mod tests {
         assert_eq!(paths.len(), 2);
         assert!(paths.contains(&Path::new("/a")));
         assert!(paths.contains(&Path::new("/b")));
+    }
+
+    /// Resolve against a stated environment, so no test reads ambient state.
+    fn managed_home_with(windows: bool, env: &[(&str, &str)]) -> PathBuf {
+        let owned: Vec<(String, String)> = env
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        resolve_managed_kin_home(
+            windows,
+            |key| {
+                owned
+                    .iter()
+                    .find(|(name, _)| name == key)
+                    .map(|(_, value)| std::ffi::OsString::from(value))
+            },
+            || Some(PathBuf::from("/profile-root")),
+            || Some(PathBuf::from("/base-home")),
+        )
+    }
+
+    #[test]
+    fn kin_home_wins_over_kin_dir_and_the_home_fallback() {
+        assert_eq!(
+            managed_home_with(false, &[("KIN_HOME", "/pinned"), ("KIN_DIR", "/alias")]),
+            PathBuf::from("/pinned")
+        );
+    }
+
+    #[test]
+    fn kin_dir_is_the_compatibility_alias() {
+        assert_eq!(
+            managed_home_with(false, &[("KIN_DIR", "/alias")]),
+            PathBuf::from("/alias")
+        );
+    }
+
+    #[test]
+    fn an_empty_pin_is_not_a_home() {
+        assert_eq!(
+            managed_home_with(false, &[("KIN_HOME", ""), ("KIN_DIR", "")]),
+            PathBuf::from("/base-home/.kin")
+        );
+    }
+
+    #[test]
+    fn unpinned_falls_back_to_the_real_home() {
+        assert_eq!(
+            managed_home_with(false, &[]),
+            PathBuf::from("/base-home/.kin")
+        );
+    }
+
+    #[test]
+    fn windows_prefers_the_user_profile_for_the_fallback_home() {
+        assert_eq!(
+            managed_home_with(true, &[("USERPROFILE", "/users/kin")]),
+            PathBuf::from("/users/kin/.kin")
+        );
+        assert_eq!(
+            managed_home_with(true, &[]),
+            PathBuf::from("/profile-root/.kin")
+        );
+    }
+
+    /// The distinction the supervisor scoping contract rests on: a pinned
+    /// `KIN_HOME` moves the managed home while the supervisor's own directory,
+    /// which hangs off [`registry_path`], stays put.
+    #[test]
+    fn pinning_kin_home_does_not_move_the_registry_path() {
+        let pinned = managed_home_with(false, &[("KIN_HOME", "/scratch/home")]);
+        let unpinned = managed_home_with(false, &[]);
+        assert_ne!(pinned, unpinned);
+
+        // `registry_path` reads only `KIN_REGISTRY_PATH` and the real home, so
+        // no value of `KIN_HOME` can appear in it.
+        assert!(!registry_path().starts_with("/scratch/home"));
+    }
+
+    #[test]
+    fn a_missing_home_keeps_its_literal_identity() {
+        let missing = PathBuf::from("/definitely/not/present/.kin");
+        assert_eq!(
+            managed_kin_home_id(&missing),
+            missing.display().to_string()
+        );
+    }
+
+    #[test]
+    fn identity_is_stable_for_a_home_that_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            managed_kin_home_id(dir.path()),
+            managed_kin_home_id(dir.path())
+        );
     }
 }

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -63,6 +63,17 @@ pub struct RepoDaemonRegistration {
     pub endpoint: String,
     #[serde(default)]
     pub graph_entity_count: Option<usize>,
+    /// The managed Kin home this daemon runs under, as
+    /// `kin_core::registry::managed_kin_home` resolved it in this process.
+    ///
+    /// The supervisor is machine-wide, so one registry legitimately holds
+    /// daemons from several homes. This is what lets a census partition them
+    /// and lets a home-scoped stop tell its own daemons from a neighbour's. A
+    /// daemon registered by a binary predating the field sends nothing, and an
+    /// empty value stays empty rather than being resolved from the
+    /// supervisor's environment, which is a different process's home.
+    #[serde(default)]
+    pub kin_home: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,6 +89,10 @@ pub struct RegisteredRepoDaemon {
     pub endpoint: String,
     #[serde(default)]
     pub graph_entity_count: Option<usize>,
+    /// See [`RepoDaemonRegistration::kin_home`]. Empty means "not recorded",
+    /// which is never the same answer as "matches the caller".
+    #[serde(default)]
+    pub kin_home: String,
     pub registered_at: String,
     pub last_heartbeat_at: String,
     #[serde(skip)]
@@ -459,6 +474,17 @@ fn instance_id_for_payload(payload: &RepoDaemonRegistration) -> String {
     instance_id_for(payload.pid, payload.port)
 }
 
+/// The managed home a registering daemon reports, trimmed and never guessed.
+///
+/// An older daemon sends nothing here. The supervisor deliberately does not
+/// substitute its own resolved home: the supervisor is machine-wide and its
+/// environment says nothing about the environment its workers were launched
+/// with, so filling the gap would manufacture exactly the false match this
+/// field exists to prevent.
+fn kin_home_for_payload(payload: &RepoDaemonRegistration) -> String {
+    payload.kin_home.trim().to_string()
+}
+
 fn repo_registration_payload(state: &DaemonState, port: u16) -> RepoDaemonRegistration {
     let working_dir = state.layout.working_dir();
     let pid = std::process::id();
@@ -471,6 +497,9 @@ fn repo_registration_payload(state: &DaemonState, port: u16) -> RepoDaemonRegist
         port,
         endpoint: format!("http://127.0.0.1:{port}"),
         graph_entity_count: Some(state.graph.entity_count()),
+        kin_home: kin_core::registry::managed_kin_home_id(
+            &kin_core::registry::managed_kin_home(),
+        ),
     }
 }
 
@@ -1202,6 +1231,8 @@ async fn register_daemon(
     let now = chrono::Utc::now().to_rfc3339();
     let heartbeat_ms = state.elapsed_ms();
     let instance_id = instance_id_for_payload(&payload);
+    let display_name = display_name_for_payload(&payload);
+    let kin_home = kin_home_for_payload(&payload);
     let mut repos = state.repo_daemons.write().await;
     if let Some(existing) = repos.get(&payload.repo_id) {
         if existing.instance_id != instance_id {
@@ -1210,13 +1241,14 @@ async fn register_daemon(
     }
     let record = RegisteredRepoDaemon {
         repo_id: payload.repo_id.clone(),
-        display_name: display_name_for_payload(&payload),
+        display_name,
         instance_id,
         repo_root: payload.repo_root,
         pid: payload.pid,
         port: payload.port,
         endpoint: payload.endpoint,
         graph_entity_count: payload.graph_entity_count,
+        kin_home,
         registered_at: now.clone(),
         last_heartbeat_at: now,
         last_heartbeat_elapsed_ms: heartbeat_ms,
@@ -1235,6 +1267,8 @@ async fn heartbeat_daemon(
     let now = chrono::Utc::now().to_rfc3339();
     let heartbeat_ms = state.elapsed_ms();
     let instance_id = instance_id_for_payload(&payload);
+    let display_name = display_name_for_payload(&payload);
+    let kin_home = kin_home_for_payload(&payload);
     let mut repos = state.repo_daemons.write().await;
     if let Some(existing) = repos.get(&repo_id) {
         if existing.instance_id != instance_id {
@@ -1245,24 +1279,26 @@ async fn heartbeat_daemon(
         .entry(repo_id.clone())
         .or_insert_with(|| RegisteredRepoDaemon {
             repo_id: repo_id.clone(),
-            display_name: display_name_for_payload(&payload),
+            display_name: display_name.clone(),
             instance_id: instance_id.clone(),
             repo_root: payload.repo_root.clone(),
             pid: payload.pid,
             port: payload.port,
             endpoint: payload.endpoint.clone(),
             graph_entity_count: payload.graph_entity_count,
+            kin_home: kin_home.clone(),
             registered_at: now.clone(),
             last_heartbeat_at: now.clone(),
             last_heartbeat_elapsed_ms: heartbeat_ms,
         });
-    record.display_name = display_name_for_payload(&payload);
+    record.display_name = display_name;
     record.instance_id = instance_id;
     record.repo_root = payload.repo_root;
     record.pid = payload.pid;
     record.port = payload.port;
     record.endpoint = payload.endpoint;
     record.graph_entity_count = payload.graph_entity_count;
+    record.kin_home = kin_home;
     record.last_heartbeat_at = now;
     record.last_heartbeat_elapsed_ms = heartbeat_ms;
     (StatusCode::OK, Json(record.clone()))
@@ -2074,6 +2110,11 @@ async fn adopt_daemon(state: &SupervisorState, daemon: &DiscoveredDaemon, reason
         port,
         endpoint: format!("http://127.0.0.1:{port}"),
         graph_entity_count: None,
+        // An adopted daemon never registered, so nothing told the supervisor
+        // which managed home it runs under. Left unrecorded on purpose: a
+        // home-scoped stop then skips and names it instead of assuming it is
+        // the caller's.
+        kin_home: String::new(),
         registered_at: now.clone(),
         last_heartbeat_at: now,
         last_heartbeat_elapsed_ms: heartbeat_ms,
@@ -2407,6 +2448,14 @@ mod tests {
     }
 
     fn repo_payload(instance_id: &str, port: u16) -> RepoDaemonRegistration {
+        repo_payload_in_home(instance_id, port, "/homes/a/.kin")
+    }
+
+    fn repo_payload_in_home(
+        instance_id: &str,
+        port: u16,
+        kin_home: &str,
+    ) -> RepoDaemonRegistration {
         RepoDaemonRegistration {
             repo_id: "demo".to_string(),
             display_name: "demo".to_string(),
@@ -2416,6 +2465,7 @@ mod tests {
             port,
             endpoint: format!("http://127.0.0.1:{port}"),
             graph_entity_count: Some(12),
+            kin_home: kin_home.to_string(),
         }
     }
 
@@ -3740,5 +3790,100 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn registry_records_the_managed_home_a_daemon_reports() {
+        let state = Arc::new(SupervisorState::new());
+        let payload = repo_payload_in_home("instance-a", 49152, "/scratch/home/.kin");
+
+        let response = register_repo(router(Arc::clone(&state)), &payload).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let repos = state.repo_daemons.read().await;
+        assert_eq!(repos.get("demo").unwrap().kin_home, "/scratch/home/.kin");
+    }
+
+    /// One machine-wide supervisor legitimately holds daemons from several
+    /// managed homes. That is the whole premise of the scoping contract, so it
+    /// is asserted rather than assumed.
+    #[tokio::test]
+    async fn one_supervisor_holds_daemons_from_two_homes() {
+        let state = Arc::new(SupervisorState::new());
+        let app = router(Arc::clone(&state));
+
+        let mut a = repo_payload_in_home("instance-a", 49152, "/homes/a/.kin");
+        a.repo_id = "repo-a".to_string();
+        let mut b = repo_payload_in_home("instance-b", 49153, "/homes/b/.kin");
+        b.repo_id = "repo-b".to_string();
+
+        assert_eq!(
+            register_repo(app.clone(), &a).await.status(),
+            StatusCode::OK
+        );
+        assert_eq!(register_repo(app, &b).await.status(), StatusCode::OK);
+
+        let repos = state.repo_daemons.read().await;
+        assert_eq!(repos.get("repo-a").unwrap().kin_home, "/homes/a/.kin");
+        assert_eq!(repos.get("repo-b").unwrap().kin_home, "/homes/b/.kin");
+    }
+
+    /// A daemon that reports no home must stay unrecorded. The supervisor's own
+    /// environment is a different process's home, and substituting it would
+    /// manufacture a match that lets a scoped stop reach a foreign daemon.
+    #[tokio::test]
+    async fn an_unreported_home_is_never_filled_in_from_the_supervisor() {
+        let state = Arc::new(SupervisorState::new());
+        let payload = repo_payload_in_home("instance-a", 49152, "   ");
+
+        let response = register_repo(router(Arc::clone(&state)), &payload).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let repos = state.repo_daemons.read().await;
+        assert!(repos.get("demo").unwrap().kin_home.is_empty());
+    }
+
+    /// A registration from a binary predating the field omits it entirely.
+    #[test]
+    fn a_registration_without_the_field_deserializes_as_unrecorded() {
+        let json = serde_json::json!({
+            "repo_id": "demo",
+            "repo_root": "/tmp/demo",
+            "pid": 1234,
+            "port": 49152,
+            "endpoint": "http://127.0.0.1:49152",
+        });
+        let payload: RepoDaemonRegistration = serde_json::from_value(json).unwrap();
+        assert!(payload.kin_home.is_empty());
+        assert!(kin_home_for_payload(&payload).is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_heartbeat_keeps_the_recorded_home_current() {
+        let state = Arc::new(SupervisorState::new());
+        let app = router(Arc::clone(&state));
+        let payload = repo_payload_in_home("instance-a", 49152, "/homes/a/.kin");
+        assert_eq!(
+            register_repo(app.clone(), &payload).await.status(),
+            StatusCode::OK
+        );
+
+        let moved = RepoDaemonRegistration {
+            kin_home: "/homes/moved/.kin".to_string(),
+            ..payload.clone()
+        };
+        let response = tower::ServiceExt::oneshot(
+            app,
+            axum::http::Request::post("/daemons/demo/heartbeat")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(serde_json::to_vec(&moved).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let repos = state.repo_daemons.read().await;
+        assert_eq!(repos.get("demo").unwrap().kin_home, "/homes/moved/.kin");
     }
 }

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -497,9 +497,7 @@ fn repo_registration_payload(state: &DaemonState, port: u16) -> RepoDaemonRegist
         port,
         endpoint: format!("http://127.0.0.1:{port}"),
         graph_entity_count: Some(state.graph.entity_count()),
-        kin_home: kin_core::registry::managed_kin_home_id(
-            &kin_core::registry::managed_kin_home(),
-        ),
+        kin_home: kin_core::registry::managed_kin_home_id(&kin_core::registry::managed_kin_home()),
     }
 }
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -31,7 +31,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_BASE_URL` | url | GitHub Releases | operational | release mirror base URL used by the shell and PowerShell installers |
 | `KIN_BINARY_PATH` | path | *(unset)* | operational | override the kin binary path for bench dispatch |
 | `KIN_DIR` | path | *(unset)* | operational | compatibility alias for the managed Kin install root; KIN_HOME wins when both are set |
-| `KIN_HOME` | path | ~/.kin | operational | preferred root for the managed Kin install used by the launcher, setup, and shell hooks |
+| `KIN_HOME` | path | ~/.kin | operational | preferred root for the managed Kin install used by the launcher, setup, and shell hooks; bounds install and store state, NOT the machine-wide daemon supervisor |
 | `KIN_LAUNCHER_ADOPT` | bool | false | operational | force the @kinlab/kin launcher to provision its pinned release, including an intentional downgrade |
 | `KIN_MANAGED_BIN` | path | *(unset)* | operational | explicit native Kin binary used by the @kinlab/kin launcher instead of provisioning |
 | `KIN_MCP_AUTO_INIT` | bool | false | operational | allow the @kinlab/kin-mcp wrapper to initialize a missing repository before startup |

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -239,6 +239,57 @@ The authoritative list of behavior-relevant variables is defined once in
 `kin-core` (`behavior_env`) and shared by both the daemon (which reports them)
 and the CLI (which compares them), so the two sides cannot drift apart.
 
+## Supervisor scope: what `KIN_HOME` does and does not bound
+
+Kin runs one worker daemon per repository and one **supervisor** per machine.
+The supervisor directory hangs off the registry path, which resolves from the
+real home directory (or an explicit `KIN_REGISTRY_PATH`). It is deliberately
+**not** derived from `KIN_HOME`.
+
+That split is the contract:
+
+- `KIN_HOME` (and its `KIN_DIR` alias) bounds the managed install root and store
+  state.
+- The supervisor layer is machine-wide by design. One supervisor per box keeps
+  the number of inference-capable daemons bounded; a supervisor per pinned home
+  would multiply them.
+- Consequently a single supervisor legitimately holds daemons launched under
+  several managed homes, and a session that pins `KIN_HOME` still registers into
+  the machine's supervisor.
+
+Because that surprises operators who read a pinned `KIN_HOME` as full isolation,
+the surfaces above it partition by home rather than hiding the seam:
+
+- Every daemon records the managed home it was launched under at registration.
+  A daemon that reports none stays **unrecorded**, which is a distinct answer
+  from matching or not matching; the supervisor never fills the gap from its own
+  environment, which describes a different process.
+- `kin daemon status` and `kin registry daemons` label each daemon with its home
+  and whether that is the caller's, and state that the supervisor is
+  machine-wide.
+- `kin daemon stop --all` stops only daemons under the caller's `KIN_HOME`. It
+  names what it skipped, and it leaves the shared supervisor running while any
+  skipped daemon still depends on it.
+- `kin daemon stop --all --machine` performs the machine-wide sweep and names
+  the daemons from other homes it is taking down.
+- Full uninstall stays machine-wide with no opt-out, because it removes the
+  binaries every daemon on the box is running from.
+
+An unrecorded home is excluded from a scoped sweep rather than assumed to match.
+Failing to stop a daemon is visible and recoverable; stopping a daemon that
+belongs to another session is neither.
+
+### What this means for supervisor-level policies
+
+Supervisor-level behavior still sees every registered daemon regardless of home:
+the rogue-daemon reaper, idle accounting, and the stop-before-update preflight
+census all operate on the machine-wide registry. That is correct for the
+machine-level jobs among them (an install-wide update must account for every
+process running the binaries it replaces) and worth revisiting for the ones that
+act on an individual daemon's behalf. The recorded home is now available to
+those paths; using it is deliberately left to follow-up work rather than folded
+into the scoping change.
+
 ## Recovery reference
 
 | Situation | What Kin does | Your move |


### PR DESCRIPTION
`kin daemon stop --all` under a pinned `KIN_HOME` stopped every daemon on the machine, including a worker holding roughly 243 CPU-minutes of warm embedding cache that belonged to another session. Separately, a dogfood A/B showed that `KIN_HOME` and `KIN_DIR` redirect store state while `HOME` is what actually moves the daemon supervisor, so a scratch session that pins `KIN_HOME` still registers its daemon into the machine's supervisor beside production checkouts.

Verified in code before changing anything. The supervisor directory is `registry_path().parent()`, and `registry_path()` reads only `KIN_REGISTRY_PATH` or the real home from `directories::BaseDirs`. No value of `KIN_HOME` can appear in it. `stop --all` enumerated the live supervisor's `/daemons` registry with no home filter anywhere on that path, and the registry recorded no home per daemon, so nothing on that surface could have distinguished one session's daemons from another's.

The contract this settles is that the supervisor is deliberately machine-wide. One supervisor per box keeps the number of inference-capable daemons bounded, and a supervisor per pinned home would multiply them. `KIN_HOME` bounds install and store state and nothing above it. Rather than hide that seam, the surfaces above it now partition by home.

Every daemon records the managed home it was launched under at registration and heartbeat, resolved through a single `kin_core::registry::managed_kin_home()` that the CLI and the daemon both call, so two processes resolving independently agree by construction. A daemon that reports no home stays unrecorded, which is a third answer distinct from matching and from not matching, and the supervisor never fills that gap from its own environment because its environment describes a different process.

`kin daemon status` and `kin registry daemons` now label each daemon with its home and whether that home is the caller's, and both state that the supervisor is machine-wide. `kin daemon stop --all` stops only daemons under the caller's `KIN_HOME`, names what it skipped and why, and leaves the shared supervisor running while any skipped daemon still depends on it. `kin daemon stop --all --machine` performs the machine-wide sweep and names the foreign daemons it takes down. Full uninstall stays machine-wide with no opt-out, because it removes the binaries every daemon on the box is running from.

An unrecorded home is skipped rather than assumed to match. Failing to stop a daemon is visible and recoverable; stopping another session's warm worker is neither.

Tests cover both directions rather than one: the same two-home registry read from home A targets only A's daemon and read from home B targets only B's, so a partition that always kept the first entry would fail. `--machine` reaches both and still discloses. An unrecorded daemon is excluded from a scoped sweep and included in a machine one. Falsified after committing: reverting the scoping made the sweep take both pids where it should take one, and treating an unrecorded home as the caller's made it take a daemon it must skip.

On the reaper noted in FIR-2180: supervisor-level policies still see every registered daemon regardless of home, which is correct for the machine-level ones such as the stop-before-update preflight census. The recorded home is now available to those paths. Using it is left as follow-up rather than folded into this change.

Closes FIR-2167
Closes FIR-2180
