### PR TITLE
True up the public docs against the shipped CLI

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+# Canonical author identities.
+#
+# One human wrote this repository under several Git identities: a GitHub
+# noreply address, a second work address, and one address Git synthesized from
+# a hostname when a checkout had no user.email set. This file maps them onto a
+# single name and address for git log, git shortlog, git blame, and GitHub's
+# contributor view. No commit is rewritten and no SHA changes.
+#
+# Bot identities are deliberately left alone, so automated commits stay
+# visibly automated.
+
+Troy Fortin <troy@firelock.ai> <63249686+troyjr4103@users.noreply.github.com>
+Troy Fortin <troy@firelock.ai> <troy.fortin@firelock.ai>
+Troy Fortin <troy@firelock.ai> <troyfortinjr@MacBook-Pro-2.local>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
   <img src="docs/assets/kin-banner-2026.png" alt="Kin, the semantic system of record for AI-written software" width="100%" />
 </p>
 
-<!-- Demo GIF slot: embed the launch demo GIF here, directly under the banner,
-     once the final asset lands in docs/assets/. Do not link an asset that is
-     not in the tree. -->
+<p align="center">
+  <img src=".github/demos/git-interop.gif" alt="Terminal recording: kin init, kin git import, kin commit, kin status, and kin trace run against an existing Git repository" width="100%" />
+</p>
+
+<p align="center">
+  <sub>Adopting Kin on a repository that already has Git history: <code>kin init</code>,
+  <code>kin git import</code>, one semantic commit, then a trace. Recorded by
+  <a href="scripts/record-demos.sh"><code>scripts/record-demos.sh</code></a> on a
+  small sample project, so the counts are the sample's, not a benchmark.</sub>
+</p>
 
 <div align="center">
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -213,16 +213,21 @@ history in a language Kin parses expands the most. A repository with almost no
 history can finish smaller than its Git object store.
 
 `kin init` reports both sizes and the ratio when it finishes, and `kin status`
-reports the same line afterwards:
+reports the same line afterwards. On ripgrep at `e89fff89`, 2,261 commits, it
+reads:
 
 ```
-  Store size: 71.9 MiB under .kin/, 2.6x the 28.0 MiB Git object store
+  Store size: 405.4 MiB under .kin/, 66.5x the 6.1 MiB Git object store
 ```
 
-`kin init --json` carries the raw byte counts under `store_footprint`.
-[Store size](./store-size.md) explains what drives the number and records what
-has been measured. Kin does not cap store size or refuse a repository for being
-large, so plan disk against your history rather than against your checkout.
+Read that multiple as one measurement, not as a constant. The ratio moves by
+more than 3x across repositories of similar size in different languages, and a
+repository that has reset away a large commit can land below its Git object
+store entirely. [Store size](./store-size.md) explains what drives the number
+and records every repository measured so far. `kin init --json` carries the raw
+byte counts under `store_footprint`. Kin does not cap store size or refuse a
+repository for being large, so plan disk against your history rather than
+against your checkout.
 
 ### Profiling a slow command
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -4,8 +4,8 @@ This document describes the security model of the parts of Kin that run as
 long-lived local processes or interpose on the operating system: the **Kin
 daemon** (its graph and coordination control API) and the **filesystem
 projection** that serves graph-backed content to ordinary tools. It
-describes behavior as it exists today, including the cases where a protection is
-provisioned but not enforced by default. Where a boundary is owned by another
+describes behavior as it exists today, including the residual risks a shipped
+protection does not cover. Where a boundary is owned by another
 repository in the ecosystem, that is called out so the authority for the
 implementation is unambiguous.
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -160,13 +160,18 @@ addresses are re-verified.
 
 ## Residual Risks and Hardening
 
-- **Shared and multi-tenant hosts.** The default same-user trust boundary means
-  any process running as your user can reach the loopback daemon. On hosts where
-  that is not an acceptable assumption, enable `KIN_DAEMON_REQUIRE_TOKEN` (or set
-  an explicit `KIN_DAEMON_AUTH_TOKEN`).
-- **Provisioned-but-unenforced token.** Because the per-install token is
-  provisioned but not enforced by default, do not assume bearer authentication is
-  active unless one of the enforcement variables above is set.
+- **Shared and multi-tenant hosts.** Bearer authentication is enforced by
+  default, but the token file is readable by its owner, so any process running as
+  your user can read it and reach the loopback daemon. That is the default
+  same-user trust boundary, and a token does not raise it. On hosts where the
+  assumption does not hold, set an explicit `KIN_DAEMON_AUTH_TOKEN` that lives
+  outside the repository, and never set `KIN_DAEMON_REQUIRE_TOKEN` to a falsy
+  value.
+- **The escape hatch is real.** A falsy `KIN_DAEMON_REQUIRE_TOKEN` turns bearer
+  authentication off for a daemon that then relies on the loopback bind and the
+  Host/Origin guard alone. Check the variable before assuming an audited host is
+  enforcing the token, since the opt-out survives in whatever shell profile or
+  service unit set it.
 - **Off-host exposure.** Binding the daemon to a non-loopback address requires a
   token, but exposing it to a network still widens the attack surface
   considerably; treat it as a deliberate, audited deployment choice.

--- a/packages/kin-mcp/README.md
+++ b/packages/kin-mcp/README.md
@@ -45,14 +45,18 @@ Use it directly from an MCP client with `npx`:
 }
 ```
 
-For a pinned version:
+To pin a version, add it to the package spec. Take the number from the
+[published version list](https://www.npmjs.com/package/@kinlab/kin-mcp?activeTab=versions)
+rather than from this page, because a version written into a README is stale by
+the next release and pins whoever copies it to whatever shipped when the line
+was typed:
 
 ```json
 {
   "mcpServers": {
     "kin": {
       "command": "npx",
-      "args": ["-y", "@kinlab/kin-mcp@0.5.14"]
+      "args": ["-y", "@kinlab/kin-mcp@<version>"]
     }
   }
 }


### PR DESCRIPTION
Five documentation defects an evaluating engineer would hit, each verified against the code rather than against another document.

The kin-mcp install block pinned @kinlab/kin-mcp@0.5.14, three releases behind what npm serves, and that block is the copy-paste path published to the registry. It now carries a placeholder and a link to the version list, keeping the section's point that you should pin.

A .mailmap maps four non-canonical identities onto one author, including the git-synthesized troyfortinjr@MacBook-Pro-2.local that git invents when identity is unset. Shortlog collapses from four human rows to one. No sha is rewritten, which is why this is safe.

The quickstart's store-size example cited an unsourced 2.6x. It now uses the measured ripgrep row from docs/store-size.md, names the commit and the commit count behind it, and says the multiple is one measurement rather than a constant.

The threat model claimed the per-install bearer token is provisioned but not enforced by default and told operators to enable it. Enforcement has been default-on since 2026-07-07. The bullets now state that, keep the risk that is genuinely residual, and warn that a falsy KIN_DAEMON_REQUIRE_TOKEN is a live opt-out worth checking on an audited host.

The README's demo placeholder is filled from .github/demos/, linked where scripts/record-demos.sh writes it so a re-record updates the README instead of creating a second copy that drifts.

One open question for review: the GIF is a small sample project and it now sits above the ripgrep impact proof, which is the stronger evidence. Reordering or re-recording is worth deciding before this lands.