### PR TITLE
Give the four locally-answered list commands a real --json

### DIFF
--- a/crates/kin-cli/src/commands/assistant.rs
+++ b/crates/kin-cli/src/commands/assistant.rs
@@ -145,6 +145,20 @@ fn adapter_entries(adapters: &[kin_core::AssistantAdapterConfig]) -> Vec<Assista
         .collect()
 }
 
+/// The envelope `--json` prints, built in one place so a test can gate it.
+///
+/// The runtime must not assemble this inline: a test that built its own copy
+/// would keep passing while the printed document drifted, which is the shape of
+/// a check that cannot fail.
+fn assistant_list_payload(adapters: &[kin_core::AssistantAdapterConfig]) -> AssistantListJson {
+    let adapters = adapter_entries(adapters);
+    AssistantListJson {
+        schema: ASSISTANT_LIST_SCHEMA,
+        count: adapters.len(),
+        adapters,
+    }
+}
+
 /// `kin assistant list` — List installed assistant adapters.
 pub async fn list(json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
@@ -155,13 +169,10 @@ pub async fn list(json: bool) -> Result<()> {
     // adapter. That guidance is for a human at a terminal; the machine surface
     // answers with a zero count and the same stamped envelope.
     if json {
-        let entries = adapter_entries(&adapters);
-        let payload = AssistantListJson {
-            schema: ASSISTANT_LIST_SCHEMA,
-            count: entries.len(),
-            adapters: entries,
-        };
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&assistant_list_payload(&adapters))?
+        );
         return Ok(());
     }
 
@@ -474,15 +485,9 @@ mod tests {
     /// right answer for a human and unparseable for anything else.
     #[test]
     fn no_installed_adapter_answers_with_a_stamped_zero() {
-        let entries = adapter_entries(&[]);
-        assert!(entries.is_empty());
+        assert!(adapter_entries(&[]).is_empty());
 
-        let payload = AssistantListJson {
-            schema: ASSISTANT_LIST_SCHEMA,
-            count: entries.len(),
-            adapters: entries,
-        };
-        let value = serde_json::to_value(&payload).unwrap();
+        let value = serde_json::to_value(assistant_list_payload(&[])).unwrap();
         assert_eq!(value["schema"], ASSISTANT_LIST_SCHEMA);
         assert_eq!(value["count"].as_u64().unwrap(), 0);
         assert!(

--- a/crates/kin-cli/src/commands/assistant.rs
+++ b/crates/kin-cli/src/commands/assistant.rs
@@ -3,9 +3,13 @@
 
 use anyhow::Result;
 use kin_model::{EntityStore, WorkStore};
+use serde::Serialize;
 
 use kin_core::{doctor, install_adapter, list_adapters, AssistantKind};
 use kin_core::{ManagedDocConfig, RepoSummary, SyncMode};
+
+/// Schema token stamped on every `kin assistant list --json` answer.
+pub const ASSISTANT_LIST_SCHEMA: &str = "kin.assistant.list.v1";
 
 /// `kin assistant install <assistant>` — Install an assistant adapter.
 pub async fn install(assistant: String) -> Result<()> {
@@ -112,11 +116,54 @@ pub async fn run_doctor(assistant: Option<String>) -> Result<()> {
     Ok(())
 }
 
+/// One installed assistant adapter.
+#[derive(Debug, Serialize)]
+pub struct AssistantAdapterEntry {
+    /// Canonical adapter id, the token `kin assistant install` accepts.
+    pub kind: String,
+    pub display_name: String,
+    pub mcp_capable: bool,
+    pub cooperative: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AssistantListJson {
+    pub schema: &'static str,
+    pub count: usize,
+    pub adapters: Vec<AssistantAdapterEntry>,
+}
+
+fn adapter_entries(adapters: &[kin_core::AssistantAdapterConfig]) -> Vec<AssistantAdapterEntry> {
+    adapters
+        .iter()
+        .map(|config| AssistantAdapterEntry {
+            kind: config.kind.as_str().to_string(),
+            display_name: config.display_name.clone(),
+            mcp_capable: config.mcp_capable,
+            cooperative: config.cooperative,
+        })
+        .collect()
+}
+
 /// `kin assistant list` — List installed assistant adapters.
-pub async fn list() -> Result<()> {
+pub async fn list(json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
 
     let adapters = list_adapters(&layout)?;
+
+    // The text path spends its empty case teaching the reader how to install an
+    // adapter. That guidance is for a human at a terminal; the machine surface
+    // answers with a zero count and the same stamped envelope.
+    if json {
+        let entries = adapter_entries(&adapters);
+        let payload = AssistantListJson {
+            schema: ASSISTANT_LIST_SCHEMA,
+            count: entries.len(),
+            adapters: entries,
+        };
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
 
     if adapters.is_empty() {
         println!("No assistant adapters installed.");
@@ -415,4 +462,75 @@ fn build_repo_summary(layout: &kin_core::KinLayout) -> Result<RepoSummary> {
         work_item_count: work_items.len(),
         coverage_ratio: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A repository with no adapter installed answers with a stamped zero.
+    ///
+    /// The text path spends its empty case on install guidance, which is the
+    /// right answer for a human and unparseable for anything else.
+    #[test]
+    fn no_installed_adapter_answers_with_a_stamped_zero() {
+        let entries = adapter_entries(&[]);
+        assert!(entries.is_empty());
+
+        let payload = AssistantListJson {
+            schema: ASSISTANT_LIST_SCHEMA,
+            count: entries.len(),
+            adapters: entries,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(value["schema"], ASSISTANT_LIST_SCHEMA);
+        assert_eq!(value["count"].as_u64().unwrap(), 0);
+        assert!(
+            value["adapters"].is_array(),
+            "the list must be present and empty, never absent"
+        );
+    }
+
+    /// Every installed adapter reaches the payload with the fields the table
+    /// prints, and `kind` is the canonical token rather than the display name.
+    ///
+    /// The two are different strings on purpose: `kind` is what
+    /// `kin assistant install` accepts back, so a caller round-tripping the
+    /// display name would build a command that fails.
+    #[test]
+    fn the_json_surface_carries_each_adapter_with_its_installable_kind() {
+        let installed = list_adapters_fixture();
+        let entries = adapter_entries(&installed);
+
+        assert_eq!(entries.len(), installed.len());
+        for (entry, config) in entries.iter().zip(installed.iter()) {
+            assert_eq!(entry.kind, config.kind.as_str());
+            assert_eq!(entry.display_name, config.display_name);
+            assert_eq!(entry.mcp_capable, config.mcp_capable);
+            assert_eq!(entry.cooperative, config.cooperative);
+        }
+
+        assert!(
+            AssistantKind::from_str(&entries[0].kind).is_some(),
+            "kind must be the token `kin assistant install` accepts"
+        );
+        assert!(
+            AssistantKind::from_str("kin-not-a-real-assistant").is_none(),
+            "the round-trip probe must be able to answer no, or the assertion \
+             above proves nothing"
+        );
+    }
+
+    fn list_adapters_fixture() -> Vec<kin_core::AssistantAdapterConfig> {
+        let dir = tempfile::tempdir().unwrap();
+        kin_core::init(dir.path()).unwrap();
+        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
+        install_adapter(&layout, AssistantKind::ClaudeCode).unwrap();
+        let installed = list_adapters(&layout).unwrap();
+        assert!(
+            !installed.is_empty(),
+            "an empty fixture would make every assertion above vacuous"
+        );
+        installed
+    }
 }

--- a/crates/kin-cli/src/commands/backup.rs
+++ b/crates/kin-cli/src/commands/backup.rs
@@ -90,6 +90,19 @@ fn collect_backups(backups_dir: &PathBuf) -> Result<Vec<BackupEntry>> {
     Ok(backups)
 }
 
+/// The envelope `--json` prints, built in one place so a test can gate it.
+///
+/// The runtime must not assemble this inline: a test that built its own copy
+/// would keep passing while the printed document drifted, which is the shape of
+/// a check that cannot fail.
+fn backup_list_payload(backups: Vec<BackupEntry>) -> BackupListJson {
+    BackupListJson {
+        schema: BACKUP_LIST_SCHEMA,
+        count: backups.len(),
+        backups,
+    }
+}
+
 /// `kin backup list` — List available backups.
 pub async fn list(json: bool) -> Result<()> {
     let layout = discover_layout()?;
@@ -102,12 +115,10 @@ pub async fn list(json: bool) -> Result<()> {
     // A caller parsing this must never have to distinguish "no backups" from
     // "not JSON".
     if json {
-        let payload = BackupListJson {
-            schema: BACKUP_LIST_SCHEMA,
-            count: backups.len(),
-            backups,
-        };
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&backup_list_payload(backups))?
+        );
         return Ok(());
     }
 
@@ -367,12 +378,7 @@ mod tests {
         let backups = collect_backups(&dir.path().to_path_buf()).unwrap();
         assert!(backups.is_empty());
 
-        let payload = BackupListJson {
-            schema: BACKUP_LIST_SCHEMA,
-            count: backups.len(),
-            backups,
-        };
-        let value = serde_json::to_value(&payload).unwrap();
+        let value = serde_json::to_value(backup_list_payload(backups)).unwrap();
         assert_eq!(value["schema"], BACKUP_LIST_SCHEMA);
         assert_eq!(value["count"].as_u64().unwrap(), 0);
         assert!(
@@ -403,12 +409,7 @@ mod tests {
         assert_eq!(backups[1].size_bytes, 2);
         assert!(backups[0].path.ends_with("graph-20260101-000000.kndb"));
 
-        let payload = BackupListJson {
-            schema: BACKUP_LIST_SCHEMA,
-            count: backups.len(),
-            backups,
-        };
-        let value = serde_json::to_value(&payload).unwrap();
+        let value = serde_json::to_value(backup_list_payload(backups)).unwrap();
         assert_eq!(
             value["count"].as_u64().unwrap() as usize,
             value["backups"].as_array().unwrap().len()

--- a/crates/kin-cli/src/commands/backup.rs
+++ b/crates/kin-cli/src/commands/backup.rs
@@ -5,7 +5,11 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
+
+/// Schema token stamped on every `kin backup list --json` answer.
+pub const BACKUP_LIST_SCHEMA: &str = "kin.backup.list.v1";
 
 /// `kin backup create` — Create a timestamped backup of the graph snapshot.
 pub async fn create(tag: Option<String>) -> Result<()> {
@@ -48,28 +52,73 @@ pub async fn create(tag: Option<String>) -> Result<()> {
     Ok(())
 }
 
+/// One backup on disk, as both the table and the JSON surface describe it.
+#[derive(Debug, Serialize)]
+pub struct BackupEntry {
+    /// Backup filename, the token `kin backup restore` matches against.
+    pub name: String,
+    /// Absolute path to the backup file.
+    pub path: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackupListJson {
+    pub schema: &'static str,
+    pub count: usize,
+    pub backups: Vec<BackupEntry>,
+}
+
+/// The backups directory's contents, projected for display.
+///
+/// Reads the same `list_backup_entries` walk the text path has always used, so
+/// the two surfaces cannot report different sets.
+fn collect_backups(backups_dir: &PathBuf) -> Result<Vec<BackupEntry>> {
+    let mut backups = Vec::new();
+    for path in list_backup_entries(backups_dir)? {
+        let meta = fs::metadata(&path)
+            .with_context(|| format!("failed to read metadata for {}", path.display()))?;
+        backups.push(BackupEntry {
+            name: path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            path: path.display().to_string(),
+            size_bytes: meta.len(),
+        });
+    }
+    Ok(backups)
+}
+
 /// `kin backup list` — List available backups.
-pub async fn list() -> Result<()> {
+pub async fn list(json: bool) -> Result<()> {
     let layout = discover_layout()?;
     let backups_dir = layout.backups_dir();
 
-    let entries = list_backup_entries(&backups_dir)?;
+    let backups = collect_backups(&backups_dir)?;
 
-    if entries.is_empty() {
+    // An empty set is an ANSWER, not an absence, so `--json` emits the same
+    // stamped envelope with a zero count rather than the prose the table shows.
+    // A caller parsing this must never have to distinguish "no backups" from
+    // "not JSON".
+    if json {
+        let payload = BackupListJson {
+            schema: BACKUP_LIST_SCHEMA,
+            count: backups.len(),
+            backups,
+        };
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    if backups.is_empty() {
         println!("No backups found.");
         return Ok(());
     }
 
-    println!("{} backup(s):", entries.len());
-    for entry in &entries {
-        let meta = fs::metadata(entry)
-            .with_context(|| format!("failed to read metadata for {}", entry.display()))?;
-        let name = entry
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_default();
-        let size = meta.len();
-        println!("  {} ({} bytes)", name, size);
+    println!("{} backup(s):", backups.len());
+    for entry in &backups {
+        println!("  {} ({} bytes)", entry.name, entry.size_bytes);
     }
 
     Ok(())
@@ -304,6 +353,66 @@ mod tests {
             .unwrap()
             .to_string_lossy()
             .starts_with("graph-"));
+    }
+
+    /// An empty backups directory is an answer, so the envelope still goes out
+    /// stamped with a zero count.
+    ///
+    /// This is the property the whole flag exists for: a caller must never have
+    /// to tell "no backups" apart from "not JSON", which is exactly what the
+    /// text path's `No backups found.` forces it to do.
+    #[test]
+    fn the_json_surface_answers_an_empty_directory_with_a_stamped_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let backups = collect_backups(&dir.path().to_path_buf()).unwrap();
+        assert!(backups.is_empty());
+
+        let payload = BackupListJson {
+            schema: BACKUP_LIST_SCHEMA,
+            count: backups.len(),
+            backups,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(value["schema"], BACKUP_LIST_SCHEMA);
+        assert_eq!(value["count"].as_u64().unwrap(), 0);
+        assert!(
+            value["backups"].is_array(),
+            "the list must be present and empty, never absent"
+        );
+    }
+
+    /// Sizes and names are read off the files rather than restated, and the
+    /// count matches the list it describes.
+    #[test]
+    fn the_json_surface_reports_the_backups_on_disk_with_their_real_sizes() {
+        let dir = tempfile::tempdir().unwrap();
+        let backups_dir = dir.path().to_path_buf();
+        fs::write(backups_dir.join("graph-20260101-000000.kndb"), b"abcde").unwrap();
+        fs::write(backups_dir.join("graph-20260102-000000.kndb"), b"xy").unwrap();
+        // Neither the extension nor the prefix matches, so neither may appear.
+        fs::write(backups_dir.join("graph-notes.txt"), b"ignored").unwrap();
+        fs::write(backups_dir.join("other-20260103-000000.kndb"), b"ignored").unwrap();
+
+        let backups = collect_backups(&backups_dir).unwrap();
+        let names: Vec<&str> = backups.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["graph-20260101-000000.kndb", "graph-20260102-000000.kndb"]
+        );
+        assert_eq!(backups[0].size_bytes, 5);
+        assert_eq!(backups[1].size_bytes, 2);
+        assert!(backups[0].path.ends_with("graph-20260101-000000.kndb"));
+
+        let payload = BackupListJson {
+            schema: BACKUP_LIST_SCHEMA,
+            count: backups.len(),
+            backups,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(
+            value["count"].as_u64().unwrap() as usize,
+            value["backups"].as_array().unwrap().len()
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -17,6 +17,9 @@ use url::Url;
 
 use crate::commands::auth;
 
+/// Schema token stamped on every `kin remote list --json` answer.
+pub const REMOTE_LIST_SCHEMA: &str = "kin.remote.list.v1";
+
 #[derive(Debug, Clone)]
 pub(crate) struct PushPlanContext {
     pub(crate) remote: RemoteRefConfig,
@@ -368,9 +371,87 @@ pub(crate) fn ensure_git_remote(working_dir: &Path, name: &str, url: Option<&str
     Ok(())
 }
 
-pub async fn list() -> Result<()> {
+/// One explicitly configured Kin remote.
+#[derive(Debug, Serialize)]
+pub struct RemoteEntry {
+    pub name: String,
+    pub host: String,
+    pub transport: String,
+    pub default: bool,
+    pub url: Option<String>,
+}
+
+/// One Git coexistence remote sealed from repository-local Git config.
+#[derive(Debug, Serialize)]
+pub struct SealedGitRemoteEntry {
+    pub name: String,
+    pub host: String,
+    pub transport: String,
+    pub url: Option<String>,
+}
+
+/// `count` counts `remotes` alone, never the two lists summed.
+///
+/// The sealed list is a different kind of thing: those remotes were read out of
+/// Git rather than configured in Kin, and a single total would let a caller
+/// report configured remotes that do not exist. Its length is its own count.
+///
+/// Both arrays are always emitted. The text path shows sealed remotes only when
+/// no explicit remote is configured, which is a display choice about what is
+/// worth crowding a terminal with; a machine surface that dropped them would be
+/// hiding state the repository actually holds.
+#[derive(Debug, Serialize)]
+pub struct RemoteListJson {
+    pub schema: &'static str,
+    pub count: usize,
+    pub remotes: Vec<RemoteEntry>,
+    pub sealed_git_remotes: Vec<SealedGitRemoteEntry>,
+}
+
+fn collect_remotes(config: &KinConfig) -> Vec<RemoteEntry> {
+    config
+        .remote
+        .refs
+        .iter()
+        .map(|remote| RemoteEntry {
+            name: remote.name.clone(),
+            host: remote.host.to_string(),
+            transport: remote.transport.to_string(),
+            default: config.remote.default.as_deref() == Some(remote.name.as_str()),
+            url: remote.url.clone(),
+        })
+        .collect()
+}
+
+fn collect_sealed_git_remotes(config: &KinConfig) -> Vec<SealedGitRemoteEntry> {
+    config
+        .git
+        .remotes
+        .iter()
+        .map(|sealed| SealedGitRemoteEntry {
+            name: sealed.name.clone(),
+            host: sealed.host_kind().to_string(),
+            transport: RemoteTransportKind::GitExport.to_string(),
+            url: sealed.publish_url().map(str::to_string),
+        })
+        .collect()
+}
+
+pub async fn list(json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let config = KinConfig::load_or_default(&layout.config_path())?;
+
+    if json {
+        let remotes = collect_remotes(&config);
+        let payload = RemoteListJson {
+            schema: REMOTE_LIST_SCHEMA,
+            count: remotes.len(),
+            remotes,
+            sealed_git_remotes: collect_sealed_git_remotes(&config),
+        };
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
 
     if config.remote.refs.is_empty() {
         println!("No explicit Kin remotes configured.");
@@ -931,6 +1012,97 @@ mod tests {
             fetch_refspecs: vec![format!("+refs/heads/*:refs/remotes/{name}/*")],
             push_refspecs: Vec::new(),
         }
+    }
+
+    /// `count` describes `remotes` alone.
+    ///
+    /// Summing the two lists would report configured Kin remotes that were
+    /// never configured, so this asserts the count against a config where the
+    /// two lengths differ. Were `count` the sum, it would read 3 here.
+    #[test]
+    fn the_json_count_describes_the_configured_remotes_alone() {
+        let mut config = KinConfig::default();
+        config.remote.refs = vec![test_remote("origin")];
+        config.remote.default = Some("origin".to_string());
+        config.git.remotes = vec![
+            sealed_remote("upstream", "https://github.invalid/acme/app.git"),
+            sealed_remote("mirror", "https://gitlab.invalid/acme/mirror.git"),
+        ];
+
+        let remotes = super::collect_remotes(&config);
+        let payload = super::RemoteListJson {
+            schema: super::REMOTE_LIST_SCHEMA,
+            count: remotes.len(),
+            remotes,
+            sealed_git_remotes: super::collect_sealed_git_remotes(&config),
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(value["schema"], super::REMOTE_LIST_SCHEMA);
+        assert_eq!(value["count"].as_u64().unwrap(), 1);
+        assert_eq!(value["remotes"].as_array().unwrap().len(), 1);
+        assert_eq!(value["sealed_git_remotes"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            value["count"].as_u64().unwrap() as usize,
+            value["remotes"].as_array().unwrap().len(),
+            "count must track the remotes array, never the two lists summed"
+        );
+    }
+
+    /// Sealed Git remotes are emitted even when an explicit remote exists.
+    ///
+    /// The text path shows them only when no explicit remote is configured.
+    /// That is a choice about crowding a terminal, and a machine surface that
+    /// copied it would drop state the repository actually holds, invisibly.
+    #[test]
+    fn sealed_git_remotes_survive_an_explicit_remote_being_configured() {
+        let mut config = KinConfig::default();
+        config.remote.refs = vec![test_remote("origin")];
+        config.git.remotes = vec![sealed_remote(
+            "upstream",
+            "https://github.invalid/acme/app.git",
+        )];
+
+        let sealed = super::collect_sealed_git_remotes(&config);
+        assert_eq!(sealed.len(), 1);
+        assert_eq!(sealed[0].name, "upstream");
+        assert_eq!(
+            sealed[0].url.as_deref(),
+            Some("https://github.invalid/acme/app.git")
+        );
+        assert_eq!(
+            sealed[0].transport,
+            RemoteTransportKind::GitExport.to_string()
+        );
+        assert_eq!(sealed[0].host, RemoteHostKind::GitHub.to_string());
+
+        // The control: with no sealed remotes the list is empty, so the
+        // assertions above distinguish presence from a list that is always full.
+        config.git.remotes.clear();
+        assert!(super::collect_sealed_git_remotes(&config).is_empty());
+    }
+
+    /// The default flag marks exactly the configured default, and nothing else.
+    #[test]
+    fn exactly_the_default_remote_is_flagged_default() {
+        let mut config = KinConfig::default();
+        config.remote.refs = vec![test_remote("origin"), test_remote("backup")];
+        config.remote.default = Some("backup".to_string());
+
+        let remotes = super::collect_remotes(&config);
+        let flagged: Vec<&str> = remotes
+            .iter()
+            .filter(|remote| remote.default)
+            .map(|remote| remote.name.as_str())
+            .collect();
+        assert_eq!(flagged, vec!["backup"]);
+
+        // With no default configured nothing is flagged, so the assertion above
+        // is about the configured value rather than about position in the list.
+        config.remote.default = None;
+        assert!(super::collect_remotes(&config)
+            .iter()
+            .all(|remote| !remote.default));
     }
 
     #[cfg(unix)]

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -437,19 +437,30 @@ fn collect_sealed_git_remotes(config: &KinConfig) -> Vec<SealedGitRemoteEntry> {
         .collect()
 }
 
+/// The envelope `--json` prints, built in one place so a test can gate it.
+///
+/// The runtime must not assemble this inline: a test that built its own copy
+/// would keep passing while the printed document drifted, which is the shape of
+/// a check that cannot fail.
+fn remote_list_payload(config: &KinConfig) -> RemoteListJson {
+    let remotes = collect_remotes(config);
+    RemoteListJson {
+        schema: REMOTE_LIST_SCHEMA,
+        count: remotes.len(),
+        remotes,
+        sealed_git_remotes: collect_sealed_git_remotes(config),
+    }
+}
+
 pub async fn list(json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
     let config = KinConfig::load_or_default(&layout.config_path())?;
 
     if json {
-        let remotes = collect_remotes(&config);
-        let payload = RemoteListJson {
-            schema: REMOTE_LIST_SCHEMA,
-            count: remotes.len(),
-            remotes,
-            sealed_git_remotes: collect_sealed_git_remotes(&config),
-        };
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&remote_list_payload(&config))?
+        );
         return Ok(());
     }
 
@@ -1029,14 +1040,7 @@ mod tests {
             sealed_remote("mirror", "https://gitlab.invalid/acme/mirror.git"),
         ];
 
-        let remotes = super::collect_remotes(&config);
-        let payload = super::RemoteListJson {
-            schema: super::REMOTE_LIST_SCHEMA,
-            count: remotes.len(),
-            remotes,
-            sealed_git_remotes: super::collect_sealed_git_remotes(&config),
-        };
-        let value = serde_json::to_value(&payload).unwrap();
+        let value = serde_json::to_value(super::remote_list_payload(&config)).unwrap();
 
         assert_eq!(value["schema"], super::REMOTE_LIST_SCHEMA);
         assert_eq!(value["count"].as_u64().unwrap(), 1);

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -1067,7 +1067,10 @@ mod tests {
             "https://github.invalid/acme/app.git",
         )];
 
-        let sealed = super::collect_sealed_git_remotes(&config);
+        // Read the payload the command prints, not the collector beneath it.
+        // Suppression would live in the payload builder, so a test that called
+        // the collector directly could not see it happen.
+        let sealed = super::remote_list_payload(&config).sealed_git_remotes;
         assert_eq!(sealed.len(), 1);
         assert_eq!(sealed[0].name, "upstream");
         assert_eq!(
@@ -1083,7 +1086,9 @@ mod tests {
         // The control: with no sealed remotes the list is empty, so the
         // assertions above distinguish presence from a list that is always full.
         config.git.remotes.clear();
-        assert!(super::collect_sealed_git_remotes(&config).is_empty());
+        assert!(super::remote_list_payload(&config)
+            .sealed_git_remotes
+            .is_empty());
     }
 
     /// The default flag marks exactly the configured default, and nothing else.

--- a/crates/kin-cli/src/commands/spec.rs
+++ b/crates/kin-cli/src/commands/spec.rs
@@ -80,6 +80,19 @@ fn collect_specs(specs_dir: &Path) -> Result<Vec<SpecEntry>> {
     Ok(specs)
 }
 
+/// The envelope `--json` prints, built in one place so a test can gate it.
+///
+/// The runtime must not assemble this inline: a test that built its own copy
+/// would keep passing while the printed document drifted, which is the shape of
+/// a check that cannot fail.
+fn spec_list_payload(specs: Vec<SpecEntry>) -> SpecListJson {
+    SpecListJson {
+        schema: SPEC_LIST_SCHEMA,
+        count: specs.len(),
+        specs,
+    }
+}
+
 pub async fn list(json: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
 
@@ -89,12 +102,10 @@ pub async fn list(json: bool) -> Result<()> {
     // An empty set is an answer, so the stamped envelope goes out with a zero
     // count rather than the prose the text path prints.
     if json {
-        let payload = SpecListJson {
-            schema: SPEC_LIST_SCHEMA,
-            count: specs.len(),
-            specs,
-        };
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&spec_list_payload(specs))?
+        );
         return Ok(());
     }
 
@@ -187,12 +198,7 @@ mod tests {
         let specs = collect_specs(&dir.path().join("specs")).unwrap();
         assert!(specs.is_empty());
 
-        let payload = SpecListJson {
-            schema: SPEC_LIST_SCHEMA,
-            count: specs.len(),
-            specs,
-        };
-        let value = serde_json::to_value(&payload).unwrap();
+        let value = serde_json::to_value(spec_list_payload(specs)).unwrap();
         assert_eq!(value["schema"], SPEC_LIST_SCHEMA);
         assert_eq!(value["count"].as_u64().unwrap(), 0);
         assert!(
@@ -221,12 +227,7 @@ mod tests {
         assert_eq!(specs[0].intent, "name the embedding gap");
         assert_eq!(specs[1].intent, "tighten the reconcile loop");
 
-        let payload = SpecListJson {
-            schema: SPEC_LIST_SCHEMA,
-            count: specs.len(),
-            specs,
-        };
-        let value = serde_json::to_value(&payload).unwrap();
+        let value = serde_json::to_value(spec_list_payload(specs)).unwrap();
         assert_eq!(
             value["count"].as_u64().unwrap() as usize,
             value["specs"].as_array().unwrap().len()

--- a/crates/kin-cli/src/commands/spec.rs
+++ b/crates/kin-cli/src/commands/spec.rs
@@ -2,8 +2,13 @@
 // Copyright 2026 Firelock, LLC
 
 use std::fs;
+use std::path::Path;
 
 use anyhow::Result;
+use serde::Serialize;
+
+/// Schema token stamped on every `kin spec list --json` answer.
+pub const SPEC_LIST_SCHEMA: &str = "kin.spec.list.v1";
 
 pub async fn create(intent: String) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
@@ -33,30 +38,72 @@ pub async fn create(intent: String) -> Result<()> {
     Ok(())
 }
 
-pub async fn list() -> Result<()> {
-    let layout = crate::commands::require_repository_layout()?;
+/// One stored spec, as both the list and the JSON surface describe it.
+#[derive(Debug, Serialize)]
+pub struct SpecEntry {
+    pub id: String,
+    pub intent: String,
+}
 
-    let specs_dir = layout.root().join("specs");
+#[derive(Debug, Serialize)]
+pub struct SpecListJson {
+    pub schema: &'static str,
+    pub count: usize,
+    pub specs: Vec<SpecEntry>,
+}
+
+/// Every spec stored under `<root>/specs`, ordered by filename.
+///
+/// A missing directory yields an empty list rather than an error: a repository
+/// that has never created a spec is a repository with no specs, which is an
+/// answer both surfaces can state.
+fn collect_specs(specs_dir: &Path) -> Result<Vec<SpecEntry>> {
     if !specs_dir.exists() {
-        println!("No specs found.");
-        return Ok(());
+        return Ok(Vec::new());
     }
 
-    let mut entries: Vec<_> = fs::read_dir(&specs_dir)?
+    let mut entries: Vec<_> = fs::read_dir(specs_dir)?
         .filter_map(|e| e.ok())
         .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
         .collect();
+    entries.sort_by_key(|e| e.file_name());
 
-    if entries.is_empty() {
+    let mut specs = Vec::new();
+    for entry in &entries {
+        let content = fs::read_to_string(entry.path())?;
+        let spec: kin_model::Spec = serde_json::from_str(&content)?;
+        specs.push(SpecEntry {
+            id: spec.id.to_string(),
+            intent: spec.intent,
+        });
+    }
+    Ok(specs)
+}
+
+pub async fn list(json: bool) -> Result<()> {
+    let layout = crate::commands::require_repository_layout()?;
+
+    let specs_dir = layout.root().join("specs");
+    let specs = collect_specs(&specs_dir)?;
+
+    // An empty set is an answer, so the stamped envelope goes out with a zero
+    // count rather than the prose the text path prints.
+    if json {
+        let payload = SpecListJson {
+            schema: SPEC_LIST_SCHEMA,
+            count: specs.len(),
+            specs,
+        };
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    if specs.is_empty() {
         println!("No specs found.");
         return Ok(());
     }
 
-    entries.sort_by_key(|e| e.file_name());
-
-    for entry in &entries {
-        let content = fs::read_to_string(entry.path())?;
-        let spec: kin_model::Spec = serde_json::from_str(&content)?;
+    for spec in &specs {
         println!("  {} - {}", spec.id, spec.intent);
     }
 
@@ -104,4 +151,87 @@ pub async fn show(id: String) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The filename and the stored id are set independently on purpose: the
+    /// walk orders by filename and reads the id out of the file, so a test that
+    /// tied them together could not tell the two apart.
+    fn write_spec(specs_dir: &Path, file_stem: &str, id: &str, intent: &str) {
+        let spec = serde_json::json!({
+            "id": id,
+            "intent": intent,
+            "scope": [],
+            "constraints": [],
+            "acceptance_criteria": [],
+            "affected_systems": [],
+            "validation_requirements": [],
+        });
+        fs::write(
+            specs_dir.join(format!("{file_stem}.json")),
+            serde_json::to_string_pretty(&spec).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// A repository that never created a spec has no specs, which is an answer.
+    ///
+    /// The directory is absent in that case, and the text path prints prose for
+    /// it. The machine surface must still emit a parseable stamped envelope.
+    #[test]
+    fn a_missing_specs_directory_answers_with_a_stamped_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let specs = collect_specs(&dir.path().join("specs")).unwrap();
+        assert!(specs.is_empty());
+
+        let payload = SpecListJson {
+            schema: SPEC_LIST_SCHEMA,
+            count: specs.len(),
+            specs,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(value["schema"], SPEC_LIST_SCHEMA);
+        assert_eq!(value["count"].as_u64().unwrap(), 0);
+        assert!(
+            value["specs"].is_array(),
+            "the list must be present and empty, never absent"
+        );
+    }
+
+    /// Specs come back ordered by filename, carrying the id and intent the text
+    /// path prints, and non-JSON files in the directory are not specs.
+    #[test]
+    fn the_json_surface_carries_every_stored_spec_in_filename_order() {
+        const FIRST_ID: &str = "11111111-1111-4111-8111-111111111111";
+        const SECOND_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+        let dir = tempfile::tempdir().unwrap();
+        let specs_dir = dir.path().join("specs");
+        fs::create_dir_all(&specs_dir).unwrap();
+        write_spec(&specs_dir, "b", SECOND_ID, "tighten the reconcile loop");
+        write_spec(&specs_dir, "a", FIRST_ID, "name the embedding gap");
+        fs::write(specs_dir.join("notes.md"), b"not a spec").unwrap();
+
+        let specs = collect_specs(&specs_dir).unwrap();
+        let ids: Vec<&str> = specs.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec![FIRST_ID, SECOND_ID]);
+        assert_eq!(specs[0].intent, "name the embedding gap");
+        assert_eq!(specs[1].intent, "tighten the reconcile loop");
+
+        let payload = SpecListJson {
+            schema: SPEC_LIST_SCHEMA,
+            count: specs.len(),
+            specs,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(
+            value["count"].as_u64().unwrap() as usize,
+            value["specs"].as_array().unwrap().len()
+        );
+        assert!(value["specs"][0]["id"].is_string());
+        assert!(value["specs"][0]["intent"].is_string());
+    }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1242,7 +1242,11 @@ enum BackupAction {
         tag: Option<String>,
     },
     /// List available backups
-    List,
+    List {
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Restore the graph from a backup
     Restore {
         /// Backup name (partial match supported)
@@ -1288,7 +1292,11 @@ enum SpecAction {
         intent: String,
     },
     /// List specs
-    List,
+    List {
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Show a spec
     Show {
         /// Spec ID
@@ -1378,7 +1386,11 @@ enum GitAction {
 #[derive(Subcommand)]
 enum RemoteAction {
     /// List configured and detected remotes
-    List,
+    List {
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Add or update a configured remote
     Add {
         /// Remote name
@@ -1611,7 +1623,11 @@ enum AssistantAction {
         assistant: Option<String>,
     },
     /// List installed adapters
-    List,
+    List {
+        /// Output machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Sync managed doc blocks
     Sync,
     /// Configure managed doc sync targets
@@ -2813,7 +2829,7 @@ fn main() -> Result<()> {
                 Command::Xref { entity } => commands::xref::run(entity).await,
                 Command::Spec { action } => match action {
                     SpecAction::Create { intent } => commands::spec::create(intent).await,
-                    SpecAction::List => commands::spec::list().await,
+                    SpecAction::List { json } => commands::spec::list(json).await,
                     SpecAction::Show { id } => commands::spec::show(id).await,
                 },
                 Command::Merge { branch, json } => {
@@ -2878,7 +2894,7 @@ fn main() -> Result<()> {
                     AuthAction::Status { base_url } => commands::auth::status(base_url).await,
                 },
                 Command::Remote { action } => match action {
-                    RemoteAction::List => commands::remote::list().await,
+                    RemoteAction::List { json } => commands::remote::list(json).await,
                     RemoteAction::Add {
                         name,
                         host,
@@ -3021,7 +3037,7 @@ fn main() -> Result<()> {
                 }
                 Command::Backup { action } => match action {
                     BackupAction::Create { tag } => commands::backup::create(tag).await,
-                    BackupAction::List => commands::backup::list().await,
+                    BackupAction::List { json } => commands::backup::list(json).await,
                     BackupAction::Restore { name, latest } => {
                         commands::backup::restore(name, latest).await
                     }
@@ -3123,7 +3139,7 @@ fn main() -> Result<()> {
                     AssistantAction::Doctor { assistant } => {
                         commands::assistant::run_doctor(assistant).await
                     }
-                    AssistantAction::List => commands::assistant::list().await,
+                    AssistantAction::List { json } => commands::assistant::list(json).await,
                     AssistantAction::Sync => commands::assistant::sync().await,
                     AssistantAction::Configure {
                         sync_mode,

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -47,7 +47,7 @@
         "fs::create_dir_all(&specs_dir)?;",
         "fs::write(&spec_file, &json)?;",
         "if !specs_dir.exists() {",
-        "let mut entries: Vec<_> = fs::read_dir(&specs_dir)?",
+        "let mut entries: Vec<_> = fs::read_dir(specs_dir)?",
         "let content = fs::read_to_string(entry.path())?;",
         "if !spec_file.exists() {",
         "let content = fs::read_to_string(&spec_file)?;"


### PR DESCRIPTION
FIR-2159 named thirteen list commands with no `--json` and described one mechanism behind all of them: a daemon-rendered `lines` array with no structured field to serialize. A source read found that holds for four of the thirteen. Four others never reach the daemon at all, and this change covers those.

`backup list` reads the backups directory, `spec list` reads the specs directory, `remote list` reads `KinConfig`, and `assistant list` reads the adapter registry. Each printed as it walked, so the problem was that there was nothing to serialize, not that what came back was unstructured.

Each command now splits collecting from printing, and `--json` emits a stamped envelope carrying a schema token, a count, and the list. The text output is unchanged, and the diff shows no format string altered.

An empty result goes out as a stamped envelope with a zero count rather than the prose the text path prints. That is the property the flag exists for. Every one of these commands answered an empty set with a sentence, so a caller had to tell "no backups" apart from "not JSON", and now it does not.

Two shapes here are deliberate and carry tests. `remote list` holds two lists, so `count` describes the configured Kin remotes alone; summing it with the sealed Git remotes would report Kin remotes that were never configured. And the JSON surface emits sealed Git remotes even when an explicit remote exists, where the text path hides them, because that suppression is a choice about crowding a terminal and a machine surface copying it would drop repository state invisibly.

Steps 3 and 4 of the ticket's recipe, a response schema version and a version-skew guard, do not apply to these four. Both presuppose a daemon that can be older than its client, and there is no second process here.

The tests were built to be able to fail, and that was not true at first. They asserted against payloads they constructed themselves, so the runtime could have printed anything. Each command now has one payload builder that both the runtime and its test call. Four canaries confirm the tests bite: counting the two remote lists summed fails with left 3 against right 1, hiding sealed remotes behind an explicit remote fails with left 0 against right 1, reporting an adapter's display name where its installable token belongs fails with "Claude Code" against "claude-code", and flooring an empty count at one fails with left 1 against right 0.

Not closing FIR-2159. This is the no-daemon group, four of thirteen. The nine remaining split into four the ticket's recipe fits as written and five that already parse a structured payload and throw it away to print. Those five gate on whether the CLI re-emits the hosted API shape or maps into a Kin-owned type, which is a contract decision rather than mechanical work.

Gate: `cargo nextest run --workspace` plus `cargo test --doc` run through `bin/kin-lane run` against the lane worktree, header confirming `.kin-coord/worktrees/smalltix2-kin @ c8c68294`. 5615 tests run, 5615 passed. Clippy under the ci.yml allowlist is clean. Smoked end to end on a real repo: all four flags emit a parseable envelope empty and populated, and `intent list --json` still errors, which is the control that this change is scoped to the four commands it names.
