### PR TITLE
Read unchanged source bodies from the store that promises them

### DIFF
--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -137,6 +137,7 @@ mod repository_rollback;
 mod repository_stash;
 mod repository_tag;
 pub mod session_registry;
+mod source_cas;
 pub mod state;
 pub mod supervisor;
 pub mod traffic_adapter;

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1694,14 +1694,19 @@ mod tests {
         );
     }
 
-    /// The same loss on the native commit path, which reads unchanged bodies
-    /// twice: once to measure every rule file while deriving the policy, and
-    /// once to copy every source the change references into repository CAS.
-    /// Neither read is bounded to what moved, so an untouched `.gitignore` is
-    /// consulted by every commit forever, and before this both reads went to
-    /// ingestion staging alone.
-    #[test]
-    fn a_native_commit_publishes_after_ingestion_staging_is_lost() {
+    /// Publish a rule file and one source, lose the whole staging directory,
+    /// then publish a second source through `publish`.
+    ///
+    /// The second transition has to read one body from each store: the new
+    /// file's is staged, and the untouched `.gitignore` the policy still
+    /// measures is only in repository CAS.
+    fn publish_across_a_lost_staging_directory(
+        publish: fn(
+            &kin_core::KinLayout,
+            &kin_blobs::BlobStore,
+            NativeCommitPlan,
+        ) -> Result<NativeCommitResult>,
+    ) -> (tempfile::TempDir, kin_core::InitResult) {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
@@ -1727,7 +1732,7 @@ mod tests {
             "publish the rule file and one source".to_string(),
         )
         .unwrap();
-        commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+        publish(&init.layout, &blobs, plan).unwrap();
 
         // Lose the staging directory the way a restore that carries the
         // authority database but not a directory named like a cache does.
@@ -1741,8 +1746,6 @@ mod tests {
             "the fixture only proves anything while the staged rule body is genuinely gone"
         );
 
-        // The new file's body is staged, the rule file's is not. One commit has
-        // to read both stores to publish.
         add_artifact(
             &graph,
             &blobs,
@@ -1760,18 +1763,44 @@ mod tests {
             "publish a change that leaves the rule file untouched".to_string(),
         )
         .unwrap();
-        let result = commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+        let result = publish(&init.layout, &blobs, plan).unwrap();
         assert_eq!(result.receipt.generation, 3);
-        assert_eq!(
-            std::fs::read(root.path().join("second.rs")).unwrap(),
-            b"pub fn second() {}\n"
-        );
 
         let authority = reopen(&init);
         assert_eq!(
             authority.load_source_blob(rules_hash).unwrap().as_deref(),
             Some(b"target/\n".as_slice()),
             "the rule body the commit measured is the one authority already held"
+        );
+        (root, init)
+    }
+
+    /// The same loss on the native commit path, which reads unchanged bodies
+    /// twice: once to measure every rule file while deriving the policy, and
+    /// once to copy every source the change references into repository CAS.
+    /// Neither read is bounded to what moved, so an untouched `.gitignore` is
+    /// consulted by every commit forever, and before this both reads went to
+    /// ingestion staging alone.
+    #[test]
+    fn a_native_commit_publishes_after_ingestion_staging_is_lost() {
+        let (root, _init) =
+            publish_across_a_lost_staging_directory(commit_native_plan_with_projection);
+        assert_eq!(
+            std::fs::read(root.path().join("second.rs")).unwrap(),
+            b"pub fn second() {}\n",
+            "the projecting path still materializes what it published"
+        );
+    }
+
+    /// The bare publication path carries its own copy loop, and tests reach
+    /// authority through it. A test helper that reads one store where product
+    /// code reads two would pass while the thing it stands in for fails.
+    #[test]
+    fn a_bare_native_publication_publishes_after_ingestion_staging_is_lost() {
+        let (root, _init) = publish_across_a_lost_staging_directory(commit_native_plan);
+        assert!(
+            !root.path().join("second.rs").exists(),
+            "publication without projection is what distinguishes this path from the other"
         );
     }
 

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -24,6 +24,7 @@ use kin_model::{
 use crate::commit_deltas::compute_deltas_vs_repository_authority;
 use crate::error::{DaemonError, Result};
 use crate::local_repository_authority::LocalRepositoryAuthorityContext;
+use crate::source_cas::read_publishable_source;
 
 type ProjectionEntry = (kin_model::RepoPath, kin_model::TreeEntry, Arc<[u8]>);
 
@@ -223,25 +224,12 @@ pub(crate) fn plan_session_workspace_admission(
             if let Some(length) = source_lengths.get(&hash) {
                 return Ok(*length);
             }
-            let blob_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
-            let body = match blobs.read(&blob_hash) {
-                Ok(body) => body,
-                Err(ingestion_error) => authority
-                    .load_source_blob(hash)
-                    .map_err(|error| {
-                        ModelError::InvalidOperation(format!(
-                            "read repository source {hash} while deriving exact session policy: \
-                             {error}"
-                        ))
-                    })?
-                    .ok_or_else(|| {
-                        ModelError::InvalidOperation(format!(
-                            "exact session admission-policy source {hash} is absent from both \
-                             ingestion and repository CAS ({ingestion_error})"
-                        ))
-                    })?,
-            };
-            let length = u64::try_from(body.len()).map_err(|_| {
+            let source = read_publishable_source(blobs, &authority, hash).map_err(|error| {
+                ModelError::InvalidOperation(format!(
+                    "{error}, while deriving the exact session admission policy"
+                ))
+            })?;
+            let length = u64::try_from(source.body().len()).map_err(|_| {
                 ModelError::InvalidOperation(format!(
                     "exact session admission-policy source {hash} exceeds u64"
                 ))
@@ -378,17 +366,8 @@ pub(crate) fn commit_session_workspace_admission(
     }
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     for hash in &plan.source_hashes {
-        let blob_hash = kin_blobs::Hash256::from_bytes(*hash.as_bytes());
-        match blobs.read(&blob_hash) {
-            Ok(body) => authority.save_source_blob(*hash, &body)?,
-            Err(ingestion_error) => {
-                if authority.load_source_blob(*hash)?.is_none() {
-                    return Err(invalid(format!(
-                        "exact session source {hash} is absent from both ingestion and repository \
-                         CAS ({ingestion_error})"
-                    )));
-                }
-            }
+        if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish() {
+            authority.save_source_blob(*hash, body)?;
         }
     }
 
@@ -508,30 +487,14 @@ pub(crate) fn publish_workspace_tree(
                 return Ok(*length);
             }
             // Every rule file in the desired tree is measured here, changed or
-            // not, because the policy is derived from the whole tree. Ingestion
-            // staging is not authority and carries no retention promise, while
-            // a source the repository already published is durable in its own
-            // CAS. Reading staging first and authority second is what keeps an
-            // untouched `.gitignore` from making publication depend on a
-            // staging directory that any restore or cleanup may have dropped.
-            let body = match blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes())) {
-                Ok(body) => body,
-                Err(ingestion_error) => authority
-                    .load_source_blob(hash)
-                    .map_err(|error| {
-                        ModelError::InvalidOperation(format!(
-                            "read repository source {hash} while deriving the admitted workspace \
-                             policy: {error}"
-                        ))
-                    })?
-                    .ok_or_else(|| {
-                        ModelError::InvalidOperation(format!(
-                            "admitted workspace policy source {hash} is absent from both \
-                             ingestion and repository CAS ({ingestion_error})"
-                        ))
-                    })?,
-            };
-            let length = u64::try_from(body.len()).map_err(|_| {
+            // not, because the policy is derived from the whole tree rather
+            // than from what moved.
+            let source = read_publishable_source(blobs, &authority, hash).map_err(|error| {
+                ModelError::InvalidOperation(format!(
+                    "{error}, while deriving the admitted workspace policy"
+                ))
+            })?;
+            let length = u64::try_from(source.body().len()).map_err(|_| {
                 ModelError::InvalidOperation(format!(
                     "admitted workspace policy source {hash} exceeds u64"
                 ))
@@ -603,19 +566,12 @@ pub(crate) fn publish_workspace_tree(
     source_hashes.extend(shared_policy.sources.iter().map(|source| source.body_hash));
     drop(lease);
 
+    // Copying a staged body into repository CAS is how a newly referenced
+    // source becomes durable. An unchanged rule source is already there and
+    // needs no copy.
     for hash in source_hashes {
-        // Copying a staged body into repository CAS is how a newly referenced
-        // source becomes durable. An unchanged rule source is already there and
-        // needs no copy, so staging having dropped it is not a failure. A body
-        // neither store holds still fails the publication, as the typed blob
-        // absence a caller can match on.
-        match blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes())) {
-            Ok(body) => authority.save_source_blob(hash, &body)?,
-            Err(ingestion_error) => {
-                if authority.load_source_blob(hash)?.is_none() {
-                    return Err(DaemonError::from(ingestion_error));
-                }
-            }
+        if let Some(body) = read_publishable_source(blobs, &authority, hash)?.body_to_publish() {
+            authority.save_source_blob(hash, body)?;
         }
     }
     let receipt = authority.commit_repository_transaction(transaction)?;
@@ -833,14 +789,12 @@ fn plan_native_commit_inner(
             if let Some(length) = source_lengths.get(&hash) {
                 return Ok(*length);
             }
-            let body = blobs
-                .read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))
-                .map_err(|error| {
-                    ModelError::InvalidOperation(format!(
-                        "read graph-owned admission source {hash}: {error}"
-                    ))
-                })?;
-            let length = u64::try_from(body.len()).map_err(|_| {
+            let source = read_publishable_source(blobs, &authority, hash).map_err(|error| {
+                ModelError::InvalidOperation(format!(
+                    "{error}, while deriving the graph-owned admission policy"
+                ))
+            })?;
+            let length = u64::try_from(source.body().len()).map_err(|_| {
                 ModelError::InvalidOperation(format!(
                     "graph-owned admission source {hash} exceeds u64"
                 ))
@@ -1111,8 +1065,9 @@ pub(crate) fn commit_native_plan(
     }
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     for hash in &plan.source_hashes {
-        let body = blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))?;
-        authority.save_source_blob(*hash, &body)?;
+        if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish() {
+            authority.save_source_blob(*hash, body)?;
+        }
     }
     let receipt = authority.commit_repository_transaction(plan.transaction)?;
     receipt.validate()?;
@@ -1149,8 +1104,9 @@ pub(crate) fn commit_native_plan_with_projection(
     }
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     for hash in &plan.source_hashes {
-        let body = blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))?;
-        authority.save_source_blob(*hash, &body)?;
+        if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish() {
+            authority.save_source_blob(*hash, body)?;
+        }
     }
 
     let mut body_cache = BTreeMap::new();
@@ -1735,6 +1691,143 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![rules.path.clone()],
             "the derived policy still names the rule file whose body only authority holds"
+        );
+    }
+
+    /// The same loss on the native commit path, which reads unchanged bodies
+    /// twice: once to measure every rule file while deriving the policy, and
+    /// once to copy every source the change references into repository CAS.
+    /// Neither read is bounded to what moved, so an untouched `.gitignore` is
+    /// consulted by every commit forever, and before this both reads went to
+    /// ingestion staging alone.
+    #[test]
+    fn a_native_commit_publishes_after_ingestion_staging_is_lost() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        let rules = add_artifact(&graph, &blobs, b".gitignore", b"target/\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        add_artifact(
+            &graph,
+            &blobs,
+            b"first.rs",
+            b"pub fn first() {}\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("fir2171"),
+            "publish the rule file and one source".to_string(),
+        )
+        .unwrap();
+        commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+
+        // Lose the staging directory the way a restore that carries the
+        // authority database but not a directory named like a cache does.
+        let rules_hash = rules.entry.blob_identity().unwrap();
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        assert!(
+            blobs
+                .read(&kin_blobs::Hash256::from_bytes(*rules_hash.as_bytes()))
+                .is_err(),
+            "the fixture only proves anything while the staged rule body is genuinely gone"
+        );
+
+        // The new file's body is staged, the rule file's is not. One commit has
+        // to read both stores to publish.
+        add_artifact(
+            &graph,
+            &blobs,
+            b"second.rs",
+            b"pub fn second() {}\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("fir2171"),
+            "publish a change that leaves the rule file untouched".to_string(),
+        )
+        .unwrap();
+        let result = commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+        assert_eq!(result.receipt.generation, 3);
+        assert_eq!(
+            std::fs::read(root.path().join("second.rs")).unwrap(),
+            b"pub fn second() {}\n"
+        );
+
+        let authority = reopen(&init);
+        assert_eq!(
+            authority.load_source_blob(rules_hash).unwrap().as_deref(),
+            Some(b"target/\n".as_slice()),
+            "the rule body the commit measured is the one authority already held"
+        );
+    }
+
+    /// The control that keeps the fallback from swallowing a real loss. A body
+    /// no store holds is not an unchanged body that authority already owns, and
+    /// a publication that cannot find one must still refuse, as the typed blob
+    /// absence rather than as a sentence.
+    #[test]
+    fn a_native_commit_still_refuses_a_body_neither_store_holds() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        add_artifact(&graph, &blobs, b".gitignore", b"target/\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("fir2171"),
+            "publish the rule file".to_string(),
+        )
+        .unwrap();
+        commit_native_plan(&init.layout, &blobs, plan).unwrap();
+
+        // Staged and never published, then lost: the one body that is genuinely
+        // gone rather than merely unstaged.
+        add_artifact(
+            &graph,
+            &blobs,
+            b"orphan.rs",
+            b"pub fn orphan() {}\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("fir2171"),
+            "publish a body no store holds".to_string(),
+        )
+        .expect("the rule file authority still owns lets planning get as far as publication");
+        let error = commit_native_plan(&init.layout, &blobs, plan)
+            .expect_err("a body neither store holds cannot be published");
+        assert!(
+            matches!(error, DaemonError::Blob(_)),
+            "absence stays the typed blob failure a caller can match on: {error}"
         );
     }
 

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -17,7 +17,7 @@ use axum::http::StatusCode;
 use kin_cli::commands::merge::{
     MergeOutcome, MergeReport, MergeRequest, MergeResponse, MERGE_REPORT_SCHEMA,
 };
-use kin_db::LocalRepositoryAuthorityFreeze;
+use kin_db::{LocalFileBackend, LocalRepositoryAuthorityFreeze, RepositoryAuthorityManager};
 use kin_model::{
     compute_resolved_tree_hash, compute_semantic_change_id, ChangeOrigin, ChangeStore,
     EffectiveAdmissionPolicyStamp, EntityStore, Hash256, MergeConflictEntry, MergeConflictSubject,
@@ -34,6 +34,7 @@ use kin_model::{
 use crate::local_repository_authority::{
     require_fresh_daemon_workspace, ActiveLocalRepositoryAuthority, RepositoryAuthorityBindRefusal,
 };
+use crate::source_cas::read_publishable_source;
 use crate::state::{DaemonEvent, DaemonState};
 
 const MERGE_REASON: &str = "publish exact repository-v6 semantic merge";
@@ -571,8 +572,12 @@ fn three_way(
 
     let desired_tree = ResolvedTree::from_artifacts(merged_artifacts.into_values())
         .context("compose exact merged repository tree")?;
-    let (shared_policy, admission_policy_delta) =
-        derive_policy(state, &plan.ours_policy, &desired_tree)?;
+    let (shared_policy, admission_policy_delta) = derive_policy(
+        &state.blobs,
+        &authority.manager,
+        &plan.ours_policy,
+        &desired_tree,
+    )?;
     if admission_policy_delta.is_some() || shared_policy != plan.ours_policy {
         return Err(merge_conflict(format!(
             "merging {} into {} changes the shared admission policy; a merge that transitions \
@@ -922,8 +927,12 @@ pub(crate) fn publish_resolved_merge(
 
     let desired_tree = ResolvedTree::from_artifacts(merged_artifacts.into_values())
         .context("compose exact resolved repository tree")?;
-    let (shared_policy, admission_policy_delta) =
-        derive_policy(state, &ours_policy, &desired_tree)?;
+    let (shared_policy, admission_policy_delta) = derive_policy(
+        &state.blobs,
+        &authority.manager,
+        &ours_policy,
+        &desired_tree,
+    )?;
     if admission_policy_delta.is_some() || shared_policy != ours_policy {
         return Err(merge_conflict(format!(
             "merging {} into {} changes the shared admission policy; a merge that transitions \
@@ -1468,8 +1477,16 @@ fn artifacts_by_id(
         .collect()
 }
 
+/// Measure the merged tree's rule sources to derive its admission policy.
+///
+/// Takes the two stores rather than the daemon state because a merge composes
+/// published trees: every rule file it measures was published by an earlier
+/// change and is therefore durable in repository CAS, whether or not its staged
+/// copy survived. Naming both stores here is what keeps a merge from depending
+/// on ingestion staging that nothing promises to retain.
 fn derive_policy(
-    state: &DaemonState,
+    blobs: &kin_blobs::BlobStore,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
     parent: &SharedAdmissionPolicy,
     tree: &ResolvedTree,
 ) -> Result<(
@@ -1481,15 +1498,12 @@ fn derive_policy(
         if let Some(length) = lengths.get(&hash) {
             return Ok(*length);
         }
-        let body = state
-            .blobs
-            .read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))
-            .map_err(|error| {
-                ModelError::InvalidOperation(format!(
-                    "read graph-owned admission source {hash}: {error}"
-                ))
-            })?;
-        let length = u64::try_from(body.len()).map_err(|_| {
+        let source = read_publishable_source(blobs, authority, hash).map_err(|error| {
+            ModelError::InvalidOperation(format!(
+                "{error}, while deriving the merged tree's admission policy"
+            ))
+        })?;
+        let length = u64::try_from(source.body().len()).map_err(|_| {
             ModelError::InvalidOperation(format!("graph-owned admission source {hash} exceeds u64"))
         })?;
         lengths.insert(hash, length);
@@ -2274,5 +2288,89 @@ mod tests {
         )
         .unwrap();
         assert_eq!(merged_relations.get(&relation.id), Some(&relation));
+    }
+
+    fn rule_source_fixture() -> (
+        tempfile::TempDir,
+        kin_core::InitResult,
+        Hash256,
+        ResolvedTree,
+    ) {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let hash = Hash256::from_bytes(blobs.write(b"target/\n").unwrap().0);
+        let tree = ResolvedTree::from_artifacts([ResolvedArtifact::new(
+            ArtifactId::new(),
+            RepoPath::from_utf8(".gitignore").unwrap(),
+            TreeEntry::blob(hash, false),
+        )])
+        .unwrap();
+        (root, init, hash, tree)
+    }
+
+    fn empty_policy() -> SharedAdmissionPolicy {
+        SharedAdmissionPolicy::derive_from_tree(None, &ResolvedTree::default(), |_| Ok(0))
+            .unwrap()
+            .0
+    }
+
+    fn authority(init: &kin_core::InitResult) -> RepositoryAuthorityManager<LocalFileBackend> {
+        RepositoryAuthorityManager::open(
+            init.repository_id.clone(),
+            std::sync::Arc::new(LocalFileBackend::new(init.layout.kindb_dir())),
+        )
+        .unwrap()
+    }
+
+    /// A merge measures every rule file in the merged tree, and by construction
+    /// every one of them was published by an earlier change rather than
+    /// observed by this one. Reading only ingestion staging made a merge depend
+    /// on a store that promises no retention, for bodies the repository already
+    /// owns and for a policy the merge then refuses to let change.
+    #[test]
+    fn a_merge_derives_its_policy_after_ingestion_staging_is_lost() {
+        let (_root, init, hash, tree) = rule_source_fixture();
+        let authority = authority(&init);
+        authority.save_source_blob(hash, b"target/\n").unwrap();
+
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        assert!(
+            blobs
+                .read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))
+                .is_err(),
+            "the fixture only proves anything while the staged rule body is genuinely gone"
+        );
+
+        let (policy, _) = derive_policy(&blobs, &authority, &empty_policy(), &tree)
+            .expect("a merged tree whose rule bodies authority owns still derives its policy");
+        assert_eq!(
+            policy
+                .sources
+                .iter()
+                .map(|source| source.body_len)
+                .collect::<Vec<_>>(),
+            vec![8],
+            "the measured length is the published body's, not a guess"
+        );
+    }
+
+    /// The control. A rule body no store holds still fails the merge, so the
+    /// fallback cannot be mistaken for one that invents a length.
+    #[test]
+    fn a_merge_still_refuses_a_rule_body_neither_store_holds() {
+        let (_root, init, _hash, tree) = rule_source_fixture();
+        let authority = authority(&init);
+
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+
+        let error = derive_policy(&blobs, &authority, &empty_policy(), &tree)
+            .expect_err("a rule body neither store holds cannot be measured");
+        assert!(
+            format!("{error:#}").contains("absent from both ingestion staging and repository CAS"),
+            "the refusal names both stores it consulted: {error:#}"
+        );
     }
 }

--- a/crates/kin-daemon/src/source_cas.rs
+++ b/crates/kin-daemon/src/source_cas.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The two stores a publication may find a source body in.
+//!
+//! Ingestion staging is not authority. Layout documents it as
+//! non-authoritative and nothing promises to retain it, while a body the
+//! repository has already published is durable in its own CAS. So every
+//! publication path that reads a body the current transition did not itself
+//! observe reads staging first and repository CAS second, and a store whose
+//! staging directory is lost while its authority survives still commits,
+//! merges, and admits.
+//!
+//! The rule lives here rather than at each read because those reads could not
+//! miss while every publication was preceded by a scan that rewrote all leaves
+//! back into staging. Bounding one tick to what moved removed that accidental
+//! standing repair, and the fallback became the only thing keeping the rule
+//! true. Spread across separate copies, it was true at the copies that had it
+//! and false everywhere else.
+
+use kin_blobs::BlobStore;
+use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
+use kin_model::Hash256;
+use thiserror::Error;
+
+use crate::error::DaemonError;
+
+/// One source body, and which store answered for it.
+pub(crate) enum PublishableSource {
+    /// Ingestion staging holds the body. A publication that newly references
+    /// it must copy it into repository CAS to make it durable.
+    Staged(Vec<u8>),
+    /// Only repository CAS holds the body. It is already durable there, so no
+    /// copy has to move it and staging having dropped it is not a failure.
+    AlreadyPublished(Vec<u8>),
+}
+
+impl PublishableSource {
+    /// The body, wherever it came from. For callers that only measure it.
+    pub(crate) fn body(&self) -> &[u8] {
+        match self {
+            Self::Staged(body) | Self::AlreadyPublished(body) => body,
+        }
+    }
+
+    /// The body only while a copy still has to move it into repository CAS.
+    pub(crate) fn body_to_publish(&self) -> Option<&[u8]> {
+        match self {
+            Self::Staged(body) => Some(body),
+            Self::AlreadyPublished(_) => None,
+        }
+    }
+}
+
+/// Names the store and the size, never the body. These carry user source, and a
+/// debug print is the one place a whole file leaks into a log by accident.
+impl std::fmt::Debug for PublishableSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (store, body) = match self {
+            Self::Staged(body) => ("Staged", body),
+            Self::AlreadyPublished(body) => ("AlreadyPublished", body),
+        };
+        write!(formatter, "{store}({} bytes)", body.len())
+    }
+}
+
+/// Why a source body a publication needs could not be produced.
+#[derive(Debug, Error)]
+pub(crate) enum SourceBodyUnavailable {
+    /// Repository CAS could not be consulted, so whether it holds the body is
+    /// unknown. That is not absence and must never be reported as it: one says
+    /// the body is gone, the other says nobody managed to look.
+    #[error("read repository source {hash}: {source}")]
+    Authority {
+        hash: Hash256,
+        source: kin_db::KinDbError,
+    },
+
+    /// Neither store holds the body. Carries the ingestion refusal so absence
+    /// stays matchable as the typed blob error it has always been, rather than
+    /// as a sentence a caller would have to parse.
+    #[error("source {hash} is absent from both ingestion staging and repository CAS ({source})")]
+    Absent {
+        hash: Hash256,
+        source: kin_blobs::BlobError,
+    },
+}
+
+impl From<SourceBodyUnavailable> for DaemonError {
+    fn from(error: SourceBodyUnavailable) -> Self {
+        match error {
+            SourceBodyUnavailable::Authority { source, .. } => Self::Graph(source),
+            SourceBodyUnavailable::Absent { source, .. } => Self::Blob(source),
+        }
+    }
+}
+
+/// Read one source body from the two stores a publication may find it in.
+///
+/// Staging answers first because a body observed this tick is there and may
+/// not be in repository CAS yet. Repository CAS answers second because a body
+/// published by an earlier transition is durable there whether or not its
+/// staged copy survived.
+pub(crate) fn read_publishable_source(
+    blobs: &BlobStore,
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    hash: Hash256,
+) -> Result<PublishableSource, SourceBodyUnavailable> {
+    let ingestion_error = match blobs.read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes())) {
+        Ok(body) => return Ok(PublishableSource::Staged(body)),
+        Err(error) => error,
+    };
+    match authority
+        .load_source_blob(hash)
+        .map_err(|source| SourceBodyUnavailable::Authority { hash, source })?
+    {
+        Some(body) => Ok(PublishableSource::AlreadyPublished(body)),
+        None => Err(SourceBodyUnavailable::Absent {
+            hash,
+            source: ingestion_error,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    fn authority(init: &kin_core::InitResult) -> RepositoryAuthorityManager<LocalFileBackend> {
+        RepositoryAuthorityManager::open(
+            init.repository_id.clone(),
+            Arc::new(LocalFileBackend::new(init.layout.kindb_dir())),
+        )
+        .unwrap()
+    }
+
+    /// A body the current transition just observed is in staging and not yet in
+    /// repository CAS, so it has to be reported as still needing a copy.
+    #[test]
+    fn a_staged_body_is_reported_as_still_needing_publication() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let authority = authority(&init);
+
+        let digest = blobs.write(b"target/\n").unwrap();
+        let hash = Hash256::from_bytes(digest.0);
+
+        let source = read_publishable_source(&blobs, &authority, hash).unwrap();
+        assert_eq!(source.body(), b"target/\n");
+        assert_eq!(source.body_to_publish(), Some(b"target/\n".as_slice()));
+    }
+
+    /// The read this whole module exists for: staging is gone, authority is
+    /// intact, and the body is still produced, with no copy asked for because
+    /// repository CAS already owns it.
+    #[test]
+    fn a_published_body_survives_losing_ingestion_staging() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let authority = authority(&init);
+
+        let digest = blobs.write(b"target/\n").unwrap();
+        let hash = Hash256::from_bytes(digest.0);
+        authority.save_source_blob(hash, b"target/\n").unwrap();
+
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+        let blobs = BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        assert!(
+            blobs
+                .read(&kin_blobs::Hash256::from_bytes(*hash.as_bytes()))
+                .is_err(),
+            "the fixture only proves anything while the staged body is genuinely gone"
+        );
+
+        let source = read_publishable_source(&blobs, &authority, hash).unwrap();
+        assert_eq!(source.body(), b"target/\n");
+        assert_eq!(
+            source.body_to_publish(),
+            None,
+            "a body repository CAS already owns needs no copy"
+        );
+    }
+
+    /// The control that keeps the fallback from swallowing a real loss. A body
+    /// neither store holds still fails, and fails as the typed blob absence a
+    /// caller can match on rather than as a sentence.
+    #[test]
+    fn a_body_neither_store_holds_fails_as_the_typed_blob_absence() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let authority = authority(&init);
+
+        let hash = Hash256::from_bytes([7; 32]);
+        let error = read_publishable_source(&blobs, &authority, hash)
+            .expect_err("a body no store holds cannot be produced");
+        assert!(
+            matches!(error, SourceBodyUnavailable::Absent { .. }),
+            "absence is absence, not an authority read failure: {error}"
+        );
+        assert!(
+            matches!(
+                DaemonError::from(error),
+                DaemonError::Blob(kin_blobs::BlobError::NotFound { .. })
+            ),
+            "a caller matching on the typed blob absence still sees it"
+        );
+    }
+}


### PR DESCRIPTION
Four publication reads consulted ingestion staging alone for bodies the current transition never observed: the native commit planner's admission-policy closure, both native source-copy loops, and the merge policy derivation. Staging is documented as non-authoritative and nothing promises to retain it, so a store that lost it while its authority survived would wedge every later commit and merge on a repository whose truth was perfectly intact.

Those reads could not miss while every publication was preceded by a scan that rewrote all leaves back into staging. Bounding one tick to what moved removed that accidental standing repair, and the session-admission and workspace-publication paths were then fixed one site at a time as each was found. Fixing them that way left the rule true where it had been written by hand and false everywhere else.

The two-store read now lives in one place. A small `source_cas` module reads staging first and repository CAS second, reports which store answered so a copy loop skips a body that is already durable, and fails as the typed blob absence when neither store holds it. All eight reads across commit, session admission, and merge go through it, including the four that already carried the fallback as their own copy of the same match.

Merge is the clearest case. A merge composes published trees, so every rule body it measures was published by an earlier change, and the derived policy must equal its parent or the merge is refused outright. That read could only ever fail. `derive_policy` now takes the two stores rather than the whole daemon state, which is also what makes it testable without a daemon.

Each site has its own falsifying test. A native commit publishes after the whole ingest CAS directory is deleted, reading one body from each store in the same transaction, and a merge derives its policy the same way. Reverting any single site fails exactly the test that covers it and no others. Both paths still refuse a body neither store holds, and absence at the copy loops stays the typed blob failure a caller can match on, in place of the sentence the session path used to format by hand.

One test was added rather than reused. The bare publication helper carries its own copy of the copy loop, and the only test reaching it asserted a refusal, so removing the fallback there broke nothing at all.

Closes FIR-2171
