### PR TITLE
Stop an unnamed ranking from certifying that the symbol is absent

### DIFF
--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -449,12 +449,12 @@ fn absence_consequence(always: bool, trustworthy: bool) -> &'static str {
 /// empty result: here the rows are real and stay ranked, and what is absent is
 /// the NAME, so the advice has to separate "these are neighbors" from "the
 /// symbol does not exist" instead of collapsing them into one verdict.
-fn unnamed_ranking_consequence(trustworthy: bool) -> &'static str {
-    if trustworthy {
-        "These hits are neighbors, not the symbol: no ranked entity carries the name the query asked for, and on a complete graph that means no entity carries it at all. Do not treat the top hit as the requested symbol."
-    } else {
-        "These hits are neighbors, not the symbol: no ranked entity carries the name the query asked for. The name's absence is NOT authoritative — it may simply not be indexed yet — so do not conclude the symbol does not exist. Re-check after embedding is complete and the daemon is healthy."
-    }
+fn unnamed_ranking_consequence() -> &'static str {
+    "These hits are neighbors, not the symbol: no ranked entity carries the name the query \
+     asked for. That is a fact about this ranking, not about the graph, because a ranking is \
+     a bounded candidate set and the name may belong to an entity it never considered. Do not \
+     treat the top hit as the requested symbol, and do not conclude the symbol does not exist: \
+     settle that with find_references or semantic_search, which resolve a name directly."
 }
 
 /// The kind the payload reports for its focal entity, whichever shape carries
@@ -676,6 +676,35 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         kind = "no_named_match";
         subject = "the query named a symbol and no ranked entity carries that name; \
                    every hit was surfaced by content or embedding similarity";
+        // A ranking is a bounded candidate set, so this verdict can never be
+        // authoritative no matter how complete the index is.
+        //
+        // Certifying it was a false statement about the graph, not a strict
+        // reading of a true one. A dogfood on the shipped artifact asked for
+        // `prune_orphaned_vectors` on a fully covered store and got ten wrong
+        // rows carrying `safe_to_conclude_absent: true`, `trust: authoritative`,
+        // and advice reading "on a complete graph that means no entity carries
+        // it at all". `find_references` resolved that exact name to a real
+        // method 1.9 seconds later in the same run. The fabricated control
+        // returned the IDENTICAL envelope, so the verdict could not separate a
+        // symbol retrieval missed from one that does not exist, and stamped both
+        // authoritative.
+        //
+        // Coverage completeness licenses nothing here. It says every entity has
+        // an embedding, not that the ranker considered every entity, and the
+        // name absent from a window says nothing about the rows outside it. The
+        // surfaces that CAN answer existence resolve a name directly, so the
+        // advice sends the caller to those instead.
+        trustworthy = false;
+        // The substrate reason is kept after the gap rather than replaced. It is
+        // still true and still useful, and on a complete index it reads
+        // "the substrate is fine, the ranking is the limit", which is exactly
+        // the distinction that was being collapsed.
+        trust_reason = format!(
+            "ranking_is_bounded: no ranked entity carries the name, and a ranking is a bounded \
+             candidate set rather than an enumeration of the graph, so the name may belong to an \
+             entity this query never ranked; observed substrate state: {trust_reason}"
+        );
     }
     if tool == "graph_neighborhood" {
         // The emitted edge array is capped by the caller's `limit`, and a
@@ -757,7 +786,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         "absent_as_indexed"
     };
     let consequence = if ranking_names_nothing {
-        unnamed_ranking_consequence(trustworthy)
+        unnamed_ranking_consequence()
     } else {
         absence_consequence(spec.always, trustworthy)
     };
@@ -1918,6 +1947,93 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("neighbors, not the symbol"));
+    }
+
+    #[test]
+    fn an_unnamed_ranking_never_certifies_that_the_symbol_is_absent() {
+        // A dogfood on the shipped artifact asked a fully covered store for
+        // `prune_orphaned_vectors`, got ten wrong rows, and the envelope stamped
+        // them `safe_to_conclude_absent: true`, `trust: authoritative`, advising
+        // that "on a complete graph that means no entity carries it at all".
+        // `find_references` resolved that exact name to a real method 1.9
+        // seconds later in the same run.
+        //
+        // A ranking is a bounded candidate set. Complete coverage says every
+        // entity has an embedding, not that the ranker considered every entity,
+        // so absence from a ranking can never license absence from the graph.
+        // Certifying it turned a silent miss into a confident false statement.
+        let mut existing = empty_fused_locate_page("prune_orphaned_vectors");
+        existing["entities"] = json!((0..10)
+            .map(|index| fused_locate_hit(&format!("neighbor_{index}")))
+            .collect::<Vec<_>>());
+        existing["total_ranked"] = json!(10);
+        existing["all_fallback"] = json!(true);
+        let negative = negative_for(
+            "semantic_locate",
+            &existing,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("an unnamed ranking is qualified");
+
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .contains("ranking_is_bounded"),
+            "the reason must name the bound: {}",
+            negative["trust_reason"]
+        );
+        // The substrate observation is kept rather than replaced: on a complete
+        // index the honest reading is "the substrate is fine, the ranking is the
+        // limit", which is the distinction that was being collapsed.
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("semantic_authoritative"));
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            !advice.contains("no entity carries it at all"),
+            "the advice must not assert graph-wide absence: {advice}"
+        );
+        assert!(
+            advice.contains("find_references") || advice.contains("semantic_search"),
+            "the advice must send the caller to a surface that resolves a name: {advice}"
+        );
+
+        // The control from the dogfood that makes this matter: a FABRICATED
+        // symbol produced the identical envelope, so the verdict could not
+        // separate a symbol retrieval missed from one that does not exist. Both
+        // are still inconclusive here, which is the honest answer for both,
+        // because this surface cannot tell them apart and must not pretend to.
+        let mut fabricated = empty_fused_locate_page("zzqqxx_nonexistent_symbol_9f3a");
+        fabricated["entities"] = json!((0..10)
+            .map(|index| fused_locate_hit(&format!("neighbor_{index}")))
+            .collect::<Vec<_>>());
+        fabricated["total_ranked"] = json!(10);
+        fabricated["all_fallback"] = json!(true);
+        let fabricated = negative_for(
+            "semantic_locate",
+            &fabricated,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
+        assert_eq!(fabricated["safe_to_conclude_absent"], json!(false));
+
+        // And the gate that still works: an EMPTY page on the same envelope is a
+        // real absence and stays authoritative. The bound applies to a populated
+        // ranking that missed a name, not to a query that ranked nothing, so
+        // this fix removes no verdict it was entitled to make.
+        let empty = json!({ "query": "auth", "results": [], "total_ranked": 0 });
+        let empty = negative_for(
+            "semantic_locate",
+            &empty,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
+        assert_eq!(empty["safe_to_conclude_absent"], json!(true));
+        assert_eq!(empty["kind"], json!("no_ranked_match"));
     }
 
     #[test]


### PR DESCRIPTION
The v0.5.19 dogfood asked a fully covered kin-db store for `prune_orphaned_vectors`, a bare exact symbol name. `semantic_locate` returned ten entities, none of them the target, and attached this:

```json
"kind": "no_named_match",
"safe_to_conclude_absent": true,
"trust": "authoritative",
"trust_reason": "semantic_authoritative: daemon-owned truth with complete embedding coverage and no degraded signals",
"advice": "...no ranked entity carries the name the query asked for, and on a complete graph
           that means no entity carries it at all."
```

`find_references` resolved that exact name to a real method 1.9 seconds later in the same driver run: `InMemoryGraph::prune_orphaned_vectors`, `crates/kin-db/src/engine/graph.rs`. **The entity exists and the envelope said authoritatively that it does not.** The fabricated control `zzqqxx_nonexistent_symbol_9f3a` returned the *identical* envelope on the same store in the same run, so the verdict could not separate a symbol retrieval missed from one that does not exist, and stamped both authoritative.

Against 0.5.17 this is a regression in kind, not degree. There, locate returned confident wrong rows and said nothing. Here it returns confident wrong rows and adds a truth claim.

**The inference was wrong, not the plumbing.** A ranking is a bounded candidate set. Complete coverage says every entity has an embedding; it does not say the ranker considered every entity, and a name absent from a window says nothing about the rows outside it. So `no_named_match` is now never authoritative, regardless of coverage.

The reason names the bound and keeps the substrate observation after it rather than replacing it, because both facts are true and the pair is the point: on a complete index it reads "the substrate is fine, the ranking is the limit", which is exactly the distinction that was being collapsed. The advice stops asserting graph-wide absence and sends the caller to `find_references` or `semantic_search`, which resolve a name directly and which the same dogfood found answer this correctly.

**Nothing the envelope was entitled to claim is lost.** An empty page on the same envelope stays `safe_to_conclude_absent: true`. The bound applies to a populated ranking that missed a name, not to a query that ranked nothing, and the test asserts that third case explicitly so this cannot quietly become a blanket downgrade.

The test carries the dogfood's own controls: the existing symbol, the fabricated symbol (both inconclusive now, which is the honest answer for both, because this surface cannot tell them apart and must not pretend to), and the empty page that stays authoritative.

**Why this is a separate PR.** It was written on #777, whose coverage lift is what makes this verdict reachable on the default arm at all: before it, the cosine arm reported coverage unknown and could never certify. I intended to ship them together, #777 entered the merge queue first, and a queued branch cannot be updated. So this lands right behind it and closes the window. Reviewers of #777 should know that landing it alone widens this claim from the fused arm to the default one, which is the reason this PR should not wait.

Verified before opening: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --all-features` clean under ci.yml's allowlist, `negative::` suite 55 passed standalone on `main` without #777, and the full lane gate green at 5544 tests plus doctests with no tracked lock contamination.

Not claimed: this does not add a relevance floor and does not change which rows are returned or their order. It changes only what the envelope is willing to certify. FIR-2178's ranking-quality half is untouched.

Advances FIR-2178
