### PR TITLE
Settle dying group members and reserve the tests' closed ports

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7908,14 +7908,54 @@ mod tests {
     // later command repeated the same failure until the first daemon exited.
     // A timeout is evidence that a daemon is slow, never that it is dead.
 
-    /// A loopback port with nothing listening: connections are refused
-    /// immediately, so the probe exercises the unreachable-endpoint path
-    /// without waiting on a real timeout.
-    fn closed_loopback_port() -> u16 {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        port
+    /// A loopback port that refuses connections for as long as this guard
+    /// lives, so the probe exercises the unreachable-endpoint path without
+    /// waiting on a real timeout.
+    ///
+    /// The refusal has to hold for the width of the probe, not just at
+    /// acquisition. This test binary runs hundreds of sibling tests that bind
+    /// ephemeral loopback listeners the whole time, so a port that was merely
+    /// observed closed and then released can be handed by the kernel to a
+    /// sibling's mock daemon mid-probe. The probe then receives a real health
+    /// answer naming a different repository, which is positive evidence of a
+    /// stale record, and the verdict the test meant to be about "nothing
+    /// listens here" becomes a retirement. Holding the socket bound but never
+    /// listening keeps both properties at once: without a listen queue every
+    /// connect is refused, and while the reservation is held no other socket
+    /// can bind the port.
+    struct ReservedClosedPort {
+        port: u16,
+        _reservation: tokio::net::TcpSocket,
+    }
+
+    fn reserved_closed_loopback_port() -> ReservedClosedPort {
+        let socket = tokio::net::TcpSocket::new_v4().expect("create the port reservation socket");
+        socket
+            .bind("127.0.0.1:0".parse().expect("loopback bind address"))
+            .expect("bind the port reservation");
+        let port = socket.local_addr().expect("read the reserved port").port();
+        ReservedClosedPort {
+            port,
+            _reservation: socket,
+        }
+    }
+
+    #[test]
+    fn a_reserved_closed_port_refuses_connections_and_cannot_be_rebound() {
+        let reserved = reserved_closed_loopback_port();
+        let address = std::net::SocketAddr::from(([127, 0, 0, 1], reserved.port));
+
+        let error = std::net::TcpStream::connect(address)
+            .expect_err("a reserved closed port must refuse connections while held");
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::ConnectionRefused,
+            "refusal must be immediate, not a timeout: {error}"
+        );
+        assert!(
+            std::net::TcpListener::bind(address).is_err(),
+            "no listener may take the port while the reservation is held"
+        );
     }
 
     fn write_endpoint_files(kin_root: &Path, pid: u32, port: u16) {
@@ -7942,7 +7982,8 @@ mod tests {
         let root = dir.path();
         // The recorded owner is this test process, so it is provably alive —
         // exactly the daemon-still-loading shape.
-        write_endpoint_files(root, std::process::id(), closed_loopback_port());
+        let closed = reserved_closed_loopback_port();
+        write_endpoint_files(root, std::process::id(), closed.port);
 
         let verdict = wait_for_existing_daemon_within(
             root,
@@ -7970,7 +8011,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let pid = std::process::id();
-        write_endpoint_files(root, pid, closed_loopback_port());
+        let closed = reserved_closed_loopback_port();
+        write_endpoint_files(root, pid, closed.port);
 
         let ExistingDaemon::LiveNotReady(message) = wait_for_existing_daemon_within(
             root,
@@ -8156,9 +8198,11 @@ mod tests {
             .arg("30")
             .spawn()
             .expect("spawn predecessor process");
-        write_endpoint_files(&root, predecessor.id(), closed_loopback_port());
+        let predecessor_port = reserved_closed_loopback_port();
+        write_endpoint_files(&root, predecessor.id(), predecessor_port.port);
 
-        let successor_port = closed_loopback_port();
+        let successor_reservation = reserved_closed_loopback_port();
+        let successor_port = successor_reservation.port;
         let successor_root = root.clone();
         let handover = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(300)).await;
@@ -9114,7 +9158,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let legacy_startup_authority =
             try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
-        let legacy_port = closed_loopback_port();
+        let legacy_reservation = reserved_closed_loopback_port();
+        let legacy_port = legacy_reservation.port;
 
         let initial = wait_for_existing_supervisor_in_dir_with_hook(dir.path(), None, || {
             // The merge-base supervisor itself writes without either new lock.
@@ -9625,7 +9670,8 @@ mod tests {
     async fn contended_retirement_never_becomes_start_authorization() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        write_endpoint_files(root, 999_999_999, closed_loopback_port());
+        let closed = reserved_closed_loopback_port();
+        write_endpoint_files(root, 999_999_999, closed.port);
         let lifecycle = OpenOptions::new()
             .create(true)
             .read(true)
@@ -9759,7 +9805,8 @@ mod tests {
             .open(dir.path().join(SUPERVISOR_SINGLETON_FILE))
             .unwrap();
         singleton.lock_exclusive().unwrap();
-        let port = closed_loopback_port();
+        let reservation = reserved_closed_loopback_port();
+        let port = reservation.port;
         std::fs::write(
             dir.path().join(SUPERVISOR_PID_FILE),
             std::process::id().to_string(),
@@ -9805,7 +9852,8 @@ mod tests {
         // positive evidence, so the record is cleared and a start proceeds.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        write_endpoint_files(root, 999_999_999, closed_loopback_port());
+        let closed = reserved_closed_loopback_port();
+        write_endpoint_files(root, 999_999_999, closed.port);
 
         let verdict = wait_for_existing_daemon_within(
             root,

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -10161,9 +10161,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join(".kin");
         std::fs::create_dir_all(&root).unwrap();
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
+        let closed = reserved_closed_loopback_port();
+        let port = closed.port;
         let pid =
             write_attributed_endpoint_files(&root, recycled_identity_for_this_process(), port);
 
@@ -10299,9 +10298,8 @@ mod tests {
     #[test]
     fn live_daemon_endpoint_returns_alive_pid_even_before_port_binds() {
         let dir = tempfile::tempdir().unwrap();
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
+        let closed = reserved_closed_loopback_port();
+        let port = closed.port;
         std::fs::write(
             dir.path().join("daemon.pid"),
             std::process::id().to_string(),

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7908,11 +7908,11 @@ mod tests {
     // later command repeated the same failure until the first daemon exited.
     // A timeout is evidence that a daemon is slow, never that it is dead.
 
-    /// A loopback port that refuses connections for as long as this guard
-    /// lives, so the probe exercises the unreachable-endpoint path without
-    /// waiting on a real timeout.
+    /// A loopback port guaranteed to answer no probe for as long as this
+    /// guard lives, so a test's unreachable endpoint stays unreachable for the
+    /// width of the test.
     ///
-    /// The refusal has to hold for the width of the probe, not just at
+    /// That guarantee has to hold for the width of the probe, not just at
     /// acquisition. This test binary runs hundreds of sibling tests that bind
     /// ephemeral loopback listeners the whole time, so a port that was merely
     /// observed closed and then released can be handed by the kernel to a
@@ -7920,9 +7920,11 @@ mod tests {
     /// answer naming a different repository, which is positive evidence of a
     /// stale record, and the verdict the test meant to be about "nothing
     /// listens here" becomes a retirement. Holding the socket bound but never
-    /// listening keeps both properties at once: without a listen queue every
-    /// connect is refused, and while the reservation is held no other socket
-    /// can bind the port.
+    /// listening keeps the port unanswerable and unbindable at once: no other
+    /// socket can take it, and with no listen queue a connect gets a reset on
+    /// Linux and Windows and an unanswered SYN on macOS. Both read as "no
+    /// usable answer" to every prober here, which judges through its own
+    /// deadline rather than through the shape of the connect failure.
     struct ReservedClosedPort {
         port: u16,
         _reservation: tokio::net::TcpSocket,
@@ -7941,16 +7943,18 @@ mod tests {
     }
 
     #[test]
-    fn a_reserved_closed_port_refuses_connections_and_cannot_be_rebound() {
+    fn a_reserved_closed_port_answers_no_connection_and_cannot_be_rebound() {
         let reserved = reserved_closed_loopback_port();
         let address = std::net::SocketAddr::from(([127, 0, 0, 1], reserved.port));
 
-        let error = std::net::TcpStream::connect(address)
-            .expect_err("a reserved closed port must refuse connections while held");
-        assert_eq!(
-            error.kind(),
-            std::io::ErrorKind::ConnectionRefused,
-            "refusal must be immediate, not a timeout: {error}"
+        let error = std::net::TcpStream::connect_timeout(&address, Duration::from_millis(500))
+            .expect_err("a reserved closed port must never yield a connection while held");
+        assert!(
+            matches!(
+                error.kind(),
+                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::TimedOut
+            ),
+            "the connect failure must be refusal or silence, not a different failure: {error}"
         );
         assert!(
             std::net::TcpListener::bind(address).is_err(),

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -2000,6 +2000,35 @@ fn quiesce_pinned_process_group(
     Ok(())
 }
 
+/// Wait out the kill-to-exit window of the group's remaining members.
+///
+/// The cleanup barrier delivers SIGKILL to the whole group before finalization
+/// runs, but delivery is not death: the kernel retires a condemned process on
+/// its own schedule, and on a loaded host that lags the barrier by whole
+/// scheduler quanta, longer when the member is mid-fsync in uninterruptible
+/// sleep. The probe after sentinel reap runs exactly once, so any settling has
+/// to happen here, while the unreaped sentinel handle still pins the numeric
+/// group id and every member this reads is provably ours.
+///
+/// This settles and never judges. Whatever state the group is in at the
+/// deadline, the caller's single post-reap probe stays the one authority that
+/// can fail, with its richer diagnosis (sentinel exit reason included) intact.
+#[cfg(unix)]
+fn settle_pinned_group_member_exits(process_group: libc::pid_t, deadline: std::time::Instant) {
+    loop {
+        match process_group_containment(process_group) {
+            ProcessGroupContainment::Empty | ProcessGroupContainment::OnlyExited => return,
+            ProcessGroupContainment::LiveMember { .. }
+            | ProcessGroupContainment::Indeterminate { .. } => {
+                if std::time::Instant::now() >= deadline {
+                    return;
+                }
+                std::thread::sleep(PROCESS_GROUP_GUARDIAN_POLL_INTERVAL);
+            }
+        }
+    }
+}
+
 #[cfg(unix)]
 fn finalize_owned_process_group(
     sentinel: &mut Option<std::process::Child>,
@@ -2009,6 +2038,7 @@ fn finalize_owned_process_group(
     let sentinel_child = sentinel
         .as_mut()
         .ok_or_else(|| std::io::Error::other("process-group sentinel was already finalized"))?;
+    settle_pinned_group_member_exits(process_group, deadline);
     let status = reap_child_until(sentinel_child, deadline)?.ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::TimedOut,
@@ -3289,6 +3319,63 @@ mod tests {
             process_group_containment(pgid),
             ProcessGroupContainment::LiveMember { pid: pgid },
             "a running member must be reported, and named"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
+    #[test]
+    fn finalization_settle_outwaits_a_member_the_kill_has_not_yet_torn_down() {
+        // The merge-queue shape: the barrier's SIGKILL is delivered, the member
+        // has not yet been retired by the kernel, and finalization begins. The
+        // settle must keep reading until the member stops being live instead of
+        // judging the transient.
+        let mut child = spawn_in_own_group("sleep", &["30"]);
+        let pgid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+        assert_eq!(
+            process_group_containment(pgid),
+            ProcessGroupContainment::LiveMember { pid: pgid },
+            "the member must still be live when the settle begins"
+        );
+
+        let killer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            unsafe { libc::kill(pgid, libc::SIGKILL) };
+        });
+        settle_pinned_group_member_exits(pgid, std::time::Instant::now() + Duration::from_secs(10));
+        assert_eq!(
+            process_group_containment(pgid),
+            ProcessGroupContainment::OnlyExited,
+            "the settle returned while its member could still run"
+        );
+
+        killer.join().expect("join the killer thread");
+        child.wait().expect("collect the member");
+    }
+
+    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
+    #[test]
+    fn finalization_settle_stays_bounded_and_leaves_a_live_member_reported() {
+        // The inverse: a member nothing killed must not be settled away. The
+        // wait uses its whole bound, returns, and leaves the live member for
+        // the post-reap probe to report, so failing loud still works.
+        let mut child = spawn_in_own_group("sleep", &["30"]);
+        let pgid = libc::pid_t::try_from(child.id()).expect("child pid fits pid_t");
+
+        let bound = Duration::from_millis(200);
+        let began = std::time::Instant::now();
+        settle_pinned_group_member_exits(pgid, began + bound);
+        let waited = began.elapsed();
+        assert!(
+            waited >= bound,
+            "the settle gave up on a live member after {waited:?}, before its {bound:?} bound"
+        );
+        assert_eq!(
+            process_group_containment(pgid),
+            ProcessGroupContainment::LiveMember { pid: pgid },
+            "a member that never exits must stay reported for the probe to judge"
         );
 
         let _ = child.kill();


### PR DESCRIPTION
Two live CI flakes were ejecting green PRs from the merge queue. Both had the
same shape, a check that judged a transient as a terminal state, and both are
now held still.

The containment guardian judged a SIGKILLed process mid-death. The cleanup
barrier delivers SIGKILL to the whole pinned group, then finalization reaps the
sentinel and probes containment exactly once, and a grandchild the kernel had
not yet retired classified as a live escape. That one probe consumed the
guardian, failed the teardown, and ejected whichever test was unlucky:
locate_json_keeps_tracing_warnings_off_stdout in run 31656801146 (ejected
kin#771), drift_reports_diverged_tracked_bytes_without_admitting_them in run
31640059080. The guardian now settles before it judges. While the unreaped
sentinel still pins the numeric group id, a bounded wait lets condemned members
finish dying, and the single post-reap probe stays the one authority that can
fail, every diagnosis unchanged. FIR-1719 closed the exited-but-unreaped
window; this closes the killed-but-not-yet-exited one.

The daemon-client tests trusted a port to stay closed after releasing it.
closed_loopback_port() bound a listener, took the port, and dropped it, while
1347 sibling tests in the same binary bind ephemeral loopback mocks the whole
time. When the kernel re-handed the port mid-probe, the probe received a real
health answer naming a different repository, which is positive evidence of a
stale record, so retirement proceeded and
a_successor_endpoint_survives_a_verdict_about_its_predecessor got None instead
of LiveNotReady (run 31622548773, ejected kin#781). The helper now returns a
guard that keeps the port bound and never listening: nothing can rebind it and
nothing can ever answer on it. Linux and Windows reset such connects; macOS
drops the SYN, which every prober here reads identically through its own
deadline, and the helper doc records the difference.

Two tests in that file still took a port and released it. In
live_daemon_endpoint_returns_alive_pid_even_before_port_binds that was the same
live defect: it asserts daemon_is_up returns None, daemon_is_up connects to the
recorded port, so a sibling that took the freed port flipped the assertion to
Some(port). Binding a listener on the released port reproduced that failure
deterministically. probing_a_recycled_pid_endpoint_proves_it_invalid used the
pattern without being able to fail, because the probe returns Invalid off
endpoint_owner_liveness before it issues any HTTP request. Both hold the
reservation now, so the file leaves no released-port endpoint for a later test
to copy.

Determinism was measured, not assumed. With the settle stubbed back to the old
single-probe behavior, both new kin-daemon-spawn tests fail; with it real, the
spawn suite is 48/48. Reverting the reservation to a released port fails the new
reservation test on its rebind assertion, and while the reservation is held a
listener can no longer take the port at all. The daemon_client module is 116/116
including that test, and three consecutive full kin-cli lib runs are 1375/1375,
which is the run shape that generates the sibling port pressure. Formatting, the
CI clippy allowlist, and the full workspace gate run clean.

Closes FIR-2259
Closes FIR-2288
