### PR TITLE
Stop reading an empty embed queue as finished coverage, and time the commit finalize

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -584,6 +584,36 @@ fn embed_work_outstanding(embed_pass_active: bool, queued: bool, worker_can_drai
     embed_pass_active || (queued && worker_can_drain)
 }
 
+/// What the background embed worker should do when its queue drains.
+///
+/// The queue is the worker's whole notion of work, so a retrieval key with no
+/// vector and no queue entry is work nothing will ever do, announced as
+/// `remaining=0`. Coverage is the authority for whether work exists; the queue
+/// is only how it gets done, and `kin embed` has always known the difference.
+/// Re-queueing the gap is therefore the right answer, and bounding it is what
+/// keeps a key that can never be embedded from spinning the worker every
+/// interval: the same gap twice running means the previous re-queue changed
+/// nothing, so the worker reports it once and stops asking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoverageDrainVerdict {
+    /// Coverage is whole. The drain really is finished.
+    Complete,
+    /// Coverage is short and no re-queue has been tried at this gap yet.
+    Backfill { missing: usize },
+    /// Coverage is short and the last re-queue at this gap produced nothing.
+    Stalled { missing: usize },
+}
+
+fn coverage_drain_verdict(missing: usize, backfilled_gap: Option<usize>) -> CoverageDrainVerdict {
+    if missing == 0 {
+        CoverageDrainVerdict::Complete
+    } else if backfilled_gap == Some(missing) {
+        CoverageDrainVerdict::Stalled { missing }
+    } else {
+        CoverageDrainVerdict::Backfill { missing }
+    }
+}
+
 fn embed_work_in_flight(state: &DaemonState) -> bool {
     embed_work_outstanding(
         state.embed_pass_active(),
@@ -1713,6 +1743,11 @@ pub async fn run_with_authority_on(
         let mut index_reset_triggered = false;
         let mut error_backoff: Option<Duration> = None;
         const EMBED_ERROR_BACKOFF_MAX: Duration = Duration::from_secs(60);
+        // The coverage gap this worker last re-queued, so a gap it cannot close
+        // is reported once instead of re-queued every interval. Cleared by any
+        // batch that embeds something, since progress makes the next gap a new
+        // question.
+        let mut backfilled_gap: Option<usize> = None;
         'wake: loop {
             // Between wakes this worker is genuinely doing nothing, so the
             // working stretch ends here. A wedged drain never reaches this
@@ -1780,12 +1815,54 @@ pub async fn run_with_authority_on(
                 let pending = embed_state.graph.pending_embeddings();
                 let pending_artifacts = embed_state.graph.pending_artifact_embeddings();
                 if pending == 0 && pending_artifacts == 0 {
-                    // The queue is drained: this is where coverage becomes
-                    // whole, so it is where the has-ever-completed marker is
-                    // published. Recording it here rather than from a reader
-                    // keeps the claim on the side that actually did the work.
-                    embed_state.record_embedding_coverage_complete();
-                    break;
+                    // An empty queue is not the same fact as whole coverage,
+                    // and the difference is what let every commit cost a store
+                    // part of its memory in silence. A change mints a HEAD
+                    // revision key per touched entity, and anything that puts a
+                    // retrievable key into truth without queueing it leaves the
+                    // worker nothing to do and no reason to say so. Ask coverage
+                    // before believing the drain.
+                    let status = embed_state.graph.embedding_status();
+                    let missing = status.total.saturating_sub(status.indexed);
+                    match coverage_drain_verdict(missing, backfilled_gap) {
+                        CoverageDrainVerdict::Backfill { missing } => {
+                            warn!(
+                                missing,
+                                indexed = status.indexed,
+                                total = status.total,
+                                "embedding queue drained while coverage is short; re-queueing the missing keys"
+                            );
+                            backfilled_gap = Some(missing);
+                            #[cfg(feature = "embeddings")]
+                            embed_state.graph.queue_missing_for_embedding();
+                            embed_state.graph.queue_missing_artifacts_for_embedding();
+                            if embed_state.graph.pending_embeddings() > 0
+                                || embed_state.graph.pending_artifact_embeddings() > 0
+                            {
+                                continue;
+                            }
+                            warn!(
+                                missing,
+                                "no retrievable key could be queued for the missing coverage"
+                            );
+                            break;
+                        }
+                        CoverageDrainVerdict::Stalled { missing } => {
+                            debug!(
+                                missing,
+                                "embedding coverage is short and re-queueing it changed nothing"
+                            );
+                            break;
+                        }
+                        CoverageDrainVerdict::Complete => {
+                            // Coverage is whole here, so this is where the
+                            // has-ever-completed marker is published. Recording
+                            // it on the side that did the work keeps the claim
+                            // off a reader that only saw a quiet queue.
+                            embed_state.record_embedding_coverage_complete();
+                            break;
+                        }
+                    }
                 }
                 // From here to the next `idle` this worker is spending the
                 // machine. Latched, so a drain that never finishes keeps one
@@ -1828,6 +1905,9 @@ pub async fn run_with_authority_on(
                         // embedder — clear any error backoff / reset latch.
                         index_reset_triggered = false;
                         error_backoff = None;
+                        // Progress makes the next coverage gap a new question,
+                        // so a gap that once looked unclosable gets asked again.
+                        backfilled_gap = None;
                         embed_pass.reset_retries();
                         info!(count, remaining = remaining.saturating_sub(count), label);
                         // Serialize successive flushes: the previous batch's
@@ -2877,10 +2957,10 @@ async fn select_with_signals(
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        drain_pending_flush, embed_work_outstanding, format_singleton_contention,
-        next_embed_error_backoff, parse_duration_secs, parse_owner_watch_pid,
-        should_enable_lsp_enrichment, should_flush_now, shutdown_signalled,
-        watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
+        coverage_drain_verdict, drain_pending_flush, embed_work_outstanding,
+        format_singleton_contention, next_embed_error_backoff, parse_duration_secs,
+        parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now, shutdown_signalled,
+        watched_process_is_alive, ControlPlane, CoverageDrainVerdict, DaemonConfig, DaemonState,
         DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE, RECON_IDLE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -2890,6 +2970,45 @@ mod tests {
     #[test]
     fn default_embed_batch_is_backlog_friendly() {
         assert_eq!(DaemonConfig::default().embed_batch_size, 512);
+    }
+
+    /// FIR-2254's accounting half. A drained queue over a store that is short
+    /// on coverage is the exact state the daemon used to log as `remaining=0`
+    /// while `kin graph status` reported hundreds pending, because the worker
+    /// asked the queue and the status asked coverage. An empty queue alone must
+    /// never be read as finished.
+    #[test]
+    fn a_drained_queue_over_short_coverage_is_not_finished() {
+        assert_eq!(
+            coverage_drain_verdict(641, None),
+            CoverageDrainVerdict::Backfill { missing: 641 }
+        );
+        assert_eq!(
+            coverage_drain_verdict(0, None),
+            CoverageDrainVerdict::Complete
+        );
+    }
+
+    /// Re-queueing is bounded by what it achieves. The same gap twice running
+    /// means the previous re-queue placed nothing the worker could embed, so
+    /// the worker reports it and stands down instead of rebuilding the same
+    /// queue every interval forever.
+    #[test]
+    fn a_gap_that_requeueing_cannot_close_is_reported_not_retried() {
+        assert_eq!(
+            coverage_drain_verdict(641, Some(641)),
+            CoverageDrainVerdict::Stalled { missing: 641 }
+        );
+        // A different gap is a different question, and gets its own attempt.
+        assert_eq!(
+            coverage_drain_verdict(210, Some(641)),
+            CoverageDrainVerdict::Backfill { missing: 210 }
+        );
+        // Coverage closing outranks the latch entirely.
+        assert_eq!(
+            coverage_drain_verdict(0, Some(641)),
+            CoverageDrainVerdict::Complete
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -881,6 +881,20 @@ fn require_bound_authority_revision(
     })
 }
 
+/// Whether the derived graph and repository authority agree on the workspace.
+///
+/// This snapshots both sides to compare three fields of the result, and a
+/// snapshot deep-clones every sub-store, including the entity revision history
+/// and the audit log, both of which grow with every commit a repository has
+/// ever taken. So a comparison of three maps costs two whole-graph clones, the
+/// reply path runs it twice, and both runs sit after the change is already
+/// durable. That is most of what a caller waits through on a large store, and
+/// `timed_finalize_step` is what makes the cost visible instead of silent.
+///
+/// kin-db 0.7.21 answers the same question under its own read lock with no
+/// clone at all (`InMemoryGraph::semantic_workspace_matches`). This call site
+/// moves to it once that version is published and `kin` re-locks against it;
+/// the comparison is identical, so the swap is a cost change only.
 fn semantic_workspace_matches(left: &kin_db::InMemoryGraph, right: &kin_db::InMemoryGraph) -> bool {
     let left = left.to_snapshot();
     let right = right.to_snapshot();
@@ -1491,6 +1505,31 @@ fn replay_applied_commit(
     Ok(kin_mcp::ToolCallResult::text(json))
 }
 
+/// A finalize step slower than this names itself at `info`, the level an
+/// operator actually sees.
+const SLOW_FINALIZE_STEP: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Run one step of the post-durability finalize and record what it cost.
+///
+/// The change is already durable when this stretch begins, and on a large store
+/// the caller waited minutes in it with not one line in the log. That silence
+/// is why the block was attributed to re-embedding across two releases, until a
+/// reconstruction against `kin log` timestamps showed the re-embedding was
+/// under a second of it. Every step reports its own duration now, so the next
+/// slow commit says which part was slow instead of leaving it to be guessed.
+fn timed_finalize_step<T>(step: &'static str, work: impl FnOnce() -> T) -> T {
+    let started = std::time::Instant::now();
+    let outcome = work();
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if elapsed >= SLOW_FINALIZE_STEP {
+        tracing::info!(step, elapsed_ms, "slow commit finalize step");
+    } else {
+        tracing::debug!(step, elapsed_ms, "commit finalize step");
+    }
+    outcome
+}
+
 fn finalize_committed_transaction(
     state: &Arc<DaemonState>,
     sessions: &kin_mcp::SessionRegistry,
@@ -1506,8 +1545,10 @@ fn finalize_committed_transaction(
         None => (Vec::new(), None),
     };
     let authority_context = authority_context(state)?;
-    let authority = load_native_commit_base(&authority_context)
-        .map_err(|error| format!("reload committed MCP repository authority: {error}"))?;
+    let authority = timed_finalize_step("reload_repository_authority", || {
+        load_native_commit_base(&authority_context)
+    })
+    .map_err(|error| format!("reload committed MCP repository authority: {error}"))?;
     // A resume has no plan and still owes the same answer, so it recovers the
     // split from the staged operations the interruption left behind.
     let carried_pending_files = planned_carry.unwrap_or_else(|| {
@@ -1527,30 +1568,41 @@ fn finalize_committed_transaction(
         ));
     }
 
-    install_authority_graph(state.graph.as_ref(), &authority.graph, &committed)?;
-    let layouts = if planned_layouts.is_empty() && committed.file_count > 0 {
-        rebuild_changed_layouts(state, &authority, &committed.change)?
-    } else {
-        planned_layouts
-    };
-    for layout in layouts {
-        state.graph.upsert_file_layout(&layout).map_err(|error| {
-            format!("install committed exact layout {}: {error}", layout.file_id)
-        })?;
-    }
-    if !semantic_workspace_matches(state.graph.as_ref(), &authority.graph) {
+    timed_finalize_step("install_authority_graph", || {
+        install_authority_graph(state.graph.as_ref(), &authority.graph, &committed)
+    })?;
+    let layouts = timed_finalize_step("rebuild_changed_layouts", || {
+        if planned_layouts.is_empty() && committed.file_count > 0 {
+            rebuild_changed_layouts(state, &authority, &committed.change)
+        } else {
+            Ok(planned_layouts)
+        }
+    })?;
+    timed_finalize_step("install_layouts", || {
+        for layout in layouts {
+            state.graph.upsert_file_layout(&layout).map_err(|error| {
+                format!("install committed exact layout {}: {error}", layout.file_id)
+            })?;
+        }
+        Ok::<(), String>(())
+    })?;
+    if !timed_finalize_step("verify_workspace_matches_authority", || {
+        semantic_workspace_matches(state.graph.as_ref(), &authority.graph)
+    }) {
         return Err(format!(
             "derived daemon graph does not match repository authority after transaction {}",
             transaction.transaction_id
         ));
     }
-    record_commit_provenance(
-        state.graph.as_ref(),
-        actor,
-        &transaction,
-        &committed,
-        &carried_pending_files,
-    )?;
+    timed_finalize_step("record_commit_provenance", || {
+        record_commit_provenance(
+            state.graph.as_ref(),
+            actor,
+            &transaction,
+            &committed,
+            &carried_pending_files,
+        )
+    })?;
 
     let observed_generation = state.snapshot_generation.load(Ordering::SeqCst);
     if observed_generation < committed.receipt.generation {
@@ -1572,7 +1624,9 @@ fn finalize_committed_transaction(
             .map_err(|error| format!("terminalize exact MCP transaction: {error}"))?
     };
     let modified_files = changed_file_ids(&committed.change)?;
-    let root_hash = hex::encode(state.graph.compute_root_hash());
+    let root_hash = timed_finalize_step("compute_root_hash", || {
+        hex::encode(state.graph.compute_root_hash())
+    });
     let mut result = serde_json::json!({
         "transaction_id": terminal.transaction_id,
         "state": "committed",


### PR DESCRIPTION
Two halves of the same silence, both after a write is already durable. Found by the v0.5.19 re-dogfood, findings G1 and G2.

## An empty embed queue is not whole coverage

The background embed worker treats a drained queue as a finished drain and logs `remaining=0`. A commit puts one new HEAD revision key per touched entity into retrieval truth, and anything that enters truth without also entering the queue leaves the worker nothing to do and no reason to say so. On a 3166-entity store that read as `remaining=0` beside a status line reporting 641 pending, and only a manual `kin embed` closed it. `kin embed` has always known the difference; `should_queue_missing_embedding_pass` says it in one line: coverage, not queue length, is the authority for whether backfill work exists.

The worker now asks coverage before believing its own drain. A short gap is re-queued and drained. A gap that re-queueing cannot close is reported once and stood down from, rather than rebuilt every interval forever, and the has-ever-completed marker is published only where coverage is actually whole. The verdict is a pure function, so both the re-queue and the stand-down are asserted directly.

The root cause of the gap itself is in kin-db and lands in kin-db#180 (FIR-2254): `create_change` mints revision keys nothing ever filled. This side is the accounting, and it is worth having on its own, because it is what turns any future instance of the same class from silent into loud.

## The commit reply was silent for the entire time it was slow

A four-line comment edit on a 555 MiB store returns in 189 seconds. The change is durable at 24 seconds. The remaining 166 are after durability and every one of them is silent, which is why the block was attributed to re-embedding across two releases, until a reconstruction against `kin log` timestamps showed the re-embedding was 0.7 s of it and the two-sided control on a small store committed in 3.5 s.

`finalize_committed_transaction` now times each step and names anything past half a second at `info`. The reload of repository authority, the authority-graph install, the layout rebuild, the two workspace comparisons, the provenance record, and the root hash are timed separately.

The measurement is not the whole fix, and the doc comment on `semantic_workspace_matches` says which part is expected to dominate: it snapshots both graphs to compare three fields, a snapshot deep-clones every sub-store including revision history and the audit log, and the reply path runs it twice. kin-db 0.7.21 answers the same question with no clone; this call site moves to it once that version publishes and `kin` re-locks. That is a one-line swap gated on the ladder, so it is deliberately not in this PR.

Refs FIR-2254