### PR TITLE
Regenerate the fuzz lock for the kin-model 0.7.8 and kin-vector 0.1.11 pins

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.7"
+version = "0.7.8"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9e39741a0edad255687301dc087a915f787a31c0a9eee028150081c884e940ea"
+checksum = "75c237b19289638e728e70048011c5d5731d9ef45878f078e7663f2b0e9475e1"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -702,12 +702,13 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.9"
+version = "0.1.11"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "fd4c2a7ebb07f6ca4ae49fe57eaafa91adbca5e38e76d133b25008c87679f7e8"
+checksum = "c1904ba13d244810b195168b04ada8884094f8d5374c54f36e9b9375ac6e625a"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
+ "memmap2",
  "parking_lot",
  "rayon",
  "rmp-serde",
@@ -756,6 +757,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "num-traits"


### PR DESCRIPTION
kin#758 moved the workspace to kin-db 0.7.20, which carries kin-model =0.7.8 and kin-vector 0.1.11, without regenerating the detached fuzz package's lock. cargo metadata --locked has refused the fuzz manifest since, failing both cargo-fuzz jobs on every PR that touches the pin surface, including the v0.5.19 release bump PR (kin#767). Fuzz ran red on kin#758 itself and did not gate that merge, which is a separate requiredness gap being ticketed.

Regenerated with cargo +nightly-2026-06-17 update -p kin-model --manifest-path fuzz/Cargo.toml. The resolved set now matches the root Cargo.lock: kin-model 0.7.8, kin-vector 0.1.11, memmap2 0.9.11 transitive, registry checksums preserved. Verified with the CI gate's exact command: cargo +nightly-2026-06-17 metadata --locked --manifest-path fuzz/Cargo.toml passes on this lock, and it failed with rc=101 on the parent commit.