### PR TITLE
Run the install proof's capability contract against main instead of only at a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,14 @@ jobs:
             ./scripts/release-archive-shape.test.cjs \
             ./scripts/release-order.test.mjs \
             ./scripts/release-hold-alarm.test.mjs \
+            ./scripts/verify-capability-proof.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs
           node --check ./scripts/read-update-build-identity.cjs
           node --check ./scripts/check-release-version.mjs
           node --check ./scripts/prepare-release.mjs
           node --check ./scripts/release-order.mjs
           node --check ./scripts/release-hold-alarm.mjs
+          node --check ./scripts/verify-capability-proof.mjs
           node --check ./scripts/verify-npm-attestation.mjs
           bash -n ./scripts/publish-npm-release.sh
           bash -n ./scripts/verify-npm-release.sh

--- a/.github/workflows/install-proof-canary.yml
+++ b/.github/workflows/install-proof-canary.yml
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Install Proof Canary
+
+# The Public Install Proof runs only once a tag exists, because it installs from
+# get.kinlab.dev with no checkout and no secrets, which is exactly what makes it
+# worth trusting. The cost of that is a feedback loop one release long: a change
+# that breaks the proof lands green, ships, and fences the release it shipped in.
+# That is the v0.5.18 story. The classifier change landed with green CI, the
+# proof caught it correctly at tag time, and the tag could not be repaired,
+# because a tag run resolves its workflows from the tag. Nothing on main can
+# reach an existing tag's run, so prevention has to fire before a tag exists.
+#
+# This is that prevention. It builds Kin from the branch, installs it into the
+# same layout the public installer uses, drives a real first run, and holds the
+# result to the portable half of the proof's capability contract. It publishes
+# nothing, promotes nothing, and proves nothing about a release: a branch binary
+# is not a release binary, and the release provenance assertions stay where they
+# belong, in the proof itself. What moves here is the part that broke.
+#
+# It is deliberately not on every pull request. The paths below are the proof's
+# known inputs, so a change that cannot affect the proof does not pay for a Rust
+# build, and the nightly run covers anything the path list fails to anticipate.
+on:
+  schedule:
+    # Nightly, so a break that arrives through a path this filter does not name
+    # is still found within hours instead of at the next cut.
+    - cron: "0 7 * * *"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/install-proof.yml"
+      - ".github/workflows/install-proof-canary.yml"
+      - "scripts/verify-capability-proof.mjs"
+      - "scripts/verify-capability-proof.test.mjs"
+      - "crates/kin-cli/src/commands/health.rs"
+      - "crates/kin-cli/src/commands/setup.rs"
+      - "crates/kin-cli/src/commands/status.rs"
+      - "crates/kin-cli/src/commands/resources.rs"
+      - "crates/kin-cli/src/commands/embed.rs"
+      - "crates/kin-cli/src/commands/init.rs"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/install-proof.yml"
+      - ".github/workflows/install-proof-canary.yml"
+      - "scripts/verify-capability-proof.mjs"
+      - "scripts/verify-capability-proof.test.mjs"
+      - "crates/kin-cli/src/commands/health.rs"
+      - "crates/kin-cli/src/commands/setup.rs"
+      - "crates/kin-cli/src/commands/status.rs"
+      - "crates/kin-cli/src/commands/resources.rs"
+      - "crates/kin-cli/src/commands/embed.rs"
+      - "crates/kin-cli/src/commands/init.rs"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  capability-canary:
+    name: Capability Contract Canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+
+      - name: Verify kin cargo registry config
+        run: |
+          set -euo pipefail
+          test -f .cargo/config.toml
+          grep -q '^\[registries\.kin\]' .cargo/config.toml
+          if grep -q '^\[patch\.kin\]' .cargo/config.toml; then
+            echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"
+            exit 1
+          fi
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: "false"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build kin + kin-daemon from this branch
+        run: cargo build --bin kin --bin kin-daemon --locked
+
+      # The public installer puts both binaries in ~/.kin/bin, and several health
+      # checks resolve the launcher by that path rather than by whatever happens
+      # to be named `kin` on PATH. Reproduce the layout so the canary fails for
+      # the branch's behavior and never for its own staging.
+      - name: Install the branch build into the public layout
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.kin/bin"
+          install -m 0755 target/debug/kin "$HOME/.kin/bin/kin"
+          install -m 0755 target/debug/kin-daemon "$HOME/.kin/bin/kin-daemon"
+          printf '%s\n' "$HOME/.kin/bin" >> "$GITHUB_PATH"
+
+      - name: Drive a real first run and capture what the proof reads
+        env:
+          SHELL: /bin/bash
+        run: |
+          set -euo pipefail
+          captures="$RUNNER_TEMP/kin-canary-captures"
+          mkdir -p "$captures"
+
+          # The proof's own fixture. `kin init` fails closed on a populated
+          # directory that is not a Git repository, so the fixture is committed
+          # and initialization takes the exact Git admission path.
+          work="$RUNNER_TEMP/kin-canary-repo"
+          mkdir -p "$work"
+          cd "$work"
+          git init -q
+          git config user.email ci@firelock.ai
+          git config user.name ci
+          printf 'def hello():\n    return 42\n' > probe.py
+          git add -A
+          git commit -qm probe
+
+          # Inert shims so setup exercises the real agent-config writers without
+          # the proprietary clients being present, exactly as the proof does.
+          # Without them the mcp_client_* checks report missing and the canary
+          # would fail for the runner rather than for the branch.
+          shims="$RUNNER_TEMP/kin-canary-agent-bin"
+          mkdir -p "$shims"
+          for agent in claude cursor codex gemini windsurf agy; do
+            printf '#!/bin/sh\nexit 0\n' > "$shims/$agent"
+            chmod +x "$shims/$agent"
+          done
+          export PATH="$shims:$PATH"
+
+          # Captures live outside the admitted worktree. The daemon admits new
+          # files as they are written, so a report written into this tree becomes
+          # corpus and the store grows while it is being measured.
+          kin init > "$captures/kin-init.txt" 2>&1
+          cat "$captures/kin-init.txt"
+          kin setup --no-interactive --intent agent --shell bash \
+            > "$captures/kin-setup.txt" 2>&1
+          cat "$captures/kin-setup.txt"
+
+          # First capture: the store as a new user finds it, before any embedding
+          # pass has been asked for.
+          kin status --json > "$captures/first-status.json"
+          kin setup status --json > "$captures/first-health.json"
+          kin doctor --json > "$captures/first-doctor.json"
+
+          # Then ask for the pass and let it run to a bounded budget. Whatever
+          # state the store reaches is a state the contract can judge, so this
+          # never needs the pass to succeed in order to mean something. The
+          # settled regime is where v0.5.18 died, so reaching it is the good case
+          # and the contract says so either way.
+          kin embed --max-seconds 240 --json > "$captures/kin-embed.json" 2>&1 || \
+            echo "::notice::the bounded embedding pass did not complete; the contract judges whatever state the store reached."
+          kin status --json > "$captures/settled-status.json"
+          kin setup status --json > "$captures/settled-health.json"
+          kin doctor --json > "$captures/settled-doctor.json"
+          echo "KIN_CANARY_CAPTURES=$captures" >> "$GITHUB_ENV"
+
+      - name: Hold the branch build to the install proof's capability contract
+        run: |
+          set -euo pipefail
+          captures="$KIN_CANARY_CAPTURES"
+          echo "::group::first run, before any embedding pass was asked for"
+          node scripts/verify-capability-proof.mjs \
+            --status "$captures/first-status.json" \
+            --report "$captures/first-health.json" \
+            --report "$captures/first-doctor.json"
+          echo "::endgroup::"
+
+          # `--require-observed` is the anti-vacuity guard. Coverage that was
+          # never observable is a window the contract deliberately concludes
+          # nothing from, and a canary that passed on nothing but windows would
+          # be a check that cannot fail rather than evidence.
+          echo "::group::after the bounded embedding pass"
+          node scripts/verify-capability-proof.mjs \
+            --require-observed \
+            --status "$captures/settled-status.json" \
+            --report "$captures/settled-health.json" \
+            --report "$captures/settled-doctor.json"
+          echo "::endgroup::"
+
+      - name: Preserve the canary captures
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: install-proof-canary-captures
+          path: ${{ runner.temp }}/kin-canary-captures
+          if-no-files-found: warn
+          retention-days: 7

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -29,6 +29,9 @@ RELEASE_TRAIN = WORKFLOWS / "release-train.yml"
 RELEASE_SENTINEL = WORKFLOWS / "release-sentinel.yml"
 HOLD_ALARM = ROOT / "scripts" / "release-hold-alarm.mjs"
 HOLD_ALARM_POLICY = "scripts/release-hold-alarm.mjs"
+INSTALL_PROOF_CANARY = WORKFLOWS / "install-proof-canary.yml"
+CAPABILITY_CONTRACT = ROOT / "scripts" / "verify-capability-proof.mjs"
+CAPABILITY_CONTRACT_POLICY = "scripts/verify-capability-proof.mjs"
 RELEASE_BOT_DOC = ROOT / "docs" / "release-bot.md"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 WINDOWS_INIT_CONTRACT = ROOT / "scripts" / "assert-windows-init-contract.sh"
@@ -537,6 +540,9 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/release-sentinel.yml": {
         "preflight": "Resolve sentinel credential",
         "patrol": "Patrol the release rail",
+    },
+    ".github/workflows/install-proof-canary.yml": {
+        "capability-canary": "Capability Contract Canary",
     },
     ".github/workflows/release-tag.yml": {
         "mint-release-tag": "Mint release tag",
@@ -6502,6 +6508,125 @@ def assert_release_hold_marker_contract(
         )
 
 
+def assert_capability_canary_contract(
+    install_proof: str,
+    canary: str,
+    capability_script: str,
+) -> None:
+    """Bind the branch canary to the same capability contract the proof enforces.
+
+    The install proof cannot read a tracked script. It runs anonymously with no
+    checkout, which is what makes it worth trusting and also why the contract
+    cannot simply be shared by import. Two copies of a contract drift, and this
+    pair drifts in the worst direction: the canary keeps passing while the proof
+    it was built to predict starts failing at tag time, where no fix on main can
+    reach the tag. So the copies are compared here instead.
+    """
+
+    blocks = re.findall(
+        r"const required = new Map\(\[\n(.*?)\n\s*\]\);", install_proof, re.S
+    )
+    if len(blocks) != 2:
+        raise AssertionError(
+            "the install proof is expected to carry exactly two required-check "
+            f"tables, the Windows repo-free one and the capability one; found {len(blocks)}"
+        )
+    # The second table is the capability validator's, which is the one the canary
+    # mirrors. The first belongs to the Windows repository-free proof, which
+    # asserts a different surface on a leg the canary does not run.
+    proof_ids = set(re.findall(r'\["([a-z_0-9]+)",', blocks[1]))
+    # The proof asserts readiness in its own arm rather than in the table, so it
+    # is required by the proof without appearing in it.
+    proof_ids.add("semantic_query_readiness")
+
+    listed = re.search(
+        r"export const REQUIRED_CHECK_IDS = \[(.*?)\];", capability_script, re.S
+    )
+    if listed is None:
+        raise AssertionError(
+            "the capability contract must export the check ids it requires"
+        )
+    canary_ids = set(re.findall(r'"([a-z_0-9]+)"', listed.group(1)))
+
+    if canary_ids != proof_ids:
+        missing = sorted(proof_ids - canary_ids)
+        extra = sorted(canary_ids - proof_ids)
+        raise AssertionError(
+            "the canary's capability contract must require exactly the health "
+            "checks the install proof requires; "
+            f"absent from the canary: {missing or 'none'}; "
+            f"required by the canary but not the proof: {extra or 'none'}"
+        )
+
+    # The rule the proof applies to every health report it reads. A canary that
+    # judges the aggregate differently would pass a report the proof rejects.
+    if 'check.id === READINESS_ID && check.status === "stale"' not in capability_script:
+        raise AssertionError(
+            "the canary must apply the proof's own aggregate-health rule, in "
+            "which a stale readiness makes the report unhealthy"
+        )
+
+    # Everything below is judged on active lines only, in both directions.
+    #
+    # A comment must not be able to satisfy a requirement, which is the trap this
+    # suite already guards elsewhere: this file explains its own rules at length,
+    # so a whole-file scan would find `--require-observed` in the paragraph
+    # explaining it and pass a canary that no longer passes the flag. A comment
+    # must not be able to trip a prohibition either, for the same reason in
+    # reverse: the header explains why the proof installs from the public
+    # endpoint and why the canary must not, and a naive scan refuses the very
+    # sentence documenting the rule.
+    active_canary = "\n".join(
+        line for line in canary.splitlines() if not line.lstrip().startswith("#")
+    )
+
+    # The two triggers the ticket asked for, and the reason for each. A canary
+    # with only a path filter misses a break arriving through a path nobody
+    # anticipated; one with only a schedule finds it a night late.
+    if "schedule:" not in active_canary:
+        raise AssertionError("the canary must run nightly against main")
+    if "pull_request:" not in active_canary or "paths:" not in active_canary:
+        raise AssertionError(
+            "the canary must run path-filtered on the proof's known inputs"
+        )
+    for required_path in (
+        '".github/workflows/install-proof.yml"',
+        '"crates/kin-cli/src/commands/health.rs"',
+    ):
+        if required_path not in active_canary:
+            raise AssertionError(
+                "the canary's path filter must cover the proof itself and the "
+                f"readiness classifier that fenced v0.5.18; absent: {required_path}"
+            )
+
+    if "scripts/verify-capability-proof.mjs" not in active_canary:
+        raise AssertionError(
+            "the canary must actually run the shared capability contract"
+        )
+    if "--require-observed" not in active_canary:
+        raise AssertionError(
+            "the canary must assert against an observed coverage at least once; "
+            "a run that only ever saw unobservable coverage judged nothing, and a "
+            "check that cannot fail is not evidence"
+        )
+
+    # A canary publishes nothing and promotes nothing. The release path stays the
+    # release path, and a branch binary never touches it.
+    for forbidden in (
+        "contents: write",
+        "id-token: write",
+        "packages: write",
+        "gh release",
+        "npm publish",
+        "get.kinlab.dev",
+        "curl -fsSL https://get",
+    ):
+        if forbidden in active_canary:
+            raise AssertionError(
+                f"the canary must neither publish nor promote anything: {forbidden}"
+            )
+
+
 def assert_abandoned_tag_admission(
     release_tag: str,
     release_train: str,
@@ -6994,6 +7119,8 @@ def main() -> None:
     hold_alarm = HOLD_ALARM.read_text(encoding="utf-8")
     release_bot_doc = RELEASE_BOT_DOC.read_text(encoding="utf-8")
     install_proof = INSTALL_PROOF.read_text(encoding="utf-8")
+    install_proof_canary = INSTALL_PROOF_CANARY.read_text(encoding="utf-8")
+    capability_contract = CAPABILITY_CONTRACT.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
     ci_workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     installer_callback = INSTALLER_CALLBACK.read_text(encoding="utf-8")
@@ -7553,6 +7680,76 @@ def main() -> None:
     # spend runners or raise an advisory alarm for a release the reviewed record
     # retired. Parse active step fields so a comment repeating the condition
     # cannot satisfy the guard while the YAML `if` omits it.
+    # The proof is the best gate Kin has and it ran only once a tag existed, so
+    # a change that broke it was discovered one release late and could not be
+    # repaired in place. The canary moves the portable half of that contract onto
+    # main. What binds the two is here, because two copies of one contract drift
+    # in the direction that matters: the canary stays green while the proof it
+    # predicts starts failing at a tag.
+    assert_capability_canary_contract(
+        install_proof, install_proof_canary, capability_contract
+    )
+    expect_assertion(
+        "the proof requires a check the canary does not",
+        "must require exactly the health checks",
+        lambda: assert_capability_canary_contract(
+            install_proof,
+            install_proof_canary,
+            capability_contract.replace('  "setup_ledger",\n', "", 1),
+        ),
+    )
+    expect_assertion(
+        "the canary drops the classifier that fenced v0.5.18 from its path filter",
+        "path filter must cover",
+        lambda: assert_capability_canary_contract(
+            install_proof,
+            install_proof_canary.replace(
+                '      - "crates/kin-cli/src/commands/health.rs"\n', "", 2
+            ),
+            capability_contract,
+        ),
+    )
+    expect_assertion(
+        "the canary can pass without ever observing coverage",
+        "check that cannot fail is not evidence",
+        lambda: assert_capability_canary_contract(
+            install_proof,
+            install_proof_canary.replace("--require-observed \\\n", ""),
+            capability_contract,
+        ),
+    )
+    expect_assertion(
+        "the canary grows the authority to publish",
+        "must neither publish nor promote",
+        lambda: assert_capability_canary_contract(
+            install_proof,
+            install_proof_canary.replace(
+                "permissions:\n  contents: read\n",
+                "permissions:\n  contents: write\n",
+                1,
+            ),
+            capability_contract,
+        ),
+    )
+    expect_assertion(
+        "the canary stops running the shared contract at all",
+        "must actually run the shared capability contract",
+        lambda: assert_capability_canary_contract(
+            install_proof,
+            install_proof_canary.replace("scripts/verify-capability-proof.mjs", "true"),
+            capability_contract,
+        ),
+    )
+    expect_assertion(
+        "the canary loses its nightly run and only fires on anticipated paths",
+        "must run nightly against main",
+        lambda: assert_capability_canary_contract(
+            install_proof,
+            install_proof_canary.replace("  schedule:\n", "  # schedule:\n", 1),
+            capability_contract,
+        ),
+    )
+
     assert_recovery_abandonment_stand_down(release_recovery)
     expect_assertion(
         "recovery repeats its stand-down condition only in comments",

--- a/scripts/verify-capability-proof.mjs
+++ b/scripts/verify-capability-proof.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// The portable half of the Public Install Proof's capability contract, so it
+// can run against a binary built from a branch instead of only against a
+// published release.
+//
+// The proof is the best gate Kin has and it had the worst feedback loop. It
+// installs from get.kinlab.dev with no checkout and no secrets, which is the
+// point, and it therefore runs only once a tag exists. A change that breaks it
+// lands green, ships, and fences the release it ships in. That is what happened
+// to v0.5.18: a readiness classifier started reporting `pending` on a host that
+// could never make progress, the proof caught it correctly at tag time, and the
+// tag could not be repaired because a tag run resolves its workflows from the
+// tag.
+//
+// What moves here is only what a branch build can honestly assert. Release
+// provenance stays in the proof: a canary binary is not the release binary and
+// must never claim to prove anything about one. What is left is the part that
+// broke, and it is the part that needs no release at all.
+
+import { readFileSync } from "node:fs";
+
+// Every check id the install proof requires by name. A rename or a removal
+// makes the proof fail at tag time with nothing on main to warn about it, so the
+// canary requires the same ids to be present. The expected STATUS per id is
+// deliberately not copied: a canary host is not an installed host, and asserting
+// a status this environment cannot produce would fail for the environment rather
+// than for the change. Presence is what a rename breaks, and presence is what is
+// portable. The release authority suite pins this list against the proof's own
+// inline table, so the two cannot drift.
+export const REQUIRED_CHECK_IDS = [
+  "kin_binary",
+  "kin_daemon_binary",
+  "daemon_running",
+  "repo_init",
+  "shell_path",
+  "setup_ledger",
+  "registry_authority",
+  "vfs_projection",
+  "mcp_client_claude",
+  "mcp_client_cursor",
+  "mcp_client_codex",
+  "mcp_client_gemini",
+  "mcp_client_windsurf",
+  "mcp_client_antigravity",
+  "mcp_client_antigravity_workspace",
+  "semantic_query_readiness",
+];
+
+export const READINESS_ID = "semantic_query_readiness";
+
+export class CapabilityProofError extends Error {}
+
+function fail(message) {
+  throw new CapabilityProofError(message);
+}
+
+// Byte-for-byte the rule the install proof applies to every health report it
+// reads. The aggregate is not an independent opinion: it is a function of the
+// checks, and a report whose summary disagrees with its own contents is the
+// failure mode that hides every other one.
+export function validateHealthReport(report, reportPath) {
+  if (!report || typeof report !== "object" || !Array.isArray(report.checks)) {
+    fail(`${reportPath}: checks is missing or malformed`);
+  }
+  const checks = new Map(report.checks.map((check) => [check.id, check]));
+  if (checks.size !== report.checks.length) {
+    fail(`${reportPath}: duplicate health-check ids are not authoritative`);
+  }
+  const expectedHealthy = !report.checks.some(
+    (check) =>
+      check.status === "missing" ||
+      check.status === "misconfigured" ||
+      (check.id === READINESS_ID && check.status === "stale"),
+  );
+  if (report.healthy !== expectedHealthy) {
+    fail(
+      `${reportPath}: aggregate healthy=${report.healthy} disagrees with checks; ` +
+        `expected ${expectedHealthy}`,
+    );
+  }
+  return checks;
+}
+
+export function assertRequiredChecksPresent(checks, reportPath) {
+  const absent = REQUIRED_CHECK_IDS.filter((id) => !checks.has(id));
+  if (absent.length > 0) {
+    fail(
+      `${reportPath}: the install proof requires health checks this build does not ` +
+        `report: ${absent.join(", ")}. A renamed or removed check fails the proof at ` +
+        "tag time, where no fix on main can reach it.",
+    );
+  }
+}
+
+export function assertNoHardFailures(report, reportPath) {
+  const hard = report.checks.filter(
+    (check) => check.status === "missing" || check.status === "misconfigured",
+  );
+  if (hard.length > 0) {
+    fail(
+      `${reportPath}: hard failures: ${hard.map((check) => check.id).join(", ")}`,
+    );
+  }
+}
+
+// The whole status vocabulary `HealthStatus` serializes, in snake_case. The
+// proof compares these as strings, so a variant renamed on the Rust side stops
+// matching silently and every comparison the proof makes goes quietly false.
+// Reading a status outside this set is that rename, caught before a tag exists.
+export const HEALTH_STATUSES = [
+  "healthy",
+  "missing",
+  "stale",
+  "misconfigured",
+  "pending",
+  "unsupported",
+];
+
+// What `pending` is allowed to mean.
+//
+// Pending must mean work is actually moving toward ready. Where nothing can
+// move, `pending` is a claim the host will never make good on, and it is the
+// exact lie that fenced v0.5.18: on a runner the readiness check sat pending
+// forever, the proof required healthy, and every cut after it failed the same
+// way. The judgement is made against the coverage counters rather than against
+// the readiness field's own word for itself, because a classifier that lies is
+// not a witness to its own honesty.
+//
+// Coverage carries exactly `state`, `source`, `reason`, `indexed`, `pending`,
+// and `total`. Nothing here reads a field the daemon does not publish.
+//
+//   settled      observed, total above zero, pending zero, indexed equal to
+//                total. The proof's post-embed assertion requires `healthy`
+//                here, so anything else fails the release gate at tag time.
+//   nothing      observed with a total of zero. There is no work that could
+//                ever resolve a `pending`, which is the structural-zero
+//                honesty class sitting in the release gate.
+//   working      observed with work outstanding. `pending` is correct, and so
+//                is `healthy` when the pass finished between the two reads.
+//   unobserved   a window rather than a shortfall. Conclude nothing.
+export function assertReadinessCoherent(checks, coverage, reportPath) {
+  const readiness = checks.get(READINESS_ID)?.status;
+  if (readiness === undefined) {
+    fail(`${reportPath}: ${READINESS_ID} is missing`);
+  }
+  if (!HEALTH_STATUSES.includes(readiness)) {
+    fail(
+      `${reportPath}: ${READINESS_ID} reports ${readiness}, which is not a status ` +
+        "this build's health vocabulary defines. The proof compares these as " +
+        "strings, so a renamed variant makes every comparison quietly false.",
+    );
+  }
+  const state = coverage?.state;
+  if (state === undefined) {
+    fail(
+      `${reportPath}: embedding coverage carries no state, so readiness cannot be ` +
+        "judged against it. An unread coverage is not an empty one.",
+    );
+  }
+
+  if (state !== "observed") {
+    return readiness;
+  }
+
+  if (!Number.isInteger(coverage.total)) {
+    fail(
+      `${reportPath}: observed embedding coverage carries no whole total ` +
+        `(${JSON.stringify(coverage)}), so it observed nothing it can be held to.`,
+    );
+  }
+
+  if (coverage.total === 0) {
+    if (readiness === "pending") {
+      fail(
+        `${reportPath}: ${READINESS_ID} is pending against a store with nothing to ` +
+          "embed, so no amount of waiting resolves it. Pending has to mean work is " +
+          "moving toward ready; where nothing can move, say unsupported.",
+      );
+    }
+    return readiness;
+  }
+
+  const settled = coverage.pending === 0 && coverage.indexed === coverage.total;
+  if (settled && readiness !== "healthy") {
+    fail(
+      `${reportPath}: ${READINESS_ID} is ${readiness} on a settled store ` +
+        `(${JSON.stringify(coverage)}). The install proof requires healthy here, so ` +
+        "this fails the release gate at tag time, where no fix on main can reach it.",
+    );
+  }
+  return readiness;
+}
+
+export function verifyReport(report, coverage, reportPath) {
+  const checks = validateHealthReport(report, reportPath);
+  assertRequiredChecksPresent(checks, reportPath);
+  assertNoHardFailures(report, reportPath);
+  const readiness = assertReadinessCoherent(checks, coverage, reportPath);
+  return { checks, readiness };
+}
+
+// Which of the coverage regimes a capture was judged under. An `unobserved`
+// coverage is a window the proof settles over rather than asserts into, so
+// nothing about readiness follows from it. That tolerance is correct and it is
+// also the one way this check could pass while proving nothing, which is why the
+// regime is printed and why `--require-observed` exists.
+export function coverageRegime(coverage) {
+  if (coverage?.state !== "observed") return "unobserved";
+  if (!Number.isInteger(coverage.total)) return "unobserved";
+  if (coverage.total === 0) return "nothing-to-embed";
+  return coverage.pending === 0 && coverage.indexed === coverage.total
+    ? "settled"
+    : "working";
+}
+
+function parseArgs(argv) {
+  const args = { reports: [], status: null, requireObserved: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === "--report") args.reports.push(argv[++index]);
+    else if (flag === "--status") args.status = argv[++index];
+    else if (flag === "--require-observed") args.requireObserved = true;
+    else throw new Error(`unknown argument: ${flag}`);
+  }
+  if (args.reports.length === 0) throw new Error("at least one --report <path> is required");
+  if (!args.status) throw new Error("--status <path> is required");
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  const status = JSON.parse(readFileSync(args.status, "utf8"));
+  const coverage = status.embedding_coverage;
+  const regime = coverageRegime(coverage);
+  if (args.requireObserved && regime === "unobserved") {
+    throw new Error(
+      "embedding coverage was never observed, so this run judged readiness " +
+        "against nothing and proved nothing. A check that cannot fail is not " +
+        `evidence. Coverage read: ${JSON.stringify(coverage)}`,
+    );
+  }
+  for (const reportPath of args.reports) {
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    const { readiness } = verifyReport(report, coverage, reportPath);
+    process.stdout.write(
+      `${reportPath}: capability contract holds under the ${regime} regime, ` +
+        `${READINESS_ID}=${readiness}\n`,
+    );
+  }
+  process.stdout.write(
+    `coverage regime: ${regime}\ncoverage: ${JSON.stringify(coverage)}\n` +
+      "the branch build satisfies the portable half of the install proof's " +
+      "capability contract\n",
+  );
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/verify-capability-proof.test.mjs
+++ b/scripts/verify-capability-proof.test.mjs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  CapabilityProofError,
+  REQUIRED_CHECK_IDS,
+  assertReadinessCoherent,
+  coverageRegime,
+  validateHealthReport,
+  verifyReport,
+} from './verify-capability-proof.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./verify-capability-proof.mjs', import.meta.url));
+
+function report({ readiness = 'healthy', overrides = {}, healthy = null } = {}) {
+  const checks = REQUIRED_CHECK_IDS.map((id) => ({
+    id,
+    label: id,
+    status: id === 'semantic_query_readiness' ? readiness : 'healthy',
+    detail: '',
+    ...(overrides[id] ?? {}),
+  }));
+  const blocking = checks.some(
+    (check) =>
+      check.status === 'missing' ||
+      check.status === 'misconfigured' ||
+      (check.id === 'semantic_query_readiness' && check.status === 'stale'),
+  );
+  return { healthy: healthy === null ? !blocking : healthy, checks };
+}
+
+const settled = { state: 'observed', source: 'live_query_graph', indexed: 18, pending: 0, total: 18 };
+const working = { state: 'observed', source: 'live_query_graph', indexed: 4, pending: 14, total: 18 };
+const nothing = { state: 'observed', source: 'live_query_graph', indexed: 0, pending: 0, total: 0 };
+const unobserved = { state: 'unobserved', reason: 'graph_mutation_in_flight' };
+
+function expectFailure(fn, pattern) {
+  assert.throws(fn, (error) => {
+    assert.ok(error instanceof CapabilityProofError, `wrong error type: ${error}`);
+    assert.match(error.message, pattern);
+    return true;
+  });
+}
+
+test('a settled store with healthy readiness satisfies the contract', () => {
+  const { readiness } = verifyReport(report(), settled, 'kin-health.json');
+  assert.equal(readiness, 'healthy');
+});
+
+// The v0.5.18 fence, reproduced. This is the assertion the whole canary exists
+// for: it fails on main's branch build instead of at tag time on a tag nothing
+// can repair.
+test('readiness pending on a settled store fails, which is the v0.5.18 fence', () => {
+  expectFailure(
+    () => verifyReport(report({ readiness: 'pending' }), settled, 'kin-embedded-health.json'),
+    /pending on a settled store/,
+  );
+});
+
+test('readiness pending against a store with nothing to embed fails', () => {
+  expectFailure(
+    () => verifyReport(report({ readiness: 'pending' }), nothing, 'kin-health.json'),
+    /no amount of waiting resolves it/,
+  );
+});
+
+test('unsupported against a store with nothing to embed is the honest answer', () => {
+  const { readiness } = verifyReport(report({ readiness: 'unsupported' }), nothing, 'kin-health.json');
+  assert.equal(readiness, 'unsupported');
+});
+
+test('pending while a first pass is genuinely filling is correct and passes', () => {
+  const { readiness } = verifyReport(report({ readiness: 'pending' }), working, 'kin-health.json');
+  assert.equal(readiness, 'pending');
+});
+
+test('an unobserved coverage window concludes nothing about readiness', () => {
+  for (const readiness of ['pending', 'healthy', 'unsupported']) {
+    const { checks } = { checks: validateHealthReport(report({ readiness }), 'p') };
+    assert.equal(assertReadinessCoherent(checks, unobserved, 'p'), readiness);
+  }
+});
+
+test('an aggregate that disagrees with its own checks fails', () => {
+  const lying = report({ overrides: { repo_init: { status: 'missing' } }, healthy: true });
+  expectFailure(
+    () => verifyReport(lying, settled, 'kin-health.json'),
+    /aggregate healthy=true disagrees with checks/,
+  );
+});
+
+test('a stale readiness must drag the aggregate unhealthy, exactly as the proof requires', () => {
+  const honest = report({ readiness: 'stale' });
+  assert.equal(honest.healthy, false);
+  expectFailure(
+    () => verifyReport(report({ readiness: 'stale', healthy: true }), settled, 'p'),
+    /disagrees with checks/,
+  );
+});
+
+test('a renamed or removed check id fails before a tag exists', () => {
+  const renamed = report();
+  renamed.checks = renamed.checks.map((check) =>
+    check.id === 'semantic_query_readiness'
+      ? { ...check, id: 'semantic_query_state' }
+      : check,
+  );
+  expectFailure(
+    () => verifyReport(renamed, settled, 'kin-health.json'),
+    /requires health checks this build does not report: semantic_query_readiness/,
+  );
+});
+
+test('a status outside the build vocabulary is a rename, not a new state', () => {
+  expectFailure(
+    () => verifyReport(report({ readiness: 'ready' }), settled, 'p'),
+    /not a status this build's health vocabulary defines/,
+  );
+});
+
+test('duplicate check ids are refused rather than silently deduplicated', () => {
+  const duplicated = report();
+  duplicated.checks.push({ ...duplicated.checks[0] });
+  expectFailure(() => verifyReport(duplicated, settled, 'p'), /duplicate health-check ids/);
+});
+
+test('a hard failure fails even when the aggregate honestly agrees', () => {
+  const broken = report({ overrides: { setup_ledger: { status: 'misconfigured' } } });
+  assert.equal(broken.healthy, false);
+  expectFailure(() => verifyReport(broken, settled, 'p'), /hard failures: setup_ledger/);
+});
+
+test('a malformed report is refused rather than read as empty', () => {
+  expectFailure(() => verifyReport({}, settled, 'p'), /checks is missing or malformed/);
+  expectFailure(() => verifyReport(null, settled, 'p'), /checks is missing or malformed/);
+});
+
+test('an unreadable coverage is refused rather than treated as an empty store', () => {
+  expectFailure(() => verifyReport(report(), undefined, 'p'), /carries no state/);
+  expectFailure(
+    () => verifyReport(report(), { state: 'observed', source: 'live_query_graph' }, 'p'),
+    /carries no whole total/,
+  );
+});
+
+test('the command line passes a good capture and fails the fence capture', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-capability-'));
+  const statusPath = path.join(dir, 'kin-status.json');
+  const goodPath = path.join(dir, 'good-health.json');
+  const fencePath = path.join(dir, 'fence-health.json');
+  fs.writeFileSync(statusPath, JSON.stringify({ embedding_coverage: settled }));
+  fs.writeFileSync(goodPath, JSON.stringify(report()));
+  fs.writeFileSync(fencePath, JSON.stringify(report({ readiness: 'pending' })));
+
+  const passed = execFileSync(
+    'node',
+    [SCRIPT, '--status', statusPath, '--report', goodPath],
+    { encoding: 'utf8' },
+  );
+  assert.match(passed, /capability contract holds/);
+
+  assert.throws(
+    () => execFileSync('node', [SCRIPT, '--status', statusPath, '--report', fencePath], { stdio: 'pipe' }),
+    (error) => {
+      assert.match(error.stderr.toString(), /pending on a settled store/);
+      assert.equal(error.status, 1);
+      return true;
+    },
+  );
+});
+
+test('the command line refuses to run with nothing to check', () => {
+  assert.throws(() => execFileSync('node', [SCRIPT], { stdio: 'pipe' }));
+});
+
+test('the regimes are named from the coverage the daemon actually publishes', () => {
+  assert.equal(coverageRegime(settled), 'settled');
+  assert.equal(coverageRegime(working), 'working');
+  assert.equal(coverageRegime(nothing), 'nothing-to-embed');
+  assert.equal(coverageRegime(unobserved), 'unobserved');
+  assert.equal(coverageRegime(undefined), 'unobserved');
+});
+
+// The canary's own anti-vacuity guard. A run whose coverage never became
+// observable judged readiness against nothing, and a pass there would be a check
+// that cannot fail rather than evidence that anything works.
+test('require-observed refuses a run that proved nothing', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-capability-vacuous-'));
+  const statusPath = path.join(dir, 'kin-status.json');
+  const reportPath = path.join(dir, 'health.json');
+  fs.writeFileSync(statusPath, JSON.stringify({ embedding_coverage: unobserved }));
+  fs.writeFileSync(reportPath, JSON.stringify(report({ readiness: 'pending' })));
+
+  const tolerated = execFileSync('node', [SCRIPT, '--status', statusPath, '--report', reportPath], {
+    encoding: 'utf8',
+  });
+  assert.match(tolerated, /unobserved regime/);
+
+  assert.throws(
+    () =>
+      execFileSync(
+        'node',
+        [SCRIPT, '--status', statusPath, '--report', reportPath, '--require-observed'],
+        { stdio: 'pipe' },
+      ),
+    (error) => {
+      assert.match(error.stderr.toString(), /judged readiness against nothing/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
The Public Install Proof is the best gate Kin has and it had the worst feedback
loop. It installs from the public endpoint with no checkout and no secrets,
which is what makes it worth trusting, and it therefore runs only once a tag
exists. A change that breaks it lands green, ships, and fences the release it
shipped in. That is the v0.5.18 story: a readiness classifier started reporting
pending on a host that could never make progress, the proof caught it correctly
at tag time, and the tag could not be repaired, because a tag run resolves its
workflows from the tag. Prevention has to fire before a tag exists.

A canary now builds Kin from the branch, installs it into the same layout the
public installer uses, drives a real first run, and holds the result to the
portable half of the proof's capability contract. It runs nightly against main
and path-filtered on the proof's known inputs, which are the proof itself, the
health and readiness classifiers, status, resources, embed, and init. It
publishes nothing and promotes nothing, and it makes no claim about a release,
because a branch binary is not a release binary. Release provenance stays in the
proof, where it belongs.

The contract it enforces is the part that broke. A report's aggregate must agree
with its own checks by the proof's own rule. Every check id the proof requires
must be present, so a rename fails here rather than at a tag. And readiness is
judged against the coverage counters rather than against its own word for
itself: a settled store must report healthy, a store with nothing to embed must
not report pending, and an unobserved coverage settles nothing either way. That
last tolerance is correct and it is also the one way this could pass while
proving nothing, so the run after the embedding pass asserts under
--require-observed and fails a run that judged readiness against nothing.

The proof cannot read a tracked script, so the contract exists twice and the
release authority suite compares the copies. Two copies drift in the direction
that matters most here, where the canary stays green while the proof it was
built to predict starts failing at a tag. Six falsifications drive that link: a
check the proof requires and the canary drops, a path filter that loses the
classifier which fenced v0.5.18, a canary that can pass without ever observing
coverage, one that grows the authority to publish, one that stops running the
contract at all, and one that keeps only its path filter and loses the nightly
run that covers the paths nobody anticipated.

Closes FIR-2221