### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod artifacts;
 pub mod common;
+pub mod youcom;
 
 // Handler submodules are public so each tool's rich `*_DESC` description const
 // can live next to the handler that implements it, and be referenced by the
@@ -156,6 +157,8 @@ pub async fn handle_tool_call<G: GraphStore>(
         "kin_graph_status" => entities::handle_graph_status(arguments, store),
         // Benchmark
         "benchmark" => bench::handle_benchmark(arguments, store),
+        // Optional external web search
+        "youcom_search" => youcom::handle_youcom_search(arguments).await,
         _ => Err(McpError::ToolNotFound(tool_name.to_string())),
     }
 }

--- a/crates/kin-mcp/src/handlers/youcom.rs
+++ b/crates/kin-mcp/src/handlers/youcom.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::error::{McpError, Result};
+use crate::types::ToolCallResult;
+
+use super::common::{
+    get_optional_string_array, get_optional_string_param, get_optional_u64, get_string_param,
+};
+
+pub const YOUCOM_SEARCH_DESC: &str = "\
+Search the public web with You.com and return the raw LLM-ready results payload. \
+Use this when you want fresh external context that Kin's graph-native search cannot \
+provide: news, current web pages, and optional domain filtering. This tool is opt-in \
+and requires YDC_API_KEY; YOUCOM_BASE_URL defaults to https://api.you.com. If no key \
+is configured, the tool returns a clear error instead of changing Kin's default \
+behavior.";
+
+fn resolve_youcom_base_url_with<F>(mut get_var: F) -> String
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    get_var("YOUCOM_BASE_URL")
+        .and_then(|value| {
+            let trimmed = value.trim().trim_end_matches('/').to_string();
+            (!trimmed.is_empty()).then_some(trimmed)
+        })
+        .unwrap_or_else(|| "https://api.you.com".to_string())
+}
+
+fn resolve_youcom_api_key_with<F>(mut get_var: F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    get_var("YDC_API_KEY").and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then_some(trimmed.to_string())
+    })
+}
+
+fn validate_domain_filters(
+    include_domains: &Option<Vec<String>>,
+    exclude_domains: &Option<Vec<String>>,
+    boost_domains: &Option<Vec<String>>,
+) -> Result<()> {
+    if include_domains.is_some() && exclude_domains.is_some() {
+        return Err(McpError::InvalidParams(
+            "include_domains and exclude_domains cannot be used together".into(),
+        ));
+    }
+    if include_domains.is_some() && boost_domains.is_some() {
+        return Err(McpError::InvalidParams(
+            "include_domains and boost_domains cannot be used together".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn build_search_request(args: &HashMap<String, Value>) -> Result<(String, serde_json::Value)> {
+    let query = get_string_param(args, "query")?;
+    let count = get_optional_u64(args, "count", 10).clamp(1, 100) as u64;
+    let freshness = get_optional_string_param(args, "freshness");
+    let offset = get_optional_u64(args, "offset", 0).min(9);
+    let country = get_optional_string_param(args, "country");
+    let language = get_optional_string_param(args, "language");
+    let safesearch = get_optional_string_param(args, "safesearch");
+    let include_domains = get_optional_string_array(args, "include_domains");
+    let exclude_domains = get_optional_string_array(args, "exclude_domains");
+    let boost_domains = get_optional_string_array(args, "boost_domains");
+
+    validate_domain_filters(&include_domains, &exclude_domains, &boost_domains)?;
+
+    let mut request = serde_json::json!({
+        "query": query,
+        "count": count,
+        "offset": offset,
+    });
+
+    if let Some(value) = freshness {
+        request["freshness"] = serde_json::json!(value);
+    }
+    if let Some(value) = country {
+        request["country"] = serde_json::json!(value);
+    }
+    if let Some(value) = language {
+        request["language"] = serde_json::json!(value);
+    }
+    if let Some(value) = safesearch {
+        request["safesearch"] = serde_json::json!(value);
+    }
+    if let Some(value) = include_domains {
+        request["include_domains"] = serde_json::json!(value);
+    }
+    if let Some(value) = exclude_domains {
+        request["exclude_domains"] = serde_json::json!(value);
+    }
+    if let Some(value) = boost_domains {
+        request["boost_domains"] = serde_json::json!(value);
+    }
+
+    Ok((query, request))
+}
+
+async fn perform_youcom_search(
+    base_url: &str,
+    api_key: &str,
+    request: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|error| McpError::Other(format!("failed to build reqwest client: {error}")))?;
+
+    let response = client
+        .post(format!("{}/v1/search", base_url.trim_end_matches('/')))
+        .header("X-API-Key", api_key)
+        .header(
+            reqwest::header::USER_AGENT,
+            format!("kin-mcp/{} (youcom_search)", env!("CARGO_PKG_VERSION")),
+        )
+        .json(request)
+        .send()
+        .await
+        .map_err(|error| McpError::Other(format!("You.com search request failed: {error}")))?;
+
+    let status = response.status();
+    let body = response.text().await.map_err(|error| {
+        McpError::Other(format!("failed to read You.com response body: {error}"))
+    })?;
+
+    if !status.is_success() {
+        return Err(McpError::Other(format!(
+            "You.com search API returned {status}: {body}"
+        )));
+    }
+
+    serde_json::from_str(&body).map_err(|error| {
+        McpError::Other(format!(
+            "failed to parse You.com search response: {error}; body: {body}"
+        ))
+    })
+}
+
+pub async fn handle_youcom_search(args: &HashMap<String, Value>) -> Result<ToolCallResult> {
+    let (query, request) = build_search_request(args)?;
+    let api_key = resolve_youcom_api_key_with(|key| std::env::var(key).ok()).ok_or_else(|| {
+        McpError::Other(
+            "YDC_API_KEY is required for youcom_search; set it to a You.com API key or use a different MCP tool profile"
+                .to_string(),
+        )
+    })?;
+    let base_url = resolve_youcom_base_url_with(|key| std::env::var(key).ok());
+
+    let response = perform_youcom_search(&base_url, &api_key, &request).await?;
+    let envelope = serde_json::json!({
+        "provider": "you.com",
+        "query": query,
+        "base_url": base_url,
+        "request": request,
+        "response": response,
+    });
+
+    let json = serde_json::to_string_pretty(&envelope).map_err(McpError::Json)?;
+    Ok(ToolCallResult::text(json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_url_defaults_to_youcom() {
+        assert_eq!(
+            resolve_youcom_base_url_with(|_| None),
+            "https://api.you.com"
+        );
+    }
+
+    #[test]
+    fn base_url_trims_trailing_slashes_and_whitespace() {
+        let base = resolve_youcom_base_url_with(|key| {
+            (key == "YOUCOM_BASE_URL").then_some(" https://example.com/api/// ".to_string())
+        });
+        assert_eq!(base, "https://example.com/api");
+    }
+
+    #[test]
+    fn api_key_trims_and_skips_blank_values() {
+        assert_eq!(
+            resolve_youcom_api_key_with(|key| {
+                (key == "YDC_API_KEY").then_some("  secret-key  ".to_string())
+            }),
+            Some("secret-key".to_string())
+        );
+        assert_eq!(
+            resolve_youcom_api_key_with(|_| Some("   ".to_string())),
+            None
+        );
+    }
+
+    #[test]
+    fn request_body_includes_supported_filters() {
+        let mut args = HashMap::new();
+        args.insert("query".into(), serde_json::json!("kin release"));
+        args.insert("count".into(), serde_json::json!(25));
+        args.insert("offset".into(), serde_json::json!(2));
+        args.insert("freshness".into(), serde_json::json!("week"));
+        args.insert("country".into(), serde_json::json!("US"));
+        args.insert("language".into(), serde_json::json!("en"));
+        args.insert("safesearch".into(), serde_json::json!("moderate"));
+        args.insert(
+            "boost_domains".into(),
+            serde_json::json!(["github.com", "docs.rs"]),
+        );
+
+        let (query, request) = build_search_request(&args).unwrap();
+        assert_eq!(query, "kin release");
+        assert_eq!(request["query"], serde_json::json!("kin release"));
+        assert_eq!(request["count"], serde_json::json!(25));
+        assert_eq!(request["offset"], serde_json::json!(2));
+        assert_eq!(request["freshness"], serde_json::json!("week"));
+        assert_eq!(request["country"], serde_json::json!("US"));
+        assert_eq!(request["language"], serde_json::json!("en"));
+        assert_eq!(request["safesearch"], serde_json::json!("moderate"));
+        assert_eq!(
+            request["boost_domains"],
+            serde_json::json!(["github.com", "docs.rs"])
+        );
+    }
+
+    #[test]
+    fn request_body_rejects_conflicting_domain_filters() {
+        let mut args = HashMap::new();
+        args.insert("query".into(), serde_json::json!("kin"));
+        args.insert("include_domains".into(), serde_json::json!(["you.com"]));
+        args.insert("exclude_domains".into(), serde_json::json!(["example.com"]));
+
+        let err = build_search_request(&args).unwrap_err();
+        assert!(err.to_string().contains("cannot be used together"));
+    }
+}

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -1049,6 +1049,68 @@ pub fn tool_definitions() -> ToolsListResult {
                     "additionalProperties": false
                 }),
             },
+            ToolDefinition {
+                name: "youcom_search".into(),
+                description: crate::handlers::youcom::YOUCOM_SEARCH_DESC.into(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The web query to send to You.com"
+                        },
+                        "count": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 10,
+                            "description": "Maximum results per section returned by You.com"
+                        },
+                        "freshness": {
+                            "type": "string",
+                            "description": "Freshness window such as day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD"
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9,
+                            "default": 0,
+                            "description": "Pagination offset"
+                        },
+                        "country": {
+                            "type": "string",
+                            "description": "Country code to focus results"
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "BCP 47 language code"
+                        },
+                        "safesearch": {
+                            "type": "string",
+                            "enum": ["off", "moderate", "strict"],
+                            "default": "moderate",
+                            "description": "Content filtering level"
+                        },
+                        "include_domains": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Strict domain allowlist"
+                        },
+                        "exclude_domains": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Domain blocklist"
+                        },
+                        "boost_domains": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Domains that should get a ranking boost"
+                        }
+                    },
+                    "required": ["query"],
+                    "additionalProperties": false
+                }),
+            },
         ],
     }
 }
@@ -1273,8 +1335,8 @@ mod tests {
     fn expected_tool_count() {
         let list = tool_definitions();
         // 54 + 5 transaction tools + 1 semantic_locate + 1 shadow_gate_report
-        // + 1 get_entity_sources + 2 exact artifact tools = 64
-        assert_eq!(list.tools.len(), 64);
+        // + 1 get_entity_sources + 2 exact artifact tools + 1 You.com search = 65
+        assert_eq!(list.tools.len(), 65);
     }
 
     /// The tool reference must name every tool the registry serves, and its

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # Model Context Protocol (MCP) Tool Surface Reference
 
-The Kin MCP server exposes 64 semantic tools to AI assistants (Claude, Cursor, Gemini,
+The Kin MCP server exposes 65 semantic tools to AI assistants (Claude, Cursor, Gemini,
 Codex, etc.). These tools bridge the gap between traditional file-first navigation and
 Kin's graph-first semantic substrate: instead of issuing raw shell commands or reading raw
 files, an assistant interacts with the codebase through entity-level primitives.
@@ -63,6 +63,10 @@ command line (the flag wins):
 
 A value that is not one of these is not silently treated as "serve everything": the server
 falls back to `agent-default` and says on stderr what it was asked for and what it served.
+
+The `full` profile also includes optional, externally integrated tools such as
+`youcom_search`. Configure `YDC_API_KEY` and optionally `YOUCOM_BASE_URL`
+before launching `kin mcp start` if you want that surface available.
 
 ---
 


### PR DESCRIPTION
Adds an optional `youcom_search` MCP tool so Kin agents can reach the public web when the graph-local search tools aren’t enough.

What changed:
- Added a new `youcom_search` handler backed by the You.com Search API.
- Wired the tool into the MCP dispatcher and tool registry.
- Kept it out of the default MCP profile so existing users do not see a new surface unless they opt into `KIN_MCP_TOOL_PROFILE=full`.
- Documented the opt-in setup in `docs/mcp-tools.md`.

Setup:
- `YDC_API_KEY` is required.
- `YOUCOM_BASE_URL` is optional and defaults to `https://api.you.com`.
- `KIN_MCP_TOOL_PROFILE=full` exposes the new tool.

Usage:
```bash
KIN_MCP_TOOL_PROFILE=full kin mcp start
# then call `youcom_search` from an MCP client after setting YDC_API_KEY
```

Validation:
- `cargo fmt --all`
- `cargo test -p kin-mcp --lib --tests`

Fallback and error handling:
- Missing `YDC_API_KEY` returns a clear tool error.
- Conflicting domain filters are rejected with `InvalidParams`.
- Non-2xx You.com responses are surfaced with status code and response body.

Tracking:
- https://github.com/youdotcom-oss/integration-tracking/issues/188
