### PR TITLE
Re-key the installer and bug-report version examples to 0.5.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Kin Version
       description: The whole first line of `kin --version`, build identity included
-      placeholder: "kin 0.5.20 (<sha> <ref> <timestamp>)"
+      placeholder: "kin 0.5.23 (<sha> <ref> <timestamp>)"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Kin Version
       description: The whole first line of `kin --version`, build identity included
-      placeholder: "kin 0.5.23 (<sha> <ref> <timestamp>)"
+      placeholder: "kin 0.5.25 (<sha> <ref> <timestamp>)"
     validations:
       required: true
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1848,7 +1848,7 @@ kin release apply <crate-name> <version> [repos] [options]
 | Argument | Required | Description |
 | --- | --- | --- |
 | `<crate-name>` | yes | The registry crate whose pin to bump (e.g. kin-db). |
-| `<version>` | yes | The version to pin (e.g. 0.2.24). |
+| `<version>` | yes | The version to pin (e.g. 0.7.21). |
 | `[repos]` | no | Repos to update (default: every consumer repo). |
 
 | Flag | Default | Description |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,7 +81,7 @@ what Kin admitted, run `git config --global core.autocrlf false` and clone again
 Configure the installers with environment variables (supported by both `install.sh`
 and `install.ps1` unless noted):
 
-- `KIN_VERSION`: pin a specific version (e.g. `0.1.0`); otherwise the latest release is
+- `KIN_VERSION`: pin a specific version (e.g. `0.5.23`); otherwise the latest release is
   resolved automatically.
 - `KIN_HOME`: custom managed install directory (preferred; defaults to `~/.kin`).
 - `KIN_DIR`: compatibility alias for `KIN_HOME`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,7 +81,7 @@ what Kin admitted, run `git config --global core.autocrlf false` and clone again
 Configure the installers with environment variables (supported by both `install.sh`
 and `install.ps1` unless noted):
 
-- `KIN_VERSION`: pin a specific version (e.g. `0.5.23`); otherwise the latest release is
+- `KIN_VERSION`: pin a specific version (e.g. `0.5.25`); otherwise the latest release is
   resolved automatically.
 - `KIN_HOME`: custom managed install directory (preferred; defaults to `~/.kin`).
 - `KIN_DIR`: compatibility alias for `KIN_HOME`.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://get.kinlab.dev/install.ps1 | iex
 #
 # Options (via env vars):
-#   $env:KIN_VERSION = "0.5.23"  Pin a specific version (default: latest)
+#   $env:KIN_VERSION = "0.5.25"  Pin a specific version (default: latest)
 #   $env:KIN_HOME = "$HOME\.kin" Install directory (preferred; default: ~/.kin)
 #   $env:KIN_DIR = "$HOME\.kin"  Install directory compatibility alias
 #   $env:KIN_NO_SETUP = "1"     CI compatibility; native repository setup is always skipped

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,7 +7,7 @@
 #   irm https://get.kinlab.dev/install.ps1 | iex
 #
 # Options (via env vars):
-#   $env:KIN_VERSION = "0.1.0"   Pin a specific version (default: latest)
+#   $env:KIN_VERSION = "0.5.23"  Pin a specific version (default: latest)
 #   $env:KIN_HOME = "$HOME\.kin" Install directory (preferred; default: ~/.kin)
 #   $env:KIN_DIR = "$HOME\.kin"  Install directory compatibility alias
 #   $env:KIN_NO_SETUP = "1"     CI compatibility; native repository setup is always skipped

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,7 @@
 #   curl -fsSL https://get.kinlab.dev/install | sh
 #
 # Options (via env vars):
-#   KIN_VERSION=0.1.0    Pin a specific version (default: latest)
+#   KIN_VERSION=0.5.23    Pin a specific version (default: latest)
 #   KIN_HOME=~/.kin       Install directory (preferred; default: ~/.kin)
 #   KIN_DIR=~/.kin        Install directory compatibility alias
 #   KIN_NO_SETUP=1        Skip interactive setup after install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,7 @@
 #   curl -fsSL https://get.kinlab.dev/install | sh
 #
 # Options (via env vars):
-#   KIN_VERSION=0.5.23    Pin a specific version (default: latest)
+#   KIN_VERSION=0.5.25    Pin a specific version (default: latest)
 #   KIN_HOME=~/.kin       Install directory (preferred; default: ~/.kin)
 #   KIN_DIR=~/.kin        Install directory compatibility alias
 #   KIN_NO_SETUP=1        Skip interactive setup after install


### PR DESCRIPTION
Every version example a reader can copy now names 0.5.25. The examples name a shipped tag without asserting which release is current, because a hand-keyed Latest claim in this repo went stale twice in one day; when no pin is given the installers resolve the actual latest release on their own.

Before this, the shell and PowerShell installers each offered `KIN_VERSION=0.1.0` as the pin example, the quickstart repeated it, and the bug report template asked for `kin --version` while showing `kin 0.5.20`. Those tags all still exist, so nobody was handed a broken command. They just pointed a reader at a build we stopped shipping months ago, and a version example is the one line people copy without reading.

The `kin release apply` example moves from 0.2.24 to 0.7.21, matching the kin-db pin in this repository's Cargo.toml.

This is a mechanical re-key. It touches comment blocks, one docs table, one docs bullet, and a form placeholder. No product claim changes and no behavior changes.
