### PR TITLE
Drop the dead triage-doc pointer from the CI clippy comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1002,8 +1002,8 @@ jobs:
           # nothing.
           python3 scripts/falsify-hydration-semantics.py "$poisoned"
 
-      # TEMPORARY debt allow-list — burn down per crates/kin-cli/docs/kin-cli-clippy-triage.md
-      # + release-ops task; no additions without lead sign-off.
+      # TEMPORARY debt allow-list; burn entries down and delete each allow once its
+      # lint is clean. No additions without lead sign-off.
       # Enumerated from `cargo clippy --all-targets --all-features` on main against
       # the CI toolchain (rustc/clippy 1.96.0, dtolnay rust-toolchain@stable):
       # 45 distinct clippy lints (the 1.96 bump from 1.94 added collapsible_match,


### PR DESCRIPTION
The Clippy debt allow-list comment in ci.yml told readers to burn entries down per crates/kin-cli/docs/kin-cli-clippy-triage.md, a file deleted in 7ecefffa and never relocated, so the instruction pointed nowhere. The comment now stands alone. The allow-list is temporary debt, each allow is deleted once its lint comes clean, and additions still need lead sign-off.

A docs audit against shipped v0.5.17 flagged four more claims, and re-verification found all four already true on current main. The README entity table mirrors ENTITY_SOURCE_EXTENSIONS in crates/kin-index/src/classifier.rs exactly. docs/language-support.md carries Swift, PHP, and HCL in its full-semantic table. docs/mcp-tools.md counts 64 tools and documents get_entity_sources, kin_artifact_list, kin_artifact_read, and shadow_gate_report. CHANGELOG.md carries the 0.5.15 through 0.5.17 sections verbatim from their releases. PR #727 and the release train landed those corrections, so this pointer reword is the one remaining fix.

Part of FIR-2207