### PR TITLE
Stop Git auto-maintenance from racing test fixture repositories

### DIFF
--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -1366,12 +1366,81 @@ pub struct Command<'runtime> {
 
 impl Command<'static> {
     pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        let program = program.as_ref();
+        let mut inner = std::process::Command::new(program);
+        if is_git_program(program) {
+            inner.args(FIXTURE_GIT_MAINTENANCE_SUPPRESSION);
+        }
         Self {
-            inner: Some(std::process::Command::new(program)),
+            inner: Some(inner),
             runtime: None,
             intentional_env: Vec::new(),
         }
     }
+}
+
+/// Command-scope configuration prepended to every fixture Git launch.
+///
+/// Integration fixtures commit a repository and then admit it. Git otherwise
+/// ends a commit by spawning `git maintenance run --auto --quiet --detach`,
+/// which outlives the commit, and whose incremental-repack task runs
+/// `git multi-pack-index write` and holds
+/// `objects/pack/multi-pack-index.lock` for the width of that write. Kin's
+/// admission preflight reads any lock under `objects/pack` as concurrent
+/// repository mutation and refuses, so the fixture was racing a background
+/// process it never asked for.
+///
+/// This rides on the argument list rather than in the environment on purpose.
+/// The environment of a fixture command is inherited by the `kin` binary under
+/// test and by every Git process it spawns, and the fixture boundary keeps that
+/// environment free of Git configuration scope so the product is exercised with
+/// the Git behavior a user would get.
+const FIXTURE_GIT_MAINTENANCE_SUPPRESSION: [&str; 4] =
+    ["-c", "maintenance.auto=false", "-c", "gc.auto=0"];
+
+/// Whether a program name launches Git, so the suppression above reaches every
+/// fixture Git command without each call site having to remember it.
+///
+/// Matched on the file stem so an absolute path and a `.exe` suffix both
+/// resolve, and case-insensitively because Windows paths do.
+fn is_git_program(program: &OsStr) -> bool {
+    std::path::Path::new(program)
+        .file_stem()
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("git"))
+}
+
+#[test]
+fn fixture_git_commands_prepend_maintenance_suppression() {
+    for program in ["git", "/usr/bin/git", "git.exe", "GIT"] {
+        assert!(
+            is_git_program(OsStr::new(program)),
+            "{program} was not recognized as Git, so its commits would detach maintenance"
+        );
+    }
+    for program in ["sh", "kin", "gitk", "git-upload-pack", "/usr/bin/legit"] {
+        assert!(
+            !is_git_program(OsStr::new(program)),
+            "{program} was misread as Git"
+        );
+    }
+
+    let git = Command::new("git");
+    let arguments = git
+        .inner_ref()
+        .get_args()
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        arguments.iter().map(String::as_str).collect::<Vec<_>>(),
+        FIXTURE_GIT_MAINTENANCE_SUPPRESSION.to_vec(),
+        "a fixture Git command did not lead with the maintenance suppression"
+    );
+
+    // The suppression is Git configuration, so it must not reach anything else.
+    assert!(
+        Command::new("sh").inner_ref().get_args().next().is_none(),
+        "a non-Git fixture command was given Git configuration arguments"
+    );
 }
 
 impl<'runtime> Command<'runtime> {

--- a/crates/kin-cli/tests/git_fixture_hermeticity.rs
+++ b/crates/kin-cli/tests/git_fixture_hermeticity.rs
@@ -30,6 +30,46 @@ fn integration_git_fixtures_ignore_command_scope_config() {
     assert!(output.stderr.is_empty());
 }
 
+/// Integration fixtures commit a repository and then admit it, and Git ends a
+/// commit by detaching `git maintenance run --auto`. That background process
+/// outlives the commit and its incremental-repack task holds
+/// `objects/pack/multi-pack-index.lock` while it writes, which Kin's admission
+/// preflight reads as concurrent repository mutation and refuses. The
+/// suppression has to reach Git through this harness, not only through the
+/// lower-level fixture command type.
+#[test]
+fn integration_git_fixtures_disable_automatic_repository_maintenance() {
+    let temp = tempdir().unwrap();
+    for (key, expected) in [("maintenance.auto", "false"), ("gc.auto", "0")] {
+        let output = Command::new("git")
+            .args(["config", "--get", key])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git config --get {key} failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            expected,
+            "{key} did not reach Git through the integration fixture harness"
+        );
+    }
+
+    // Control: a key the boundary never sets must still read as absent, so a
+    // passing assertion above cannot be an artifact of the read itself.
+    let absent = Command::new("git")
+        .args(["config", "--get", "maintenance.never.set"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert_eq!(absent.status.code(), Some(1), "{absent:?}");
+    assert!(absent.stdout.is_empty());
+}
+
 #[cfg(unix)]
 #[test]
 fn integration_git_fixtures_ignore_global_hooks() {

--- a/crates/kin-index/tests/cross_repo_xref_admission.rs
+++ b/crates/kin-index/tests/cross_repo_xref_admission.rs
@@ -304,6 +304,12 @@ where
     S: AsRef<OsStr>,
 {
     Command::new("git")
+        // This fixture commits a repository and then admits it in the same
+        // test. Git otherwise ends a commit by detaching
+        // `git maintenance run --auto`, which outlives the commit and can hold
+        // `objects/pack/multi-pack-index.lock` while the admission preflight
+        // reads the object store and refuses on any lock it finds there.
+        .args(["-c", "maintenance.auto=false", "-c", "gc.auto=0"])
         .args(args)
         .current_dir(repo)
         .env("GIT_CONFIG_NOSYSTEM", "1")


### PR DESCRIPTION
Git ends `git commit` by spawning `git maintenance run --auto --quiet --detach`.
That process is detached, so it outlives the commit that started it, and its
incremental-repack task runs `git multi-pack-index write`, which holds
`objects/pack/multi-pack-index.lock` for the width of the write. Kin's admission
preflight treats any lock under `objects/pack` as concurrent repository mutation
and refuses, so a fixture that committed a repository and then admitted it was
racing a background process it never asked for.

That is what ejected a workflow-only PR from the merge queue on 2026-08-11.
`a_captured_init_writes_phase_summaries_and_no_progress_frames` failed with
"Git lock ... multi-pack-index.lock indicates concurrent repository mutation"
while the queued change touched no Rust code.

Prepend `-c maintenance.auto=false -c gc.auto=0` to every fixture Git command
built through the CLI integration harness, matched on the program name so no call
site has to remember it, and give the cross-repo admission fixture in kin-index
the same two settings on its own argv. The bundled fixture command type already
carried them, which is also why one hand-rolled copy of these flags already sits
in a unit fixture with a comment naming this exact failure.

The suppression rides on the argument list rather than in the environment. A
fixture command's environment is inherited by the `kin` binary under test and by
every Git process it spawns, and that environment is deliberately kept free of Git
configuration scope, both so the product is exercised with the Git behavior a real
user would get and because the runtime hermeticity suite asserts that no
configuration scope reaches a fixture subprocess.

Verified rather than assumed. Traced against Git 2.52.0: a default commit starts
exactly one child, `git maintenance run --auto --quiet --detach`, and with these
two settings it starts none. Both new guards were falsified by canary. With the
injection deleted, the sniff guard fails on an empty argument list and the
end-to-end guard fails because Git reports no value for either setting.

Test fixtures only. No product behavior changes, no test is ignored, and no retry
is added. Whether Kin's admission should tolerate Git's own maintenance locks is
the product question, filed as FIR-2225.

Part of FIR-2220. The branch-switch and mid-capture-kill races in that ticket
remain open.

Review note: IsolatedDaemonRuntime::command builds its process command directly and bypasses the automatic prepend. No call site passes Git today, so it is a latent hole, not a live one; routing that constructor through the same prepend is a cheap follow-up.
