### PR TITLE
Report a files-mode resolution miss from impact_analysis

### DIFF
--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2735,8 +2735,27 @@ pub fn resolve_diff<G: GraphStore>(
     // Mode 2: file paths
     if let Some(files) = get_optional_string_array(args, "files") {
         if !files.is_empty() {
-            return kin_review::diff_from_files(store, &files)
-                .map_err(|e| McpError::Review(e.to_string()));
+            return kin_review::diff_from_files(store, &files).map_err(|error| match error {
+                // Files mode resolves each path to the entities the graph holds
+                // for it and diffs those. When none resolve there is nothing to
+                // diff, and the shared review error for that is worded for the
+                // base/head mode: "no changes between base and head". A caller
+                // who passed neither a base nor a head reads a complaint about
+                // a comparison that never happened and looks for a diff
+                // problem, when the fact is that the paths named no entities.
+                // Tracked paths with no parser-emitted entities are the common
+                // case here: a workflow file is a real artifact and resolves to
+                // nothing.
+                kin_review::ReviewError::NoChanges => McpError::Review(format!(
+                    "no entity resolved from the given files, so nothing was diffed: [{}]. \
+                     These paths named no entities in this graph, which is what a tracked file \
+                     the parsers emit no entities for looks like; no base or head was \
+                     compared. Confirm the paths with kin_artifact_list, or pass entity_ids \
+                     for the declarations you mean.",
+                    files.join(", ")
+                )),
+                other => McpError::Review(other.to_string()),
+            });
         }
     }
 

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5271,7 +5271,10 @@ mod tests {
         let absent_args = HashMap::from([
             (
                 "files".to_string(),
-                serde_json::json!(["crates/kin-index/src/classifier.rs", ".github/workflows/release.yml"]),
+                serde_json::json!([
+                    "crates/kin-index/src/classifier.rs",
+                    ".github/workflows/release.yml"
+                ]),
             ),
             ("include_traffic".to_string(), serde_json::json!(false)),
         ]);

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5247,6 +5247,88 @@ mod tests {
         assert_eq!(rows[0]["span"]["start_line"], 41);
     }
 
+    /// FIR-2217. Files mode reported a diff-mode complaint on a resolution
+    /// failure.
+    ///
+    /// `impact_analysis {files: [...]}` on paths that resolve to no entities came
+    /// back as "review error: no changes between base and head" when no base and
+    /// no head had been passed. An agent reads that as a diff problem and starts
+    /// looking for one, which is the wrong-cause error class this workspace
+    /// polices. Tracked paths with no parser-emitted entities are the ordinary
+    /// way to hit it: a workflow file is a real artifact and resolves to nothing.
+    #[tokio::test]
+    async fn impact_analysis_files_mode_names_a_resolution_miss_not_a_diff_complaint() {
+        let store = InMemoryGraph::new();
+        let present = impact_probe_entity("resolvable_probe_2217", Some(3));
+        let present_path = present
+            .file_origin
+            .as_ref()
+            .expect("the probe carries a file origin")
+            .to_string();
+        kin_model::graph::EntityStore::upsert_entity(&store, &present).unwrap();
+        let sessions = SessionRegistry::new();
+
+        let absent_args = HashMap::from([
+            (
+                "files".to_string(),
+                serde_json::json!(["crates/kin-index/src/classifier.rs", ".github/workflows/release.yml"]),
+            ),
+            ("include_traffic".to_string(), serde_json::json!(false)),
+        ]);
+        let error = review::handle_impact_analysis(&absent_args, &store, &sessions)
+            .await
+            .expect_err("files resolving to no entities is an error, not an empty report")
+            .to_string();
+
+        assert!(
+            error.contains("no entity resolved from the given files"),
+            "the error must name the resolution miss: {error}"
+        );
+        assert!(
+            !error.contains("no changes between base and head"),
+            "a files-mode miss must not report a diff-mode complaint: {error}"
+        );
+        assert!(
+            error.contains(".github/workflows/release.yml"),
+            "the error must name the paths that resolved to nothing: {error}"
+        );
+
+        // The wording has to be one the envelope recognizes, or the tool fails
+        // loudly and still carries no negative object beside it.
+        let negative = crate::negative::resolution_miss_for(
+            "impact_analysis",
+            &error,
+            &crate::Envelope::daemon(),
+        )
+        .expect("a files-mode miss must carry the standard negative object");
+        assert_eq!(negative["kind"], serde_json::json!("scope_not_resolved"));
+
+        // Positive control: a path that DOES resolve still produces a report, so
+        // the new arm reads the resolution rather than rejecting files mode.
+        let present_args = HashMap::from([
+            ("files".to_string(), serde_json::json!([present_path])),
+            ("include_traffic".to_string(), serde_json::json!(false)),
+        ]);
+        let value = tool_result_json(
+            review::handle_impact_analysis(&present_args, &store, &sessions)
+                .await
+                .expect("a resolvable file must still yield an impact report"),
+        );
+        assert!(
+            value.get("affected_callers").is_some() || value.get("changed_entities").is_some(),
+            "the control must return a real report: {value}"
+        );
+
+        // Negative control on the envelope side: an unrelated failure from the
+        // same tool must NOT be dressed up as a resolution miss.
+        assert!(crate::negative::resolution_miss_for(
+            "impact_analysis",
+            "review error: graph store error: disk went away",
+            &crate::Envelope::daemon(),
+        )
+        .is_none());
+    }
+
     /// The artifact-identity binding is SKIPPED for an entity committed history
     /// has no revision for, and that skip is the fresh-clone case this read exists
     /// to serve.

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -800,6 +800,16 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
 /// it, which is the one shape an agent cannot calibrate.
 fn resolution_miss_spec(tool: &str) -> Option<(&'static str, &'static str)> {
     match tool {
+        // The review family's files mode resolves each named path to the
+        // entities the graph holds for it. When none resolve, nothing was
+        // compared, and that is a fact about the paths rather than about a diff.
+        // All three tools share one `resolve_diff`, so all three report the same
+        // miss; a spec for only the tool it was found on would leave its
+        // siblings failing loudly with no negative beside them.
+        "impact_analysis" | "semantic_diff" | "semantic_review" => Some((
+            "scope_not_resolved",
+            "the files that were named resolved to no entities, so nothing was diffed or analyzed",
+        )),
         "find_references" => Some((
             "focal_not_resolved",
             "the entity that was asked about could not be resolved, so no references were looked up",


### PR DESCRIPTION
`impact_analysis {files: [...]}` on paths that resolve to no entities returned `review error: no changes between base and head`. No base and no head had been passed, and one of the paths in the report that found this existed in the store as an artifact. An agent reads a diff-mode complaint and goes looking for a diff problem, which is exactly the wrong-cause error class this workspace polices.

Files mode resolves each named path to the entities the graph holds for it and diffs those, so none resolving means nothing was diffed. The shared review error for an empty comparison is worded for the base/head mode, and the files arm now translates it into what actually happened: it names the paths, says no base or head was compared, and points at `kin_artifact_list` or `entity_ids` as the way forward. A tracked file the parsers emit no entities for is the ordinary way to hit this, so the message says that too.

The wording is chosen so the envelope recognizes it as a resolution miss, which means the loud failure now carries the standard `negative` object under a new `scope_not_resolved` kind rather than arriving as a bare message. All three review-family tools share one `resolve_diff`, so `semantic_diff` and `semantic_review` get the spec as well; giving it only to the tool the defect was found on would leave the siblings failing loudly with nothing beside them.

The test was falsified before being trusted: with the fix reverted it fails with the exact reported string, `the error must name the resolution miss: review error: no changes between base and head`. It carries a positive control (a path that does resolve still returns a real report, so the new arm reads the resolution rather than rejecting files mode) and a negative control on the envelope side (an unrelated graph-store failure from the same tool is not dressed up as a resolution miss).

Full lane gate green from the lane worktree: 5513 tests, doctests, no tracked lock contamination.

Closes FIR-2217
