### PR TITLE
Name why an embedding count is zero instead of leaving it to read as loss

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -422,10 +422,17 @@ fn build_graph_status_response(
     lines.push(format!("Kinds: {}", kind_parts.join(", ")));
 
     lines.push(String::new());
-    if let Some(reason) = &embedding_runtime.vector_index_discarded {
+    if let Some(reason) = embedding_runtime
+        .vector_index_discarded
+        .as_ref()
+        .filter(|_| embed_status.pending > 0)
+    {
         // A real gap, reported with its cause. The bare counters here read as
         // discovered loss; naming the open-time discard and the automatic
-        // recovery is what tells the operator no manual GPU pass is owed.
+        // recovery is what tells the operator no manual GPU pass is owed. The
+        // discard reason is recorded once at open and never cleared, so it is
+        // named only while the gap it explains is still open; a recovered
+        // store goes back to the plain measured line.
         lines.push(format!(
             "Embeddings: {}/{} indexed ({} pending); the persisted vector index was not loaded \
              when this daemon opened ({reason}); the daemon restores coverage in the background",
@@ -1715,6 +1722,39 @@ mod tests {
                 .any(|line| line.contains("embeddings are still pending")),
             "a real gap keeps its warning: {:?}",
             discarded.lines
+        );
+
+        // The reason is recorded once at open and never cleared, so once the
+        // gap it explains is closed the line must not keep naming it. A graph
+        // with nothing pending renders the plain measured line.
+        let (_temp2, binding2, empty_graph) = graph_validation_fixture();
+        let recovered = build_graph_status_response(
+            &binding2,
+            &empty_graph,
+            &Default::default(),
+            &GraphStatusEmbeddingRuntime {
+                vector_index_discarded: Some(
+                    "fixture: metadata no longer matches graph truth".to_string(),
+                ),
+                coverage_ever_complete: true,
+            },
+        )
+        .unwrap();
+        assert!(
+            !recovered
+                .lines
+                .iter()
+                .any(|line| line.contains("was not loaded")),
+            "a closed gap must not keep naming its discard: {:?}",
+            recovered.lines
+        );
+        assert!(
+            recovered
+                .lines
+                .iter()
+                .any(|line| line == "Embeddings: 0/0 indexed (0 pending)"),
+            "a store with nothing pending renders the plain measured line: {:?}",
+            recovered.lines
         );
     }
 

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -10,7 +10,7 @@ use kin_model::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::graph_health::inspect_graph;
+use super::graph_health::{inspect_graph, inspect_graph_with_embedding_observation};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -221,9 +221,12 @@ pub fn execute_graph_command(
     graph: &kin_db::InMemoryGraph,
     request: &GraphCommandRequest,
     reconcile: &crate::commands::resources::ReconcileHealth,
+    embedding_runtime: &GraphStatusEmbeddingRuntime,
 ) -> Result<GraphCommandResponse> {
     match request {
-        GraphCommandRequest::Status => build_graph_status_response(binding, graph, reconcile),
+        GraphCommandRequest::Status => {
+            build_graph_status_response(binding, graph, reconcile, embedding_runtime)
+        }
         GraphCommandRequest::Validate => build_graph_validate_response(binding, graph),
         GraphCommandRequest::Inspect { name } => build_graph_inspect_response(graph, name),
         GraphCommandRequest::Source { entity } => build_graph_source_response(
@@ -234,12 +237,73 @@ pub fn execute_graph_command(
     }
 }
 
+/// What the daemon knows about this store's embedding runtime that the graph
+/// alone cannot say.
+///
+/// `embedding_status` structurally answers zero indexed for every retrievable
+/// object while no vector index is attached, and a restart serves exactly that
+/// window: the v0.5.21 battery watched `kin graph status` announce
+/// `0/10456 indexed (10456 pending)` on a store whose vectors sat intact on
+/// disk and recovered in seconds with zero embed dispatches. Telling that
+/// window apart from a first fill or a real discard takes two facts only the
+/// daemon holds, so the daemon hands them in the way it already hands
+/// `ReconcileHealth`.
+#[derive(Debug, Clone, Default)]
+pub struct GraphStatusEmbeddingRuntime {
+    /// Why the persisted vector index on disk was not installed when this
+    /// daemon opened, when it was there and was not. Mirrors
+    /// `DaemonState::vector_index_discarded`.
+    pub vector_index_discarded: Option<String>,
+    /// Whether this store's embedding coverage has ever been whole, read from
+    /// the persisted completion marker. A first fill and a restart window show
+    /// identical counters; only this tells them apart.
+    pub coverage_ever_complete: bool,
+}
+
+/// Whether coverage counters describe an attached vector index.
+///
+/// With no index attached, `embedding_status` answers `indexed = 0` for every
+/// retrievable object. That zero is structural; `vector_index_stats()` is the
+/// call that distinguishes an index that is absent from one that is measured.
+#[cfg(feature = "vector")]
+fn embedding_coverage_is_measured(graph: &kin_db::InMemoryGraph) -> bool {
+    graph.vector_index_stats().is_some()
+}
+
+/// Without vector support there is no index to attach and no structural zero
+/// to guard against; the legacy rendering stays.
+#[cfg(not(feature = "vector"))]
+fn embedding_coverage_is_measured(_graph: &kin_db::InMemoryGraph) -> bool {
+    true
+}
+
 fn build_graph_status_response(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
     reconcile: &crate::commands::resources::ReconcileHealth,
+    embedding_runtime: &GraphStatusEmbeddingRuntime,
 ) -> Result<GraphCommandResponse> {
-    let health = inspect_graph(binding, graph)?;
+    // One sample for every embedding line in this response. The counter below
+    // and the health warning used to sample coverage independently, and an
+    // embed batch completing between the two reads made the warning name a
+    // pending count the counter beside it contradicted by exactly one batch
+    // (the v0.5.21 battery caught 1 of 12 paired readings disagreeing by 512).
+    let embed_status = graph.embedding_status();
+    let coverage_is_measured = embedding_coverage_is_measured(graph) || embed_status.total == 0;
+    // The restart window: nothing is attached, nothing was discarded, and this
+    // store has been whole before. Pending work in that state is the reader's
+    // timing, not lost coverage, and must not be warned about as loss.
+    let pending_is_not_loss = !coverage_is_measured
+        && embedding_runtime.vector_index_discarded.is_none()
+        && embedding_runtime.coverage_ever_complete;
+    let health = inspect_graph_with_embedding_observation(
+        binding,
+        graph,
+        Some(&super::graph_health::EmbeddingCoverageObservation {
+            status: embed_status.clone(),
+            pending_is_not_loss,
+        }),
+    )?;
 
     let entities = graph.list_all_entities()?;
 
@@ -293,9 +357,6 @@ fn build_graph_status_response(
         .iter()
         .filter_map(|e| e.file_origin.as_ref().map(|f| f.0.clone()))
         .collect();
-
-    // Embedding status
-    let embed_status = graph.embedding_status();
 
     // Doc summary coverage
     let with_docs = defined.iter().filter(|e| e.doc_summary.is_some()).count();
@@ -361,10 +422,28 @@ fn build_graph_status_response(
     lines.push(format!("Kinds: {}", kind_parts.join(", ")));
 
     lines.push(String::new());
-    lines.push(format!(
-        "Embeddings: {}/{} indexed ({} pending)",
-        embed_status.indexed, embed_status.total, embed_status.pending
-    ));
+    if let Some(reason) = &embedding_runtime.vector_index_discarded {
+        // A real gap, reported with its cause. The bare counters here read as
+        // discovered loss; naming the open-time discard and the automatic
+        // recovery is what tells the operator no manual GPU pass is owed.
+        lines.push(format!(
+            "Embeddings: {}/{} indexed ({} pending); the persisted vector index was not loaded \
+             when this daemon opened ({reason}); the daemon restores coverage in the background",
+            embed_status.indexed, embed_status.total, embed_status.pending
+        ));
+    } else if pending_is_not_loss {
+        lines.push(format!(
+            "Embeddings: not measured at this instant; no vector index is attached to this graph \
+             yet, coverage completed before on this store, and nothing was discarded at open, so \
+             {} retrievable objects await the index rather than re-embedding",
+            embed_status.total
+        ));
+    } else {
+        lines.push(format!(
+            "Embeddings: {}/{} indexed ({} pending)",
+            embed_status.indexed, embed_status.total, embed_status.pending
+        ));
+    }
     lines.push(format!(
         "Doc summaries: {}/{} ({:.0}%)",
         with_docs,
@@ -1282,7 +1361,7 @@ mod tests {
         // separates the two halves here and asserting on it would pass whatever
         // the reconcile term did. What must differ is the reconcile warning
         // itself: absent on a healthy daemon, present on this one.
-        let healthy = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
+        let healthy = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
         assert!(
             !healthy
                 .lines
@@ -1302,6 +1381,7 @@ mod tests {
                 last_admission_success_age_seconds: Some(172_800),
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         assert!(
@@ -1349,6 +1429,7 @@ mod tests {
                 untracked_paths_sample: vec!["fir2152_probe.rs".to_string()],
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         assert!(
@@ -1390,6 +1471,7 @@ mod tests {
                 last_error_age_seconds: Some(90),
                 ..Default::default()
             },
+            &Default::default(),
         )
         .unwrap();
         // The reconcile warning is the assertion that carries this test. The
@@ -1462,7 +1544,7 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
-        let response = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
+        let response = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
 
         // The entity-rooted total and the whole-table total count different
         // scopes, so neither line may carry a bare "Relations" label.
@@ -1505,7 +1587,7 @@ mod tests {
             ))
             .unwrap();
 
-        let response = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
+        let response = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
 
         assert!(response
             .lines
@@ -2435,7 +2517,7 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
 
         let validate = build_graph_validate_response(&binding, &graph).unwrap();
-        let status = build_graph_status_response(&binding, &graph, &Default::default()).unwrap();
+        let status = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
 
         let validate_notes = note_lines(&validate);
         assert!(

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -10,7 +10,7 @@ use kin_model::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::graph_health::{inspect_graph, inspect_graph_with_embedding_observation};
+use super::graph_health::{inspect_graph, inspect_graph_with_pending_embeddings};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -221,7 +221,7 @@ pub fn execute_graph_command(
     graph: &kin_db::InMemoryGraph,
     request: &GraphCommandRequest,
     reconcile: &crate::commands::resources::ReconcileHealth,
-    embedding_runtime: &GraphStatusEmbeddingRuntime,
+    embedding_runtime: &crate::commands::resources::EmbedRuntimeState,
 ) -> Result<GraphCommandResponse> {
     match request {
         GraphCommandRequest::Status => {
@@ -235,29 +235,6 @@ pub fn execute_graph_command(
             entity,
         ),
     }
-}
-
-/// What the daemon knows about this store's embedding runtime that the graph
-/// alone cannot say.
-///
-/// `embedding_status` structurally answers zero indexed for every retrievable
-/// object while no vector index is attached, and a restart serves exactly that
-/// window: the v0.5.21 battery watched `kin graph status` announce
-/// `0/10456 indexed (10456 pending)` on a store whose vectors sat intact on
-/// disk and recovered in seconds with zero embed dispatches. Telling that
-/// window apart from a first fill or a real discard takes two facts only the
-/// daemon holds, so the daemon hands them in the way it already hands
-/// `ReconcileHealth`.
-#[derive(Debug, Clone, Default)]
-pub struct GraphStatusEmbeddingRuntime {
-    /// Why the persisted vector index on disk was not installed when this
-    /// daemon opened, when it was there and was not. Mirrors
-    /// `DaemonState::vector_index_discarded`.
-    pub vector_index_discarded: Option<String>,
-    /// Whether this store's embedding coverage has ever been whole, read from
-    /// the persisted completion marker. A first fill and a restart window show
-    /// identical counters; only this tells them apart.
-    pub coverage_ever_complete: bool,
 }
 
 /// Whether coverage counters describe an attached vector index.
@@ -281,7 +258,7 @@ fn build_graph_status_response(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
     reconcile: &crate::commands::resources::ReconcileHealth,
-    embedding_runtime: &GraphStatusEmbeddingRuntime,
+    embedding_runtime: &crate::commands::resources::EmbedRuntimeState,
 ) -> Result<GraphCommandResponse> {
     // One sample for every embedding line in this response. The counter below
     // and the health warning used to sample coverage independently, and an
@@ -290,20 +267,7 @@ fn build_graph_status_response(
     // (the v0.5.21 battery caught 1 of 12 paired readings disagreeing by 512).
     let embed_status = graph.embedding_status();
     let coverage_is_measured = embedding_coverage_is_measured(graph) || embed_status.total == 0;
-    // The restart window: nothing is attached, nothing was discarded, and this
-    // store has been whole before. Pending work in that state is the reader's
-    // timing, not lost coverage, and must not be warned about as loss.
-    let pending_is_not_loss = !coverage_is_measured
-        && embedding_runtime.vector_index_discarded.is_none()
-        && embedding_runtime.coverage_ever_complete;
-    let health = inspect_graph_with_embedding_observation(
-        binding,
-        graph,
-        Some(&super::graph_health::EmbeddingCoverageObservation {
-            status: embed_status.clone(),
-            pending_is_not_loss,
-        }),
-    )?;
+    let health = inspect_graph_with_pending_embeddings(binding, graph, Some(embed_status.pending))?;
 
     let entities = graph.list_all_entities()?;
 
@@ -422,35 +386,59 @@ fn build_graph_status_response(
     lines.push(format!("Kinds: {}", kind_parts.join(", ")));
 
     lines.push(String::new());
-    if let Some(reason) = embedding_runtime
-        .vector_index_discarded
-        .as_ref()
-        .filter(|_| embed_status.pending > 0)
-    {
-        // A real gap, reported with its cause. The bare counters here read as
-        // discovered loss; naming the open-time discard and the automatic
-        // recovery is what tells the operator no manual GPU pass is owed. The
-        // discard reason is recorded once at open and never cleared, so it is
-        // named only while the gap it explains is still open; a recovered
-        // store goes back to the plain measured line.
-        lines.push(format!(
-            "Embeddings: {}/{} indexed ({} pending); the persisted vector index was not loaded \
-             when this daemon opened ({reason}); the daemon restores coverage in the background",
-            embed_status.indexed, embed_status.total, embed_status.pending
-        ));
-    } else if pending_is_not_loss {
-        lines.push(format!(
-            "Embeddings: not measured at this instant; no vector index is attached to this graph \
-             yet, coverage completed before on this store, and nothing was discarded at open, so \
-             {} retrievable objects await the index rather than re-embedding",
-            embed_status.total
-        ));
-    } else {
-        lines.push(format!(
-            "Embeddings: {}/{} indexed ({} pending)",
-            embed_status.indexed, embed_status.total, embed_status.pending
-        ));
+    // The counters are true in every state below: with no vector index
+    // attached, zero retrievable objects really are indexed in this graph.
+    // What the bare counters cannot say is WHY, and a reader who cannot tell a
+    // discarded index from a first fill reads every one of them as loss. So the
+    // counters always render and the cause is appended when the daemon knows
+    // one. Each clause states only a fact the daemon holds; none of them
+    // promises the vectors are intact, because nothing on this path can know
+    // that. `kin status` reports the same absence as "the live graph carries no
+    // vector index" and publishes no coverage at all, which is the wording
+    // followed here.
+    let mut embeddings_line = format!(
+        "Embeddings: {}/{} indexed ({} pending)",
+        embed_status.indexed, embed_status.total, embed_status.pending
+    );
+    if embed_status.pending > 0 {
+        if embedding_runtime.embed_persistence_unavailable {
+            // Outranks every clause below, exactly as it does in
+            // `semantic_query_health_from_runtime`: this store's graph
+            // authority is a remote backend, the embedding worker never starts
+            // and `/embed` refuses, so a backlog here is not filling and no
+            // clause may imply that it is.
+            embeddings_line.push_str(
+                "; this store's graph authority is a remote storage backend, which carries no \
+                 durable local vector-sidecar contract, so nothing will embed here",
+            );
+        } else if let Some(reason) = embedding_runtime.vector_index_discarded.as_ref() {
+            // A real gap, reported with its cause. Naming the open-time discard
+            // and the automatic recovery is what tells the operator no manual
+            // GPU pass is owed. The reason is recorded once at open and never
+            // cleared, so it is named only while the gap it explains is still
+            // open; a recovered store goes back to the plain line.
+            embeddings_line.push_str(&format!(
+                "; the persisted vector index was not loaded when this daemon opened ({reason}); \
+                 the daemon restores coverage in the background"
+            ));
+        } else if !coverage_is_measured {
+            // No index is attached and the daemon recorded no discard at open,
+            // so these zeros are structural rather than a measurement of a
+            // store that lost ground. That is all this path knows. It does NOT
+            // know the vectors are sitting intact somewhere: an index that
+            // loaded at open would still be attached, so this branch is reached
+            // only when there was no sidecar to load, or when a later reset
+            // detached one. Both of those rebuild rather than re-attach, so no
+            // clause here may tell the reader to wait instead of embedding.
+            embeddings_line.push_str(
+                "; the live graph carries no vector index, so nothing in it is indexed yet",
+            );
+            if embedding_runtime.embedding_coverage_ever_complete {
+                embeddings_line.push_str(" and coverage has completed on this store before");
+            }
+        }
     }
+    lines.push(embeddings_line);
     lines.push(format!(
         "Doc summaries: {}/{} ({:.0}%)",
         with_docs,
@@ -1585,91 +1573,158 @@ mod tests {
         );
     }
 
-    /// The v0.5.21 battery's restart transient. Right after a daemon restart,
-    /// `kin graph status` announced `Embeddings: 0/10456 indexed (10456
-    /// pending)` with a pending warning on a store whose vectors were intact,
-    /// because `embedding_status` answers zero indexed for every retrievable
-    /// object while no vector index is attached. The state that must never be
-    /// read as loss: nothing was discarded at open and coverage has completed
-    /// on this store before.
+    /// A graph carrying no attached vector index must never be told its
+    /// embeddings are intact.
+    ///
+    /// `embedding_status` answers zero indexed for every retrievable object
+    /// while no index is attached, so the bare counters read as discovered
+    /// loss on a store that simply has nothing attached yet. Disclosing that
+    /// is the fix. Promising the vectors are sitting somewhere intact is not:
+    /// an index that loaded at open would still be attached, so whenever this
+    /// state is reached there was no sidecar to load or a later reset detached
+    /// one, and both of those rebuild rather than re-attach. The warning is the
+    /// reader's only signal that coverage is not there, so it stays.
     #[cfg(feature = "vector")]
     #[test]
-    fn a_restart_attach_window_is_not_reported_as_lost_coverage() {
+    fn a_graph_with_no_attached_index_is_not_told_its_embeddings_are_intact() {
         let (_temp, binding, graph) = graph_validation_fixture();
         graph
             .upsert_entity(&test_entity("alpha_transform"))
             .unwrap();
-        let total = graph.embedding_status().total;
-        assert!(total > 0, "the fixture must carry retrievable objects");
+        let status = graph.embedding_status();
+        assert!(
+            status.total > 0,
+            "the fixture must carry retrievable objects"
+        );
         assert!(
             graph.vector_index_stats().is_none(),
             "the fixture graph must carry no attached vector index"
         );
 
-        // Control: the same graph with no daemon context is a first fill, and
-        // a first fill keeps the measured counters and the pending warning.
-        let first_fill =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
-                .unwrap();
-        let measured = format!("Embeddings: 0/{total} indexed ({total} pending)");
-        assert!(
-            first_fill.lines.iter().any(|line| line == &measured),
-            "a first fill keeps its measured line: {:?}",
-            first_fill.lines
-        );
-        assert!(
-            first_fill
-                .lines
-                .iter()
-                .any(|line| line.contains("embeddings are still pending")),
-            "a first fill keeps its pending warning: {:?}",
-            first_fill.lines
-        );
-
-        // The restart window itself.
-        let restart = build_graph_status_response(
+        // The state the daemon can actually produce with no discard recorded:
+        // no sidecar was on disk at open, while the persisted marker says this
+        // store finished a fill once.
+        let no_sidecar = build_graph_status_response(
             &binding,
             &graph,
             &Default::default(),
-            &GraphStatusEmbeddingRuntime {
+            &crate::commands::resources::EmbedRuntimeState {
                 vector_index_discarded: None,
-                coverage_ever_complete: true,
+                embedding_coverage_ever_complete: true,
+                ..Default::default()
             },
         )
         .unwrap();
-        assert!(
-            !restart.lines.iter().any(|line| line.contains("indexed (")),
-            "the structural zero must not be printed as a measured count: {:?}",
-            restart.lines
-        );
-        assert!(
-            !restart
-                .lines
-                .iter()
-                .any(|line| line.contains("embeddings are still pending")),
-            "the restart window must not warn about lost coverage: {:?}",
-            restart.lines
-        );
-        let embeddings_line = restart
+        let embeddings_line = no_sidecar
             .lines
             .iter()
             .find(|line| line.starts_with("Embeddings:"))
             .expect("the embeddings line still renders");
         assert!(
-            embeddings_line.contains("not measured at this instant"),
-            "{embeddings_line}"
+            embeddings_line.contains(&format!(
+                "{}/{} indexed ({} pending)",
+                status.indexed, status.total, status.pending
+            )),
+            "the counters are true and stay disclosed: {embeddings_line}"
         );
         assert!(
-            embeddings_line.contains(&total.to_string()),
-            "the total stays disclosed: {embeddings_line}"
+            embeddings_line.contains("the live graph carries no vector index"),
+            "the structural zero is named rather than left to read as loss: {embeddings_line}"
         );
         assert!(
-            restart
+            embeddings_line.contains("coverage has completed on this store before"),
+            "the marker is disclosed so this is not read as a first fill: {embeddings_line}"
+        );
+        for forbidden in [
+            "await the index",
+            "nothing was discarded",
+            "startup timing",
+            "rather than re-embedding",
+        ] {
+            assert!(
+                !no_sidecar.lines.iter().any(|line| line.contains(forbidden)),
+                "no line may claim the vectors are intact ({forbidden}): {:?}",
+                no_sidecar.lines
+            );
+        }
+        assert!(
+            no_sidecar
                 .lines
                 .iter()
-                .any(|line| line.starts_with('ℹ') && line.contains("startup timing")),
-            "the window is disclosed as a note rather than hidden: {:?}",
-            restart.lines
+                .any(|line| line.contains("embeddings are still pending")),
+            "the only signal that coverage is absent must survive: {:?}",
+            no_sidecar.lines
+        );
+
+        // A store that has never finished a fill is in the same structural
+        // state and says so, minus the marker clause it has not earned.
+        let first_fill =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
+        let first_fill_line = first_fill
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            first_fill_line.contains("the live graph carries no vector index"),
+            "a first fill names the same structural absence: {first_fill_line}"
+        );
+        assert!(
+            !first_fill_line.contains("completed on this store before"),
+            "a first fill must not claim a completion it never had: {first_fill_line}"
+        );
+    }
+
+    /// A store whose graph authority is a remote backend has no durable local
+    /// vector-sidecar contract: the embedding worker never starts and `/embed`
+    /// refuses, so its backlog is not filling and never will. That fact
+    /// outranks both the discard reason and the coverage marker here for the
+    /// same reason it does in semantic query readiness, because every other
+    /// clause implies work that is going to happen.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_store_that_can_never_embed_is_not_promised_background_recovery() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        graph
+            .upsert_entity(&test_entity("gamma_transform"))
+            .unwrap();
+
+        let remote = build_graph_status_response(
+            &binding,
+            &graph,
+            &Default::default(),
+            &crate::commands::resources::EmbedRuntimeState {
+                vector_index_discarded: Some(
+                    "fixture: metadata no longer matches graph truth".to_string(),
+                ),
+                embedding_coverage_ever_complete: true,
+                embed_persistence_unavailable: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let embeddings_line = remote
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            embeddings_line.contains("remote storage backend")
+                && embeddings_line.contains("nothing will embed here"),
+            "a store that cannot embed must say so: {embeddings_line}"
+        );
+        assert!(
+            !embeddings_line.contains("restores coverage in the background"),
+            "no recovery may be promised where nothing will embed: {embeddings_line}"
+        );
+        assert!(
+            remote
+                .lines
+                .iter()
+                .any(|line| line.contains("embeddings are still pending")),
+            "a backlog that will never fill keeps its warning: {:?}",
+            remote.lines
         );
     }
 
@@ -1687,11 +1742,12 @@ mod tests {
             &binding,
             &graph,
             &Default::default(),
-            &GraphStatusEmbeddingRuntime {
+            &crate::commands::resources::EmbedRuntimeState {
                 vector_index_discarded: Some(
                     "fixture: metadata no longer matches graph truth".to_string(),
                 ),
-                coverage_ever_complete: true,
+                embedding_coverage_ever_complete: true,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -1732,11 +1788,12 @@ mod tests {
             &binding2,
             &empty_graph,
             &Default::default(),
-            &GraphStatusEmbeddingRuntime {
+            &crate::commands::resources::EmbedRuntimeState {
                 vector_index_discarded: Some(
                     "fixture: metadata no longer matches graph truth".to_string(),
                 ),
-                coverage_ever_complete: true,
+                embedding_coverage_ever_complete: true,
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1361,7 +1361,9 @@ mod tests {
         // separates the two halves here and asserting on it would pass whatever
         // the reconcile term did. What must differ is the reconcile warning
         // itself: absent on a healthy daemon, present on this one.
-        let healthy = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
+        let healthy =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
         assert!(
             !healthy
                 .lines
@@ -1544,7 +1546,9 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
-        let response = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
+        let response =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
 
         // The entity-rooted total and the whole-table total count different
         // scopes, so neither line may carry a bare "Relations" label.
@@ -1585,7 +1589,9 @@ mod tests {
     #[test]
     fn a_restart_attach_window_is_not_reported_as_lost_coverage() {
         let (_temp, binding, graph) = graph_validation_fixture();
-        graph.upsert_entity(&test_entity("alpha_transform")).unwrap();
+        graph
+            .upsert_entity(&test_entity("alpha_transform"))
+            .unwrap();
         let total = graph.embedding_status().total;
         assert!(total > 0, "the fixture must carry retrievable objects");
         assert!(
@@ -1725,7 +1731,9 @@ mod tests {
             ))
             .unwrap();
 
-        let response = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
+        let response =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
 
         assert!(response
             .lines
@@ -2655,7 +2663,9 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
 
         let validate = build_graph_validate_response(&binding, &graph).unwrap();
-        let status = build_graph_status_response(&binding, &graph, &Default::default(), &Default::default()).unwrap();
+        let status =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
 
         let validate_notes = note_lines(&validate);
         assert!(

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1574,6 +1574,144 @@ mod tests {
         );
     }
 
+    /// The v0.5.21 battery's restart transient. Right after a daemon restart,
+    /// `kin graph status` announced `Embeddings: 0/10456 indexed (10456
+    /// pending)` with a pending warning on a store whose vectors were intact,
+    /// because `embedding_status` answers zero indexed for every retrievable
+    /// object while no vector index is attached. The state that must never be
+    /// read as loss: nothing was discarded at open and coverage has completed
+    /// on this store before.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_restart_attach_window_is_not_reported_as_lost_coverage() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        graph.upsert_entity(&test_entity("alpha_transform")).unwrap();
+        let total = graph.embedding_status().total;
+        assert!(total > 0, "the fixture must carry retrievable objects");
+        assert!(
+            graph.vector_index_stats().is_none(),
+            "the fixture graph must carry no attached vector index"
+        );
+
+        // Control: the same graph with no daemon context is a first fill, and
+        // a first fill keeps the measured counters and the pending warning.
+        let first_fill =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
+        let measured = format!("Embeddings: 0/{total} indexed ({total} pending)");
+        assert!(
+            first_fill.lines.iter().any(|line| line == &measured),
+            "a first fill keeps its measured line: {:?}",
+            first_fill.lines
+        );
+        assert!(
+            first_fill
+                .lines
+                .iter()
+                .any(|line| line.contains("embeddings are still pending")),
+            "a first fill keeps its pending warning: {:?}",
+            first_fill.lines
+        );
+
+        // The restart window itself.
+        let restart = build_graph_status_response(
+            &binding,
+            &graph,
+            &Default::default(),
+            &GraphStatusEmbeddingRuntime {
+                vector_index_discarded: None,
+                coverage_ever_complete: true,
+            },
+        )
+        .unwrap();
+        assert!(
+            !restart.lines.iter().any(|line| line.contains("indexed (")),
+            "the structural zero must not be printed as a measured count: {:?}",
+            restart.lines
+        );
+        assert!(
+            !restart
+                .lines
+                .iter()
+                .any(|line| line.contains("embeddings are still pending")),
+            "the restart window must not warn about lost coverage: {:?}",
+            restart.lines
+        );
+        let embeddings_line = restart
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            embeddings_line.contains("not measured at this instant"),
+            "{embeddings_line}"
+        );
+        assert!(
+            embeddings_line.contains(&total.to_string()),
+            "the total stays disclosed: {embeddings_line}"
+        );
+        assert!(
+            restart
+                .lines
+                .iter()
+                .any(|line| line.starts_with('ℹ') && line.contains("startup timing")),
+            "the window is disclosed as a note rather than hidden: {:?}",
+            restart.lines
+        );
+    }
+
+    /// A discard at open is a real gap and keeps its accounting, but it names
+    /// its cause beside the counters. Bare `0/N (N pending)` after a restart is
+    /// what sent operators toward a manual GPU embed pass the daemon's own
+    /// recovery made unnecessary.
+    #[test]
+    fn a_discarded_index_names_its_reason_beside_the_counters() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        graph.upsert_entity(&test_entity("beta_transform")).unwrap();
+        let status = graph.embedding_status();
+
+        let discarded = build_graph_status_response(
+            &binding,
+            &graph,
+            &Default::default(),
+            &GraphStatusEmbeddingRuntime {
+                vector_index_discarded: Some(
+                    "fixture: metadata no longer matches graph truth".to_string(),
+                ),
+                coverage_ever_complete: true,
+            },
+        )
+        .unwrap();
+        let embeddings_line = discarded
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Embeddings:"))
+            .expect("the embeddings line still renders");
+        assert!(
+            embeddings_line.contains(&format!(
+                "{}/{} indexed ({} pending)",
+                status.indexed, status.total, status.pending
+            )),
+            "a real gap keeps its measured counters: {embeddings_line}"
+        );
+        assert!(
+            embeddings_line.contains("fixture: metadata no longer matches graph truth"),
+            "the discard reason is named where the counters are read: {embeddings_line}"
+        );
+        assert!(
+            embeddings_line.contains("restores coverage in the background"),
+            "the automatic recovery is named so nobody runs a manual pass: {embeddings_line}"
+        );
+        assert!(
+            discarded
+                .lines
+                .iter()
+                .any(|line| line.contains("embeddings are still pending")),
+            "a real gap keeps its warning: {:?}",
+            discarded.lines
+        );
+    }
+
     #[test]
     fn graph_status_does_not_call_a_mixed_relation_graph_relationless() {
         let (_temp, binding, graph) = graph_validation_fixture();

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -704,6 +704,7 @@ mod tests {
                 path_samples: vec!["out/generated.rs".to_string()],
             },
             complete_coverage(),
+            None,
         )
     }
 
@@ -795,6 +796,7 @@ mod tests {
                 path_samples: Vec::new(),
             },
             coverage,
+            None,
         );
 
         assert!(report.repository_artifact_coverage.complete);
@@ -840,6 +842,7 @@ mod tests {
             &empty_supported_inputs(),
             &no_contamination(),
             coverage,
+            None,
         );
 
         assert!(!report.repository_artifact_coverage.complete);
@@ -873,6 +876,7 @@ mod tests {
             },
             &no_contamination(),
             coverage,
+            None,
         );
 
         assert!(report.critical_issues.is_empty());
@@ -905,6 +909,7 @@ mod tests {
             },
             &no_contamination(),
             coverage,
+            None,
         );
 
         assert!(!report.graph_empty_for_supported_inputs);
@@ -931,6 +936,7 @@ mod tests {
             },
             &no_contamination(),
             coverage,
+            None,
         );
 
         assert!(report.graph_empty_for_supported_inputs);

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -97,36 +97,28 @@ struct ContaminationSummary {
     path_samples: Vec<String>,
 }
 
-/// One embedding-coverage sample shared by every line of a single report.
-///
-/// The status surface prints a coverage counter and a pending warning in one
-/// response. Sampling coverage twice for that response lets an embed batch
-/// complete between the two reads, so the warning names a pending count the
-/// counter beside it contradicts by exactly one batch. Whoever renders both
-/// takes one sample and hands it here so the two cannot disagree.
-///
-/// `pending_is_not_loss` marks the one state where pending work must not be
-/// warned about as if coverage had been lost: no vector index is attached to
-/// the graph at this instant, nothing was discarded at open, and this store
-/// has completed coverage before. `embedding_status` structurally answers
-/// `indexed = 0` for every retrievable object while no index is attached, so
-/// in that state the counters describe the reader's timing, not the store.
-pub(crate) struct EmbeddingCoverageObservation {
-    pub status: kin_db::EmbeddingStatus,
-    pub pending_is_not_loss: bool,
-}
-
 pub(crate) fn inspect_graph(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
 ) -> Result<GraphHealthReport> {
-    inspect_graph_with_embedding_observation(binding, graph, None)
+    inspect_graph_with_pending_embeddings(binding, graph, None)
 }
 
-pub(crate) fn inspect_graph_with_embedding_observation(
+/// Build the report against a pending count the caller already sampled.
+///
+/// The status surface prints a coverage counter and this report's pending
+/// warning in one response. Sampling coverage twice for that response lets an
+/// embed batch complete between the two reads, so the warning names a pending
+/// count the counter beside it contradicts by exactly one batch. The two are
+/// not even drawn from the same population: `graph_stats().pending_embedding_count`
+/// counts entity ids while `embedding_status()` counts retrievable keys, so
+/// they can disagree at a single instant with no race at all. Whoever renders
+/// both takes one sample and hands it here so the two cannot disagree. Callers
+/// that render no counter pass `None` and keep the report's own sample.
+pub(crate) fn inspect_graph_with_pending_embeddings(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
-    embedding: Option<&EmbeddingCoverageObservation>,
+    pending_embeddings: Option<usize>,
 ) -> Result<GraphHealthReport> {
     let stats = graph.graph_stats();
     let supported_inputs = collect_supported_inputs(graph);
@@ -137,7 +129,7 @@ pub(crate) fn inspect_graph_with_embedding_observation(
         &supported_inputs,
         &contamination,
         artifact_coverage,
-        embedding,
+        pending_embeddings,
     ))
 }
 
@@ -412,7 +404,7 @@ fn build_graph_health_report(
     supported_inputs: &SupportedInputCounts,
     contamination: &ContaminationSummary,
     artifact_coverage: RepositoryArtifactCoverage,
-    embedding: Option<&EmbeddingCoverageObservation>,
+    pending_embeddings: Option<usize>,
 ) -> GraphHealthReport {
     let test_role_entity_count = stats.role_counts.get("Test").copied().unwrap_or(0);
     let cochange_relation_count = stats.relation_counts.get("CoChanges").copied().unwrap_or(0);
@@ -536,34 +528,12 @@ fn build_graph_health_report(
         ));
     }
 
-    // One sample rules both surfaces when the caller took one. The status
-    // renderer prints its coverage counter from the same observation, so the
-    // warning can never name a pending count the counter beside it has already
-    // moved past. Callers that render no counter keep the report's own sample.
-    let pending_embeddings = embedding
-        .map(|observation| observation.status.pending)
-        .unwrap_or(stats.pending_embedding_count);
-    let pending_is_not_loss = embedding.is_some_and(|observation| observation.pending_is_not_loss);
+    // One sample rules both surfaces when the caller took one, so the warning
+    // can never name a pending count the counter beside it has already moved
+    // past.
+    let pending_embeddings = pending_embeddings.unwrap_or(stats.pending_embedding_count);
     if pending_embeddings > 0 {
-        if pending_is_not_loss {
-            // Structural, not observed: with no vector index attached,
-            // `embedding_status` answers zero indexed for every retrievable
-            // object, and this store has proven full coverage before with
-            // nothing discarded at open. Warning here told a restart reader
-            // their whole embedding corpus was lost while it sat intact on
-            // disk, so the state is reported as what it is instead.
-            notes.push(format!(
-                "{} retrievable objects are not covered by an attached vector index at this \
-                 instant; coverage completed before on this store and nothing was discarded at \
-                 open, so this is startup timing rather than lost embeddings",
-                pending_embeddings
-            ));
-        } else {
-            warnings.push(format!(
-                "{} embeddings are still pending",
-                pending_embeddings
-            ));
-        }
+        warnings.push(format!("{pending_embeddings} embeddings are still pending"));
     }
 
     GraphHealthReport {

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -97,9 +97,36 @@ struct ContaminationSummary {
     path_samples: Vec<String>,
 }
 
+/// One embedding-coverage sample shared by every line of a single report.
+///
+/// The status surface prints a coverage counter and a pending warning in one
+/// response. Sampling coverage twice for that response lets an embed batch
+/// complete between the two reads, so the warning names a pending count the
+/// counter beside it contradicts by exactly one batch. Whoever renders both
+/// takes one sample and hands it here so the two cannot disagree.
+///
+/// `pending_is_not_loss` marks the one state where pending work must not be
+/// warned about as if coverage had been lost: no vector index is attached to
+/// the graph at this instant, nothing was discarded at open, and this store
+/// has completed coverage before. `embedding_status` structurally answers
+/// `indexed = 0` for every retrievable object while no index is attached, so
+/// in that state the counters describe the reader's timing, not the store.
+pub(crate) struct EmbeddingCoverageObservation {
+    pub status: kin_db::EmbeddingStatus,
+    pub pending_is_not_loss: bool,
+}
+
 pub(crate) fn inspect_graph(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
+) -> Result<GraphHealthReport> {
+    inspect_graph_with_embedding_observation(binding, graph, None)
+}
+
+pub(crate) fn inspect_graph_with_embedding_observation(
+    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    graph: &kin_db::InMemoryGraph,
+    embedding: Option<&EmbeddingCoverageObservation>,
 ) -> Result<GraphHealthReport> {
     let stats = graph.graph_stats();
     let supported_inputs = collect_supported_inputs(graph);
@@ -110,6 +137,7 @@ pub(crate) fn inspect_graph(
         &supported_inputs,
         &contamination,
         artifact_coverage,
+        embedding,
     ))
 }
 
@@ -384,6 +412,7 @@ fn build_graph_health_report(
     supported_inputs: &SupportedInputCounts,
     contamination: &ContaminationSummary,
     artifact_coverage: RepositoryArtifactCoverage,
+    embedding: Option<&EmbeddingCoverageObservation>,
 ) -> GraphHealthReport {
     let test_role_entity_count = stats.role_counts.get("Test").copied().unwrap_or(0);
     let cochange_relation_count = stats.relation_counts.get("CoChanges").copied().unwrap_or(0);
@@ -507,11 +536,31 @@ fn build_graph_health_report(
         ));
     }
 
-    if stats.pending_embedding_count > 0 {
-        warnings.push(format!(
-            "{} embeddings are still pending",
-            stats.pending_embedding_count
-        ));
+    // One sample rules both surfaces when the caller took one. The status
+    // renderer prints its coverage counter from the same observation, so the
+    // warning can never name a pending count the counter beside it has already
+    // moved past. Callers that render no counter keep the report's own sample.
+    let pending_embeddings = embedding
+        .map(|observation| observation.status.pending)
+        .unwrap_or(stats.pending_embedding_count);
+    let pending_is_not_loss = embedding.is_some_and(|observation| observation.pending_is_not_loss);
+    if pending_embeddings > 0 {
+        if pending_is_not_loss {
+            // Structural, not observed: with no vector index attached,
+            // `embedding_status` answers zero indexed for every retrievable
+            // object, and this store has proven full coverage before with
+            // nothing discarded at open. Warning here told a restart reader
+            // their whole embedding corpus was lost while it sat intact on
+            // disk, so the state is reported as what it is instead.
+            notes.push(format!(
+                "{} retrievable objects are not covered by an attached vector index at this \
+                 instant; coverage completed before on this store and nothing was discarded at \
+                 open, so this is startup timing rather than lost embeddings",
+                pending_embeddings
+            ));
+        } else {
+            warnings.push(format!("{} embeddings are still pending", pending_embeddings));
+        }
     }
 
     GraphHealthReport {
@@ -626,7 +675,7 @@ mod tests {
             ..complete_coverage()
         };
 
-        let report = build_graph_health_report(&stats, &supported_inputs, &contamination, coverage);
+        let report = build_graph_health_report(&stats, &supported_inputs, &contamination, coverage, None);
 
         assert!(!report.graph_empty_for_supported_inputs);
         assert!(report.critical_issues.is_empty());

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -559,7 +559,10 @@ fn build_graph_health_report(
                 pending_embeddings
             ));
         } else {
-            warnings.push(format!("{} embeddings are still pending", pending_embeddings));
+            warnings.push(format!(
+                "{} embeddings are still pending",
+                pending_embeddings
+            ));
         }
     }
 
@@ -675,7 +678,8 @@ mod tests {
             ..complete_coverage()
         };
 
-        let report = build_graph_health_report(&stats, &supported_inputs, &contamination, coverage, None);
+        let report =
+            build_graph_health_report(&stats, &supported_inputs, &contamination, coverage, None);
 
         assert!(!report.graph_empty_for_supported_inputs);
         assert!(report.critical_issues.is_empty());

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2011,11 +2011,18 @@ fn semantic_query_health_from_runtime(
         "semantic_query_readiness",
         "Semantic query readiness",
         HealthStatus::Stale,
-        format!("{detail}; {reason}, so it is being rebuilt from scratch"),
+        // Not "rebuilt from scratch". The daemon's recovery pass answers
+        // unchanged texts from the embedder's persistent cache and forwards
+        // only misses, so promising a full rebuild overstates the cost and
+        // sends operators to run an embed pass nobody needed. The open-time
+        // daemon log makes the same statement in the same words, and two
+        // surfaces disagreeing about one fact invites a reader to trust the
+        // wrong one.
+        format!("{detail}; {reason}, so the daemon is restoring coverage in the background"),
     )
     .with_manual_fix(
-        "allow daemon embedding to finish or run `kin embed`; the rebuild is not lost work \
-         repeating itself once it completes",
+        "allow daemon embedding to finish, or run `kin embed` to force it now; the restore \
+         reuses prior vectors where they still apply",
     )
 }
 
@@ -3321,8 +3328,19 @@ mod tests {
         assert!(matches!(semantic.status, HealthStatus::Stale));
         assert!(
             semantic.detail.contains("graph.kvec")
-                && semantic.detail.contains("rebuilt from scratch"),
+                && semantic
+                    .detail
+                    .contains("restoring coverage in the background"),
             "a discarded index must be named, not left to be inferred from coverage: {}",
+            semantic.detail
+        );
+        // The recovery serves unchanged texts from the embedding cache, so no
+        // surface may promise a full re-embed. The open-time daemon log used to
+        // say this too and no longer does; this check keeps the two from
+        // drifting apart again.
+        assert!(
+            !semantic.detail.contains("from scratch"),
+            "a recovery that reuses prior vectors must not be announced as a full rebuild: {}",
             semantic.detail
         );
         assert!(semantic.manual_fix.is_some());

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -208,6 +208,7 @@ fn graph_status(
         graph,
         &GraphCommandRequest::Status,
         &Default::default(),
+        &Default::default(),
     )
     .expect("run graph status")
 }
@@ -268,6 +269,7 @@ fn graph_validate(
         binding,
         graph,
         &GraphCommandRequest::Validate,
+        &Default::default(),
         &Default::default(),
     )
     .expect("run graph validate")

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3424,6 +3424,19 @@ async fn command_graph(
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
+    // The runtime facts below describe the HEAD store: why its persisted
+    // vector index was not installed at open, and whether its coverage has
+    // ever been whole. A session temporal scope serves a different graph, so
+    // those facts would mislabel it; a scoped request gets the default, which
+    // renders exactly as before.
+    let embedding_runtime = if std::sync::Arc::ptr_eq(&graph, &state.graph) {
+        kin_cli::commands::graph::GraphStatusEmbeddingRuntime {
+            vector_index_discarded: state.vector_index_discarded().map(str::to_string),
+            coverage_ever_complete: state.embedding_coverage_ever_complete(),
+        }
+    } else {
+        kin_cli::commands::graph::GraphStatusEmbeddingRuntime::default()
+    };
     let response = kin_cli::commands::graph::execute_graph_command(
         &repository_authority,
         graph.as_ref(),
@@ -3432,6 +3445,7 @@ async fn command_graph(
             .background_work
             .reconcile()
             .report(std::time::Instant::now()),
+        &embedding_runtime,
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3403,6 +3403,34 @@ fn metal_profile_runtime() -> Option<kin_cli::commands::resources::MetalProfileR
     None
 }
 
+/// The daemon-owned embedding facts `kin graph status` renders beside its
+/// coverage counters, in the same carrier `/commands/resources` and semantic
+/// query readiness already use.
+///
+/// Only the facts this path renders are populated. The counter fields stay at
+/// their defaults on purpose: the status renderer takes the single
+/// `embedding_status()` sample that governs every embedding line of its
+/// response, so a second sample taken here could only become a number that
+/// disagrees with the line beside it. Nothing here is rendered as a count.
+///
+/// The facts describe the HEAD store. A session temporal scope serves a
+/// different graph, so they would mislabel it; a scoped request gets the
+/// default, which renders exactly as it did before any of them existed.
+fn graph_status_embedding_runtime(
+    state: &DaemonState,
+    graph: &Arc<kin_db::InMemoryGraph>,
+) -> kin_cli::commands::resources::EmbedRuntimeState {
+    if !Arc::ptr_eq(graph, &state.graph) {
+        return kin_cli::commands::resources::EmbedRuntimeState::default();
+    }
+    kin_cli::commands::resources::EmbedRuntimeState {
+        vector_index_discarded: state.vector_index_discarded().map(str::to_string),
+        embedding_coverage_ever_complete: state.embedding_coverage_ever_complete(),
+        embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
+        ..Default::default()
+    }
+}
+
 /// POST /commands/graph — render graph CLI commands from daemon-owned graph state.
 async fn command_graph(
     headers: axum::http::HeaderMap,
@@ -3424,19 +3452,7 @@ async fn command_graph(
     let repository_authority = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
-    // The runtime facts below describe the HEAD store: why its persisted
-    // vector index was not installed at open, and whether its coverage has
-    // ever been whole. A session temporal scope serves a different graph, so
-    // those facts would mislabel it; a scoped request gets the default, which
-    // renders exactly as before.
-    let embedding_runtime = if std::sync::Arc::ptr_eq(&graph, &state.graph) {
-        kin_cli::commands::graph::GraphStatusEmbeddingRuntime {
-            vector_index_discarded: state.vector_index_discarded().map(str::to_string),
-            coverage_ever_complete: state.embedding_coverage_ever_complete(),
-        }
-    } else {
-        kin_cli::commands::graph::GraphStatusEmbeddingRuntime::default()
-    };
+    let embedding_runtime = graph_status_embedding_runtime(&state, &graph);
     let response = kin_cli::commands::graph::execute_graph_command(
         &repository_authority,
         graph.as_ref(),
@@ -12956,6 +12972,92 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let layout = kin_core::init(&dir).unwrap().layout;
         Arc::new(DaemonState::open(layout).unwrap())
+    }
+
+    /// The state a hand-built runtime literal cannot reach: a real store with
+    /// no vector-index sidecar on disk and a coverage-completion marker from an
+    /// earlier life.
+    ///
+    /// `DaemonState::load_validated_vector_index` returns `None` both when the
+    /// index loaded and when there was none to load, and a loaded index stays
+    /// attached, so a store reporting no attached index with no discard reason
+    /// is the second case: the vectors are absent, not waiting. This opens the
+    /// store, reads both facts off it rather than asserting them into a struct,
+    /// and renders through the production builder, so the claim under test is
+    /// the one `kin graph status` actually prints.
+    #[cfg(feature = "vector")]
+    #[test]
+    fn a_store_with_no_sidecar_is_never_told_its_embeddings_are_intact() {
+        let state = test_state();
+        std::fs::write(state.layout.kindb_embedding_coverage_marker_path(), b"1").unwrap();
+
+        assert!(
+            !state.layout.kindb_vector_index_path().exists(),
+            "the fixture store must carry no persisted vector index"
+        );
+        assert_eq!(
+            state.vector_index_discarded(),
+            None,
+            "a store that never had an index has had nothing discarded"
+        );
+        assert!(
+            state.embedding_coverage_ever_complete(),
+            "the marker must read back as a completed fill"
+        );
+
+        state
+            .graph
+            .upsert_entity(&test_entity("alpha_transform", "src/alpha.py"))
+            .unwrap();
+        let status = state.graph.embedding_status();
+        assert!(
+            status.pending > 0,
+            "the fixture must carry uncovered retrievable objects"
+        );
+        assert!(
+            state.graph.vector_index_stats().is_none(),
+            "no index may be attached in this state"
+        );
+
+        let runtime = graph_status_embedding_runtime(&state, &state.graph);
+        let response = kin_cli::commands::graph::execute_graph_command(
+            &state.local_repository_authority_binding().unwrap(),
+            state.graph.as_ref(),
+            &kin_cli::commands::graph::GraphCommandRequest::Status,
+            &Default::default(),
+            &runtime,
+        )
+        .unwrap();
+
+        for forbidden in [
+            "await the index",
+            "nothing was discarded",
+            "startup timing",
+            "rather than re-embedding",
+        ] {
+            assert!(
+                !response.lines.iter().any(|line| line.contains(forbidden)),
+                "absent vectors must not be reported as intact ({forbidden}): {:?}",
+                response.lines
+            );
+        }
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.contains("embeddings are still pending")),
+            "the only signal that coverage is absent must survive: {:?}",
+            response.lines
+        );
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.starts_with("Embeddings:")
+                    && line.contains("the live graph carries no vector index")),
+            "the structural zero is named where the counters are read: {:?}",
+            response.lines
+        );
     }
 
     fn unattached_vector_coverage_reason() -> kin_cli::commands::status::EmbeddingCoverageUnobserved

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1614,10 +1614,17 @@ impl DaemonState {
                 vector_path.display()
             ),
         };
+        // Not "embedded again from scratch": the preserved sidecar stays on
+        // disk, and the recovery pass reuses prior vectors where they still
+        // apply. A dirty-restart repro on v0.5.23 watched a discarded index
+        // restore full coverage with zero embed dispatches, so promising a
+        // full GPU rebuild here overstated the cost and sent operators to run
+        // an embed pass nobody needed.
         warn!(
             path = %vector_path.display(),
-            "{discarded}; every entity will be embedded again from scratch. \
-             Run `kin embed` to rebuild it now, or `kin health` to watch coverage recover."
+            "{discarded}; the daemon restores coverage in the background and reuses prior \
+             vectors where they still apply. Run `kin health` to watch coverage recover, or \
+             `kin embed` to force a rebuild now."
         );
         Some(discarded)
     }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1614,12 +1614,13 @@ impl DaemonState {
                 vector_path.display()
             ),
         };
-        // Not "embedded again from scratch": the preserved sidecar stays on
-        // disk, and the recovery pass reuses prior vectors where they still
-        // apply. A dirty-restart repro on v0.5.23 watched a discarded index
-        // restore full coverage with zero embed dispatches, so promising a
-        // full GPU rebuild here overstated the cost and sent operators to run
-        // an embed pass nobody needed.
+        // Not "embedded again from scratch": the sidecar is preserved on disk,
+        // and the recovery pass answers unchanged texts from the embedder's
+        // persistent EmbeddingCache, forwarding only misses. A dirty-restart
+        // repro on v0.5.23 watched a discarded index restore full coverage
+        // with zero embed dispatches, so promising a full GPU rebuild here
+        // overstated the cost and sent operators to run an embed pass nobody
+        // needed.
         warn!(
             path = %vector_path.display(),
             "{discarded}; the daemon restores coverage in the background and reuses prior \


### PR DESCRIPTION
`kin graph status` after a dirty daemon restart announced `Embeddings: 0/10456 indexed (10456 pending)` with a pending warning, on a store that recovered seconds later with zero embed dispatches. Nothing was wrong, and the surface said everything was. That is the v0.5.21 battery's B7 finding, reproduced on shipped v0.5.23.

The zero is structural rather than measured. A dirty restart leaves a sidecar whose stamp trails graph truth, the daemon refuses to install it at open, and while no index is attached `embedding_status` answers zero indexed for every retrievable object. The counters are true, so they were never the problem. What a reader cannot get from them is why, and a zero with no cause reads exactly like a repository that lost its work.

So the counters always render now, and the daemon's reason is appended when it has one. A discard at open names itself beside the numbers and says the daemon restores coverage in the background, which is what tells an operator no manual GPU pass is owed. A store with no attached index and no discard on record is told the live graph carries no vector index, the same words `kin status` already uses for that absence, plus the coverage-completion marker when it is set.

No clause claims the vectors are sitting intact somewhere, because nothing on this path can know that. `load_validated_vector_index` returns `None` both when the index loaded and when there was none to load, and a loaded index stays attached, so that branch is only reached when there was no sidecar to load or a later reset detached one. Both of those rebuild rather than re-attach. An earlier revision of this branch read the same `None` as "nothing was discarded" and told the reader to await the index rather than re-embed, which was false in every state that could reach it, and it dropped the pending warning that was the only remaining signal.

A store whose graph authority is a remote backend never embeds at all. Its worker does not start and `/embed` refuses, so the discard clause would name a background recovery that will never run. That fact now outranks both the discard reason and the marker here, matching the order semantic query readiness already checks them in.

The three runtime facts travel in `commands::resources::EmbedRuntimeState`, the carrier `/commands/resources` and readiness already use, and the daemon builds it in one named function so a test can drive the real construction instead of asserting a hand-built literal. A session-scoped graph still gets the default and renders as before.

The coverage counter and the pending warning now come from one embedding-status sample, so they can no longer disagree by exactly one embed batch. That was the battery's B12 residue, one of twelve paired samples off by 512. The two were not even drawn from the same population: `graph_stats().pending_embedding_count` counts entity ids while `embedding_status()` counts retrievable keys, so they could differ at a single instant with no race at all.

Both surfaces that described a discard as a from-scratch rebuild stop doing so. The open-time daemon log and `kin health` now say the same thing, that the daemon restores coverage in the background and reuses prior vectors where they still apply. That is what the dirty-restart repro observed, full coverage restored with zero embed dispatches.

The new arms are pinned by value, and each assertion was checked against its own canary: restoring the rejected claim, dropping the remote-backend arm, and putting "from scratch" back each turned the matching test red. One of those tests opens a real store with no sidecar and a coverage marker, reads both facts off the daemon rather than asserting them into a struct, and renders through the production builder.

The root cause, a dirty restart guaranteeing a whole-sidecar discard, is filed as FIR-2290 and is not changed here.

Closes FIR-2289
