### PR TITLE
Add MCP Registry publish chain, MCPB packaging, and a stdio Docker stage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2002,6 +2002,153 @@ jobs:
             "$daemon_bin" --version
           fi
 
+  # Update the MCP Registry entry for `ai.kinlab/kin`. The registry is the
+  # substrate the other MCP catalogs read, and it validates the npm package the
+  # entry points at against live npm, so this runs only after @kinlab/kin-mcp
+  # is public at this exact version. Prerelease tags are skipped: the registry
+  # treats the newest published version as the current one, and a candidate
+  # must not become what a catalog offers.
+  #
+  # Authority is the DNS door: an Ed25519 key proves control of kinlab.ai
+  # through a TXT record. The registry also accepts
+  # `./mcp-publisher login http --domain kinlab.ai`, which proves the same
+  # namespace from https://kinlab.ai/.well-known/mcp-registry-auth, if that
+  # record is ever lost.
+  #
+  # The whole job is continue-on-error. A registry outage, a lapsed DNS record,
+  # or an unset key must never refuse a release that is already public on npm
+  # and GitHub, and the registry publishes no uptime or durability guarantee.
+  # When the publish does not happen the summary says so plainly, because a
+  # green job that published nothing is the failure mode this posture buys.
+  publish_mcp_registry:
+    name: Publish to the MCP Registry
+    needs: publish_npm_compatibility
+    if: >-
+      ${{
+        always() &&
+        needs.publish_npm_compatibility.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v') &&
+        !contains(github.ref_name, '-')
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release
+    permissions:
+      contents: read
+    continue-on-error: true
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set the released version in server.json
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          jq --arg v "$version" '.version = $v | .packages[0].version = $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          jq -e --arg v "$version" \
+            '.version == $v and .packages[0].version == $v' server.json > /dev/null
+          # The registry refuses the publish unless package.json's mcpName is
+          # exactly server.json's name, and it reports that as a package
+          # validation failure rather than as the mismatch it is.
+          jq -e --slurpfile pkg packages/kin-mcp/package.json \
+            '.name == $pkg[0].mcpName' server.json > /dev/null
+          jq -e --slurpfile pkg packages/kin-mcp/package.json \
+            '.packages[0].identifier == $pkg[0].name' server.json > /dev/null
+
+      - name: Wait for npm to serve the published version
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          for attempt in $(seq 1 12); do
+            if [ "$(npm view "@kinlab/kin-mcp@${version}" version 2>/dev/null)" = "$version" ]; then
+              echo "npm serves @kinlab/kin-mcp@${version}"
+              exit 0
+            fi
+            [ "$attempt" -eq 12 ] || sleep 10
+          done
+          echo "::error::npm does not serve @kinlab/kin-mcp@${version} yet; the registry validates against live npm, so nothing was published"
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
+            | tar xz mcp-publisher
+          test -x ./mcp-publisher
+
+      - name: Authenticate to the MCP Registry
+        id: registry_login
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MCP_PRIVATE_KEY:-}" ]; then
+            echo "::warning::MCP_PRIVATE_KEY is not configured; the MCP Registry entry will not be published"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+          ./mcp-publisher login dns --domain kinlab.ai --private-key "$MCP_PRIVATE_KEY"
+
+      - name: Publish the server entry
+        id: registry_publish
+        if: steps.registry_login.outputs.configured == 'true'
+        run: ./mcp-publisher publish
+
+      - name: Read the entry back from the registry
+        id: registry_verify
+        if: steps.registry_login.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          body="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=ai.kinlab")"
+          printf '%s\n' "$body" | jq .
+          {
+            echo "### MCP Registry search for ai.kinlab"
+            echo
+            echo '```json'
+            printf '%s\n' "$body" | jq .
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s' "$body" \
+            | jq -e '[.servers[]? | .server | select(.name == "ai.kinlab/kin")] | length > 0' \
+            > /dev/null
+
+      - name: Report the registry outcome
+        if: always()
+        env:
+          CONFIGURED: ${{ steps.registry_login.outputs.configured }}
+          PUBLISHED: ${{ steps.registry_publish.outcome }}
+          READ_BACK: ${{ steps.registry_verify.outcome }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          if [ "${PUBLISHED:-}" = "success" ] && [ "${READ_BACK:-}" = "success" ]; then
+            {
+              echo "### MCP Registry"
+              echo
+              echo "\`ai.kinlab/kin\` ${version} is published and reads back from the registry."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "### MCP Registry"
+            echo
+            echo "**The MCP Registry publish did NOT happen for ${GITHUB_REF_NAME}.**"
+            echo
+            echo "- credential configured: ${CONFIGURED:-no}"
+            echo "- publish step: ${PUBLISHED:-did not run}"
+            echo "- read back step: ${READ_BACK:-did not run}"
+            echo
+            echo "The release itself is unaffected. npm, GitHub, the installers, and the images do not depend on this entry, which is why this job cannot refuse a release. Rerun this job, or run mcp-publisher by hand, once the cause is fixed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   finalize_release:
     name: Promote Proven Release
     needs: [publish, install_proof, version_tag_image, smoke_npm_published]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,35 @@ RUN if [ -n "$KIN_BUILD_GIT_SHA" ] || [ -n "$KIN_BUILD_DIRTY" ] || [ -n "$KIN_BU
       cargo build --locked --release --features gcs --bin kin-daemon --bin kin; \
     fi
 
+# Alternate image: Kin's MCP stdio server instead of the daemon. Select it
+# explicitly with `docker build --target mcp`. It sits BEFORE the runtime stage
+# on purpose: a build with no `--target` takes the last stage, so the daemon
+# image every existing build produces (docker.yml, cloudbuild.yaml,
+# release.yml, docker-compose.yml) is unchanged by this stage existing.
+#
+# It repeats the pinned base rather than deriving from that runtime stage
+# because every FROM here has to name its registry and pin a digest:
+# scripts/verify-base-image-pins.sh proves each pin against two registries, and
+# scripts/test-release-workflow-authority.py refuses any base a mirror could
+# resolve differently. A `FROM <stage>` line carries neither, and both checks
+# gate a release.
+FROM docker.io/library/debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd AS mcp
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
+RUN groupadd -r kin \
+    && useradd -r -g kin -d /home/kin -m kin \
+    && chmod 0700 /home/kin
+ENV HOME=/home/kin
+WORKDIR /app
+COPY --from=builder /build/kin/target/release/kin /usr/local/bin/kin
+# The MCP server is transport-only: it forwards graph tools to the repo daemon
+# it resolves for the mounted repository, so the daemon binary has to be here
+# even though nothing in this image starts one and no port is published.
+COPY --from=builder /build/kin/target/release/kin-daemon /usr/local/bin/kin-daemon
+USER kin
+# stdio transport: MCP travels over stdin and stdout, so run this image with
+# `-i`, mount the repository, and set the working directory to it.
+ENTRYPOINT ["/usr/local/bin/kin", "mcp", "start"]
+
 FROM docker.io/library/debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates curl libssl3 && rm -rf /var/lib/apt/lists/*
 RUN groupadd -r kin \

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kinlab/kin-mcp",
   "version": "0.5.27",
+  "mcpName": "ai.kinlab/kin",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/scripts/mcpb/build.sh
+++ b/scripts/mcpb/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Build the Claude Desktop extension bundle (.mcpb) that wraps the published
+# @kinlab/kin-mcp launcher.
+#
+# Run this by hand. No release job packs the bundle yet, so nothing here is
+# release evidence and nothing here may be cited as a shipped channel.
+set -euo pipefail
+
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${here}/../.." && pwd)"
+icon_source="${repo_root}/assets/mcp/icon-512.png"
+icon_target="${here}/icon.png"
+
+if [ ! -f "$icon_source" ]; then
+  echo "error: the extension icon is missing: ${icon_source}" >&2
+  echo "manifest.json declares icon.png and Claude Desktop renders it on the extension card, so a bundle built without it ships an extension with no icon. Create that file as a 512x512 PNG with transparency, then rerun this script." >&2
+  exit 1
+fi
+
+cp -- "$icon_source" "$icon_target"
+echo "icon: ${icon_source} -> ${icon_target}"
+
+cd -- "$here"
+exec npx -y @anthropic-ai/mcpb pack

--- a/scripts/mcpb/manifest.json
+++ b/scripts/mcpb/manifest.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/mcpb/main/schemas/mcpb-manifest-v0.3.schema.json",
+  "manifest_version": "0.3",
+  "name": "kin",
+  "display_name": "Kin",
+  "version": "0.5.27",
+  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "author": {
+    "name": "Firelock, LLC",
+    "url": "https://kinlab.ai"
+  },
+  "homepage": "https://kinlab.ai",
+  "documentation": "https://github.com/firelock-ai/kin#readme",
+  "support": "https://github.com/firelock-ai/kin/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/firelock-ai/kin"
+  },
+  "license": "Apache-2.0",
+  "icon": "icon.png",
+  "keywords": [
+    "kin",
+    "mcp",
+    "code",
+    "search",
+    "graph"
+  ],
+  "privacy_policies": [
+    "https://kinlab.ai/privacy"
+  ],
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "win32"
+    ],
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  },
+  "user_config": {
+    "workspace_directory": {
+      "type": "directory",
+      "title": "Kin workspace",
+      "description": "The Kin repository this server answers from. Choose the directory that carries .kin/; run `kin init .` there first if it does not.",
+      "required": true
+    }
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/index.js"
+      ],
+      "env": {
+        "KIN_MCP_REPO": "${user_config.workspace_directory}"
+      }
+    }
+  }
+}

--- a/scripts/mcpb/server/index.js
+++ b/scripts/mcpb/server/index.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Entry point for the Claude Desktop extension. It runs the published
+// @kinlab/kin-mcp launcher through npx, from the workspace the user chose.
+//
+// The indirection is load-bearing in two ways that are invisible from the
+// manifest. An MCPB `mcp_config` carries command, args, env, and
+// platform_overrides, and no working directory. The launcher decides which
+// repository it serves from its own working directory and refuses every extra
+// argument, so neither an argument nor an environment variable alone can point
+// it at the workspace. Setting the child's cwd here is what binds the two.
+
+'use strict';
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+
+const workspace = process.env.KIN_MCP_REPO;
+
+if (!workspace) {
+  process.stderr.write(
+    'Kin: no workspace is configured. Open the Kin extension settings and choose the Kin repository to serve.\n'
+  );
+  process.exit(2);
+}
+
+let stats;
+try {
+  stats = fs.statSync(workspace);
+} catch (error) {
+  process.stderr.write(`Kin: the configured workspace ${workspace} could not be read (${error.message}).\n`);
+  process.exit(2);
+}
+
+if (!stats.isDirectory()) {
+  process.stderr.write(`Kin: the configured workspace ${workspace} is not a directory.\n`);
+  process.exit(2);
+}
+
+const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const child = spawn(npx, ['-y', '@kinlab/kin-mcp'], {
+  cwd: workspace,
+  stdio: 'inherit',
+  env: process.env
+});
+
+child.on('error', (error) => {
+  process.stderr.write(`Kin: ${npx} could not be started (${error.message}).\n`);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  process.exit(signal ? 1 : code === null ? 1 : code);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    child.kill(signal);
+  });
+}

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -570,6 +570,7 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
         "smoke_npm_published": (
             "Anonymous Published npm Smoke (${{ matrix.package }})"
         ),
+        "publish_mcp_registry": "Publish to the MCP Registry",
         "finalize_release": "Promote Proven Release",
         "promote_ghcr_latest": "Promote stable ghcr latest",
         "publish_boundary_contracts": "Post-release boundary contracts publish",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "ai.kinlab/kin",
+  "title": "Kin",
+  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "repository": {
+    "url": "https://github.com/firelock-ai/kin",
+    "source": "github"
+  },
+  "version": "0.5.27",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@kinlab/kin-mcp",
+      "version": "0.5.27",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds mcpName ai.kinlab/kin to the kin-mcp npm package, a root server.json (registry schema 2025-12-11, npm stdio package entry), and a publish_mcp_registry job in release.yml that runs after npm publish on release tags: installs mcp-publisher, authenticates via DNS with the MCP_PRIVATE_KEY secret, syncs both server.json version fields from the tag, publishes, and verifies via a registry search into the step summary. The job is continue-on-error with contents read-only and a 15 minute timeout so a registry outage or missing DNS record can never break the release train; prerelease tags are skipped.

Also adds scripts/mcpb (Desktop Extension manifest, entry-point shim that sets the server cwd from user config, and a pack script) and an mcp Dockerfile stage that runs kin mcp start on stdio. The default docker build target is unchanged. One census line added to scripts/test-release-workflow-authority.py for the new job.

Closes FIR-2303
Closes FIR-2306