### PR TITLE
Report already_applied and session capabilities truthfully on the MCP write path

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -839,8 +839,11 @@ struct StartSessionRequest {
     #[serde(default)]
     pid: Option<u32>,
     cwd: String,
+    /// What the client restricts itself to, when it says. Absent means the
+    /// client declared nothing, which is different from declaring read-only
+    /// and must not be collapsed into it.
     #[serde(default)]
-    capabilities: SessionCapabilities,
+    capabilities: Option<SessionCapabilities>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -858,6 +861,10 @@ struct SessionStartResponse {
     transport: SessionTransport,
     started_at: kin_model::timestamp::Timestamp,
     capabilities: SessionCapabilities,
+    /// What produced each capability bit, so a reader can tell a store
+    /// permission from a client's own restriction from a bit Kin gates on
+    /// nothing.
+    capability_policy: CapabilityPolicy,
     status: String,
     /// How long the session may go idle before the sweeper may reap it.
     idle_timeout_secs: u64,
@@ -2657,6 +2664,85 @@ async fn list_sessions(
     Ok(Json(sessions))
 }
 
+/// What decided one capability bit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CapabilitySource {
+    /// This store decides the bit, and the value reported is what it permits.
+    Store,
+    /// The client restricted itself below what the store permits.
+    ClientDeclared,
+    /// Kin gates nothing on this bit today. It carries the client's own
+    /// declaration and no Kin surface checks it.
+    Ungated,
+}
+
+/// What produced each bit of a session's capability report.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+struct CapabilityPolicy {
+    can_read: CapabilitySource,
+    can_write: CapabilitySource,
+    can_execute: CapabilitySource,
+    can_branch: CapabilitySource,
+    can_commit: CapabilitySource,
+}
+
+fn capability_source(store_permits: bool, declared: Option<bool>) -> CapabilitySource {
+    if !store_permits {
+        CapabilitySource::Store
+    } else if declared == Some(false) {
+        CapabilitySource::ClientDeclared
+    } else {
+        CapabilitySource::Store
+    }
+}
+
+/// Resolve what a session may actually do on this store.
+///
+/// The report used to echo the request's capabilities straight back, and the
+/// MCP layer materialized a read-only declaration for a client that sent none,
+/// so a session that could write and commit was told it could do neither. An
+/// agent that honors its declared capabilities then refuses work it is
+/// permitted to perform, which silently disables the write path for exactly the
+/// well-behaved callers.
+///
+/// Writes and commits follow the one condition the write path really enforces:
+/// exact repository commits are refused while a hosted snapshot backend is
+/// attached. A client that declares less than the store permits keeps its own
+/// restriction, because a declaration is a self-limit and outranks a
+/// permission. Execution and branching gate nothing in Kin today, so they carry
+/// the declaration unchanged and the policy map labels them `ungated` rather
+/// than dressing an unchecked bit as a grant.
+fn resolve_session_capabilities(
+    commits_permitted: bool,
+    declared: Option<&SessionCapabilities>,
+) -> (SessionCapabilities, CapabilityPolicy) {
+    let capabilities = SessionCapabilities {
+        can_read: declared.map_or(true, |declared| declared.can_read),
+        can_write: declared.map_or(commits_permitted, |declared| declared.can_write)
+            && commits_permitted,
+        can_execute: declared.is_some_and(|declared| declared.can_execute),
+        can_branch: declared.is_some_and(|declared| declared.can_branch),
+        can_commit: declared.map_or(commits_permitted, |declared| declared.can_commit)
+            && commits_permitted,
+        max_concurrent_intents: declared.map_or(1, |declared| declared.max_concurrent_intents),
+    };
+    let policy = CapabilityPolicy {
+        can_read: capability_source(true, declared.map(|declared| declared.can_read)),
+        can_write: capability_source(
+            commits_permitted,
+            declared.map(|declared| declared.can_write),
+        ),
+        can_execute: CapabilitySource::Ungated,
+        can_branch: CapabilitySource::Ungated,
+        can_commit: capability_source(
+            commits_permitted,
+            declared.map(|declared| declared.can_commit),
+        ),
+    };
+    (capabilities, policy)
+}
+
 /// POST /session — register a rich session and return its authoritative state.
 async fn start_session(
     State(state): State<Arc<DaemonState>>,
@@ -2681,6 +2767,13 @@ async fn start_session(
             ));
         }
     }
+    // The resolved set is what gets registered, not the request's, so the
+    // capability violations the write preflight records and the report handed
+    // to the caller describe one session rather than two.
+    let (capabilities, capability_policy) = resolve_session_capabilities(
+        state.storage_backend.is_none(),
+        request.capabilities.as_ref(),
+    );
     let session_id = state
         .coordinator
         .register_session_with_id(
@@ -2690,7 +2783,7 @@ async fn start_session(
             transport,
             request.pid,
             PathBuf::from(request.cwd),
-            request.capabilities,
+            capabilities,
         )
         .map_err(internal_error)?;
     let session = state
@@ -2713,6 +2806,7 @@ async fn start_session(
         transport: session.transport,
         started_at: session.started_at,
         capabilities: session.capabilities,
+        capability_policy,
         status: "active".to_string(),
         idle_timeout_secs: idle_ttl.as_secs(),
         idle_reap_eligible_at,
@@ -23371,6 +23465,134 @@ mod tests {
         // reconcile loop, so the list contains exactly that one session.
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].vendor, "kin-daemon");
+    }
+
+    /// A session that declares nothing must be reported able to do what this
+    /// store lets it do.
+    ///
+    /// The report echoed the request straight back, and the MCP layer
+    /// materialized a read-only declaration for a client that sent none, so a
+    /// session that went on to stage and commit entity edits was told
+    /// can_write false and can_commit false. An agent that honors its declared
+    /// capabilities refuses the write it is permitted to make, which disables
+    /// the write path for exactly the well-behaved callers.
+    #[tokio::test]
+    async fn an_undeclared_session_is_reported_able_to_write_and_commit() {
+        let state = test_state();
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::post("/session")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "vendor": "claude-code",
+                            "client_name": "undeclared",
+                            "transport": "mcp",
+                            "cwd": "/project"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let started: SessionStartResponse = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            started.capabilities.can_write,
+            "this store accepts commits, so the session may write"
+        );
+        assert!(started.capabilities.can_commit);
+        assert_eq!(started.capability_policy.can_write, CapabilitySource::Store);
+        assert_eq!(started.capability_policy.can_commit, CapabilitySource::Store);
+        assert_eq!(
+            started.capability_policy.can_execute,
+            CapabilitySource::Ungated,
+            "Kin gates nothing on can_execute, and the report must not dress it as a grant"
+        );
+    }
+
+    /// A client that restricts itself keeps that restriction, and the report
+    /// says the client is what produced it.
+    ///
+    /// Without this the fix would be indistinguishable from hardcoding the bits
+    /// true, which is the same defect facing the other way.
+    #[tokio::test]
+    async fn a_self_declared_read_only_session_keeps_its_restriction() {
+        let state = test_state();
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::post("/session")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "vendor": "claude-code",
+                            "client_name": "reader",
+                            "transport": "mcp",
+                            "cwd": "/project",
+                            "capabilities": {
+                                "can_read": true,
+                                "can_write": false,
+                                "can_execute": false,
+                                "can_branch": false,
+                                "can_commit": false,
+                                "max_concurrent_intents": 1
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let started: SessionStartResponse = serde_json::from_slice(&body).unwrap();
+
+        assert!(!started.capabilities.can_write);
+        assert!(!started.capabilities.can_commit);
+        assert_eq!(
+            started.capability_policy.can_write,
+            CapabilitySource::ClientDeclared,
+            "the store permits writes here, so the client is what made this false"
+        );
+    }
+
+    /// A store that refuses commits reports it, and names itself as the cause.
+    ///
+    /// Exact repository commits are refused while a hosted snapshot backend is
+    /// attached, so a session there genuinely cannot write however it declared
+    /// itself.
+    #[test]
+    fn a_store_that_refuses_commits_reports_no_write_capability() {
+        let declared = SessionCapabilities {
+            can_read: true,
+            can_write: true,
+            can_execute: false,
+            can_branch: false,
+            can_commit: true,
+            max_concurrent_intents: 1,
+        };
+
+        let (permitted, permitted_policy) = resolve_session_capabilities(true, Some(&declared));
+        assert!(permitted.can_write);
+        assert!(permitted.can_commit);
+        assert_eq!(permitted_policy.can_write, CapabilitySource::Store);
+
+        let (refused, refused_policy) = resolve_session_capabilities(false, Some(&declared));
+        assert!(
+            !refused.can_write,
+            "a declaration cannot grant what the store refuses"
+        );
+        assert!(!refused.can_commit);
+        assert_eq!(refused_policy.can_write, CapabilitySource::Store);
+        assert_eq!(refused_policy.can_commit, CapabilitySource::Store);
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -23499,7 +23499,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
         let started: SessionStartResponse = serde_json::from_slice(&body).unwrap();
 
         assert!(
@@ -23508,7 +23510,10 @@ mod tests {
         );
         assert!(started.capabilities.can_commit);
         assert_eq!(started.capability_policy.can_write, CapabilitySource::Store);
-        assert_eq!(started.capability_policy.can_commit, CapabilitySource::Store);
+        assert_eq!(
+            started.capability_policy.can_commit,
+            CapabilitySource::Store
+        );
         assert_eq!(
             started.capability_policy.can_execute,
             CapabilitySource::Ungated,
@@ -23552,7 +23557,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
         let started: SessionStartResponse = serde_json::from_slice(&body).unwrap();
 
         assert!(!started.capabilities.can_write);

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -163,6 +163,30 @@ fn declare_carried_split(
     result["carried_pending_files"] = serde_json::json!(carried);
 }
 
+/// Whether the receipt a commit reply describes was published by this call or
+/// by an earlier one under the same caller-stable transaction id.
+///
+/// A caller that retried needs exactly this bit to know whether its re-send
+/// double-applied, and no other field in the reply carries it: a replay
+/// restates the original change id, repository generation, and root hash
+/// exactly, which is what makes the idempotency correct and also what makes it
+/// invisible. So the bit is threaded from the path that knows rather than
+/// inferred at the reply.
+#[derive(Clone, Copy)]
+enum CommitApplication {
+    /// This call moved repository authority.
+    Applied,
+    /// Authority had already moved under this transaction id before this call
+    /// ran, so the reply restates a landing this call did not make.
+    AlreadyApplied,
+}
+
+impl CommitApplication {
+    fn already_applied(self) -> bool {
+        matches!(self, Self::AlreadyApplied)
+    }
+}
+
 /// Commit one daemon-owned MCP transaction through exact repository authority.
 ///
 /// The caller holds `DaemonState::coordination_gate` and the graph-authority
@@ -295,6 +319,8 @@ fn commit_exact_transaction_inner(
         if let Some(recovered) = recover_native_commit(&authority_context, operation_id)
             .map_err(|error| format!("recover exact MCP repository receipt: {error}"))?
         {
+            // The fence this recovered against was set by an earlier attempt,
+            // so authority moved before this call ran.
             return finalize_committed_transaction(
                 state,
                 sessions,
@@ -303,6 +329,7 @@ fn commit_exact_transaction_inner(
                 recovered,
                 None,
                 coordination,
+                CommitApplication::AlreadyApplied,
             );
         }
         if transaction.state == "committed" {
@@ -400,6 +427,9 @@ fn commit_exact_transaction_inner(
         ));
     }
 
+    // This call planned and published under its own fence, including the branch
+    // where the mutation reported an error and the receipt recovery below it
+    // found the receipt that same attempt had already written.
     finalize_committed_transaction(
         state,
         sessions,
@@ -411,6 +441,7 @@ fn commit_exact_transaction_inner(
             carried_pending_files: plan.carried_pending_files,
         }),
         coordination,
+        CommitApplication::Applied,
     )
 }
 
@@ -1468,6 +1499,7 @@ fn finalize_committed_transaction(
     committed: NativeCommitResult,
     planned: Option<PlannedCommitFacts>,
     coordination: Option<&kin_mcp::CoordinationWritePreflight>,
+    application: CommitApplication,
 ) -> Result<kin_mcp::ToolCallResult, String> {
     let (planned_layouts, planned_carry) = match planned {
         Some(planned) => (planned.layouts, Some(planned.carried_pending_files)),
@@ -1545,6 +1577,7 @@ fn finalize_committed_transaction(
         "transaction_id": terminal.transaction_id,
         "state": "committed",
         "status": "committed",
+        "already_applied": application.already_applied(),
         "ops_applied": terminal.staged_operations.len(),
         "entity_deltas": committed.entity_count,
         "relation_deltas": committed.relation_count,
@@ -4960,6 +4993,104 @@ mod tests {
                 .generation,
             generation_after_first,
             "answering the retry must not publish a second repository generation"
+        );
+    }
+
+    /// `already_applied` must separate a first application from a replay, and
+    /// it is the only field that can.
+    ///
+    /// A replay restates the original change id, repository generation, and
+    /// root hash exactly, which is what makes the idempotency correct and also
+    /// what makes it invisible. The field was emitted only on the replay path,
+    /// where it is hardcoded true, and was absent from the reply a fresh commit
+    /// returns, so no code path could ever answer false and a caller deciding
+    /// whether its retry double-applied had nothing to read.
+    #[test]
+    fn already_applied_separates_a_first_application_from_a_replay() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+
+        let first = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(first.is_error, Some(true), "{}", result_text(&first));
+        let first_body: serde_json::Value = serde_json::from_str(result_text(&first)).unwrap();
+        assert_eq!(
+            first_body["already_applied"],
+            serde_json::json!(false),
+            "a first-ever application must report that it moved authority: {}",
+            result_text(&first)
+        );
+
+        // Exactly what a successful commit leaves behind for the next attempt.
+        state
+            .mcp_transactions
+            .lock()
+            .unwrap()
+            .remove(&transaction_id);
+        let retry_sessions = test_sessions();
+        let retry = commit_exact_transaction(&state, &retry_sessions, &arguments, None);
+        assert_ne!(retry.is_error, Some(true), "{}", result_text(&retry));
+        let retry_body: serde_json::Value = serde_json::from_str(result_text(&retry)).unwrap();
+        assert_eq!(
+            retry_body["already_applied"],
+            serde_json::json!(true),
+            "an exact replay must report that it published nothing further: {}",
+            result_text(&retry)
+        );
+
+        assert_eq!(retry_body["change_id"], first_body["change_id"]);
+        assert_eq!(retry_body["new_root_hash"], first_body["new_root_hash"]);
+        assert_eq!(
+            retry_body["repository_generation"], first_body["repository_generation"],
+            "the two replies agree on every fact about the change, which is why \
+             already_applied is the only bit that can carry the distinction"
+        );
+    }
+
+    /// Resuming a fenced commit is a replay too, and must say so.
+    ///
+    /// The publication crashed after the repository receipt existed, so
+    /// authority moved under the earlier attempt. The resume recovers that
+    /// receipt and publishes nothing, which is the same fact the evicted-record
+    /// retry reports and reaches the caller through a different path.
+    #[test]
+    fn a_resumed_fenced_commit_reports_that_authority_had_already_moved() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let (transaction_id, arguments) =
+            stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+
+        state
+            .mcp_fail_after_authority_once
+            .store(true, Ordering::SeqCst);
+        let crashed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(crashed.is_error, Some(true), "{}", result_text(&crashed));
+        assert_eq!(
+            sessions.get_transaction(&transaction_id).unwrap().state,
+            "committing"
+        );
+
+        let resumed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(resumed.is_error, Some(true), "{}", result_text(&resumed));
+        let resumed_body: serde_json::Value = serde_json::from_str(result_text(&resumed)).unwrap();
+        assert_eq!(
+            resumed_body["already_applied"],
+            serde_json::json!(true),
+            "a resume recovers a receipt an earlier attempt published: {}",
+            result_text(&resumed)
         );
     }
 

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -417,11 +417,12 @@ async fn forward_entity_source_memoized(
     Ok(result)
 }
 
-fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> SessionCapabilities {
-    let Some(obj) = args.get("capabilities").and_then(|value| value.as_object()) else {
-        return SessionCapabilities::default();
-    };
-    SessionCapabilities {
+/// Read the capabilities a client declared for itself, or `None` when it
+/// declared none. See the sibling in `handlers::common` for why the two must
+/// not collapse into one.
+fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> Option<SessionCapabilities> {
+    let obj = args.get("capabilities").and_then(|value| value.as_object())?;
+    Some(SessionCapabilities {
         can_read: obj
             .get("can_read")
             .and_then(|value| value.as_bool())
@@ -447,7 +448,7 @@ fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> SessionCapab
             .and_then(|value| value.as_u64())
             .map(|value| value as usize)
             .unwrap_or(1),
-    }
+    })
 }
 
 fn scope_to_string(value: &serde_json::Value) -> Result<String, String> {
@@ -1302,15 +1303,7 @@ pub async fn forward_tool_call(
             let cwd = std::env::current_dir()
                 .map(|path| path.display().to_string())
                 .unwrap_or_else(|_| ".".to_string());
-            let capabilities = SessionCapabilities::default();
-            forward_session_start(
-                &assistant_name,
-                &assistant_name,
-                "mcp",
-                None,
-                &cwd,
-                &capabilities,
-            )
+            forward_session_start(&assistant_name, &assistant_name, "mcp", None, &cwd, None)
             .await?
             .map(text_result_from_value)
             .transpose()
@@ -1322,7 +1315,14 @@ pub async fn forward_tool_call(
             let transport = optional_string(arguments, "transport").unwrap_or("mcp");
             let pid = optional_u32(arguments, "pid");
             let capabilities = parse_capabilities(arguments);
-            forward_session_start(&vendor, &client_name, transport, pid, &cwd, &capabilities)
+            forward_session_start(
+                &vendor,
+                &client_name,
+                transport,
+                pid,
+                &cwd,
+                capabilities.as_ref(),
+            )
                 .await?
                 .map(text_result_from_value)
                 .transpose()
@@ -1567,7 +1567,7 @@ pub async fn forward_session_start(
     transport: &str,
     pid: Option<u32>,
     cwd: &str,
-    capabilities: &SessionCapabilities,
+    capabilities: Option<&SessionCapabilities>,
 ) -> Result<Option<serde_json::Value>, String> {
     let Some(base) = daemon_base_url() else {
         return Ok(None);
@@ -1577,8 +1577,12 @@ pub async fn forward_session_start(
         "client_name": client_name,
         "transport": transport,
         "cwd": cwd,
-        "capabilities": capabilities,
     });
+    // Omitted rather than defaulted, so the daemon can tell a client that
+    // declared nothing from one that declared itself read-only.
+    if let Some(capabilities) = capabilities {
+        body["capabilities"] = serde_json::json!(capabilities);
+    }
     if let Some(p) = pid {
         body["pid"] = serde_json::json!(p);
     }

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -421,7 +421,9 @@ async fn forward_entity_source_memoized(
 /// declared none. See the sibling in `handlers::common` for why the two must
 /// not collapse into one.
 fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> Option<SessionCapabilities> {
-    let obj = args.get("capabilities").and_then(|value| value.as_object())?;
+    let obj = args
+        .get("capabilities")
+        .and_then(|value| value.as_object())?;
     Some(SessionCapabilities {
         can_read: obj
             .get("can_read")
@@ -1304,9 +1306,9 @@ pub async fn forward_tool_call(
                 .map(|path| path.display().to_string())
                 .unwrap_or_else(|_| ".".to_string());
             forward_session_start(&assistant_name, &assistant_name, "mcp", None, &cwd, None)
-            .await?
-            .map(text_result_from_value)
-            .transpose()
+                .await?
+                .map(text_result_from_value)
+                .transpose()
         }
         "kin_session_start" => {
             let vendor = required_string(arguments, "vendor")?;
@@ -1323,9 +1325,9 @@ pub async fn forward_tool_call(
                 &cwd,
                 capabilities.as_ref(),
             )
-                .await?
-                .map(text_result_from_value)
-                .transpose()
+            .await?
+            .map(text_result_from_value)
+            .transpose()
         }
         "kin_session_heartbeat" => {
             let session_id = required_string(arguments, "session_id")?;

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2519,12 +2519,19 @@ pub fn get_json_object<'a>(
         .ok_or_else(|| McpError::InvalidParams(format!("{} must be a valid JSON object", key)))
 }
 
-pub fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> SessionCapabilities {
-    let Some(obj) = args.get("capabilities").and_then(|v| v.as_object()) else {
-        return SessionCapabilities::default();
-    };
+/// Read the capabilities a client declared for itself, or `None` when it
+/// declared none.
+///
+/// Materializing the read-only default here loses the distinction the daemon
+/// needs: a client that says nothing is not a client that says it cannot write,
+/// and the session report is only able to tell the truth about what the session
+/// may do if the two arrive differently.
+pub fn parse_capabilities(
+    args: &HashMap<String, serde_json::Value>,
+) -> Option<SessionCapabilities> {
+    let obj = args.get("capabilities").and_then(|v| v.as_object())?;
 
-    SessionCapabilities {
+    Some(SessionCapabilities {
         can_read: obj
             .get("can_read")
             .and_then(|v| v.as_bool())
@@ -2549,7 +2556,7 @@ pub fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> SessionC
             .get("max_concurrent_intents")
             .and_then(|v| v.as_u64())
             .unwrap_or(1) as usize,
-    }
+    })
 }
 
 // ── Search filter helpers ──

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -794,7 +794,10 @@ publishes nothing further. That answer is derived from the repository receipt ra
 in-memory record, so it survives the transaction being forgotten and stays correct however many \
 times it is retried, and it declares the same carried_pending_files split the original answer did. \
 It omits ops_applied, which only the staged record could name. A commit that never landed under \
-this id still fails closed and says authority was consulted too.";
+this id still fails closed and says authority was consulted too. already_applied is present on \
+every successful commit and is the one field that separates these two answers: false means this \
+call moved authority, true means an earlier call did and this one published nothing. Read it to \
+decide whether a retry double-applied, because every other field is identical across both.";
 
 fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
     if !scopes.contains(&scope) {

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -68,7 +68,13 @@ expiry (a live registered PID is stronger liveness evidence). If your next step 
 phase that could outlast that boundary, send kin_session_heartbeat; any session-bound call \
 also refreshes the window. A call on an already-reaped session fails saying so and names \
 kin_session_start as the recovery. An in-process session returns neither field; heartbeat \
-it on the same cadence rather than reading a boundary off the response.";
+it on the same cadence rather than reading a boundary off the response. The capabilities \
+in the response are what this session may actually do on this store, not an echo of what \
+you sent: declaring nothing gets you what the store permits, and declaring less than that \
+keeps your own restriction. capability_policy names what decided each bit, so you can tell \
+a store permission (`store`) from your own self-limit (`client_declared`) from a bit Kin \
+checks nowhere today (`ungated`). Read can_write and can_commit before deciding a write is \
+forbidden; they now report false only when this store really refuses it.";
 
 pub async fn handle_session_start(
     args: &HashMap<String, serde_json::Value>,
@@ -96,7 +102,7 @@ pub async fn handle_session_start(
             transport_str,
             pid,
             &cwd_str,
-            &capabilities,
+            capabilities.as_ref(),
         )
         .await;
         match daemon_result {
@@ -115,6 +121,17 @@ pub async fn handle_session_start(
         }
     }
 
+    // This surface accepts kin_transaction_commit, so a session that declared
+    // nothing is not a read-only session and must not be reported as one. The
+    // daemon resolves the same question against its store.
+    let capabilities = capabilities.unwrap_or(kin_model::SessionCapabilities {
+        can_read: true,
+        can_write: true,
+        can_execute: false,
+        can_branch: false,
+        can_commit: true,
+        max_concurrent_intents: 1,
+    });
     let session =
         sessions.start_agent_session(&vendor, &client_name, transport, pid, cwd, capabilities);
 


### PR DESCRIPTION
Two fields on the MCP write and session surfaces reported something other than what was true, and in both cases an agent that believed them would do the wrong thing.

kin_transaction_commit carried already_applied on exactly one code path, the replay that answers a commit whose transaction record is gone, where it is hardcoded true. The reply a fresh commit returns carried no such field at all, so nothing in Kin could ever answer false and a caller deciding whether its retry double-applied had nothing to read. The rest of the reply is no help, because a replay restates the original change id, repository generation, and root hash exactly. That identity is what makes the idempotency correct and also what makes it invisible. The bit is now threaded from the paths that know it: a call that plans and publishes under its own fence reports false, and a call that recovers a receipt an earlier attempt published reports true, whether it got there by resuming a fenced transaction or by answering after the record was evicted. The resume path was previously unlabelled too.

kin_session_start reported can_write false and can_commit false to sessions that went on to stage and commit entity edits that landed in graph truth. The capabilities were parsed from the caller's own arguments, defaulted to read-only when the caller sent none, and echoed back by the daemon without consulting the store. Nothing on the write path reads them, so the report was a fabricated declaration presented as a grant. An agent that honors its declared capabilities refuses the write it is permitted to make, which silently disables the write path for exactly the well-behaved callers.

The MCP boundary now keeps "declared nothing" and "declared read-only" apart instead of collapsing them, and the daemon resolves the report against the store. Writes and commits follow the one condition the write path actually enforces, which is that exact repository commits are refused while a hosted snapshot backend is attached. A client that declares less than the store permits keeps its own restriction, because a self-limit outranks a permission. The reply carries a capability_policy naming what decided each bit, so a store permission, a client's own restriction, and a bit Kin checks nowhere are told apart rather than blurred. The resolved set is what gets registered, so the write preflight's capability violations and the report describe one session rather than two.

No enforcement is switched on here. The hosted-snapshot refusal already existed, and session ownership stays unenforced.

Five tests cover both halves, and each was falsified by reverting the fix and watching it fail on the symptom. With already_applied removed from the first-application reply, the discriminating test fails with left Null against right false, which is direct evidence the field was absent rather than wrongly true. With the capability report reverted to echoing the request, the undeclared-session test fails while the self-declared read-only control keeps passing, so the fix cannot be satisfied by hardcoding the bits true.

Closes FIR-2185
Closes FIR-2186
