### PR TITLE
Check Kin/kin-vfs compatibility on pull requests, not only at release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -917,6 +917,7 @@ jobs:
         run: |
           python3 scripts/test-release-workflow-authority.py
           node --test \
+            scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \
@@ -924,6 +925,19 @@ jobs:
           node --check scripts/check-release-version.mjs
           node --check scripts/prepare-release.mjs
           node --check scripts/release-intent.mjs
+
+      # release.yml refuses a release whose Kin lock resolves a different
+      # kin-vfs-core than the pinned kin-vfs checkout builds, and that
+      # comparison ran nowhere else: a pull request moving the Kin lock passed
+      # every required context and failed only after the tag existed, where the
+      # tag has already resolved its own workflows. Run the same comparison
+      # here, against the pin read out of release.yml, so the answer arrives
+      # while a commit can still change it.
+      - name: Verify Kin/kin-vfs compatibility at the pinned release input
+        if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/check-kin-vfs-compat.mjs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16

--- a/scripts/check-kin-vfs-compat.mjs
+++ b/scripts/check-kin-vfs-compat.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Pull-request counterpart to release.yml's Kin/kin-vfs compatibility check.
+//
+// release.yml compares the kin-vfs-core that Kin resolves from the registry
+// against the kin-vfs-core that the pinned kin-vfs checkout builds, and refuses
+// the release on a mismatch. That comparison ran nowhere else. ci.yml carried no
+// kin-vfs reference at all, so a pull request that moved Kin's kin-vfs-core
+// requirement satisfied every required context and failed only after the tag
+// existed, where the tag's own workflows are already resolved and no fix lands
+// without cutting another tag.
+//
+// The pinned commit is read out of release.yml rather than recorded again here.
+// The pin already has five homes in that file; a sixth living in the gate that
+// predicts the release would be the one most likely to drift, and a gate
+// checking a different commit than the release uses is worse than no gate.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const VFS_REPOSITORY = 'firelock-ai/kin-vfs';
+export const VFS_CORE = 'kin-vfs-core';
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+// Every site in release.yml that records the pin: the checkout steps that
+// materialize it, and the expected-commit values that provenance and the
+// install proof assert against. Requiring them to agree is stronger than
+// reading any one of them, because a half-updated pin (checkout moved, proof
+// left behind) is exactly the shape that reaches a tag before anyone notices.
+export function readPinnedVfsCommit(releaseYaml) {
+  const sites = new Map();
+  const record = (sha, site) => {
+    if (!COMMIT_SHA.test(sha)) {
+      throw new Error(
+        `${site} records "${sha}", which is not a 40-character commit sha; ` +
+        'release inputs must be immutable',
+      );
+    }
+    sites.set(sha, [...(sites.get(sha) ?? []), site]);
+  };
+
+  for (const step of releaseYaml.split(/^\s*-\s+name:/m).slice(1)) {
+    if (!step.includes(`repository: ${VFS_REPOSITORY}`)) {
+      continue;
+    }
+    const ref = step.match(/^\s*ref:\s*(\S+)/m);
+    if (!ref) {
+      throw new Error(
+        `a ${VFS_REPOSITORY} checkout in release.yml records no ref, so the ` +
+        'release input floats with that repository default branch',
+      );
+    }
+    record(ref[1], `${VFS_REPOSITORY} checkout ref`);
+  }
+
+  for (const match of releaseYaml.matchAll(
+    /^\s*(?:EXPECTED_VFS_COMMIT|expected_vfs_commit):\s*(\S+)/gm,
+  )) {
+    record(match[1], 'expected_vfs_commit');
+  }
+
+  if (sites.size === 0) {
+    throw new Error(
+      `release.yml records no ${VFS_REPOSITORY} pin, so this gate has nothing ` +
+      'to compare against and cannot be trusted to have checked anything',
+    );
+  }
+  if (sites.size > 1) {
+    const detail = [...sites.entries()]
+      .map(([sha, where]) => `${sha} (${[...new Set(where)].sort().join(', ')})`)
+      .sort()
+      .join(' and ');
+    throw new Error(
+      `release.yml records disagreeing ${VFS_REPOSITORY} pins: ${detail}; ` +
+      'the release would build one commit and prove another',
+    );
+  }
+  return [...sites.keys()][0];
+}
+
+// Mirrors release.yml's own lock reader. Kept deliberately identical so the two
+// cannot disagree about what a lock entry is while agreeing about the versions.
+export function lockPackages(text) {
+  return text
+    .split('[[package]]')
+    .slice(1)
+    .map((block) => ({
+      name: block.match(/^name = "([^"]+)"/m)?.[1],
+      version: block.match(/^version = "([^"]+)"/m)?.[1],
+      source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
+    }));
+}
+
+export function compareVfsCore(kinLock, pinnedLock) {
+  const resolved = lockPackages(kinLock).filter(
+    (pkg) => pkg.name === VFS_CORE && pkg.source?.startsWith('sparse+'),
+  );
+  const pinned = lockPackages(pinnedLock).filter(
+    (pkg) => pkg.name === VFS_CORE && pkg.source === null,
+  );
+  if (resolved.length !== 1 || pinned.length !== 1) {
+    throw new Error(
+      `expected one registry Kin ${VFS_CORE} and one pinned local ${VFS_CORE}; ` +
+      `found ${resolved.length} and ${pinned.length}`,
+    );
+  }
+  if (resolved[0].version !== pinned[0].version) {
+    throw new Error(
+      `Kin resolves ${VFS_CORE} ${resolved[0].version}, but the pinned kin-vfs ` +
+      `checkout builds ${pinned[0].version}; advance the immutable kin-vfs pin ` +
+      'in .github/workflows/release.yml, or hold this lock change until kin-vfs ' +
+      'ships a matching commit. Landing them apart reds the release after the ' +
+      'tag exists.',
+    );
+  }
+  return resolved[0].version;
+}
+
+// Fails closed. An unreadable pin is not a passing comparison, so a transport
+// failure raises here rather than returning something the caller could mistake
+// for agreement.
+export async function fetchPinnedLock(commit, { token, fetchImpl = fetch } = {}) {
+  const url =
+    `https://api.github.com/repos/${VFS_REPOSITORY}/contents/Cargo.lock?ref=${commit}`;
+  const headers = {
+    accept: 'application/vnd.github.raw',
+    'user-agent': 'kin-vfs-compat-gate',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(url, { headers });
+  } catch (cause) {
+    throw new Error(
+      `could not reach ${VFS_REPOSITORY} to read Cargo.lock at ${commit}: ${cause.message}`,
+      { cause },
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `could not read ${VFS_REPOSITORY} Cargo.lock at ${commit}: ` +
+      `HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  const text = await response.text();
+  if (!text.includes('[[package]]')) {
+    throw new Error(
+      `${VFS_REPOSITORY} Cargo.lock at ${commit} carried no lock packages; ` +
+      'refusing to read an empty answer as agreement',
+    );
+  }
+  return text;
+}
+
+export async function main({
+  root = process.cwd(),
+  env = process.env,
+  fetchImpl = fetch,
+  log = console.log,
+} = {}) {
+  const releaseYaml = await fs.readFile(
+    path.join(root, '.github', 'workflows', 'release.yml'),
+    'utf8',
+  );
+  const commit = readPinnedVfsCommit(releaseYaml);
+  const kinLock = await fs.readFile(path.join(root, 'Cargo.lock'), 'utf8');
+  const pinnedLock = await fetchPinnedLock(commit, {
+    token: env.GH_TOKEN || env.GITHUB_TOKEN,
+    fetchImpl,
+  });
+  const version = compareVfsCore(kinLock, pinnedLock);
+  log(`Verified Kin/kin-vfs compatibility at ${VFS_CORE} ${version} (pinned kin-vfs ${commit})`);
+  return version;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-kin-vfs-compat.test.mjs
+++ b/scripts/check-kin-vfs-compat.test.mjs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  VFS_CORE,
+  VFS_REPOSITORY,
+  compareVfsCore,
+  fetchPinnedLock,
+  lockPackages,
+  readPinnedVfsCommit,
+} from './check-kin-vfs-compat.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PIN_A = 'a'.repeat(40);
+const PIN_B = 'b'.repeat(40);
+
+const releaseYamlWith = (checkoutRef, expectedCommit) => `
+jobs:
+  build:
+    steps:
+      - name: Checkout kin-vfs
+        uses: actions/checkout@0000000000000000000000000000000000000000 # v7.0.0
+        with:
+          repository: ${VFS_REPOSITORY}
+          path: kin-vfs
+          # Release inputs must never move under an unchanged Kin tag.
+          ref: ${checkoutRef}
+          persist-credentials: false
+
+      - name: Generate artifact provenance manifest
+        env:
+          EXPECTED_VFS_COMMIT: ${expectedCommit}
+        run: node ./provenance.mjs
+`;
+
+const lockWith = (entries) =>
+  entries
+    .map(
+      ({ name, version, source }) =>
+        `[[package]]\nname = "${name}"\nversion = "${version}"\n` +
+        (source === null ? '' : `source = "${source}"\n`),
+    )
+    .join('\n');
+
+const REGISTRY = 'sparse+https://kinlab.ai/registry/cargo/';
+
+test('reads a single agreeing pin from every site that records one', () => {
+  assert.equal(readPinnedVfsCommit(releaseYamlWith(PIN_A, PIN_A)), PIN_A);
+});
+
+test('refuses a half-updated pin where the checkout moved and the proof did not', () => {
+  assert.throws(
+    () => readPinnedVfsCommit(releaseYamlWith(PIN_B, PIN_A)),
+    /disagreeing .* pins/,
+  );
+});
+
+test('refuses a release workflow that records no pin at all', () => {
+  assert.throws(
+    () => readPinnedVfsCommit('jobs:\n  build:\n    steps: []\n'),
+    /records no .* pin/,
+  );
+});
+
+test('refuses a checkout of the pinned repository with no ref', () => {
+  const floating = `
+jobs:
+  build:
+    steps:
+      - name: Checkout kin-vfs
+        with:
+          repository: ${VFS_REPOSITORY}
+          path: kin-vfs
+`;
+  assert.throws(() => readPinnedVfsCommit(floating), /records no ref/);
+});
+
+test('refuses a pin that is not a full commit sha', () => {
+  assert.throws(() => readPinnedVfsCommit(releaseYamlWith('main', 'main')), /not a 40-character/);
+});
+
+test('reads the real release workflow and finds one pin', () => {
+  const releaseYaml = fs.readFileSync(
+    path.join(ROOT, '.github', 'workflows', 'release.yml'),
+    'utf8',
+  );
+  const commit = readPinnedVfsCommit(releaseYaml);
+  assert.match(commit, /^[0-9a-f]{40}$/);
+});
+
+test('parses lock entries the way the release workflow does', () => {
+  const entries = lockPackages(
+    lockWith([
+      { name: VFS_CORE, version: '0.3.0', source: REGISTRY },
+      { name: 'lru', version: '0.16.4', source: REGISTRY },
+    ]),
+  );
+  assert.deepEqual(entries, [
+    { name: VFS_CORE, version: '0.3.0', source: REGISTRY },
+    { name: 'lru', version: '0.16.4', source: REGISTRY },
+  ]);
+});
+
+test('accepts a lock pair that agrees', () => {
+  assert.equal(
+    compareVfsCore(
+      lockWith([{ name: VFS_CORE, version: '0.3.0', source: REGISTRY }]),
+      lockWith([{ name: VFS_CORE, version: '0.3.0', source: null }]),
+    ),
+    '0.3.0',
+  );
+});
+
+// The shape this gate exists to catch, taken from kin#788: its first commit
+// moved Kin's lock to kin-vfs-core 0.4.2 while the release pin still built
+// 0.3.0. Landed alone that commit passed every required context and would have
+// failed the release after the tag existed.
+test('refuses the lock-moved-pin-did-not shape', () => {
+  assert.throws(
+    () =>
+      compareVfsCore(
+        lockWith([{ name: VFS_CORE, version: '0.4.2', source: REGISTRY }]),
+        lockWith([{ name: VFS_CORE, version: '0.3.0', source: null }]),
+      ),
+    /resolves kin-vfs-core 0\.4\.2, but the pinned kin-vfs checkout builds 0\.3\.0/,
+  );
+});
+
+test('refuses a lock pair it cannot resolve to exactly one entry each', () => {
+  assert.throws(
+    () => compareVfsCore(lockWith([{ name: 'lru', version: '0.16.4', source: REGISTRY }]),
+      lockWith([{ name: VFS_CORE, version: '0.3.0', source: null }])),
+    /found 0 and 1/,
+  );
+});
+
+test('fails closed when the pinned lock cannot be read', async () => {
+  await assert.rejects(
+    () =>
+      fetchPinnedLock(PIN_A, {
+        fetchImpl: async () => ({ ok: false, status: 404, statusText: 'Not Found' }),
+      }),
+    /HTTP 404 Not Found/,
+  );
+});
+
+test('fails closed when the transport itself throws', async () => {
+  await assert.rejects(
+    () =>
+      fetchPinnedLock(PIN_A, {
+        fetchImpl: async () => {
+          throw new Error('getaddrinfo ENOTFOUND');
+        },
+      }),
+    /could not reach/,
+  );
+});
+
+test('fails closed on a successful response carrying no lock packages', async () => {
+  await assert.rejects(
+    () =>
+      fetchPinnedLock(PIN_A, {
+        fetchImpl: async () => ({ ok: true, status: 200, text: async () => '' }),
+      }),
+    /no lock packages/,
+  );
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -59,6 +59,10 @@ ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
 TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
 ASSERTION_REACHABILITY = ROOT / "scripts" / "test-assertion-reachability.py"
 ASSERTION_REACHABILITY_POLICY = "scripts/test-assertion-reachability.py"
+KIN_VFS_COMPAT_GUARD = ROOT / "scripts" / "check-kin-vfs-compat.mjs"
+KIN_VFS_COMPAT_GUARD_POLICY = "scripts/check-kin-vfs-compat.mjs"
+KIN_VFS_COMPAT_TEST = ROOT / "scripts" / "check-kin-vfs-compat.test.mjs"
+KIN_VFS_COMPAT_TEST_POLICY = "scripts/check-kin-vfs-compat.test.mjs"
 INSTALLER_ASSET_GUARD = ROOT / "scripts" / "verify-installer-release-assets.py"
 INSTALLER_ASSET_GUARD_POLICY = "scripts/verify-installer-release-assets.py"
 INSTALLER_ASSET_FALSIFIER = ROOT / "scripts" / "falsify-installer-release-assets.py"
@@ -3449,6 +3453,53 @@ def assert_assertion_reachability_gate_wired(workflow: str) -> None:
             f"{ASSERTION_REACHABILITY_POLICY} is missing; the release gates "
             "would no longer prove their own checks run"
         )
+
+
+def assert_kin_vfs_compat_gate_wired(ci: str) -> None:
+    """Keep the pull-request half of the Kin/kin-vfs compatibility check.
+
+    release.yml refuses a release whose Kin lock resolves a different
+    kin-vfs-core than the pinned kin-vfs checkout builds. That comparison used
+    to run only at release time, so a pull request moving the Kin lock passed
+    every required context and went red after the tag existed, where the tag
+    has already resolved its own workflows and no fix lands without cutting
+    another tag. kin#788 was exactly that shape: its first commit moved the
+    lock to 0.4.2 while the pin still built 0.3.0.
+
+    The gate reads the pin out of release.yml instead of recording it a sixth
+    time, so its unit tests are load-bearing rather than decorative: an
+    extraction that silently found nothing would be a gate that cannot fail.
+    Both halves are required here for that reason.
+    """
+
+    # Match whole invocations rather than searching for the path, which a
+    # commented-out line would still satisfy.
+    lines = {line.strip() for line in ci.splitlines()}
+    command = f"node {KIN_VFS_COMPAT_GUARD_POLICY}"
+    if not lines & {command, f"run: {command}"}:
+        raise AssertionError(
+            "ci.yml must run "
+            f"{KIN_VFS_COMPAT_GUARD_POLICY}; without it a Kin lock change that "
+            "outruns the immutable kin-vfs pin stays green until it reds a tag"
+        )
+    # The test list is a line-continuation block, so the invocation carries a
+    # trailing backslash on every entry but the last.
+    if not lines & {KIN_VFS_COMPAT_TEST_POLICY, f"{KIN_VFS_COMPAT_TEST_POLICY} \\"}:
+        raise AssertionError(
+            "ci.yml must run "
+            f"{KIN_VFS_COMPAT_TEST_POLICY}; the gate reads the pin out of "
+            "release.yml, and an unproven extraction is a gate that cannot fail"
+        )
+    for path, policy in (
+        (KIN_VFS_COMPAT_GUARD, KIN_VFS_COMPAT_GUARD_POLICY),
+        (KIN_VFS_COMPAT_TEST, KIN_VFS_COMPAT_TEST_POLICY),
+    ):
+        if not path.is_file():
+            raise AssertionError(
+                f"{policy} is missing; Kin could resolve a kin-vfs-core that "
+                "the pinned release input does not build and no pull request "
+                "would go red"
+            )
 
 
 def assert_installer_asset_guard_wired(ci: str, release: str) -> None:
@@ -9664,6 +9715,31 @@ def main() -> None:
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(ci_workflow)
     assert_assertion_reachability_gate_wired(ci_workflow)
+    assert_kin_vfs_compat_gate_wired(ci_workflow)
+    expect_assertion(
+        "ci.yml drops the pull-request Kin/kin-vfs compatibility gate",
+        "ci.yml must run",
+        lambda: assert_kin_vfs_compat_gate_wired(
+            ci_workflow.replace(f"run: node {KIN_VFS_COMPAT_GUARD_POLICY}", "run: true")
+        ),
+    )
+    expect_assertion(
+        "the Kin/kin-vfs gate survives only as a commented-out ci.yml step",
+        "ci.yml must run",
+        lambda: assert_kin_vfs_compat_gate_wired(
+            ci_workflow.replace(
+                f"run: node {KIN_VFS_COMPAT_GUARD_POLICY}",
+                f"run: # node {KIN_VFS_COMPAT_GUARD_POLICY}",
+            )
+        ),
+    )
+    expect_assertion(
+        "ci.yml keeps the Kin/kin-vfs gate but drops the tests proving its parse",
+        "ci.yml must run",
+        lambda: assert_kin_vfs_compat_gate_wired(
+            ci_workflow.replace(KIN_VFS_COMPAT_TEST_POLICY, "scripts/absent.test.mjs")
+        ),
+    )
     assert_installer_asset_guard_wired(ci_workflow, release)
     expect_assertion(
         "ci.yml drops the guard that installer asset names are published",


### PR DESCRIPTION
release.yml refuses a release whose Kin lock resolves a different kin-vfs-core
than the pinned kin-vfs checkout builds. That comparison ran nowhere else. ci.yml
carried no kin-vfs reference at all, so a pull request that moved Kin's
kin-vfs-core requirement satisfied every required context and only went red after
the tag existed, where the tag has already resolved its own workflows and no fix
lands without cutting another tag.

kin#788 is that shape. Its first commit moved the lock to kin-vfs-core 0.4.2
while the pin still built 0.3.0, and the pin caught up two commits later. Landed
alone, that first commit was green everywhere it was asked.

The same comparison now runs in the check job, which is a required context, so a
lock change that outruns the pin is answered while a commit can still fix it. The
pinned commit is read out of release.yml rather than recorded a sixth time. A pin
living in the gate that predicts the release is the copy most likely to drift,
and a gate checking a different commit than the release uses would be worse than
no gate. The extraction reads every site that records the pin, the checkout refs
and the expected-commit values alike, and refuses a half-updated set where the
checkout moved and the proof did not.

The gate fails closed. An unreadable pin, an unreachable transport, and a
successful response carrying no lock packages each raise rather than returning
something a caller could mistake for agreement.

Verified against real commits rather than fixtures alone. On main it passes at
kin-vfs-core 0.3.0. Against kin#788's first commit alone it exits 1 naming both
versions and the remedy. Against that PR's tip, where the pin advanced to
a1ba0a3a, it passes again at 0.4.2, which also proves the extraction reads
release.yml rather than matching a constant.

Thirteen unit tests cover the extraction, the comparison, and all three
fail-closed paths, including a test that the parse works against the real
release.yml. test-release-workflow-authority.py now asserts both halves stay
wired, with falsifications for the step being deleted, commented out, or kept
while its tests are dropped; each was confirmed to fire. The reachability gate
independently confirms the new assertion has a call site.

Closes FIR-2256.
