### PR TITLE
Capture the install proof's own reports outside the tree it measures

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -737,24 +737,29 @@ jobs:
           git add -A && git commit -qm "probe"
           # kin init admits this worktree exactly and repeats that proof across
           # publication, so a report file must neither exist in it nor grow
-          # while init runs. Capture outside the admitted tree and copy the log
-          # back afterwards, on success and on failure alike, so a refusal still
-          # reaches the uploaded proof reports.
-          init_log="$RUNNER_TEMP/kin-init.txt"
+          # while init runs. Every later capture is under the same constraint
+          # for the same reason: the daemon admits observed new files as they
+          # are written, so a report written into this tree becomes semantic
+          # corpus and the store the proof measures keeps growing while it is
+          # being measured. Capture outside the admitted tree throughout, and
+          # copy the whole set back after the last assertion that reads the
+          # store, on success and on failure alike, so a refusal still reaches
+          # the uploaded proof reports.
+          captures="$RUNNER_TEMP/kin-proof-captures"
+          mkdir -p "$captures"
           init_status=0
-          kin init > "$init_log" 2>&1 || init_status=$?
-          cat "$init_log"
-          cp "$init_log" kin-init.txt
+          kin init > "$captures/kin-init.txt" 2>&1 || init_status=$?
+          cat "$captures/kin-init.txt"
           if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi
           # Do not pipe this command through tee. On Windows, the daemon child
           # inherits the pipe and keeps it open until idle shutdown, which makes
           # the shell wait for the daemon and then tests a process that just exited.
-          kin status > kin-status.txt 2>&1
-          cat kin-status.txt
-          kin status --json > kin-status.json 2>&1
-          cat kin-status.json
-          kin bench-meta --json > kin-build-meta.json
-          cat kin-build-meta.json
+          kin status > "$captures/kin-status.txt" 2>&1
+          cat "$captures/kin-status.txt"
+          kin status --json > "$captures/kin-status.json" 2>&1
+          cat "$captures/kin-status.json"
+          kin bench-meta --json > "$captures/kin-build-meta.json"
+          cat "$captures/kin-build-meta.json"
           # Prove every supported agent-client config writer without requiring
           # the proprietary clients on a public runner. Detection is PATH-based;
           # these inert shims make setup exercise the real merge paths while the
@@ -802,12 +807,12 @@ jobs:
           NODE
 
           kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
-            2>&1 | tee kin-setup.txt
+            2>&1 | tee "$captures/kin-setup.txt"
 
           # Normalize the real TOML Codex entry with Python's standard parser
           # so the later cross-platform Node validator can apply the same exact
           # command/args/profile checks it applies to JSON clients.
-          CODEX_CONFIG="$HOME/.codex/config.toml" python3 - <<'PY'
+          CODEX_CONFIG="$HOME/.codex/config.toml" PROOF_CAPTURES="$captures" python3 - <<'PY'
           import json
           import os
           import pathlib
@@ -816,7 +821,7 @@ jobs:
           config = pathlib.Path(os.environ["CODEX_CONFIG"])
           with config.open("rb") as handle:
               entry = tomllib.load(handle)["mcp_servers"]["kin"]
-          pathlib.Path("kin-codex-config.json").write_text(
+          pathlib.Path(os.environ["PROOF_CAPTURES"], "kin-codex-config.json").write_text(
               json.dumps({"mcpServers": {"kin": entry}}, indent=2) + "\n",
               encoding="utf-8",
           )
@@ -846,26 +851,31 @@ jobs:
           HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
           KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
             kin setup --no-interactive --intent agent --shell "$PROOF_SHELL" \
-            2>&1 | tee kin-claude-fallback-setup.txt
+            2>&1 | tee "$captures/kin-claude-fallback-setup.txt"
           if [ -e "$claude_fallback_home/.claude.json" ]; then
             echo "Claude fallback proof unexpectedly wrote the primary ~/.claude.json path" >&2
             exit 1
           fi
-          cp "$claude_fallback_home/.claude/config.json" kin-claude-fallback-config.json
+          cp "$claude_fallback_home/.claude/config.json" "$captures/kin-claude-fallback-config.json"
           HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
           KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
-            kin setup status --json > kin-claude-fallback-health.json
+            kin setup status --json > "$captures/kin-claude-fallback-health.json"
           HOME="$claude_fallback_home" USERPROFILE="$claude_fallback_home" \
           KIN_HOME="$primary_home/.kin" PATH="$claude_fallback_path" \
-            kin doctor --json > kin-claude-fallback-doctor.json
+            kin doctor --json > "$captures/kin-claude-fallback-doctor.json"
 
       - name: Graph query and MCP tool-call proof
         shell: bash
         working-directory: kin-install-proof
         run: |
           set -euo pipefail
-          kin search hello --json | tee kin-search.json
-          kin locate hello --json --explain --max-files 5 | tee kin-locate.json
+          # Same capture directory the first-run step opened, for the same
+          # reason: nothing this proof writes may land in the tree the daemon
+          # is watching until every assertion that reads the store has run.
+          captures="$RUNNER_TEMP/kin-proof-captures"
+          mkdir -p "$captures"
+          kin search hello --json | tee "$captures/kin-search.json"
+          kin locate hello --json --explain --max-files 5 | tee "$captures/kin-locate.json"
 
           # `kin status` deliberately does not auto-start the daemon. The graph
           # query above does, so capture daemon provenance only after that
@@ -877,7 +887,7 @@ jobs:
               exit 1
               ;;
           esac
-          DAEMON_PORT="$daemon_port" node <<'NODE' > kin-daemon-health.json
+          DAEMON_PORT="$daemon_port" node <<'NODE' > "$captures/kin-daemon-health.json"
           const http = require("http");
           const request = http.get(
             `http://127.0.0.1:${process.env.DAEMON_PORT}/health`,
@@ -903,9 +913,9 @@ jobs:
             process.exitCode = 1;
           });
           NODE
-          cat kin-daemon-health.json
-          kin setup status --json | tee kin-health.json
-          kin doctor --json | tee kin-doctor.json
+          cat "$captures/kin-daemon-health.json"
+          kin setup status --json | tee "$captures/kin-health.json"
+          kin doctor --json | tee "$captures/kin-doctor.json"
 
           # Drive the absolute installed MCP stdio server through initialize,
           # tools/list, a real graph-backed semantic_search call, daemon loss,
@@ -913,10 +923,12 @@ jobs:
           # directory from the child's PATH and clear KIN_DAEMON_BIN: sibling
           # discovery must work on its own, including kin-daemon.exe on Windows.
           # Node owns the timeout so this behaves the same on every runner.
-          node <<'NODE'
+          PROOF_CAPTURES="$captures" node <<'NODE'
           const fs = require("fs");
           const path = require("path");
           const { execFileSync, spawn, spawnSync } = require("child_process");
+
+          const captures = process.env.PROOF_CAPTURES;
 
           const resolver = process.platform === "win32"
             ? ["where.exe", ["kin"]]
@@ -962,7 +974,7 @@ jobs:
               },
             );
             fs.appendFileSync(
-              "kin-mcp-daemon-stop.txt",
+              path.join(captures, "kin-mcp-daemon-stop.txt"),
               `${phase}: status=${stopped.status}\n${stopped.stdout ?? ""}${stopped.stderr ?? ""}\n`,
             );
             if (stopped.error || stopped.status !== 0) {
@@ -1018,8 +1030,8 @@ jobs:
             if (settled) return;
             settled = true;
             clearTimeout(timer);
-            fs.writeFileSync("kin-mcp-out.jsonl", stdout);
-            fs.writeFileSync("kin-mcp-err.txt", stderr);
+            fs.writeFileSync(path.join(captures, "kin-mcp-out.jsonl"), stdout);
+            fs.writeFileSync(path.join(captures, "kin-mcp-err.txt"), stderr);
             if (error) {
               if (!child.killed) child.kill("SIGKILL");
               console.error(error);
@@ -1106,6 +1118,11 @@ jobs:
         working-directory: kin-install-proof
         run: |
           set -euo pipefail
+          # Same capture directory the first-run step opened. The VFS logs and
+          # the probe's own output are reports about the tree, so they stay out
+          # of it while the daemon is watching.
+          captures="$RUNNER_TEMP/kin-proof-captures"
+          mkdir -p "$captures"
           # The shipped shim deliberately bypasses Kin-family control-plane
           # processes (basenames beginning with `kin-`). Keep this external
           # probe outside that namespace so the proof exercises interposition.
@@ -1176,7 +1193,7 @@ jobs:
             cleanup_status=0
             chmod u+rw probe.py || cleanup_status=1
             if [ -n "$vfs_pid" ]; then
-              kin-vfs stop --workspace . >> kin-vfs-daemon.log 2>&1 || cleanup_status=1
+              kin-vfs stop --workspace . >> "$captures/kin-vfs-daemon.log" 2>&1 || cleanup_status=1
               stopped=false
               for _ in $(seq 1 150); do
                 # A missing PID is the expected successful-stop state. Keep
@@ -1190,7 +1207,7 @@ jobs:
                 sleep 0.1
               done
               if [ "$stopped" != true ]; then
-                cat kin-vfs-daemon.log >&2
+                cat "$captures/kin-vfs-daemon.log" >&2
                 echo "installed kin-vfs daemon did not stop cleanly" >&2
                 kill "$vfs_pid" 2>/dev/null || true
                 sleep 1
@@ -1227,7 +1244,7 @@ jobs:
           trap 'on_vfs_signal 130' INT
           trap 'on_vfs_signal 143' TERM
 
-          kin-vfs start --workspace . > kin-vfs-daemon.log 2>&1 &
+          kin-vfs start --workspace . > "$captures/kin-vfs-daemon.log" 2>&1 &
           vfs_pid=$!
           socket_ready=false
           for _ in $(seq 1 150); do
@@ -1241,7 +1258,7 @@ jobs:
             sleep 0.1
           done
           if [ "$socket_ready" != true ]; then
-            cat kin-vfs-daemon.log >&2
+            cat "$captures/kin-vfs-daemon.log" >&2
             echo "installed kin-vfs daemon did not bind its socket" >&2
             exit 1
           fi
@@ -1250,26 +1267,26 @@ jobs:
           # only the installed shim and real Kin daemon can return probe.py.
           chmod 000 probe.py
           set +e
-          "$probe_bin" "$PWD/probe.py" > vfs-negative.txt 2>&1
+          "$probe_bin" "$PWD/probe.py" > "$captures/vfs-negative.txt" 2>&1
           negative_status=$?
           set -e
           if [ "$negative_status" -ne 4 ]; then
-            cat vfs-negative.txt >&2
+            cat "$captures/vfs-negative.txt" >&2
             echo "negative control failed before the expected raw-disk open denial (status $negative_status)" >&2
             exit 1
           fi
-          if ! grep -Eq '^open: (Permission denied|Operation not permitted)$' vfs-negative.txt; then
-            cat vfs-negative.txt >&2
+          if ! grep -Eq '^open: (Permission denied|Operation not permitted)$' "$captures/vfs-negative.txt"; then
+            cat "$captures/vfs-negative.txt" >&2
             echo "negative control did not fail with the expected raw-disk permission error" >&2
             exit 1
           fi
 
           KIN_VFS_STRICT=1 kin-vfs exec --workspace . -- \
             "$probe_bin" "$PWD/probe.py" \
-            > vfs-graph-read.txt 2> vfs-graph-read.stderr.txt
-          printf 'def hello():\n    return 42\n' > vfs-expected.txt
-          if ! cmp -s vfs-expected.txt vfs-graph-read.txt; then
-            cmp -l vfs-expected.txt vfs-graph-read.txt >&2 || true
+            > "$captures/vfs-graph-read.txt" 2> "$captures/vfs-graph-read.stderr.txt"
+          printf 'def hello():\n    return 42\n' > "$captures/vfs-expected.txt"
+          if ! cmp -s "$captures/vfs-expected.txt" "$captures/vfs-graph-read.txt"; then
+            cmp -l "$captures/vfs-expected.txt" "$captures/vfs-graph-read.txt" >&2 || true
             echo "installed VFS did not return the exact graph-owned probe.py bytes" >&2
             exit 1
           fi
@@ -1302,7 +1319,119 @@ jobs:
               ;;
             *) echo "unsupported Unix install-proof shell: $PROOF_SHELL" >&2; exit 1 ;;
           esac
-          kin embed --max-seconds 300 --json | tee kin-embed.json
+          # Same capture directory the first-run step opened, for the same
+          # reason. This step is where it matters most: everything below reads
+          # the store and asserts on what it read.
+          captures="$RUNNER_TEMP/kin-proof-captures"
+          mkdir -p "$captures"
+          kin embed --max-seconds 300 --json | tee "$captures/kin-embed.json"
+
+          # A pass reports on the work it took, and the store can still be
+          # taking on content the pass never saw: kin init admits the worktree,
+          # setup writes the agent config into it, and the watcher admits new
+          # non-ignored files as they arrive. Coverage is an instantaneous
+          # whole-store read, so a capture taken while any of that is still
+          # landing measures a corpus that grows underneath it, which is what
+          # left one leg reading complete coverage in health and 13 of 18 in
+          # locate a second later. Settle the store before measuring it: poll
+          # the counters until an embedding pass has nothing left pending and
+          # two consecutive reads agree that nothing new was admitted between
+          # them. A sleep would be a guess about how long that takes; this is
+          # the measurement itself, bounded, and loud about the exact counter
+          # that never settled when the budget runs out.
+          PROOF_CAPTURES="$captures" node <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+          const { execFileSync } = require("child_process");
+
+          const captures = process.env.PROOF_CAPTURES;
+          const budgetMs = 180_000;
+          const pollSeconds = 1;
+          const log = [];
+          const record = (line) => {
+            log.push(line);
+            console.log(line);
+          };
+          const flush = () => {
+            fs.writeFileSync(
+              path.join(captures, "kin-embedding-settle.txt"),
+              `${log.join("\n")}\n`,
+            );
+          };
+
+          // Everything a later read could see change: the counters an embedding
+          // pass drains, and the generations and counts admission moves. Equal
+          // fingerprints across two consecutive reads is what "nothing arrived
+          // between them" means here.
+          const fingerprint = (status) => {
+            const enrichment = status.semantic_enrichment ?? {};
+            const coverage = status.embedding_coverage ?? {};
+            return JSON.stringify({
+              repository_generation: status.repository?.generation,
+              workspace_generation: status.workspace?.generation,
+              authority_generation: enrichment.authority_generation,
+              enrichment_workspace_generation: enrichment.workspace_generation,
+              entity_count: enrichment.entity_count,
+              relation_count: enrichment.relation_count,
+              semantic_change_count: enrichment.semantic_change_count,
+              coverage_state: coverage.state,
+              coverage_reason: coverage.reason,
+              indexed: coverage.indexed,
+              pending: coverage.pending,
+              total: coverage.total,
+            });
+          };
+
+          const deadline = Date.now() + budgetMs;
+          let previous = null;
+          let last = "no status read completed";
+          let reads = 0;
+          let settled = false;
+          while (Date.now() < deadline) {
+            reads += 1;
+            let status;
+            try {
+              status = JSON.parse(
+                execFileSync("kin", ["status", "--json"], { encoding: "utf8", timeout: 120_000 }),
+              );
+            } catch (error) {
+              // A read that fails is not a settled store. Keep polling and let
+              // the expiry below report the last failure rather than treating
+              // an unreadable store as a quiet one.
+              last = `kin status --json failed: ${error.message}`;
+              previous = null;
+              execFileSync("sleep", [String(pollSeconds)]);
+              continue;
+            }
+            const current = fingerprint(status);
+            last = current;
+            const coverage = status.embedding_coverage ?? {};
+            const drained =
+              coverage.state === "observed" &&
+              coverage.total > 0 &&
+              coverage.pending === 0 &&
+              coverage.indexed === coverage.total;
+            if (drained && current === previous) {
+              record(`settled after ${reads} reads: ${current}`);
+              settled = true;
+              break;
+            }
+            previous = current;
+            execFileSync("sleep", [String(pollSeconds)]);
+          }
+          if (!settled) {
+            record(`did not settle within ${budgetMs / 1000}s over ${reads} reads: ${last}`);
+            flush();
+            console.log(
+              `::error::the store never settled: ${last}. ` +
+              "Embedding coverage must reach observed with pending 0 and indexed equal to total, " +
+              "and two consecutive reads must agree that nothing new was admitted between them.",
+            );
+            process.exit(1);
+          }
+          flush();
+          NODE
+
           # Coverage can be momentarily unobservable rather than incomplete: a
           # graph mutation batch spanning the sample leaves the daemon unable to
           # pair counters with a stable authority epoch, and status then reports
@@ -1321,19 +1450,52 @@ jobs:
           case "$settle_probe" in
             *--wait-quiesce*)
               printf 'bounded settle (kin status --wait-quiesce 60)\n' \
-                | tee kin-status-settle-mode.txt
-              kin status --json --wait-quiesce 60 | tee kin-embedded-status.json
+                | tee "$captures/kin-status-settle-mode.txt"
+              kin status --json --wait-quiesce 60 | tee "$captures/kin-embedded-status.json"
               ;;
             *)
               printf 'single sample (installed kin has no --wait-quiesce)\n' \
-                | tee kin-status-settle-mode.txt >&2
-              kin status --json | tee kin-embedded-status.json
+                | tee "$captures/kin-status-settle-mode.txt" >&2
+              kin status --json | tee "$captures/kin-embedded-status.json"
               ;;
           esac
-          kin setup status --json | tee kin-embedded-health.json
-          kin doctor --json | tee kin-embedded-doctor.json
-          kin search hello --semantic --json | tee kin-semantic-search.json
-          kin locate hello --json --explain --max-files 5 | tee kin-semantic-locate.json
+          kin setup status --json | tee "$captures/kin-embedded-health.json"
+          kin doctor --json | tee "$captures/kin-embedded-doctor.json"
+          kin search hello --semantic --json | tee "$captures/kin-semantic-search.json"
+          kin locate hello --json --explain --max-files 5 | tee "$captures/kin-semantic-locate.json"
+
+      - name: Restore captured proof reports into the proof repository
+        # Every assertion that reads the store has run by now, so the captures
+        # can take their place in the tree and the uploaded artifact keeps the
+        # layout it has always had. This runs on failure too: a leg that died
+        # early still has to hand over what it captured before it died, which
+        # is the whole reason the init log was already copied back on both
+        # paths before any of the rest moved out here.
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          captures="$RUNNER_TEMP/kin-proof-captures"
+          destination="$PWD/kin-install-proof"
+          if [ ! -d "$captures" ]; then
+            echo "no proof captures were taken"
+            exit 0
+          fi
+          if [ ! -d "$destination" ]; then
+            echo "no proof repository exists to restore captures into"
+            exit 0
+          fi
+          # List the directory rather than globbing it. RUNNER_TEMP is a
+          # backslash path on Windows, which reaches a syscall intact but does
+          # not survive pathname expansion, so a `"$captures"/*` pattern would
+          # match nothing there and restore nothing while exiting clean.
+          restored=0
+          while IFS= read -r capture; do
+            [ -n "$capture" ] || continue
+            cp "$captures/$capture" "$destination/$capture"
+            restored=$((restored + 1))
+          done < <(ls -1 "$captures")
+          echo "restored $restored proof capture(s) into the proof repository"
 
       - name: Validate installed capability proof
         shell: bash

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2328,6 +2328,10 @@ def assert_windows_contract_stage_check_is_reachable(contract_source: str) -> No
         require(active, policy, "reachable Windows stage-leak check")
 
 
+PROOF_CAPTURE_DIRECTORY = 'captures="$RUNNER_TEMP/kin-proof-captures"'
+PROOF_CAPTURE_DIRECTORY_CREATE = 'mkdir -p "$captures"'
+
+
 def assert_install_proof_init_log_authority(first_run: str) -> None:
     """Keep the install proof's own report files out of the worktree kin init admits.
 
@@ -2335,24 +2339,25 @@ def assert_install_proof_init_log_authority(first_run: str) -> None:
     before publication, and repeats it again afterwards, refusing when the two
     differ. A report file written into that worktree therefore breaks admission
     twice over: it is an untracked non-ignored path, and an ignored one would
-    still change size between the repeats.
+    still change size between the repeats. The same worktree stays under a
+    watcher that admits new non-ignored files for the rest of the job, so the
+    constraint outlives init and every later capture is held to it by
+    `assert_install_proof_captures_stay_out_of_the_admitted_tree`.
 
     Pinning the capture lines is not enough on its own, because the property is
-    about the whole span between entering that worktree and admitting it. Three
-    mutations leave every pinned line in place and still break admission or the
-    evidence it produces: an unrelated write into the worktree before init, a
-    copy-back reordered above init, and a second init that an exact-prefix count
-    cannot see. So the span is closed-form, the capture order is asserted, and
-    an `init` this function does not recognize is refused by name.
+    about the whole span between entering that worktree and admitting it. Two
+    mutations leave every pinned line in place and still break admission: an
+    unrelated write into the worktree before init, and a second init that an
+    exact-prefix count cannot see. So the span is closed-form and an `init` this
+    function does not recognize is refused by name.
     """
 
     active = active_lines(first_run)
-    admission = 'kin init > "$init_log" 2>&1 || init_status=$?'
+    admission = 'kin init > "$captures/kin-init.txt" 2>&1 || init_status=$?'
     bootstrap = (
         "git init -q && git config user.email ci@firelock.ai && git config user.name ci"
     )
     entry = "mkdir -p kin-install-proof && cd kin-install-proof"
-    copy_back = 'cp "$init_log" kin-init.txt'
     propagate = 'if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi'
     # An `init` token anywhere in an active line, not a prefix of one:
     # `(cd sub && kin init)`, `eval kin init`, and `"$KIN" init` all admit a
@@ -2373,22 +2378,22 @@ def assert_install_proof_init_log_authority(first_run: str) -> None:
         )
     for policy in (
         entry,
-        'init_log="$RUNNER_TEMP/kin-init.txt"',
-        copy_back,
+        PROOF_CAPTURE_DIRECTORY,
+        PROOF_CAPTURE_DIRECTORY_CREATE,
         propagate,
     ):
         if policy not in active:
             raise AssertionError(
                 f"install-proof init log capture lost an active line: {policy}"
             )
-    # The log is copied back after admission and kin's own exit status is
-    # propagated after that. Reordering the copy above init leaves every pinned
-    # line present, and only `set -e` on a not-yet-created file catches it.
-    order = [active.index(step) for step in (admission, copy_back, propagate)]
+    # kin's own exit status is propagated after admission. Reordering the
+    # propagation above init leaves every pinned line present and reports the
+    # status of whatever ran before it instead.
+    order = [active.index(step) for step in (admission, propagate)]
     if order != sorted(order):
         raise AssertionError(
-            "install-proof init log capture must admit, then copy the log back, "
-            f"then propagate kin's own exit status; found line order {order}"
+            "install-proof init log capture must admit, then propagate kin's "
+            f"own exit status; found line order {order}"
         )
     # Nothing may write into the worktree between entering it and admitting it.
     # A line-presence check cannot see an inserted write, and an inserted write
@@ -2398,7 +2403,8 @@ def assert_install_proof_init_log_authority(first_run: str) -> None:
         bootstrap,
         "printf 'def hello():\\n    return 42\\n' > probe.py",
         'git add -A && git commit -qm "probe"',
-        'init_log="$RUNNER_TEMP/kin-init.txt"',
+        PROOF_CAPTURE_DIRECTORY,
+        PROOF_CAPTURE_DIRECTORY_CREATE,
         "init_status=0",
     ]
     if prelude != committed_prelude:
@@ -2406,6 +2412,123 @@ def assert_install_proof_init_log_authority(first_run: str) -> None:
             "only the committed Git bootstrap may run between entering the "
             f"worktree kin init admits and admitting it; found {prelude}"
         )
+
+
+def assert_install_proof_captures_stay_out_of_the_admitted_tree(
+    proof_steps: dict[str, str], restore: str, restore_position: tuple[int, int, int]
+) -> None:
+    """Keep every proof report out of the admitted tree until nothing measures it.
+
+    The worktree the proof admits stays under a watcher for the rest of the job,
+    so a report written into it becomes semantic corpus and the store the
+    assertions read grows while they read it. That is not a hypothesis: a leg
+    read complete coverage in health and 13 of 18 in locate one second later,
+    and it fenced a release.
+
+    A report is therefore captured under RUNNER_TEMP and restored afterwards. A
+    presence check on the restore step cannot see the mutation that matters,
+    which is one capture reverting to a relative path, so every report-shaped
+    redirect, tee, and Node write in these steps is examined instead and a
+    relative target is refused by name. The restore itself has to run after the
+    last step that reads the store, before the validator that reads the files,
+    and on failure as well, or a leg that dies early hands over no evidence at
+    all.
+    """
+
+    # A bare filename with a report extension and no directory part: exactly
+    # the shape a write into the admitted tree takes, and one no capture under
+    # `"$captures/..."` can wear, so a match is the defect rather than a
+    # candidate for it.
+    in_tree_report = re.compile(r"[\w.\-]+\.(?:json|jsonl|txt|log)")
+    writes = (
+        re.compile(r"(?:^|\s)\d?>>?\s*(\S+)"),
+        re.compile(r"\|\s*tee\s+(\S+)"),
+        re.compile(r"(?:write|append)FileSync\(\s*\"([^\"]+)\""),
+    )
+    for step_name, step_source in proof_steps.items():
+        for line in active_lines(step_source):
+            for pattern in writes:
+                for raw in pattern.findall(line):
+                    if in_tree_report.fullmatch(raw.strip('"')):
+                        raise AssertionError(
+                            f"{step_name} writes a proof report into the "
+                            f"admitted tree rather than the capture "
+                            f"directory: {line}"
+                        )
+
+    restore_active = active_lines(restore)
+    for policy in (
+        PROOF_CAPTURE_DIRECTORY,
+        'destination="$PWD/kin-install-proof"',
+        'cp "$captures/$capture" "$destination/$capture"',
+        'done < <(ls -1 "$captures")',
+    ):
+        if policy not in restore_active:
+            raise AssertionError(
+                f"install-proof capture restore lost an active line: {policy}"
+            )
+    if "if: always()" not in restore_active:
+        raise AssertionError(
+            "install-proof capture restore must run on failure too, or a leg "
+            "that dies early uploads no captured evidence"
+        )
+    last_store_read, restore_start, validation_start = restore_position
+    if not last_store_read < restore_start < validation_start:
+        raise AssertionError(
+            "install-proof captures must be restored after the last step that "
+            "reads the store and before the step that reads the files; found "
+            f"positions {restore_position}"
+        )
+
+
+def assert_install_proof_embedding_settles_before_measurement(embedding: str) -> None:
+    """Require a bounded, counter-driven settle between the embed and its captures.
+
+    An embedding pass reports on the work it took, and content that belongs in
+    the corpus is admitted asynchronously around it, so coverage read straight
+    afterwards can be a sample of a store still taking work on. Waiting is
+    therefore mandatory, but only in the form that can fail: a sleep asserts a
+    duration nobody measured, while a poll asserts the counters themselves and
+    says which one never settled when its budget runs out.
+    """
+
+    active = active_lines(embedding)
+    embed = 'kin embed --max-seconds 300 --json | tee "$captures/kin-embed.json"'
+    settle = 'PROOF_CAPTURES="$captures" node <<\'NODE\''
+    capture = (
+        'kin status --json --wait-quiesce 60 | tee "$captures/kin-embedded-status.json"'
+    )
+    for policy in (embed, settle, capture):
+        if policy not in active:
+            raise AssertionError(
+                f"install-proof embedding settle lost an active line: {policy}"
+            )
+    settle_body = "\n".join(active)
+    for policy in (
+        'coverage.state === "observed" &&',
+        "coverage.total > 0 &&",
+        "coverage.pending === 0 &&",
+        "coverage.indexed === coverage.total",
+        "drained && current === previous",
+        "process.exit(1);",
+    ):
+        if policy not in settle_body:
+            raise AssertionError(
+                "install-proof embedding settle must poll the counters to "
+                f"quiescence and fail on expiry: {policy}"
+            )
+    order = [active.index(step) for step in (embed, settle, capture)]
+    if order != sorted(order):
+        raise AssertionError(
+            "install-proof must embed, then settle, then capture the status it "
+            f"asserts on; found line order {order}"
+        )
+    for line in active:
+        if re.fullmatch(r"sleep [\d.]+", line):
+            raise AssertionError(
+                "install-proof must settle on the counters rather than on a "
+                f"duration nobody measured: {line}"
+            )
 
 
 def assert_install_proof_windows_experimental_posture(install_proof: str) -> None:
@@ -2639,7 +2762,7 @@ def assert_install_proof_status_contract(
 
     require(
         first_run_active,
-        "kin bench-meta --json > kin-build-meta.json",
+        'kin bench-meta --json > "$captures/kin-build-meta.json"',
         "installed CLI provenance capture",
     )
     require(
@@ -2651,7 +2774,7 @@ def assert_install_proof_status_contract(
         "for agent in claude cursor codex gemini windsurf agy; do",
         'antigravity_legacy="$HOME/.gemini/antigravity-ide/mcp_config.json"',
         'command: "/stale/kin"',
-        'CODEX_CONFIG="$HOME/.codex/config.toml" python3',
+        'CODEX_CONFIG="$HOME/.codex/config.toml" PROOF_CAPTURES="$captures" python3',
         'tomllib.load(handle)["mcp_servers"]["kin"]',
         'claude_fallback_home="$RUNNER_TEMP/kin-proof-claude-fallback-home"',
         'printf \'{}\\n\' > "$claude_fallback_home/.claude/config.json"',
@@ -2664,13 +2787,13 @@ def assert_install_proof_status_contract(
     graph_active_lines = active_lines(graph_query)
     graph_active = "\n".join(graph_active_lines)
     for policy in (
-        "kin search hello --json | tee kin-search.json",
+        'kin search hello --json | tee "$captures/kin-search.json"',
         "daemon_port=\"$(tr -d '[:space:]' < .kin/daemon.port)\"",
         'DAEMON_PORT="$daemon_port" node',
         "http://127.0.0.1:${process.env.DAEMON_PORT}/health",
         "kin-daemon-health.json",
-        "kin setup status --json | tee kin-health.json",
-        "kin doctor --json | tee kin-doctor.json",
+        'kin setup status --json | tee "$captures/kin-health.json"',
+        'kin doctor --json | tee "$captures/kin-doctor.json"',
         'path.join(process.cwd(), ".agents", "mcp_config.json")',
         "spawn(entry.command, entry.args",
         'const stripVerbatim = (p) => (typeof p === "string" && p.startsWith("\\\\\\\\?\\\\") ? p.slice(4) : p);',
@@ -2679,10 +2802,10 @@ def assert_install_proof_status_contract(
     ):
         require(graph_active, policy, "installed daemon startup and health capture")
 
-    daemon_start = "kin search hello --json | tee kin-search.json"
+    daemon_start = 'kin search hello --json | tee "$captures/kin-search.json"'
     endpoint_capture = "daemon_port=\"$(tr -d '[:space:]' < .kin/daemon.port)\""
-    setup_health = "kin setup status --json | tee kin-health.json"
-    doctor_health = "kin doctor --json | tee kin-doctor.json"
+    setup_health = 'kin setup status --json | tee "$captures/kin-health.json"'
+    doctor_health = 'kin doctor --json | tee "$captures/kin-doctor.json"'
     daemon_start_index = graph_active_lines.index(daemon_start)
     if any(
         daemon_start_index >= graph_active_lines.index(capture)
@@ -2742,7 +2865,7 @@ def assert_install_proof_status_contract(
 
     require(
         embedding_active,
-        "kin status --json | tee kin-embedded-status.json",
+        'kin status --json | tee "$captures/kin-embedded-status.json"',
         "post-embedding repository status capture",
     )
 
@@ -7238,9 +7361,13 @@ def main() -> None:
         "      - name: Unix embedding and semantic retrieval proof",
         graph_query_start,
     )
+    restore_start = install_proof.index(
+        "      - name: Restore captured proof reports into the proof repository",
+        embedding_start,
+    )
     validation_start = install_proof.index(
         "      - name: Validate installed capability proof",
-        embedding_start,
+        restore_start,
     )
     preserve_start = install_proof.index(
         "      - name: Preserve proof reports",
@@ -7248,7 +7375,8 @@ def main() -> None:
     )
     first_run = install_proof[first_run_start:graph_query_start]
     graph_query = install_proof[graph_query_start:embedding_start]
-    embedding = install_proof[embedding_start:validation_start]
+    embedding = install_proof[embedding_start:restore_start]
+    restore = install_proof[restore_start:validation_start]
     validation = install_proof[validation_start:preserve_start]
     for policy in (
         'case "$PROOF_SHELL" in',
@@ -7263,7 +7391,7 @@ def main() -> None:
         "outside the worktree it admits",
         lambda: assert_install_proof_init_log_authority(
             first_run.replace(
-                'kin init > "$init_log" 2>&1 || init_status=$?',
+                'kin init > "$captures/kin-init.txt" 2>&1 || init_status=$?',
                 "kin init 2>&1 | tee kin-init.txt",
                 1,
             )
@@ -7278,8 +7406,8 @@ def main() -> None:
     )
     for label, active_line in (
         (
-            "the captured init log never reaches the proof reports",
-            'cp "$init_log" kin-init.txt',
+            "the capture directory stops being rooted outside the worktree",
+            'captures="$RUNNER_TEMP/kin-proof-captures"',
         ),
         (
             "a refused init stops failing the install proof",
@@ -7310,24 +7438,159 @@ def main() -> None:
         "only the committed Git bootstrap may run",
         lambda: assert_install_proof_init_log_authority(
             first_run.replace(
-                '          init_log="$RUNNER_TEMP/kin-init.txt"\n',
+                '          captures="$RUNNER_TEMP/kin-proof-captures"\n',
                 "          echo scratch > proof-note.txt\n"
-                '          init_log="$RUNNER_TEMP/kin-init.txt"\n',
+                '          captures="$RUNNER_TEMP/kin-proof-captures"\n',
                 1,
             )
         ),
     )
     expect_assertion(
-        "the init log is copied back before the worktree is admitted",
-        "must admit, then copy the log back",
+        "kin's own init status is propagated before init has run",
+        "must admit, then propagate",
         lambda: assert_install_proof_init_log_authority(
             first_run.replace(
-                '          kin init > "$init_log" 2>&1 || init_status=$?\n'
-                '          cat "$init_log"\n'
-                '          cp "$init_log" kin-init.txt\n',
-                '          cp "$init_log" kin-init.txt\n'
-                '          kin init > "$init_log" 2>&1 || init_status=$?\n'
-                '          cat "$init_log"\n',
+                '          kin init > "$captures/kin-init.txt" 2>&1 || init_status=$?\n'
+                '          cat "$captures/kin-init.txt"\n'
+                '          if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi\n',
+                '          if [ "$init_status" -ne 0 ]; then exit "$init_status"; fi\n'
+                '          kin init > "$captures/kin-init.txt" 2>&1 || init_status=$?\n'
+                '          cat "$captures/kin-init.txt"\n',
+                1,
+            )
+        ),
+    )
+
+    # The capture contract the init log was the first case of, now covering
+    # every report the proof writes while the watcher is admitting.
+    proof_steps = {
+        "the first-run proof": first_run,
+        "the graph query, MCP, and VFS proof": graph_query,
+        "the embedding proof": embedding,
+    }
+    restore_position = (embedding_start, restore_start, validation_start)
+    assert_install_proof_captures_stay_out_of_the_admitted_tree(
+        proof_steps, restore, restore_position
+    )
+    for label, step_name, original, mutation in (
+        (
+            "a first-run capture reverts to a relative redirect",
+            "the first-run proof",
+            'kin status --json > "$captures/kin-status.json" 2>&1',
+            "kin status --json > kin-status.json 2>&1",
+        ),
+        (
+            "a graph-query capture reverts to a relative tee",
+            "the graph query, MCP, and VFS proof",
+            'kin doctor --json | tee "$captures/kin-doctor.json"',
+            "kin doctor --json | tee kin-doctor.json",
+        ),
+        (
+            "a VFS capture reverts to a relative stderr redirect",
+            "the graph query, MCP, and VFS proof",
+            '2> "$captures/vfs-graph-read.stderr.txt"',
+            "2> vfs-graph-read.stderr.txt",
+        ),
+        (
+            "an embedding capture reverts to a relative tee",
+            "the embedding proof",
+            'kin locate hello --json --explain --max-files 5 | tee "$captures/kin-semantic-locate.json"',
+            "kin locate hello --json --explain --max-files 5 | tee kin-semantic-locate.json",
+        ),
+        (
+            "an MCP Node capture reverts to a relative write",
+            "the graph query, MCP, and VFS proof",
+            'fs.writeFileSync(path.join(captures, "kin-mcp-out.jsonl"), stdout);',
+            'fs.writeFileSync("kin-mcp-out.jsonl", stdout);',
+        ),
+    ):
+        expect_assertion(
+            label,
+            "writes a proof report into the admitted tree",
+            lambda mutated_steps={
+                **proof_steps,
+                step_name: proof_steps[step_name].replace(original, mutation, 1),
+            }: assert_install_proof_captures_stay_out_of_the_admitted_tree(
+                mutated_steps, restore, restore_position
+            ),
+        )
+    for label, active_line in (
+        (
+            "the captures never reach the proof reports",
+            'cp "$captures/$capture" "$destination/$capture"',
+        ),
+        (
+            "the restore stops listing the capture directory",
+            'done < <(ls -1 "$captures")',
+        ),
+    ):
+        expect_assertion(
+            label,
+            "install-proof capture restore",
+            lambda mutated=restore.replace(
+                active_line, f"# {active_line}", 1
+            ): assert_install_proof_captures_stay_out_of_the_admitted_tree(
+                proof_steps, mutated, restore_position
+            ),
+        )
+    expect_assertion(
+        "a failed leg stops handing over what it captured",
+        "must run on failure too",
+        lambda: assert_install_proof_captures_stay_out_of_the_admitted_tree(
+            proof_steps, restore.replace("if: always()", "if: success()", 1), restore_position
+        ),
+    )
+    expect_assertion(
+        "the captures are restored before the assertions that read the store",
+        "after the last step that reads the store",
+        lambda: assert_install_proof_captures_stay_out_of_the_admitted_tree(
+            proof_steps, restore, (embedding_start, embedding_start - 1, validation_start)
+        ),
+    )
+
+    assert_install_proof_embedding_settles_before_measurement(embedding)
+    for label, expected, original, mutation in (
+        (
+            "the settle stops requiring a drained embedding pass",
+            "poll the counters to quiescence",
+            "coverage.pending === 0 &&",
+            "coverage.pending >= 0 &&",
+        ),
+        (
+            "the settle stops requiring two agreeing reads",
+            "poll the counters to quiescence",
+            "drained && current === previous",
+            "drained",
+        ),
+        (
+            "an expired settle stops failing the leg",
+            "poll the counters to quiescence",
+            "process.exit(1);",
+            "process.exitCode = 0;",
+        ),
+        (
+            "the store is measured before it has settled",
+            "embed, then settle, then capture",
+            'PROOF_CAPTURES="$captures" node <<\'NODE\'',
+            "kin status --json --wait-quiesce 60 | tee \"$captures/kin-embedded-status.json\"\n"
+            "          PROOF_CAPTURES=\"$captures\" node <<'NODE'",
+        ),
+    ):
+        expect_assertion(
+            label,
+            expected,
+            lambda mutated=embedding.replace(
+                original, mutation, 1
+            ): assert_install_proof_embedding_settles_before_measurement(mutated),
+        )
+    expect_assertion(
+        "the settle becomes a duration nobody measured",
+        "rather than on a duration nobody measured",
+        lambda: assert_install_proof_embedding_settles_before_measurement(
+            embedding.replace(
+                '          PROOF_CAPTURES="$captures" node',
+                "          sleep 30\n"
+                '          PROOF_CAPTURES="$captures" node',
                 1,
             )
         ),
@@ -7924,8 +8187,8 @@ def main() -> None:
         "installed CLI provenance capture",
         lambda: assert_install_proof_status_contract(
             first_run.replace(
-                "kin bench-meta --json > kin-build-meta.json",
-                "kin --version > kin-build-meta.json",
+                'kin bench-meta --json > "$captures/kin-build-meta.json"',
+                'kin --version > "$captures/kin-build-meta.json"',
                 1,
             ),
             graph_query,
@@ -7939,12 +8202,12 @@ def main() -> None:
         lambda: assert_install_proof_status_contract(
             first_run,
             graph_query.replace(
-                "kin search hello --json | tee kin-search.json",
+                'kin search hello --json | tee "$captures/kin-search.json"',
                 "# graph query moved below daemon provenance capture",
                 1,
             ).replace(
-                "cat kin-daemon-health.json",
-                "cat kin-daemon-health.json\n          kin search hello --json | tee kin-search.json",
+                'cat "$captures/kin-daemon-health.json"',
+                'cat "$captures/kin-daemon-health.json"\n          kin search hello --json | tee "$captures/kin-search.json"',
                 1,
             ),
             embedding,
@@ -7957,8 +8220,8 @@ def main() -> None:
         lambda: assert_install_proof_status_contract(
             first_run,
             graph_query.replace(
-                "kin search hello --json | tee kin-search.json",
-                "# kin search hello --json | tee kin-search.json",
+                'kin search hello --json | tee "$captures/kin-search.json"',
+                '# kin search hello --json | tee "$captures/kin-search.json"',
                 1,
             ),
             embedding,
@@ -7971,20 +8234,20 @@ def main() -> None:
         lambda: assert_install_proof_status_contract(
             first_run,
             graph_query.replace(
-                "kin setup status --json | tee kin-health.json",
+                'kin setup status --json | tee "$captures/kin-health.json"',
                 "# setup health moved above daemon startup",
                 1,
             )
             .replace(
-                "kin doctor --json | tee kin-doctor.json",
+                'kin doctor --json | tee "$captures/kin-doctor.json"',
                 "# doctor health moved above daemon startup",
                 1,
             )
             .replace(
-                "kin search hello --json | tee kin-search.json",
-                "kin setup status --json | tee kin-health.json\n"
-                "          kin doctor --json | tee kin-doctor.json\n"
-                "          kin search hello --json | tee kin-search.json",
+                'kin search hello --json | tee "$captures/kin-search.json"',
+                'kin setup status --json | tee "$captures/kin-health.json"\n'
+                '          kin doctor --json | tee "$captures/kin-doctor.json"\n'
+                '          kin search hello --json | tee "$captures/kin-search.json"',
                 1,
             ),
             embedding,
@@ -8148,7 +8411,7 @@ def main() -> None:
         "fstat(STDOUT_FILENO, &stdout_stat)",
         "chmod 000 probe.py",
         "KIN_VFS_STRICT=1 kin-vfs exec --workspace .",
-        "cmp -s vfs-expected.txt vfs-graph-read.txt",
+        'cmp -s "$captures/vfs-expected.txt" "$captures/vfs-graph-read.txt"',
         "installed VFS did not return the exact graph-owned probe.py bytes",
         "release-provenance-attestation.json",
         "installed-vfs-provenance.json",


### PR DESCRIPTION
The Public Install Proof tees every capture straight into the repository it
measures. The daemon under test admits new non-ignored files as they arrive, so
each report becomes semantic corpus while the proof is still running, and the
store the assertions read keeps growing underneath them. That is what fenced
v0.5.18: on ubuntu-24.04-arm the readiness check read 13 of 13 and healthy, and
the locate payload one second later read 13 indexed of 18 with 5 pending and
complete false.

This file already solved that once, for the init log alone. It wrote it to
RUNNER_TEMP under a comment saying a report file must neither exist in the
admitted tree nor grow while init runs, then copied it back. Every other capture
reintroduced the hazard that precedent was written to avoid. The same design now
covers all of them. Thirty capture sites write into one directory under
RUNNER_TEMP, and a single restore step copies the whole set back after the last
assertion that reads the store, so the uploaded artifact keeps the layout it has
always had. That step runs on failure too, so a leg that dies early still hands
over what it captured.

Keeping the reports out is not sufficient on its own. Content that genuinely
belongs in the corpus, the agent config setup writes and the probe file itself,
is admitted asynchronously, and coverage is an instantaneous whole-store read, so
a capture taken too early measures a store that is still settling. A bounded
settle poll now runs between the embedding pass and the captures that assert on
it. It reads the counters once a second until an embedding pass has nothing
pending and two consecutive reads agree that nothing new was admitted between
them, and on expiry it names the exact counters it was still waiting on rather
than failing later somewhere less informative. No sleep anywhere, and no
assertion relaxed anywhere: every validator check is exactly what it was.

Capture sites moved, all keeping their file names and gaining the
RUNNER_TEMP/kin-proof-captures prefix. First-run proof: kin-init.txt (already
outside, its copy-back is now deferred rather than immediate), kin-status.txt,
kin-status.json, kin-build-meta.json, kin-setup.txt, kin-codex-config.json,
kin-claude-fallback-setup.txt, kin-claude-fallback-config.json,
kin-claude-fallback-health.json, kin-claude-fallback-doctor.json. Graph query and
MCP proof: kin-search.json, kin-locate.json, kin-daemon-health.json,
kin-health.json, kin-doctor.json, kin-mcp-daemon-stop.txt, kin-mcp-out.jsonl,
kin-mcp-err.txt. VFS proof: kin-vfs-daemon.log, vfs-negative.txt,
vfs-graph-read.txt, vfs-graph-read.stderr.txt, vfs-expected.txt. Embedding proof:
kin-embed.json, kin-status-settle-mode.txt, kin-embedded-status.json,
kin-embedded-health.json, kin-embedded-doctor.json, kin-semantic-search.json,
kin-semantic-locate.json. One capture is new, kin-embedding-settle.txt, which
records what the poll observed and is uploaded by the existing text glob.

The release-authority suite pinned the init log's capture by its exact shape, so
this failed it on the very line that generalizes what it was protecting. That
suite is updated to the new shape and extended rather than relaxed. The
init-log check keeps its exactly-once admission count, its closed-form prelude,
and its status propagation, against the capture directory instead of a single
log variable. A new check examines every report-shaped redirect, tee, and Node
write in the proof steps and refuses a relative target by name, which is the
mutation a presence check on the restore step cannot see, and it requires the
restore to run after the last step that reads the store, before the step that
reads the files, and on failure as well. A third requires the settle to poll
the counters and fail on expiry, and refuses a bare sleep in that step. Each
property is falsified beside itself: fourteen mutations, one per property, each
expected to fail for its own stated reason.

Evidence. The contamination was reproduced against the exact 0.5.18 binary the
failing run installed, extracted from that run's own release artifact: writing
the capture set into the admitted tree moved retrievable objects from 4 to 18
with no git operation, and writing the identical set outside it held at 4. The
settle poll was executed verbatim on both sides of its verdict, settling a real
embedded store in 1 second over 2 reads and refusing a store whose backlog can
never drain after 176 reads with the counters named. The release-authority suite
and the four sibling scripts in its CI step pass locally. actionlint with
shellcheck reports nothing, and every embedded bash, Node, and Python block parses; both
checks were falsified against a deliberately broken copy first. The zero
file-search verifier passes, though it scans Rust sources rather than workflows
and says nothing about this diff.

A workflow change cannot be executed locally end to end. A tag run resolves its
workflows from the tag, so the executable proof of this change is the next tag
cut, and v0.5.18 stays fenced.

Closes FIR-2205
