### PR TITLE
Re-lock kin-db 0.7.21 and stop deep-cloning both graphs to compare three maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.20"
+version = "0.7.21"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1fc985fca4e1f858c069592c01ffe6deadedf8fee9f50dc61a0fc1e0abca9204"
+checksum = "2a6c754f946db0f26e836ba0c6c9a0e7fd416f7324c0b0d09692d3dd888f0933"
 dependencies = [
  "bincode",
  "bstr",
@@ -6625,7 +6625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.20", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.21", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -892,15 +892,11 @@ fn require_bound_authority_revision(
 /// `timed_finalize_step` is what makes the cost visible instead of silent.
 ///
 /// kin-db 0.7.21 answers the same question under its own read lock with no
-/// clone at all (`InMemoryGraph::semantic_workspace_matches`). This call site
-/// moves to it once that version is published and `kin` re-locks against it;
-/// the comparison is identical, so the swap is a cost change only.
+/// clone at all, and the comparison is identical, so this wrapper is a cost
+/// change only: three-map equality without deep-cloning revision history and
+/// the audit log on both sides, twice per reply.
 fn semantic_workspace_matches(left: &kin_db::InMemoryGraph, right: &kin_db::InMemoryGraph) -> bool {
-    let left = left.to_snapshot();
-    let right = right.to_snapshot();
-    left.entities == right.entities
-        && left.relations == right.relations
-        && left.resolved_tree == right.resolved_tree
+    left.semantic_workspace_matches(right)
 }
 
 fn plan_exact_transaction(


### PR DESCRIPTION
kin-db 0.7.21 carries the revision-key vector carry that completes FIR-2254's substrate half, and InMemoryGraph::semantic_workspace_matches, which answers the workspace-agreement question under its own read lock with no clone. The daemon's local wrapper previously snapshotted both graphs to compare three fields, deep-cloning every sub-store including revision history and the audit log, twice per commit reply, after the change was already durable; the dogfood measured 111 to 163 seconds of that silence. The wrapper now delegates; the comparison predicate is identical (verified in the kin-db#180 review: snapshot equality and live-map equality are the same content-based test), so this is a cost change only.

Lock re-locked patch-off: kin-db 0.7.21 resolves from the sparse registry with its checksum, no path or git source. Full workspace gate green on this tree (nextest plus doctests), fmt clean, clippy clean on the touched crate under the ci.yml allowlist.

Part of FIR-2254 and FIR-2258. The felt proof (commit reply in seconds on a large store) belongs to the next dogfood, not this PR.