### PR TITLE
Trim the registry description under the cap and add a dispatchable republish

### DIFF
--- a/.github/workflows/mcp-registry-republish.yml
+++ b/.github/workflows/mcp-registry-republish.yml
@@ -1,0 +1,105 @@
+# Publishes an already-released version to the MCP Registry from main's
+# server.json. A tag run resolves its source from the tag, so a server.json fix
+# on main can never reach a release whose registry publish already failed; this
+# dispatch is the fix-forward path for exactly that case. It requires the tag
+# and the npm package to exist, and unlike the release job it fails loud,
+# because a person asked for this publish and should hear the answer.
+name: MCP Registry Republish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Released version to publish, no leading v (tag and npm package must already exist)"
+        required: true
+        type: string
+
+jobs:
+  republish_mcp_registry:
+    name: Publish to the MCP Registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Validate the requested version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+          git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" > /dev/null
+
+      - name: Set the released version in server.json
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          jq -e --arg v "$VERSION" \
+            '.version == $v and .packages[0].version == $v' server.json > /dev/null
+          # The registry refuses the publish unless package.json's mcpName is
+          # exactly server.json's name, and it reports that as a package
+          # validation failure rather than as the mismatch it is.
+          jq -e --slurpfile pkg packages/kin-mcp/package.json \
+            '.name == $pkg[0].mcpName' server.json > /dev/null
+          jq -e --slurpfile pkg packages/kin-mcp/package.json \
+            '.packages[0].identifier == $pkg[0].name' server.json > /dev/null
+
+      - name: Confirm npm serves the published version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$(npm view "@kinlab/kin-mcp@${VERSION}" version 2>/dev/null)" != "$VERSION" ]; then
+            echo "::error::npm does not serve @kinlab/kin-mcp@${VERSION}; the registry validates against live npm, so this publish would be refused"
+            exit 1
+          fi
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
+            | tar xz mcp-publisher
+          test -x ./mcp-publisher
+
+      - name: Authenticate to the MCP Registry
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${MCP_PRIVATE_KEY:-}"
+          ./mcp-publisher login dns --domain kinlab.ai --private-key "$MCP_PRIVATE_KEY"
+
+      - name: Publish the server entry
+        run: ./mcp-publisher publish
+
+      - name: Read the entry back from the registry
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          body="$(curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=ai.kinlab")"
+          printf '%s\n' "$body" | jq .
+          {
+            echo "### MCP Registry search for ai.kinlab"
+            echo
+            echo '```json'
+            printf '%s\n' "$body" | jq .
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s' "$body" \
+            | jq -e --arg v "$VERSION" \
+              '[.servers[]? | .server | select(.name == "ai.kinlab/kin" and .version == $v)] | length > 0' \
+            > /dev/null

--- a/.github/workflows/mcp-registry-republish.yml
+++ b/.github/workflows/mcp-registry-republish.yml
@@ -6,6 +6,9 @@
 # because a person asked for this publish and should hear the answer.
 name: MCP Registry Republish
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -516,6 +516,11 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/link-check.yml": {
         "link-check": "Check public documentation links",
     },
+    # Manual fix-forward publisher for a release whose registry entry failed;
+    # workflow_dispatch only, so it never produces a pull request check.
+    ".github/workflows/mcp-registry-republish.yml": {
+        "republish_mcp_registry": "Publish to the MCP Registry",
+    },
     # Reports an ejection on the pull request the merge queue dropped. It runs
     # on workflow_run after the fact, produces no check on a pull request, and
     # so is never a required-context producer.

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.kinlab/kin",
   "title": "Kin",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance.",
   "repository": {
     "url": "https://github.com/firelock-ai/kin",
     "source": "github"


### PR DESCRIPTION
The v0.5.28 release's registry publish authenticated via the DNS proof and then failed validation: 422, `expected length <= 100` on `body.description`, because server.json carries the 184-character canonical description. This trims it to its first sentence (89 characters) and adds an `mcp-registry-republish` workflow_dispatch that publishes an already-released version from main's server.json, since a tag run resolves source from the tag and can never pick up this fix. The dispatch validates the version format, requires the tag and the live npm package, fails loud, and asserts the entry reads back from the registry search.

Closes FIR-2311