### PR TITLE
Let the registry republish dispatch from main

### DIFF
--- a/.github/workflows/mcp-registry-republish.yml
+++ b/.github/workflows/mcp-registry-republish.yml
@@ -22,7 +22,6 @@ jobs:
     name: Publish to the MCP Registry
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: release
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
The dispatched republish for 0.5.28 failed instantly: the release environment's deployment branch policy admits tags only, so a main dispatch is rejected before any step runs. MCP_PRIVATE_KEY is a repository-level secret, so the job never needed the environment; this drops it. The workflow-authority census passes.

Refs FIR-2311