### PR TITLE
Get the Windows install proof past daemon endpoint provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,15 @@ jobs:
             "managed_spawn_fence" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-daemon-spawn --lib
+          # The one clause of the spawn contract only Windows can answer. Unix
+          # gets handle release from CLOEXEC, so this case passes there whether
+          # or not the code that provides it on Windows exists, and a host run
+          # of it is not evidence about Windows. Same compilation unit as the
+          # fence leg above, so it costs a run rather than a build.
+          run_required_exact "detached spawn releases the caller's stdio" \
+            "tests::a_detached_spawn_does_not_hold_the_callers_stdout_open" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-daemon-spawn --lib
           run_required_filter "daemon shutdown identity" "shutdown" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-daemon --no-default-features --lib

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -878,13 +878,13 @@ jobs:
           # step gives `kin status` and for the same reason. A daemon that
           # inherits the caller's pipe holds it until it idles out, so a piped
           # query returns its answer and then leaves this shell waiting for the
-          # daemon to die. Every assertion below reads state the daemon owns, so
-          # a step that waits for the daemon before making them measures the
-          # wreckage instead: the endpoint read three lines down is retired
-          # during shutdown, and a missing `.kin/daemon.port` is what this step
-          # then reports. Releasing that handle is the fix, and this is the
-          # shape that stops one released build's regression from being read as
-          # a daemon that never published at all.
+          # daemon to die. Everything below reads state the daemon owns, so a
+          # step that waits for the daemon before reading measures the wreckage
+          # instead: shutdown retires the endpoint, and the endpoint read just
+          # below then reports a `.kin/daemon.port` that never existed as far as
+          # it can tell. That is what this leg reported for two releases, and it
+          # is why the queries here must not be piped even once the daemon stops
+          # holding handles it was never given.
           kin search hello --json > "$captures/kin-search.json"
           cat "$captures/kin-search.json"
           kin locate hello --json --explain --max-files 5 > "$captures/kin-locate.json"

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -874,8 +874,21 @@ jobs:
           # is watching until every assertion that reads the store has run.
           captures="$RUNNER_TEMP/kin-proof-captures"
           mkdir -p "$captures"
-          kin search hello --json | tee "$captures/kin-search.json"
-          kin locate hello --json --explain --max-files 5 | tee "$captures/kin-locate.json"
+          # Redirect and print rather than pipe, the same treatment the first-run
+          # step gives `kin status` and for the same reason. A daemon that
+          # inherits the caller's pipe holds it until it idles out, so a piped
+          # query returns its answer and then leaves this shell waiting for the
+          # daemon to die. Every assertion below reads state the daemon owns, so
+          # a step that waits for the daemon before making them measures the
+          # wreckage instead: the endpoint read three lines down is retired
+          # during shutdown, and a missing `.kin/daemon.port` is what this step
+          # then reports. Releasing that handle is the fix, and this is the
+          # shape that stops one released build's regression from being read as
+          # a daemon that never published at all.
+          kin search hello --json > "$captures/kin-search.json"
+          cat "$captures/kin-search.json"
+          kin locate hello --json --explain --max-files 5 > "$captures/kin-locate.json"
+          cat "$captures/kin-locate.json"
 
           # `kin status` deliberately does not auto-start the daemon. The graph
           # query above does, so capture daemon provenance only after that

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -184,10 +184,17 @@ jobs:
           # state=unobserved reason=no_running_daemon wherever it is placed, and
           # returns that negative in under a second rather than hanging.
           #
+          # The cause is the pipe, not the daemon's own lifetime. A daemon
+          # spawned on Windows used to inherit every handle its caller held, so
+          # the `tee` above could not reach end of file until the daemon idled
+          # out, and the shell reached the next line only once it had. Releasing
+          # the caller's standard handles ends that wait, which may in turn let
+          # this read start observing a live daemon.
+          #
           # Keeping it after the queries costs nothing, so it stays there, but do
-          # not read the placement as buying coverage. Nothing here depends on it:
-          # the read is captured as a diagnostic and every assertion below runs
-          # off `kin embed`'s own report instead.
+          # not read the placement as buying coverage under either answer.
+          # Nothing here depends on it: the read is captured as a diagnostic and
+          # every assertion below runs off `kin embed`'s own report instead.
           kin.exe status --json | tee "$RUNNER_TEMP/kin-status.json"
 
       - name: Assert the runtime proved semantic search

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -2678,15 +2678,24 @@ impl DaemonSpawnPlan {
     }
 }
 
-/// Put the daemon in its own session so it outlives the process that started
-/// it and never receives the caller's terminal signals.
+/// Cut the daemon loose from the caller so it outlives the process that started
+/// it and takes none of that process's session with it.
 ///
-/// A test runtime is the one exception. Its guardian puts the invoking process
-/// in a stable process group and passes both an owner capability and the exact
-/// group id. Keeping the daemon in that verified group lets the harness reap
-/// the complete process tree even if graceful product cleanup fails. The owner
-/// marker alone is never sufficient: a missing, malformed, non-positive, or
-/// mismatched group keeps normal production detachment enabled.
+/// Unix reads that as the signal side: `setsid` puts the daemon in its own
+/// session, where the caller's terminal signals cannot reach it, and the file
+/// descriptors it does not need are already gone because Rust opens everything
+/// `CLOEXEC`.
+///
+/// Windows has no `CLOEXEC`, so the same sentence has to be enforced on the
+/// handle side instead; see [`release_caller_standard_handles`].
+///
+/// A test runtime is the one exception on the signal side. Its guardian puts
+/// the invoking process in a stable process group and passes both an owner
+/// capability and the exact group id. Keeping the daemon in that verified group
+/// lets the harness reap the complete process tree even if graceful product
+/// cleanup fails. The owner marker alone is never sufficient: a missing,
+/// malformed, non-positive, or mismatched group keeps normal production
+/// detachment enabled.
 pub fn detach_from_caller(cmd: &mut std::process::Command) {
     #[cfg(unix)]
     {
@@ -2703,9 +2712,61 @@ pub fn detach_from_caller(cmd: &mut std::process::Command) {
             }
         }
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
     {
         let _ = cmd;
+        release_caller_standard_handles();
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = cmd;
+    }
+}
+
+/// Stop a spawned daemon from holding the caller's standard handles open.
+///
+/// `CreateProcess` hands a child every handle currently marked inheritable, not
+/// only the three the parent chose for its stdio. A handle the caller itself
+/// inherited keeps that mark, so a shell pipeline's write end reaches the daemon
+/// even though the daemon's own stdout and stderr were redirected into the
+/// daemon log. Nothing in the daemon knows it holds that handle, so it stays
+/// open for the daemon's whole life and the reader on the far side never sees
+/// end of file: `kin search --json | jq` prints its answer and then hangs until
+/// the daemon idles out, and whatever runs next in that shell observes a daemon
+/// that has just retired its endpoint rather than the live one that served the
+/// query.
+///
+/// Clearing the inherit flag on this process's standard handles is the
+/// equivalent of the `CLOEXEC` Unix gets for free. It does not affect stdio the
+/// caller assigns to a child, because `std::process` duplicates whatever handle
+/// a `Stdio` names into a fresh inheritable one for the child rather than
+/// passing this flag through, and it does not affect this process's own use of
+/// its handles, which is why it is safe to do once and leave done.
+#[cfg(windows)]
+fn release_caller_standard_handles() {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Foundation::{
+        SetHandleInformation, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+    };
+
+    let standard = [
+        std::io::stdin().as_raw_handle(),
+        std::io::stdout().as_raw_handle(),
+        std::io::stderr().as_raw_handle(),
+    ];
+    for handle in standard {
+        // A process started without a console reports its standard handles as
+        // null or as the invalid sentinel. Neither names anything a child could
+        // inherit, and asking the kernel about them only produces an error to
+        // discard.
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            continue;
+        }
+        // Nothing here can be repaired by a caller: the flag is either cleared
+        // or the handle was never inheritable in the first place.
+        unsafe {
+            let _ = SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0);
+        }
     }
 }
 
@@ -5292,5 +5353,144 @@ mod tests {
 
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    // ── A detached spawn releases the caller's stdio ─────────────────────
+
+    /// Set on the process standing in for a spawned daemon; its value is the
+    /// path that process publishes to prove it really started.
+    const DETACHED_HOLDER_ENV: &str = "KIN_INTERNAL_TEST_DETACHED_HOLDER";
+
+    /// Set on the process standing in for the CLI that does the spawning; its
+    /// value is the readiness path it passes down.
+    const DETACHED_RELAY_ENV: &str = "KIN_INTERNAL_TEST_DETACHED_RELAY";
+
+    /// Long enough that anything still waiting on this process is waiting for
+    /// it and not for a slow runner, short enough that a failing run leaves
+    /// nothing behind for long.
+    const DETACHED_HOLDER_LIFETIME: Duration = Duration::from_secs(60);
+
+    /// A third of the holder's lifetime, so the pass and the failure are told
+    /// apart by a wide margin rather than by a race.
+    const DETACHED_CLOSE_BUDGET: Duration = Duration::from_secs(20);
+
+    /// Stand-in for the spawned daemon: publish readiness, then outlive the
+    /// process that started it.
+    #[test]
+    fn detached_spawn_holder_worker() {
+        let Some(ready) = std::env::var_os(DETACHED_HOLDER_ENV) else {
+            return;
+        };
+        let ready = PathBuf::from(ready);
+        let staged = ready.with_extension("staging");
+        std::fs::write(&staged, b"holding\n").expect("stage holder readiness");
+        std::fs::rename(&staged, &ready).expect("publish holder readiness");
+        std::thread::sleep(DETACHED_HOLDER_LIFETIME);
+    }
+
+    /// Stand-in for the CLI: spawn a daemon through the shared contract and
+    /// exit immediately, leaving only the question of what the daemon still
+    /// holds.
+    #[test]
+    fn detached_spawn_relay_worker() {
+        use std::process::Stdio;
+
+        let Some(ready) = std::env::var_os(DETACHED_RELAY_ENV) else {
+            return;
+        };
+        let executable = std::env::current_exe().expect("resolve the relay executable");
+        let mut holder = Command::new(executable);
+        holder
+            .args([
+                "--exact",
+                "tests::detached_spawn_holder_worker",
+                "--nocapture",
+            ])
+            .env(DETACHED_HOLDER_ENV, ready)
+            .env_remove(DETACHED_RELAY_ENV)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        detach_from_caller(&mut holder);
+        let holder = holder.spawn().expect("spawn the detached holder");
+        // Outliving this process is the point, so the handle is released
+        // deliberately rather than waited on.
+        std::mem::forget(holder);
+    }
+
+    fn detached_probe_started(ready: &Path, budget: Duration) -> bool {
+        let deadline = std::time::Instant::now() + budget;
+        while !ready.is_file() {
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        true
+    }
+
+    /// A daemon started through the shared contract must not keep the stdio the
+    /// caller was given.
+    ///
+    /// Unix gets this from `CLOEXEC` and has always had it. Windows hands a
+    /// child every inheritable handle, so before the caller's standard handles
+    /// were released the daemon silently held its spawner's stdout: the reader
+    /// on the far side of `kin search --json | jq` saw no end of file until the
+    /// daemon idled out, and by then the daemon had retired the endpoint the
+    /// next command was about to read.
+    #[test]
+    fn a_detached_spawn_does_not_hold_the_callers_stdout_open() {
+        use std::io::Read as _;
+        use std::process::Stdio;
+
+        let dir = tempfile::tempdir().expect("temporary directory for the detach probe");
+        let ready = dir.path().join("holder.ready");
+        let executable = std::env::current_exe().expect("resolve the probe executable");
+
+        let mut relay = Command::new(executable)
+            .args([
+                "--exact",
+                "tests::detached_spawn_relay_worker",
+                "--nocapture",
+            ])
+            .env(DETACHED_RELAY_ENV, &ready)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn the detach relay");
+        let mut relay_stdout = relay.stdout.take().expect("the relay's stdout is a pipe");
+
+        // Read on a thread the test never joins: when the handle did leak, this
+        // read cannot return until the holder's own lifetime ends, and the test
+        // has to be able to report that rather than wait it out.
+        let (closed_tx, closed_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut drained = Vec::new();
+            let closed = relay_stdout.read_to_end(&mut drained).is_ok();
+            let _ = closed_tx.send(closed);
+        });
+
+        // Readiness first, and it is not a formality: a relay that never
+        // managed to start a holder closes the pipe on its own, which is the
+        // exact observation this test would otherwise call a pass.
+        let started = detached_probe_started(&ready, DETACHED_CLOSE_BUDGET);
+        let closed = closed_rx.recv_timeout(DETACHED_CLOSE_BUDGET);
+
+        let _ = relay.kill();
+        let _ = relay.wait();
+
+        assert!(
+            started,
+            "the relay never started a detached holder, so this run proves nothing about what a \
+             holder keeps open"
+        );
+        assert_eq!(
+            closed.ok(),
+            Some(true),
+            "the detached holder is still holding its spawner's stdout open {} seconds after the \
+             spawner exited",
+            DETACHED_CLOSE_BUDGET.as_secs()
+        );
     }
 }

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -2804,8 +2804,25 @@ def assert_install_proof_status_contract(
 
     graph_active_lines = active_lines(graph_query)
     graph_active = "\n".join(graph_active_lines)
+    # A query that starts the daemon must be redirected, never piped. Windows
+    # hands a spawned daemon every handle its caller was given, so a piped query
+    # leaves the reader on the far side waiting for the daemon rather than for
+    # the CLI. The step then resumes only once the daemon has idled out and
+    # retired the endpoint the next line reads, so it reports a missing
+    # `.kin/daemon.port`. That reads as a daemon which never published one, and
+    # for two releases it was recorded as exactly that.
+    for line in graph_active_lines:
+        if line.startswith(("kin search ", "kin locate ")) and "|" in line:
+            raise AssertionError(
+                "install proof must redirect a daemon-starting query rather than "
+                "pipe it: a daemon that inherits the pipe holds it until idle "
+                "shutdown and retires the endpoint this step reads before the "
+                f"read happens: {line}"
+            )
+
     for policy in (
-        'kin search hello --json | tee "$captures/kin-search.json"',
+        'kin search hello --json > "$captures/kin-search.json"',
+        'kin locate hello --json --explain --max-files 5 > "$captures/kin-locate.json"',
         "daemon_port=\"$(tr -d '[:space:]' < .kin/daemon.port)\"",
         'DAEMON_PORT="$daemon_port" node',
         "http://127.0.0.1:${process.env.DAEMON_PORT}/health",
@@ -2820,7 +2837,7 @@ def assert_install_proof_status_contract(
     ):
         require(graph_active, policy, "installed daemon startup and health capture")
 
-    daemon_start = 'kin search hello --json | tee "$captures/kin-search.json"'
+    daemon_start = 'kin search hello --json > "$captures/kin-search.json"'
     endpoint_capture = "daemon_port=\"$(tr -d '[:space:]' < .kin/daemon.port)\""
     setup_health = 'kin setup status --json | tee "$captures/kin-health.json"'
     doctor_health = 'kin doctor --json | tee "$captures/kin-doctor.json"'
@@ -8267,12 +8284,12 @@ def main() -> None:
         lambda: assert_install_proof_status_contract(
             first_run,
             graph_query.replace(
-                'kin search hello --json | tee "$captures/kin-search.json"',
+                'kin search hello --json > "$captures/kin-search.json"',
                 "# graph query moved below daemon provenance capture",
                 1,
             ).replace(
                 'cat "$captures/kin-daemon-health.json"',
-                'cat "$captures/kin-daemon-health.json"\n          kin search hello --json | tee "$captures/kin-search.json"',
+                'cat "$captures/kin-daemon-health.json"\n          kin search hello --json > "$captures/kin-search.json"',
                 1,
             ),
             embedding,
@@ -8285,8 +8302,40 @@ def main() -> None:
         lambda: assert_install_proof_status_contract(
             first_run,
             graph_query.replace(
+                'kin search hello --json > "$captures/kin-search.json"',
+                '# kin search hello --json > "$captures/kin-search.json"',
+                1,
+            ),
+            embedding,
+            validation,
+        ),
+    )
+    expect_assertion(
+        "a daemon-starting query is piped again",
+        "must redirect a daemon-starting query rather than pipe it",
+        lambda: assert_install_proof_status_contract(
+            first_run,
+            graph_query.replace(
+                'kin search hello --json > "$captures/kin-search.json"\n'
+                '          cat "$captures/kin-search.json"',
                 'kin search hello --json | tee "$captures/kin-search.json"',
-                '# kin search hello --json | tee "$captures/kin-search.json"',
+                1,
+            ),
+            embedding,
+            validation,
+        ),
+    )
+    expect_assertion(
+        "the second daemon-starting query is piped again",
+        "must redirect a daemon-starting query rather than pipe it",
+        lambda: assert_install_proof_status_contract(
+            first_run,
+            graph_query.replace(
+                "kin locate hello --json --explain --max-files 5 > "
+                '"$captures/kin-locate.json"\n'
+                '          cat "$captures/kin-locate.json"',
+                "kin locate hello --json --explain --max-files 5 | tee "
+                '"$captures/kin-locate.json"',
                 1,
             ),
             embedding,
@@ -8309,10 +8358,10 @@ def main() -> None:
                 1,
             )
             .replace(
-                'kin search hello --json | tee "$captures/kin-search.json"',
+                'kin search hello --json > "$captures/kin-search.json"',
                 'kin setup status --json | tee "$captures/kin-health.json"\n'
                 '          kin doctor --json | tee "$captures/kin-doctor.json"\n'
-                '          kin search hello --json | tee "$captures/kin-search.json"',
+                '          kin search hello --json > "$captures/kin-search.json"',
                 1,
             ),
             embedding,


### PR DESCRIPTION
The Windows install-proof leg has failed at the same line since v0.4.9, and the cause on record was wrong. The installed daemon does publish `.kin/daemon.port`. The proof could not read it, because the step waited for the daemon to die first.

`install-proof.yml` ran both daemon-starting queries through `tee`. On Windows `CreateProcess` hands a child every handle currently marked inheritable, not only the three the parent named for its stdio, so the daemon inherits the shell pipeline's write end even though its own stdout and stderr were redirected into the daemon log. Nothing in the daemon knows it holds that handle, so `tee` never reaches end of file and the shell does not reach the next line until the daemon idles out. Shutdown removes `daemon.pid`, `daemon.port` and the owner record, so the step resumed at the exact moment the endpoint stopped existing, read it, and reported it missing.

Measured rather than argued. On run 31599425865 (main, 2026-08-12) the locate JSON flushed complete at 13:05:28 and the shell did not reach the port read until 13:07:37, a 129 second stall with the CLI already finished printing. That is close to two 60 second idle timeouts, the repo daemon's and the supervisor's. This repo had already measured the same behavior twice and written it down, at `install-proof.yml` line 754 and at `windows-vector-proof.yml` lines 176 to 190, and both notes sat beside a step that kept piping.

## What changes

The two queries redirect and `cat` instead of piping, which is the treatment `kin status` in the first-run step already had for this reason. `kin setup status` and `kin doctor` keep their pipes on purpose: the daemon is up by then, so those invocations spawn nothing.

`detach_from_caller` gains a Windows arm. It carried `setsid` on Unix and `let _ = cmd` everywhere else, so a spawned daemon kept every inheritable handle its caller held. It now clears the inherit flag on the caller's standard handles, which is the equivalent of the `CLOEXEC` Unix gets for free. Both spawn paths reach it, the repo daemon through `DaemonSpawnPlan::command()` and the supervisor through its own call. This is user facing and not only CI: before it, `kin search --json | jq` on Windows printed its answer and then hung until the daemon idled out.

The release authority suite gains the rule rather than only the new spelling. No `kin search` or `kin locate` line in that step may be piped, the refusal names the mechanism, and one falsification per query is registered.

## Proof

Install proof was dispatched from this branch against the same public v0.5.23 install the failing run used: run 31731277257, job 94552131603. Step 9, "Graph query and MCP tool-call proof", went from 4 minutes 16 seconds and a failure on main to 11 seconds and a pass here. Endpoint provenance passed against a genuinely published endpoint record, which is the first half of FIR-2206's acceptance.

The Windows-only spawn case runs on native Windows CI beside the managed-install fence leg it shares a compilation unit with. It fails in 20 seconds when the holder keeps the handle, and refuses to pass at all when no holder started, so it cannot go green vacuously. Unix passes it whether or not the fix exists, which is why it needs that leg.

`bin/kin-dev local-test kin` is green on this branch, 5608 tests, new cases included. Clippy is clean for `x86_64-pc-windows-msvc`, `x86_64-unknown-linux-gnu` and the host under the ci.yml allowlist, and an injected type error inside the Windows arm proves the cross-target check can see that code at all.

## Why the leg is still not gating

Getting past step 9 exposed step 13, which had been skipped on every Windows run since v0.4.9 and now fails: `kin setup` writes an MCP command of `C:/Users/runneradmin/.kin\bin\kin.exe` against an installed launcher of `C:\Users\runneradmin\.kin\bin\kin.exe`. That is FIR-2293, filed with the captured artifact. Flipping `experimental: true` here would block every release on a defect this change does not fix, and the leg proves released bytes, so even the handle fix cannot appear in it until it rides a release. The flag and its posture assertion come out together once FIR-2293 lands and ships, which is what FIR-1921 already says done means.

Refs FIR-2206, FIR-1921, FIR-2293.
