### PR TITLE
Record graph-truth freshness durably and state it on kin graph status

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -82,7 +82,35 @@ pub enum EntitySourceOutcome {
 /// `kin graph status` — quick health check of the semantic graph.
 pub async fn status() -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
-    print_graph_response(run_daemon_graph(&layout, &GraphCommandRequest::Status).await?)
+    let mut response = run_daemon_graph(&layout, &GraphCommandRequest::Status).await?;
+    append_freshness_line(
+        &mut response.lines,
+        &kin_core::last_admission::read(&layout),
+        chrono::Utc::now(),
+    );
+    print_graph_response(response)
+}
+
+/// State how fresh the graph truth being reported actually is.
+///
+/// Read here rather than asked of the daemon, the same way the MCP path reads
+/// the durable authority-head marker straight off disk. The daemon's own report
+/// is scoped to the graph it holds in memory, and freshness is a property of the
+/// store on disk, which the CLI is standing in.
+///
+/// Appended unconditionally. Every other line in this report can be absent when
+/// there is nothing to say, but "how old is this" has no such state: a report
+/// that stays silent about freshness is exactly what let a months-behind store
+/// answer with a clean bill of health. When the record is missing or unreadable
+/// the line says the freshness is unknown, which is a different and more useful
+/// answer than nothing.
+fn append_freshness_line(
+    lines: &mut Vec<String>,
+    freshness: &kin_core::last_admission::LastAdmissionRead,
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    lines.push(String::new());
+    lines.push(format!("ℹ graph truth: {}", freshness.describe(now)));
 }
 
 /// `kin graph validate` — structural integrity checks.
@@ -1058,6 +1086,65 @@ mod tests {
         SemanticFingerprint, SourceSpan, TreeEntry, Visibility,
     };
     use std::fs;
+
+    mod freshness {
+        use super::super::append_freshness_line;
+        use chrono::TimeZone;
+        use kin_core::last_admission::{LastAdmission, LastAdmissionRead};
+
+        fn at(secs: i64) -> chrono::DateTime<chrono::Utc> {
+            chrono::Utc.timestamp_opt(secs, 0).unwrap()
+        }
+
+        fn rendered(read: &LastAdmissionRead, now: i64) -> String {
+            let mut lines = Vec::new();
+            append_freshness_line(&mut lines, read, at(now));
+            lines.join("\n")
+        }
+
+        /// The Aug-11 store, stated as a test: months behind, and the report has
+        /// to say so with an order of magnitude and a coverage count.
+        #[test]
+        fn a_store_months_behind_reports_its_age_and_coverage() {
+            let read = LastAdmissionRead::Recorded(LastAdmission::new(at(0), 31));
+            let out = rendered(&read, 86_400 * 70);
+            assert!(out.contains("70d"), "expected a day-scale age: {out}");
+            assert!(
+                out.contains("31 tracked artifact"),
+                "expected the coverage count: {out}"
+            );
+        }
+
+        /// The property that kills the false all-clear: a healthy, current store
+        /// still emits the freshness line. If freshness were only reported when
+        /// something looked wrong, a reader could never tell silence from health.
+        #[test]
+        fn a_current_store_still_states_its_freshness() {
+            let read = LastAdmissionRead::Recorded(LastAdmission::new(at(1_000), 125));
+            let out = rendered(&read, 1_030);
+            assert!(
+                out.contains("graph truth:"),
+                "a current store must still state freshness: {out}"
+            );
+            assert!(out.contains("30s"), "expected a fresh age: {out}");
+        }
+
+        /// Absent and unreadable both have to reach the reader as unknown, never
+        /// as silence and never as current.
+        #[test]
+        fn unknown_freshness_is_stated_rather_than_omitted() {
+            for read in [
+                LastAdmissionRead::Absent,
+                LastAdmissionRead::Unreadable("truncated".to_string()),
+            ] {
+                let out = rendered(&read, 500);
+                assert!(
+                    out.contains("unknown"),
+                    "unknown freshness must be stated: {out}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn graph_entity_not_found_lines_keep_signal_and_offer_next_steps() {

--- a/crates/kin-core/src/last_admission.rs
+++ b/crates/kin-core/src/last_admission.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Durable record of when a complete exact-tree admission last succeeded.
+//!
+//! The reconcile probes already know this fact and already publish it as
+//! `last_admission_success_at`. They hold it in daemon memory, so a restart
+//! erases it and every freshness surface then reports that no admission has ever
+//! succeeded in this daemon's life. A store last admitted months ago therefore
+//! reads exactly like one admitted a second ago, and a quiescent store produces
+//! no failures to trip the one age clock that reaches a verdict. That is how a
+//! graph can fall arbitrarily far behind its repository while every status
+//! surface prints the all-clear.
+//!
+//! This marker is the durable half. It is deliberately NOT written by the
+//! generation-publish path, which also runs on daemon startup: stamping it there
+//! would refresh the timestamp on every restart and manufacture the false
+//! freshness the marker exists to prevent. It is written only where an admission
+//! actually completed.
+//!
+//! Reads are three-way on purpose. Absent and unreadable are different answers,
+//! and neither may be collapsed into "current". A surface that turns an
+//! unreadable marker into a zero age, or into silence, reintroduces the defect in
+//! a new place.
+
+use crate::layout::KinLayout;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Schema token carried in the marker so a future format change is legible
+/// rather than silently misparsed.
+pub const LAST_ADMISSION_SCHEMA: &str = "kin.last-admission.v1";
+
+/// When a complete exact-tree admission last succeeded, and how much of the tree
+/// it left behind.
+///
+/// `tracked_artifacts` is recorded beside the timestamp because age alone cannot
+/// distinguish a store that is current from one whose admission succeeded while
+/// covering a fraction of the repository. A reader comparing this count to what
+/// the repository actually holds is how "31 of 125 files" becomes a number
+/// instead of a silence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LastAdmission {
+    pub schema: String,
+    pub at: DateTime<Utc>,
+    pub tracked_artifacts: u64,
+}
+
+impl LastAdmission {
+    pub fn new(at: DateTime<Utc>, tracked_artifacts: u64) -> Self {
+        Self {
+            schema: LAST_ADMISSION_SCHEMA.to_string(),
+            at,
+            tracked_artifacts,
+        }
+    }
+
+    /// Whole seconds between this admission and `now`.
+    ///
+    /// Saturates at zero rather than going negative. A marker stamped slightly
+    /// ahead of the reader's clock is a clock-skew artifact, and reporting a
+    /// negative age would make a surface look broken where the honest answer is
+    /// "as good as current".
+    pub fn age_seconds(&self, now: DateTime<Utc>) -> u64 {
+        let seconds = now.signed_duration_since(self.at).num_seconds();
+        if seconds <= 0 {
+            0
+        } else {
+            seconds as u64
+        }
+    }
+}
+
+/// The outcome of consulting the marker.
+///
+/// Three variants rather than an `Option` because the surfaces have three honest
+/// things to say. A store with no marker has either never been admitted or was
+/// admitted by a build that predates this record, and in both cases the age is
+/// unknown rather than zero. A marker that exists but will not parse is a
+/// different and louder fact: something wrote or truncated it, and pretending it
+/// is merely absent hides that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LastAdmissionRead {
+    Recorded(LastAdmission),
+    Absent,
+    Unreadable(String),
+}
+
+impl LastAdmissionRead {
+    /// The recorded admission, when there is one.
+    pub fn recorded(&self) -> Option<&LastAdmission> {
+        match self {
+            Self::Recorded(recorded) => Some(recorded),
+            Self::Absent | Self::Unreadable(_) => None,
+        }
+    }
+
+    /// One line naming the freshness of graph truth, for a status surface.
+    ///
+    /// Every variant produces a line. That is the point: a surface that prints
+    /// nothing when the answer is unknown is indistinguishable from one reporting
+    /// a healthy store, which is the failure this whole marker exists to end.
+    pub fn describe(&self, now: DateTime<Utc>) -> String {
+        match self {
+            Self::Recorded(recorded) => {
+                let age = recorded.age_seconds(now);
+                format!(
+                    "last complete admission {} ({} ago), covering {} tracked artifact(s)",
+                    recorded.at.to_rfc3339(),
+                    humanize_age(age),
+                    recorded.tracked_artifacts
+                )
+            }
+            Self::Absent => "no complete admission is recorded for this store, so how far graph \
+                             truth has fallen behind the repository is unknown; run `kin admit` \
+                             to admit the complete exact tree and record one"
+                .to_string(),
+            Self::Unreadable(reason) => format!(
+                "the last-admission record could not be read ({reason}), so freshness is unknown \
+                 rather than current; run `kin admit` to rewrite it"
+            ),
+        }
+    }
+}
+
+/// Render an age in the largest unit that stays honest.
+///
+/// Seconds for the first minute, then minutes, hours, days. A reader deciding
+/// whether to trust a store cares about the order of magnitude, and "893821s"
+/// buries it.
+pub fn humanize_age(seconds: u64) -> String {
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+    if seconds < MINUTE {
+        format!("{seconds}s")
+    } else if seconds < HOUR {
+        format!("{}m", seconds / MINUTE)
+    } else if seconds < DAY {
+        format!("{}h", seconds / HOUR)
+    } else {
+        format!("{}d", seconds / DAY)
+    }
+}
+
+/// Read the durable marker for `layout`.
+///
+/// Never fails: a missing marker is [`LastAdmissionRead::Absent`] and anything
+/// unparseable is [`LastAdmissionRead::Unreadable`], both of which the surfaces
+/// can state honestly. A read error must not be able to present as freshness.
+pub fn read(layout: &KinLayout) -> LastAdmissionRead {
+    let path = layout.kindb_last_admission_path();
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return LastAdmissionRead::Absent
+        }
+        Err(error) => return LastAdmissionRead::Unreadable(error.to_string()),
+    };
+    match serde_json::from_str::<LastAdmission>(&raw) {
+        Ok(recorded) if recorded.schema == LAST_ADMISSION_SCHEMA => {
+            LastAdmissionRead::Recorded(recorded)
+        }
+        Ok(recorded) => LastAdmissionRead::Unreadable(format!(
+            "schema {} is not {LAST_ADMISSION_SCHEMA}",
+            recorded.schema
+        )),
+        Err(error) => LastAdmissionRead::Unreadable(error.to_string()),
+    }
+}
+
+/// Write the durable marker for `layout`, atomically.
+///
+/// Staged beside the target and renamed into place after an fsync, then the
+/// directory metadata is synced, so a crash mid-write leaves either the previous
+/// record or the new one and never a truncated file that would read as
+/// unreadable forever. This mirrors how the durable authority head marker beside
+/// it is published.
+pub fn write(layout: &KinLayout, recorded: &LastAdmission) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let path = layout.kindb_last_admission_path();
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("last-admission path has no parent directory"))?;
+    std::fs::create_dir_all(parent)?;
+    let staged = path.with_extension(format!("tmp-{}", std::process::id()));
+    let body = serde_json::to_vec(recorded).map_err(std::io::Error::other)?;
+    {
+        let mut file = std::fs::File::create(&staged)?;
+        file.write_all(&body)?;
+        file.sync_all()?;
+    }
+    if let Err(error) = std::fs::rename(&staged, &path) {
+        let _ = std::fs::remove_file(&staged);
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn layout_in(dir: &std::path::Path) -> KinLayout {
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("kindb")).unwrap();
+        KinLayout::new(kin_dir)
+    }
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    #[test]
+    fn a_written_record_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        let recorded = LastAdmission::new(at(1_000_000), 125);
+        write(&layout, &recorded).unwrap();
+        assert_eq!(read(&layout), LastAdmissionRead::Recorded(recorded));
+    }
+
+    /// The durability property this whole marker exists for. A record survives
+    /// being read by a process that never wrote it, which is what a daemon
+    /// restart looks like from the reader's side.
+    #[test]
+    fn a_record_survives_a_reader_that_did_not_write_it() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let layout = layout_in(dir.path());
+            write(&layout, &LastAdmission::new(at(500), 7)).unwrap();
+        }
+        let reopened = layout_in(dir.path());
+        let read_back = read(&reopened);
+        assert_eq!(
+            read_back.recorded().map(|r| r.tracked_artifacts),
+            Some(7),
+            "a durable marker must outlive the process that wrote it"
+        );
+    }
+
+    #[test]
+    fn a_missing_marker_is_absent_and_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        assert_eq!(read(&layout), LastAdmissionRead::Absent);
+        let line = read(&layout).describe(at(0));
+        assert!(
+            line.contains("unknown"),
+            "an absent marker must report unknown freshness, not silence: {line}"
+        );
+    }
+
+    /// Absent and unreadable must not collapse into each other, and neither may
+    /// present as a current store.
+    #[test]
+    fn a_corrupt_marker_is_unreadable_rather_than_absent_or_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        std::fs::write(layout.kindb_last_admission_path(), b"{ truncated").unwrap();
+        let read_back = read(&layout);
+        assert!(
+            matches!(read_back, LastAdmissionRead::Unreadable(_)),
+            "a corrupt marker must be unreadable, got {read_back:?}"
+        );
+        let line = read_back.describe(at(0));
+        assert!(
+            line.contains("unknown"),
+            "an unreadable marker must not read as current: {line}"
+        );
+    }
+
+    #[test]
+    fn a_wrong_schema_is_unreadable_rather_than_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        std::fs::write(
+            layout.kindb_last_admission_path(),
+            br#"{"schema":"kin.last-admission.v0","at":"2026-08-02T16:10:00Z","tracked_artifacts":31}"#,
+        )
+        .unwrap();
+        assert!(matches!(read(&layout), LastAdmissionRead::Unreadable(_)));
+    }
+
+    #[test]
+    fn a_rewrite_replaces_the_previous_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = layout_in(dir.path());
+        write(&layout, &LastAdmission::new(at(100), 1)).unwrap();
+        write(&layout, &LastAdmission::new(at(200), 2)).unwrap();
+        let read_back = read(&layout);
+        assert_eq!(read_back.recorded().map(|r| r.tracked_artifacts), Some(2));
+        assert_eq!(read_back.recorded().map(|r| r.at), Some(at(200)));
+    }
+
+    #[test]
+    fn age_saturates_at_zero_under_clock_skew() {
+        let recorded = LastAdmission::new(at(1_000), 3);
+        assert_eq!(recorded.age_seconds(at(1_060)), 60);
+        assert_eq!(
+            recorded.age_seconds(at(900)),
+            0,
+            "a marker ahead of the reader's clock must not report a negative age"
+        );
+    }
+
+    #[test]
+    fn age_is_rendered_in_the_largest_honest_unit() {
+        assert_eq!(humanize_age(45), "45s");
+        assert_eq!(humanize_age(600), "10m");
+        assert_eq!(humanize_age(7_200), "2h");
+        assert_eq!(humanize_age(864_000), "10d");
+    }
+
+    /// The months-behind case from the Aug-11 dogfood, stated as a test: the
+    /// describe line has to carry an order of magnitude a reader can act on.
+    #[test]
+    fn a_months_old_record_reports_days_not_seconds() {
+        let recorded = LastAdmission::new(at(0), 31);
+        let line = LastAdmissionRead::Recorded(recorded).describe(at(86_400 * 70));
+        assert!(line.contains("70d"), "expected a day-scale age: {line}");
+        assert!(
+            line.contains("31 tracked artifact"),
+            "expected the coverage count beside the age: {line}"
+        );
+    }
+}

--- a/crates/kin-core/src/last_admission.rs
+++ b/crates/kin-core/src/last_admission.rs
@@ -196,6 +196,28 @@ pub fn write(layout: &KinLayout, recorded: &LastAdmission) -> std::io::Result<()
         let _ = std::fs::remove_file(&staged);
         return Err(error);
     }
+    sync_directory_metadata(parent)?;
+    Ok(())
+}
+
+/// Sync the containing directory so the rename that published the marker is
+/// itself durable.
+///
+/// A rename is only as durable as the directory entry recording it. Syncing the
+/// staged file alone leaves a window where a crash loses the publication even
+/// though the bytes reached the platter, which is exactly the restart this
+/// record exists to survive. This is the step that makes the atomic publish
+/// above mirror the authority head marker beside it rather than merely resemble
+/// it.
+#[cfg(unix)]
+fn sync_directory_metadata(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::File::open(path).and_then(|directory| directory.sync_all())
+}
+
+/// Non-unix platforms expose no portable directory handle to sync, so the
+/// rename's own ordering guarantees are all there is.
+#[cfg(not(unix))]
+fn sync_directory_metadata(_path: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -124,6 +124,25 @@ impl KinLayout {
         self.kindb_dir().join("head-generation")
     }
 
+    /// `.kin/kindb/last-admission` — when a complete exact-tree admission last
+    /// succeeded.
+    ///
+    /// Durable rather than in-process on purpose. The reconcile probes already
+    /// record this, but they record it in daemon memory, so a restart erases it
+    /// and every freshness surface reports that no admission has ever succeeded.
+    /// A store that has not been admitted since March then reads the same as one
+    /// admitted a second ago, which is the whole defect: nothing a reader can
+    /// consult says how far graph truth has fallen behind the repository.
+    ///
+    /// Deliberately not written by the generation-publish path. That path also
+    /// runs on daemon startup, so stamping it there would refresh the timestamp
+    /// on every restart and manufacture exactly the false freshness this marker
+    /// exists to prevent. It is written only where an admission actually
+    /// succeeded.
+    pub fn kindb_last_admission_path(&self) -> PathBuf {
+        self.kindb_dir().join("last-admission")
+    }
+
     /// `.kin/kindb/graph.kvec` — persisted vector index aligned with the snapshot.
     pub fn kindb_vector_index_path(&self) -> PathBuf {
         self.kindb_snapshot_path().with_extension("kvec")

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod hooks;
 pub mod init;
 mod init_progress;
 mod init_staging;
+pub mod last_admission;
 pub mod layout;
 pub mod manifest;
 pub mod ranking;

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -603,6 +603,32 @@ impl RecordedFault {
     }
 }
 
+/// Persist the durable last-admission marker after a complete pass succeeded.
+///
+/// Called beside [`ReconcileProbes::record_admission_success`] rather than from
+/// inside it, for two reasons. The probes hold a mutex while they record, and
+/// doing file I/O under it would put a disk write on a lock every admission
+/// waits behind. And the probes deliberately know nothing about the store's
+/// layout, which keeps them a pure in-memory disclosure.
+///
+/// A write failure is logged and swallowed. An admission that succeeded did
+/// succeed, and turning a marker-write failure into an admission failure would
+/// report an admitted tree as unadmitted, which is a worse lie than the one this
+/// marker fixes. The failure direction is also the safe one: an unwritten marker
+/// leaves the previous, older timestamp in place, so the store reads as staler
+/// than it is and never as fresher.
+pub fn record_durable_admission(layout: &kin_core::KinLayout, tracked_artifacts: u64) {
+    let recorded =
+        kin_core::last_admission::LastAdmission::new(chrono::Utc::now(), tracked_artifacts);
+    if let Err(error) = kin_core::last_admission::write(layout, &recorded) {
+        tracing::warn!(
+            error = %error,
+            "could not persist the last-admission marker; freshness surfaces will report the \
+             previous admission until the next pass rewrites it"
+        );
+    }
+}
+
 /// What the filesystem reconciliation loop has actually managed to admit.
 ///
 /// The loop already knew every fact here. It logged an admission failure at

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1557,6 +1557,10 @@ pub async fn run_loop(
                     .background_work
                     .reconcile()
                     .record_admission_success(Instant::now());
+                crate::background_work::record_durable_admission(
+                    &state.layout,
+                    state.graph.resolved_tree().len() as u64,
+                );
                 admission
             }
             Err(error) => {

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -213,6 +213,15 @@ async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
     // on exactly the path where an operator most needs to know it did.
     // `summary_lines` derives its wording from the two sides instead.
     let after = census(state);
+
+    // The durable freshness marker is stamped from the after side, and only for
+    // a pass that succeeded. Stamping a failed pass would record that the store
+    // is current at the exact moment it was refused, which is the false
+    // freshness this marker exists to prevent, reached by the other door.
+    if failure.is_none() {
+        crate::background_work::record_durable_admission(&state.layout, after.tracked as u64);
+    }
+
     let embeddings = state.graph.embedding_status();
     let report = AdmitReport {
         schema: ADMIT_SCHEMA.to_string(),

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -337,6 +337,20 @@
       ]
     },
     {
+      "file": "crates/kin-core/src/last_admission.rs",
+      "reason": "Durable bookkeeping marker published beside the authority head, not an answer authority. The excused bodies read and write .kin/kindb/last-admission, which records when a complete exact-tree admission last succeeded and how many artifacts it covered. It is written only where an admission actually completed and read only by freshness surfaces, which is what lets `kin graph status` state how far graph truth has fallen behind instead of printing an all-clear over a store admitted months ago. The record names no entity, carries no repository content, and cannot change what any query returns: a reader that lied in either direction would change only the wording of a freshness line, never a locate, search, context, trace, review, or xref answer. Publication is a temp-and-rename with an fsync of the staged file and then of the containing directory, the same shape write_generation_marker and read_generation_marker in crates/kin-daemon/src/state.rs use for the authority head marker this sits beside, and the two cfg-gated sync_directory_metadata bodies are that directory fsync. Routing through a shared boundary helper instead was not available: kin-core exposes no public atomic-write path, and config.rs, registry.rs, and the daemon's state.rs each open-code their own. Function-scoped rather than whole-file so the rest of the module stays scanned, including the three-way read classification and the age arithmetic the surfaces render, and so any newly added filesystem primitive here fails the guard until it is justified.",
+      "owner": "kin-core",
+      "expiration": "2026-12-31",
+      "allow_fn": [
+        "read",
+        "write",
+        {
+          "fn": "sync_directory_metadata",
+          "count": 2
+        }
+      ]
+    },
+    {
       "file": "crates/kin-daemon/src/loop_runner.rs",
       "reason": "Host event ingestion boundary. The excused bodies are the file watcher's admission path: reading a host file or symlink target and its mode so the change can be admitted into the graph as exact tree state, and comparing a host entry against what the graph already holds so an unchanged file is not re-admitted. Reading the working tree is the entire job of an ingestion boundary, and the result is written into graph truth rather than returned as an answer. The remaining three are repository binding, which precedes any graph consult: recognizing a bare git layout, canonicalizing a host parent while preserving the leaf, and resolving a path relative to the bound root. The cfg-gated executable-bit helper is the pair that carries a count of two. Function-scoped so the rest of the runner stays scanned.",
       "owner": "kin-daemon",


### PR DESCRIPTION
A store whose graph had not been admitted in months reported a clean bill of health, and nothing a reader could consult said otherwise. The reconcile probes already knew when an admission last succeeded, but they held it in daemon memory, so a restart erased it and the surfaces then reported that no admission had ever succeeded in this daemon's life. The one age clock that could reach a verdict was gated behind three consecutive admission failures, and a quiescent store produces no failures at all. So a graph could fall arbitrarily far behind its repository while every status surface printed the all-clear.

This lands the durable record and the first surface that states it.

The record is a marker beside the durable authority-head marker, written atomically the same way, carrying the admission time and the tracked-artifact count that admission left behind. The count rides along because age alone cannot separate a current store from one whose admission succeeded while covering a fraction of the tree, which is the shape the Aug-11 dogfood actually hit: 31 of 125 tracked files served with nothing disclosing it.

Where it is written matters as much as what it holds. It is deliberately not written by the generation-publish path, because that path also runs on daemon startup, so stamping it there would refresh the timestamp on every restart and manufacture exactly the false freshness the marker exists to prevent. It is written only where an admission actually completed, which is both such places: the ambient watcher tick and the on-demand `kin admit` seam. Covering one and not the other would make a store's reported freshness depend on which door its last admission came through. On the requested path it is stamped from the after census and only for a pass that succeeded, since stamping a refused pass would record the store as current at the moment it was refused.

The write sits beside the probe call rather than inside it. The probes hold a mutex while recording, so file I/O under it would put a disk write on a lock every admission waits behind, and the probes deliberately know nothing about the store's layout, which keeps them a pure in-memory disclosure. A write failure is logged and swallowed: an admission that succeeded did succeed, and failing it over a marker write would report an admitted tree as unadmitted, a worse lie than the one being fixed. The failure direction is the safe one, since the previous older timestamp stays and the store reads staler than it is rather than fresher.

Reads are three-way rather than optional. Absent and unreadable are different answers and neither may collapse into "current". A surface that turns an unreadable marker into a zero age, or into silence, puts the defect back in a new place.

On `kin graph status` the freshness line is unconditional. Every other line in that report can be absent when there is nothing to report, but "how old is this" has no such state, and silence there is what let a stale store read as a healthy one. A current store states a fresh age, a months-behind store states a day-scale age beside its coverage, and a missing or unreadable record states that freshness is unknown. The marker is read in the CLI rather than asked of the daemon, the same way the MCP path reads the authority-head marker straight off disk: the daemon's report is scoped to the graph it holds in memory, while freshness is a property of the store on disk that the CLI is standing in.

What this deliberately does not do, so the scope is legible. The verdict itself is unchanged: deciding a store is BEHIND rather than merely old needs the admitted tree compared against what the repository holds, and that comparison is the follow-up. `kin status` and the daemon health routes do not carry the field yet; those routes are being edited by several lanes right now and the field is additive when they settle. The MCP surface needs a schema decision rather than a field, because its graph-status schema bars unscoped health metadata on purpose.

Verification: `cargo fmt --check` clean; clippy under the ci.yml allowlist with `-D warnings` clean on kin-core, kin-cli and kin-daemon; `cargo test -p kin-core -p kin-cli --lib` green at 544 and 1362. Twelve new tests cover the durable round trip, survival across a process that did not write the record, absent versus unreadable versus wrong-schema reads, clock-skew saturation, age rendering, and that a current store still states its freshness. Honest limit on those tests: they pin the pure logic, and an end-to-end assertion on real `kin graph status` output against a genuinely stale store still needs the integration harness. The full workspace gate has not been run on this branch.

Refs FIR-2226