### PR TITLE
Name the MCPB bundle output and give it a README

### DIFF
--- a/scripts/mcpb/.gitignore
+++ b/scripts/mcpb/.gitignore
@@ -1,0 +1,2 @@
+icon.png
+*.mcpb

--- a/scripts/mcpb/.mcpbignore
+++ b/scripts/mcpb/.mcpbignore
@@ -1,0 +1,2 @@
+build.sh
+.gitignore

--- a/scripts/mcpb/README.md
+++ b/scripts/mcpb/README.md
@@ -22,6 +22,9 @@ Windows are the supported platforms.
 
 https://kinlab.ai/privacy
 
+Every network exit the CLI, the daemon, and this launcher can make is enumerated in
+https://github.com/firelock-ai/kin/blob/main/docs/security/what-leaves-the-machine.md.
+
 ## Support
 
 Report problems at https://github.com/firelock-ai/kin/issues. The core is Apache-2.0 at

--- a/scripts/mcpb/README.md
+++ b/scripts/mcpb/README.md
@@ -1,0 +1,28 @@
+# Kin for Claude Desktop
+
+Kin keeps a living map of the software itself, so Claude answers from a graph of entities,
+relationships, changes, and provenance rather than from raw file search.
+
+The extension runs Kin's MCP server on your machine over stdio, against one repository you
+choose in the extension settings. Claude gets `semantic_locate`, `semantic_search`,
+`get_context_pack`, `trace_data_flow`, `impact_analysis`, and `find_references`, and
+answers them from that graph.
+
+## Setup
+
+Choose the Kin workspace in the extension settings. That directory has to carry `.kin/`.
+If it does not, run `kin init .` there first, otherwise the server stops and says so.
+
+You need Node 20 or newer. On first run the extension starts the published
+`@kinlab/kin-mcp` launcher, which downloads the matching Kin release archive from
+`https://github.com/firelock-ai/kin/releases/download` and caches it locally. macOS and
+Windows are the supported platforms.
+
+## Privacy Policy
+
+https://kinlab.ai/privacy
+
+## Support
+
+Report problems at https://github.com/firelock-ai/kin/issues. The core is Apache-2.0 at
+https://github.com/firelock-ai/kin.

--- a/scripts/mcpb/build.sh
+++ b/scripts/mcpb/build.sh
@@ -13,6 +13,7 @@ here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${here}/../.." && pwd)"
 icon_source="${repo_root}/assets/mcp/icon-512.png"
 icon_target="${here}/icon.png"
+bundle="${here}/kin.mcpb"
 
 if [ ! -f "$icon_source" ]; then
   echo "error: the extension icon is missing: ${icon_source}" >&2
@@ -23,5 +24,9 @@ fi
 cp -- "$icon_source" "$icon_target"
 echo "icon: ${icon_source} -> ${icon_target}"
 
+# Name the output explicitly. With no output argument mcpb names the bundle after the
+# directory it packed, so the file lands as mcpb.mcpb while the pack summary reports a
+# filename of kin-<version>.mcpb, and neither name is what gets uploaded.
 cd -- "$here"
-exec npx -y @anthropic-ai/mcpb pack
+npx -y @anthropic-ai/mcpb pack . "$bundle"
+echo "bundle: ${bundle}"


### PR DESCRIPTION
`mcpb pack` with no output argument names the bundle after the directory it packed, so `scripts/mcpb/build.sh` produced `scripts/mcpb/mcpb.mcpb` while the pack summary reported a filename of `kin-0.5.27.mcpb`. Neither name identifies the artifact that gets uploaded. The script now passes an explicit output path and prints it.

The bundle also shipped `build.sh` to whoever installed the extension and carried no README at all. A `.mcpbignore` drops the build script, and `README.md` gives the bundle its own Privacy Policy section pointing at https://kinlab.ai/privacy, beside the manifest's `privacy_policies` array.

The generated `icon.png` and the packed bundle landed untracked inside a tracked directory, so every build left the tree dirty. A directory-local `.gitignore` covers both.

Verified by running `scripts/mcpb/build.sh` from a clean checkout of `origin/main` at 0c2f0dfc: manifest schema validation passes, the bundle lands at `scripts/mcpb/kin.mcpb` at 12.9 kB over four entries (README.md, icon.png, manifest.json, server/index.js), `git status` is clean afterward, and `shellcheck` and `bash -n` are clean on the script.

Part of FIR-2306