### PR TITLE
Drop the em dash and the retired category line from NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
-Kin — Semantic Version Control
+Kin
+The system of record for AI-written software.
 Copyright 2026 Firelock, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License").


### PR DESCRIPTION
NOTICE opened with a dash construction and a category line the brand canon has retired. Line 1 is now the name on its own with the locked canon line beneath it, so the dash is gone by restructuring rather than by substituting a comma or a colon.

Nothing else in the repo is touched.

Two things found while here and deliberately left alone: generate_agents_md() in crates/kin-core/src/assistant.rs carries the same retired phrase and a separate em dash a couple of lines below it, and that text is written into every user repo by kin setup, which is a wider distribution surface than this file. Both belong in their own change.