### PR TITLE
Replace tracker ids in source comments with the reasons they stood in for

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -616,9 +616,10 @@ mod tests {
         assert_eq!(parse_oom_kill_count("oom_kill notanumber\n"), None);
     }
 
-    /// The FIR-2023 shape, both ways round. An 18-core host whose memory probe
-    /// fails must not be scored `Minimal` and reported as though 4 GB had been
-    /// measured; the same host with a reading must score `Performance`.
+    /// A failed memory probe and a real one, both ways round. An 18-core host
+    /// whose memory probe fails must not be scored `Minimal` and reported as
+    /// though 4 GB had been measured; the same host with a reading must score
+    /// `Performance`.
     #[test]
     fn a_failed_memory_probe_is_reported_rather_than_scored_as_four_gigabytes() {
         let misread = CapabilityDetection::resolve(

--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -2231,8 +2231,9 @@ mod tests {
         ]
     }
 
-    /// The FIR-2167 refusal: a pinned session sweeping `--all` reaches only its
-    /// own daemons, and the neighbour's survives.
+    /// The refusal that keeps a sweep inside one home: a pinned session
+    /// sweeping `--all` reaches only its own daemons, and the neighbour's
+    /// survives.
     #[test]
     fn a_home_scoped_sweep_stops_only_its_own_daemons() {
         let (targets, foreign) = partition_by_home(two_homes(), "/homes/a/.kin", StopScope::Home);
@@ -2312,7 +2313,7 @@ mod tests {
     }
 
     /// The census must be able to say which daemons are the caller's, which is
-    /// the FIR-2180 visibility half of the contract.
+    /// the visibility half of the home-scoping contract the sweep enforces.
     #[test]
     fn the_census_labels_every_home() {
         let labels: Vec<_> = two_homes()

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1242,12 +1242,12 @@ mod tests {
     /// The command names host content the loop declined to track, and does not
     /// call it a fault.
     ///
-    /// This is the FIR-2152 shape from the reader's side. A file was written, no
-    /// entity for it ever appeared, and the only surface that could have
-    /// explained why said nothing about it at all. Naming it as a warning would
-    /// be the opposite error: a working copy mid-edit holds untracked files
-    /// constantly, and a status command that cries fault over every one of them
-    /// is one nobody reads.
+    /// This is the untracked-content shape from the reader's side. A file was
+    /// written, no entity for it ever appeared, and the only surface that could
+    /// have explained why said nothing about it at all. Naming it as a warning
+    /// would be the opposite error: a working copy mid-edit holds untracked
+    /// files constantly, and a status command that cries fault over every one
+    /// of them is one nobody reads.
     #[test]
     fn graph_status_names_untracked_paths_without_calling_them_a_fault() {
         let (_temp, binding, graph) = graph_validation_fixture();
@@ -1286,9 +1286,8 @@ mod tests {
         );
     }
 
-    /// A dropped reconcile event reaches the same verdict. This is the FIR-2145
-    /// shape, where events errored and were skipped while every surface read
-    /// clean.
+    /// A dropped reconcile event reaches the same verdict: events errored and
+    /// were skipped while every surface read clean.
     #[test]
     fn graph_status_names_dropped_reconcile_events() {
         let (_temp, binding, graph) = graph_validation_fixture();

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2265,10 +2265,10 @@ mod tests {
         );
     }
 
-    /// The FIR-2147 shape at the `kin health` surface. No pass is stopped —
-    /// the reconcile loop is waking, failing, and sleeping on schedule, which
-    /// is exactly why the supervisor never stopped it — and the check still
-    /// must not answer healthy.
+    /// The failing-admission shape at the `kin health` surface. No pass is
+    /// stopped — the reconcile loop is waking, failing, and sleeping on
+    /// schedule, which is exactly why the supervisor never stopped it — and the
+    /// check still must not answer healthy.
     #[test]
     fn background_work_degrades_when_reconcile_admits_nothing_though_no_pass_is_stopped() {
         let check =
@@ -3953,7 +3953,7 @@ mod tests {
         assert_eq!(canonical_health_repo(vanished.clone()), vanished);
     }
 
-    /// Regression, FIR-1911: on Windows the first `kin setup` wrote the global
+    /// Regression: on Windows the first `kin setup` wrote the global
     /// Antigravity binding with the canonicalized (`\\?\` verbatim) repository
     /// root, then `kin setup status --json` reported it misconfigured, because
     /// the global arm compared it against a non-canonicalized root by exact

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -1093,8 +1093,8 @@ mod tests {
         );
     }
 
-    /// FIR-2032, at the unit boundary: the qualifier miss is reported as a miss,
-    /// the machine surface carries the identities the name does resolve to, and
+    /// The qualifier miss at the unit boundary. It is reported as a miss, the
+    /// machine surface carries the identities the name does resolve to, and
     /// the count of matches after qualification stays zero.
     #[tokio::test]
     async fn qualifier_miss_names_the_unfiltered_candidates_on_both_surfaces() {

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1446,8 +1446,8 @@ fn record_vector_index_degradation(
 ///
 /// A tier chosen after a failed host probe is reported as its own thing. The
 /// ordinary entry's remediation tells the reader to run on a bigger host, which
-/// is wrong advice when the host was never read: the machine that produced
-/// FIR-2023 had eight times the RAM the entry implied it lacked.
+/// is wrong advice when the host was never read: the machine that produced this
+/// misreport had eight times the RAM the entry implied it lacked.
 fn record_capability_tier_degradation(
     detection: &CapabilityDetection,
     sink: &mut Vec<RetrievalDegradation>,
@@ -3757,9 +3757,9 @@ fn run_with_graph_capture_budgeted(
         }
     }
 
-    // FIR-2183. Runs on every profile and outside the floor's lever, because the
-    // floor is a re-ranking choice for code files while this is the only door a
-    // tracked artifact has at all. It runs after the floor so that when both can
+    // Runs on every profile and outside the floor's lever, because the floor is
+    // a re-ranking choice for code files while this is the only door a tracked
+    // artifact has at all. It runs after the floor so that when both can
     // admit the same path the floor's placement wins and nothing is admitted
     // twice.
     admit_text_matched_artifacts(&mut fused, &artifact_candidates, &mut degradations);
@@ -4056,8 +4056,8 @@ fn run_with_graph_capture_budgeted(
     // authority open is a full recovery and the committed state a body's
     // artifact-identity binding needs is a whole-history replay, so a session
     // per function pays both twice for one answer, and a session per read pays
-    // them once per definition symbol. That per-symbol shape is the FIR-1897
-    // defect itself, and holding it here is what keeps it off this path.
+    // them once per definition symbol. That per-symbol shape is the defect
+    // itself, and holding it here is what keeps it off this path.
     //
     // Constructing the session performs no IO, so hoisting it above the
     // `opts.enabled` guards inside both callees costs a disabled request
@@ -16040,7 +16040,7 @@ fn match_symbol_entity<'a>(
 ///
 /// Reads through the request's held authority. The one-shot entry point builds a
 /// fresh session per call, which is correct for a single-entity surface and is
-/// the FIR-1897 defect here: this runs once per definition symbol on a page.
+/// the defect here: this runs once per definition symbol on a page.
 fn bounded_entity_body_with_note(
     held_authority: &kin_mcp::handlers::common::HeldSourceAuthority<'_, kin_db::InMemoryGraph>,
     entity: &kin_model::Entity,
@@ -16115,8 +16115,9 @@ fn bounded_entity_body_with_note(
 /// Takes the SAME held authority [`attach_snippets`] just used. Both walk the
 /// same symbol set in the same request, so a body here resolves against
 /// authority and committed state already derived; deriving them again per
-/// definition symbol is the FIR-1897 shape, and it reaches every locate entry
-/// point because they all funnel through [`run_with_graph_capture_budgeted`].
+/// definition symbol is the defect this removes, and it reaches every locate
+/// entry point because they all funnel through
+/// [`run_with_graph_capture_budgeted`].
 /// Project one ranked artifact file into a [`LocateEntity`] row.
 ///
 /// The row deliberately carries no `entity_id`: there is no entity behind it,
@@ -16810,10 +16811,10 @@ mod tests {
             .expect("a sub-Performance tier must record a capability_tier degradation")
     }
 
-    /// FIR-2023 in the surface a caller actually reads. A tier the host chose
-    /// and a tier a failed probe chose must not produce the same entry: the
-    /// first's remediation is sound advice, the second's told an operator with
-    /// 128 GB to obtain more RAM.
+    /// The misread host in the surface a caller actually reads. A tier the host
+    /// chose and a tier a failed probe chose must not produce the same entry:
+    /// the first's remediation is sound advice, the second's told an operator
+    /// with 128 GB to obtain more RAM.
     #[test]
     fn a_misread_host_is_a_distinct_capability_entry_from_a_small_one() {
         let mut misread = Vec::new();
@@ -17118,11 +17119,10 @@ mod tests {
             .find(|event| event.component == "artifact_candidates" && event.reason == reason)
     }
 
-    /// FIR-2183, the ticket's own battery: a store whose answer lives in an
-    /// artifact must be able to say so on the surface an agent reads. This is the
-    /// dogfood session's exact failure, where a store proven by
-    /// `kin_artifact_read` to hold a phrase answered queries for that phrase with
-    /// Python function names.
+    /// A store whose answer lives in an artifact must be able to say so on the
+    /// surface an agent reads. This is the dogfood session's exact failure,
+    /// where a store proven by `kin_artifact_read` to hold a phrase answered
+    /// queries for that phrase with Python function names.
     #[test]
     #[serial_test::serial]
     fn a_ranked_artifact_reaches_the_graph_native_entity_surface() {
@@ -18372,9 +18372,9 @@ mod tests {
         );
     }
 
-    /// FIR-2179. Nothing on the ingest path writes an opaque artifact for a
-    /// source file, so on a real store the body lookup misses for every
-    /// candidate and the reranker used to score a batch of empty documents.
+    /// Nothing on the ingest path writes an opaque artifact for a source file,
+    /// so on a real store the body lookup misses for every candidate and the
+    /// reranker used to score a batch of empty documents.
     /// The entities the graph does hold for the path carry the same text the
     /// embedder reads, so they stand in.
     #[cfg(feature = "embeddings")]

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -635,8 +635,8 @@ mod tests {
         assert!(message.contains("disabled"));
     }
 
-    /// FIR-2025(a), both sides. An unconfigured server serves the curated belt
-    /// and the whole surface is reachable only by asking for it.
+    /// Both sides. An unconfigured server serves the curated belt, and the
+    /// whole surface is reachable only by asking for it.
     ///
     /// The counts are asserted against the profile lists themselves rather than
     /// against literals, so this stays true as tools are added; what it pins is
@@ -667,9 +667,9 @@ mod tests {
         );
     }
 
-    /// FIR-2025(b). "What breaks if I change this" is the product's flagship
-    /// question, and the tool whose name says exactly that must be in the
-    /// profile every agent receives.
+    /// "What breaks if I change this" is the product's flagship question, and
+    /// the tool whose name says exactly that must be in the profile every agent
+    /// receives.
     #[test]
     fn the_default_profile_carries_impact_analysis() {
         let served = resolve_tool_profile(None, None)

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -770,8 +770,8 @@ mod tests {
     /// Untracked host content is announced and is not a fault.
     ///
     /// Both halves matter. Without the notice, a file a reader can see on disk
-    /// has no entities and no surface says why, which is the question FIR-2152
-    /// arrived as. Without the second assertion, every working copy mid-edit
+    /// has no entities and no surface says why, which is the question a reader
+    /// arrives with. Without the second assertion, every working copy mid-edit
     /// would report `attention`, and a health signal that is always on is one
     /// nobody reads.
     #[test]

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -16553,10 +16553,10 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         (dir, home)
     }
 
-    /// FIR-1878: the Kin-first directive is a standing instruction to prefer
-    /// Kin's MCP tools over grep and raw file reads, in every repository, for
-    /// every session. Writing it for a client whose MCP server setup never
-    /// registered points that agent at tools which are not wired.
+    /// The Kin-first directive is a standing instruction to prefer Kin's MCP
+    /// tools over grep and raw file reads, in every repository, for every
+    /// session. Writing it for a client whose MCP server setup never registered
+    /// points that agent at tools which are not wired.
     ///
     /// Models the reported first-install shape: Cursor registers, Claude Code
     /// does not, and the run still reaches the reminder step. Against the

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1678,9 +1678,9 @@ mod tests {
         (report, reads.get(), tokio::time::Instant::now() - started)
     }
 
-    /// The FIR-1877 race itself: the daemon could not pair a stable authority
-    /// epoch with a sample, and the coverage it was hiding is observable a
-    /// moment later. A single-sample caller failed here.
+    /// The race itself: the daemon could not pair a stable authority epoch with
+    /// a sample, and the coverage it was hiding is observable a moment later. A
+    /// single-sample caller failed here.
     #[tokio::test]
     async fn a_mutation_in_flight_settles_into_the_observation_it_was_hiding() {
         let base = settle_base_report();

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -446,9 +446,9 @@ pub fn build_trace_data_flow_response_within(
     // Opening authority verifies every stored body, linear in store size. The
     // per-step body projection used to open its own, so a chain of N steps paid
     // N+1 full-store verifications and a structurally tiny trace ran for
-    // minutes on a large store (FIR-1937, FIR-1909). Holding one open also
-    // makes the chain coherent: every step is now read from the same
-    // generation, where per-step opens could straddle a publication.
+    // minutes on a large store. Holding one open also makes the chain coherent:
+    // every step is now read from the same generation, where per-step opens
+    // could straddle a publication.
     //
     // A store with no readable authority still gets its chain. Bodies were
     // always optional per step, and hoisting the open must not turn a payload
@@ -1162,8 +1162,8 @@ mod tests {
         );
     }
 
-    /// The property FIR-1898 is actually about: the WORK stops, not just the
-    /// response. A cancelled walk must leave traversal undone that the same
+    /// The property cancellation is actually about: the WORK stops, not just
+    /// the response. A cancelled walk must leave traversal undone that the same
     /// walk uncancelled completes, measured against that walk rather than a
     /// constant.
     ///

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -4171,8 +4171,8 @@ fn resolve_idle_timeout_env(
 /// back a process whose window was fixed by whoever started it, which on a
 /// developer machine is almost always an ordinary CLI command taking the short
 /// CLI default. An MCP session that attached there inherited 60 seconds and had
-/// the daemon expire underneath it between tool calls (FIR-1886). A caller with
-/// a stated need has to say so to the daemon it actually got.
+/// the daemon expire underneath it between tool calls. A caller with a stated
+/// need has to say so to the daemon it actually got.
 ///
 /// `None` means the caller stated no need of its own and is content with
 /// whatever the daemon is running, which is the pre-existing behavior for every
@@ -10866,10 +10866,10 @@ mod tests {
 
     // ── idle-timeout carried to a daemon this process did not start ────────
 
-    /// FIR-1886, both sides. Injecting at spawn only helps the caller that
-    /// spawns, and an MCP session usually attaches to a daemon an ordinary CLI
-    /// command already started at the 60-second default. A caller with a stated
-    /// need must carry it; a caller with none must leave the daemon alone.
+    /// Both sides. Injecting at spawn only helps the caller that spawns, and an
+    /// MCP session usually attaches to a daemon an ordinary CLI command already
+    /// started at the 60-second default. A caller with a stated need must carry
+    /// it; a caller with none must leave the daemon alone.
     #[test]
     fn an_mcp_session_carries_its_window_to_a_daemon_it_did_not_start() {
         assert_eq!(

--- a/crates/kin-cli/tests/declaration_resolution_e2e.rs
+++ b/crates/kin-cli/tests/declaration_resolution_e2e.rs
@@ -367,7 +367,7 @@ async fn impact_on_a_genuinely_isolated_entity_still_reports_plain_empty() {
     );
 }
 
-/// FIR-2032. `--file` narrows the candidates the ordinary lookup already found.
+/// `--file` narrows the candidates the ordinary lookup already found.
 /// When it narrows them to none, the answer must say the filter matched nothing
 /// and name what the name itself resolves to. Claiming the entity is absent from
 /// the graph is false: the unfiltered lookup just found it.

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -540,7 +540,7 @@ fn install_full_vector_index(graph: &kin_db::InMemoryGraph, sidecar: &Path) -> u
     keys.len()
 }
 
-/// FIR-1785: coverage must come from a graph that actually holds an index.
+/// Coverage must come from a graph that actually holds an index.
 ///
 /// The regression this pins is not a wrong number, it is a well-formed one.
 /// `embedding_status` answers `indexed = 0` for every retrievable object when

--- a/crates/kin-cli/tests/init_reproducibility.rs
+++ b/crates/kin-cli/tests/init_reproducibility.rs
@@ -32,10 +32,10 @@
 //! projection additionally carries a random operation id and the wall-clock
 //! commit time. Two admissions agree on those roots only by adopting one
 //! repository identity, which is what `KinManifest::adopting` is for and which
-//! two independent `kin init` runs deliberately do not do. Closing them is
-//! FIR-2068's follow-up and needs a repository-identity decision plus a root
-//! schema version, because every existing store validates that its recorded
-//! root bundle recomputes from its persisted envelope.
+//! two independent `kin init` runs deliberately do not do. Closing them needs a
+//! repository-identity decision plus a root schema version, because every
+//! existing store validates that its recorded root bundle recomputes from its
+//! persisted envelope.
 
 use serde_json::Value;
 use std::fs;

--- a/crates/kin-core/dependency_env_allowlist.txt
+++ b/crates/kin-core/dependency_env_allowlist.txt
@@ -24,7 +24,7 @@
 # anywhere, so nothing in a kin process ever reads them and registering them
 # would document a surface an operator cannot reach: setting KIN_EMBED_MAX_SECS
 # against today's binaries caps nothing. They stay out of the registry until a
-# caller exists (FIR-2163).
+# caller exists.
 #
 # Wiring the watchdog is the real open question rather than a registration one.
 # Umbrella doctrine wants embed drivers to carry a parent-death watchdog and a

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3578,7 +3578,7 @@ async fn command_trace_data_flow(
 /// server-side work is not cancelled, then revives and loses the race for a repo
 /// lock the live daemon still holds. What actually made the call slow enough to
 /// trip that ladder was one repository-authority open per step, fixed alongside
-/// this (FIR-1937).
+/// this.
 ///
 /// So this is defence in depth for the concurrent case rather than the fix, and
 /// it is what makes cancellation reachable at all: a walk inline in the handler
@@ -3616,7 +3616,7 @@ async fn run_trace_data_flow_off_runtime(
 /// disconnect, a timeout, a cancelled task — stops the server-side work rather
 /// than merely stopping anyone from reading its result. Without this, a query
 /// whose caller had gone kept burning CPU to completion, and a repository could
-/// be held out of service by work nobody was waiting for (FIR-1898).
+/// be held out of service by work nobody was waiting for.
 struct CancelOnDrop(kin_cli::commands::trace_data_flow::TraceCancel);
 
 impl Drop for CancelOnDrop {
@@ -11632,8 +11632,8 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
 
-    /// The HTTP contract an attached client uses to state its idle need
-    /// (FIR-1886), driven through the real router.
+    /// The HTTP contract an attached client uses to state its idle need, driven
+    /// through the real router.
     ///
     /// Both sides: a client whose session outlasts the daemon's window grows
     /// it, and a request that is not a floor is refused rather than silently
@@ -12406,9 +12406,9 @@ mod tests {
         }
     }
 
-    /// FIR-2183: an artifact hit reads the same whichever arm answered. The
-    /// fused arm used to write a constant `id_space: "entity"`, which was true
-    /// for exactly as long as the projection could only emit graph entities;
+    /// An artifact hit reads the same whichever arm answered. The fused arm
+    /// used to write a constant `id_space: "entity"`, which was true for
+    /// exactly as long as the projection could only emit graph entities;
     /// once a ranked artifact reaches this surface the constant relabels it as a
     /// resolvable id that every id-consuming tool refuses. Asserted on the
     /// serialized body, because the identity is written into the JSON after the
@@ -12446,9 +12446,9 @@ mod tests {
         assert!(rows[1].get("artifact_path").is_none());
     }
 
-    /// FIR-2170, asserted against the serializer rather than a hand-written
-    /// payload. `LocateResult` skips `entities` when the vector is empty, so an
-    /// empty fused page reaches the negative machinery carrying `files` and no
+    /// Asserted against the serializer rather than a hand-written payload.
+    /// `LocateResult` skips `entities` when the vector is empty, so an empty
+    /// fused page reaches the negative machinery carrying `files` and no
     /// `entities` key at all — the shape that has to be recognized, and the one
     /// a fixture written from the struct definition would miss.
     #[test]
@@ -12469,9 +12469,9 @@ mod tests {
         assert_eq!(negative["result_count"], json!(0));
     }
 
-    /// FIR-2178 on the same serialized shape: a full page for a symbol the
-    /// ranking never names is qualified, and every row it served is still
-    /// counted, because the contract reports and never filters.
+    /// The same serialized shape again: a full page for a symbol the ranking
+    /// never names is qualified, and every row it served is still counted,
+    /// because the contract reports and never filters.
     #[test]
     fn unnamed_fused_locate_body_is_qualified_without_dropping_rows() {
         let result = kin_cli::commands::locate::LocateResult {
@@ -14819,8 +14819,8 @@ mod tests {
 
     /// A daemon that has bound but not yet opened state ANSWERS.
     ///
-    /// FIR-2081. Opening state re-verifies the whole durable publication, so the
-    /// window is proportional to repository size. Two failure modes bracket it:
+    /// Opening state re-verifies the whole durable publication, so the window
+    /// is proportional to repository size. Two failure modes bracket it:
     /// binding after the open makes every arrival a connection refusal, and
     /// binding without answering leaves probes in the accept backlog until a
     /// readiness timeout kills a daemon that is working correctly.
@@ -20638,8 +20638,8 @@ mod tests {
         assert!(mcp_status.response_envelope.is_none());
     }
 
-    /// FIR-1785: the endpoint must publish the coverage of the index this
-    /// daemon is actually holding.
+    /// The endpoint must publish the coverage of the index this daemon is
+    /// actually holding.
     ///
     /// The sibling case above proves an unindexed graph is reported as an
     /// absence, which a handler that always answered "unobserved" would also
@@ -22455,8 +22455,8 @@ mod tests {
         assert_eq!(body["focal_entity"]["name"], json!("resolvable_target"));
     }
 
-    /// The cfg-twin shape from FIR-2146: one name, two entities, one of them the
-    /// ranked winner. The short-circuit decides only whether the index can place
+    /// The cfg-twin shape: one name, two entities, one of them the ranked
+    /// winner. The short-circuit decides only whether the index can place
     /// a name at all, so an ambiguous name has to reach the ranker and come back
     /// with the same choice it made before.
     #[tokio::test]
@@ -23417,7 +23417,7 @@ mod tests {
     // Health and readiness
     // -----------------------------------------------------------------------
 
-    /// The FIR-2147 shape end to end on `/health`.
+    /// The failing-admission shape end to end on `/health`.
     ///
     /// Nothing here is stopped and nothing is wedged. The reconcile loop wakes,
     /// fails its whole-tree admission, defers the paths, and sleeps, on
@@ -23491,9 +23491,9 @@ mod tests {
         assert!(!json.reconcile.degraded());
     }
 
-    /// The FIR-2145 shape: events errored and were dropped while every surface
-    /// read clean. Each dropped event leaves one path's enrichment stale, so the
-    /// count and the daemon's own error both have to reach `/health`.
+    /// Events errored and were dropped while every surface read clean. Each
+    /// dropped event leaves one path's enrichment stale, so the count and the
+    /// daemon's own error both have to reach `/health`.
     #[tokio::test]
     async fn health_degrades_and_names_the_error_when_reconcile_events_are_dropped() {
         let state = test_state();
@@ -27691,9 +27691,9 @@ mod tests {
     /// has, and it is the one where a per-result authority open multiplies.
     /// Distinct query tools at ONE publication share ONE authority load.
     ///
-    /// FIR-2079. Every MCP query request used to open repository authority for
-    /// itself, and an open decodes the whole persisted snapshot and re-verifies
-    /// every persisted body against its content address, so the query floor was
+    /// Every MCP query request used to open repository authority for itself,
+    /// and an open decodes the whole persisted snapshot and re-verifies every
+    /// persisted body against its content address, so the query floor was
     /// whole-repository work per REQUEST rather than per publication.
     ///
     /// The bound is a COUNT, never elapsed time. What an open costs is a
@@ -27709,9 +27709,9 @@ mod tests {
     #[tokio::test]
     async fn distinct_query_tools_share_one_authority_load_per_publication() {
         const PAGE: usize = 3;
-        // Same reason as the FIR-1897 test above: a phase budget exhausted by a
-        // stalled host makes locate return early with nothing projected, which
-        // reads at these assertions exactly like the regression they catch.
+        // Budgets disabled: a phase budget exhausted by a stalled host makes
+        // locate return early with nothing projected, which reads at these
+        // assertions exactly like the regression they catch.
         let _budget = kin_core::test_env::EnvVarGuard::set("KIN_LOCATE_TOTAL_TIMEOUT_SECS", "0")
             .with("KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS", "0")
             .with("KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS", "0")
@@ -27848,11 +27848,11 @@ mod tests {
     /// The three tools that resolve source through kin-cli command helpers share
     /// ONE authority load at one publication.
     ///
-    /// The other wrapper, and the gap FIR-2079 left open. `get_entity_source`,
-    /// `get_entity_sources`, and `trace_data_flow` do not read through kin-mcp's
-    /// authority; they route into kin-cli's, which opened per call. The batched
-    /// one was worse than per-request: it resolves source per entity, so N
-    /// entities cost N whole-store verifications.
+    /// The other wrapper, and the gap the per-request fix left open.
+    /// `get_entity_source`, `get_entity_sources`, and `trace_data_flow` do not
+    /// read through kin-mcp's authority; they route into kin-cli's, which
+    /// opened per call. The batched one was worse than per-request: it resolves
+    /// source per entity, so N entities cost N whole-store verifications.
     ///
     /// A count, not elapsed time, for the same reason as the query-tool bound
     /// above: what an open costs is a property of the store, so a timing
@@ -28051,15 +28051,16 @@ mod tests {
 
     /// The FUSED `semantic_locate` page opens repository authority ONCE.
     ///
-    /// This is the call-site regression test for FIR-1897 on the arm `POST
-    /// /locate` always uses, that `pipeline: "fused"` selects, that multi-query
-    /// forces, and that `KIN_PROFILE=accuracy-v1` selects. It runs the real MCP
-    /// dispatch route, so what it bounds is the shipped path rather than a
-    /// primitive: fused locate funnels into `run_with_graph_capture_budgeted`,
-    /// which projects bodies TWICE over the same symbol set -- once in
-    /// `attach_snippets` and again in `build_entity_view`. Holding one session
-    /// across both is the whole fix; reverting either to the one-shot entry point
-    /// compiles, changes no output, and must fail HERE.
+    /// This is the call-site regression test for the per-body authority open,
+    /// on the arm `POST /locate` always uses, that `pipeline: "fused"` selects,
+    /// that multi-query forces, and that `KIN_PROFILE=accuracy-v1` selects. It
+    /// runs the real MCP dispatch route, so what it bounds is the shipped path
+    /// rather than a primitive: fused locate funnels into
+    /// `run_with_graph_capture_budgeted`, which projects bodies TWICE over the
+    /// same symbol set -- once in `attach_snippets` and again in
+    /// `build_entity_view`. Holding one session across both is the whole fix;
+    /// reverting either to the one-shot entry point compiles, changes no
+    /// output, and must fail HERE.
     ///
     /// The assertion is on COUNTS, never on elapsed time. An authority open is a
     /// full recovery that re-verifies every persisted body against its content

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -823,9 +823,8 @@ mod tests {
         BackgroundWorkSupervisor::default().pass(PASS_RECONCILE)
     }
 
-    /// The FIR-2165 correction. A pass with deferred work owed reports a state
-    /// of its own, so a retry ladder that never converges stops reading as a
-    /// pass with nothing to do.
+    /// A pass with deferred work owed reports a state of its own, so a retry
+    /// ladder that never converges stops reading as a pass with nothing to do.
     #[test]
     fn deferred_work_is_reported_separately_from_idle() {
         let base = Instant::now();
@@ -1243,8 +1242,8 @@ mod tests {
         assert_eq!(supervisor.reports(Instant::now()).len(), 1);
     }
 
-    /// The FIR-2147 shape: every complete admission failing, for long enough
-    /// that the last success is hours old. The streak is what names it.
+    /// Every complete admission failing, for long enough that the last success
+    /// is hours old. The streak is what names it.
     #[test]
     fn consecutive_admission_failures_accumulate_into_a_streak() {
         let probes = ReconcileProbes::default();

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1442,8 +1442,8 @@ mod tests {
         );
     }
 
-    /// FIR-2147: the walk declines to observe a tracked path its rules cover,
-    /// so the observation carries that path's existing truth forward unchanged.
+    /// The walk declines to observe a tracked path its rules cover, so the
+    /// observation carries that path's existing truth forward unchanged.
     /// Reading "unobserved" as "absent" would delete graph-owned identity by
     /// inference, and it would do it on the exact pass that stopped reading the
     /// path. Retiring an ignored member stays an announced retraction.
@@ -1559,7 +1559,7 @@ mod tests {
     /// blob for those exact bytes, so nothing is left to read and this succeeds;
     /// the earlier code read every leaf a second time and fails here.
     ///
-    /// This is the whole-store phase FIR-2152 found inside the per-event path.
+    /// This is the whole-store phase that used to sit inside the per-event path.
     /// The reconcile loop runs this on every tick, so a working copy of twenty
     /// thousand files paid two complete reads of itself to observe that one file
     /// had moved. What it costs now is proportional to what moved.

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -3125,9 +3125,9 @@ mod tests {
         );
     }
 
-    /// FIR-1886 at the daemon: an attached client whose session outlasts the
-    /// window this daemon was spawned with grows it, and the grown window is
-    /// what the shutdown decision then reads.
+    /// The idle-window contract at the daemon: an attached client whose session
+    /// outlasts the window this daemon was spawned with grows it, and the grown
+    /// window is what the shutdown decision then reads.
     ///
     /// The two-sided part is the second half. Growing the window must not stop
     /// the daemon idling out; it must only move when.
@@ -3171,10 +3171,10 @@ mod tests {
 
     /// The monitor reads the live window, not the one it was handed at start.
     ///
-    /// This is the half of FIR-1886 that the state round-trip above cannot
-    /// reach: a monitor that closed over its startup value would keep counting
-    /// against 60 seconds however loudly an attached session said 1800, and the
-    /// state accessor would look perfectly correct while the daemon still died.
+    /// This is the half the state round-trip above cannot reach: a monitor that
+    /// closed over its startup value would keep counting against 60 seconds
+    /// however loudly an attached session said 1800, and the state accessor
+    /// would look perfectly correct while the daemon still died.
     #[tokio::test]
     async fn the_idle_monitor_counts_against_the_live_window_not_its_startup_one() {
         async fn open_idle_state() -> (tempfile::TempDir, Arc<DaemonState>) {

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -2480,10 +2480,10 @@ mod tests {
     /// A watcher event for host content the repository has never tracked is
     /// declined outright, and the decline is published.
     ///
-    /// This is FIR-2152. The path could not be admitted, because ambient
-    /// observation may revise graph-owned history but never enlarge it, and it
-    /// could not be enriched either, because the revalidation compares host
-    /// bytes against a tree entry authority does not hold. The loop deferred it
+    /// The path could not be admitted, because ambient observation may revise
+    /// graph-owned history but never enlarge it, and it could not be enriched
+    /// either, because the revalidation compares host bytes against a tree
+    /// entry authority does not hold. The loop deferred it
     /// instead, and every retry bought another complete exact-tree admission
     /// over the whole working copy that arrived at the identical refusal: the
     /// backlog never emptied, the status never returned to idle, the reported
@@ -2740,7 +2740,7 @@ mod tests {
     /// explicit seam and produces no watcher event of its own, so on a working
     /// copy nobody is editing there is no next ambient tick to replace the
     /// record. The surface would keep naming a path whose entities resolve,
-    /// which is the same misdirection FIR-2152 set out to remove.
+    /// which is the same misdirection the disclosure exists to remove.
     #[test]
     fn admitting_a_declined_path_clears_its_disclosure_without_another_host_event() {
         let repo = tempfile::tempdir().unwrap();
@@ -3481,9 +3481,9 @@ mod tests {
     ///
     /// The loop reports `set_deferred(retry_lane.deferred_owed(), tick_started)` and
     /// then finds `pending_events` empty, because a path waiting out its step is
-    /// dropped from incoming events and its retry is not yet due. Before
-    /// FIR-2165 that combination reported plain `idle` for the whole wait, so a
-    /// ladder that never converged was indistinguishable from a quiet loop.
+    /// dropped from incoming events and its retry is not yet due. That
+    /// combination used to report plain `idle` for the whole wait, so a ladder
+    /// that never converged was indistinguishable from a quiet loop.
     #[test]
     fn a_ladder_waiting_tick_reports_waiting_deferred_rather_than_idle() {
         let base = Duration::from_millis(100);

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1011,10 +1011,10 @@ impl IdleTimeoutRaise {
 /// returning the new window when one is warranted and `None` when the current
 /// window already covers the request.
 ///
-/// This is the whole decision behind FIR-1886. The idle window is fixed by
-/// whichever process spawns the daemon, and on a developer machine that is
-/// almost always an ordinary CLI command taking the short CLI default. A
-/// later client with a much longer session — an MCP agent loop that goes quiet
+/// This is the whole decision the idle floor exists to make. The idle window is
+/// fixed by whichever process spawns the daemon, and on a developer machine
+/// that is almost always an ordinary CLI command taking the short CLI default.
+/// A later client with a much longer session — an MCP agent loop that goes quiet
 /// between tool calls — used to inherit that short window silently and have the
 /// daemon expire underneath it mid-session.
 ///
@@ -5219,9 +5219,9 @@ mod tests {
             .expect("directory metadata sync must not reject a valid host directory");
     }
 
-    /// FIR-1886, both sides at the resolution layer. A client whose session
-    /// outlasts the window this daemon was spawned with grows it; a client that
-    /// already fits inside it changes nothing.
+    /// Both sides at the resolution layer. A client whose session outlasts the
+    /// window this daemon was spawned with grows it; a client that already fits
+    /// inside it changes nothing.
     #[test]
     fn an_idle_floor_grows_a_short_window_and_leaves_a_long_one_alone() {
         let secs = Duration::from_secs;

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -1481,10 +1481,10 @@ mod tests {
         assert!(prefixed.matches(&path("target/other.o")));
     }
 
-    /// The trap behind FIR-1854: a default exclude alone retires nothing. The
-    /// walk stops observing the path, and stopping short of observing it is
-    /// exactly why it cannot report the path gone. Retirement stays an
-    /// announced retraction the caller performs against graph truth.
+    /// The trap: a default exclude alone retires nothing. The walk stops
+    /// observing the path, and stopping short of observing it is exactly why it
+    /// cannot report the path gone. Retirement stays an announced retraction
+    /// the caller performs against graph truth.
     #[test]
     fn default_excludes_never_retire_an_already_tracked_path() {
         let temp = tempfile::tempdir().unwrap();
@@ -1715,9 +1715,9 @@ mod tests {
         );
     }
 
-    /// FIR-2147: an ignore rule is a statement about IO, not only about
-    /// membership. A tracked path the rules exclude is observed as unverified
-    /// and never opened, so no byte of an ignored subtree reaches the hasher.
+    /// An ignore rule is a statement about IO, not only about membership. A
+    /// tracked path the rules exclude is observed as unverified and never
+    /// opened, so no byte of an ignored subtree reaches the hasher.
     #[test]
     fn an_ignored_subtree_costs_no_content_reads_even_when_tracked() {
         let temp = tempfile::tempdir().unwrap();
@@ -1769,10 +1769,10 @@ mod tests {
         );
     }
 
-    /// The live shape behind FIR-2147: a 120GB VM image inside an ignored
-    /// subtree rewrote itself while the walk hashed it, and the churn failed
-    /// every whole-tree admission for two days. Nothing in an ignored subtree
-    /// is read now, so its churn cannot reach the rest of the tree.
+    /// The live shape: a 120GB VM image inside an ignored subtree rewrote
+    /// itself while the walk hashed it, and the churn failed every whole-tree
+    /// admission for two days. Nothing in an ignored subtree is read now, so
+    /// its churn cannot reach the rest of the tree.
     #[test]
     fn churn_beneath_an_ignored_subtree_admits_the_rest_of_the_tree() {
         use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1849,8 +1849,8 @@ mod tests {
 
     // ── Session-path revival over real sockets ─────────────────────────────
     //
-    // The regression FIR-1575 reports: only `/mcp/tools/call` had a revival
-    // path, so a repo daemon that idled out between two tool calls left every
+    // The regression: only `/mcp/tools/call` had a revival path, so a repo
+    // daemon that idled out between two tool calls left every
     // session/intent/traffic/status forward failing forever. These drive the
     // shared state machine those forwards now use, against real loopback
     // sockets, so reqwest's own error classification is exercised rather than

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4023,12 +4023,12 @@ mod tests {
         parsed_response(&handle_graph_neighborhood(&args, store).unwrap())
     }
 
-    /// The FIR-1595 regression. The tool has always described itself as
-    /// returning "both what it depends on and what depends on it", but traversed
-    /// the outgoing index alone, so `caller` — the only entity whose behavior a
-    /// change to `focal` can break — was never in the answer. An agent asking
-    /// this tool for blast radius got the focal's dependencies instead, with
-    /// nothing in the output to reveal the substitution.
+    /// The tool has always described itself as returning "both what it depends
+    /// on and what depends on it", but traversed the outgoing index alone, so
+    /// `caller` — the only entity whose behavior a change to `focal` can
+    /// break — was never in the answer. An agent asking this tool for blast
+    /// radius got the focal's dependencies instead, with nothing in the output
+    /// to reveal the substitution.
     #[test]
     fn graph_neighborhood_returns_dependents_not_only_dependencies() {
         let (store, _, focal_id, _) = neighborhood_fixture();
@@ -4705,7 +4705,7 @@ mod tests {
 
     #[test]
     fn graph_status_names_index_staleness_beside_complete_coverage() {
-        // FIR-2215. The umbrella store reported coverage {complete: true,
+        // The umbrella store reported coverage {complete: true,
         // indexed: 49, pending: 0, total: 49} beside entity_count 0, while
         // semantic_locate reported 40 of those ranked vector keys resolving to
         // entities the graph no longer holds. Coverage is measured against what

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -5326,7 +5326,7 @@ mod tests {
     /// A page of retrieval hits derives repository authority ONCE, not once per
     /// hit.
     ///
-    /// This is the bound FIR-1897 was filed on. `semantic_locate` fans a client
+    /// This is the bound that matters. `semantic_locate` fans a client
     /// `limit: 5` out to 40 daemon candidates, and the body projection re-opened
     /// the persisted authority and replayed the whole committed history for each
     /// one, so on a 23,683-blob store a single query ran past 44 minutes with no
@@ -5441,9 +5441,9 @@ mod tests {
 
     /// An entity the current workspace does not contain is history, not a gap.
     ///
-    /// FIR-1935. The graph ingests whole reachable history, so it carries
-    /// entities for files a repository deleted or renamed -- on the first
-    /// repository this was tried against, `httpx/models.py`, deleted in 2020.
+    /// The graph ingests whole reachable history, so it carries entities for
+    /// files a repository deleted or renamed -- on the first repository this
+    /// was tried against, `httpx/models.py`, deleted in 2020.
     /// The body projection reported that absence as an authority gap, and every
     /// surface projecting many entities turned one such candidate into a failed
     /// request.
@@ -5554,11 +5554,11 @@ mod tests {
 
     /// One caller deleted by history does not cost the whole reference set.
     ///
-    /// The page-level half of FIR-1935, on the multi-entity surface this crate
-    /// owns: `find_references` projects a body per referencing entity, so before
-    /// the fix a single historical caller propagated its error out of the loop
-    /// and the call returned nothing at all. The daemon's `semantic_locate` had
-    /// the identical shape and is what the ticket was filed on.
+    /// The page-level half, on the multi-entity surface this crate owns:
+    /// `find_references` projects a body per referencing entity, so before the
+    /// fix a single historical caller propagated its error out of the loop and
+    /// the call returned nothing at all. The daemon's `semantic_locate` had
+    /// the identical shape and is where it was first found.
     ///
     /// The assertion that matters is that the LIVE callers come back. A test
     /// that only asserted the call no longer errors would also pass if the fix
@@ -5648,9 +5648,9 @@ mod tests {
     /// `collect_graph_reference_rows` projects a bounded body per REFERENCING
     /// entity, so it has the same multi-entity shape as a retrieval page and had
     /// the same defect: a full authority recovery and a whole-history replay per
-    /// caller found. It was missed when FIR-1897 was first scoped because the
-    /// surface reads relations rather than running retrieval, and the ticket was
-    /// written about `semantic_locate`.
+    /// caller found. It was missed when the defect was first scoped because the
+    /// surface reads relations rather than running retrieval, and the scoping
+    /// was written about `semantic_locate`.
     ///
     /// Same counting discipline as the page test above, and the same second arm
     /// so a cheap fixture cannot be mistaken for a fixed one.

--- a/crates/kin-mcp/src/handlers/provenance.rs
+++ b/crates/kin-mcp/src/handlers/provenance.rs
@@ -786,8 +786,8 @@ mod tests {
 
     #[test]
     fn an_unresolvable_id_is_a_reported_miss_rather_than_an_empty_record() {
-        // FIR-2218. An id resolving to no entity with nothing recorded against
-        // it returned a clean success, so a resolution failure and "no
+        // An id resolving to no entity with nothing recorded against it
+        // returned a clean success, so a resolution failure and "no
         // provenance recorded" were the same answer on this surface while
         // get_entity_source failed loudly on the same id.
         let store = kin_db::InMemoryGraph::new();

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1815,8 +1815,8 @@ mod tests {
 
     #[test]
     fn empty_fused_locate_page_carries_the_negative() {
-        // FIR-2170: the fused arm is the default for code-bearing stores, and
-        // its empty page used to reach an agent as a bare `files: []` with no
+        // The fused arm is the default for code-bearing stores, and its empty
+        // page used to reach an agent as a bare `files: []` with no
         // qualification at all — an honest-looking negative that had qualified
         // nothing.
         let payload = empty_fused_locate_page("where does the daemon start");
@@ -1895,8 +1895,8 @@ mod tests {
 
     #[test]
     fn fabricated_symbol_gets_a_full_fused_page_qualified_as_unnamed() {
-        // FIR-2178: five confidently-scored hits for a symbol that exists
-        // nowhere. The page is real and stays whole; what it is NOT is the
+        // Five confidently-scored hits for a symbol that exists nowhere. The
+        // page is real and stays whole; what it is NOT is the
         // symbol that was asked for, and that is now stated.
         let mut payload = empty_fused_locate_page("zzqqxx_nonexistent_symbol_9f3a");
         payload["entities"] = json!((0..5)


### PR DESCRIPTION
Internal tracker ids are fine in commit messages and pull request bodies, where they record what a change resolved. They are barred from source comments, because there a ticket id is a stale pointer rather than a record, and it sends a reader of a public repo somewhere they cannot go.

This removes 68 of them across 28 files. Each one is replaced by the durable technical reason the code is shaped the way it is, taken from reading the surrounding code, rather than stripped and left as a stump. Where a comment carried nothing beyond the id and the code already said the same thing, the comment goes.

Comments only. No executable line changes, which the diff shows: every changed line is a comment.

Two further references sit inside assertion message strings rather than comments, in crates/kin-daemon/src/api.rs and crates/kin-mcp/src/handlers/mod.rs, both naming a ticket in an assert message. Those are executable lines and are left for a change that can touch code.
