### PR TITLE
Decide nested-checkout membership at the transition, not at drain

### DIFF
--- a/crates/kin-daemon/src/graph_only_members.rs
+++ b/crates/kin-daemon/src/graph_only_members.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Which repository paths own their host subtree independently of this
+//! repository's source projection, decided against a consistent snapshot.
+//!
+//! A graph-only member (a Gitlink, or a path the host cannot represent)
+//! declares that this repository does not own the host subtree beneath it.
+//! Admission never traverses one, so host content written under it is not this
+//! repository's content and no watcher event naming it carries an observation
+//! of this repository's projection.
+//!
+//! Removing the member does not turn that content into something someone just
+//! wrote. Watcher events outlive the transition that removes it, though, so a
+//! membership verdict read off the tree as it stands when those events drain
+//! reads them as ordinary new files: ambient admission sweeps the nested
+//! checkout into the workspace, and the next transition refuses because the
+//! workspace is ahead of the base it was just made level with.
+//!
+//! The retirement below is what makes the verdict independent of arrival time.
+//! It is recorded by the transition that drops the member, while both sides of
+//! that transition are in hand, rather than sampled from the tree afterwards.
+//! Every instant is then covered by exactly one of the two rules: before the
+//! transition the member is live and the event is dropped, after it the path is
+//! retired and the content is reported untracked instead of admitted. There is
+//! no window in between for a stale event to fall through, which is the
+//! difference between closing this race and shortening it.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use kin_model::{RepoPath, ResolvedTree};
+
+/// The graph-only members of one repository tree.
+///
+/// A member is any tracked path whose source projection is not materialized:
+/// Gitlinks everywhere, plus paths the host cannot name. Both own their host
+/// subtree in the sense that matters here, which is that admission does not
+/// traverse them.
+pub fn members_of(tree: &ResolvedTree) -> kin_core::Result<BTreeSet<RepoPath>> {
+    let mut members = BTreeSet::new();
+    for artifact in tree.artifacts_by_path() {
+        if kin_core::source_projection_disposition(&artifact.path, artifact.entry)?
+            != kin_core::SourceProjectionDisposition::Materialized
+        {
+            members.insert(artifact.path.clone());
+        }
+    }
+    Ok(members)
+}
+
+/// Paths that were graph-only repository members until a transition dropped
+/// them, and whose host subtrees are therefore pre-existing content rather than
+/// content ambient observation may admit.
+///
+/// A retirement suppresses ambient admission only. The paths stay visible: they
+/// are counted and named by the untracked-content surfaces exactly like any
+/// other host content the walk declined to take, so an explicit admission seam
+/// still sweeps them and reports what it took.
+#[derive(Debug, Default)]
+pub struct RetiredGraphOnlyMembers {
+    paths: Mutex<BTreeSet<RepoPath>>,
+}
+
+impl RetiredGraphOnlyMembers {
+    /// Record that these paths stopped being graph-only repository members.
+    ///
+    /// Additive by construction. A transition may only ever widen what is
+    /// retired, so ordering this before the graph advances leaves no instant at
+    /// which a path is neither a live member nor a retired one.
+    pub fn retire<'a>(&self, paths: impl IntoIterator<Item = &'a RepoPath>) {
+        let mut retired = match self.paths.lock() {
+            Ok(retired) => retired,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        for path in paths {
+            retired.insert(path.clone());
+        }
+    }
+
+    /// Drop retirements for paths that are graph-only repository members again.
+    ///
+    /// Called with the live member set, so a path restored by a later
+    /// transition is covered by the live rule from then on and does not need a
+    /// retirement standing behind it.
+    pub fn forget_live_members<'a>(&self, live: impl IntoIterator<Item = &'a RepoPath>) {
+        let mut retired = match self.paths.lock() {
+            Ok(retired) => retired,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        for path in live {
+            retired.remove(path);
+        }
+    }
+
+    /// Forget every retirement.
+    ///
+    /// An explicit admission seam walks the whole working copy and takes what it
+    /// finds, including the subtrees a retirement was holding back. Once that
+    /// has happened the caller has said outright that this content is theirs, so
+    /// ambient observation resumes over it.
+    pub fn clear(&self) {
+        let mut retired = match self.paths.lock() {
+            Ok(retired) => retired,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        retired.clear();
+    }
+
+    /// Whether one repository path is a retired member or lies beneath one.
+    pub fn covers(&self, path: &RepoPath) -> bool {
+        let retired = match self.paths.lock() {
+            Ok(retired) => retired,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        covered_by(&retired, path)
+    }
+
+    /// The retired members, for one pass to read instead of locking per path.
+    pub fn snapshot(&self) -> BTreeSet<RepoPath> {
+        match self.paths.lock() {
+            Ok(retired) => retired.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+}
+
+/// Whether one repository path is a member of `retired` or lies beneath one.
+///
+/// The prefix compare is on path segments, so a sibling whose name merely
+/// begins with a retired member's name is a different path.
+pub fn covered_by(retired: &BTreeSet<RepoPath>, path: &RepoPath) -> bool {
+    retired.iter().any(|member| {
+        path == member
+            || path
+                .as_bytes()
+                .strip_prefix(member.as_bytes())
+                .is_some_and(|suffix| suffix.starts_with(b"/"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path(value: &str) -> RepoPath {
+        RepoPath::from_utf8(value).expect("repository path")
+    }
+
+    #[test]
+    fn a_retired_member_covers_itself_and_its_descendants() {
+        let retired = RetiredGraphOnlyMembers::default();
+        retired.retire([&path("vendor/dependency")]);
+        assert!(retired.covers(&path("vendor/dependency")));
+        assert!(retired.covers(&path("vendor/dependency/nested/owned.txt")));
+    }
+
+    /// The prefix compare is on path segments, not bytes. A sibling whose name
+    /// merely starts with a retired member's name is a different path and must
+    /// keep reconciling.
+    #[test]
+    fn a_sibling_sharing_a_name_prefix_is_not_covered() {
+        let retired = RetiredGraphOnlyMembers::default();
+        retired.retire([&path("vendor/dependency")]);
+        assert!(!retired.covers(&path("vendor/dependency-notes.md")));
+        assert!(!retired.covers(&path("vendor/other/lib.rs")));
+        assert!(!retired.covers(&path("vendor")));
+    }
+
+    #[test]
+    fn a_member_restored_by_a_later_transition_stops_being_retired() {
+        let retired = RetiredGraphOnlyMembers::default();
+        retired.retire([&path("vendor/dependency")]);
+        retired.forget_live_members([&path("vendor/dependency")]);
+        assert!(!retired.covers(&path("vendor/dependency/nested/owned.txt")));
+        assert!(retired.snapshot().is_empty());
+    }
+
+    #[test]
+    fn an_explicit_sweep_forgets_every_retirement() {
+        let retired = RetiredGraphOnlyMembers::default();
+        retired.retire([&path("vendor/dependency"), &path("vendor/other")]);
+        retired.clear();
+        assert!(!retired.covers(&path("vendor/dependency/nested/owned.txt")));
+        assert!(!retired.covers(&path("vendor/other/lib.rs")));
+    }
+}

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -119,6 +119,7 @@ pub mod background_work;
 pub mod commit_deltas;
 pub mod daemon;
 pub mod error;
+pub mod graph_only_members;
 pub mod lifecycle;
 mod local_repository_authority;
 pub mod loop_runner;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -499,14 +499,7 @@ fn exact_tree_admission(
         .artifacts_by_path()
         .map(|artifact| artifact.path.clone())
         .collect::<Vec<_>>();
-    let mut graph_only_paths = Vec::new();
-    for artifact in previous.artifacts_by_path() {
-        if kin_core::source_projection_disposition(&artifact.path, artifact.entry)?
-            != kin_core::SourceProjectionDisposition::Materialized
-        {
-            graph_only_paths.push(artifact.path.clone());
-        }
-    }
+    let graph_only_paths = crate::graph_only_members::members_of(&previous)?;
     let ignore =
         kin_index::RepositoryIgnore::load(working_dir).map_err(kin_index::IndexError::from)?;
     // A rule that begins matching an already-admitted path retracts it. Ignoring
@@ -572,20 +565,35 @@ fn exact_tree_admission(
         // explicit pass will. The scan behind this is complete, so each pass
         // replaces the previous answer instead of adding to it, and the explicit
         // seam below replaces it again the moment one takes what was left.
+        //
+        // A retired graph-only member takes its host subtree out of the bound
+        // for the same reason, and it is the half that cannot be decided from
+        // this tree alone. Content beneath a Gitlink was written while the
+        // Gitlink still stood, so the events naming it were never observations
+        // of this repository's projection. They keep arriving after a transition
+        // removes the member, and this tree no longer remembers that it was
+        // there, so without the retirement they read as ordinary new files and
+        // one branch switch leaves the workspace ahead of the base it was just
+        // made level with. The paths stay in the untracked report either way, so
+        // an explicit seam still sweeps them and says what it took.
+        //
+        // The retired set is read once for the whole pass rather than per path.
+        // It is small and usually empty, but `observed` is the working copy.
+        let retired = state.retired_graph_only_members.snapshot();
+        let admissible = |path: &RepoPath| {
+            observation_covers_path(observation, path)
+                && !crate::graph_only_members::covered_by(&retired, path)
+        };
         state
             .background_work
             .reconcile()
             .record_untracked_observation(
                 observed.entries().keys().filter(|path| {
-                    previous.artifact_id_at_path(path).is_none()
-                        && !observation_covers_path(observation, path)
+                    previous.artifact_id_at_path(path).is_none() && !admissible(path)
                 }),
                 excluded_host_content(&scan),
             );
-        observed.retain(|path, _| {
-            previous.artifact_id_at_path(path).is_some()
-                || observation_covers_path(observation, path)
-        });
+        observed.retain(|path, _| previous.artifact_id_at_path(path).is_some() || admissible(path));
     }
     // A bounded tick re-inserts every tracked path its observation did not
     // cover, which would restore the paths the rules just retracted. Editing
@@ -687,6 +695,11 @@ fn exact_tree_admission(
                 std::iter::empty::<&RepoPath>(),
                 excluded_host_content(&scan),
             );
+        // The same pass took whatever the retirements were holding back, so they
+        // have served their purpose. A caller who explicitly admits the subtree
+        // under a removed Gitlink has said outright that the content is theirs,
+        // and ambient observation resumes over it from here.
+        state.retired_graph_only_members.clear();
     }
 
     Ok(ExactTreeAdmission {
@@ -2832,6 +2845,140 @@ mod tests {
         ));
         assert_eq!(tree_entry(&state, "submodule"), Some(gitlink));
         assert!(tree_entry(&state, "submodule/src/lib.rs").is_none());
+    }
+
+    /// Stage the shape of the branch-switch race without racing anything.
+    ///
+    /// A Gitlink stands, host content is written beneath it, the member is
+    /// removed, and only then does the watcher event for that content reach
+    /// admission. That is exactly what a switch produces when its watcher
+    /// backlog outlives the transition, and the ordering here is fixed rather
+    /// than raced, so the assertion does not depend on any timing.
+    fn state_whose_gitlink_was_removed_under_a_pending_event(
+        repo: &tempfile::TempDir,
+    ) -> (Arc<DaemonState>, std::path::PathBuf) {
+        let state = open_test_state(repo);
+        let gitlink = TreeEntry::gitlink(kin_model::GitObjectId::sha1([0x5a; 20]));
+        let artifact_id = kin_model::ArtifactId::new();
+        let member = test_repo_path("submodule");
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id,
+                    new: kin_model::LocatedEntry::new(member.clone(), gitlink),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        std::fs::create_dir_all(repo.path().join("submodule/src")).unwrap();
+        let nested = repo.path().join("submodule/src/lib.rs");
+        std::fs::write(&nested, b"independent checkout content").unwrap();
+        state
+            .graph
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Removed {
+                    artifact_id,
+                    old: kin_model::LocatedEntry::new(member, gitlink),
+                }],
+                ..TransactionDelta::default()
+            })
+            .unwrap();
+        (state, nested)
+    }
+
+    /// The fix. The transition retired the member, so the host content beneath
+    /// it stays out of the workspace however late its event arrives.
+    #[test]
+    fn a_retired_gitlink_keeps_its_host_subtree_out_of_ambient_admission() {
+        let repo = tempfile::tempdir().unwrap();
+        let (state, nested) = state_whose_gitlink_was_removed_under_a_pending_event(&repo);
+        state
+            .retired_graph_only_members
+            .retire([&test_repo_path("submodule")]);
+
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(nested)).unwrap();
+        assert!(
+            matches!(admitted, AdmittedFileEvent::Untracked { .. }),
+            "content beneath a retired member is untracked, not admitted: {admitted:?}"
+        );
+        assert!(
+            tree_entry(&state, "submodule/src/lib.rs").is_none(),
+            "a removed Gitlink must not hand its host subtree to the workspace"
+        );
+        let report = state
+            .background_work
+            .reconcile()
+            .report(std::time::Instant::now());
+        assert_eq!(
+            report.untracked_paths_sample,
+            vec!["submodule/src/lib.rs"],
+            "the content is reported rather than hidden, so an explicit seam can take it"
+        );
+    }
+
+    /// The control that proves the assertion above can fail. Without the
+    /// retirement, the identical sequence admits the nested content, which is
+    /// the defect: the workspace goes ahead of the base a switch just made it
+    /// level with, and the next switch refuses.
+    #[test]
+    fn without_the_retirement_a_removed_gitlink_leaks_its_host_subtree() {
+        let repo = tempfile::tempdir().unwrap();
+        let (state, nested) = state_whose_gitlink_was_removed_under_a_pending_event(&repo);
+
+        admit_file_event_ambient(&state, &FileEvent::Changed(nested)).unwrap();
+        assert!(
+            tree_entry(&state, "submodule/src/lib.rs").is_some(),
+            "this control exists to fail the day the leak stops reproducing without a retirement"
+        );
+    }
+
+    /// An explicit admission seam takes what the retirement was holding back,
+    /// and ambient observation resumes over the subtree afterwards.
+    #[test]
+    fn an_explicit_seam_sweeps_a_retired_subtree_and_ends_the_retirement() {
+        let repo = tempfile::tempdir().unwrap();
+        let (state, nested) = state_whose_gitlink_was_removed_under_a_pending_event(&repo);
+        state
+            .retired_graph_only_members
+            .retire([&test_repo_path("submodule")]);
+
+        admit_file_event(&state, &FileEvent::Changed(nested.clone())).unwrap();
+        assert!(
+            tree_entry(&state, "submodule/src/lib.rs").is_some(),
+            "an explicit seam admits every host path the complete walk met"
+        );
+        assert!(
+            state.retired_graph_only_members.snapshot().is_empty(),
+            "the sweep is the caller saying the subtree is theirs"
+        );
+
+        std::fs::write(&nested, b"edited after the explicit sweep").unwrap();
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(nested)).unwrap();
+        let AdmittedFileEvent::Regular { tree_changed, .. } = admitted else {
+            panic!("an edit under a swept subtree is ordinary content now: {admitted:?}");
+        };
+        assert!(tree_changed);
+    }
+
+    /// A retirement is scoped to its own subtree. Nothing else in the working
+    /// copy stops being ambiently admissible because one Gitlink went away.
+    #[test]
+    fn a_retirement_leaves_the_rest_of_the_working_copy_admissible() {
+        let repo = tempfile::tempdir().unwrap();
+        let (state, _) = state_whose_gitlink_was_removed_under_a_pending_event(&repo);
+        state
+            .retired_graph_only_members
+            .retire([&test_repo_path("submodule")]);
+
+        let sibling = repo.path().join("sibling.rs");
+        std::fs::write(&sibling, b"pub fn sibling() -> u32 { 1 }\n").unwrap();
+        let admitted = admit_file_event_ambient(&state, &FileEvent::Changed(sibling)).unwrap();
+        assert!(
+            !matches!(admitted, AdmittedFileEvent::Untracked { .. }),
+            "an unrelated new file is still admitted from the act of writing it: {admitted:?}"
+        );
+        assert!(tree_entry(&state, "sibling.rs").is_some());
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1268,6 +1268,11 @@ pub struct DaemonState {
     /// daemon-health signal; cleared on the next tick whose deletions are within
     /// the anti-wipe threshold.
     pub mass_deletion_blocked: AtomicBool,
+    /// Repository paths that were graph-only members until a transition dropped
+    /// them. Host content beneath one was on disk while the member still stood,
+    /// so it is pre-existing content rather than something ambient observation
+    /// saw arrive, however late the watcher event naming it drains.
+    pub retired_graph_only_members: crate::graph_only_members::RetiredGraphOnlyMembers,
     /// True when the background embedding worker has permanently stopped (it
     /// exhausted its consecutive-panic budget). The graph/locate/reconcile
     /// surfaces keep serving — embeddings are a DERIVED index — but the vector
@@ -2280,6 +2285,7 @@ impl DaemonState {
             is_shutdown: AtomicBool::new(false),
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
+            retired_graph_only_members: Default::default(),
             embed_worker_failed: AtomicBool::new(false),
             derived_views_stale: RwLock::new(None),
             mcp_transactions: Mutex::new(HashMap::new()),
@@ -2498,6 +2504,7 @@ impl DaemonState {
             is_shutdown: AtomicBool::new(false),
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
+            retired_graph_only_members: Default::default(),
             embed_worker_failed: AtomicBool::new(false),
             derived_views_stale: RwLock::new(None),
             mcp_transactions: Mutex::new(HashMap::new()),
@@ -4194,6 +4201,29 @@ impl DaemonState {
             )));
         }
 
+        // Record what this transition does to graph-only membership before the
+        // query tree moves. Every repository transition seam finalizes here, so
+        // this is the one place that sees both sides of one, and taking the
+        // verdict from the transition rather than from the tree afterwards is
+        // what makes it independent of when a watcher event drains: until the
+        // apply below, a member is live and ambient observation drops events
+        // beneath it; from here on it is retired and the host content under it
+        // is reported untracked instead of admitted as something newly written.
+        let previous_members = crate::graph_only_members::members_of(expected_previous_tree)
+            .map_err(|error| {
+                DaemonError::Graph(kin_db::KinDbError::StorageError(format!(
+                    "cannot read graph-only members of the repository transition base: {error}"
+                )))
+            })?;
+        let desired_members =
+            crate::graph_only_members::members_of(desired_tree).map_err(|error| {
+                DaemonError::Graph(kin_db::KinDbError::StorageError(format!(
+                    "cannot read graph-only members of the repository transition result: {error}"
+                )))
+            })?;
+        self.retired_graph_only_members
+            .retire(previous_members.difference(&desired_members));
+
         let authority_snapshot = authority_graph.to_snapshot();
         let live_snapshot = self.graph.to_snapshot();
         let semantics = kin_core::diff_workspace_semantics(
@@ -4242,6 +4272,12 @@ impl DaemonState {
                     .to_string(),
             )));
         }
+        // A path this transition restored as a graph-only member is covered by
+        // the live rule again from here on, so its retirement has nothing left
+        // to do. Dropped after the apply rather than before it, so the two rules
+        // never hand off through a gap.
+        self.retired_graph_only_members
+            .forget_live_members(&desired_members);
 
         let generation_advanced = live_generation == receipt.roots_before.generation;
         if generation_advanced {


### PR DESCRIPTION
The reconcile loop drops watcher events beneath a graph-only repository member, but it read that membership off the tree as it stood when the events were drained. A branch switch that removes a Gitlink while events for its host subtree are still queued therefore left those events looking like ordinary new files, ambient admission swept the nested checkout into the workspace, and the next switch refused because the workspace was ahead of the base the previous switch had just made it level with.

Membership is now recorded by the transition that drops the member. Every repository transition seam finalizes through `finalize_local_repository_commit`, so that is where both sides of a transition are in hand: the graph-only members the transition drops are retired there, before the query tree advances. Ambient admission then excludes retired subtrees from its observation bound. Between the retire and the apply there are only reads and a preflight against a copy, so at every instant either the member is live and the drain filter drops the event, or the path is retired and admission excludes it. No interval exists where neither holds, which is what makes the verdict independent of when an event arrives rather than merely narrowing the window.

Retired content stays visible. It is counted and named by the untracked-content surfaces exactly like any other host content the walk declined to take, so an explicit admission seam still sweeps it and reports what it took. Sweeping ends the retirement, as does a later transition that restores the member.

Nothing else can drop a graph-only member. `observed_tree_from_complete_scan` seeds the observed tree with every Gitlink from the previous tree before it reads the scan, and `tracked_paths_retracted_by_ignore` strips graph-only paths from the retracted set, so an ambient tick can neither plan a Gitlink removal nor retract one by rule.

Measured on the test this race was flaking, 25 runs per arm on one box in one session: 18 pass and 7 fail before, 25 pass and 0 fail after. Every baseline failure carried the recorded 409 signature over `vendor/dependency/nested/owned.txt` and `vendor/dependency/untracked.bin`, and all of them landed on the final switch rather than on the settle assertion, which is the bounded wait narrowing this race without closing it.

The new tests stage the same ordering without racing it, and ship a control that admits the content when the retirement is absent, so the positive assertion is known to be able to fail.

Full gate from the lane worktree: 5520 tests run, 5520 passed, 11 skipped, plus doctests.

Closes FIR-2187
Part of FIR-2220