### PR TITLE
Clear RUSTSEC-2026-0253 and make the advisory gate able to fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,7 +468,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
+          ref: a1ba0a3a2556011c508aeb108ff9e2e21addd615
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -999,7 +999,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
+          EXPECTED_VFS_COMMIT: a1ba0a3a2556011c508aeb108ff9e2e21addd615
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1287,7 +1287,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
+          ref: a1ba0a3a2556011c508aeb108ff9e2e21addd615
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1355,7 +1355,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
+          EXPECTED_VFS_COMMIT: a1ba0a3a2556011c508aeb108ff9e2e21addd615
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1717,7 +1717,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42
+      expected_vfs_commit: a1ba0a3a2556011c508aeb108ff9e2e21addd615
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.3.0"
+version = "0.4.2"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "12ff474623a86dced7abba355db891e534a15b2ca31be382fc14ab6c73790385"
+checksum = "5032cf253334f030b958f36417f84978eafcdbf12708e777cf4e1f395ba49cd5"
 dependencies = [
  "lru",
  "parking_lot",
@@ -3864,11 +3864,11 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,9 +3952,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.20", registry = "kin", default-features = false }
-kin-vfs-core = { version = "0.3.0", registry = "kin" }
+kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,16 @@ feature-depth = 1
 
 # --- Advisory database (replaces standalone cargo-audit) ---
 [advisories]
+# cargo-deny defaults `unsound` to "workspace", which surfaces unsound advisories
+# only for crates the workspace declares directly. Every third-party crate kin
+# ships is transitive, so the default left this required context structurally
+# unable to fail on an unsound advisory. Two sat in the shipped graph while the
+# check reported success: RUSTSEC-2026-0253, a use-after-free in lru 0.16.4
+# reached through kin-vfs-core, and RUSTSEC-2026-0186, an unchecked pointer
+# offset in memmap2 0.9.10 reached through gix. Both are fixed in the lock beside
+# this line. "all" is what lets the check fail; do not weaken it back without
+# replacing the coverage.
+unsound = "all"
 # Ignore specific advisories that cannot be resolved yet.
 # Each entry must have a reason explaining why it is safe to ignore.
 ignore = [

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -11186,7 +11186,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 921c24ec67240ec6dce66bb2c05a333e1c9a2b42",
+        "expected_vfs_commit: a1ba0a3a2556011c508aeb108ff9e2e21addd615",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
The `kin` binary users install still carries RUSTSEC-2026-0253, a use-after-free
in `lru` 0.16.4, and it got there past a green required `cargo-deny` context.
Both halves of that sentence were broken, and clearing the advisory in `kin`'s
own lock does not by itself take it out of what a user runs. All three are fixed
here.

## The advisory

`kin-vfs` cleared the advisory and published `kin-vfs-core` 0.4.2 against `lru`
0.18.2, but `Cargo.toml` pinned `kin-vfs-core = "0.3.0"`, and `^0.3.0` cannot
resolve 0.4.x. The downstream rebuild dispatch fired against that pin, resolved
nothing new, and reported success.

`kin-vfs-core` is the only path to `lru` here. `cargo tree -i lru` gives a
single chain, `lru 0.16.4 -> kin-vfs-core 0.3.0 -> kin-cli -> kin-daemon`, and
no manifest in the workspace declares `lru`, so moving the pin removes the crate
rather than deduplicating it.

The 0.3 to 0.4 jump is a deliberate breaking minor: `VfsResponse::Stat` becomes
a struct variant carrying a generation, `VfsResponse::Error` gains the same
field, `VFS_PROTOCOL_VERSION` goes 3 to 4, and `ContentProvider` gains a
defaulted `stat_at`. `kin` names none of those types. The only source mentions
of `kin_vfs_core` are a crate-to-repo table row and a test fixture string in
`crates/kin-core/src/dependencies.rs`, neither of which imports the crate, so
this is a pin change with no call-site work. Pinned exactly, matching
`kin-model`, `kin-blobs`, and `kin-db`.

## Why the gate did not catch it

cargo-deny defaults `[advisories] unsound` to `"workspace"`, which reports
unsound advisories only for crates the workspace declares directly. Every
third-party crate in `kin`'s graph is transitive, so this required context was
structurally unable to fail on the entire unsound class. RUSTSEC-2026-0253 is
classified `informational = "unsound"`.

That claim was measured rather than inferred. Against `kin`'s pre-fix graph with
a current advisory database and `ci.yml`'s own argv, cargo-deny reports
`advisories ok` and exits 0 while `lru` 0.16.4 is in the lock. Setting
`unsound = "all"` on the same graph reports `advisories FAILED` and names the
advisory. Same graph, same tool, same database, so the setting is the whole
difference. It also explains why `kin-vfs` caught this and `kin` did not, since
`kin-vfs` declares `lru` directly.

Turning the setting on surfaced a second advisory that had been equally
invisible: RUSTSEC-2026-0186, an unchecked pointer offset in `memmap2` 0.9.10
reached through `gix-commitgraph`, fixed upstream in 0.9.11. `deny.toml`'s own
policy bars ignoring a vulnerability that has an available fix, so this bumps
the lock rather than adding an ignore entry.

## The release pin, which is where the user-visible fix actually lives

`release.yml` checks out `kin-vfs` at a fixed commit and refuses to build when
`kin`'s registry-resolved `kin-vfs-core` disagrees with the version that
checkout builds. The pin was `921c24ec`, which builds `kin-vfs-core` 0.3.0.
Moving `kin` to 0.4.2 without moving the pin makes every platform leg throw
`update the immutable kin-vfs pin`. No pull-request check covers this, because
the gate exists only in `release.yml`, so the two commits above would have
merged green and failed at tag time.

The pin now names `a1ba0a3`, the tip of `kin-vfs` main and one metadata-only
commit past the `v0.4.2` tag. That checkout builds `kin-vfs-core` 0.4.2 and
resolves `lru` 0.18.2.

`kin` links `kin-vfs-core` and calls none of it, so the vulnerable `lru` was
dead weight in the `kin` binary, which makes the pin the half of this change a
user can feel. The release builds `kin-vfs-cli` and `kin-vfs-shim` out of the
pinned checkout, and the shim is the process that actually drives the LRU cache,
now directly, since 0.4.2 gave it a stat cache and a `lru` dependency of its own.
At the old pin that shim carried `lru` 0.16.4. Advancing the pin is what takes
the use-after-free out of the artifact a user runs.

## Verification

The lock check extracts every `lru` version from `Cargo.lock` and fails on
0.16.4 or anything below the patched 0.18.2 line. It fails against the pre-fix
lock, refuses an unreadable lock, and passes against `kin-vfs`'s own lock. An
earlier draft used `mapfile`, which this host's bash lacks, so it read nothing
and exited 0. Running the falsification before trusting the pass is what caught
that.

| graph | `unsound` | result |
| --- | --- | --- |
| pre-fix | default | `advisories ok`, rc 0 |
| pre-fix | `all` | FAILED, names 0253 and 0186 |
| lru fixed | `all` | FAILED, names 0186 |
| both fixed | `all` | `advisories ok`, rc 0 |

The release gate's own comparison was replayed against real locks. `kin` at
0.4.2 against the old pin throws and names both versions. The pre-fix `kin` lock
against the old pin passes, which is `main` today. `kin` at 0.4.2 against the new
pin passes. Package names, the shim `crate-type`, and the artifact filenames the
release asserts are unchanged across the pin move.
`scripts/test-release-workflow-authority.py` asserts the pinned commit verbatim
and moves with it; reverting only the test makes it fail, so it still binds.

Also green on this branch: the full cargo-deny check set (`advisories ok, bans
ok, licenses ok, sources ok`), `cargo fmt --all --check`, `cargo clippy
--all-targets --all-features` under `ci.yml`'s 45-lint allowlist with
`-D warnings`, and `kin-dev local-test kin` at 5530 tests. The lock was
re-locked patch-off. Every `kin-*` entry keeps its `sparse+` registry source and
checksum, and the lock diff touches exactly three packages.

Targets the next release coalesce.

Closes FIR-2253
