### PR TITLE
Consume the shared merge-queue ejection notice

### DIFF
--- a/.github/workflows/merge-queue-ejection-notice.yml
+++ b/.github/workflows/merge-queue-ejection-notice.yml
@@ -1,0 +1,38 @@
+name: Merge Queue Ejection Notice
+
+# The hosted merge queue drops a pull request when a `merge_group` check fails,
+# and it marks nothing on the pull request it dropped. The failing run belongs
+# to a `gh-readonly-queue` ref and names no pull request, so PR-level checks and
+# mergeable state keep reading CLEAN and MERGEABLE. What a captain sees is a
+# healthy change that simply never merges, which is indistinguishable from one
+# still waiting its turn.
+#
+# The shared implementation lives in firelock-ai/kin-actions and has run on that
+# repo's own pull requests since the defect was first observed there, where PR
+# #26 was admitted, built, and ejected twice before anyone noticed. This repo
+# had the same blind spot and no consumer.
+#
+# The three workflows below are every workflow here that runs on `merge_group`,
+# which makes them the three whose failure can eject an entry. Adding a
+# `merge_group:` trigger to a fourth workflow means adding its name here too, or
+# the ejections it causes go back to being invisible. `workflow_run` is the
+# right trigger rather than an `if: failure()` job inside each of them, because
+# the check that ejects is frequently in a different workflow from the one
+# anybody would think to edit.
+on:
+  workflow_run:
+    workflows: ["CI", "PR Text Hygiene", "SAST"]
+    types: [completed]
+
+# Read-only by default, with the comment capability granted only to the job that
+# needs it, matching the per-job elevation the other kin-actions consumers here
+# use. A reusable workflow can narrow the caller's token but never widen it, so
+# the grant has to be made on this side.
+permissions:
+  contents: read
+
+jobs:
+  notice:
+    permissions:
+      pull-requests: write
+    uses: firelock-ai/kin-actions/.github/workflows/merge-queue-ejection-notice.yml@v0.1.25

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -502,6 +502,12 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/link-check.yml": {
         "link-check": "Check public documentation links",
     },
+    # Reports an ejection on the pull request the merge queue dropped. It runs
+    # on workflow_run after the fact, produces no check on a pull request, and
+    # so is never a required-context producer.
+    ".github/workflows/merge-queue-ejection-notice.yml": {
+        "notice": None,
+    },
     ".github/workflows/notify-approver.yml": {
         "notify": None,
     },


### PR DESCRIPTION
A pull request dropped from the hosted merge queue by a failing merge_group
check leaves nothing on the pull request. The failing run belongs to a
gh-readonly-queue ref and names no pull request, so PR-level checks and mergeable
state keep reading CLEAN and MERGEABLE while the change never merges, which is
indistinguishable from an entry still waiting its turn.

The reusable notice in kin-actions recovers the number from the queue ref and
comments the workflow name and run link on the pull request it belongs to. It has
run on that repo's own pull requests since the defect was first observed there,
where PR 26 was admitted, built, and ejected twice before anyone noticed. This
repo had the same blind spot and no consumer.

The workflows list names every workflow here that runs on merge_group (CI, PR
Text Hygiene, SAST), which makes them the three whose failure can eject an entry;
a fourth merge_group trigger needs its name added here or its ejections stay
invisible. Pinned to v0.1.25, the tag the other kin-actions consumers in this
repo already use, whose copy of the workflow is byte-identical to kin-actions
main. Permissions follow the same shape as those consumers: read-only at the top
level with pull-requests write granted per job.

The workflow census in test-release-workflow-authority.py pins every workflow
path, job id, and display name so no second required-context producer can appear
unreviewed, so the new file is registered there. It produces no check on a pull
request and is never a required context: it runs on workflow_run, after the fact.

Advances FIR-1985.
