### PR TITLE
Abandon the v0.5.18 release tag

### DIFF
--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -56,6 +56,13 @@
       "reason": "The Public Install Proof frozen at this tag fails on all five platforms because the tagged binary reports semantic_query_readiness=stale while a fresh install's first embedding fill is still in progress, and the health rollup at the tag treats that state as blocking; the same report also scores an unconfigured retrieval profile as stale on Windows. The discriminators that tell a first fill apart from lost coverage and an unconfigured install apart from a degraded one landed on main only after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing checks. Both attempts of the cited run failed with the same signature on all five legs, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm and Homebrew were verified untouched, and the tag never became the finalized Latest release.",
       "superseded_by": "v0.5.8",
       "failed_release_run_id": "31193919695"
+    },
+    {
+      "tag": "v0.5.18",
+      "sha": "f111bf6b9f73a45cc283b751d974b267e35945fb",
+      "reason": "The Public Install Proof frozen at this tag fails on its three gating Unix legs and the tag can receive none of the repairs. The tagged binary never records that an explicit embedding fill completed, because only the background worker publishes the fill-completed marker and it stands down for the duration of an explicit pass, and the tag's health rollup then classifies the backlog on that completed store as lost ground, which blocks the aggregate on ubuntu-latest and macos-15-intel. The tag's proof harness also tees its own capture files into the worktree it measures, and this is the first tag whose watcher admits new non-ignored files as they are written, so the captures become semantic corpus mid-proof and the ubuntu-24.04-arm locate coverage assertion races a store the proof itself is growing. The repairs landed on main only after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing checks. Both attempts of the cited run failed, the windows leg is non-gating by its own matrix, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm was verified untouched at 0.5.17, and the tag never became the finalized Latest release.",
+      "superseded_by": "v0.5.19",
+      "failed_release_run_id": "31478318322"
     }
   ]
 }


### PR DESCRIPTION
The release train holds every new mint while the highest admissible tag is not the finalized Latest, and v0.5.18 can never become it: its Public Install Proof fails on the three gating Unix legs for defects frozen into the tag itself. The tagged binary never records that an explicit embedding fill completed and then classifies the resulting backlog as lost ground, and the tag's proof harness tees its own captures into the worktree it measures on the first release whose watcher admits new files as they are written, so the arm leg's coverage assertion races a corpus the proof itself grows. The repairs are on main and resolve from tags cut after them, so no rerun of this tag's release can pass.

This records the reviewed abandonment in the manifest the train's tag selector reads, in the same form as the eight waivers before it: the exact commit, the failed run, and v0.5.19 as the superseding tag. The prerelease object stays as the fence, npm was verified untouched at 0.5.17, and the next train cycle after this lands is free to mint v0.5.19 carrying both repairs.

Refs FIR-2203
Refs FIR-2205