### PR TITLE
Serve MCP initialize instructions so agents know the semantic tools on first contact

### DIFF
--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -831,6 +831,17 @@ pub async fn process_daemon_message(
 /// The MCP protocol version this server supports.
 const SUPPORTED_PROTOCOL_VERSION: &str = "2024-11-05";
 
+/// Usage instructions returned at initialize time so a connecting agent knows
+/// what this server is before its first tool call. Kept factual: what the
+/// tools answer from, when to prefer them over text search, and how to read
+/// the envelope and negative contract on retrieval results.
+const SERVER_INSTRUCTIONS: &str = "Kin answers repository questions from a semantic graph rather than raw file search. \
+Prefer semantic_locate to find symbols and behavior by meaning, get_context_pack for a structured context bundle \
+around an entity or file, and trace_data_flow for cross-file data lineage; reach for grep only when no graph-backed \
+tool answers the question. Every tool response carries a `_kin` envelope reporting graph freshness and coverage. An \
+empty retrieval result also carries a `negative` object whose `safe_to_conclude_absent` field says whether the \
+absence can be trusted; when it is false, treat the answer as unknown rather than absent.";
+
 fn handle_initialize(
     id: Option<serde_json::Value>,
     params: &serde_json::Value,
@@ -855,6 +866,7 @@ fn handle_initialize(
             name: config.server_name.clone(),
             version: config.server_version.clone(),
         },
+        instructions: Some(SERVER_INSTRUCTIONS.into()),
     })
     .unwrap_or_default();
 
@@ -1422,6 +1434,10 @@ mod tests {
         assert_eq!(result["serverInfo"]["name"], "kin-mcp");
         // P2-2.3: kinVersion must be present in serverInfo
         assert!(result["serverInfo"]["kinVersion"].is_string());
+        // The spec's instructions field must reach the wire with usable content.
+        let instructions = result["instructions"].as_str().unwrap();
+        assert!(instructions.contains("semantic_locate"));
+        assert!(instructions.contains("safe_to_conclude_absent"));
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/types.rs
+++ b/crates/kin-mcp/src/types.rs
@@ -88,6 +88,10 @@ pub struct InitializeResult {
     pub capabilities: ServerCapabilities,
     #[serde(rename = "serverInfo")]
     pub server_info: ServerInfo,
+    /// Optional usage hint the client may inject into the model's context
+    /// (`instructions` in the MCP 2024-11-05 schema).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }
 
 /// Server info.
@@ -174,6 +178,29 @@ mod tests {
         assert!(json.contains("-32601"));
         assert!(json.contains("Method not found"));
         assert!(!json.contains("\"result\""));
+    }
+
+    #[test]
+    fn initialize_result_serializes_instructions() {
+        let make = |instructions: Option<String>| InitializeResult {
+            protocol_version: "2024-11-05".into(),
+            capabilities: ServerCapabilities {
+                tools: ToolsCapability {
+                    list_changed: false,
+                },
+            },
+            server_info: ServerInfo {
+                name: "kin-mcp".into(),
+                version: "0.0.0".into(),
+            },
+            instructions,
+        };
+
+        let with = serde_json::to_value(make(Some("use the graph".into()))).unwrap();
+        assert_eq!(with["instructions"], "use the graph");
+
+        let without = serde_json::to_value(make(None)).unwrap();
+        assert!(without.get("instructions").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Kin's MCP server answered initialize with only a name and version, so every connecting agent started blind. The MCP 2024-11-05 schema, the protocol version this crate pins, defines an optional `instructions` string on the initialize result as a hint the client may inject into the model's context.

This adds the `instructions` field to `InitializeResult`, serialized as the spec's lowercase `instructions` and omitted when `None`, and populates it from the server. The string stays factual. It says the tools answer from a semantic graph, tells agents to prefer `semantic_locate`, `get_context_pack`, and `trace_data_flow` over grep, and describes the `_kin` envelope and the `negative` object whose `safe_to_conclude_absent` field says whether an empty result can be trusted as absence.

Every claim in the string was checked against the code it describes. `envelope::finalize` is the chokepoint on each tool dispatch path, so every tool response carries the envelope, and the negative contract is retrieval-scoped in `negative.rs`.

A types-level test asserts the field serializes when present and disappears when absent. The existing initialize wire test now also asserts the instructions reach the wire with usable content.

Closes FIR-2266
