### PR TITLE
Bump kin-db to 0.7.20 for entity-granular embedding invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.16"
+version = "0.7.20"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9a26e0d31085f0bb8fb5c8626502cfd295671f8898815c4d5397f05b138b589c"
+checksum = "1fc985fca4e1f858c069592c01ffe6deadedf8fee9f50dc61a0fc1e0abca9204"
 dependencies = [
  "bincode",
  "bstr",
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.7"
+version = "0.7.8"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9e39741a0edad255687301dc087a915f787a31c0a9eee028150081c884e940ea"
+checksum = "75c237b19289638e728e70048011c5d5731d9ef45878f078e7663f2b0e9475e1"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3737,12 +3737,13 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.9"
+version = "0.1.11"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "fd4c2a7ebb07f6ca4ae49fe57eaafa91adbca5e38e76d133b25008c87679f7e8"
+checksum = "c1904ba13d244810b195168b04ada8884094f8d5374c54f36e9b9375ac6e625a"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
+ "memmap2",
  "parking_lot",
  "rayon",
  "rmp-serde",
@@ -6624,7 +6625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.7", registry = "kin" }
+kin-model = { version = "=0.7.8", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.16", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.20", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.3.0", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
kin-db 0.7.20 carries the FIR-2181 fix: an entity re-embeds only when the text an embedder would read differs, so a comment-only edit stops re-embedding every entity in its file, and the relation-delta un-skip keeps context-line changes invalidating their endpoints. Provenance counts stay whole; only the embedding invalidation narrowed. The bump carries kin-model to 0.7.8 and kin-vector to 0.1.11, the versions kin-db 0.7.20 pins, and the lock diff is exactly the three registry bumps with sparse sources and checksums preserved.

The registry serves 0.7.20 at checksum 1fc985fca4e1f858, verified directly with a fabricated-crate negative control, and the pinned-dependency env scan passes against the new versions, so 0.7.20 introduced no unregistered runtime variables. The full workspace suite passed at this exact tree.

This is the delivery half of FIR-2181; the ticket closed on the kin-db change and this pickup is what puts it in a shipped kin.