### PR TITLE
Move the bootstrap transaction into the commit instead of copying it

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -359,7 +359,7 @@ fn init_from_git_with_hooks(
     progress.begin("commit bootstrap transaction");
     {
         let _span = info_span!("kin.init.commit_bootstrap_transaction").entered();
-        prepared.commit_repository_bootstrap(&transaction)?;
+        prepared.commit_repository_bootstrap(transaction)?;
     }
 
     let mut result = publish_repository_layout_linearized(prepared, |publication| {

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -304,12 +304,13 @@ impl PreparedRepositoryInit {
     /// different transaction is rejected once bootstrap authority exists.
     pub fn commit_repository_bootstrap(
         &mut self,
-        transaction: &RepositoryTransaction,
+        transaction: RepositoryTransaction,
     ) -> Result<&RepositoryBootstrap> {
         verify_metadata_seal(&self.layout, &self.metadata_seal)?;
         let transaction_hash = transaction
             .transaction_hash()
             .map_err(|error| KinError::Other(error.to_string()))?;
+        let operation_id = transaction.operation_id;
         let repository_id = &self.repository_id;
         let workspace_id = self.workspace_id;
         let default_ref = &self.default_ref;
@@ -320,7 +321,7 @@ impl PreparedRepositoryInit {
         match &mut self.bootstrap {
             Some(bootstrap) => {
                 if bootstrap.receipt.transaction_hash != transaction_hash
-                    || bootstrap.receipt.operation_id != transaction.operation_id
+                    || bootstrap.receipt.operation_id != operation_id
                 {
                     return Err(KinError::Other(
                         "staged repository already has a different bootstrap transaction"
@@ -333,7 +334,7 @@ impl PreparedRepositoryInit {
                 {
                     let _span = info_span!("kin.init.commit.validate_bootstrap").entered();
                     validate_bootstrap_transaction(
-                        transaction,
+                        &transaction,
                         repository_id,
                         workspace_id,
                         default_ref,
@@ -580,7 +581,7 @@ fn init_with_config(
         SharedAdmissionPolicy::empty(0),
         None,
     )?;
-    prepared.commit_repository_bootstrap(&transaction)?;
+    prepared.commit_repository_bootstrap(transaction)?;
     let result = publish_repository_layout(prepared)?;
 
     info!(
@@ -1299,7 +1300,7 @@ where
         &prepared_default_ref,
         &initial_roots,
     )?;
-    commit_bootstrap_transaction(authority, &transaction, &repository_id, workspace_id)
+    commit_bootstrap_transaction(authority, transaction, &repository_id, workspace_id)
 }
 
 fn build_repository_bootstrap_transaction(
@@ -1417,32 +1418,35 @@ fn build_repository_bootstrap_transaction(
 
 fn commit_bootstrap_transaction<B>(
     authority: &RepositoryAuthorityManager<B>,
-    transaction: &RepositoryTransaction,
+    transaction: RepositoryTransaction,
     repository_id: &RepositoryId,
     workspace_id: WorkspaceId,
 ) -> Result<RepositoryBootstrap>
 where
     B: StorageBackend + 'static,
 {
-    // The clone is measured separately from the commit it feeds. A bootstrap
-    // transaction carries every reachable external object and every change in
-    // history, so on a real repository this copies tens of thousands of records
-    // to satisfy an owned-parameter API, and the caller drops the original
-    // immediately afterwards. Whether that is worth removing is a measurement,
-    // not a guess, so it gets its own span rather than hiding inside the commit.
-    let owned_transaction = {
+    // A bootstrap transaction carries every reachable external object and every
+    // change in history, so on a repository with real history a copy taken to
+    // satisfy the owned-parameter commit is a second whole-history allocation,
+    // charged at the point init already holds its largest working set. The
+    // transaction is therefore moved into the commit rather than cloned, and
+    // every field the receipt is checked against is read before the move.
+    let initial_change_id = transaction
+        .workspace_mutation
+        .as_ref()
+        .and_then(|mutation| match mutation.new_base_target {
+            Some(RefTarget::Change { change_id }) => Some(change_id),
+            _ => None,
+        });
+    let receipt = {
         let _span = info_span!(
-            "kin.init.commit.clone_transaction",
+            "kin.init.commit.authority_commit",
             external_objects = transaction.external_objects.len(),
             changes = transaction.changes.len()
         )
         .entered();
-        transaction.clone()
-    };
-    let receipt = {
-        let _span = info_span!("kin.init.commit.authority_commit").entered();
         authority
-            .commit_repository_transaction(owned_transaction)
+            .commit_repository_transaction(transaction)
             .map_err(graph_error)?
     };
     let workspace = {
@@ -1475,13 +1479,6 @@ where
         }
         crate::durable_semantic_enrichment_summary(&lease, &workspace_id)?
     };
-    let initial_change_id = transaction
-        .workspace_mutation
-        .as_ref()
-        .and_then(|mutation| match mutation.new_base_target {
-            Some(RefTarget::Change { change_id }) => Some(change_id),
-            _ => None,
-        });
     Ok(RepositoryBootstrap {
         receipt,
         workspace,
@@ -3203,7 +3200,7 @@ mod tests {
         let expected_repository = prepared.repository_id().clone();
 
         let bootstrap = prepared
-            .commit_repository_bootstrap(&transaction)
+            .commit_repository_bootstrap(transaction.clone())
             .unwrap()
             .clone();
         let published = publish_repository_layout(prepared).unwrap();
@@ -3250,7 +3247,7 @@ mod tests {
             None,
         )
         .unwrap();
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
 
         let published = publish_repository_layout(prepared).unwrap();
 
@@ -3264,11 +3261,11 @@ mod tests {
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "retry");
 
         let first = prepared
-            .commit_repository_bootstrap(&transaction)
+            .commit_repository_bootstrap(transaction.clone())
             .unwrap()
             .clone();
         let replay = prepared
-            .commit_repository_bootstrap(&transaction)
+            .commit_repository_bootstrap(transaction.clone())
             .unwrap()
             .clone();
         assert_eq!(first, replay);
@@ -3276,7 +3273,7 @@ mod tests {
         let mut different = transaction;
         different.operation_id = OperationId::new();
         let error = prepared
-            .commit_repository_bootstrap(&different)
+            .commit_repository_bootstrap(different.clone())
             .unwrap_err();
         assert!(error
             .to_string()
@@ -3291,7 +3288,7 @@ mod tests {
         transaction.default_ref_mutation = None;
 
         let error = prepared
-            .commit_repository_bootstrap(&transaction)
+            .commit_repository_bootstrap(transaction.clone())
             .unwrap_err();
 
         assert!(error.to_string().contains("default ref must exactly match"));
@@ -3360,7 +3357,7 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "metadata-drift");
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
         std::fs::write(
             prepared.layout.config_path(),
@@ -3381,7 +3378,7 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "uncertain");
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error = publish_repository_layout_linearized(prepared, |publication| {
@@ -3405,7 +3402,7 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "collision");
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         std::fs::create_dir(&final_kin).unwrap();
@@ -3424,7 +3421,7 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "final-check");
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error = publish_repository_layout_linearized(prepared, |_publication| {
@@ -3447,7 +3444,7 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "unused-capability");
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error =
@@ -3466,7 +3463,7 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "post-publish-check");
-        prepared.commit_repository_bootstrap(&transaction).unwrap();
+        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error = publish_repository_layout_linearized(prepared, |publication| {

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -3247,7 +3247,9 @@ mod tests {
             None,
         )
         .unwrap();
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
 
         let published = publish_repository_layout(prepared).unwrap();
 
@@ -3357,7 +3359,9 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "metadata-drift");
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
         std::fs::write(
             prepared.layout.config_path(),
@@ -3378,7 +3382,9 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "uncertain");
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error = publish_repository_layout_linearized(prepared, |publication| {
@@ -3402,7 +3408,9 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "collision");
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         std::fs::create_dir(&final_kin).unwrap();
@@ -3421,7 +3429,9 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "final-check");
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error = publish_repository_layout_linearized(prepared, |_publication| {
@@ -3444,7 +3454,9 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "unused-capability");
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error =
@@ -3463,7 +3475,9 @@ mod tests {
         let working_dir = directory.path().canonicalize().unwrap();
         let final_kin = working_dir.join(".kin");
         let (mut prepared, transaction) = prepare_unborn(directory.path(), "post-publish-check");
-        prepared.commit_repository_bootstrap(transaction.clone()).unwrap();
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
         let staging_root = prepared.layout.root().to_path_buf();
 
         let error = publish_repository_layout_linearized(prepared, |publication| {

--- a/crates/kin-core/tests/init_peak_heap_ceiling.rs
+++ b/crates/kin-core/tests/init_peak_heap_ceiling.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Peak-heap ceiling for admitting real Git history.
+//!
+//! Init peaked at 46.2 GiB admitting a 2190-commit repository, holding several
+//! whole-history structures at once. Peak memory is what decides whether init
+//! runs at all on a small machine, and it is invisible to every other test in
+//! this workspace: a structure held live for a phase longer than it needs to be
+//! changes no output and fails no assertion, and is only felt on a machine that
+//! then has to swap.
+//!
+//! The guard measures live heap directly rather than resident set. RSS is a
+//! high-water mark of pages the allocator has touched, so it keeps counting
+//! memory that was freed but not returned to the OS, which makes it reproducible
+//! only within one allocator and one platform. Live heap moves when, and only
+//! when, the code allocates differently.
+//!
+//! This binary installs a counting global allocator, so it holds exactly one
+//! test on purpose. The counter is process-wide, and a second test running
+//! beside it would charge its allocations to this one.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+fn charge(bytes: usize) {
+    let live = LIVE.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    PEAK.fetch_max(live, Ordering::Relaxed);
+}
+
+// SAFETY: every branch forwards to the system allocator with the same pointer
+// and layout it was given, and only adjusts counters around that call.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            charge(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            charge(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let fresh = unsafe { System.realloc(ptr, layout, new_size) };
+        if !fresh.is_null() {
+            if new_size >= layout.size() {
+                charge(new_size - layout.size());
+            } else {
+                LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        fresh
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// Commits in the fixture history.
+///
+/// Init's cost scales with history depth, so the fixture buys depth. The
+/// modules below are sized so the admitted history, rather than init's fixed
+/// overhead, dominates the measurement; with a two-file-per-commit tree the
+/// fixed cost swamps everything and the number stops tracking the code.
+const COMMITS: usize = 32;
+
+/// Modules rewritten on every commit.
+const MODULES: usize = 10;
+
+/// Types defined in each module.
+const ITEMS_PER_MODULE: usize = 8;
+
+/// Ceiling on peak live heap for admitting `COMMITS` commits.
+///
+/// Measured at 317 MiB on this fixture. The headroom is set to catch a change
+/// that holds another whole-history structure live, which is the failure this
+/// path has actually produced: init already keeps the import plan, the admitted
+/// plan, and the bootstrap transaction alive at once, and each one it adds is a
+/// step change rather than a trim.
+///
+/// Be precise about what this ceiling does and does not catch as written.
+/// Removing the whole-history copy that motivated it moved this fixture by
+/// 22 MiB, about 6 percent, matching the 6.9 percent it moved a 2190-commit
+/// repository. This ceiling is loose enough that a change that size passes, so
+/// it is a floor under gross regressions rather than proof no copy came back,
+/// and a change to the commit path still needs its own measurement.
+///
+/// The headroom is deliberately larger than the measurement needs, and that is
+/// the part worth revisiting. Two clean runs on one host landed within 5 KB of
+/// each other, 0.002 percent, against a 22 MiB signal, so locally the ceiling
+/// could sit far tighter and still catch the copy. It is set wide because that
+/// determinism has only been observed on macOS, and this suite also runs on
+/// Linux and Windows, where a different allocator and parser behavior may shift
+/// the baseline. Tighten it once the number has been seen on all three, rather
+/// than on the strength of one platform: a ceiling that flakes in the merge
+/// queue costs more than the regression it would have caught.
+const PEAK_HEAP_CEILING: usize = 448 * 1024 * 1024;
+
+fn git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "Kin Fixture")
+        .env("GIT_AUTHOR_EMAIL", "fixture@firelock.ai")
+        .env("GIT_COMMITTER_NAME", "Kin Fixture")
+        .env("GIT_COMMITTER_EMAIL", "fixture@firelock.ai")
+        .output()
+        .unwrap_or_else(|error| panic!("git {args:?} failed to start: {error}"));
+    assert!(
+        status.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+}
+
+fn build_history(repo: &Path) {
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    git(repo, &["init", "--initial-branch=main"]);
+    git(repo, &["config", "user.name", "Kin Fixture"]);
+    git(repo, &["config", "user.email", "fixture@firelock.ai"]);
+    std::fs::write(repo.join("Cargo.toml"), b"[package]\nname = \"fixture\"\n").unwrap();
+
+    for commit in 0..COMMITS {
+        // Every commit rewrites the whole module set, so the admitted history
+        // carries a full tree delta and a fresh set of semantic entities per
+        // commit rather than a single-file edit. That is what makes history,
+        // not fixed init overhead, the dominant term in the measurement.
+        for module in 0..MODULES {
+            let mut body = String::new();
+            for item in 0..ITEMS_PER_MODULE {
+                body.push_str(&format!(
+                    "pub struct Item{module}_{item}_{commit} {{ pub field: u32 }}\n\
+                     impl Item{module}_{item}_{commit} {{\n\
+                     pub fn build() -> Self {{ Self {{ field: {commit} }} }}\n\
+                     pub fn read(&self) -> u32 {{ self.field }}\n\
+                     }}\n"
+                ));
+            }
+            std::fs::write(repo.join(format!("src/mod_{module}.rs")), body.as_bytes()).unwrap();
+        }
+        git(repo, &["add", "-A"]);
+        git(repo, &["commit", "-m", &format!("commit {commit}")]);
+    }
+}
+
+#[test]
+fn admitting_git_history_stays_under_the_init_heap_ceiling() {
+    let workspace = tempfile::tempdir().unwrap();
+    let repo = workspace.path().join("source");
+    std::fs::create_dir(&repo).unwrap();
+    build_history(&repo);
+
+    let repo = repo.canonicalize().unwrap();
+    PEAK.store(LIVE.load(Ordering::SeqCst), Ordering::SeqCst);
+    let baseline = LIVE.load(Ordering::SeqCst);
+
+    kin_core::init_from_git(&repo).expect("admit the fixture repository");
+
+    let peak = PEAK.load(Ordering::SeqCst).saturating_sub(baseline);
+    println!(
+        "peak live heap admitting {COMMITS} commits: {peak} bytes ({:.1} MiB), ceiling {} MiB",
+        peak as f64 / 1024.0 / 1024.0,
+        PEAK_HEAP_CEILING / 1024 / 1024
+    );
+    assert!(
+        peak < PEAK_HEAP_CEILING,
+        "admitting {COMMITS} commits peaked at {peak} bytes of live heap, over the \
+         {PEAK_HEAP_CEILING} byte ceiling. Init already holds the import plan, the admitted \
+         plan, and the bootstrap transaction at the same time, so a structure kept live for \
+         a phase longer than it needs to be is charged where the working set is already \
+         largest. On a repository with real history that is the difference between init \
+         running on a small machine and swapping it."
+    );
+}


### PR DESCRIPTION
A fresh `kin init` on this repository peaks at 46.2 GiB resident. That is a first-touch
adoption blocker, and it is worse than the 25 GB the ticket recorded. This moves it to
43.1 GiB and cuts 4 minutes off the run, and it corrects the diagnosis the ticket was
carrying.

## The diagnosis on the ticket was wrong, and so were its numbers

The only prior reproduction was killed at 21.1 GB while step 11 was still running, so it
concluded step 11 was the peak. Running it to completion on the same corpus shows step 11
is not close. The peak is step 13, "commit bootstrap transaction", which adds 20 GiB on its
own and holds the maximum. "Step 11" was an artifact of where the kill landed.

Method, because a number without one is not evidence: full local clone of this repository,
2190 commits and 699 files at HEAD, identical corpus and method on both arms, embeddings
off. Peak is `/usr/bin/time -l` `ru_maxrss`, the kernel high-water mark, chosen over
sampling because sampling can miss a peak. An independent 2s sampler agreed to within
0.01 GiB on the before arm. The host had 128 GB and zero swap in use, so the full arm could
run to completion instead of being killed.

| phase | before | after | change |
|---|---|---|---|
| 5 derive semantic history | +7.03G | +7.08G | +0.05G |
| 6 apply admission policy | +2.50G | +2.46G | -0.04G |
| 7 prove Git source | +3.46G | +3.46G | -0.01G |
| 11 build bootstrap transaction | +5.44G | +5.46G | +0.01G |
| **13 commit bootstrap transaction** | **+19.97G** | **+16.78G** | **-3.19G** |
| **peak** | **46.24G** | **43.06G** | **-3.17G** |

Wall time went from 1356s to 1111s. Every phase except the one edited moves within noise,
which is the evidence that the change does what it claims and nothing else.

## The change

Committing a bootstrap transaction took an owned parameter while the caller held a borrow,
so init copied the transaction whole and dropped the original immediately afterwards. That
transaction carries every reachable external object and every change in history, so the copy
is a second whole-history allocation charged exactly where init's working set is already
largest.

The comment on that code asked for a measurement before anyone touched it. This is that
measurement, so the copy is now a move: ownership is threaded from both production callers
through `commit_repository_bootstrap` into `commit_bootstrap_transaction`. The receipt
identity and the initial change id are read before the move. No derivation, validation, or
proof changes. Tests that reuse a transaction across calls clone explicitly.

The three fixes proposed on the ticket all target step 11, which the measurement shows is
not the peak. The third of them, streaming admission, is the one that removes the class, and
it is architectural enough to want its own lane.

## Guard

A peak-heap ceiling over a fixture whose history dominates init's fixed overhead, in its own
test binary because it installs a counting global allocator. It counts live heap rather than
resident set: RSS keeps counting pages the allocator freed but never returned, so it is
reproducible only within one platform.

It was falsified rather than assumed. Putting the copy back moves the fixture 6.5%, matching
the 6.9% seen at full scale, which is evidence the fixture tracks the defect and also proof
that this ceiling cannot catch that particular regression, since a ceiling loose enough not
to flake cannot see 6%. So it is set to catch a change that holds *another whole-history
structure* live, which is this path's real failure class, and the constant says exactly that
in place along with what would have to be observed before tightening it.

## What this does not do

It does not resolve the ticket. 43 GiB is still far above a 16 GB laptop, so the adoption
blocker stands and FIR-2166 stays open. The remaining cost is located: 16.8 GiB of step 13
is `commit_repository_transaction` inside kin-db, and roughly 16 GiB more sits in steps 5, 7
and 11, which re-derive whole histories in-process to compare against values the same
process derived moments earlier from the same inputs. Those are in-repo and are the obvious
next lever, but they remove proofs on the citable init path and deserve their own review
rather than being folded into a memory fix.

One protocol note for whoever picks that up: the depth-ladder reproduction proposed on the
ticket cannot run. `kin init` refuses a shallow repository outright at phase 2, so history
depth has to be varied with `reset --hard` plus a prune, not `git clone --depth`.

Refs FIR-2166. Deliberately not a Closes line: the blocker the ticket was filed for is
still there at 43 GiB, so the issue stays open with the phase profile above recorded on it.
