### PR TITLE
Give Windows its zip suffix in the manual install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ coordination metadata rather than claiming zero residual bytes.
 For manual installation, each archive and its `.sha256` file is published under
 `https://github.com/firelock-ai/kin/releases/latest/download/`. The moving asset
 names are `kin-macos-aarch64`, `kin-macos-x86_64`, `kin-linux-aarch64`,
-`kin-linux-x86_64`, and `kin-windows-x86_64`; use the `.tar.gz` suffix shown on
-the latest release page. Windows also publishes `kin-windows-x86_64.zip`, which
-is what the PowerShell installer and the npm launcher fetch.
+`kin-linux-x86_64`, and `kin-windows-x86_64`; use the `.tar.gz` suffix for the
+macOS and Linux archives and the `.zip` suffix for Windows, as shown on the
+latest release page. The Windows zip is also what the PowerShell installer and
+the npm launcher fetch.
 
 The npm entry point resolves the same public release channel:
 


### PR DESCRIPTION
The manual-installation paragraph told every platform to use the .tar.gz suffix while the Windows asset on the current release is a zip. A Windows reader following it composes kin-windows-x86_64.tar.gz, which 404s on v0.5.17. Name which suffix belongs to which platform. The PowerShell installer and the npm launcher already fetch the zip and are unaffected.

Part of FIR-2207