### PR TITLE
Retain tracked artifact text at ingest so retrieval has something to index

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -17341,6 +17341,59 @@ mod tests {
             .all(|entity| entity.id_space == LocateIdSpace::Artifact));
     }
 
+    /// The same promise through the REAL ingest enrichment instead of a
+    /// hand-rolled preview. Every fixture above hands `put_opaque` its full
+    /// body as `text_preview`, which is a state ingest never produced: the
+    /// enrichment pipeline stored every opaque artifact with no text at all,
+    /// so on a real store the text index held only a path and a MIME type and
+    /// every one of these green tests described a store that could not exist.
+    /// This test routes the bytes through `IndexPipeline::index_any_content`,
+    /// exactly what the daemon runs on admit, and puts the phrase past any
+    /// head-sized preview so head-only retention fails it too.
+    #[test]
+    #[serial_test::serial]
+    fn a_pipeline_enriched_docs_store_answers_for_deep_content() {
+        let mut body = String::from("# Kin Ecosystem AGENTS.md\n\n");
+        for index in 0..40 {
+            body.push_str(&format!(
+                "Ordinary paragraph {index} about workspace upkeep and lane hygiene, nothing \
+                 doctrinal here.\n\n"
+            ));
+        }
+        body.push_str("## Verification Rule\n\nChecks That Cannot Fail is doctrine here.\n");
+        assert!(
+            body.find("Checks That Cannot Fail").unwrap() > 2_000,
+            "the phrase must sit beyond any head-sized preview"
+        );
+
+        let bytes = body.as_bytes();
+        let indexed = kin_index::pipeline::IndexPipeline::new()
+            .index_any_content(
+                &FilePathId::new("AGENTS.md"),
+                bytes,
+                kin_blobs::digest(bytes),
+            )
+            .unwrap();
+        let kin_index::pipeline::IndexedAny::OpaqueArtifact(artifact) = indexed else {
+            panic!("markdown must take the opaque enrichment facet");
+        };
+
+        let graph = kin_db::InMemoryGraph::new();
+        graph.put_opaque(&artifact).unwrap();
+        graph.flush_text_index().unwrap();
+
+        let result = agent_locate(&graph, "Checks That Cannot Fail");
+        assert!(
+            artifact_row(&result, "AGENTS.md").is_some(),
+            "a pipeline-enriched docs store must answer for its own deep content; entities: {:?}",
+            result
+                .entities
+                .iter()
+                .map(|entity| entity.name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
     /// The bound holds, and a short page says it was short. A page cut to its
     /// limit with nothing said reads as the store having only that much.
     #[test]

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -915,6 +915,22 @@ fn entity_to_daemon_record(
     }
 }
 
+/// Characters of artifact text a search record renders.
+///
+/// The stored preview is a retrieval retention (up to
+/// `kin_index::artifacts::ARTIFACT_TEXT_RETENTION_CHARS`), not a display
+/// string; a record that carried it whole would put an entire document on the
+/// wire per row.
+const ARTIFACT_PREVIEW_DISPLAY_CHARS: usize = 320;
+
+fn artifact_display_preview(preview: Option<&str>) -> Option<String> {
+    let text = preview?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    Some(text.chars().take(ARTIFACT_PREVIEW_DISPLAY_CHARS).collect())
+}
+
 fn resolved_item_to_daemon_record(
     item: &ResolvedRetrievalItem,
     match_kind: SearchMatchKind,
@@ -964,7 +980,7 @@ fn resolved_item_to_daemon_record(
             file,
             artifact_kind: format!("{:?}", artifact.kind),
             line: 1,
-            preview: artifact.text_preview.clone(),
+            preview: artifact_display_preview(artifact.text_preview.as_deref()),
             score,
             match_kind: Some(match_kind),
         },
@@ -980,7 +996,7 @@ fn resolved_item_to_daemon_record(
                 .clone()
                 .unwrap_or_else(|| "opaque".to_string()),
             line: 1,
-            preview: artifact.text_preview.clone(),
+            preview: artifact_display_preview(artifact.text_preview.as_deref()),
             score,
             match_kind: Some(match_kind),
         },
@@ -1102,8 +1118,12 @@ fn record_preview(item: &ResolvedRetrievalItem) -> Option<String> {
                 ))
             }
         }
-        ResolvedRetrievalItem::StructuredArtifact(artifact) => artifact.text_preview.clone(),
-        ResolvedRetrievalItem::OpaqueArtifact(artifact) => artifact.text_preview.clone(),
+        ResolvedRetrievalItem::StructuredArtifact(artifact) => {
+            artifact_display_preview(artifact.text_preview.as_deref())
+        }
+        ResolvedRetrievalItem::OpaqueArtifact(artifact) => {
+            artifact_display_preview(artifact.text_preview.as_deref())
+        }
     }
 }
 

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -847,6 +847,30 @@ where
     Ok(file_ids)
 }
 
+/// Upper bound, in characters, on one supporting-artifact entry in a pack.
+///
+/// A tracked artifact retains its text up to
+/// `kin_index::artifacts::ARTIFACT_TEXT_RETENTION_CHARS` so the text index and
+/// the artifact embedding see the whole document. A pack entry is a different
+/// thing: an excerpt sitting beside the focal entity under a shared token
+/// budget. Unbounded, one ordinary document claims the entire budget, and every
+/// other artifact for every other file loses its seat. The whole text stays
+/// reachable through the artifact read path.
+const ARTIFACT_ENTRY_CONTENT_CHARS: usize = 2_000;
+
+/// Trim an artifact entry to the excerpt a pack can afford to carry.
+fn bounded_artifact_entry_content(content: String) -> String {
+    if content.len() <= ARTIFACT_ENTRY_CONTENT_CHARS {
+        return content;
+    }
+    content.chars().take(ARTIFACT_ENTRY_CONTENT_CHARS).collect()
+}
+
+/// Admit supporting artifacts for the planned files under the pack's budget.
+///
+/// Admission skips an entry that does not fit rather than stopping at it.
+/// Entries sort by file path, so stopping let whichever artifact happened to
+/// sort early decide how many of the others were seen at all.
 fn append_supporting_artifacts<G>(
     graph: &G,
     pack: &mut ContextPack,
@@ -873,7 +897,7 @@ where
                 retrieval_key: RetrievalKey::Artifact(artifact_id),
                 file_path: file.file_id.clone(),
                 kind: ArtifactContextKind::ShallowFile,
-                content: kin_db::embed::format_shallow_text(&file),
+                content: bounded_artifact_entry_content(kin_db::embed::format_shallow_text(&file)),
             });
         }
 
@@ -885,7 +909,9 @@ where
                 retrieval_key: RetrievalKey::Artifact(artifact_id),
                 file_path: artifact.file_id.clone(),
                 kind: ArtifactContextKind::StructuredArtifact(artifact.kind),
-                content: kin_db::embed::format_artifact_text(&artifact),
+                content: bounded_artifact_entry_content(kin_db::embed::format_artifact_text(
+                    &artifact,
+                )),
             });
         }
 
@@ -897,7 +923,9 @@ where
                 retrieval_key: RetrievalKey::Artifact(artifact_id),
                 file_path: artifact.file_id.clone(),
                 kind: ArtifactContextKind::OpaqueArtifact,
-                content: kin_db::embed::format_opaque_text(&artifact),
+                content: bounded_artifact_entry_content(kin_db::embed::format_opaque_text(
+                    &artifact,
+                )),
             });
         }
     }
@@ -912,7 +940,7 @@ where
     for entry in entries {
         let tokens = estimate_tokens(&entry.content);
         if pack.actual_tokens + tokens > budget_max {
-            break;
+            continue;
         }
         pack.actual_tokens += tokens;
         pack.supporting_artifacts.push(entry);
@@ -1839,6 +1867,186 @@ mod tests {
             .annotations
             .iter()
             .all(|entry| !entry.content.contains("Keep this target cached")));
+    }
+
+    /// A docs store is the case FIR-2183 is about, and a real doc is far larger
+    /// than the metadata line artifacts used to carry. The entry must be
+    /// excerpted to a size a pack can afford, and an entry that still does not
+    /// fit must not decide whether the rest of the files are seen at all. The
+    /// sibling Makefile sorts after AGENTS.md, so it is exactly the seat a
+    /// stop-at-first-overflow admission gave away.
+    #[test]
+    fn a_large_docs_artifact_neither_empties_nor_dominates_supporting_artifacts() {
+        let store = kin_db::InMemoryGraph::new();
+        let focal = make_file_entity("handler", EntityKind::Function, "src/main.rs");
+        store.upsert_entity(&focal).unwrap();
+
+        let mut docs_body =
+            String::from("# Kin Ecosystem AGENTS.md\n\nThe canonical umbrella doc.\n\n");
+        while docs_body.len() < 53_000 {
+            docs_body.push_str(
+                "Ordinary paragraph about workspace upkeep, lane hygiene, and the ordered \
+                 story this file keeps durable.\n\n",
+            );
+        }
+
+        let agents = FilePathId::new("AGENTS.md");
+        let makefile = FilePathId::new("Makefile");
+        let agents_artifact_id = admit_test_artifact(&store, &agents, Hash256::from_bytes([7; 32]));
+        let makefile_artifact_id =
+            admit_test_artifact(&store, &makefile, Hash256::from_bytes([3; 32]));
+
+        store
+            .upsert_opaque_artifact(&OpaqueArtifact {
+                file_id: agents.clone(),
+                content_hash: Hash256::from_bytes([7; 32]),
+                mime_type: Some("text/markdown".to_string()),
+                text_preview: Some(docs_body),
+            })
+            .unwrap();
+        store
+            .upsert_structured_artifact(&StructuredArtifact {
+                file_id: makefile.clone(),
+                kind: ArtifactKind::Makefile,
+                content_hash: Hash256::from_bytes([3; 32]),
+                text_preview: Some("build:\n\tcargo test".to_string()),
+            })
+            .unwrap();
+
+        let plan = ContextPlan {
+            seeds: vec![
+                ContextPlanSeed {
+                    retrieval_key: RetrievalKey::Artifact(agents_artifact_id),
+                    file_path: Some(agents.clone()),
+                    score: 3.0,
+                    lexical: true,
+                    semantic: false,
+                },
+                ContextPlanSeed {
+                    retrieval_key: RetrievalKey::Artifact(makefile_artifact_id),
+                    file_path: Some(makefile.clone()),
+                    score: 2.0,
+                    lexical: true,
+                    semantic: false,
+                },
+            ],
+        };
+
+        let options = ContextOptions::default();
+        let budget_max = options.budget.max_tokens();
+        let pack = build_context_pack_from_plan(&store, &focal.id, &options, &plan).unwrap();
+
+        let docs_entry = pack
+            .supporting_artifacts
+            .iter()
+            .find(|entry| entry.file_path == agents)
+            .expect("a docs store must carry its own artifact in a default-budget pack");
+        assert!(
+            docs_entry.content.contains("Kin Ecosystem AGENTS.md"),
+            "the admitted entry must carry artifact text, not just its metadata line"
+        );
+        assert!(
+            docs_entry.content.chars().count() <= ARTIFACT_ENTRY_CONTENT_CHARS,
+            "one artifact entry must stay an excerpt"
+        );
+        assert!(
+            estimate_tokens(&docs_entry.content) * 4 < budget_max,
+            "one artifact entry must not claim a quarter of the budget"
+        );
+
+        assert!(
+            pack.supporting_artifacts
+                .iter()
+                .any(|entry| entry.file_path == makefile),
+            "a large artifact must not cost a later file its seat"
+        );
+        assert!(pack.actual_tokens <= budget_max);
+    }
+
+    /// Admission skips what it cannot afford instead of stopping there. The
+    /// budget here fits the Makefile entry and not the AGENTS.md one, and
+    /// AGENTS.md sorts first, so stopping at the first overflow costs the
+    /// Makefile a seat it could have paid for.
+    #[test]
+    fn an_unaffordable_artifact_does_not_cost_the_next_file_its_seat() {
+        let store = kin_db::InMemoryGraph::new();
+        let focal = make_file_entity("handler", EntityKind::Function, "src/main.rs");
+        store.upsert_entity(&focal).unwrap();
+
+        let agents = FilePathId::new("AGENTS.md");
+        let makefile = FilePathId::new("Makefile");
+        assert!(agents.0 < makefile.0, "the large entry must sort first");
+
+        let agents_artifact_id = admit_test_artifact(&store, &agents, Hash256::from_bytes([7; 32]));
+        let makefile_artifact_id =
+            admit_test_artifact(&store, &makefile, Hash256::from_bytes([3; 32]));
+
+        let opaque = OpaqueArtifact {
+            file_id: agents.clone(),
+            content_hash: Hash256::from_bytes([7; 32]),
+            mime_type: Some("text/markdown".to_string()),
+            text_preview: Some("Doctrine paragraph about lane hygiene. ".repeat(40)),
+        };
+        let structured = StructuredArtifact {
+            file_id: makefile.clone(),
+            kind: ArtifactKind::Makefile,
+            content_hash: Hash256::from_bytes([3; 32]),
+            text_preview: Some("build:\n\tcargo test".to_string()),
+        };
+        store.upsert_opaque_artifact(&opaque).unwrap();
+        store.upsert_structured_artifact(&structured).unwrap();
+
+        let agents_tokens = estimate_tokens(&bounded_artifact_entry_content(
+            kin_db::embed::format_opaque_text(&opaque),
+        ));
+        let makefile_tokens = estimate_tokens(&bounded_artifact_entry_content(
+            kin_db::embed::format_artifact_text(&structured),
+        ));
+        assert!(
+            makefile_tokens < agents_tokens,
+            "the fixture must make only the later entry affordable"
+        );
+
+        let baseline = build_context_pack(&store, &focal.id, &ContextOptions::default())
+            .unwrap()
+            .actual_tokens;
+        let options = ContextOptions {
+            budget: TokenBudget::Custom(baseline + makefile_tokens),
+            ..ContextOptions::default()
+        };
+
+        let plan = ContextPlan {
+            seeds: vec![
+                ContextPlanSeed {
+                    retrieval_key: RetrievalKey::Artifact(agents_artifact_id),
+                    file_path: Some(agents.clone()),
+                    score: 3.0,
+                    lexical: true,
+                    semantic: false,
+                },
+                ContextPlanSeed {
+                    retrieval_key: RetrievalKey::Artifact(makefile_artifact_id),
+                    file_path: Some(makefile.clone()),
+                    score: 2.0,
+                    lexical: true,
+                    semantic: false,
+                },
+            ],
+        };
+
+        let pack = build_context_pack_from_plan(&store, &focal.id, &options, &plan).unwrap();
+
+        let admitted: Vec<&FilePathId> = pack
+            .supporting_artifacts
+            .iter()
+            .map(|entry| &entry.file_path)
+            .collect();
+        assert_eq!(
+            admitted,
+            vec![&makefile],
+            "the affordable later entry must still be admitted"
+        );
+        assert!(pack.actual_tokens <= options.budget.max_tokens());
     }
 
     #[test]

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -955,29 +955,7 @@ fn historical_source_text(content: &[u8]) -> Option<String> {
 }
 
 fn preview_text_if_likely_text(content: &[u8], mime_hint: Option<&str>) -> Option<String> {
-    let textual_mime = mime_hint.is_some_and(|mime| {
-        mime.starts_with("text/")
-            || mime.contains("json")
-            || mime.contains("yaml")
-            || mime.contains("toml")
-            || mime.contains("xml")
-            || mime.contains("javascript")
-            || mime.contains("shell")
-    });
-    if textual_mime {
-        return preview_text(content);
-    }
-
-    let printable = content
-        .iter()
-        .copied()
-        .filter(|byte| byte.is_ascii_graphic() || byte.is_ascii_whitespace())
-        .count();
-    if !content.is_empty() && printable * 100 / content.len() >= 92 {
-        return preview_text(content);
-    }
-
-    None
+    kin_index::artifacts::opaque_text_preview(content, mime_hint)
 }
 
 fn build_entity_file_layout(
@@ -1193,6 +1171,51 @@ mod tests {
             .unwrap()
             .is_empty());
         assert!(historical.text_search("Deployment", 10).unwrap().is_empty());
+    }
+
+    /// A historical docs artifact keeps its deep text, not a head-sized
+    /// preview: FIR-2183's mechanism was that only the head of a document ever
+    /// reached the text index, so any phrase past it was unfindable.
+    #[test]
+    fn build_graph_at_ref_keeps_deep_opaque_text() {
+        let graph = InMemoryGraph::new();
+        let temp = tempfile::tempdir().unwrap();
+        let authority = test_authority(temp.path());
+
+        let genesis_id = create_fixture_change(&graph, vec![], "genesis", vec![], vec![]);
+
+        let mut body = String::from("# Notes\n\n");
+        for index in 0..40 {
+            body.push_str(&format!(
+                "Routine paragraph {index} about ordinary upkeep of the greenhouse ledger, \
+                 nothing remarkable here.\n\n"
+            ));
+        }
+        body.push_str("The quokka semaphore doctrine sits far past any head-sized preview.\n");
+        assert!(body.find("quokka").unwrap() > 2_000);
+
+        let notes_hash = save_source_blob(&authority, body.as_bytes());
+        let add_id = create_fixture_change(
+            &graph,
+            vec![genesis_id],
+            "add deep notes",
+            vec![],
+            vec![added(0x104, "NOTES.md", notes_hash)],
+        );
+
+        let historical = build_graph_at_ref_from_graph(&graph, &authority, &add_id).unwrap();
+
+        assert!(historical
+            .list_opaque_artifacts()
+            .unwrap()
+            .iter()
+            .any(|artifact| artifact.file_id.0 == "NOTES.md"
+                && artifact
+                    .text_preview
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("quokka semaphore doctrine")));
+        assert!(!historical.text_search("quokka", 10).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/kin-index/src/artifacts.rs
+++ b/crates/kin-index/src/artifacts.rs
@@ -195,6 +195,56 @@ fn preview_text(content: &str) -> Option<String> {
     }
 }
 
+/// Upper bound, in characters, on the text a tracked artifact retains for
+/// retrieval enrichment.
+///
+/// A tracked artifact is its own text and nothing else: this retained text is
+/// the only content the text index and the artifact embedding ever see, so a
+/// head-sized cap silently unindexes everything below it. The bound matches
+/// the historical-source retention used by ref materialization. It is a
+/// retention cap, not a display size; surfaces that render a preview apply
+/// their own display bound.
+pub const ARTIFACT_TEXT_RETENTION_CHARS: usize = 256_000;
+
+/// Bounded full text of a tracked artifact, when its bytes are text at all.
+///
+/// A textual MIME hint qualifies the bytes outright. Without one, they qualify
+/// by being at least 92% printable, which keeps extensionless binaries out of
+/// the text index. Either way the bytes must be valid UTF-8. Returns `None`
+/// for binary or empty content, never an empty string.
+pub fn opaque_text_preview(content: &[u8], mime_hint: Option<&str>) -> Option<String> {
+    let text = std::str::from_utf8(content).ok()?;
+    let textual_mime = mime_hint.is_some_and(|mime| {
+        mime.starts_with("text/")
+            || mime.contains("json")
+            || mime.contains("yaml")
+            || mime.contains("toml")
+            || mime.contains("xml")
+            || mime.contains("javascript")
+            || mime.contains("shell")
+    });
+    if !textual_mime {
+        let printable = content
+            .iter()
+            .copied()
+            .filter(|byte| byte.is_ascii_graphic() || byte.is_ascii_whitespace())
+            .count();
+        if content.is_empty() || printable * 100 / content.len() < 92 {
+            return None;
+        }
+    }
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .chars()
+            .take(ARTIFACT_TEXT_RETENTION_CHARS)
+            .collect(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -496,7 +496,7 @@ impl IndexPipeline {
                     file_id: file_id.clone(),
                     content_hash: Hash256::from_bytes(blob_hash.0),
                     mime_type: None,
-                    text_preview: None,
+                    text_preview: artifacts::opaque_text_preview(content, None),
                 }))
             }
             FileClassification::OpaqueArtifact { mime_hint } => {
@@ -507,11 +507,12 @@ impl IndexPipeline {
                     "enriched opaque artifact"
                 );
 
+                let text_preview = artifacts::opaque_text_preview(content, mime_hint.as_deref());
                 Ok(IndexedAny::OpaqueArtifact(OpaqueArtifact {
                     file_id: file_id.clone(),
                     content_hash: Hash256::from_bytes(blob_hash.0),
                     mime_type: mime_hint,
-                    text_preview: None,
+                    text_preview,
                 }))
             }
         }
@@ -1409,6 +1410,74 @@ pub fn add(a: i32, b: i32) -> i32 { a + b }\n";
         assert_eq!(
             artifact.mime_type.as_deref(),
             Some("application/octet-stream")
+        );
+        assert!(
+            artifact.text_preview.is_none(),
+            "binary bytes must not enter the text index"
+        );
+    }
+
+    /// The FIR-2183 mechanism: real ingest stored every opaque artifact with no
+    /// text at all, so the text index and the artifact embedding saw only a
+    /// path and a MIME type, and a docs store could not answer for its own
+    /// content. The deep marker sits past any head-sized preview, so this test
+    /// fails against head-only retention too, not just against `None`.
+    #[test]
+    fn admitted_markdown_keeps_deep_text_in_its_retrieval_preview() {
+        let mut body =
+            String::from("# Field Notes\n\nHead marker: zebrafish lantern protocol.\n\n");
+        for index in 0..40 {
+            body.push_str(&format!(
+                "Routine paragraph {index} about ordinary upkeep of the greenhouse ledger and \
+                 irrigation schedule, nothing remarkable here.\n\n"
+            ));
+        }
+        body.push_str(
+            "## Deep Doctrine\n\nThe quokka semaphore doctrine states that a docs store must \
+             answer for its own content.\n",
+        );
+        assert!(
+            body.find("quokka").unwrap() > 2_000,
+            "the deep marker must sit beyond any head-sized preview"
+        );
+
+        let bytes = body.as_bytes();
+        let hash = kin_blobs::digest(bytes);
+        let indexed = IndexPipeline::new()
+            .index_any_content(&FilePathId::new("AGENTS.md"), bytes, hash)
+            .unwrap();
+
+        let IndexedAny::OpaqueArtifact(artifact) = indexed else {
+            panic!("markdown must take the opaque enrichment facet");
+        };
+        let preview = artifact
+            .text_preview
+            .expect("a textual artifact must retain its text for retrieval");
+        assert!(preview.contains("zebrafish lantern protocol"));
+        assert!(preview.contains("quokka semaphore doctrine"));
+    }
+
+    /// The retention bound holds, and an extensionless text file qualifies by
+    /// content rather than by MIME hint.
+    #[test]
+    fn artifact_text_retention_is_bounded_and_content_qualified() {
+        let body = "word ".repeat(60_000);
+        let bytes = body.as_bytes();
+        let hash = kin_blobs::digest(bytes);
+        let indexed = IndexPipeline::new()
+            .index_any_content(&FilePathId::new("NOTICE"), bytes, hash)
+            .unwrap();
+
+        let IndexedAny::OpaqueArtifact(artifact) = indexed else {
+            panic!("extensionless text must take the opaque enrichment facet");
+        };
+        assert_eq!(artifact.mime_type, None);
+        let preview = artifact
+            .text_preview
+            .expect("printable extensionless bytes must qualify as text");
+        assert_eq!(
+            preview.chars().count(),
+            crate::artifacts::ARTIFACT_TEXT_RETENTION_CHARS
         );
     }
 


### PR DESCRIPTION
A docs store still could not answer for its own content on v0.5.21, with the store fully embedded, after the candidacy door for exactly this shipped in kin#760. The door was never the obstacle: it reads its candidates from a text search, and the text search had nothing to find. Real ingest stored every opaque artifact with `text_preview: None` in both branches of `IndexPipeline::index_any_content`, ref materialization capped the preview at 64 words, and kin-db indexes an opaque artifact's preview or nothing (`opaque_artifact_fields`), then embeds that same preview or nothing (`format_opaque_text`). On a real store both retrieval arms therefore held one path, one MIME type, and the literal word opaque_artifact per document, and every phrase past the head of a file was unfindable by construction. kin#760's twelve tests all passed because their fixtures handed `put_opaque` the full body as the preview, a state no ingest path ever produced.

Ingest now retains bounded full text for textual artifact bytes, in one helper both live enrichment and ref materialization call. A textual MIME hint qualifies the bytes outright; without one, printable-majority UTF-8 qualifies, so extensionless text is kept and binaries stay out. The bound is 256,000 characters, matching the retention ref materialization already grants historical source text. Because `upsert_opaque_artifact` re-queues the artifact for embedding, the retained text reaches the vector arm through the existing queue with no new plumbing.

That bound is a retention cap rather than a display size, so each surface that renders the text sets its own. Search records still render the 320 characters they carried before. Context packs needed a real change, because a pack entry took the retained text verbatim and admission stopped at the first entry it could not afford instead of skipping it. Measured on a 53 KB doc against the default 8,000 token budget, that one entry estimated 8,957 tokens, and since entries sort by file path it emptied the pack for every other file too, taking supporting artifacts from two entries to none. Each entry is now excerpted to 2,000 characters and admission continues past what it cannot afford, so both entries hold. The whole text stays reachable through the artifact read path.

Six new tests pin it. Markdown through the real enrichment keeps a phrase placed past any head-sized preview. An extensionless text file qualifies by content and the bound holds exactly. The existing binary case gains an assertion that binary bytes still retain nothing. The ticket's own shape runs the real pipeline output through a store write, the text index, and locate, and requires the artifact-labelled row for a phrase 2,000 characters deep. Another holds the same deep retention on the ref materialization path. The last two cover the pack, one per half of that change. Reverting the two pipeline lines fails the three deep-text tests while the binary control and kin#760's own fixture tests stay green, which is the original defect reproduced in miniature: fixture green, real ingest red. Reverting either half of the pack change fails that half's test and only that one.

Not claimed: stores admitted before this change keep their empty previews until their files re-enrich, so felt acceptance on an already-built store still needs a fresh admit; the vector arm stays dark until FIR-2202 lands, because artifact vectors do not reach real stores yet, so the re-queue above is the plumbing being right rather than the vector arm working; structured artifacts keep their 64-word normalized preview, a shallower version of the same gap left for its own decision because deepening it re-prices manifests; and this changes recall on fresh stores in a way that has not been measured against the benchmark suite.

FIR-2183
