### PR TITLE
Make a held release train say so instead of concluding green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,13 @@ jobs:
             ./scripts/read-update-build-identity.test.cjs \
             ./scripts/release-archive-shape.test.cjs \
             ./scripts/release-order.test.mjs \
+            ./scripts/release-hold-alarm.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs
           node --check ./scripts/read-update-build-identity.cjs
           node --check ./scripts/check-release-version.mjs
           node --check ./scripts/prepare-release.mjs
           node --check ./scripts/release-order.mjs
+          node --check ./scripts/release-hold-alarm.mjs
           node --check ./scripts/verify-npm-attestation.mjs
           bash -n ./scripts/publish-npm-release.sh
           bash -n ./scripts/verify-npm-release.sh

--- a/.github/workflows/release-sentinel.yml
+++ b/.github/workflows/release-sentinel.yml
@@ -3,12 +3,19 @@
 
 name: Release Sentinel
 
-# Patrols the three release-rail failures that are silent by construction: a
-# green pull request whose auto-merge was disarmed and which therefore simply
-# never lands, a train that holds while main keeps accumulating releasable
-# drift, and a release whose own tag carries the defect that blocks it. None of
-# the three reports itself. Each one has previously been found by a human
-# noticing that nothing happened, which is the slowest detector available.
+# Patrols the release-rail failures that are silent by construction: a green
+# pull request whose auto-merge was disarmed and which therefore simply never
+# lands, and a release whose own tag carries the defect that blocks it. Neither
+# reports itself. Each has previously been found by a human noticing that
+# nothing happened, which is the slowest detector available.
+#
+# The third failure, a train holding while main keeps accumulating releasable
+# drift, is no longer one of them. The train now publishes a structured hold
+# marker on every cycle and a deterministic job in that same workflow opens the
+# alarm and fails its run, with no credential a founder has to mint. This patrol
+# reads the same marker but does not own the alarm, because a reporting path
+# that only works once a human wires a secret is a reporting path that was still
+# silent the day it was needed.
 #
 # ACTIVATION IS ONE FOUNDER STEP. This workflow reads
 # `secrets.CLAUDE_CODE_OAUTH_TOKEN_TROY_FIRELOCK_AI`, which only the founder can mint because
@@ -153,45 +160,45 @@ jobs:
             entry, not merging. If the command fails, report the error it printed
             and move on to the next pull request rather than trying another spelling.
 
-            DUTY TWO. Surface a train that is holding while main keeps drifting.
+            DUTY TWO. Read the rail's own hold marker and judge what it cannot.
 
-            Read the newest Release Train run with
-            `gh run list --repo ${{ github.repository }} --workflow release-train.yml
-            --limit 1 --json databaseId,conclusion,createdAt,url` and then read its
-            log with `gh run view <id> --repo ${{ github.repository }} --log`.
-
-            The train prints its decision. A line reading `release drift: N
-            first-parent range commit(s), base=<tag>, bump=<bump>` means it resolved
-            releasable drift and proceeded, which is healthy. A notice saying the
-            highest tag is not finalized GitHub Latest, or that a tag is already
-            staged on main, means the rail is HELD: the train has stood down and is
-            waiting for something else to move. A hold is only worth alarming about
-            when main has releasable drift behind it, because a held rail with
-            nothing to release is simply idle.
-
-            When the rail is held with drift, open or update ONE alarm issue. Its
-            title is exactly, with no tag or count appended:
+            The train no longer leaves its decision in prose. Every cycle publishes
+            a `release-hold-marker` artifact carrying schema `kin.release-hold.v1`,
+            and a deterministic job in the same workflow already owns the alarm: it
+            opens, updates, and closes ONE issue titled exactly
 
               Release rail is held with releasable drift
 
-            Find it first with `gh issue list --repo ${{ github.repository }} --state
-            open --search "\"Release rail is held with releasable drift\" in:title"
-            --json number,title --jq '.[] | select(.title == "Release rail is held
-            with releasable drift") | .number'`. GitHub title search is fuzzy, so
-            the exact-title filter is what makes this idempotent. If a number comes
-            back, update that issue's body with `gh issue edit <number> --repo
-            ${{ github.repository }} --body-file <file>`. Only when nothing comes
-            back do you `gh issue create`. Never open a second one, and never key
-            the title to a tag, because the tag changes while the condition does not.
+            once the rail has held with drift for four consecutive cycles, and it
+            fails its own run while that alarm stands. That job needs no credential
+            of yours and runs whether or not you are wired, so do NOT open, edit, or
+            close that issue, and never open a second issue about the same hold. It
+            is not yours. Duplicating it is how a rail ends up with two alarms that
+            disagree.
 
-            The body names the blocking tag, the failed release run id and its URL,
-            the drift count, and the two ways out: land the fix that unblocks the
-            tag, or record the tag as abandoned so the rail can step past it. Write
-            it as prose a captain can act on without opening the run.
+            Your duty here is the judgement the deterministic job deliberately does
+            not make. Read the newest cycle with `gh run list --repo
+            ${{ github.repository }} --workflow release-train.yml --limit 1 --json
+            databaseId,conclusion,url`, then read its marker with `gh run download
+            <id> --repo ${{ github.repository }} --name release-hold-marker --dir
+            <dir>`. Parse the JSON. Its `state` is `held` or `clear`, `reason` says
+            which stand-down the train took, `drift` is the count of reviewed commits
+            waiting, `blocking_tag` names the tag in the way, and
+            `failed_release_run_id` names the Release run that failed on it, or null
+            when no such run was found.
 
-            If the rail is healthy and that issue is open, say so in a comment and
-            close it. A stale alarm is worse than no alarm, because the next reader
-            learns to ignore it.
+            A `drift` of null means that cycle could not measure the count. Report it
+            as unmeasured. Never read it as zero: an unreadable count and a real zero
+            are different findings and only one of them means the rail is idle.
+
+            If `state` is `clear`, the rail is healthy and there is nothing to do
+            here. Say so and move on.
+
+            If `state` is `held` with drift above zero, go to duty three and decide
+            whether the blocking tag is structurally dead. That decision is the one
+            thing on this rail no deterministic job can make, and it is why you are
+            here. Comment your reasoning on the existing alarm issue when one is
+            open, so the captain reading it finds your judgement beside the facts.
 
             DUTY THREE. Draft an abandonment when the blocking release is
             structurally dead. You DRAFT it. You never merge it.
@@ -280,5 +287,5 @@ jobs:
             than the dash did, not less.
           claude_args: |
             --max-turns 60
-            --allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge --auto --squash:*),Bash(gh pr create --draft:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(git ls-remote:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push --set-upstream origin automation/abandon-:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(python3 scripts/select-admissible-release-tag.py:*),Bash(jq:*),Read,Edit,Write"
+            --allowedTools "Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr merge --auto --squash:*),Bash(gh pr create --draft:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh run download:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh issue close:*),Bash(git ls-remote:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push --set-upstream origin automation/abandon-:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rev-parse:*),Bash(python3 scripts/select-admissible-release-tag.py:*),Bash(jq:*),Read,Edit,Write"
             --disallowedTools "WebFetch,WebSearch"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -39,6 +39,14 @@ jobs:
     # the branch writer. Only the repository-scoped installation token leaves
     # the credential-minting step.
     environment: release-tag
+    outputs:
+      # This cycle's observation, handed straight to the alarm job rather than
+      # read back out of the artifact this run uploads. An artifact is listable
+      # only once the upload settles, and a newest observation that arrives late
+      # reads exactly like one that never came, which is the reading that keeps
+      # the alarm quiet. The artifact stays, because later cycles need this run
+      # to be readable from outside it.
+      marker: ${{ steps.plan.outputs.marker }}
     steps:
       - name: Mint repository-scoped release branch token
         id: app-token
@@ -195,13 +203,127 @@ jobs:
             "$admissible"
           highest_tag="$(cat "$admissible")"
           latest_tag="$(gh api "repos/${REPO}/releases/latest" --jq .tag_name)"
+
+          # Every path out of this step now states the rail's condition in one
+          # machine-readable place, because a decision that only reaches a log
+          # notice is a decision nobody reads. Standing down is correct and
+          # frequent; standing down invisibly is how a held rail once sat for
+          # roughly twenty hours with nine merged pull requests behind it while
+          # its run history read all-green.
+          #
+          # The marker records what this run observed. It never decides what to
+          # do about it. The alarm job below owns that, so the threshold can be
+          # tested without running a rail and this step keeps exactly the exit
+          # statuses it had.
+          marker="$RUNNER_TEMP/release-hold-marker.json"
+
+          # Reviewed commits waiting behind a base tag. A base that does not
+          # resolve leaves the count absent rather than zero, because the alarm
+          # reader treats an absent count as an observation it could not make
+          # and stays quiet, while a zero would assert that nothing is waiting.
+          count_drift() {
+            local base="$1" counted=""
+            if [ -z "$base" ]; then printf 'null'; return 0; fi
+            if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+              printf 'null'
+              return 0
+            fi
+            counted="$(git rev-list --count "${base}..${main_sha}" 2>/dev/null || true)"
+            case "$counted" in
+              ''|*[!0-9]*) printf 'null' ;;
+              *) printf '%s' "$counted" ;;
+            esac
+          }
+
+          # Name the Release run that owns a blocking tag so the alarm can point
+          # at the run instead of leaving a captain to find it. Every read here
+          # is allowed to fail: an absent run id is a fact the alarm can state,
+          # and an invented one would send recovery somewhere real.
+          release_run_for_tag() {
+            local blocking="$1" runs="" found=""
+            [ -n "$blocking" ] || { printf '%s' 'null null'; return 0; }
+            runs="$(gh api \
+              "repos/${REPO}/actions/workflows/release.yml/runs?per_page=100" \
+              2>/dev/null || true)"
+            [ -n "$runs" ] || { printf '%s' 'null null'; return 0; }
+            found="$(jq -r --arg tag "$blocking" '
+              [
+                .workflow_runs[]? |
+                select(
+                  .head_branch == $tag and
+                  .status == "completed" and
+                  (
+                    .conclusion == "failure" or
+                    .conclusion == "timed_out" or
+                    .conclusion == "startup_failure"
+                  )
+                )
+              ] | sort_by(.created_at) | last // empty
+              | "\"\(.id)\" \"\(.html_url)\""
+            ' <<< "$runs" 2>/dev/null || true)"
+            case "$found" in
+              '"'*) printf '%s' "$found" ;;
+              *) printf '%s' 'null null' ;;
+            esac
+          }
+
+          write_marker() {
+            local state="$1" reason="$2" detail="$3"
+            local blocking="$4" base="$5" drift_json="$6"
+            local failed_id=null failed_url=null
+            if [ "$state" = held ]; then
+              read -r failed_id failed_url <<< "$(release_run_for_tag "$blocking")" || true
+            fi
+            jq -n \
+              --arg state "$state" \
+              --arg reason "$reason" \
+              --arg detail "$detail" \
+              --arg blocking_tag "$blocking" \
+              --arg latest_tag "$latest_tag" \
+              --arg base_tag "$base" \
+              --arg main_sha "$main_sha" \
+              --arg run_id "$GITHUB_RUN_ID" \
+              --arg run_url "${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+              --argjson drift "$drift_json" \
+              --argjson failed_release_run_id "$failed_id" \
+              --argjson failed_release_run_url "$failed_url" \
+              '{
+                schema: "kin.release-hold.v1",
+                state: $state,
+                reason: $reason,
+                detail: $detail,
+                blocking_tag: $blocking_tag,
+                latest_tag: $latest_tag,
+                base_tag: $base_tag,
+                drift: $drift,
+                main_sha: $main_sha,
+                run_id: $run_id,
+                run_url: $run_url,
+                failed_release_run_id: $failed_release_run_id,
+                failed_release_run_url: $failed_release_run_url,
+                observed_at: (now | todateiso8601)
+              }' > "$marker"
+            {
+              echo "marker<<KIN_RELEASE_HOLD_MARKER"
+              jq -c . "$marker"
+              echo "KIN_RELEASE_HOLD_MARKER"
+            } >> "$GITHUB_OUTPUT"
+            echo "release hold marker: $(jq -c . "$marker")"
+          }
+
           if [ -z "$highest_tag" ] || [ "$highest_tag" != "$latest_tag" ]; then
-            echo "::notice::highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}; release recovery owns this state."
+            hold_detail="highest tag ${highest_tag:-<none>} is not finalized GitHub Latest ${latest_tag}; release recovery owns this state"
+            echo "::notice::${hold_detail}."
+            write_marker held tag_not_finalized "$hold_detail" \
+              "$highest_tag" "$highest_tag" "$(count_drift "$highest_tag")"
             echo "needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ! git rev-parse --verify --quiet "${tag}^{commit}" >/dev/null; then
-            echo "::notice::${tag} is already staged on main; tag reconciliation owns the next transition."
+            hold_detail="${tag} is already staged on main; tag reconciliation owns the next transition"
+            echo "::notice::${hold_detail}."
+            write_marker held tag_staged "$hold_detail" \
+              "$tag" "$highest_tag" "$(count_drift "$highest_tag")"
             echo "needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -209,6 +331,8 @@ jobs:
           drift="$(git rev-list --count "${tag}..${main_sha}")"
           if [ "$drift" -eq 0 ]; then
             echo "::notice::main has no commits beyond ${tag}."
+            write_marker held no_drift "main has no commits beyond ${tag}" \
+              "" "$tag" 0
             echo "needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -246,6 +370,13 @@ jobs:
             echo "drift=$drift"
           } >> "$GITHUB_OUTPUT"
           echo "release drift: ${drift} first-parent range commit(s), base=${tag}, bump=${bump}"
+          # The all-clear is a marker too, and it is the one that closes the
+          # alarm. Reporting only holds would leave a resolved rail carrying an
+          # open issue until someone noticed, which is the same silence wearing
+          # the opposite costume.
+          write_marker clear "" \
+            "release drift resolved: ${drift} first-parent range commit(s), base=${tag}, bump=${bump}" \
+            "" "$tag" "$drift"
 
       - name: Create or coalesce the release branch
         id: branch
@@ -534,3 +665,186 @@ jobs:
             echo "- coalesced commits: ${DRIFT}"
             echo "- merge: armed only after protected checks"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Uploaded on every path, including the ones that stood down and the ones
+      # that failed. Later cycles read this to learn what this cycle saw, and a
+      # cycle that uploaded nothing is read as an observation that could not be
+      # made rather than as an all-clear.
+      - name: Publish this cycle's hold marker
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: release-hold-marker
+          path: ${{ runner.temp }}/release-hold-marker.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # The train's decision is now readable. This job is what makes it heard.
+  #
+  # A hold is correct and common, so this deliberately does not ring on one. It
+  # rings when the rail has declined to mint for several consecutive cycles
+  # while reviewed work piled up behind it, which is the shape that cost roughly
+  # twenty hours of rail time and was visible only to a captain who read a run
+  # log by hand.
+  #
+  # A red run here is the alarm working, exactly as a red Release Recovery run
+  # is. Do not "fix" this job by making it conclude success while an issue it
+  # just opened is still open: the all-green run history is the surface that
+  # lied in the first place, and the issue alone would leave it lying.
+  hold-alarm:
+    name: Report a held rail
+    needs: reconcile
+    # Runs even when the reconcile job failed or was skipped. A failed train run
+    # is already loud, and its absent marker reads as unreadable here, which
+    # neither opens an alarm nor closes one.
+    if: always()
+    permissions:
+      # Reading prior cycles' markers, and nothing else, needs actions:read.
+      # Nothing in this job writes to a branch, a tag, or a pull request.
+      actions: read
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # No `ref:` input. Every trigger on this workflow resolves GITHUB_SHA to a
+      # commit on the default branch, so the decision policy is read from one
+      # immutable snapshot rather than from whatever main becomes mid-run. The
+      # checkout is sparse because the only tracked file this job reads is the
+      # decision script.
+      - name: Checkout the alarm policy from the default-branch commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts
+          persist-credentials: false
+
+      - name: Gather this cycle and the cycles before it
+        id: history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CURRENT_MARKER: ${{ needs.reconcile.outputs.marker }}
+          THRESHOLD: "4"
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/release-hold-history"
+          mkdir -p "$work"
+          markers="$work/markers.json"
+
+          # This cycle first, then each earlier cycle that actually ran the
+          # reconcile job. A skipped run is not a cycle: the workflow_run trigger
+          # skips whenever CI concluded on something other than a successful main
+          # push, and counting those as observations would let a quiet stretch of
+          # skips stand in for a rail nobody watched.
+          current="$work/current.json"
+          if [ -n "${CURRENT_MARKER:-}" ] && jq -e . >/dev/null 2>&1 <<< "$CURRENT_MARKER"; then
+            printf '%s\n' "$CURRENT_MARKER" > "$current"
+          else
+            jq -n --arg run "$GITHUB_RUN_ID" '{unreadable: true, run_id: $run}' > "$current"
+            echo "::notice::this cycle produced no readable hold marker, so the rail's current state is unknown here."
+          fi
+
+          prior_ids="$(gh run list \
+            --repo "$REPO" \
+            --workflow release-train.yml \
+            --limit 40 \
+            --json databaseId,conclusion \
+            --jq "[.[] | select((.databaseId|tostring) != \"$GITHUB_RUN_ID\") | select(.conclusion != \"skipped\" and .conclusion != \"cancelled\") | .databaseId] | .[0:$((THRESHOLD - 1))] | .[]")"
+
+          collected="$work/collected"
+          : > "$collected"
+          printf '%s\n' "$(jq -c . "$current")" >> "$collected"
+          while IFS= read -r run_id; do
+            [ -n "$run_id" ] || continue
+            download="$work/$run_id"
+            mkdir -p "$download"
+            # A download that fails and a marker that is absent are the same
+            # finding here, and it is not "no drift". The reader treats an
+            # unreadable entry as a broken streak rather than as a quiet cycle.
+            if gh run download "$run_id" \
+                 --repo "$REPO" \
+                 --name release-hold-marker \
+                 --dir "$download" >/dev/null 2>&1 &&
+               [ -s "$download/release-hold-marker.json" ] &&
+               jq -e . "$download/release-hold-marker.json" >/dev/null 2>&1; then
+              jq -c . "$download/release-hold-marker.json" >> "$collected"
+            else
+              jq -nc --arg run "$run_id" '{unreadable: true, run_id: $run}' >> "$collected"
+            fi
+          done <<< "$prior_ids"
+
+          jq -s . "$collected" > "$markers"
+          echo "markers=$markers" >> "$GITHUB_OUTPUT"
+          echo "observed cycles: $(jq 'length' "$markers")"
+          jq -c '.[] | {run_id, state, reason, drift, unreadable}' "$markers"
+
+      - name: Decide whether the rail is quietly held, and say so if it is
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          MARKERS: ${{ steps.history.outputs.markers }}
+          THRESHOLD: "4"
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/release-hold-history"
+
+          # The one title the alarm ever carries. GitHub's title search is fuzzy,
+          # so the exact-title filter after it is what keeps this idempotent: a
+          # fuzzy hit on a differently titled issue would edit the wrong one.
+          title="Release rail is held with releasable drift"
+          existing="$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --search "\"$title\" in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$title\") | .number" \
+            | head -1)"
+
+          issue_arg=none
+          if [ -n "$existing" ]; then
+            issue_arg="$work/issue.json"
+            jq -n --argjson number "$existing" --arg title "$title" \
+              '{number: $number, title: $title}' > "$issue_arg"
+          fi
+
+          decision="$work/decision.json"
+          node scripts/release-hold-alarm.mjs \
+            --markers "$MARKERS" \
+            --issue "$issue_arg" \
+            --threshold "$THRESHOLD" > "$decision"
+          jq -c . "$decision"
+
+          action="$(jq -er .action "$decision")"
+          reason="$(jq -er .reason "$decision")"
+          case "$action" in
+            quiet)
+              echo "rail alarm quiet (${reason}): $(jq -r '.detail // ""' "$decision")"
+              ;;
+            open)
+              body="$work/body.md"
+              jq -er .body "$decision" > "$body"
+              gh issue create --repo "$REPO" --title "$title" --body-file "$body" >/dev/null
+              echo "::error::The release rail has held with releasable drift for $(jq -er .consecutive "$decision") consecutive cycles. Opened the tracking issue that names the blocking tag and the two ways out."
+              exit 1
+              ;;
+            update)
+              body="$work/body.md"
+              jq -er .body "$decision" > "$body"
+              number="$(jq -er .issue "$decision")"
+              gh issue edit "$number" --repo "$REPO" --body-file "$body" >/dev/null
+              echo "::error::The release rail is still held with releasable drift after $(jq -er .consecutive "$decision") consecutive cycles; issue #${number} carries the current state."
+              exit 1
+              ;;
+            close)
+              number="$(jq -er .issue "$decision")"
+              comment="$work/comment.md"
+              jq -er .comment "$decision" > "$comment"
+              gh issue comment "$number" --repo "$REPO" --body-file "$comment" >/dev/null
+              gh issue close "$number" --repo "$REPO" >/dev/null
+              echo "Closed rail-hold issue #${number}: the train is minting again."
+              ;;
+            *)
+              echo "::error::unsupported alarm action: ${action}"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -694,10 +694,23 @@ jobs:
   hold-alarm:
     name: Report a held rail
     needs: reconcile
-    # Runs even when the reconcile job failed or was skipped. A failed train run
+    # Runs when the reconcile job ran, whatever it concluded. A failed train run
     # is already loud, and its absent marker reads as unreadable here, which
     # neither opens an alarm nor closes one.
-    if: always()
+    #
+    # It deliberately stands down when reconcile was SKIPPED, and that condition
+    # is load-bearing rather than tidiness. The workflow_run trigger fires on
+    # every CI completion and the reconcile job's own `if` filters almost all of
+    # them out: seventeen of the last twenty runs concluded skipped, against two
+    # that reconciled. A bare `always()` would run this job on all of them, which
+    # breaks the alarm twice over. Each skipped run would contribute a cycle with
+    # no marker, and an unreadable cycle breaks the streak, so the count could
+    # never reach four. Worse, a run whose only job was skipped concludes
+    # skipped, which is exactly how the gather step below tells a non-cycle from
+    # a cycle; adding a job that always runs would conclude those runs success
+    # and hide the distinction. The alarm would have read as working and been
+    # structurally unable to fire.
+    if: always() && needs.reconcile.result != 'skipped'
     permissions:
       # Reading prior cycles' markers, and nothing else, needs actions:read.
       # Nothing in this job writes to a branch, a tag, or a pull request.

--- a/scripts/release-hold-alarm.mjs
+++ b/scripts/release-hold-alarm.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Decides whether a held release train has been quiet for long enough to be
+// worth alarming about. The decision is a pure function of the recent hold
+// markers and the currently open alarm issue, so it can be tested against every
+// state the rail reaches without running a rail. The workflow around it does
+// the reading and the writing and never makes the judgement itself.
+//
+// A hold is a correct decision. The failure this exists to prevent is a hold
+// nobody can see: the train concluded success while declining to mint, carried
+// its reason in a log notice, and sat for roughly twenty hours with nine merged
+// pull requests behind it. Concluding is not reporting.
+
+import { readFileSync } from "node:fs";
+
+// The one title the alarm ever uses. It carries no tag and no count, because
+// the tag moves while the condition does not, and a title that moves opens a
+// second issue every time it does. The release train workflow and the release
+// sentinel prompt both repeat this string, and the release authority suite
+// asserts all three agree, so a rename cannot land in one of them alone.
+export const ALARM_TITLE = "Release rail is held with releasable drift";
+
+// Roughly an hour of a train that ticks at 7, 22, 37, and 52 past the hour. Low
+// enough that a captain hears about a real hold inside one coffee, high enough
+// that a single cycle spent mid-reconcile never rings.
+export const DEFAULT_THRESHOLD = 4;
+
+export const MARKER_SCHEMA = "kin.release-hold.v1";
+
+// A marker this reader cannot vouch for is not a quiet rail and it is not a
+// held one either. It breaks the streak and it never closes an open alarm,
+// because an unreadable observation and an observed all-clear are different
+// findings and only one of them is safe to act on.
+function classify(marker) {
+  if (!marker || typeof marker !== "object") return "unreadable";
+  if (marker.unreadable === true) return "unreadable";
+  if (marker.schema !== MARKER_SCHEMA) return "unreadable";
+  if (marker.state === "clear") return "clear";
+  if (marker.state !== "held") return "unreadable";
+  if (!Number.isInteger(marker.drift) || marker.drift < 0) return "unreadable";
+  return marker.drift > 0 ? "held_with_drift" : "held_idle";
+}
+
+function leadingHeldWithDrift(markers) {
+  let count = 0;
+  for (const marker of markers) {
+    if (classify(marker) !== "held_with_drift") break;
+    count += 1;
+  }
+  return count;
+}
+
+function plural(count, singular) {
+  return count === 1 ? singular : `${singular}s`;
+}
+
+function describeFailedRelease(marker) {
+  const id = marker.failed_release_run_id;
+  const url = marker.failed_release_run_url;
+  if (!id) {
+    return (
+      "No failed Release run was found for that tag, so the tag may have never " +
+      "been cut, or its run may have aged out of the window this read covers. " +
+      "Check the Release workflow before assuming either."
+    );
+  }
+  return `The Release run that owns it is ${url || `run ${id}`} (id ${id}).`;
+}
+
+export function buildBody(marker, consecutive, threshold) {
+  const drift = marker.drift;
+  const blocking = marker.blocking_tag || "an unresolved tag";
+  const latest = marker.latest_tag || "an unread Latest";
+  const lines = [];
+
+  lines.push(
+    `The release train has declined to mint for ${consecutive} consecutive ` +
+      `${plural(consecutive, "cycle")} while ${drift} reviewed ` +
+      `${plural(drift, "commit")} sat on main waiting to ship. Each of those ` +
+      "runs concluded success, so nothing about the run history says the rail " +
+      "stopped moving. This issue is the part that says it.",
+  );
+  lines.push("");
+  lines.push(`Blocking tag: \`${blocking}\`. GitHub Latest is \`${latest}\`.`);
+  lines.push(`Releasable drift: ${drift} ${plural(drift, "commit")} beyond \`${marker.base_tag || blocking}\`.`);
+  lines.push(`Hold reason reported by the train: ${marker.detail || marker.reason || "unreported"}.`);
+  lines.push(`Most recent train run: ${marker.run_url || `run ${marker.run_id ?? "unknown"}`}.`);
+  lines.push("");
+  lines.push(describeFailedRelease(marker));
+  lines.push("");
+  lines.push("There are two ways out, and both of them move the rail.");
+  lines.push("");
+  lines.push(
+    "Recover the release. If the defect that blocks the tag can still be " +
+      "reached, fix it and let Release Recovery retry the tag. A tag run " +
+      "resolves its workflows from the tag, so confirm the fix is reachable " +
+      "from the tagged tree before spending a retry on it.",
+  );
+  lines.push("");
+  lines.push(
+    "Record the abandonment. If the defect is frozen into the tag, add the " +
+      "tag to `scripts/abandoned-release-tags.json` with all five required " +
+      "fields, prove the entry with `python3 " +
+      "scripts/select-admissible-release-tag.py`, and land it. The train steps " +
+      "past a tag only on a reviewed record.",
+  );
+  lines.push("");
+  lines.push(
+    `This issue closes itself on the next cycle that mints, and it stays quiet ` +
+      `until a hold carries drift for ${threshold} consecutive cycles, so it ` +
+      "never rings for a rail that is merely idle.",
+  );
+  return lines.join("\n");
+}
+
+export function decide({ markers, issue, threshold = DEFAULT_THRESHOLD }) {
+  const list = Array.isArray(markers) ? markers : [];
+  const open = issue && typeof issue === "object" && issue.number ? issue : null;
+  const newest = list[0];
+  const state = classify(newest);
+
+  if (state === "unreadable") {
+    return {
+      action: "quiet",
+      reason: "newest_marker_unreadable",
+      // An open alarm is deliberately left alone. Closing on an unreadable read
+      // would disarm the alarm in exactly the state that most needs it armed.
+      detail:
+        "The newest release-train hold marker could not be read, so the rail's " +
+        "state is unknown. An unknown never opens an alarm and never closes one.",
+    };
+  }
+
+  if (state === "clear") {
+    if (open) {
+      return {
+        action: "close",
+        reason: "train_minted",
+        issue: open.number,
+        comment:
+          "The release train is minting again, so the hold this issue tracked " +
+          "is over. Closing on the train's own all-clear rather than on a " +
+          "reader's judgement.",
+      };
+    }
+    return { action: "quiet", reason: "rail_healthy", detail: "The train resolved drift and proceeded." };
+  }
+
+  if (state === "held_idle") {
+    return {
+      action: "quiet",
+      reason: "held_without_drift",
+      detail:
+        "The rail is held with nothing to release. A held rail with zero drift " +
+        "is idle, and idle is not an alarm.",
+    };
+  }
+
+  const consecutive = leadingHeldWithDrift(list);
+  if (consecutive < threshold) {
+    return {
+      action: "quiet",
+      reason: "below_threshold",
+      consecutive,
+      threshold,
+      detail:
+        `The rail has held with drift for ${consecutive} consecutive ` +
+        `${plural(consecutive, "cycle")}, under the ${threshold} it takes to alarm.`,
+    };
+  }
+
+  const body = buildBody(newest, consecutive, threshold);
+  if (open) {
+    return {
+      action: "update",
+      reason: "hold_persists",
+      issue: open.number,
+      consecutive,
+      threshold,
+      title: ALARM_TITLE,
+      body,
+    };
+  }
+  return {
+    action: "open",
+    reason: "hold_established",
+    consecutive,
+    threshold,
+    title: ALARM_TITLE,
+    body,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { markers: null, issue: null, threshold: DEFAULT_THRESHOLD };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === "--markers") args.markers = argv[++index];
+    else if (flag === "--issue") args.issue = argv[++index];
+    else if (flag === "--threshold") args.threshold = Number.parseInt(argv[++index], 10);
+    else throw new Error(`unknown argument: ${flag}`);
+  }
+  if (!args.markers) throw new Error("--markers <path> is required");
+  if (!Number.isInteger(args.threshold) || args.threshold < 1) {
+    throw new Error("--threshold must be a positive integer");
+  }
+  return args;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  const markers = readJson(args.markers);
+  // "none" is how the caller says it looked for an open alarm and found none,
+  // which is a different statement from having never looked. An absent path
+  // would be the second, so the caller has to spell the first.
+  const issue = !args.issue || args.issue === "none" ? null : readJson(args.issue);
+  process.stdout.write(`${JSON.stringify(decide({ markers, issue, threshold: args.threshold }), null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/release-hold-alarm.test.mjs
+++ b/scripts/release-hold-alarm.test.mjs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  ALARM_TITLE,
+  DEFAULT_THRESHOLD,
+  MARKER_SCHEMA,
+  decide,
+} from './release-hold-alarm.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./release-hold-alarm.mjs', import.meta.url));
+
+function held({ drift = 9, blocking = 'v0.5.18', latest = 'v0.5.17' } = {}) {
+  return {
+    schema: MARKER_SCHEMA,
+    state: 'held',
+    reason: 'tag_not_finalized',
+    detail: `highest tag ${blocking} is not finalized GitHub Latest ${latest}`,
+    blocking_tag: blocking,
+    latest_tag: latest,
+    base_tag: blocking,
+    drift,
+    run_id: '31727271358',
+    run_url: 'https://github.com/firelock-ai/kin/actions/runs/31727271358',
+    main_sha: '6eae51d0000000000000000000000000000000ab',
+    failed_release_run_id: '31478318322',
+    failed_release_run_url: 'https://github.com/firelock-ai/kin/actions/runs/31478318322',
+    observed_at: '2026-08-12T09:00:00Z',
+  };
+}
+
+function clear() {
+  return {
+    schema: MARKER_SCHEMA,
+    state: 'clear',
+    reason: '',
+    detail: 'release drift resolved, train proceeding',
+    drift: 3,
+    run_id: '31727271359',
+    observed_at: '2026-08-12T09:15:00Z',
+  };
+}
+
+const OPEN_ISSUE = { number: 4242, title: ALARM_TITLE };
+
+test('a hold with drift below the threshold stays quiet', () => {
+  const markers = [held(), held(), held()];
+  const decision = decide({ markers, issue: null });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'below_threshold');
+  assert.equal(decision.consecutive, 3);
+});
+
+test('a hold with drift at the threshold opens exactly one issue', () => {
+  const markers = [held(), held(), held(), held()];
+  const decision = decide({ markers, issue: null });
+  assert.equal(decision.action, 'open');
+  assert.equal(decision.title, ALARM_TITLE);
+  assert.equal(decision.consecutive, DEFAULT_THRESHOLD);
+  assert.match(decision.body, /Blocking tag: `v0\.5\.18`/);
+  assert.match(decision.body, /9 commits beyond/);
+  assert.match(decision.body, /31478318322/);
+});
+
+test('a persisting hold updates the issue it already opened instead of opening a second', () => {
+  const markers = [held(), held(), held(), held(), held(), held()];
+  const decision = decide({ markers, issue: OPEN_ISSUE });
+  assert.equal(decision.action, 'update');
+  assert.equal(decision.issue, 4242);
+  assert.equal(decision.title, ALARM_TITLE);
+});
+
+test('the title carries no tag and no count, so it never forks into a second issue', () => {
+  const four = [held(), held(), held(), held()];
+  const opened = decide({ markers: four, issue: null });
+  const later = decide({
+    markers: [held({ drift: 31, blocking: 'v0.6.4' }), ...four],
+    issue: OPEN_ISSUE,
+  });
+  assert.equal(opened.title, later.title);
+  assert.doesNotMatch(opened.title, /v0\.5\.18|[0-9]/);
+});
+
+test('a mint closes the issue on the train own all-clear', () => {
+  const decision = decide({ markers: [clear(), held(), held(), held(), held()], issue: OPEN_ISSUE });
+  assert.equal(decision.action, 'close');
+  assert.equal(decision.issue, 4242);
+  assert.match(decision.comment, /minting again/);
+});
+
+test('a healthy rail with no open issue says nothing at all', () => {
+  const decision = decide({ markers: [clear(), clear()], issue: null });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'rail_healthy');
+});
+
+test('a hold with zero drift stays quiet however long it lasts', () => {
+  const idle = { ...held(), drift: 0 };
+  const decision = decide({ markers: [idle, idle, idle, idle, idle, idle], issue: null });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'held_without_drift');
+});
+
+test('one clear cycle inside the window breaks the streak', () => {
+  const markers = [held(), held(), clear(), held(), held()];
+  const decision = decide({ markers, issue: null });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.consecutive, 2);
+});
+
+test('an unreadable newest marker neither opens an alarm nor closes one', () => {
+  const unreadable = { unreadable: true, run_id: '1' };
+  const withoutIssue = decide({ markers: [unreadable, held(), held(), held(), held()], issue: null });
+  assert.equal(withoutIssue.action, 'quiet');
+  assert.equal(withoutIssue.reason, 'newest_marker_unreadable');
+  const withIssue = decide({ markers: [unreadable, held(), held(), held(), held()], issue: OPEN_ISSUE });
+  assert.equal(withIssue.action, 'quiet');
+  assert.equal(withIssue.reason, 'newest_marker_unreadable');
+});
+
+test('an unreadable marker inside the window breaks the streak rather than counting as a hold', () => {
+  const markers = [held(), held(), { unreadable: true }, held(), held()];
+  const decision = decide({ markers, issue: null });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.consecutive, 2);
+});
+
+test('an empty history is unknown, not healthy', () => {
+  const decision = decide({ markers: [], issue: OPEN_ISSUE });
+  assert.equal(decision.action, 'quiet');
+  assert.equal(decision.reason, 'newest_marker_unreadable');
+});
+
+test('a marker from a schema this reader does not know is unreadable, not held', () => {
+  const future = { ...held(), schema: 'kin.release-hold.v2' };
+  const decision = decide({ markers: [future, held(), held(), held(), held()], issue: null });
+  assert.equal(decision.reason, 'newest_marker_unreadable');
+});
+
+test('a held marker whose drift is not a whole count is unreadable rather than zero', () => {
+  for (const drift of [null, undefined, 'nine', -1, 1.5]) {
+    const decision = decide({ markers: [{ ...held(), drift }], issue: null });
+    assert.equal(decision.reason, 'newest_marker_unreadable', `drift=${String(drift)}`);
+  }
+});
+
+test('an absent failed Release run is reported as absent rather than invented', () => {
+  const marker = { ...held(), failed_release_run_id: null, failed_release_run_url: null };
+  const decision = decide({ markers: [marker, marker, marker, marker], issue: null });
+  assert.equal(decision.action, 'open');
+  assert.match(decision.body, /No failed Release run was found/);
+  assert.doesNotMatch(decision.body, /null/);
+});
+
+test('the threshold is configurable and honoured', () => {
+  const markers = [held(), held()];
+  assert.equal(decide({ markers, issue: null, threshold: 2 }).action, 'open');
+  assert.equal(decide({ markers, issue: null, threshold: 3 }).action, 'quiet');
+});
+
+test('the body names both exits and never uses an em dash', () => {
+  const markers = [held(), held(), held(), held()];
+  const { body } = decide({ markers, issue: null });
+  assert.match(body, /abandoned-release-tags\.json/);
+  assert.match(body, /Release Recovery retry the tag/);
+  assert.doesNotMatch(body, /—/);
+});
+
+test('the command line agrees with the exported decision', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-release-hold-'));
+  const markersPath = path.join(dir, 'markers.json');
+  const issuePath = path.join(dir, 'issue.json');
+  const markers = [held(), held(), held(), held()];
+  fs.writeFileSync(markersPath, JSON.stringify(markers));
+  fs.writeFileSync(issuePath, JSON.stringify(OPEN_ISSUE));
+
+  const opened = JSON.parse(
+    execFileSync('node', [SCRIPT, '--markers', markersPath, '--issue', 'none'], { encoding: 'utf8' }),
+  );
+  assert.equal(opened.action, 'open');
+
+  const updated = JSON.parse(
+    execFileSync('node', [SCRIPT, '--markers', markersPath, '--issue', issuePath], { encoding: 'utf8' }),
+  );
+  assert.equal(updated.action, 'update');
+  assert.equal(updated.issue, 4242);
+});
+
+test('the command line refuses a threshold it cannot honour', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-release-hold-'));
+  const markersPath = path.join(dir, 'markers.json');
+  fs.writeFileSync(markersPath, JSON.stringify([held()]));
+  assert.throws(() =>
+    execFileSync('node', [SCRIPT, '--markers', markersPath, '--threshold', '0'], { stdio: 'pipe' }),
+  );
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -26,6 +26,9 @@ RELEASE = WORKFLOWS / "release.yml"
 RELEASE_RECOVERY = WORKFLOWS / "release-recovery.yml"
 RELEASE_TAG = WORKFLOWS / "release-tag.yml"
 RELEASE_TRAIN = WORKFLOWS / "release-train.yml"
+RELEASE_SENTINEL = WORKFLOWS / "release-sentinel.yml"
+HOLD_ALARM = ROOT / "scripts" / "release-hold-alarm.mjs"
+HOLD_ALARM_POLICY = "scripts/release-hold-alarm.mjs"
 RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 WINDOWS_INIT_CONTRACT = ROOT / "scripts" / "assert-windows-init-contract.sh"
@@ -540,6 +543,7 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     },
     ".github/workflows/release-train.yml": {
         "reconcile": "Reconcile release PR",
+        "hold-alarm": "Report a held rail",
     },
     ".github/workflows/release.yml": {
         "config": "Resolve release config",
@@ -6322,6 +6326,145 @@ def assert_recovery_abandonment_stand_down(release_recovery: str) -> None:
             )
 
 
+def assert_release_hold_marker_contract(
+    release_train: str,
+    release_sentinel: str,
+    hold_alarm: str,
+) -> None:
+    """Pin the hold marker to a producer, a consumer, and one alarm title.
+
+    A marker nobody reads and an alarm keyed to a title that moves are the two
+    ways this reporting path fails back into silence, and both of them look
+    exactly like a working rail from the run history. The producer, the
+    deterministic consumer, and the sentinel prompt each spell the same title
+    and the same schema, so this is what stops the three drifting apart.
+    """
+
+    plan = "\n".join(
+        job_step_active_lines(
+            release_train, "reconcile", "name: Resolve releasable drift"
+        )
+    )
+    stand_downs = plan.count('echo "needed=false"')
+    holds = plan.count("write_marker held ")
+    if stand_downs == 0:
+        raise AssertionError(
+            "the release train must still have a stand-down path to report"
+        )
+    if holds != stand_downs:
+        raise AssertionError(
+            "every release-train stand-down must publish a hold marker; "
+            f"{stand_downs} stand-down(s) publish {holds} marker(s)"
+        )
+    if "write_marker clear " not in plan:
+        raise AssertionError(
+            "the release train must publish an all-clear marker when it "
+            "proceeds, because only an all-clear can close the alarm"
+        )
+
+    schema = '"kin.release-hold.v1"'
+    if schema not in plan:
+        raise AssertionError(
+            "the release train must stamp the reviewed hold-marker schema"
+        )
+    if f"MARKER_SCHEMA = {schema}" not in hold_alarm:
+        raise AssertionError(
+            "the hold-alarm reader must accept exactly the schema the release "
+            "train stamps, or every marker reads as unreadable"
+        )
+
+    artifact = "name: release-hold-marker"
+    upload = "\n".join(
+        job_step_active_lines(
+            release_train, "reconcile", "name: Publish this cycle's hold marker"
+        )
+    )
+    if artifact not in upload:
+        raise AssertionError(
+            "the release train must upload the hold marker under the reviewed "
+            "artifact name"
+        )
+    if "if: always()" not in upload:
+        raise AssertionError(
+            "the hold marker must be uploaded on every path, including the "
+            "stand-downs that are the whole reason it exists"
+        )
+    gather = "\n".join(
+        job_step_active_lines(
+            release_train, "hold-alarm", "name: Gather this cycle"
+        )
+    )
+    # Compared as a whole token, not as a substring. `release-hold-marker-v2`
+    # contains `release-hold-marker`, so a prefix test would pass a rename that
+    # points the reader at an artifact the train never uploads, and the alarm
+    # would go quiet exactly the way it did before any of this existed.
+    downloaded = re.findall(r"--name (\S+)", gather)
+    if downloaded != ["release-hold-marker"]:
+        raise AssertionError(
+            "the alarm must download exactly the artifact the train uploads, "
+            f"not {downloaded}"
+        )
+
+    title = "Release rail is held with releasable drift"
+    for source, surface in (
+        (hold_alarm, "the hold-alarm reader"),
+        (release_train, "the release train's alarm job"),
+        (release_sentinel, "the release sentinel prompt"),
+    ):
+        if source.count(title) < 1:
+            raise AssertionError(
+                f"{surface} must spell the one reviewed alarm title exactly, "
+                "or a second issue is opened every time the wording drifts"
+            )
+    if re.search(r"v\d+\.\d+\.\d+", title) or any(char.isdigit() for char in title):
+        raise AssertionError(
+            "the alarm title must carry no tag and no count, because a title "
+            "that moves with the rail opens a new issue on every move"
+        )
+
+    decide = "\n".join(
+        job_step_active_lines(
+            release_train, "hold-alarm", "name: Decide whether the rail"
+        )
+    )
+    # An issue on its own leaves the run history reading all-green, and the
+    # all-green run history is the surface that lied. Both loud verdicts have to
+    # end the job nonzero, and neither quiet verdict may.
+    for verdict in ("open)", "update)"):
+        segment = decide.split(verdict, 1)
+        if len(segment) != 2:
+            raise AssertionError(
+                f"the alarm must still handle the {verdict[:-1]} verdict"
+            )
+        tail = segment[1].split(";;", 1)[0]
+        if "exit 1" not in tail:
+            raise AssertionError(
+                f"an alarm that {verdict[:-1]}s an issue must also fail its run; "
+                "a green run beside an open alarm is the silence this replaces"
+            )
+    for verdict in ("quiet)", "close)"):
+        segment = decide.split(verdict, 1)
+        if len(segment) != 2:
+            raise AssertionError(
+                f"the alarm must still handle the {verdict[:-1]} verdict"
+            )
+        tail = segment[1].split(";;", 1)[0]
+        if "exit 1" in tail:
+            raise AssertionError(
+                f"a {verdict[:-1]} verdict must not fail the run; a rail that "
+                "is merely idle would then cry wolf every cycle"
+            )
+
+    threshold = re.search(r"DEFAULT_THRESHOLD = (\d+)", hold_alarm)
+    if threshold is None:
+        raise AssertionError("the hold-alarm reader must declare its threshold")
+    if f'THRESHOLD: "{threshold.group(1)}"' not in release_train:
+        raise AssertionError(
+            "the release train must pass the same consecutive-cycle threshold "
+            "the reader defaults to, so one number describes the alarm"
+        )
+
+
 def assert_abandoned_tag_admission(
     release_tag: str,
     release_train: str,
@@ -6810,6 +6953,8 @@ def main() -> None:
     release_recovery = RELEASE_RECOVERY.read_text(encoding="utf-8")
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
     release_train = RELEASE_TRAIN.read_text(encoding="utf-8")
+    release_sentinel = RELEASE_SENTINEL.read_text(encoding="utf-8")
+    hold_alarm = HOLD_ALARM.read_text(encoding="utf-8")
     release_bot_doc = RELEASE_BOT_DOC.read_text(encoding="utf-8")
     install_proof = INSTALL_PROOF.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
@@ -7380,6 +7525,93 @@ def main() -> None:
                 "          steps.record.outputs.abandoned != 'true'",
                 "          # steps.record.outputs.abandoned != 'true'",
             )
+        ),
+    )
+
+    # A hold is a correct decision that used to reach nobody. The marker is what
+    # makes it readable and the alarm job is what makes it heard, so the pair is
+    # pinned together: a producer with no consumer and a consumer with no
+    # producer both read exactly like a healthy rail.
+    assert_release_hold_marker_contract(release_train, release_sentinel, hold_alarm)
+    expect_assertion(
+        "a release-train stand-down publishes no hold marker",
+        "must publish a hold marker",
+        lambda: assert_release_hold_marker_contract(
+            release_train.replace(
+                '            write_marker held no_drift "main has no commits beyond ${tag}" \\\n'
+                '              "" "$tag" 0\n',
+                "",
+                1,
+            ),
+            release_sentinel,
+            hold_alarm,
+        ),
+    )
+    expect_assertion(
+        "the alarm opens an issue and still concludes the run green",
+        "must also fail its run",
+        lambda: assert_release_hold_marker_contract(
+            release_train.replace(
+                '              echo "::error::The release rail has held with releasable drift '
+                'for $(jq -er .consecutive "$decision") consecutive cycles. Opened the tracking '
+                'issue that names the blocking tag and the two ways out."\n'
+                "              exit 1\n",
+                '              echo "::error::The release rail has held with releasable drift '
+                'for $(jq -er .consecutive "$decision") consecutive cycles. Opened the tracking '
+                'issue that names the blocking tag and the two ways out."\n',
+                1,
+            ),
+            release_sentinel,
+            hold_alarm,
+        ),
+    )
+    expect_assertion(
+        "the sentinel stops naming the one alarm title the reader owns",
+        "must spell the one reviewed alarm title",
+        lambda: assert_release_hold_marker_contract(
+            release_train,
+            release_sentinel.replace(
+                "Release rail is held with releasable drift",
+                "Release rail is stuck",
+            ),
+            hold_alarm,
+        ),
+    )
+    expect_assertion(
+        "the reader accepts a schema the train never stamps",
+        "must accept exactly the schema",
+        lambda: assert_release_hold_marker_contract(
+            release_train,
+            release_sentinel,
+            hold_alarm.replace(
+                'MARKER_SCHEMA = "kin.release-hold.v1"',
+                'MARKER_SCHEMA = "kin.release-hold.v2"',
+            ),
+        ),
+    )
+    expect_assertion(
+        "the train and the reader disagree about how many cycles it takes",
+        "must pass the same consecutive-cycle threshold",
+        lambda: assert_release_hold_marker_contract(
+            release_train,
+            release_sentinel,
+            hold_alarm.replace(
+                "DEFAULT_THRESHOLD = 4",
+                "DEFAULT_THRESHOLD = 6",
+            ),
+        ),
+    )
+    expect_assertion(
+        "the train stops uploading the marker later cycles read",
+        "must download exactly the artifact the train uploads",
+        lambda: assert_release_hold_marker_contract(
+            release_train.replace(
+                "--name release-hold-marker \\",
+                "--name release-hold-marker-v2 \\",
+                1,
+            ),
+            release_sentinel,
+            hold_alarm,
         ),
     )
     for forbidden in (

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -6455,6 +6455,26 @@ def assert_release_hold_marker_contract(
                 "is merely idle would then cry wolf every cycle"
             )
 
+    # The alarm must stand down when the reconcile job was skipped, and this is
+    # load-bearing rather than tidiness. Almost every train run is a skipped
+    # workflow_run tick. A job that ran on those would contribute a cycle with no
+    # marker, and an unreadable cycle breaks the streak, so the count could never
+    # reach the threshold. It would also conclude those runs success rather than
+    # skipped, which is exactly how the gather step tells a non-cycle from a
+    # cycle. The alarm would read as working and be unable to fire.
+    alarm_job = workflow_job_blocks(release_train).get("hold-alarm")
+    if alarm_job is None:
+        raise AssertionError("the release train must declare its hold-alarm job")
+    alarm_condition = "\n".join(
+        line for line in alarm_job.splitlines() if not line.lstrip().startswith("#")
+    )
+    if "needs.reconcile.result != 'skipped'" not in alarm_condition:
+        raise AssertionError(
+            "the hold alarm must stand down on a skipped reconcile; counting "
+            "skipped ticks as cycles breaks the streak it needs to reach and "
+            "erases the skipped conclusion the gather step reads"
+        )
+
     threshold = re.search(r"DEFAULT_THRESHOLD = (\d+)", hold_alarm)
     if threshold is None:
         raise AssertionError("the hold-alarm reader must declare its threshold")
@@ -7599,6 +7619,19 @@ def main() -> None:
                 "DEFAULT_THRESHOLD = 4",
                 "DEFAULT_THRESHOLD = 6",
             ),
+        ),
+    )
+    expect_assertion(
+        "the alarm counts every skipped workflow_run tick as a cycle",
+        "must stand down on a skipped reconcile",
+        lambda: assert_release_hold_marker_contract(
+            release_train.replace(
+                "    if: always() && needs.reconcile.result != 'skipped'",
+                "    if: always()",
+                1,
+            ),
+            release_sentinel,
+            hold_alarm,
         ),
     )
     expect_assertion(


### PR DESCRIPTION
After v0.5.18 fenced, every release-train cycle concluded SUCCESS while
declining to mint, carrying its reason in a log notice. Nine merged pull
requests piled up behind it and the rail sat held for roughly twenty hours until
a captain read a run log by hand. The hold was the right decision. Concluding
success was not reporting it.

The train now publishes a structured hold marker on every path it takes, holds
and all-clears alike, and a job in the same workflow reads the last four cycles
and acts. Four consecutive holds with reviewed work waiting opens one issue
naming the blocking tag, the failed Release run, the drift count, and the two
ways out, and it fails its own run so the history stops reading all-green. The
next cycle that mints closes the issue on the train's own all-clear. A hold with
zero drift stays quiet, because a rail with nothing to release is idle rather
than stuck.

That alarm job stands down when the reconcile job was skipped, and the condition
is load-bearing. Almost every train run is a skipped workflow_run tick, seventeen
of the last twenty against two that reconciled. Running on all of them would have
broken the alarm twice: each skipped tick contributes a cycle carrying no marker,
an unreadable cycle breaks the streak, and the count could never reach four. It
would also have concluded those runs success rather than skipped, and the skipped
conclusion is exactly how the gather step tells a non-cycle from a cycle. The
alarm would have read as working and been unable to fire.

The decision is a pure function in scripts/release-hold-alarm.mjs, so every
state the rail reaches is tested without running a rail, including the ones that
must stay silent. An unreadable marker never opens an alarm and never closes
one: an observation that could not be made and an observed all-clear are
different findings, and only one of them is safe to act on.

The alarm needs no credential a founder has to mint, which is why it does not
live in the release sentinel. That patrol has been skipped on every run since it
landed, waiting on a secret, so the one duty that had to work unattended could
not. The sentinel now reads the same marker and keeps the judgement no
deterministic job can make, deciding whether a blocking tag is structurally dead,
and it is told in as many words not to open a second issue about a hold it does
not own.

The release authority suite pins the pair together, since a marker nobody reads
and a reader with no marker both look exactly like a healthy rail. Seven
falsifications drive it: a stand-down that publishes nothing, an alarm that opens
an issue and still concludes green, an alarm that counts skipped ticks as cycles,
a sentinel that stops naming the one alarm title, a reader that accepts a schema
the train never stamps, a threshold the two sides disagree on, and an artifact
rename that a prefix test would have let through.

Closes FIR-2222
