### PR TITLE
Time every phase of an MCP commit, including the authority publication boundary

### DIFF
--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -3330,7 +3330,40 @@ impl<T> ProjectionAuthorityCommit<T> {
     }
 }
 
+const SLOW_AUTHORITY_PUBLICATION: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Time repository authority publication and record what it cost.
+///
+/// The daemon times its own commit phases, but its innermost phase spans both
+/// the workspace projection this crate performs and the authority publication
+/// that runs inside it, so a slow commit cannot be attributed to either side
+/// from the daemon log alone. Naming the publication separately splits that
+/// span at the crate boundary without changing what either side does. The
+/// whole helper is timed rather than its first attempt, because a caller that
+/// waits through a retry waited for all of it.
+fn timed_authority_publication<T>(work: impl FnOnce() -> T) -> T {
+    let started = std::time::Instant::now();
+    let outcome = work();
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if elapsed >= SLOW_AUTHORITY_PUBLICATION {
+        tracing::info!(elapsed_ms, "slow repository authority publication");
+    } else {
+        tracing::debug!(elapsed_ms, "repository authority publication");
+    }
+    outcome
+}
+
 fn commit_repository_transaction_exact(
+    authority: &RepositoryAuthorityManager<LocalFileBackend>,
+    transaction: RepositoryTransaction,
+) -> ProjectionAuthorityCommit<RepositoryCommitReceipt> {
+    timed_authority_publication(|| {
+        commit_repository_transaction_exact_inner(authority, transaction)
+    })
+}
+
+fn commit_repository_transaction_exact_inner(
     authority: &RepositoryAuthorityManager<LocalFileBackend>,
     transaction: RepositoryTransaction,
 ) -> ProjectionAuthorityCommit<RepositoryCommitReceipt> {

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -349,17 +349,21 @@ fn commit_exact_transaction_inner(
             .map_err(|error| format!("persist receipt-less committing reset: {error}"))?;
     }
 
-    let base = load_native_commit_base(&authority_context)
-        .map_err(|error| format!("load exact MCP commit base: {error}"))?;
+    let base = timed_commit_phase("load_commit_base", || {
+        load_native_commit_base(&authority_context)
+    })
+    .map_err(|error| format!("load exact MCP commit base: {error}"))?;
     require_bound_authority_revision(state, &base, &transaction_id)?;
-    let plan = match plan_exact_transaction(
-        state,
-        &authority_context,
-        &transaction,
-        &actor,
-        operation_id,
-        &base,
-    ) {
+    let plan = match timed_commit_phase("plan_transaction", || {
+        plan_exact_transaction(
+            state,
+            &authority_context,
+            &transaction,
+            &actor,
+            operation_id,
+            &base,
+        )
+    }) {
         Ok(plan) => plan,
         Err(error) => {
             return Err(unstage_failed_attempt(
@@ -383,12 +387,14 @@ fn commit_exact_transaction_inner(
         ));
     }
 
-    let committed = match commit_native_plan_with_projection(
-        &state.layout,
-        state.blobs.as_ref(),
-        &authority_context,
-        plan.native,
-    ) {
+    let committed = match timed_commit_phase("publish_authority_and_projection", || {
+        commit_native_plan_with_projection(
+            &state.layout,
+            state.blobs.as_ref(),
+            &authority_context,
+            plan.native,
+        )
+    }) {
         Ok(committed) => committed,
         Err(commit_error) => match recover_native_commit(&authority_context, operation_id) {
             Ok(Some(recovered)) => recovered,
@@ -1522,6 +1528,28 @@ fn timed_finalize_step<T>(step: &'static str, work: impl FnOnce() -> T) -> T {
         tracing::info!(step, elapsed_ms, "slow commit finalize step");
     } else {
         tracing::debug!(step, elapsed_ms, "commit finalize step");
+    }
+    outcome
+}
+
+/// Run one phase of the commit that precedes durable publication and record
+/// what it cost.
+///
+/// The finalize after authority publication already times its own steps, and
+/// the first measurement under that timing showed the multi-minute wait
+/// sitting in front of it instead: building and persisting the authority
+/// successor runs whole-graph work with nothing in the log. Naming these
+/// phases lets the next slow commit attribute the wait to the phase that
+/// spent it instead of leaving the reply gap unexplained.
+pub(crate) fn timed_commit_phase<T>(phase: &'static str, work: impl FnOnce() -> T) -> T {
+    let started = std::time::Instant::now();
+    let outcome = work();
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if elapsed >= SLOW_FINALIZE_STEP {
+        tracing::info!(phase, elapsed_ms, "slow commit phase");
+    } else {
+        tracing::debug!(phase, elapsed_ms, "commit phase");
     }
     outcome
 }

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1102,41 +1102,56 @@ pub(crate) fn commit_native_plan_with_projection(
             plan.transaction.repository_id, repository_id
         )));
     }
-    let authority = authority_context.open().map_err(DaemonError::Graph)?;
-    for hash in &plan.source_hashes {
-        if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish() {
-            authority.save_source_blob(*hash, body)?;
+    let authority = crate::mcp_commit::timed_commit_phase("open_repository_authority", || {
+        authority_context.open()
+    })
+    .map_err(DaemonError::Graph)?;
+    crate::mcp_commit::timed_commit_phase("stage_changed_source_blobs", || {
+        for hash in &plan.source_hashes {
+            if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish()
+            {
+                authority.save_source_blob(*hash, body)?;
+            }
         }
-    }
+        Ok::<(), DaemonError>(())
+    })?;
 
     let mut body_cache = BTreeMap::new();
-    let target_entries = load_projection_entries(&authority, &plan.target_tree, &mut body_cache)?;
+    let target_entries = crate::mcp_commit::timed_commit_phase("load_projection_entries", || {
+        load_projection_entries(&authority, &plan.target_tree, &mut body_cache)
+    })?;
     let (projected, receipt) = if plan.previous_tree == plan.target_tree {
-        kin_core::verify_unchanged_source_tree_and_commit_repository_transaction(
-            layout.working_dir(),
-            &plan.target_tree,
-            target_entries
-                .iter()
-                .map(|(path, entry, body)| (path, *entry, body.as_ref())),
-            &authority,
-            plan.transaction,
-        )?
+        crate::mcp_commit::timed_commit_phase("reconcile_workspace_and_commit_authority", || {
+            kin_core::verify_unchanged_source_tree_and_commit_repository_transaction(
+                layout.working_dir(),
+                &plan.target_tree,
+                target_entries
+                    .iter()
+                    .map(|(path, entry, body)| (path, *entry, body.as_ref())),
+                &authority,
+                plan.transaction,
+            )
+        })?
     } else {
-        let previous_entries =
-            load_projection_entries(&authority, &plan.previous_tree, &mut body_cache)?;
-        kin_core::reconcile_source_tree_and_commit_repository_transaction(
-            layout.working_dir(),
-            &plan.previous_tree,
-            &plan.target_tree,
-            previous_entries
-                .iter()
-                .map(|(path, entry, body)| (path, *entry, body.as_ref())),
-            target_entries
-                .iter()
-                .map(|(path, entry, body)| (path, *entry, body.as_ref())),
-            &authority,
-            plan.transaction,
-        )?
+        let previous_entries = crate::mcp_commit::timed_commit_phase(
+            "load_previous_projection_entries",
+            || load_projection_entries(&authority, &plan.previous_tree, &mut body_cache),
+        )?;
+        crate::mcp_commit::timed_commit_phase("reconcile_workspace_and_commit_authority", || {
+            kin_core::reconcile_source_tree_and_commit_repository_transaction(
+                layout.working_dir(),
+                &plan.previous_tree,
+                &plan.target_tree,
+                previous_entries
+                    .iter()
+                    .map(|(path, entry, body)| (path, *entry, body.as_ref())),
+                target_entries
+                    .iter()
+                    .map(|(path, entry, body)| (path, *entry, body.as_ref())),
+                &authority,
+                plan.transaction,
+            )
+        })?
     };
     let materializable = materializable_artifact_count(&plan.target_tree)?;
     if projected != materializable {

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -1133,10 +1133,10 @@ pub(crate) fn commit_native_plan_with_projection(
             )
         })?
     } else {
-        let previous_entries = crate::mcp_commit::timed_commit_phase(
-            "load_previous_projection_entries",
-            || load_projection_entries(&authority, &plan.previous_tree, &mut body_cache),
-        )?;
+        let previous_entries =
+            crate::mcp_commit::timed_commit_phase("load_previous_projection_entries", || {
+                load_projection_entries(&authority, &plan.previous_tree, &mut body_cache)
+            })?;
         crate::mcp_commit::timed_commit_phase("reconcile_workspace_and_commit_authority", || {
             kin_core::reconcile_source_tree_and_commit_repository_transaction(
                 layout.working_dir(),


### PR DESCRIPTION
A comment-only MCP commit on a large store blocks for minutes, and until now
the daemon log went quiet for almost all of it. This makes the whole call
self-reporting: every phase names itself and its duration, and the one phase
that used to hide three quarters of the wait is split at the boundary between
the workspace projection kin-core performs and the repository authority
publication kin-db performs inside it.

Nothing here changes what a commit does. Every change is a timer around an
existing call, at the same 500 ms info threshold the finalize steps already
use, with everything below it at debug.

## What the instrumentation now covers

The pre-durability stretch was previously untimed end to end: `load_commit_base`,
`plan_transaction`, `publish_authority_and_projection`, and inside the
publication `open_repository_authority`, `stage_changed_source_blobs`,
`load_projection_entries`, `load_previous_projection_entries`, and
`reconcile_workspace_and_commit_authority`. On top of that, the innermost
phase spanned both crates at once, so a slow commit could not be attributed to
either side from the log alone. `timed_authority_publication` in kin-core now
names the authority publication separately.

## What was measured

Instrumented build on a synthetic 1000-file, 3000-entity, fully embedded store,
one comment-only edit through the MCP transactional path. Caller-observed call
12.832 s cold, and the phases account for all of it:

| phase | ms |
|---|---|
| load_commit_base | 999 |
| plan_transaction | 1570 |
| publish_authority_and_projection | 9612 |
| ...open_repository_authority | 401 |
| ...stage_changed_source_blobs | 88 |
| ...load_projection_entries | 1867 |
| ...reconcile_workspace_and_commit_authority | 7249 |
| finalize reload_repository_authority | 537 |

Warm, across sixteen consecutive commits on the same store, the call settles
near 6 s with `reconcile_workspace_and_commit_authority` averaging 3560 ms and
`load_projection_entries` 897 ms. That second number is the clearest read on
the shape of the problem: a one-line edit reloads every body in the workspace
tree, every commit.

The new boundary split then says which crate owns the big phase. Three commits
on the rebuilt binary:

| reconcile phase ms | of which authority publication ms |
|---|---|
| 3114 | 2310 |
| 3140 | 2336 |
| 3678 | 2710 |

So 74% of the phase, and roughly 43% of the whole commit call, is inside
repository authority publication rather than in the workspace projection around
it. That is the number this split existed to produce, and it points the
remaining work squarely at kin-db.

## What this proves, and what it does not

It proves the cost is not the edit. It proves the block is not post-durability
either, which was the framing this work started from. The marker that made it
look post-durability is the change's own timestamp, minted at plan time and
stored on the change, while a change only becomes visible to `kin log` once the
full authority snapshot persists near the end of the call. Reply time minus
that stored timestamp manufactures a wait that never happened.

It does not prove the cost tracks history depth. A control held the workspace
fixed at 3000 entities and deepened only history across sixteen commits, and
over depth 5 to 17 the commit time was flat inside noise: a linear fit gives
0.038 s per added change at R^2 = 0.132, and extrapolating it to the 516-change
dogfood store predicts 25 s against the roughly 94 s actually observed there.
So the earlier reading, that history depth is the multiplier, is not supported
by a controlled test, and the comparison it rested on is confounded because
those two stores also differ by 14x in bytes. A superlinear effect invisible
below depth 20 is still possible; deciding that needs a fixture driven to
several hundred changes, which this lane did not run.

No timing here is citable. Shared dev box, wall clock.

## Why no fix ships with this

The dominant term is inside kin-db's `prepare_successor`, which is kin-db
scope and needs a version bump and re-lock through the release train. The one
kin-side candidate that looked free is not: the finalize reload is what
re-reads persisted authority to check its roots against the receipt, so
handing finalize the in-memory successor instead would make that check compare
a value against itself. Trading a real verification for 8.9 s is not a trade
this lane should make quietly, so it is written up rather than shipped.

There is no test asserting a log line fires. A test on timing emission would
pass or fail on machine speed rather than on behavior, and the change has no
behavior to assert beyond returning its inner value unchanged.

Refs FIR-2258
Refs FIR-2291
