### PR TITLE
Give the compat-v0 locate arm the shared file surface

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6772,6 +6772,13 @@ fn semantic_locate_payload(
         "next_cursor": next_cursor,
         "results": window,
     });
+    // The file surface, in the same `files[]` shape `kin locate --json`, `POST
+    // /locate`, and the fused arm already emit, so one consumer parses every Kin
+    // locate surface. Serialized unconditionally, including as `[]` for an empty
+    // ranking, because the fused arm serializes it unconditionally too and a key
+    // that appears only when non-empty makes absence and emptiness the same
+    // reading.
+    payload["files"] = json!(cosine_file_surface(rows));
     if !degradations.is_empty() {
         payload["degradations"] = json!(degradations);
     }
@@ -6824,6 +6831,127 @@ fn locate_rows_are_all_fallback(rows: &[serde_json::Value]) -> bool {
         && !rows.iter().any(|row| {
             row.get("match_kind") == Some(&json!(kin_cli::commands::locate::LocateMatchKind::Name))
         })
+}
+
+/// Roll the retained cosine ranking up into the shared `files[]` surface.
+///
+/// This arm is entity-centric: it demotes the file to `provenance.file` on each
+/// hit and publishes no file surface of its own, so a caller asking "which files
+/// is this query about" had to page the entity ranking and aggregate the paths
+/// itself. The fused arm answers that in one field, and a measured A/B put the
+/// correct file in accuracy-v1's top five on 18 of 18 graded queries while this
+/// arm returned no file surface on 100 of 100 calls. Since this arm is the
+/// shipped default, that surface was missing from the profile nearly every
+/// caller runs.
+///
+/// The rollup is a re-view of the ranking this arm already computed, never a
+/// second retrieval: no lexical pool, no extra scoring, no reordering. Files
+/// appear in the order their best hit ranked, and each file's `score` is that
+/// best hit's score, because `rows` arrives rank-ordered so the first occurrence
+/// of a path is its strongest. `signals` is `embeddings` alone, which is the
+/// literal provenance here — every candidate came from the vector index.
+///
+/// What this therefore does NOT do, stated so the field is not read for more
+/// than it carries: it cannot rank a file whose entities did not rank. The fused
+/// arm can, because it runs a lexical and path pool this profile does not, and
+/// closing that gap would mean adding a retrieval stage to the default rather
+/// than porting a surface onto it. Flipping the default is separately refused on
+/// measured evidence, and this change deliberately leaves that verdict alone.
+///
+/// Derived from `rows`, the whole retained ranking, never from the returned page
+/// window — the same rule `all_fallback` follows. Which files a query is about is
+/// a property of the ranking, so it must not change as the caller pages through
+/// it, and `total_ranked` beside it already reports that same whole.
+fn cosine_file_surface(
+    rows: &[serde_json::Value],
+) -> Vec<kin_cli::commands::locate::LocateFileEntry> {
+    let mut order: Vec<String> = Vec::new();
+    let mut by_path: HashMap<String, kin_cli::commands::locate::LocateFileEntry> = HashMap::new();
+
+    for row in rows {
+        // A hit with no path contributes no file. Artifact hits carry one and
+        // are included; anything genuinely pathless is skipped rather than
+        // rolled up under a placeholder path no caller could open.
+        let Some(path) = row
+            .get("provenance")
+            .and_then(|provenance| provenance.get("file"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            continue;
+        };
+        let score = row
+            .get("score")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(0.0) as f32;
+        let span = match (
+            row.get("start_line").and_then(serde_json::Value::as_u64),
+            row.get("end_line").and_then(serde_json::Value::as_u64),
+        ) {
+            (Some(start), Some(end)) => Some([start as u32, end as u32]),
+            _ => None,
+        };
+
+        if !by_path.contains_key(path) {
+            order.push(path.to_string());
+            by_path.insert(
+                path.to_string(),
+                kin_cli::commands::locate::LocateFileEntry {
+                    path: path.to_string(),
+                    score,
+                    signals: vec!["embeddings".to_string()],
+                    spans: Vec::new(),
+                    symbols: Vec::new(),
+                    explain: Vec::new(),
+                    provenance: None,
+                    // Explain-only on the fused arm, so left unset here too. The
+                    // two arms' plain file surfaces then carry the same field
+                    // set, and a consumer cannot tell them apart by shape.
+                    signal_scores: None,
+                    score_breakdown: None,
+                    matched_queries: Vec::new(),
+                },
+            );
+        }
+        let Some(entry) = by_path.get_mut(path) else {
+            continue;
+        };
+
+        if let Some(span) = span {
+            if !entry.spans.contains(&span) {
+                entry.spans.push(span);
+            }
+        }
+        // An artifact hit is a tracked file with no parsed entities, so it
+        // contributes its path and span but names no symbol.
+        let Some(name) = row.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        entry.symbols.push(kin_cli::commands::locate::LocateSymbol {
+            name: name.to_string(),
+            span,
+            score,
+            kind: row
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            // `entity_id` is present exactly on a live entity hit and absent on
+            // an artifact hit, which is the same distinction `definition` draws.
+            definition: row.get("entity_id").is_some(),
+            // Both explain-only on the fused arm; see `signal_scores` above.
+            origin: String::new(),
+            cosine: None,
+            snippet: row
+                .get("snippet")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+        });
+    }
+
+    order
+        .into_iter()
+        .filter_map(|path| by_path.remove(&path))
+        .collect()
 }
 
 /// The identity half of one `semantic_locate` row: which id space the hit
@@ -12267,6 +12395,185 @@ mod tests {
         // and cannot set it either: it is not a name hit, so a ranking of such
         // rows reads as fallback, which is the weaker claim.
         assert!(locate_rows_are_all_fallback(&[json!({ "name": "x" })]));
+    }
+
+    /// One cosine-arm ranked row, in the shape the serving loop builds.
+    fn cosine_row(
+        name: &str,
+        file: Option<&str>,
+        score: f32,
+        span: Option<(u32, u32)>,
+    ) -> serde_json::Value {
+        let mut row = json!({
+            "kind": "function",
+            "name": name,
+            "score": score,
+            "provenance": { "file": file },
+        });
+        if file.is_some() {
+            row["entity_id"] = json!("00000000-0000-0000-0000-0000000000aa");
+        }
+        if let Some((start, end)) = span {
+            row["start_line"] = json!(start);
+            row["end_line"] = json!(end);
+        }
+        row
+    }
+
+    /// Render a cosine-arm page the way the serving path does, so these assert
+    /// against the real serializer rather than a hand-written payload.
+    fn cosine_locate_body(
+        rows: &[serde_json::Value],
+        page: usize,
+        page_size: usize,
+    ) -> serde_json::Value {
+        let coverage = kin_cli::commands::locate::SemanticCoverage {
+            supported: true,
+            indexed: 10,
+            total: 10,
+            pending: 0,
+            complete: true,
+            note: None,
+        };
+        let tool = semantic_locate_payload(
+            "where does the daemon start",
+            false,
+            1.0,
+            &coverage,
+            "cursor-key",
+            page,
+            page_size,
+            rows,
+            &[],
+        );
+        serde_json::from_str(
+            tool_result_json(&tool)["content"][0]["text"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn the_cosine_arm_rolls_its_ranking_up_into_the_shared_file_surface() {
+        let rows = vec![
+            cosine_row("start_daemon", Some("src/daemon.rs"), 0.9, Some((10, 20))),
+            cosine_row("serve", Some("src/api.rs"), 0.7, Some((5, 9))),
+            // A second, weaker hit in an already-seen file: it must fold into
+            // that file rather than opening a duplicate entry.
+            cosine_row("stop_daemon", Some("src/daemon.rs"), 0.4, Some((30, 40))),
+        ];
+        let files = cosine_file_surface(&rows);
+
+        // Files rank by their best hit, and `rows` is rank-ordered, so the first
+        // occurrence of a path both places and scores it.
+        let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+        assert_eq!(paths, vec!["src/daemon.rs", "src/api.rs"]);
+        assert_eq!(files[0].score, 0.9);
+        assert_eq!(files[1].score, 0.7);
+
+        // Every contributing row keeps its symbol under the file, in rank order,
+        // so the rollup adds a view and drops nothing from the ranking.
+        let symbols: Vec<&str> = files[0]
+            .symbols
+            .iter()
+            .map(|symbol| symbol.name.as_str())
+            .collect();
+        assert_eq!(symbols, vec!["start_daemon", "stop_daemon"]);
+        assert_eq!(files[0].spans, vec![[10, 20], [30, 40]]);
+        assert_eq!(files[0].signals, vec!["embeddings".to_string()]);
+        // Explain-only fields on the fused arm stay unset here, so the two arms'
+        // plain file surfaces carry the same field set.
+        assert!(files[0].symbols[0].origin.is_empty());
+        assert!(files[0].symbols[0].cosine.is_none());
+
+        // A pathless hit contributes no file rather than a placeholder path no
+        // caller could open, and does not disturb the files around it.
+        let pathless = vec![
+            cosine_row("orphan", None, 0.8, None),
+            cosine_row("serve", Some("src/api.rs"), 0.7, None),
+        ];
+        let files = cosine_file_surface(&pathless);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "src/api.rs");
+
+        // An empty ranking rolls up to an empty surface, never to a panic.
+        assert!(cosine_file_surface(&[]).is_empty());
+    }
+
+    /// The rule that keeps this field meaning one thing: which files a query is
+    /// about is a property of the RANKING, so it must not change as the caller
+    /// pages through it. Deriving from the returned window instead would look
+    /// correct on page 0 of a short ranking, which is what every casual check
+    /// exercises, and would quietly shrink the answer on exactly the deep
+    /// rankings the surface exists to summarize.
+    #[test]
+    fn the_cosine_file_surface_covers_the_whole_ranking_not_the_returned_page() {
+        let rows = vec![
+            cosine_row("start_daemon", Some("src/daemon.rs"), 0.9, None),
+            cosine_row("serve", Some("src/api.rs"), 0.7, None),
+            cosine_row("route", Some("src/router.rs"), 0.5, None),
+        ];
+
+        // One row per page: the window holds a single file, the ranking holds
+        // three, and the surface reports the ranking.
+        let body = cosine_locate_body(&rows, 0, 1);
+        assert_eq!(body["results"].as_array().unwrap().len(), 1);
+        assert_eq!(body["total_ranked"], json!(3));
+        let paths: Vec<&str> = body["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|file| file["path"].as_str().unwrap())
+            .collect();
+        assert_eq!(paths, vec!["src/daemon.rs", "src/api.rs", "src/router.rs"]);
+
+        // And it is page-invariant: paging forward re-states the same answer
+        // rather than reporting the files of whichever window was served.
+        let page_two = cosine_locate_body(&rows, 2, 1);
+        assert_eq!(page_two["results"].as_array().unwrap().len(), 1);
+        assert_eq!(page_two["files"], body["files"]);
+
+        // Serialized unconditionally, so an empty ranking says `[]` rather than
+        // omitting the key and making absence read like emptiness. This matches
+        // the fused arm, whose `files` is always serialized.
+        let empty = cosine_locate_body(&[], 0, 20);
+        assert_eq!(empty["files"], json!([]));
+    }
+
+    /// The cosine `files[]` is a rollup of `results`, so every file it names is
+    /// already counted as a row. The negative envelope must therefore keep
+    /// counting `results` alone on this arm: adding `files` into the total the
+    /// way the fused branch does would double-count the same hits and could talk
+    /// a genuinely empty page out of being qualified. The fused branch counts
+    /// both because its two surfaces are independently ranked; this one's are
+    /// not, and the shapes now look similar enough that a later tidy-up could
+    /// merge the branches without noticing.
+    #[test]
+    fn the_cosine_file_surface_does_not_change_what_the_negative_envelope_counts() {
+        let rows = vec![
+            cosine_row("start_daemon", Some("src/daemon.rs"), 0.9, None),
+            cosine_row("stop_daemon", Some("src/daemon.rs"), 0.4, None),
+        ];
+        let body = cosine_locate_body(&rows, 0, 20);
+        assert_eq!(body["routing"], json!("cosine-v0"));
+        // Two rows rolling up into one file: if the count ever became files +
+        // results it would read 3, and if it became files alone it would read 1.
+        assert_eq!(body["files"].as_array().unwrap().len(), 1);
+        assert_eq!(body["results"].as_array().unwrap().len(), 2);
+
+        // An empty cosine page still carries `files: []` and must still be
+        // qualified as an absence, which is the case a files-aware count would
+        // have broken first.
+        let empty = cosine_locate_body(&[], 0, 20);
+        let negative = kin_mcp::negative::negative_for(
+            "semantic_locate",
+            &empty,
+            &kin_mcp::Envelope::daemon(),
+        )
+        .expect("an empty cosine page must carry a negative");
+        assert_eq!(negative["kind"], json!("no_ranked_match"));
+        assert_eq!(negative["result_count"], json!(0));
     }
 
     #[test]


### PR DESCRIPTION
The default retrieval profile is entity-centric. It demotes the file to `provenance.file` on each hit and publishes no `files[]` of its own, so a caller asking which files a query is about had to page the entity ranking and aggregate the paths itself. The fused arm answers that in one field. The A/B recorded on FIR-2137 put the correct file in accuracy-v1's top five on 18 of 18 graded queries while compat-v0 returned no file surface on 100 of 100 calls, and compat-v0 is what nearly every caller runs.

This rolls the retained cosine ranking up into the same `LocateFileEntry` shape `kin locate --json`, `POST /locate`, and the fused arm already emit, so one consumer parses every Kin locate surface. Files appear in the order their best hit ranked and carry that hit's score, because the ranking arrives rank-ordered. `signals` is `embeddings` alone, which is the literal provenance: every candidate came from the vector index. The explain-only fields stay unset, so both arms' plain file surfaces carry the same field set.

Two things this deliberately does not do. It adds no retrieval, so it costs nothing per call and cannot rank a file whose entities did not rank; the fused arm can do that only because it runs a lexical and path pool this profile does not. And it does not touch the default, whose flip stays refused on the measured evidence recorded on the ticket.

The surface is derived from the whole retained ranking rather than the returned page, the same rule `all_fallback` follows, since which files a query is about is a property of the ranking and must not change as the caller pages through it. It serializes unconditionally, so an empty ranking says `[]` instead of omitting the key and making absence read like emptiness.

Three tests, run and named in the gate log. The page-invariance one was falsified against the obvious wrong implementation: switching the rollup to the page window drops it to `["src/daemon.rs"]` against the expected three files, so it fails when the claim is false. The third test pins an interaction worth stating, because the two payload shapes now look alike enough that a later tidy-up could merge them: the negative envelope must keep counting `results` alone on this arm. Its `files[]` is a rollup of those same rows, so counting both the way the fused branch does would double-count, and the fused branch counts both only because its two surfaces are independently ranked.

Gate: `cargo nextest run --workspace` plus `cargo test --doc`, green at 5608 passed on this worktree.

Closes FIR-2137
