### PR TITLE
Read the locate honesty verdict from the answer rather than the page size

### DIFF
--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -230,17 +230,31 @@ fn query_names_a_symbol(query: &str) -> bool {
 /// scores cannot separate them: they are ranks within a result set, not evidence
 /// that anything matched.
 ///
-/// The verdict is read from what each arm already publishes about its FULL
-/// ranking, never from the page alone, because a page is a window: an exact name
-/// match sitting on page two would otherwise be reported as absent from the
-/// whole ranking.
+/// The verdict is read from what the answer publishes about its FULL ranking,
+/// never from the page alone, because a page is a window: an exact name match
+/// sitting on page two would otherwise be reported as absent from the whole
+/// ranking.
 ///
-/// - Fused arm: `all_fallback` is computed over the full ranking before paging
-///   and means precisely this, so it is used verbatim.
-/// - Cosine arm: every row's `match_evidence.name_match` is inspected, and only
-///   when the page holds the entire ranking. A row that reports no
-///   `match_evidence` at all leaves the question unanswered, so nothing is
-///   qualified — the same refusal to guess the rest of the module makes.
+/// `all_fallback` IS that published verdict. Both arms compute it over the whole
+/// retained ranking before the daemon windows a page, with the same rule, and
+/// both omit the field when it is false, so its presence is authoritative and
+/// routing does not enter into it.
+///
+/// A payload carrying no `all_fallback` at all is an older daemon that never
+/// published one, and only there is the fact inferred from the page: every row's
+/// `match_evidence.name_match` is inspected, and only when the page holds the
+/// entire ranking. A row that reports no `match_evidence` leaves the question
+/// unanswered, so nothing is qualified, which is the same refusal to guess the
+/// rest of the module makes.
+///
+/// The inference cannot be the primary reading, because the condition it needs
+/// is one a real store almost never meets. `total_ranked` grows with the
+/// requested limit, so the page covers the ranking only when the ranking
+/// collapses to a degenerate row or two. A fabricated symbol measured at limit 8
+/// ranked 1 and carried the disclosure; the same symbol at limit 50 ranked 56
+/// and carried none. Asking for more results removed the honesty envelope, which
+/// left the guard present in the one case nobody queries and absent in every
+/// case they do.
 fn locate_ranking_names_nothing(payload: &Value) -> bool {
     if !payload
         .get("query")
@@ -249,8 +263,11 @@ fn locate_ranking_names_nothing(payload: &Value) -> bool {
     {
         return false;
     }
+    if let Some(all_fallback) = payload.get("all_fallback").and_then(Value::as_bool) {
+        return all_fallback;
+    }
     if payload.get("routing").and_then(Value::as_str) == Some("fused-v1") {
-        return payload.get("all_fallback").and_then(Value::as_bool) == Some(true);
+        return false;
     }
     let Some(rows) = payload.get("results").and_then(Value::as_array) else {
         return false;
@@ -2401,6 +2418,136 @@ mod tests {
             &semantic_authoritative_envelope()
         )
         .is_none());
+    }
+
+    /// The measured pair, as one query at two limits against one daemon.
+    ///
+    /// `total_ranked` is not a fixed property of a query; it grows with the
+    /// requested limit. On a fresh fully embedded store a fabricated symbol
+    /// ranked 1 at limit 8 and 56 at limit 50, so the page covered the ranking
+    /// in the first case and not the second, and the disclosure that fired on
+    /// the small page vanished on the large one. Asking for more results removed
+    /// the honesty envelope, and the guard survived only because it was always
+    /// tested on a ranking small enough to satisfy it.
+    #[test]
+    fn a_cosine_page_wider_than_its_window_still_carries_the_unnamed_verdict() {
+        let page_of = |served: usize, total: u64| {
+            json!({
+                "query": "qqzz_fabricated_method_7k2b",
+                "granularity": "entity",
+                "routing": "cosine-v0",
+                "page": 0,
+                "total_ranked": total,
+                "all_fallback": true,
+                "results": (0..served)
+                    .map(|index| cosine_locate_hit(&format!("neighbor_{index}"), "none"))
+                    .collect::<Vec<_>>(),
+            })
+        };
+
+        // Limit 8: one ranked row, the page holds the whole ranking. This is the
+        // only shape that ever produced a negative.
+        let small = negative_for(
+            "semantic_locate",
+            &page_of(1, 1),
+            &semantic_authoritative_envelope(),
+        )
+        .expect("a whole-ranking page has always been qualified");
+        assert_eq!(small["kind"], json!("no_named_match"));
+
+        // Limit 50: fifty rows served out of fifty-six ranked. Same daemon, same
+        // query, seconds apart, and this page carried no negative at all.
+        let wide = negative_for(
+            "semantic_locate",
+            &page_of(50, 56),
+            &semantic_authoritative_envelope(),
+        )
+        .expect("a wider page is still a ranking that named nothing");
+        assert_eq!(wide["kind"], json!("no_named_match"));
+        assert_eq!(wide["interpretation"], json!("unnamed_ranking"));
+        // Qualification, never filtering: every row served is still counted.
+        assert_eq!(wide["result_count"], json!(50));
+        // The verdict is widened only in the safe direction. It says the ranking
+        // named nothing, never that the graph holds nothing.
+        assert_eq!(wide["safe_to_conclude_absent"], json!(false));
+        assert_eq!(wide["trust"], json!("inconclusive"));
+    }
+
+    /// The control that keeps the widened verdict honest: a published
+    /// `all_fallback` of false means a name hit is somewhere in the ranking, and
+    /// that is true of a windowed page exactly as it is of a whole one.
+    #[test]
+    fn a_cosine_page_whose_ranking_holds_a_name_hit_is_never_qualified() {
+        for (served, total) in [(50_usize, 56_u64), (2, 2)] {
+            // The daemon omits `all_fallback` when the ranking holds a name hit,
+            // so an ordinary answer carries no such key and one row reports the
+            // exact match.
+            let mut rows: Vec<Value> = (0..served.saturating_sub(1))
+                .map(|index| cosine_locate_hit(&format!("neighbor_{index}"), "none"))
+                .collect();
+            rows.insert(0, cosine_locate_hit("locate_result_count", "exact"));
+            let payload = json!({
+                "query": "locate_result_count",
+                "granularity": "entity",
+                "routing": "cosine-v0",
+                "page": 0,
+                "total_ranked": total,
+                "results": rows,
+            });
+            assert!(
+                negative_for(
+                    "semantic_locate",
+                    &payload,
+                    &semantic_authoritative_envelope()
+                )
+                .is_none(),
+                "a ranking holding the named symbol is not an unnamed ranking \
+                 ({served} of {total})"
+            );
+        }
+    }
+
+    /// An older daemon publishes no `all_fallback`, and its verdict must not
+    /// change. Everything the widened branch adds is read off a field that
+    /// daemon never sends, so the inference is exactly what still answers here.
+    #[test]
+    fn a_payload_without_all_fallback_keeps_the_inferred_verdict() {
+        let whole_ranking = json!({
+            "query": "zzqqxx_nonexistent_symbol_9f3a",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 2,
+            "results": [
+                cosine_locate_hit("neighbor_one", "none"),
+                cosine_locate_hit("neighbor_two", "partial"),
+            ],
+        });
+        assert!(
+            negative_for(
+                "semantic_locate",
+                &whole_ranking,
+                &semantic_authoritative_envelope()
+            )
+            .is_some(),
+            "the inference still qualifies a page that holds its whole ranking"
+        );
+
+        let windowed = json!({
+            "query": "zzqqxx_nonexistent_symbol_9f3a",
+            "routing": "cosine-v0",
+            "page": 0,
+            "total_ranked": 9,
+            "results": [cosine_locate_hit("neighbor_one", "none")],
+        });
+        assert!(
+            negative_for(
+                "semantic_locate",
+                &windowed,
+                &semantic_authoritative_envelope()
+            )
+            .is_none(),
+            "without a published verdict a window is still unguessable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Asking for more results removed the honesty envelope. On the default locate arm
a fabricated symbol at limit 8 came back with one ranked row and the
`no_named_match` disclosure; the same symbol at the same daemon seconds later at
limit 50 came back with fifty confident scored rows and no disclosure at all.

`locate_ranking_names_nothing` read the two arms differently. The fused arm used
the payload's own `all_fallback`, computed over the full ranking before paging.
The default cosine arm inferred the same fact from every row's
`match_evidence.name_match`, and only when `total_ranked <= rows.len()`, so it
refused to guess about rows it could not see. That refusal was right. What made
it a guard that could not fire is that `total_ranked` is not a fixed property of
a query. It grows with the requested limit, measured at 1 to 56 and 15 to 107
for two fabricated symbols on a fresh fully embedded store, so the page covers
the ranking only when the ranking collapses to a degenerate row or two. The
disclosure was present in the one case nobody queries and absent in every case
they do, which is a check that cannot fail pointed at the product's own honesty
layer.

kin#786 removed the reason for the asymmetry. The cosine arm now publishes
`all_fallback` itself, computed over the whole retained `rows` with exactly the
fused rule, before the daemon windows a page. Both arms omit the field when it
is false, so its presence is authoritative and routing does not enter into it.

The verdict now reads that published field whatever the arm, and keeps the
`match_evidence` inference only for a payload that carries no such field, which
is an older daemon. Disclosure becomes a property of the answer instead of a
property of how many rows the caller happened to ask for.

## Ordering

kin#786 and kin#791 both merged on 2026-08-12, so the two constraints the ticket
named are met. kin#791 landing first is what keeps the widened verdict
inconclusive by construction, saying the ranking named nothing and never that
the graph holds nothing, which is the safe direction the ticket asked for.

kin#813 is a third constraint the ticket did not name, and it is the one that
decides whether this widened verdict is honest or noise. On main without it,
`query_names_entity` takes only the last DOTTED segment and cannot see through
`::`. The parsers store every Rust and C++ method as `Type::method`, so no row
of a method query is labelled a name match, so `locate_rows_are_all_fallback` is
true, so the daemon publishes `all_fallback` even on a page whose top row IS the
symbol. This change makes the negative envelope act on that field at any limit,
and its admission gate fires on any token of three characters or more containing
an underscore, which is the snake_case shape a developer types. So main carrying
this change without kin#813 would tell an agent that no ranked entity carries
the name it asked for, on a page that does contain it, for essentially every
method query against a Rust or C++ graph. That converts a silent miss into a
confident false statement on the honesty layer itself, which is the failure the
0.5.19 dogfood called a regression in kind. kin#813 is what makes the published
field true only when it should be.

So this lands behind kin#813, either with kin#813 on main first or in the same
merge-group batch with kin#813 ahead. The two change different files,
`crates/kin-cli/src/commands/locate.rs` against `crates/kin-mcp/src/negative.rs`,
so batching them is mechanically fine. If kin#813 is ever reverted or ejected,
this has to go with it.

## Evidence

Three tests. The decisive one is the measured pair as one query at two limits
against one daemon, and it goes red on the unfixed code, verified by reverting
the branch locally and rerunning:

```
a_cosine_page_wider_than_its_window_still_carries_the_unnamed_verdict
  panicked: a wider page is still a ranking that named nothing
```

The other two are the controls that keep the widening honest rather than
proving it: a ranking holding a name hit is never qualified, on a windowed page
as well as a whole one, and a payload without `all_fallback` keeps today's
inferred verdict exactly, so an older daemon does not change answer. Both pass
before and after, which is what a regression guard is supposed to do.

Gate: `kin-dev local-test kin` on this worktree at 676386b1, 5608 tests run,
5608 passed, tracked lock restored with no contamination. CI-equivalent
`cargo clippy --all-targets --all-features` with the ci.yml allowlist exits 0
with no new warnings. `cargo fmt --all --check` clean.

## Not claiming

No real-store rerun of the limit-8 against limit-50 pair. The payload shapes
under test are transcribed from the recorded wire measurements rather than
captured fresh.

Closes FIR-2262
