### PR TITLE
Carry a pending workspace across kin branch switch

### DIFF
--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -604,6 +604,17 @@ pub struct WorkspaceStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_tree_hash: Option<Hash256>,
     pub tree_hash: Hash256,
+    /// Whether the workspace tree sits ahead of `base_target`, or carries
+    /// uncommitted semantics.
+    ///
+    /// This answers "does my workspace differ from the change it is based on",
+    /// and it is the only question it answers. It is emphatically not "is
+    /// everything on disk in the graph": a file the graph has never admitted
+    /// contributes nothing to this flag, so a workspace can be dirty with no
+    /// untracked file in sight and can match its base while non-ignored host
+    /// paths sit outside graph truth. `kin graph status` is what reports the
+    /// second question, and the rendered wording here avoids the bare words
+    /// clean and dirty so the two cannot be read as one.
     pub dirty: bool,
     pub artifact_count: usize,
 }
@@ -999,10 +1010,15 @@ fn render_text(
     build: Option<&BuildStatus>,
     footprint: Option<&StoreFootprint>,
 ) -> String {
+    // Named as a comparison against the base change rather than as "clean" or
+    // "dirty". Both bare words invite the reading "everything on disk is in the
+    // graph", which this flag has never meant and cannot answer: untracked host
+    // paths do not move it in either direction. `kin graph status` reports
+    // those, and saying what this line compares keeps the two questions apart.
     let workspace_state = if report.workspace.dirty {
-        "dirty"
+        "ahead of its base change"
     } else {
-        "clean"
+        "matching its base change"
     };
     let enrichment = match report.semantic_enrichment.presence {
         SemanticEnrichmentPresence::Absent => "absent",

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1180,6 +1180,19 @@ enum BranchAction {
         ref_hex: Option<String>,
     },
     /// Switch workspace authority and projection atomically
+    ///
+    /// Uncommitted work comes with you, the way it does across a Git checkout.
+    /// Pending work at a path the destination branch does not track moves
+    /// across and is still uncommitted when you arrive. Pending work at a path
+    /// the destination already tracks with identical content becomes an
+    /// ordinary member of that branch. A pending edit to a member both branches
+    /// hold identically moves across too.
+    ///
+    /// The switch refuses only where replaying the work would lose something:
+    /// a new file whose path the destination tracks with different content, or
+    /// an edit to a member the destination holds differently or does not hold
+    /// at all. It names every blocked path, and commit or `kin stash push`
+    /// clears the way.
     Switch {
         /// UTF-8 short branch name or fully-qualified refs/heads/... name
         #[arg(required_unless_present = "ref_hex", conflicts_with = "ref_hex")]

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -919,9 +919,15 @@ fn branch_switch_rejects_local_tracked_edits_and_preserves_authority() {
     );
 }
 
+/// A pending edit to a member both branches hold identically moves across.
+///
+/// `unchanged.txt` is byte-identical on `main` and `feature`, so replaying the
+/// edit onto the destination cannot overwrite anything the branch being entered
+/// holds differently. This is the Git rule: a local change carries when the
+/// branches agree about what it was changing.
 #[cfg(unix)]
 #[test]
-fn branch_switch_rejects_admitted_graph_owned_workspace_changes() {
+fn branch_switch_carries_an_admitted_edit_to_a_member_both_branches_hold_identically() {
     let root = tempdir().expect("temp root");
     let repo = root.path().join("repo");
     initialize_git_repo(&repo);
@@ -929,15 +935,93 @@ fn branch_switch_rejects_admitted_graph_owned_workspace_changes() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
     let (repository_id, manager) = open_authority(&layout);
-    admit_uncommitted_workspace_edit(&repository_id, &manager, b"unchanged.txt", b"admitted\n");
+    admit_uncommitted_workspace_edit(
+        &repository_id,
+        &manager,
+        &repo,
+        b"unchanged.txt",
+        b"admitted\n",
+    );
+
+    let switched = run_kin(&runtime, &repo, &["branch", "switch", "feature"]);
+    assert!(
+        switched.status.success(),
+        "a pending edit to a member both branches share must carry: stdout={} stderr={}",
+        String::from_utf8_lossy(&switched.stdout),
+        String::from_utf8_lossy(&switched.stderr)
+    );
+    assert_eq!(
+        fs::read(repo.join("unchanged.txt")).unwrap(),
+        b"admitted\n",
+        "the carried edit must survive on disk"
+    );
+    assert_eq!(
+        fs::read(repo.join("compose.yaml")).unwrap(),
+        b"services:\n  api:\n    build: .\n",
+        "members the workspace never touched must take the destination's content"
+    );
+
+    let workspace = reopened_workspace(&layout);
+    assert!(
+        workspace.is_dirty(),
+        "carried work stays uncommitted on the destination branch"
+    );
+    assert_eq!(
+        workspace
+            .tree
+            .artifact_at_path(&repo_path(b"unchanged.txt"))
+            .expect("carried member")
+            .entry,
+        kin_model::TreeEntry::blob(
+            kin_model::Hash256::from_bytes(kin_blobs::digest_bytes(b"admitted\n")),
+            false
+        )
+    );
+}
+
+/// A pending edit to a member the branches disagree about refuses.
+///
+/// `compose.yaml` differs between `main` and `feature`, so replaying the edit
+/// would silently drop whichever side lost. Git refuses this as "your local
+/// changes would be overwritten by checkout"; so does Kin, by exact path.
+#[cfg(unix)]
+#[test]
+fn branch_switch_refuses_an_admitted_edit_to_a_member_the_branches_disagree_about() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    initialize_git_repo(&repo);
+    add_feature_branch(&repo);
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+    let (repository_id, manager) = open_authority(&layout);
+    admit_uncommitted_workspace_edit(
+        &repository_id,
+        &manager,
+        &repo,
+        b"compose.yaml",
+        b"services:\n  mine: {}\n",
+    );
     let before = manager.read_authority().roots().clone();
 
     let switched = run_kin(&runtime, &repo, &["branch", "switch", "feature"]);
     assert!(!switched.status.success());
     let stderr = String::from_utf8_lossy(&switched.stderr);
     assert!(
-        stderr.contains("has graph-owned changes"),
-        "admitted workspace state must refuse as graph-owned, got {stderr}"
+        stderr.contains("compose.yaml"),
+        "the refusal must name the exact blocked path, got {stderr}"
+    );
+    assert!(
+        stderr.contains("holds this member differently"),
+        "the refusal must say which side the path would have cost, got {stderr}"
+    );
+    assert!(
+        stderr.contains("Commit these") && stderr.contains("kin stash push"),
+        "the refusal must name both remedies, got {stderr}"
+    );
+    assert_eq!(
+        fs::read(repo.join("compose.yaml")).unwrap(),
+        b"services:\n  mine: {}\n",
+        "a refused switch leaves the workspace exactly as it was"
     );
     assert_eq!(
         manager.read_authority().roots(),
@@ -946,48 +1030,289 @@ fn branch_switch_rejects_admitted_graph_owned_workspace_changes() {
     );
 }
 
-/// Publish one uncommitted edit to a tracked workspace member straight through
-/// repository authority, exactly as an admission seam does. This produces the
-/// graph-owned dirty state a transition must refuse without depending on
-/// whichever host events a watcher happens to deliver.
+/// A pending addition at a path the destination does not track carries.
+///
+/// This is the case the whole change exists for: ambient observation admits
+/// every new non-ignored file, so a scratch note is uncommitted graph truth
+/// within seconds of being written, and Git would have carried it in silence.
 #[cfg(unix)]
-fn admit_uncommitted_workspace_edit(
-    repository_id: &RepositoryId,
+#[test]
+fn branch_switch_carries_an_admitted_addition_the_destination_does_not_track() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    initialize_git_repo(&repo);
+    add_feature_branch(&repo);
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+    let (repository_id, manager) = open_authority(&layout);
+    let admitted = admit_uncommitted_workspace_addition(
+        &repository_id,
+        &manager,
+        &repo,
+        b"scratch-note.md",
+        b"thinking out loud\n",
+    );
+
+    let switched = run_kin(&runtime, &repo, &["branch", "switch", "feature"]);
+    assert!(
+        switched.status.success(),
+        "a pending addition the destination does not track must carry: stdout={} stderr={}",
+        String::from_utf8_lossy(&switched.stdout),
+        String::from_utf8_lossy(&switched.stderr)
+    );
+    assert_eq!(
+        fs::read(repo.join("scratch-note.md")).unwrap(),
+        b"thinking out loud\n",
+        "the carried addition must survive on disk"
+    );
+    assert!(
+        String::from_utf8_lossy(&switched.stdout).contains("scratch-note.md"),
+        "the switch must say where the pending work went, got {}",
+        String::from_utf8_lossy(&switched.stdout)
+    );
+
+    let workspace = reopened_workspace(&layout);
+    assert!(
+        workspace.is_dirty(),
+        "a carried addition is still uncommitted on the destination branch"
+    );
+    let carried = workspace
+        .tree
+        .artifact_at_path(&repo_path(b"scratch-note.md"))
+        .expect("carried addition stays in the workspace tree");
+    assert_eq!(
+        carried.artifact_id, admitted,
+        "carrying preserves the identity the entry was admitted under"
+    );
+    assert!(
+        workspace
+            .tree
+            .artifact_at_path(&repo_path(b"Dockerfile"))
+            .is_some(),
+        "the destination branch's own members arrive alongside the carried work"
+    );
+}
+
+/// A pending addition the destination tracks with different content refuses.
+///
+/// `Dockerfile` exists only on `feature`, so admitting one on `main` and then
+/// switching is exactly Git's "untracked working tree file would be overwritten
+/// by checkout".
+#[cfg(unix)]
+#[test]
+fn branch_switch_refuses_an_admitted_addition_the_destination_tracks_differently() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    initialize_git_repo(&repo);
+    add_feature_branch(&repo);
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+    let (repository_id, manager) = open_authority(&layout);
+    admit_uncommitted_workspace_addition(
+        &repository_id,
+        &manager,
+        &repo,
+        b"Dockerfile",
+        b"FROM mine\n",
+    );
+    let before = manager.read_authority().roots().clone();
+
+    let switched = run_kin(&runtime, &repo, &["branch", "switch", "feature"]);
+    assert!(!switched.status.success());
+    let stderr = String::from_utf8_lossy(&switched.stderr);
+    assert!(
+        stderr.contains("Dockerfile"),
+        "the refusal must name the exact blocked path, got {stderr}"
+    );
+    assert!(
+        stderr.contains("would overwrite"),
+        "the refusal must say what carrying would have cost, got {stderr}"
+    );
+    assert!(
+        stderr.contains("Commit these") && stderr.contains("kin stash push"),
+        "the refusal must name both remedies, got {stderr}"
+    );
+    assert_eq!(
+        fs::read(repo.join("Dockerfile")).unwrap(),
+        b"FROM mine\n",
+        "a refused switch leaves the workspace exactly as it was"
+    );
+    assert_eq!(
+        manager.read_authority().roots(),
+        &before,
+        "refused switch advanced repository authority"
+    );
+}
+
+/// Switching away and back leaves the pending tree byte-identical.
+///
+/// A carry that quietly re-identified or re-encoded the pending entry would
+/// still pass the single-hop tests. Only the round trip proves the entry that
+/// comes home is the one that left.
+#[cfg(unix)]
+#[test]
+fn branch_switch_round_trip_leaves_the_carried_workspace_byte_identical() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    initialize_git_repo(&repo);
+    add_feature_branch(&repo);
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+    let (repository_id, manager) = open_authority(&layout);
+    admit_uncommitted_workspace_addition(
+        &repository_id,
+        &manager,
+        &repo,
+        b"scratch-note.md",
+        b"thinking out loud\n",
+    );
+    let departed = reopened_workspace(&layout);
+
+    for branch in ["feature", "main"] {
+        let switched = run_kin(&runtime, &repo, &["branch", "switch", branch]);
+        assert!(
+            switched.status.success(),
+            "switch to {branch} failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&switched.stdout),
+            String::from_utf8_lossy(&switched.stderr)
+        );
+    }
+
+    let returned = reopened_workspace(&layout);
+    assert_eq!(
+        returned.tree, departed.tree,
+        "a round trip must reproduce the pending tree exactly"
+    );
+    assert_eq!(returned.tree_hash, departed.tree_hash);
+    assert_eq!(returned.base_tree_hash, departed.base_tree_hash);
+    assert_eq!(
+        fs::read(repo.join("scratch-note.md")).unwrap(),
+        b"thinking out loud\n"
+    );
+}
+
+#[cfg(unix)]
+fn repo_path(path: &[u8]) -> kin_model::RepoPath {
+    kin_model::RepoPath::from_bytes(path.to_vec()).expect("repository path")
+}
+
+#[cfg(unix)]
+fn current_workspace(
     manager: &RepositoryAuthorityManager<LocalFileBackend>,
-    path: &[u8],
-    body: &[u8],
-) {
+) -> kin_model::WorkspaceState {
     let lease = manager.read_authority();
-    let roots = lease.roots().clone();
     let workspace = lease
         .metadata()
         .workspaces
         .first()
         .expect("local workspace")
         .clone();
-    drop(lease);
+    workspace
+}
 
-    let repo_path =
-        kin_model::RepoPath::from_bytes(path.to_vec()).expect("tracked repository path");
+/// Read the workspace through a manager opened after the command under test.
+///
+/// A handle opened before a switch keeps answering from the lease it already
+/// holds, so asserting post-switch state through it reads the state the test
+/// set up and passes whether or not the switch did anything. Reopening is what
+/// makes these assertions able to disagree.
+#[cfg(unix)]
+fn reopened_workspace(layout: &kin_core::KinLayout) -> kin_model::WorkspaceState {
+    let (_, manager) = open_authority(layout);
+    current_workspace(&manager)
+}
+
+/// Publish one uncommitted addition at an untracked path, exactly as ambient
+/// observation does, and leave the bytes on disk where it found them.
+///
+/// Returns the artifact identity the entry was admitted under, so a caller can
+/// prove a carry preserved it rather than minting a fresh one.
+#[cfg(unix)]
+fn admit_uncommitted_workspace_addition(
+    repository_id: &RepositoryId,
+    manager: &RepositoryAuthorityManager<LocalFileBackend>,
+    repo: &Path,
+    path: &[u8],
+    body: &[u8],
+) -> kin_model::ArtifactId {
+    let workspace = current_workspace(manager);
+    let target = repo_path(path);
+    assert!(
+        workspace.tree.artifact_at_path(&target).is_none(),
+        "an addition fixture must name a path the workspace does not already track"
+    );
+    let artifact_id = kin_model::ArtifactId::new();
+    let entry = save_admitted_bytes(manager, body);
+    let deltas = vec![kin_model::TreeDelta::Added {
+        artifact_id,
+        new: kin_model::LocatedEntry::new(target, entry),
+    }];
+    publish_uncommitted_workspace_deltas(repository_id, manager, repo, workspace, deltas, path, body);
+    artifact_id
+}
+
+/// Publish one uncommitted edit to a tracked workspace member straight through
+/// repository authority, exactly as an admission seam does. This produces the
+/// graph-owned pending state a transition must decide about without depending
+/// on whichever host events a watcher happens to deliver.
+#[cfg(unix)]
+fn admit_uncommitted_workspace_edit(
+    repository_id: &RepositoryId,
+    manager: &RepositoryAuthorityManager<LocalFileBackend>,
+    repo: &Path,
+    path: &[u8],
+    body: &[u8],
+) {
+    let workspace = current_workspace(manager);
+    let target = repo_path(path);
     let artifact = workspace
         .tree
-        .artifact_at_path(&repo_path)
+        .artifact_at_path(&target)
         .expect("tracked workspace member")
         .clone();
+    let entry = save_admitted_bytes(manager, body);
+    let deltas = vec![kin_model::TreeDelta::Updated {
+        artifact_id: artifact.artifact_id,
+        old: artifact.located_entry(),
+        new: kin_model::LocatedEntry::new(target, entry),
+    }];
+    publish_uncommitted_workspace_deltas(repository_id, manager, repo, workspace, deltas, path, body);
+}
+
+#[cfg(unix)]
+fn save_admitted_bytes(
+    manager: &RepositoryAuthorityManager<LocalFileBackend>,
+    body: &[u8],
+) -> kin_model::TreeEntry {
     let digest = kin_model::Hash256::from_bytes(kin_blobs::digest_bytes(body));
     manager
         .save_source_blob(digest, body)
         .expect("save admitted source bytes");
-    let entry = kin_model::TreeEntry::blob(digest, false);
-    let deltas = vec![kin_model::TreeDelta::Updated {
-        artifact_id: artifact.artifact_id,
-        old: artifact.located_entry(),
-        new: kin_model::LocatedEntry::new(repo_path, entry),
-    }];
+    kin_model::TreeEntry::blob(digest, false)
+}
+
+/// Commit the admission, then leave the working copy agreeing with it.
+///
+/// Authority moves first on purpose. The projection drift check reads every
+/// tracked path before a transition, so a fixture that wrote the file first
+/// would be racing the daemon's own observation of it; admitting first and
+/// writing second means both orders end at the same agreeing state.
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
+fn publish_uncommitted_workspace_deltas(
+    repository_id: &RepositoryId,
+    manager: &RepositoryAuthorityManager<LocalFileBackend>,
+    repo: &Path,
+    workspace: kin_model::WorkspaceState,
+    deltas: Vec<kin_model::TreeDelta>,
+    path: &[u8],
+    body: &[u8],
+) {
+    let roots = manager.read_authority().roots().clone();
     let tree = workspace
         .tree
         .apply(&deltas)
-        .expect("apply admitted workspace edit");
+        .expect("apply admitted workspace change");
     let tree_hash = kin_model::compute_resolved_tree_hash(&tree).expect("hash admitted tree");
     manager
         .commit_repository_transaction(RepositoryTransaction {
@@ -1029,7 +1354,13 @@ fn admit_uncommitted_workspace_edit(
             merge_transaction_delta: None,
             sealed_observation: None,
         })
-        .expect("commit admitted workspace edit");
+        .expect("commit admitted workspace change");
+
+    let host_path = repo.join(String::from_utf8(path.to_vec()).expect("utf-8 fixture path"));
+    if let Some(parent) = host_path.parent() {
+        fs::create_dir_all(parent).expect("create admitted parent directory");
+    }
+    fs::write(&host_path, body).expect("leave the working copy agreeing with the admission");
 }
 
 #[cfg(unix)]

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -1247,7 +1247,15 @@ fn admit_uncommitted_workspace_addition(
         artifact_id,
         new: kin_model::LocatedEntry::new(target, entry),
     }];
-    publish_uncommitted_workspace_deltas(repository_id, manager, repo, workspace, deltas, path, body);
+    publish_uncommitted_workspace_deltas(
+        repository_id,
+        manager,
+        repo,
+        workspace,
+        deltas,
+        path,
+        body,
+    );
     artifact_id
 }
 
@@ -1276,7 +1284,15 @@ fn admit_uncommitted_workspace_edit(
         old: artifact.located_entry(),
         new: kin_model::LocatedEntry::new(target, entry),
     }];
-    publish_uncommitted_workspace_deltas(repository_id, manager, repo, workspace, deltas, path, body);
+    publish_uncommitted_workspace_deltas(
+        repository_id,
+        manager,
+        repo,
+        workspace,
+        deltas,
+        path,
+        body,
+    );
 }
 
 #[cfg(unix)]

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod sync_state;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_env;
 pub mod tree;
+pub mod workspace_carry;
 pub mod workspace_semantics;
 
 pub use assistant::{
@@ -87,6 +88,10 @@ pub use tree::{
     ExactProjectionEjectOutcome, ExactProjectionFreeze, ExactProjectionGitStage,
     ExactProjectionVerification, ExactSessionProjection, SourceProjectionDisposition,
     WorkspaceProjectionDrift,
+};
+pub use workspace_carry::{
+    plan_workspace_carry, WorkspaceCarry, WorkspaceCarryConflict, WorkspaceCarryConflictKind,
+    WorkspaceCarryPlan,
 };
 pub use workspace_semantics::diff_workspace_semantics;
 

--- a/crates/kin-core/src/workspace_carry.rs
+++ b/crates/kin-core/src/workspace_carry.rs
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Replaying a pending workspace onto another branch.
+//!
+//! A Kin workspace holds uncommitted work as graph truth rather than as loose
+//! bytes on disk: an exact tree that may sit ahead of its base change, plus a
+//! base-relative semantic overlay. A branch transition therefore has to decide
+//! what happens to that pending state, and the answer implemented here is the
+//! one a working day already expects from Git. Pending work is a diff against
+//! the base, and a transition replays that diff onto the destination instead of
+//! demanding an empty workspace first.
+//!
+//! The contract, stated as rules a reader can apply by hand:
+//!
+//! 1. A pending entry at a path the destination does not track **carries**. It
+//!    stays pending on the destination under the same artifact identity it was
+//!    admitted with. This is the case Git covers by leaving untracked files
+//!    alone across a checkout, and it is the common one: a scratch note that
+//!    ambient observation admitted must not block a switch.
+//! 2. A pending entry at a path the destination tracks with byte-identical
+//!    content is **absorbed**. The destination already holds that content, so
+//!    the entry stops being pending and becomes an ordinary tracked member.
+//! 3. A pending entry at a path the destination tracks with different content
+//!    **refuses**. Carrying it would overwrite a member of the branch being
+//!    switched to, which is exactly the case Git refuses with "untracked
+//!    working tree file would be overwritten by checkout".
+//! 4. A pending change to a tracked member **carries** when the destination
+//!    holds that member in precisely the state the change was made against, and
+//!    **refuses** otherwise, including when the destination does not hold the
+//!    member at all. This is Git refusing "your local changes would be
+//!    overwritten by checkout": replaying an edit is safe exactly when both
+//!    branches agree about what was being edited.
+//!
+//! Rule 4 is decided by artifact identity and located entry together, not by
+//! path, so a member the destination renamed is correctly treated as differing
+//! rather than silently accepting an edit planned against its old location.
+//!
+//! The semantic overlay follows the same shape one layer up: it is replayed
+//! onto the destination's entities and relations under the same precondition,
+//! so carried work keeps its semantics instead of degrading into tree-only
+//! bytes. A precondition that does not hold fails closed as a conflict rather
+//! than publishing a graph nobody observed.
+
+use std::collections::{BTreeMap, HashMap};
+
+use kin_model::{
+    Entity, EntityDelta, EntityId, Relation, RelationDelta, RelationId, RepoPath, ResolvedTree,
+    TreeDelta, WorkspaceSemanticOverlay,
+};
+
+use crate::{KinError, Result};
+
+/// Why one pending entry cannot be replayed onto the destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceCarryConflictKind {
+    /// The destination tracks this path with different content, so carrying the
+    /// pending addition would overwrite a member of the branch being entered.
+    AdditionWouldOverwriteMember,
+    /// The destination holds this member differently from the state the pending
+    /// change was made against, or does not hold it at all, so replaying the
+    /// change would discard whichever side the transition landed on.
+    MemberDiffersBetweenBranches,
+}
+
+impl WorkspaceCarryConflictKind {
+    /// The clause naming what this conflict would have cost, phrased for a
+    /// caller who is looking at their own working tree.
+    pub const fn reason(self) -> &'static str {
+        match self {
+            Self::AdditionWouldOverwriteMember => {
+                "the destination branch tracks this path with different content, so carrying the \
+                 pending addition would overwrite it"
+            }
+            Self::MemberDiffersBetweenBranches => {
+                "the destination branch holds this member differently from the state the pending \
+                 change was made against"
+            }
+        }
+    }
+}
+
+/// One pending entry that refuses to replay, named by the path a caller sees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceCarryConflict {
+    pub path: RepoPath,
+    pub kind: WorkspaceCarryConflictKind,
+}
+
+/// The exact destination state a carried workspace resolves to.
+///
+/// `tree`, `entities`, and `relations` describe the whole workspace after the
+/// transition, destination members and replayed pending work together. They are
+/// what the transition must publish and what its preflight must reproduce.
+#[derive(Debug, Clone)]
+pub struct WorkspaceCarryPlan {
+    pub tree: ResolvedTree,
+    pub entities: HashMap<EntityId, Entity>,
+    pub relations: HashMap<RelationId, Relation>,
+    /// Paths that remain pending on the destination, in tree order.
+    pub carried: Vec<RepoPath>,
+    /// Paths the destination already tracked at identical content, so they are
+    /// tracked members after the transition rather than pending work.
+    pub absorbed: Vec<RepoPath>,
+}
+
+/// The outcome of planning a carry: either the exact destination state, or
+/// every reason the transition must refuse.
+#[derive(Debug, Clone)]
+pub enum WorkspaceCarry {
+    Carried(Box<WorkspaceCarryPlan>),
+    Refused(Vec<WorkspaceCarryConflict>),
+}
+
+/// Plan the replay of one workspace's pending state onto a destination branch.
+///
+/// `base_tree` is the tree at the workspace's own base change, so the diff
+/// between it and `pending_tree` is precisely the uncommitted work. Nothing
+/// here reads the filesystem: the pending state is graph truth already, and the
+/// destination is resolved from graph history.
+pub fn plan_workspace_carry(
+    base_tree: &ResolvedTree,
+    pending_tree: &ResolvedTree,
+    pending_overlay: &WorkspaceSemanticOverlay,
+    destination_tree: &ResolvedTree,
+    destination_entities: &HashMap<EntityId, Entity>,
+    destination_relations: &HashMap<RelationId, Relation>,
+) -> Result<WorkspaceCarry> {
+    let pending = crate::exact_tree_correction(base_tree, pending_tree)
+        .map_err(|error| KinError::Other(format!("plan pending workspace state: {error}")))?;
+
+    let mut conflicts = BTreeMap::new();
+    let mut replay = Vec::new();
+    let mut carried = Vec::new();
+    let mut absorbed = Vec::new();
+
+    for delta in &pending {
+        match delta {
+            TreeDelta::Added { new, .. } => match destination_tree.artifact_at_path(&new.path) {
+                None => {
+                    replay.push(delta.clone());
+                    carried.push(new.path.clone());
+                }
+                Some(member) if member.entry == new.entry => absorbed.push(new.path.clone()),
+                Some(_) => {
+                    conflicts.insert(
+                        new.path.clone(),
+                        WorkspaceCarryConflictKind::AdditionWouldOverwriteMember,
+                    );
+                }
+            },
+            TreeDelta::Updated { artifact_id, old, .. }
+            | TreeDelta::Removed { artifact_id, old } => {
+                let held_identically = destination_tree
+                    .get(artifact_id)
+                    .is_some_and(|member| member.located_entry() == *old);
+                if held_identically {
+                    replay.push(delta.clone());
+                    if matches!(delta, TreeDelta::Updated { .. }) {
+                        carried.push(old.path.clone());
+                    }
+                } else {
+                    conflicts.insert(
+                        old.path.clone(),
+                        WorkspaceCarryConflictKind::MemberDiffersBetweenBranches,
+                    );
+                }
+            }
+        }
+    }
+
+    if !conflicts.is_empty() {
+        return Ok(WorkspaceCarry::Refused(
+            conflicts
+                .into_iter()
+                .map(|(path, kind)| WorkspaceCarryConflict { path, kind })
+                .collect(),
+        ));
+    }
+
+    let tree = destination_tree.apply(&replay).map_err(|error| {
+        KinError::Other(format!(
+            "replay pending workspace state onto the destination tree: {error}"
+        ))
+    })?;
+    let entities = replay_entities(pending_overlay.entity_deltas(), destination_entities)?;
+    let relations = replay_relations(pending_overlay.relation_deltas(), destination_relations)?;
+
+    Ok(WorkspaceCarry::Carried(Box::new(WorkspaceCarryPlan {
+        tree,
+        entities,
+        relations,
+        carried,
+        absorbed,
+    })))
+}
+
+/// Replay the overlay's entity deltas onto the destination's live entities.
+///
+/// An addition the destination already holds identically is absorbed, matching
+/// rule 2 one layer up. Every other precondition mismatch fails closed: the
+/// alternative is publishing a workspace whose semantics no observation
+/// produced.
+fn replay_entities(
+    deltas: &[EntityDelta],
+    destination: &HashMap<EntityId, Entity>,
+) -> Result<HashMap<EntityId, Entity>> {
+    let mut entities = destination.clone();
+    for delta in deltas {
+        match delta {
+            EntityDelta::Added { new } => match entities.get(&new.id) {
+                Some(held) if held == new => {}
+                Some(_) => return Err(semantic_replay_conflict("entity", &new.name)),
+                None => {
+                    entities.insert(new.id, new.clone());
+                }
+            },
+            EntityDelta::Modified { old, new } => {
+                if entities.get(&old.id) != Some(old) {
+                    return Err(semantic_replay_conflict("entity", &old.name));
+                }
+                entities.insert(new.id, new.clone());
+            }
+            EntityDelta::Removed { old } => {
+                if entities.get(&old.id) != Some(old) {
+                    return Err(semantic_replay_conflict("entity", &old.name));
+                }
+                entities.remove(&old.id);
+            }
+        }
+    }
+    Ok(entities)
+}
+
+/// Replay the overlay's relation deltas under the same precondition as
+/// [`replay_entities`].
+fn replay_relations(
+    deltas: &[RelationDelta],
+    destination: &HashMap<RelationId, Relation>,
+) -> Result<HashMap<RelationId, Relation>> {
+    let mut relations = destination.clone();
+    for delta in deltas {
+        match delta {
+            RelationDelta::Added { new } => match relations.get(&new.id) {
+                Some(held) if held == new => {}
+                Some(_) => return Err(semantic_replay_conflict("relation", &render_relation(new))),
+                None => {
+                    relations.insert(new.id, new.clone());
+                }
+            },
+            RelationDelta::Modified { old, new } => {
+                if relations.get(&old.id) != Some(old) {
+                    return Err(semantic_replay_conflict("relation", &render_relation(old)));
+                }
+                relations.insert(new.id, new.clone());
+            }
+            RelationDelta::Removed { old } => {
+                if relations.get(&old.id) != Some(old) {
+                    return Err(semantic_replay_conflict("relation", &render_relation(old)));
+                }
+                relations.remove(&old.id);
+            }
+        }
+    }
+    Ok(relations)
+}
+
+fn render_relation(relation: &Relation) -> String {
+    format!("{:?}", relation.kind)
+}
+
+fn semantic_replay_conflict(noun: &str, name: &str) -> KinError {
+    KinError::Other(format!(
+        "pending {noun} {name} cannot be replayed onto the destination branch, which holds it in a \
+         state this pending work was never planned against; commit the pending work or set it \
+         aside with `kin stash push` before switching branches"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::{ArtifactId, Hash256, LocatedEntry, TreeEntry};
+
+    fn path(value: &str) -> RepoPath {
+        RepoPath::from_bytes(value.as_bytes().to_vec()).expect("repository path")
+    }
+
+    fn entry(body: &str) -> TreeEntry {
+        TreeEntry::blob(
+            Hash256::from_bytes(kin_blobs::digest_bytes(body.as_bytes())),
+            false,
+        )
+    }
+
+    fn tree(members: &[(u128, &str, &str)]) -> ResolvedTree {
+        let deltas = members
+            .iter()
+            .map(|(id, at, body)| TreeDelta::Added {
+                artifact_id: ArtifactId(uuid::Uuid::from_u128(*id)),
+                new: LocatedEntry::new(path(at), entry(body)),
+            })
+            .collect::<Vec<_>>();
+        ResolvedTree::default()
+            .apply(&deltas)
+            .expect("build fixture tree")
+    }
+
+    fn plan(
+        base: &ResolvedTree,
+        pending: &ResolvedTree,
+        destination: &ResolvedTree,
+    ) -> WorkspaceCarry {
+        plan_workspace_carry(
+            base,
+            pending,
+            &WorkspaceSemanticOverlay::default(),
+            destination,
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .expect("plan workspace carry")
+    }
+
+    fn conflicts(carry: &WorkspaceCarry) -> Vec<(String, WorkspaceCarryConflictKind)> {
+        match carry {
+            WorkspaceCarry::Refused(conflicts) => conflicts
+                .iter()
+                .map(|conflict| (conflict.path.to_string(), conflict.kind))
+                .collect(),
+            WorkspaceCarry::Carried(_) => panic!("expected a refusal"),
+        }
+    }
+
+    fn carried(carry: &WorkspaceCarry) -> &WorkspaceCarryPlan {
+        match carry {
+            WorkspaceCarry::Carried(plan) => plan,
+            WorkspaceCarry::Refused(conflicts) => {
+                panic!("expected a carry, refused with {conflicts:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn an_addition_at_a_path_the_destination_does_not_track_carries() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[(1, "shared.txt", "shared"), (2, "note.md", "scratch")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "only-there.txt", "there")]);
+
+        let plan = plan(&base, &pending, &destination);
+        let plan = carried(&plan);
+
+        assert_eq!(
+            plan.carried.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec!["note.md".to_string()]
+        );
+        assert!(plan.absorbed.is_empty());
+        let note = plan
+            .tree
+            .artifact_at_path(&path("note.md"))
+            .expect("carried addition stays in the destination tree");
+        assert_eq!(
+            note.artifact_id,
+            ArtifactId(uuid::Uuid::from_u128(2)),
+            "carrying preserves the identity the entry was admitted under"
+        );
+        assert!(plan.tree.artifact_at_path(&path("only-there.txt")).is_some());
+    }
+
+    #[test]
+    fn an_addition_the_destination_tracks_with_different_content_refuses() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[(1, "shared.txt", "shared"), (2, "Dockerfile", "mine")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "Dockerfile", "theirs")]);
+
+        assert_eq!(
+            conflicts(&plan(&base, &pending, &destination)),
+            vec![(
+                "Dockerfile".to_string(),
+                WorkspaceCarryConflictKind::AdditionWouldOverwriteMember
+            )]
+        );
+    }
+
+    #[test]
+    fn an_addition_the_destination_tracks_at_identical_content_is_absorbed() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[(1, "shared.txt", "shared"), (2, "Dockerfile", "same")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "Dockerfile", "same")]);
+
+        let plan = plan(&base, &pending, &destination);
+        let plan = carried(&plan);
+
+        assert!(plan.carried.is_empty());
+        assert_eq!(
+            plan.absorbed.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec!["Dockerfile".to_string()]
+        );
+        assert_eq!(
+            plan.tree, destination,
+            "an absorbed addition leaves the destination tree exactly as it was"
+        );
+    }
+
+    #[test]
+    fn a_modification_to_a_member_identical_across_branches_carries() {
+        let base = tree(&[(1, "shared.txt", "shared"), (2, "differs.txt", "base")]);
+        let pending = tree(&[(1, "shared.txt", "edited"), (2, "differs.txt", "base")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (2, "differs.txt", "other")]);
+
+        let plan = plan(&base, &pending, &destination);
+        let plan = carried(&plan);
+
+        assert_eq!(
+            plan.carried.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec!["shared.txt".to_string()]
+        );
+        assert_eq!(
+            plan.tree
+                .artifact_at_path(&path("shared.txt"))
+                .expect("carried edit")
+                .entry,
+            entry("edited")
+        );
+        assert_eq!(
+            plan.tree
+                .artifact_at_path(&path("differs.txt"))
+                .expect("untouched member")
+                .entry,
+            entry("other"),
+            "a member the workspace never touched takes the destination's content"
+        );
+    }
+
+    #[test]
+    fn a_modification_to_a_member_that_differs_between_branches_refuses() {
+        let base = tree(&[(1, "compose.yaml", "base")]);
+        let pending = tree(&[(1, "compose.yaml", "mine")]);
+        let destination = tree(&[(1, "compose.yaml", "theirs")]);
+
+        assert_eq!(
+            conflicts(&plan(&base, &pending, &destination)),
+            vec![(
+                "compose.yaml".to_string(),
+                WorkspaceCarryConflictKind::MemberDiffersBetweenBranches
+            )]
+        );
+    }
+
+    #[test]
+    fn a_modification_to_a_member_the_destination_never_had_refuses() {
+        let base = tree(&[(1, "only-here.txt", "base")]);
+        let pending = tree(&[(1, "only-here.txt", "mine")]);
+        let destination = tree(&[(2, "elsewhere.txt", "there")]);
+
+        assert_eq!(
+            conflicts(&plan(&base, &pending, &destination)),
+            vec![(
+                "only-here.txt".to_string(),
+                WorkspaceCarryConflictKind::MemberDiffersBetweenBranches
+            )]
+        );
+    }
+
+    #[test]
+    fn a_removal_of_a_member_identical_across_branches_carries() {
+        let base = tree(&[(1, "shared.txt", "shared"), (2, "gone.txt", "bytes")]);
+        let pending = tree(&[(1, "shared.txt", "shared")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (2, "gone.txt", "bytes")]);
+
+        let plan = plan(&base, &pending, &destination);
+        let plan = carried(&plan);
+
+        assert!(plan.tree.artifact_at_path(&path("gone.txt")).is_none());
+    }
+
+    #[test]
+    fn every_conflicting_path_is_reported_in_one_refusal() {
+        let base = tree(&[(1, "compose.yaml", "base"), (2, "shared.txt", "shared")]);
+        let pending = tree(&[
+            (1, "compose.yaml", "mine"),
+            (2, "shared.txt", "shared"),
+            (3, "Dockerfile", "mine"),
+        ]);
+        let destination = tree(&[
+            (1, "compose.yaml", "theirs"),
+            (2, "shared.txt", "shared"),
+            (4, "Dockerfile", "theirs"),
+        ]);
+
+        assert_eq!(
+            conflicts(&plan(&base, &pending, &destination)),
+            vec![
+                (
+                    "Dockerfile".to_string(),
+                    WorkspaceCarryConflictKind::AdditionWouldOverwriteMember
+                ),
+                (
+                    "compose.yaml".to_string(),
+                    WorkspaceCarryConflictKind::MemberDiffersBetweenBranches
+                ),
+            ],
+            "a caller must learn about every blocked path from one refusal"
+        );
+    }
+
+    #[test]
+    fn a_round_trip_reproduces_the_pending_tree_exactly() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[(1, "shared.txt", "shared"), (2, "note.md", "scratch")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "only-there.txt", "there")]);
+
+        let away = plan(&base, &pending, &destination);
+        let away = carried(&away).tree.clone();
+        let back = plan_workspace_carry(
+            &destination,
+            &away,
+            &WorkspaceSemanticOverlay::default(),
+            &base,
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .expect("plan the return carry");
+
+        assert_eq!(
+            carried(&back).tree,
+            pending,
+            "switching away and back reproduces the pending tree byte for byte"
+        );
+    }
+}

--- a/crates/kin-core/src/workspace_carry.rs
+++ b/crates/kin-core/src/workspace_carry.rs
@@ -61,6 +61,17 @@ pub enum WorkspaceCarryConflictKind {
     /// change was made against, or does not hold it at all, so replaying the
     /// change would discard whichever side the transition landed on.
     MemberDiffersBetweenBranches,
+    /// The destination holds a member at an enclosing path, so the carried path
+    /// would have to live inside a file or a Gitlink.
+    ///
+    /// The common case is a Gitlink: content written beneath an independent
+    /// checkout is ordinary new content once that checkout stops being a member,
+    /// and carrying it onto a branch that has the Gitlink back would build a
+    /// tree with a path underneath a non-directory. Git refuses the same shape.
+    PathIsInsideADestinationMember,
+    /// The destination holds members beneath this path, so the carried entry
+    /// would have to replace a directory with a file.
+    PathIsADestinationDirectory,
 }
 
 impl WorkspaceCarryConflictKind {
@@ -75,6 +86,14 @@ impl WorkspaceCarryConflictKind {
             Self::MemberDiffersBetweenBranches => {
                 "the destination branch holds this member differently from the state the pending \
                  change was made against"
+            }
+            Self::PathIsInsideADestinationMember => {
+                "the destination branch tracks a file or an independent checkout at an enclosing \
+                 path, so this path cannot exist there"
+            }
+            Self::PathIsADestinationDirectory => {
+                "the destination branch tracks members beneath this path, so a file cannot take \
+                 its place"
             }
         }
     }
@@ -133,13 +152,24 @@ pub fn plan_workspace_carry(
     let mut replay = Vec::new();
     let mut carried = Vec::new();
     let mut absorbed = Vec::new();
+    let destination_paths = destination_tree
+        .artifacts_by_path()
+        .map(|artifact| artifact.path.clone())
+        .collect::<Vec<_>>();
 
     for delta in &pending {
         match delta {
             TreeDelta::Added { new, .. } => match destination_tree.artifact_at_path(&new.path) {
                 None => {
-                    replay.push(delta.clone());
-                    carried.push(new.path.clone());
+                    match path_shape_conflict(&new.path, destination_tree, &destination_paths) {
+                        Some(kind) => {
+                            conflicts.insert(new.path.clone(), kind);
+                        }
+                        None => {
+                            replay.push(delta.clone());
+                            carried.push(new.path.clone());
+                        }
+                    }
                 }
                 Some(member) if member.entry == new.entry => absorbed.push(new.path.clone()),
                 Some(_) => {
@@ -156,16 +186,40 @@ pub fn plan_workspace_carry(
                 let held_identically = destination_tree
                     .get(artifact_id)
                     .is_some_and(|member| member.located_entry() == *old);
-                if held_identically {
-                    replay.push(delta.clone());
-                    if matches!(delta, TreeDelta::Updated { .. }) {
-                        carried.push(old.path.clone());
-                    }
-                } else {
+                if !held_identically {
                     conflicts.insert(
                         old.path.clone(),
                         WorkspaceCarryConflictKind::MemberDiffersBetweenBranches,
                     );
+                    continue;
+                }
+                // A pending move lands the member somewhere the destination
+                // never held it, so its new location needs the same shape and
+                // occupancy checks an addition gets. A same-path edit does not:
+                // the destination already holds this member right there.
+                let moved_to = match delta {
+                    TreeDelta::Updated { new, .. } if new.path != old.path => Some(&new.path),
+                    _ => None,
+                };
+                if let Some(destination_path) = moved_to {
+                    let blocked = destination_tree
+                        .artifact_at_path(destination_path)
+                        .map(|_| WorkspaceCarryConflictKind::AdditionWouldOverwriteMember)
+                        .or_else(|| {
+                            path_shape_conflict(
+                                destination_path,
+                                destination_tree,
+                                &destination_paths,
+                            )
+                        });
+                    if let Some(kind) = blocked {
+                        conflicts.insert(destination_path.clone(), kind);
+                        continue;
+                    }
+                }
+                replay.push(delta.clone());
+                if matches!(delta, TreeDelta::Updated { .. }) {
+                    carried.push(old.path.clone());
                 }
             }
         }
@@ -195,6 +249,43 @@ pub fn plan_workspace_carry(
         carried,
         absorbed,
     })))
+}
+
+/// Whether the destination's own members leave room for a path at all.
+///
+/// A tree is a flat set of paths, so nothing in [`ResolvedTree::apply`] stops a
+/// carried entry from landing beneath a member that is a file or an independent
+/// checkout, or on top of a path the destination uses as a directory. Both
+/// produce a tree that no filesystem can hold, and the failure surfaces much
+/// later as a materialization error naming two paths and no remedy. Deciding it
+/// here keeps it a refusal a caller can act on.
+///
+/// `destination_paths` is the destination's paths in sorted order, so the
+/// descendant test is a range probe rather than a scan per candidate.
+fn path_shape_conflict(
+    path: &RepoPath,
+    destination_tree: &ResolvedTree,
+    destination_paths: &[RepoPath],
+) -> Option<WorkspaceCarryConflictKind> {
+    let bytes = path.as_bytes();
+    let mut boundary = 0;
+    while let Some(offset) = bytes[boundary..].iter().position(|byte| *byte == b'/') {
+        boundary += offset;
+        let ancestor = RepoPath::from_bytes(bytes[..boundary].to_vec())
+            .expect("a prefix of a valid repository path up to a separator is itself valid");
+        if destination_tree.artifact_at_path(&ancestor).is_some() {
+            return Some(WorkspaceCarryConflictKind::PathIsInsideADestinationMember);
+        }
+        boundary += 1;
+    }
+
+    let mut prefix = bytes.to_vec();
+    prefix.push(b'/');
+    let first = destination_paths.partition_point(|held| held.as_bytes() < prefix.as_slice());
+    destination_paths
+        .get(first)
+        .is_some_and(|held| held.as_bytes().starts_with(&prefix))
+        .then_some(WorkspaceCarryConflictKind::PathIsADestinationDirectory)
 }
 
 /// Replay the overlay's entity deltas onto the destination's live entities.
@@ -515,6 +606,84 @@ mod tests {
                 ),
             ],
             "a caller must learn about every blocked path from one refusal"
+        );
+    }
+
+    /// The shape a Gitlink produces, which reached materialization before this
+    /// rule existed and failed there as an unactionable internal error.
+    #[test]
+    fn an_addition_beneath_a_destination_member_refuses() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[
+            (1, "shared.txt", "shared"),
+            (2, "vendor/dependency/nested/owned.txt", "independent"),
+        ]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "vendor/dependency", "link")]);
+
+        assert_eq!(
+            conflicts(&plan(&base, &pending, &destination)),
+            vec![(
+                "vendor/dependency/nested/owned.txt".to_string(),
+                WorkspaceCarryConflictKind::PathIsInsideADestinationMember
+            )]
+        );
+    }
+
+    #[test]
+    fn an_addition_over_a_destination_directory_refuses() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[(1, "shared.txt", "shared"), (2, "src", "a file now")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "src/lib.rs", "a module")]);
+
+        assert_eq!(
+            conflicts(&plan(&base, &pending, &destination)),
+            vec![(
+                "src".to_string(),
+                WorkspaceCarryConflictKind::PathIsADestinationDirectory
+            )]
+        );
+    }
+
+    /// A path that merely shares a textual prefix with a destination member is
+    /// not inside it, so the shape rule must not fire on `src-notes.md` because
+    /// the destination happens to track `src/lib.rs`.
+    #[test]
+    fn a_sibling_sharing_a_textual_prefix_still_carries() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[(1, "shared.txt", "shared"), (2, "src-notes.md", "notes")]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "src/lib.rs", "a module")]);
+
+        let plan = plan(&base, &pending, &destination);
+        assert_eq!(
+            carried(&plan)
+                .carried
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["src-notes.md".to_string()]
+        );
+    }
+
+    /// The mirror of the above on the ancestor side: `vendor/dependency2` is not
+    /// inside `vendor/dependency`, and a byte-prefix test with no separator
+    /// boundary would wrongly refuse it.
+    #[test]
+    fn an_addition_beside_a_destination_member_still_carries() {
+        let base = tree(&[(1, "shared.txt", "shared")]);
+        let pending = tree(&[
+            (1, "shared.txt", "shared"),
+            (2, "vendor/dependency2/note.md", "beside"),
+        ]);
+        let destination = tree(&[(1, "shared.txt", "shared"), (3, "vendor/dependency", "link")]);
+
+        let plan = plan(&base, &pending, &destination);
+        assert_eq!(
+            carried(&plan)
+                .carried
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["vendor/dependency2/note.md".to_string()]
         );
     }
 

--- a/crates/kin-core/src/workspace_carry.rs
+++ b/crates/kin-core/src/workspace_carry.rs
@@ -618,7 +618,10 @@ mod tests {
             (1, "shared.txt", "shared"),
             (2, "vendor/dependency/nested/owned.txt", "independent"),
         ]);
-        let destination = tree(&[(1, "shared.txt", "shared"), (3, "vendor/dependency", "link")]);
+        let destination = tree(&[
+            (1, "shared.txt", "shared"),
+            (3, "vendor/dependency", "link"),
+        ]);
 
         assert_eq!(
             conflicts(&plan(&base, &pending, &destination)),
@@ -674,7 +677,10 @@ mod tests {
             (1, "shared.txt", "shared"),
             (2, "vendor/dependency2/note.md", "beside"),
         ]);
-        let destination = tree(&[(1, "shared.txt", "shared"), (3, "vendor/dependency", "link")]);
+        let destination = tree(&[
+            (1, "shared.txt", "shared"),
+            (3, "vendor/dependency", "link"),
+        ]);
 
         let plan = plan(&base, &pending, &destination);
         assert_eq!(

--- a/crates/kin-core/src/workspace_carry.rs
+++ b/crates/kin-core/src/workspace_carry.rs
@@ -149,7 +149,9 @@ pub fn plan_workspace_carry(
                     );
                 }
             },
-            TreeDelta::Updated { artifact_id, old, .. }
+            TreeDelta::Updated {
+                artifact_id, old, ..
+            }
             | TreeDelta::Removed { artifact_id, old } => {
                 let held_identically = destination_tree
                     .get(artifact_id)
@@ -351,7 +353,10 @@ mod tests {
         let plan = carried(&plan);
 
         assert_eq!(
-            plan.carried.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            plan.carried
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
             vec!["note.md".to_string()]
         );
         assert!(plan.absorbed.is_empty());
@@ -364,7 +369,10 @@ mod tests {
             ArtifactId(uuid::Uuid::from_u128(2)),
             "carrying preserves the identity the entry was admitted under"
         );
-        assert!(plan.tree.artifact_at_path(&path("only-there.txt")).is_some());
+        assert!(plan
+            .tree
+            .artifact_at_path(&path("only-there.txt"))
+            .is_some());
     }
 
     #[test]
@@ -393,7 +401,10 @@ mod tests {
 
         assert!(plan.carried.is_empty());
         assert_eq!(
-            plan.absorbed.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            plan.absorbed
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
             vec!["Dockerfile".to_string()]
         );
         assert_eq!(
@@ -412,7 +423,10 @@ mod tests {
         let plan = carried(&plan);
 
         assert_eq!(
-            plan.carried.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            plan.carried
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
             vec!["shared.txt".to_string()]
         );
         assert_eq!(

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -1052,10 +1052,12 @@ fn plan_switch_carry(
         return Ok(None);
     }
     let base_tree = match base_change_id {
-        Some(change_id) => graph
-            .resolve_graph_at(change_id)
-            .context("resolve the exact graph this workspace is based on")?
-            .tree,
+        Some(change_id) => {
+            graph
+                .resolve_graph_at(change_id)
+                .context("resolve the exact graph this workspace is based on")?
+                .tree
+        }
         None => ResolvedTree::default(),
     };
     match kin_core::plan_workspace_carry(
@@ -1069,9 +1071,9 @@ fn plan_switch_carry(
     .context("plan pending workspace state against the branch being switched to")?
     {
         kin_core::WorkspaceCarry::Carried(plan) => Ok(Some(plan)),
-        kin_core::WorkspaceCarry::Refused(conflicts) => Err(pending_state_conflict(
-            workspace, name, &conflicts, policy,
-        )),
+        kin_core::WorkspaceCarry::Refused(conflicts) => {
+            Err(pending_state_conflict(workspace, name, &conflicts, policy))
+        }
     }
 }
 

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -34,12 +34,13 @@ const FOLLOW_REASON: &str = "follow exact repository ref admitted by transfer";
 /// compare-and-swap; they differ in what a caller asked for, and therefore in
 /// which refusal is the honest one.
 ///
-/// A switch is a request to leave the current head, so uncommitted graph-owned
-/// state is a reason to refuse before anything is resolved: the caller can
-/// commit and ask again, and nothing has happened in the meantime. A follow is
-/// the second half of a transfer whose history is already durable, so the same
-/// state is not a reason to refuse the transfer that already landed. It is
-/// reported once the transition is known to be needed, which is why the
+/// A switch is a gesture someone typed, with a caller standing by to resolve
+/// whatever it reports, so it carries uncommitted graph-owned state onto the
+/// branch being entered and refuses only where the carry would lose work. A
+/// follow is the second half of a transfer whose history is already durable and
+/// which nobody is watching, so it keeps the stricter rule and refuses over any
+/// uncommitted state rather than replaying it unattended. The follow reports
+/// that once the transition is known to be needed, which is why the
 /// already-at-target case is settled first here and last there.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransitionPolicy {
@@ -171,10 +172,14 @@ fn transition_operation(policy: TransitionPolicy) -> &'static str {
     }
 }
 
-/// Refuse a transition over uncommitted state that graph authority already
-/// owns. Only admitted state reaches this: unadmitted working-copy bytes are
-/// reported as projection drift instead, so the wording never describes host
-/// content that has not crossed the repository-v6 compare-and-swap.
+/// Refuse a follow over uncommitted state that graph authority already owns.
+///
+/// Only a follow reaches this. A switch plans the same state against the branch
+/// it was asked for and refuses through [`pending_state_conflict`], naming the
+/// paths that actually block it. Only admitted state reaches either: unadmitted
+/// working-copy bytes are reported as projection drift instead, so the wording
+/// never describes host content that has not crossed the repository-v6
+/// compare-and-swap.
 fn graph_owned_changes(
     workspace: &kin_model::WorkspaceState,
     policy: TransitionPolicy,
@@ -748,19 +753,20 @@ fn switch(
     let roots = lease.roots().clone();
     let metadata = lease.metadata();
     let workspace = local_workspace(authority, metadata)?.clone();
-    // A transition admits nothing, so this reads persisted authority alone. It
-    // fires only where graph authority already owns uncommitted state: a
-    // non-empty semantic overlay, or a workspace tree that admission moved off
-    // its base. Admission only ever moves members the workspace already
-    // tracks, so untracked host content can never reach this refusal, and the
-    // wording never describes bytes that have not crossed the compare-and-swap.
+    // A switch no longer refuses merely because the workspace holds pending
+    // state. Ambient observation admits every new non-ignored file, so a
+    // scratch note is uncommitted graph truth within seconds of being written,
+    // and refusing on that alone would block the most frequent gesture of a
+    // working day over a file Git would have carried without comment. The
+    // pending state is planned against the destination further down instead,
+    // and only the cases that would actually lose work refuse.
     //
-    // A follow defers this until the transition is known to be needed, because
-    // the history it would refuse over is already durable and a workspace that
-    // is already at the moved ref has nothing to refuse about.
-    if policy == TransitionPolicy::Switch && workspace.is_dirty() {
-        return Err(graph_owned_changes(&workspace, policy));
-    }
+    // A follow keeps the older, stricter rule. It is the second half of a
+    // transfer rather than a gesture anyone typed, so there is no muscle memory
+    // to honour and no caller standing by to resolve a conflict; it defers the
+    // refusal until the transition is known to be needed, because the history
+    // it would refuse over is already durable and a workspace already at the
+    // moved ref has nothing to refuse about.
     if policy == TransitionPolicy::FollowMovedRef
         && !matches!(&workspace.head, WorkspaceHead::Symbolic { target } if target == name)
     {
@@ -777,6 +783,15 @@ fn switch(
     let target_change_id = lease
         .resolve_target_change_id(&target)
         .with_context(|| format!("resolve exact semantic target for branch {name}"))?;
+    // The workspace's own base, so the difference between it and the workspace
+    // tree is exactly the pending work a switch has to decide about. An unborn
+    // symbolic head has no base, and every member of its tree is pending.
+    let base_change_id = workspace
+        .base_target
+        .as_ref()
+        .map(|base| lease.resolve_target_change_id(base))
+        .transpose()
+        .context("resolve the exact authority target this workspace is based on")?;
     let target_shared_policy = metadata
         .admission_policies
         .iter()
@@ -817,25 +832,46 @@ fn switch(
 
     let graph = kin_db::InMemoryGraph::from_snapshot(snapshot)
         .context("prepare graph-owned branch target")?;
-    let target_state = graph
+    let mut desired_state = graph
         .resolve_graph_at(&target_change_id)
         .with_context(|| format!("resolve exact graph for branch {name}"))?;
-    let target_tree = target_state.tree.clone();
+    let target_tree = desired_state.tree.clone();
     let target_tree_hash =
         compute_resolved_tree_hash(&target_tree).context("hash exact branch target tree")?;
-    let tree_deltas = kin_core::exact_tree_correction(&workspace.tree, &target_tree)
+    // Plan what the pending workspace does across the transition. The result
+    // replaces the desired state wholesale, so everything downstream (the
+    // preflight, the published mutation, and the materialization) works from
+    // one description of where this workspace lands: the destination branch's
+    // members with the pending work replayed on top.
+    let carried = plan_switch_carry(
+        &graph,
+        &workspace,
+        base_change_id.as_ref(),
+        &desired_state,
+        name,
+        policy,
+    )?;
+    if let Some(plan) = &carried {
+        desired_state.tree = plan.tree.clone();
+        desired_state.entities = plan.entities.clone();
+        desired_state.relations = plan.relations.clone();
+    }
+    let desired_tree = desired_state.tree.clone();
+    let desired_tree_hash = compute_resolved_tree_hash(&desired_tree)
+        .context("hash the exact tree this branch transition lands on")?;
+    let tree_deltas = kin_core::exact_tree_correction(&workspace.tree, &desired_tree)
         .context("plan exact branch workspace transition")?;
     let semantic_delta = kin_core::diff_workspace_semantics(
         &current_workspace_graph.entities,
         &current_workspace_graph.relations,
-        &target_state.entities,
-        &target_state.relations,
+        &desired_state.entities,
+        &desired_state.relations,
     )
     .context("plan exact branch semantic transition")?;
     let daemon_semantic_delta = crate::local_repository_authority::plan_daemon_semantic_delta(
         state,
-        &target_state.entities,
-        &target_state.relations,
+        &desired_state.entities,
+        &desired_state.relations,
     )
     .context("plan the branch semantic transition for the daemon view")?;
     let daemon_delta = TransactionDelta {
@@ -845,12 +881,12 @@ fn switch(
         admission_policy_delta: None,
         external_reference_deltas: Vec::new(),
     };
-    preflight_switch_delta(state, &workspace.tree, &target_state, &daemon_delta)?;
+    preflight_switch_delta(state, &workspace.tree, &desired_state, &daemon_delta)?;
     let already_active = matches!(
         &workspace.head,
         WorkspaceHead::Symbolic { target } if target == name
     ) && workspace.base_target.as_ref() == Some(&target)
-        && workspace.tree_hash == target_tree_hash
+        && workspace.tree_hash == desired_tree_hash
         && tree_deltas.is_empty()
         && semantic_delta.is_empty()
         && workspace.shared_admission_policy == target_shared_policy
@@ -923,9 +959,12 @@ fn switch(
                 target: name.clone(),
             },
             new_base_target: Some(target),
+            // The base is always the branch that was entered. The tree may sit
+            // ahead of it, which is precisely what a carried pending workspace
+            // is: work that has not been committed to the branch now under it.
             new_base_tree_hash: Some(target_tree_hash),
             tree_deltas,
-            new_tree_hash: target_tree_hash,
+            new_tree_hash: desired_tree_hash,
             semantic_delta,
             new_shared_admission_policy: target_shared_policy.clone(),
             new_admission_policy: EffectiveAdmissionPolicyStamp {
@@ -962,7 +1001,7 @@ fn switch(
         kin_core::tree::transition_repository_workspace_tree_and_commit_repository_transaction(
             state.layout.working_dir(),
             &workspace.tree,
-            &target_tree,
+            &desired_tree,
             &authority.manager,
             transaction,
         )
@@ -970,7 +1009,7 @@ fn switch(
     Ok(BranchCommandOutcome::Commit(BranchExecution {
         response: BranchResponse {
             lines: vec![format!(
-                "{} {} at change {} ({} projected entries, authority generation {})",
+                "{} {} at change {} ({} projected entries, authority generation {}){}",
                 match policy {
                     TransitionPolicy::Switch => "Switched to",
                     TransitionPolicy::FollowMovedRef => "Followed",
@@ -978,7 +1017,8 @@ fn switch(
                 name,
                 target_change_id,
                 materialized,
-                receipt.generation
+                receipt.generation,
+                carried.as_deref().map_or_else(String::new, render_carried)
             )],
             mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
             report: None,
@@ -990,9 +1030,117 @@ fn switch(
         authority_freeze,
         daemon_delta,
         previous_tree: workspace.tree,
-        desired_tree: target_tree,
+        desired_tree,
         projection_changed: true,
     }))
+}
+
+/// Decide what a switch does with pending workspace state, or refuse.
+///
+/// Returns `None` when there is nothing pending, or when the policy is a follow
+/// rather than a switch. A follow is handled by the older refusal further down
+/// and never carries: see the note at the head of [`switch`].
+fn plan_switch_carry(
+    graph: &kin_db::InMemoryGraph,
+    workspace: &kin_model::WorkspaceState,
+    base_change_id: Option<&kin_model::SemanticChangeId>,
+    target_state: &kin_model::graph::ResolvedGraphState,
+    name: &RefName,
+    policy: TransitionPolicy,
+) -> Result<Option<Box<kin_core::WorkspaceCarryPlan>>> {
+    if policy != TransitionPolicy::Switch || !workspace.is_dirty() {
+        return Ok(None);
+    }
+    let base_tree = match base_change_id {
+        Some(change_id) => graph
+            .resolve_graph_at(change_id)
+            .context("resolve the exact graph this workspace is based on")?
+            .tree,
+        None => ResolvedTree::default(),
+    };
+    match kin_core::plan_workspace_carry(
+        &base_tree,
+        &workspace.tree,
+        &workspace.semantic_overlay,
+        &target_state.tree,
+        &target_state.entities,
+        &target_state.relations,
+    )
+    .context("plan pending workspace state against the branch being switched to")?
+    {
+        kin_core::WorkspaceCarry::Carried(plan) => Ok(Some(plan)),
+        kin_core::WorkspaceCarry::Refused(conflicts) => Err(pending_state_conflict(
+            workspace, name, &conflicts, policy,
+        )),
+    }
+}
+
+/// Refuse a switch that would lose pending work, naming every blocked path.
+///
+/// The message states which side each path would have cost, because "commit or
+/// stash" is only actionable once a caller knows whether the obstacle is their
+/// own edit or a member of the branch they asked for.
+fn pending_state_conflict(
+    workspace: &kin_model::WorkspaceState,
+    name: &RefName,
+    conflicts: &[kin_core::WorkspaceCarryConflict],
+    policy: TransitionPolicy,
+) -> anyhow::Error {
+    let detail = conflicts
+        .iter()
+        .map(|conflict| format!("{} ({})", conflict.path, conflict.kind.reason()))
+        .collect::<Vec<_>>()
+        .join("; ");
+    branch_conflict(format!(
+        "workspace {} holds pending changes that cannot move onto {name}: {detail}. Pending work \
+         at any other path moves across with you. Commit these, or set them aside with `kin stash \
+         push`, {}",
+        workspace.workspace_id,
+        transition_remedy(policy)
+    ))
+}
+
+/// Report what a carry did, so the switch line says where pending work went.
+///
+/// A caller who just moved branches with uncommitted work needs to see that it
+/// came along, and needs the absorbed case named separately: those paths are
+/// tracked members of the branch now rather than pending work, which is a real
+/// change in what a later commit would publish.
+fn render_carried(plan: &kin_core::WorkspaceCarryPlan) -> String {
+    let mut clauses = Vec::new();
+    if !plan.carried.is_empty() {
+        clauses.push(format!(
+            "{} pending path(s) carried across and still uncommitted: {}",
+            plan.carried.len(),
+            render_paths(&plan.carried)
+        ));
+    }
+    if !plan.absorbed.is_empty() {
+        clauses.push(format!(
+            "{} pending path(s) already tracked at identical content on this branch: {}",
+            plan.absorbed.len(),
+            render_paths(&plan.absorbed)
+        ));
+    }
+    if clauses.is_empty() {
+        return String::new();
+    }
+    format!("; {}", clauses.join("; "))
+}
+
+/// At most five paths, so one crowded switch cannot bury its own headline.
+fn render_paths(paths: &[kin_model::RepoPath]) -> String {
+    const SHOWN: usize = 5;
+    let listed = paths
+        .iter()
+        .take(SHOWN)
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    match paths.len().checked_sub(SHOWN) {
+        Some(remaining) if remaining > 0 => format!("{listed} and {remaining} more"),
+        _ => listed,
+    }
 }
 
 fn replay_switch(

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -1202,13 +1202,16 @@ fn render_base(change_id: Option<SemanticChangeId>) -> String {
 
 fn render_list(report: &StashListReport) -> Vec<String> {
     if report.entries.is_empty() {
+        // Phrased as a comparison against the base change for the same reason
+        // `kin status` is: "clean" reads as "everything on disk is in the
+        // graph", which this flag does not mean and cannot answer.
         return vec![format!(
             "(no sealed stashes; workspace {} is {})",
             report.workspace_id,
             if report.workspace_dirty {
-                "dirty"
+                "ahead of its base change"
             } else {
-                "clean"
+                "matching its base change"
             }
         )];
     }


### PR DESCRIPTION
Ambient admission takes every new non-ignored file into the pending workspace tree, which makes the workspace sit ahead of its base within seconds of a scratch note being written. A branch switch refused on exactly that state, so a note nobody meant to keep blocked one of the most frequent gestures of a working day, where the equivalent Git gesture carries untracked files across a checkout without comment.

A switch now plans its pending state against the branch being entered instead of refusing whenever the workspace is ahead of its base. The rules a reader can apply by hand:

A pending entry at a path the destination branch does not track carries. It stays pending on the destination under the same artifact identity it was admitted with, so its provenance survives the move. This is the case Git covers by leaving untracked files alone.

A pending entry at a path the destination already tracks with byte-identical content is absorbed. The destination holds that content, so the entry stops being pending and becomes an ordinary member of the branch. The switch line reports those paths separately, because it changes what a later commit would publish.

A pending entry at a path the destination tracks with different content refuses. Carrying it would overwrite a member of the branch being entered, which is what Git refuses as an untracked working tree file that would be overwritten by checkout.

A pending change to a tracked member carries when the destination holds that member in precisely the state the change was planned against, and refuses otherwise, including when the destination does not hold the member at all. This is Git refusing local changes that would be overwritten. The comparison is on artifact identity and located entry together rather than on path, so a member the destination renamed reads as differing instead of silently accepting an edit planned against its old location. A pending removal follows the same rule.

A carried path the destination has no room for refuses in two further shapes: the destination tracks a file or a Gitlink at an enclosing path, or it tracks members beneath the path so a file cannot take a directory's place. Both build a tree no filesystem can hold, and without this rule the failure surfaced only at materialization as an internal error naming two paths and no remedy.

Carried work keeps its entities and relations rather than degrading into tree-only bytes, because the pending semantic overlay is replayed under these same preconditions, and any precondition that does not hold fails closed instead of publishing a graph nobody observed.

A refusal names every blocked path in one message, along with which side each path would have cost. It ends with the two ways out: commit the work, or set it aside with kin stash push.

Only the switch carries. The follow path that finishes a transfer keeps refusing over any uncommitted state, because nobody typed it and nobody is standing by to resolve whatever it reports, which makes replaying pending work unattended the wrong default there.

Alongside this, kin status and kin stash list stop printing the bare words clean and dirty, and say whether the workspace is matching its base change or ahead of it. Both bare words invite the reading that everything on disk is in the graph, which the flag has never meant and cannot answer, since untracked host paths do not move it in either direction. Reporting those paths remains the job of kin graph status.

Closes FIR-2188
