### PR TITLE
Report a reconcile pass waiting on a retry ladder as waiting_deferred

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2073,6 +2073,7 @@ mod tests {
             progress: 128,
             progress_age_seconds: Some(4),
             working_seconds: Some(9),
+            deferred_seconds: None,
             stopped_reason: stopped_reason.map(str::to_string),
         }
     }

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -139,7 +139,12 @@ fn non_empty_env(key: &str) -> Option<String> {
 pub struct BackgroundPassReport {
     /// Stable pass name, e.g. `embed` or `reconcile`.
     pub name: String,
-    /// `idle`, `working`, or `stopped`.
+    /// `idle`, `working`, `waiting_deferred`, or `stopped`.
+    ///
+    /// `waiting_deferred` is not idleness. It means the pass has nothing it may
+    /// admit this instant because deferred work is waiting out a retry ladder,
+    /// and it is reported separately because a ladder that never converges
+    /// otherwise reads exactly like a pass with nothing to do.
     pub state: String,
     /// Units of work this pass has durably recorded since the daemon started.
     /// Monotonic, so a delta across two reads is meaningful.
@@ -153,6 +158,15 @@ pub struct BackgroundPassReport {
     /// absent while idle.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub working_seconds: Option<u64>,
+    /// Seconds the pass has had deferred work owed to it without that queue
+    /// draining; absent when nothing is deferred.
+    ///
+    /// Ages independently of `working_seconds`, which is the point: a retry
+    /// ladder that keeps widening leaves the pass alternating between working
+    /// and having nothing admittable, so neither of the other two clocks ever
+    /// shows the livelock this one measures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_seconds: Option<u64>,
     /// Why this pass was stopped, once it has been. A value drives
     /// `status: "attention"` on `/health`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -130,6 +130,14 @@ struct PassInner {
     progress_at: Option<Instant>,
     /// Start of the current uninterrupted working stretch; `None` while idle.
     working_since: Option<Instant>,
+    /// Start of the current stretch with deferred work owed; `None` when the
+    /// pass's retry queue is empty.
+    ///
+    /// Deliberately independent of `working_since`. A retry ladder that keeps
+    /// widening leaves the pass alternating between working on other paths and
+    /// having nothing it may admit, so tying this clock to pass activity would
+    /// reset it on exactly the ticks a livelock produces.
+    deferred_since: Option<Instant>,
     /// Why this pass stopped, once it has.
     halt: Option<String>,
     /// Cumulative delay charged to the retry ladder since the last success.
@@ -146,6 +154,7 @@ impl BackgroundPass {
                 progress: 0,
                 progress_at: None,
                 working_since: None,
+                deferred_since: None,
                 halt: None,
                 retry_spent: Duration::ZERO,
             }),
@@ -189,6 +198,35 @@ impl BackgroundPass {
     /// wedged loop still reaches would clear the very stretch being measured.
     pub fn idle(&self) {
         self.lock().working_since = None;
+    }
+
+    /// Record whether deferred work is still owed to this pass, and since when.
+    ///
+    /// Call it once per loop turn with the pass's own answer to "is my retry
+    /// queue non-empty", including on the turns that find nothing to do. That is
+    /// what separates the two ways a pass can have no admittable work: a drained
+    /// queue is [`idle`](Self::idle), and a queue whose entries are all waiting
+    /// out a retry ladder is `waiting_deferred`.
+    ///
+    /// The distinction exists because the reconcile loop reports itself idle on
+    /// every tick of a ladder wait. A path that never stabilizes keeps the loop
+    /// deferring and re-deferring forever while each individual tick truthfully
+    /// finds nothing it may admit, so the pass reads as idle throughout a
+    /// livelock that is spending real CPU.
+    ///
+    /// This deliberately does not feed the stall watchdog. Holding the working
+    /// stretch open across ladder waits would make any flapping file eventually
+    /// halt the loop, which is a worse failure than the blind spot. The livelock
+    /// becomes visible as a state and an age instead of as a stop.
+    pub fn set_deferred(&self, owed: bool, now: Instant) {
+        let mut inner = self.lock();
+        if owed {
+            if inner.deferred_since.is_none() {
+                inner.deferred_since = Some(now);
+            }
+        } else {
+            inner.deferred_since = None;
+        }
     }
 
     /// Record `units` of newly persisted work.
@@ -274,10 +312,16 @@ impl BackgroundPass {
 
     fn report(&self, now: Instant) -> BackgroundPassReport {
         let inner = self.lock();
+        // `working` outranks `waiting_deferred`: a pass burning CPU on this tick
+        // is described by that, not by the queue it also owes. `waiting_deferred`
+        // outranks `idle`, which is the whole correction: a pass waiting out a
+        // ladder is not a pass with nothing to do.
         let state = if inner.halt.is_some() {
             "stopped"
         } else if inner.working_since.is_some() {
             "working"
+        } else if inner.deferred_since.is_some() {
+            "waiting_deferred"
         } else {
             "idle"
         };
@@ -290,6 +334,9 @@ impl BackgroundPass {
                 .map(|at| now.saturating_duration_since(at).as_secs()),
             working_seconds: inner
                 .working_since
+                .map(|since| now.saturating_duration_since(since).as_secs()),
+            deferred_seconds: inner
+                .deferred_since
                 .map(|since| now.saturating_duration_since(since).as_secs()),
             stopped_reason: inner.halt.clone(),
         }
@@ -770,6 +817,114 @@ mod tests {
             Some(Duration::from_secs(86_400)),
             Duration::from_secs(60)
         ));
+    }
+
+    fn reconcile_pass() -> Arc<BackgroundPass> {
+        BackgroundWorkSupervisor::default().pass(PASS_RECONCILE)
+    }
+
+    /// The FIR-2165 correction. A pass with deferred work owed reports a state
+    /// of its own, so a retry ladder that never converges stops reading as a
+    /// pass with nothing to do.
+    #[test]
+    fn deferred_work_is_reported_separately_from_idle() {
+        let base = Instant::now();
+        let pass = reconcile_pass();
+
+        assert_eq!(pass.report(base).state, "idle");
+        assert_eq!(pass.report(base).deferred_seconds, None);
+
+        pass.set_deferred(true, base);
+        let report = pass.report(at(base, 4_021));
+        assert_eq!(report.state, "waiting_deferred");
+        assert_eq!(report.deferred_seconds, Some(4_021));
+        assert_eq!(
+            report.working_seconds, None,
+            "a waiting pass holds no working stretch"
+        );
+    }
+
+    /// Draining the queue returns the pass to true idle, so the state cannot
+    /// latch on and report a livelock that has since resolved.
+    #[test]
+    fn a_drained_queue_returns_the_pass_to_idle() {
+        let base = Instant::now();
+        let pass = reconcile_pass();
+        pass.set_deferred(true, base);
+        pass.set_deferred(false, at(base, 10));
+
+        let report = pass.report(at(base, 20));
+        assert_eq!(report.state, "idle");
+        assert_eq!(report.deferred_seconds, None);
+    }
+
+    /// The clock latches on the first tick that owes work and is not restarted
+    /// by later ticks that still owe it. Without this a loop polling every few
+    /// hundred milliseconds would report an age of roughly one tick forever.
+    #[test]
+    fn the_deferred_clock_is_not_restarted_by_repeat_reports() {
+        let base = Instant::now();
+        let pass = reconcile_pass();
+        pass.set_deferred(true, base);
+        pass.set_deferred(true, at(base, 10));
+        pass.set_deferred(true, at(base, 20));
+
+        assert_eq!(pass.report(at(base, 30)).deferred_seconds, Some(30));
+    }
+
+    /// The blast-radius guard. Deferred work must never make the watchdog stop
+    /// the loop: holding a working stretch open across ladder waits would let
+    /// any flapping file halt reconciliation, which is worse than the blind spot
+    /// this change closes.
+    #[test]
+    fn deferred_work_alone_never_stalls_a_pass() {
+        let base = Instant::now();
+        let supervisor = BackgroundWorkSupervisor::new(Duration::from_secs(60));
+        let pass = supervisor.pass(PASS_RECONCILE);
+        pass.set_deferred(true, base);
+
+        assert!(supervisor.sweep(at(base, 86_400)).is_empty());
+        assert!(!pass.halted());
+        assert_eq!(pass.report(at(base, 86_400)).state, "waiting_deferred");
+    }
+
+    /// A pass that is actually burning CPU is described by that, not by the
+    /// queue it also owes.
+    #[test]
+    fn working_outranks_waiting_deferred() {
+        let base = Instant::now();
+        let pass = reconcile_pass();
+        pass.set_deferred(true, base);
+        pass.working(at(base, 5));
+
+        let report = pass.report(at(base, 30));
+        assert_eq!(report.state, "working");
+        assert_eq!(
+            report.deferred_seconds,
+            Some(30),
+            "the deferred clock keeps aging underneath the working stretch"
+        );
+    }
+
+    /// The two clocks are independent, which is the reason this is a second
+    /// reading rather than a reuse of the working stretch. A loop alternating
+    /// between working and having nothing admittable resets `working_seconds`
+    /// every cycle while the deferred age keeps climbing.
+    #[test]
+    fn the_deferred_clock_survives_an_idle_working_cycle() {
+        let base = Instant::now();
+        let pass = reconcile_pass();
+        pass.set_deferred(true, base);
+
+        for tick in 1..=5 {
+            pass.working(at(base, tick * 10));
+            pass.idle();
+        }
+
+        let report = pass.report(at(base, 100));
+        assert_eq!(report.state, "waiting_deferred");
+        assert_eq!(report.deferred_seconds, Some(100));
+        assert_eq!(report.working_seconds, None);
     }
 
     #[test]

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1317,6 +1317,8 @@ pub async fn run_loop(
                 .reconciliation_status
                 .store(RECON_IDLE, Ordering::Relaxed);
             pass.idle();
+            // A loop that is gone owes nothing, whatever its ladder still held.
+            pass.set_deferred(false, Instant::now());
             info!("reconciliation loop shutting down");
             break;
         }
@@ -1437,17 +1439,32 @@ pub async fn run_loop(
         });
         enqueue_file_events(&mut pending_events, incoming_events);
 
+        // Report the retry queue's own state every tick, including the ticks
+        // that find nothing to do. This clock ages independently of the working
+        // stretch below, which is what makes a ladder that never converges
+        // visible: the loop keeps deferring the same paths, each individual tick
+        // truthfully has nothing it may admit, and without this the pass reports
+        // idle for the entire livelock.
+        pass.set_deferred(!retry_lane.is_empty(), tick_started);
+
         if pending_events.is_empty() {
-            // Nothing observed, so this loop is genuinely doing nothing and its
-            // working stretch ends. This is the only path that clears it: a tick
-            // that keeps retrying the same unadmittable paths never arrives
-            // here, which is what makes that spin observable.
+            // Nothing to admit this tick, so the working stretch ends.
+            //
+            // This does NOT mean the loop is doing nothing. A tick that keeps
+            // retrying the same unadmittable paths reaches here on every tick of
+            // every ladder wait: the paths waiting out a step are dropped from
+            // the incoming events above, and their retries are not yet due, so
+            // the queue is empty while the work is still owed. That is why the
+            // deferred clock above is a separate reading and why this state is
+            // reported as `waiting_deferred` rather than `idle` whenever the
+            // retry lane still holds something.
             pass.idle();
             // No events — sleep briefly then check again.
             tokio::select! {
                 _ = tokio::time::sleep(interval) => {}
                 _ = cancel.changed() => {
                     state.reconciliation_status.store(RECON_IDLE, Ordering::Relaxed);
+                    pass.set_deferred(false, Instant::now());
                     info!("reconciliation loop shutting down");
                     break;
                 }
@@ -3284,6 +3301,92 @@ mod tests {
             base * (1 << RETRY_BACKOFF_MAX_SHIFT),
             "an attempt count that cannot overflow the shift must still land on the ceiling"
         );
+    }
+
+    /// The reconcile pass as the disclosure surfaces see it.
+    fn reconcile_report(
+        supervisor: &crate::background_work::BackgroundWorkSupervisor,
+        now: Instant,
+    ) -> kin_cli::commands::resources::BackgroundPassReport {
+        supervisor
+            .reports(now)
+            .into_iter()
+            .find(|report| report.name == crate::background_work::PASS_RECONCILE)
+            .expect("the reconcile pass is registered")
+    }
+
+    /// The tick decision this loop makes about its own state, exercised against
+    /// a real ladder-waiting lane.
+    ///
+    /// The loop reports `set_deferred(!retry_lane.is_empty(), tick_started)` and
+    /// then finds `pending_events` empty, because a path waiting out its step is
+    /// dropped from incoming events and its retry is not yet due. Before
+    /// FIR-2165 that combination reported plain `idle` for the whole wait, so a
+    /// ladder that never converged was indistinguishable from a quiet loop.
+    #[test]
+    fn a_ladder_waiting_tick_reports_waiting_deferred_rather_than_idle() {
+        let base = Duration::from_millis(100);
+        let start = Instant::now();
+        let unstable = PathBuf::from("/repo/Cargo.lock");
+        let mut lane = RetryLane::default();
+        let supervisor = crate::background_work::BackgroundWorkSupervisor::default();
+        let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
+
+        // A quiet loop with an empty lane is genuinely idle.
+        pass.set_deferred(!lane.is_empty(), start);
+        pass.idle();
+        assert_eq!(reconcile_report(&supervisor, start).state, "idle");
+
+        // Defer the path, then advance to the middle of its ladder step. This is
+        // the state the livelock sits in.
+        lane.defer(&unstable, start, base);
+        let mid_wait = start + base / 2;
+        assert!(
+            lane.waiting(&unstable, mid_wait),
+            "the path must still be waiting out its step for this to be the case under test"
+        );
+        assert!(
+            lane.take_due(mid_wait).is_empty(),
+            "no retry is due yet, so the tick observes an empty event queue"
+        );
+
+        // The tick the loop actually runs: report the lane, then find nothing to
+        // admit and end the working stretch.
+        pass.set_deferred(!lane.is_empty(), mid_wait);
+        pass.idle();
+
+        let report = reconcile_report(&supervisor, mid_wait + Duration::from_secs(4_021));
+        assert_eq!(
+            report.state, "waiting_deferred",
+            "work is owed, so this tick is not idle"
+        );
+        assert_eq!(report.deferred_seconds, Some(4_021));
+        assert_eq!(report.working_seconds, None);
+    }
+
+    /// The other direction. Once the path settles and the lane drains, the same
+    /// decision reports true idle, so the state cannot be a constant.
+    #[test]
+    fn a_settled_path_returns_the_tick_to_idle() {
+        let base = Duration::from_millis(100);
+        let start = Instant::now();
+        let unstable = PathBuf::from("/repo/Cargo.lock");
+        let mut lane = RetryLane::default();
+        let supervisor = crate::background_work::BackgroundWorkSupervisor::default();
+        let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
+
+        lane.defer(&unstable, start, base);
+        pass.set_deferred(!lane.is_empty(), start);
+        pass.idle();
+        assert_eq!(
+            reconcile_report(&supervisor, start).state,
+            "waiting_deferred"
+        );
+
+        lane.forget(&unstable);
+        pass.set_deferred(!lane.is_empty(), start + base);
+        pass.idle();
+        assert_eq!(reconcile_report(&supervisor, start + base).state, "idle");
     }
 
     #[test]

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1176,6 +1176,20 @@ impl RetryLane {
     fn is_empty(&self) -> bool {
         self.queued.is_empty()
     }
+
+    /// Whether any path is unstable right now, for the pass's deferred-work
+    /// clock.
+    ///
+    /// Keyed on the ladder rather than the queue, and the difference decides
+    /// whether the clock can measure a livelock at all. [`take_due`](Self::take_due)
+    /// empties the queue every time a step elapses, so a queue-keyed clock would
+    /// clear on each due tick and restart on the re-deferral, capping the
+    /// reported age at one backoff step however long the loop churns. Ladders
+    /// survive `take_due` and are dropped only by [`forget`](Self::forget), when
+    /// a path actually settles, so this stays true across the whole spin.
+    fn deferred_owed(&self) -> bool {
+        !self.ladder.is_empty()
+    }
 }
 
 /// Report one deferral of a path that changed while it was being reconciled.
@@ -1445,7 +1459,7 @@ pub async fn run_loop(
         // visible: the loop keeps deferring the same paths, each individual tick
         // truthfully has nothing it may admit, and without this the pass reports
         // idle for the entire livelock.
-        pass.set_deferred(!retry_lane.is_empty(), tick_started);
+        pass.set_deferred(retry_lane.deferred_owed(), tick_started);
 
         if pending_events.is_empty() {
             // Nothing to admit this tick, so the working stretch ends.
@@ -3318,7 +3332,7 @@ mod tests {
     /// The tick decision this loop makes about its own state, exercised against
     /// a real ladder-waiting lane.
     ///
-    /// The loop reports `set_deferred(!retry_lane.is_empty(), tick_started)` and
+    /// The loop reports `set_deferred(retry_lane.deferred_owed(), tick_started)` and
     /// then finds `pending_events` empty, because a path waiting out its step is
     /// dropped from incoming events and its retry is not yet due. Before
     /// FIR-2165 that combination reported plain `idle` for the whole wait, so a
@@ -3333,7 +3347,7 @@ mod tests {
         let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
 
         // A quiet loop with an empty lane is genuinely idle.
-        pass.set_deferred(!lane.is_empty(), start);
+        pass.set_deferred(lane.deferred_owed(), start);
         pass.idle();
         assert_eq!(reconcile_report(&supervisor, start).state, "idle");
 
@@ -3352,7 +3366,7 @@ mod tests {
 
         // The tick the loop actually runs: report the lane, then find nothing to
         // admit and end the working stretch.
-        pass.set_deferred(!lane.is_empty(), mid_wait);
+        pass.set_deferred(lane.deferred_owed(), mid_wait);
         pass.idle();
 
         let report = reconcile_report(&supervisor, mid_wait + Duration::from_secs(4_021));
@@ -3376,7 +3390,7 @@ mod tests {
         let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
 
         lane.defer(&unstable, start, base);
-        pass.set_deferred(!lane.is_empty(), start);
+        pass.set_deferred(lane.deferred_owed(), start);
         pass.idle();
         assert_eq!(
             reconcile_report(&supervisor, start).state,
@@ -3384,9 +3398,62 @@ mod tests {
         );
 
         lane.forget(&unstable);
-        pass.set_deferred(!lane.is_empty(), start + base);
+        pass.set_deferred(lane.deferred_owed(), start + base);
         pass.idle();
         assert_eq!(reconcile_report(&supervisor, start + base).state, "idle");
+    }
+
+    /// The clock has to survive the tick that collects a due retry, which is the
+    /// tick a spinning loop runs most often.
+    ///
+    /// `take_due` empties the queue every time a ladder step elapses, so keying
+    /// the clock on the queue would clear it on each due tick and restart it on
+    /// the re-deferral. The reported age would then never exceed one backoff
+    /// step, and a loop churning for over an hour would report a few seconds.
+    #[test]
+    fn the_deferred_clock_survives_a_due_retry_and_re_deferral() {
+        let base = Duration::from_millis(100);
+        let start = Instant::now();
+        let unstable = PathBuf::from("/repo/Cargo.lock");
+        let mut lane = RetryLane::default();
+        let supervisor = crate::background_work::BackgroundWorkSupervisor::default();
+        let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
+
+        lane.defer(&unstable, start, base);
+        pass.set_deferred(lane.deferred_owed(), start);
+
+        // Five full cycles of "step elapses, retry is collected, path defers
+        // again" — the shape of a path being rewritten faster than it reconciles.
+        // Advance past the backoff ceiling each cycle so every step has genuinely
+        // elapsed however far the ladder has widened.
+        let past_ceiling = base * (1 << RETRY_BACKOFF_MAX_SHIFT) * 2;
+        let mut now = start;
+        for _ in 0..5 {
+            now += past_ceiling;
+            assert_eq!(
+                lane.take_due(now),
+                vec![unstable.clone()],
+                "the elapsed step hands the path back"
+            );
+            assert!(
+                lane.is_empty(),
+                "the queue is empty at exactly this moment, which is the trap"
+            );
+            assert!(
+                lane.deferred_owed(),
+                "the path is still unstable, so the clock must not clear here"
+            );
+            pass.set_deferred(lane.deferred_owed(), now);
+            lane.defer(&unstable, now, base);
+        }
+
+        let report = reconcile_report(&supervisor, now);
+        assert_eq!(report.state, "waiting_deferred");
+        assert_eq!(
+            report.deferred_seconds,
+            Some(now.saturating_duration_since(start).as_secs()),
+            "the age spans every cycle, not just the last one"
+        );
     }
 
     #[test]


### PR DESCRIPTION
While a deferred path's retry ladder waited out its step, pending_events was empty, so run_loop reached pass.idle() on every tick and cleared the reconcile working stretch. The probe surface therefore read reconcile_pass idle through an entire livelock: the FIR-2152 loop admitted nothing for 4,021 seconds at 62 percent of a core and the working-stretch surface never saw it, while the call site's comment claimed that could not happen. The comment was wrong and is corrected.

The probe now reports waiting_deferred with the age of the continuous stretch during which some path has been waiting on the ladder, keyed on the retry ladder itself rather than the retry queue, so a ladder that never converges is visible for as long as the condition holds and the reading can only over-report, never under. By design the loop is not halted and the working stretch is not held open: a flapping file must not be able to stop reconcile through the stretch watchdog, so this change makes the state legible to watchers and leaves acting on it to them. The health test fixture carries the new reading so the distinction from true idle is pinned by test.

Closes FIR-2165
