### PR TITLE
Flip the default profile to accuracy-v2 and route semantic_locate fused on every profile

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2090,17 +2090,10 @@ fn check_retrieval_profile() -> HealthCheck {
     let ce_model = env::var("KIN_LOCATE_CROSS_ENCODER_MODEL")
         .unwrap_or_else(|_| "BAAI/bge-reranker-base".to_string());
     let ce_cached = crate::retrieval_profile::cross_encoder_model_cached(&ce_model);
-    // Has anyone configured retrieval on this install yet? Three independent
-    // signals, any one of them sufficient: a profile was selected, the reranker
-    // was overridden either way, or a reranker model was fetched into this
-    // install's cache at some point, whether or not a usable snapshot survives
-    // there now. An empty value is not a selection.
-    let selected = |key: &str| env::var(key).is_ok_and(|value| !value.trim().is_empty());
-    let ever_configured = selected("KIN_PROFILE")
-        || selected("KIN_LOCATE_CROSS_ENCODER_ENABLED")
-        || crate::retrieval_profile::cross_encoder_model_ever_fetched(&ce_model);
     // Report the daemon-serving default (the state queries actually run
-    // under), not this one-shot CLI process's own gate.
+    // under), not this one-shot CLI process's own gate. The accessor answers
+    // exactly that question, so this check cannot drift from the profile's
+    // own definition.
     let ce_active = env::var("KIN_LOCATE_CROSS_ENCODER_ENABLED")
         .map(|value| {
             matches!(
@@ -2108,37 +2101,34 @@ fn check_retrieval_profile() -> HealthCheck {
                 "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
             )
         })
-        .unwrap_or(
-            matches!(
-                profile,
-                crate::retrieval_profile::RetrievalProfile::AccuracyV1
-            ) && ce_cached,
-        );
+        .unwrap_or_else(|_| profile.cross_encoder_daemon_default(ce_cached));
     // Every lever is read back from the profile rather than assumed from its
     // name, so a profile whose defaults change cannot leave this check
     // asserting a lever set the serving path no longer uses.
     //
-    // `declaration_cutoff_default` is deliberately excluded: it is dark for
-    // EVERY profile pending its A/B graduation gate, so counting it would make
-    // the best available profile report degraded forever, and a check that can
-    // never be green is a check nobody reads.
+    // Two levers are deliberately not counted. `declaration_cutoff_default`
+    // is dark for EVERY profile pending its A/B graduation gate. The
+    // cross-encoder rerank is off by deliberate default: the do-not-flip
+    // verdict on it stands, so serving without it is the shipped
+    // configuration, not a degradation. Counting either would make the
+    // default profile report degraded forever, and a check that can never be
+    // green is a check nobody reads. Both still show in the detail line.
     let levers_off: Vec<&str> = [
         (!profile.semantic_locate_fused()).then_some("fused semantic_locate routing"),
         (!profile.entity_fusion_default()).then_some("entity fusion"),
         (!profile.lexical_floor_readmit_default()).then_some("lexical parity floor"),
-        (!ce_active).then_some("cross-encoder rerank"),
     ]
     .into_iter()
     .flatten()
     .collect();
-    let mut detail =
+    let detail =
         format!(
         "{}profile {} — semantic_locate routing: {}; entity fusion: {}; lexical parity floor: {}; \
          cross-encoder rerank: {} (model {} {})",
-        match (levers_off.is_empty(), ever_configured) {
-            (true, _) => "",
-            (false, true) => "degraded: ",
-            (false, false) => "stock defaults: ",
+        if levers_off.is_empty() {
+            ""
+        } else {
+            "degraded: "
         },
         profile.name(),
         if profile.semantic_locate_fused() {
@@ -2152,34 +2142,19 @@ fn check_retrieval_profile() -> HealthCheck {
         ce_model,
         if ce_cached { "cached" } else { "not cached" },
     );
-    // A profile serving with levers off is answering worse than this build can,
-    // and reporting that as a passing check tells an operator their weakest
-    // retrieval configuration is the healthy one. Stale is this report's
-    // advisory tier: it renders as a yellow warning and counts as needing
-    // attention, without blocking readiness the way Missing/Misconfigured do,
-    // because a degraded profile still serves.
-    //
-    // That is the right answer for a configuration someone chose. It is the
-    // wrong answer for an install nobody has configured yet, where every lever
-    // is off because the stock profile is opt-out of nothing and the reranker
-    // model has not been downloaded: the levers were never turned off, they
-    // have never been available here. A check that scores that as degraded is
-    // permanently yellow on every machine the second its install succeeds,
-    // which is the failure `Report expected first-run states as skipped rather
-    // than failed` removed from the four checks beside this one. Unsupported is
-    // that answer: skipped rather than failed, still carrying the remediation
-    // the renderer prints for any non-Healthy check, so the opt-in stays
-    // discoverable without claiming anything is wrong.
-    let status = match (levers_off.is_empty(), ever_configured) {
-        (true, _) => HealthStatus::Healthy,
-        (false, true) => HealthStatus::Stale,
-        (false, false) => HealthStatus::Unsupported,
+    // A profile serving with levers off is answering worse than this build
+    // can, and reporting that as a passing check tells an operator their
+    // weakest retrieval configuration is the healthy one. Stale is this
+    // report's advisory tier: it renders as a yellow warning and counts as
+    // needing attention, without blocking readiness the way
+    // Missing/Misconfigured do, because a degraded profile still serves.
+    // Every counted lever is on under the shipped default, so a lever-off
+    // state can only be a profile someone chose, never a fresh install.
+    let status = if levers_off.is_empty() {
+        HealthStatus::Healthy
+    } else {
+        HealthStatus::Stale
     };
-    // Keyed on the status rather than on the conditions that produced it, so
-    // the sentence and the tier cannot drift apart.
-    if matches!(status, HealthStatus::Unsupported) {
-        detail.push_str("; opt-in, and the reranker model downloads on first use");
-    }
     let check = HealthCheck::new(
         "retrieval_profile",
         "Retrieval quality profile",
@@ -2189,30 +2164,17 @@ fn check_retrieval_profile() -> HealthCheck {
     if levers_off.is_empty() {
         return check;
     }
-    // The remediation was previously attached only when the reranker model was
-    // uncached, and the Healthy status meant the renderer never printed it. Name
-    // what is off, and name the better profile from its own identifier so this
-    // string cannot drift from the enum.
-    let best = crate::retrieval_profile::RetrievalProfile::AccuracyV1;
-    let mut fix = if ever_configured {
-        format!("off: {}", levers_off.join(", "))
-    } else {
-        format!(
-            "not enabled by the stock profile: {}",
-            levers_off.join(", ")
-        )
-    };
-    if profile != best {
+    // Name what is off, and name the way back from the default profile's own
+    // identifier so this string cannot drift from the enum. The reranker is
+    // deliberately absent from this advice: the shipped default keeps it off,
+    // and doctor must not argue with the shipped default.
+    let default_profile = crate::retrieval_profile::RetrievalProfile::default();
+    let mut fix = format!("off: {}", levers_off.join(", "));
+    if profile != default_profile {
         fix.push_str(&format!(
-            "; set KIN_PROFILE={} for the measured-accuracy defaults",
-            best.name()
+            "; unset KIN_PROFILE or set KIN_PROFILE={} for the shipped measured-accuracy defaults",
+            default_profile.name()
         ));
-    }
-    if !ce_cached {
-        fix.push_str(
-            "; prefetch the reranker model once with \
-             KIN_LOCATE_CROSS_ENCODER_ENABLED=1 (downloads on first use)",
-        );
     }
     check.with_manual_fix(fix)
 }
@@ -4296,9 +4258,9 @@ mod tests {
             .is_some_and(|fix| fix.contains("kin reconcile")));
     }
 
-    /// The degraded default must not report as a passing check. A first-run
-    /// user otherwise measures this build's weakest retrieval configuration
-    /// and is told it is the healthy one.
+    /// A lever-off profile someone chose must not report as a passing check,
+    /// and its remediation must point back at the shipped default rather than
+    /// at a profile or a download the default deliberately does not carry.
     #[test]
     #[serial]
     fn doctor_warns_on_a_profile_serving_with_levers_off() {
@@ -4322,12 +4284,18 @@ mod tests {
             .as_deref()
             .expect("a degraded profile must carry remediation");
         assert!(
-            fix.contains("cross-encoder rerank"),
+            fix.contains("entity fusion") && fix.contains("lexical parity floor"),
             "remediation must name what is off: {fix}"
         );
         assert!(
-            fix.contains("accuracy-v1"),
-            "remediation must name the better profile: {fix}"
+            fix.contains("accuracy-v2"),
+            "remediation must name the shipped default profile: {fix}"
+        );
+        // Doctor must not argue with the shipped default: no advice to select
+        // the reranker profile, no prompt to prefetch its model.
+        assert!(
+            !fix.contains("accuracy-v1") && !fix.contains("prefetch"),
+            "remediation must not recommend the reranker path: {fix}"
         );
     }
 
@@ -4362,20 +4330,18 @@ mod tests {
         );
     }
 
-    /// The state every install is in the second it succeeds: no profile
-    /// selected and no reranker model fetched. Scoring that as a degraded
-    /// serving configuration puts a permanent yellow warning on every fresh
-    /// machine, and it refused the Windows repo-free install proof, whose
-    /// tolerance requires every check to be `repo_init`, healthy, or
-    /// unsupported.
+    /// Doctor agrees with the shipped default: a fresh install with nothing
+    /// configured reports Healthy with no remediation, the deliberately-off
+    /// reranker included. A doctor that advises changing a stock install is a
+    /// doctor arguing with the product's own default.
     ///
-    /// The two falsifying halves are the point. A lever that has never been
-    /// available here is a first-run state; the same lever on an install that
-    /// fetched the model once, or that selected a profile, is the configuration
-    /// the warning exists for and still reports Stale.
+    /// The falsifying halves are the point. A cached reranker model must NOT
+    /// change the verdict (the default keeps the reranker off even where the
+    /// model is already on disk), while a lever-off profile someone chose is
+    /// the state the degraded warning exists for and still reports Stale.
     #[test]
     #[serial]
-    fn a_never_configured_install_is_not_a_degraded_retrieval_profile() {
+    fn doctor_agrees_with_the_shipped_default_and_keeps_the_reranker_off() {
         let cache = tempfile::tempdir().unwrap();
         let _hf = EnvVarGuard::set("HF_HOME", cache.path());
         let _model = EnvVarGuard::set("KIN_LOCATE_CROSS_ENCODER_MODEL", "BAAI/bge-reranker-base");
@@ -4385,23 +4351,26 @@ mod tests {
         let check = check_retrieval_profile();
 
         assert!(
-            matches!(check.status, HealthStatus::Unsupported),
-            "levers nobody has turned off are not a degradation: {:?} ({})",
+            matches!(check.status, HealthStatus::Healthy),
+            "the shipped default must report Healthy: {:?} ({})",
             check.status,
             check.detail
         );
         assert!(
-            check.detail.contains("stock defaults")
-                && check.detail.contains("downloads on first use"),
-            "the detail must name the state it is reporting: {}",
+            check.detail.contains("accuracy-v2")
+                && check.detail.contains("cross-encoder rerank: off"),
+            "the detail names the default profile and the deliberate reranker state: {}",
             check.detail
         );
-        let fix = check.manual_fix.as_deref().expect(
-            "the opt-in stays discoverable: the renderer prints a fix for any non-Healthy check",
+        assert!(
+            !check.detail.contains("degraded"),
+            "the default is not a degradation: {}",
+            check.detail
         );
         assert!(
-            fix.contains("accuracy-v1") && fix.contains("cross-encoder rerank"),
-            "the remediation still names the better profile and what it turns on: {fix}"
+            check.manual_fix.is_none(),
+            "no advice may contradict the shipped default: {:?}",
+            check.manual_fix
         );
 
         let report = assemble_health_report("test".to_string(), vec![check]);
@@ -4409,45 +4378,41 @@ mod tests {
         let summary = report.summary();
         assert_eq!(
             (summary.attention, summary.skipped),
-            (0, 1),
+            (0, 0),
             "a correct fresh install must close on zero checks needing attention"
         );
-        assert_eq!(
-            serde_json::to_value(&report).unwrap()["checks"][0]["status"],
-            "unsupported",
-            "the repo-free proof tolerance keys on this serialized status"
-        );
 
-        // Falsification one: this install fetched the reranker model once and no
-        // usable snapshot survives. That is a lever it had and lost, which is
-        // what the degraded warning exists to report.
+        // Falsification one: the reranker model is fully cached, the state
+        // earlier doctor advice created on real installs. The default must
+        // not silently start serving the reranker, and doctor must not start
+        // advising it.
         std::fs::create_dir_all(
             cache
                 .path()
                 .join("hub")
                 .join("models--BAAI--bge-reranker-base")
-                .join("blobs"),
+                .join("snapshots")
+                .join("0123456789abcdef"),
         )
         .unwrap();
-        let after_fetch = check_retrieval_profile();
+        let with_cached_model = check_retrieval_profile();
         assert!(
-            matches!(after_fetch.status, HealthStatus::Stale),
-            "a model this install fetched once must keep the warning: {:?} ({})",
-            after_fetch.status,
-            after_fetch.detail
+            matches!(with_cached_model.status, HealthStatus::Healthy),
+            "a cached model must not change the default verdict: {:?} ({})",
+            with_cached_model.status,
+            with_cached_model.detail
         );
-        assert!(after_fetch.detail.contains("degraded"));
-        assert_eq!(
-            assemble_health_report("test".to_string(), vec![after_fetch])
-                .summary()
-                .attention,
-            1
+        assert!(
+            with_cached_model
+                .detail
+                .contains("cross-encoder rerank: off"),
+            "the default keeps the reranker off even with the model cached: {}",
+            with_cached_model.detail
         );
+        assert!(with_cached_model.manual_fix.is_none());
 
-        // Falsification two: nothing fetched, but a profile was selected. The
-        // discriminator is whether anyone has engaged with retrieval
-        // configuration on this install, not the model cache alone.
-        std::fs::remove_dir_all(cache.path().join("hub")).unwrap();
+        // Falsification two: a lever-off profile someone chose. The degraded
+        // warning still exists and still fires.
         profile.apply("KIN_PROFILE", Some("compat-v0"));
         assert!(
             matches!(check_retrieval_profile().status, HealthStatus::Stale),

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -10,19 +10,27 @@
 //! lever exports, and so future lever flips land as a new version rather than
 //! silently changing what an existing pin means.
 //!
-//! - `compat-v0` (default): byte-identical to the pre-profile serving
-//!   behavior. The MCP `semantic_locate` tool keeps the single-vector cosine
-//!   ranking, and every lever keeps its historical default. It is the default
-//!   because a paired A/B on the frozen multi-file diagnostic measured the
-//!   accuracy-v1 candidate REGRESSING the CLI agent arm on every localization
-//!   metric; accuracy-v1 stays opt-in until its levers are tuned and graduate
-//!   on measurement.
-//! - `accuracy-v1` (opt-in): the candidate serving shape. The MCP
-//!   `semantic_locate` tool routes through the full fused locate pipeline,
-//!   entity-granularity fusion and the lexical parity floor are on, the
-//!   cross-encoder reranker runs in promotion-only blend mode under a latency
-//!   budget when its model is already cached locally, and the embedding
-//!   seed floor actually rejects near-orthogonal noise.
+//! - `accuracy-v2` (default): the measured-accuracy serving shape.
+//!   Entity-granularity fusion, the lexical parity floor, and the calibrated
+//!   embedding seed floor are on; the cross-encoder reranker is off
+//!   unconditionally. The reranker's standing do-not-flip verdict held when
+//!   the accuracy levers graduated to default, so the flip minted this new
+//!   version instead of editing `accuracy-v1` in place, and an existing
+//!   `accuracy-v1` pin keeps the conditional reranker it always had.
+//! - `accuracy-v1` (opt-in): the previous accuracy candidate. Same levers as
+//!   `accuracy-v2` plus the cross-encoder reranker in promotion-only blend
+//!   mode under a latency budget, when its model is already cached locally
+//!   and the process is a resident daemon.
+//! - `compat-v0` (opt-in): the historical lever defaults, kept for A/B
+//!   comparison and as an escape hatch. It was the shipped default until the
+//!   accuracy levers graduated on measurement: bare-name symbol lookup
+//!   through MCP `semantic_locate` scored 0 of 23 at rank one under cosine
+//!   serving against 20 of 23 under the fused pipeline.
+//!
+//! The MCP `semantic_locate` routing is not a profile lever: every profile
+//! routes the full fused locate pipeline, exactly like `POST /locate` always
+//! has, and the legacy cosine ranking stays reachable per call via
+//! `pipeline: "cosine"`.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -55,29 +63,35 @@ pub fn reset_daemon_serving_for_tests() {
 /// Versioned retrieval quality profile. Selected via `KIN_PROFILE`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum RetrievalProfile {
-    /// Measured-accuracy defaults (current version).
-    AccuracyV1,
-    /// Pre-profile behavior: cosine-only `semantic_locate`, historical lever
-    /// defaults. Kept for A/B comparison and as an escape hatch.
+    /// Measured-accuracy defaults (current version): the `accuracy-v1` lever
+    /// set with the cross-encoder reranker off unconditionally.
     #[default]
+    AccuracyV2,
+    /// Previous accuracy candidate: `accuracy-v2` plus the conditional
+    /// budget-gated cross-encoder. Kept addressable so an existing pin keeps
+    /// meaning exactly what it meant.
+    AccuracyV1,
+    /// Historical lever defaults. Kept for A/B comparison and as an escape
+    /// hatch.
     CompatV0,
 }
 
 impl RetrievalProfile {
     /// Resolve the active profile from `KIN_PROFILE`.
     ///
-    /// Accepts the canonical versioned names (`accuracy-v1`, `compat-v0`) plus
-    /// unversioned aliases (`accuracy`, `compat`, `legacy`) that track the
-    /// latest version of each family. Unknown values warn loudly and fall back
-    /// to the default so a typo cannot silently select an unintended serving
-    /// shape without a trace.
+    /// Accepts the canonical versioned names (`accuracy-v2`, `accuracy-v1`,
+    /// `compat-v0`) plus unversioned aliases (`accuracy`, `compat`, `legacy`)
+    /// that track the latest version of each family. Unknown values warn
+    /// loudly and fall back to the default so a typo cannot silently select an
+    /// unintended serving shape without a trace.
     pub fn from_env() -> Self {
         match std::env::var("KIN_PROFILE") {
             Ok(value) => {
                 let normalized = value.trim().to_ascii_lowercase();
                 match normalized.as_str() {
                     "" => Self::default(),
-                    "accuracy-v1" | "accuracy" => Self::AccuracyV1,
+                    "accuracy-v2" | "accuracy" => Self::AccuracyV2,
+                    "accuracy-v1" => Self::AccuracyV1,
                     "compat-v0" | "compat" | "legacy" => Self::CompatV0,
                     other => {
                         tracing::warn!(
@@ -98,22 +112,29 @@ impl RetrievalProfile {
     /// produced it.
     pub fn name(self) -> &'static str {
         match self {
+            Self::AccuracyV2 => "accuracy-v2",
             Self::AccuracyV1 => "accuracy-v1",
             Self::CompatV0 => "compat-v0",
         }
     }
 
     /// Whether the MCP `semantic_locate` tool routes through the full fused
-    /// locate pipeline (true) or the legacy single-vector cosine ranking
-    /// (false).
+    /// locate pipeline by default. True for every profile: routing is not a
+    /// profile lever. The daemon's `semantic_locate` arm routes fused
+    /// unconditionally, exactly like `POST /locate`, and the legacy cosine
+    /// ranking stays reachable per call via `pipeline: "cosine"`. Kept as an
+    /// accessor so health reporting reads one authority and a new variant has
+    /// to state its routing explicitly.
     pub fn semantic_locate_fused(self) -> bool {
-        matches!(self, Self::AccuracyV1)
+        match self {
+            Self::AccuracyV2 | Self::AccuracyV1 | Self::CompatV0 => true,
+        }
     }
 
     /// Default for `KIN_LOCATE_ENTITY_FUSION` (fuse at entity granularity
     /// before collapsing to files).
     pub fn entity_fusion_default(self) -> bool {
-        matches!(self, Self::AccuracyV1)
+        matches!(self, Self::AccuracyV2 | Self::AccuracyV1)
     }
 
     /// Default for `KIN_LOCATE_DECLARATION_CUTOFF` (confidence-calibrated
@@ -129,7 +150,7 @@ impl RetrievalProfile {
     /// over this default at the read site, so no serving default silently flips.
     pub fn declaration_cutoff_default(self) -> bool {
         match self {
-            Self::AccuracyV1 | Self::CompatV0 => false,
+            Self::AccuracyV2 | Self::AccuracyV1 | Self::CompatV0 => false,
         }
     }
 
@@ -137,12 +158,30 @@ impl RetrievalProfile {
     /// candidates the fused ranking dropped, subsuming grep on keyword
     /// queries).
     pub fn lexical_floor_readmit_default(self) -> bool {
-        matches!(self, Self::AccuracyV1)
+        matches!(self, Self::AccuracyV2 | Self::AccuracyV1)
+    }
+
+    /// The cross-encoder default a RESIDENT SERVING DAEMON applies for this
+    /// profile, given whether the model is already cached locally. One-shot
+    /// reporters (`kin doctor`, `kin setup status`) read this instead of
+    /// [`Self::cross_encoder_default`] because the state their user cares
+    /// about is the daemon's, not the reporting process's own serving gate.
+    ///
+    /// `accuracy-v2` answers false even with the model cached: the reranker's
+    /// do-not-flip verdict stands, and an install that prefetched the model
+    /// under earlier advice must not silently start paying for it when the
+    /// default profile changes. An explicit
+    /// `KIN_LOCATE_CROSS_ENCODER_ENABLED=1` still wins at the read site.
+    pub fn cross_encoder_daemon_default(self, model_cached: bool) -> bool {
+        match self {
+            Self::AccuracyV1 => model_cached,
+            Self::AccuracyV2 | Self::CompatV0 => false,
+        }
     }
 
     /// Default for `KIN_LOCATE_CROSS_ENCODER_ENABLED`.
     ///
-    /// Accuracy profile: on, but only when BOTH hold —
+    /// `accuracy-v1`: on, but only when BOTH hold —
     /// - the reranker model is already cached locally (the constructor
     ///   otherwise downloads from the network, which a default must never do
     ///   mid-query), and
@@ -150,32 +189,31 @@ impl RetrievalProfile {
     ///   so one-shot library callers and test binaries never pay a model load
     ///   by default.
     ///
+    /// `accuracy-v2` and `compat-v0` keep the reranker off unconditionally.
     /// The missing-model state is reported as a structured degradation
     /// instead of silently skipping. An explicit
     /// `KIN_LOCATE_CROSS_ENCODER_ENABLED=1` still forces the attempt (and
     /// with it the download) regardless of cache state or process kind.
     pub fn cross_encoder_default(self, model_cached: bool) -> bool {
-        match self {
-            Self::AccuracyV1 => model_cached && daemon_serving(),
-            Self::CompatV0 => false,
-        }
+        self.cross_encoder_daemon_default(model_cached) && daemon_serving()
     }
 
     /// Default for `KIN_LOCATE_RERANK_BLEND`: promotion-only additive blending
     /// of cross-encoder scores. The legacy overwrite mode substitutes raw
     /// logits for fused scores and can evict multi-signal-corroborated files,
-    /// so any profile that enables the cross-encoder must also default to the
-    /// blend.
+    /// so any profile that could serve the cross-encoder, including one whose
+    /// user enables it explicitly over a default of off, must also default to
+    /// the blend.
     pub fn rerank_blend_default(self) -> bool {
-        matches!(self, Self::AccuracyV1)
+        matches!(self, Self::AccuracyV2 | Self::AccuracyV1)
     }
 
-    /// Default for `KIN_LOCATE_RERANK_LATENCY_BUDGET_MS`. The accuracy profile
-    /// bounds the reranker so an over-budget rerank falls back to the fused
-    /// order; compat keeps the historical unbounded behavior (0).
+    /// Default for `KIN_LOCATE_RERANK_LATENCY_BUDGET_MS`. The accuracy
+    /// profiles bound the reranker so an over-budget rerank falls back to the
+    /// fused order; compat keeps the historical unbounded behavior (0).
     pub fn rerank_latency_budget_ms_default(self) -> usize {
         match self {
-            Self::AccuracyV1 => 1_500,
+            Self::AccuracyV2 | Self::AccuracyV1 => 1_500,
             Self::CompatV0 => 0,
         }
     }
@@ -189,7 +227,7 @@ impl RetrievalProfile {
     /// cosine < 0.25, which in relevance units is (1 + 0.25) / 2 = 0.625.
     pub fn embedding_min_relevance_default(self) -> f32 {
         match self {
-            Self::AccuracyV1 => 0.625,
+            Self::AccuracyV2 | Self::AccuracyV1 => 0.625,
             Self::CompatV0 => 0.25,
         }
     }
@@ -320,7 +358,7 @@ mod tests {
     #[serial_test::serial]
     fn profile_resolves_from_env_with_aliases_and_default() {
         let mut profile = kin_core::test_env::EnvVarGuard::unset("KIN_PROFILE");
-        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV2);
 
         profile.apply("KIN_PROFILE", Some("compat-v0"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
@@ -328,15 +366,75 @@ mod tests {
         profile.apply("KIN_PROFILE", Some("compat"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
+        // A versioned pin keeps meaning exactly the version it names.
         profile.apply("KIN_PROFILE", Some("ACCURACY-V1"));
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV1);
 
+        profile.apply("KIN_PROFILE", Some("accuracy-v2"));
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV2);
+
+        // The unversioned alias tracks the latest version of its family.
+        profile.apply("KIN_PROFILE", Some("accuracy"));
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV2);
+
         // Unknown values must not silently select a different serving shape.
         profile.apply("KIN_PROFILE", Some("warp-speed"));
-        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV2);
 
         profile.apply::<_, &str>("KIN_PROFILE", None);
-        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV2);
+    }
+
+    /// The shipped default: the accuracy lever set with the reranker off.
+    /// Pins the default variant, its name, and every lever value, so a future
+    /// edit cannot move the default without this test naming the change.
+    #[test]
+    #[serial_test::serial]
+    fn default_profile_is_accuracy_v2_with_the_reranker_off() {
+        let _profile = kin_core::test_env::EnvVarGuard::unset("KIN_PROFILE");
+        let default = RetrievalProfile::from_env();
+        assert_eq!(default, RetrievalProfile::AccuracyV2);
+        assert_eq!(default, RetrievalProfile::default());
+        assert_eq!(default.name(), "accuracy-v2");
+
+        assert!(default.semantic_locate_fused());
+        assert!(default.entity_fusion_default());
+        assert!(default.lexical_floor_readmit_default());
+        assert_eq!(default.rerank_latency_budget_ms_default(), 1_500);
+        assert_eq!(default.embedding_min_relevance_default(), 0.625);
+        // Blend stays the default so an explicit env enable of the
+        // cross-encoder still gets promotion-only blending.
+        assert!(default.rerank_blend_default());
+        assert!(!default.declaration_cutoff_default());
+
+        // The reranker stays off on the strongest form of its old
+        // on-condition: model cached AND resident daemon. An install that
+        // prefetched the model under earlier doctor advice must not silently
+        // start reranking when the default profile changes.
+        let _mark = DaemonServingMark;
+        mark_daemon_serving();
+        assert!(!default.cross_encoder_default(true));
+        assert!(!default.cross_encoder_daemon_default(true));
+        // ...while an accuracy-v1 pin keeps the conditional it always had.
+        assert!(RetrievalProfile::AccuracyV1.cross_encoder_default(true));
+        assert!(RetrievalProfile::AccuracyV1.cross_encoder_daemon_default(true));
+    }
+
+    /// Routing is not a profile lever: every profile, the compat escape hatch
+    /// included, routes the MCP tool through the fused pipeline.
+    #[test]
+    fn every_profile_routes_semantic_locate_fused() {
+        for profile in [
+            RetrievalProfile::AccuracyV2,
+            RetrievalProfile::AccuracyV1,
+            RetrievalProfile::CompatV0,
+        ] {
+            assert!(
+                profile.semantic_locate_fused(),
+                "{} must route semantic_locate fused",
+                profile.name()
+            );
+        }
     }
 
     #[test]
@@ -370,7 +468,11 @@ mod tests {
     #[test]
     fn compat_profile_preserves_historical_defaults() {
         let compat = RetrievalProfile::CompatV0;
-        assert!(!compat.semantic_locate_fused());
+        // The one deliberate exception: routing is profile-independent, so
+        // the compat pin preserves the historical LEVER defaults while the
+        // MCP tool routes fused like every other profile. The cosine ranking
+        // stays reachable per call via `pipeline: "cosine"`.
+        assert!(compat.semantic_locate_fused());
         assert!(!compat.entity_fusion_default());
         assert!(!compat.lexical_floor_readmit_default());
         assert!(!compat.cross_encoder_default(true));
@@ -387,7 +489,11 @@ mod tests {
         // The confidence cutoff is a graduation-gated lever: it must not be a
         // silent default under ANY profile, so that shipping it changes nothing
         // until a paired A/B flips it on. An explicit env override drives the A/B.
-        for profile in [RetrievalProfile::AccuracyV1, RetrievalProfile::CompatV0] {
+        for profile in [
+            RetrievalProfile::AccuracyV2,
+            RetrievalProfile::AccuracyV1,
+            RetrievalProfile::CompatV0,
+        ] {
             assert!(
                 !profile.declaration_cutoff_default(),
                 "{} must not enable the declaration cutoff by default",

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -181,7 +181,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     // ---- retrieval quality profile and its profile-gated levers ---------------
     // KIN_PROFILE selects the versioned retrieval profile; the levers below
     // default per-profile and an explicit value always wins over the profile.
-    EnvVarSpec { name: "KIN_PROFILE", kind: Kind::Str, default: "compat-v0", sensitivity: Sensitivity::Correctness, summary: "retrieval quality profile: compat-v0 (default, pre-profile behavior) or accuracy-v1 (opt-in candidate pending A/B-tuned graduation); proof runs pin this explicitly" },
+    EnvVarSpec { name: "KIN_PROFILE", kind: Kind::Str, default: "accuracy-v2", sensitivity: Sensitivity::Correctness, summary: "retrieval quality profile: accuracy-v2 (default: measured-accuracy levers, cross-encoder off), accuracy-v1 (opt-in: adds the budget-gated cross-encoder when its model is cached), compat-v0 (pre-profile lever defaults); proof runs pin this explicitly" },
     EnvVarSpec { name: "KIN_LOCATE_TOTAL_TIMEOUT_SECS", kind: Kind::SecsBound, default: "90", sensitivity: Sensitivity::Correctness, summary: "total locate pipeline budget in seconds; 0 disables it (unbounded)" },
     EnvVarSpec { name: "KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS", kind: Kind::SecsBound, default: "20", sensitivity: Sensitivity::Correctness, summary: "locate phase budget: entity discovery; 0 = unbounded" },
     EnvVarSpec { name: "KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS", kind: Kind::SecsBound, default: "20", sensitivity: Sensitivity::Correctness, summary: "locate phase budget: entity resolution; 0 = unbounded" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7618,8 +7618,8 @@ fn fused_semantic_locate_payload(
 
 /// Build the `semantic_locate` response from the full fused locate pipeline
 /// (the same multi-signal fusion + rerank `POST /locate` serves) instead of
-/// the single-vector cosine ranking. Selected by the retrieval quality
-/// profile (`KIN_PROFILE`) or an explicit per-call `pipeline` argument.
+/// the single-vector cosine ranking. The default arm on every profile; only
+/// an explicit per-call `pipeline: "cosine"` selects the legacy arm.
 ///
 /// Contract: args `{query, limit?=20, page_size?, cursor?,
 /// granularity?="entity"|"file", include_snippet?=true, explain?=false,
@@ -8147,17 +8147,14 @@ async fn mcp_tools_call(
         return Ok(Json(result));
     }
 
-    // R14 — `semantic_locate`: serve the agent's primary retrieval tool from
-    // the daemon's real pipelines. A stock daemon serves the legacy single-vector
-    // cosine ranking by default (the compat-v0 profile). The SAME fused
-    // multi-signal ranking `POST /locate` serves — vector, lexical, and graph
-    // fusion with role-aware ranking — is opt-in via `KIN_PROFILE=accuracy-v1`
-    // or a per-call `pipeline: "fused"` argument, so the richer product ranker is
-    // reachable without changing the default serving behavior. The legacy cosine
-    // ranking is also forceable per call with `pipeline: "cosine"` for A/B
-    // comparison. Both paths return partial results plus `semantic_coverage`
-    // rather than hard-gating on full embedding coverage (graceful degradation
-    // per R5).
+    // R14: serve the agent's primary retrieval tool from the daemon's real
+    // pipelines. The default route is the SAME fused multi-signal ranking
+    // `POST /locate` serves (vector, lexical, and graph fusion with role-aware
+    // ranking), on every profile: profiles supply lever defaults inside the
+    // pipeline, never the routing. The legacy single-vector cosine ranking
+    // stays reachable per call with `pipeline: "cosine"` for A/B comparison.
+    // Both paths return partial results plus `semantic_coverage` rather than
+    // hard-gating on full embedding coverage (graceful degradation per R5).
     if request.name == "semantic_locate" {
         let pipeline_override = request
             .arguments
@@ -8186,11 +8183,10 @@ async fn mcp_tools_call(
                     "invalid pipeline '{other}': expected \"fused\" or \"cosine\""
                 ))));
             }
-            None => {
-                has_extra_queries
-                    || kin_cli::retrieval_profile::RetrievalProfile::from_env()
-                        .semantic_locate_fused()
-            }
+            // No explicit pipeline: fused, unconditionally. Routing is not a
+            // profile decision; profiles supply lever defaults read inside the
+            // pipeline, and `POST /locate` has never consulted one either.
+            None => true,
         };
         if use_fused {
             return Ok(Json(
@@ -12332,7 +12328,8 @@ mod tests {
         }
     }
 
-    /// FIR-2199. The compat-v0 default arm emitted neither disclosure field.
+    /// FIR-2199. The cosine arm, then the shipped default, emitted neither
+    /// disclosure field.
     ///
     /// Measured on the shipped default profile, `match_kind` was absent from all
     /// 188 result rows across 40 queries and `all_fallback` never appeared once,
@@ -27961,6 +27958,9 @@ mod tests {
 
         // No vector index is populated. The handler must still return a valid
         // payload with a coverage field instead of hard-gating to an error.
+        // Pinned to the cosine arm explicitly: the shape assertions below are
+        // the legacy payload's coverage contract, and the default route is the
+        // fused arm.
         let response = app
             .clone()
             .oneshot(
@@ -27969,7 +27969,7 @@ mod tests {
                     .body(Body::from(
                         json!({
                             "name": "semantic_locate",
-                            "arguments": { "query": "handler", "limit": 5 }
+                            "arguments": { "query": "handler", "limit": 5, "pipeline": "cosine" }
                         })
                         .to_string(),
                     ))
@@ -28676,9 +28676,9 @@ mod tests {
     /// The FUSED `semantic_locate` page opens repository authority ONCE.
     ///
     /// This is the call-site regression test for the per-body authority open,
-    /// on the arm `POST /locate` always uses, that `pipeline: "fused"` selects,
-    /// that multi-query forces, and that `KIN_PROFILE=accuracy-v1` selects. It
-    /// runs the real MCP dispatch route, so what it bounds is the shipped path
+    /// on the arm `POST /locate` always uses and `semantic_locate` serves by
+    /// default on every profile; `pipeline: "cosine"` is the only route off
+    /// it. It runs the real MCP dispatch route, so what it bounds is the shipped path
     /// rather than a primitive: fused locate funnels into
     /// `run_with_graph_capture_budgeted`, which projects bodies TWICE over the
     /// same symbol set -- once in `attach_snippets` and again in
@@ -28923,6 +28923,32 @@ mod tests {
             .unwrap();
         let result: kin_mcp::ToolCallResult = serde_json::from_slice(&body).unwrap();
         assert_eq!(result.is_error, Some(true));
+    }
+
+    /// The default route (no `pipeline` argument) is the fused pipeline on
+    /// every profile, exactly the ranking `POST /locate` serves. Pinned under
+    /// an explicit compat-v0 environment because that is the profile that
+    /// used to select the cosine arm: routing must not follow it. Serial
+    /// because the guard mutates process env other lever reads consult.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn mcp_semantic_locate_routes_fused_by_default_on_every_profile() {
+        let _profile = kin_core::test_env::EnvVarGuard::set("KIN_PROFILE", "compat-v0");
+        let state = test_state();
+        state
+            .graph
+            .upsert_entity(&test_entity("handler", "src/lib.py"))
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+
+        let payload = call_semantic_locate(app, json!({ "query": "handler" })).await;
+        assert_eq!(
+            payload["routing"], "fused-v1",
+            "a compat-v0 daemon must still route the default call fused"
+        );
     }
 
     // Schema parity: the fused MCP payload IS the `LocateResult` schema

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -88,14 +88,13 @@ matches declarations by name/kind/language and ignores the query for ranking), \
 semantic_locate ranks by query relevance and returns act-on-able hits: entity_id, file, \
 line span, kind, score, and a bounded inline snippet. Set granularity to \"entity\" \
 (default) for ranked declarations or \"file\" to roll results up to the most relevant \
-files. Two pipelines can answer. By default a stock daemon serves the legacy \
-single-vector cosine ranking (the `compat-v0` profile); the full fused retrieval \
-pipeline `kin locate` serves — vector similarity, lexical search, and graph-structure \
-signals fused with role-aware ranking, exact-name promotion, and (when its model is \
-available) cross-encoder reranking — is opt-in per call with `pipeline: \"fused\"` or by \
-running the daemon under KIN_PROFILE=accuracy-v1. The `routing` field reports which \
-pipeline actually answered: `cosine-v0` for the single-vector default, `fused-v1` for \
-the fused pipeline (also selectable per call with `pipeline: \"fused\"`). Every hit also \
+files. Two pipelines can answer. The default on every profile is the full fused \
+retrieval pipeline `kin locate` serves: vector similarity, lexical search, and \
+graph-structure signals fused with role-aware ranking and exact-name promotion. The \
+legacy single-vector cosine ranking stays reachable per call with \
+`pipeline: \"cosine\"` for A/B comparison. The `routing` field reports which pipeline \
+actually answered: `fused-v1` for the fused default, `cosine-v0` for the per-call \
+legacy arm. Every hit also \
 carries an additive `match_evidence` object explaining why it ranked — the ranker that \
 produced it, the score source, whether the query matched the entity name, and the \
 ranking signals that applied — derived from graph-owned retrieval data, never a \

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -236,7 +236,7 @@ fn registered_tools() -> ToolsListResult {
                         "pipeline": {
                             "type": "string",
                             "enum": ["fused", "cosine"],
-                            "description": "Force a retrieval pipeline for this call: 'fused' (full multi-signal locate ranking) or 'cosine' (legacy single-vector). Defaults to the daemon's active KIN_PROFILE — the stock compat-v0 profile serves 'cosine'; accuracy-v1 serves 'fused'."
+                            "description": "Force a retrieval pipeline for this call: 'fused' (full multi-signal locate ranking) or 'cosine' (legacy single-vector). The default is 'fused' on every profile, the same ranking kin locate serves; 'cosine' is the per-call escape hatch for A/B comparison."
                         },
                         "explain": {
                             "type": "boolean",

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -64,7 +64,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_ORG_ID` | string | *(unset)* | operational | organization id for federation/remote |
 | `KIN_ORIGINAL_PATH` | path | *(unset)* | operational | caller's original PATH preserved across a with/exec shim |
 | `KIN_PRIMARY_REPO_ID` | string | *(unset)* | operational | primary repo id for a multi-repo daemon |
-| `KIN_PROFILE` | string | compat-v0 | correctness | retrieval quality profile: compat-v0 (default, pre-profile behavior) or accuracy-v1 (opt-in candidate pending A/B-tuned graduation); proof runs pin this explicitly |
+| `KIN_PROFILE` | string | accuracy-v2 | correctness | retrieval quality profile: accuracy-v2 (default: measured-accuracy levers, cross-encoder off), accuracy-v1 (opt-in: adds the budget-gated cross-encoder when its model is cached), compat-v0 (pre-profile lever defaults); proof runs pin this explicitly |
 | `KIN_REGEN_ENV_DOC` | string | *(unset)* | diagnostic | dev/test tooling: set to regenerate docs/env-vars.md from the registry |
 | `KIN_REMOTE_AUTH_TOKEN` | secret | *(unset)* | secret | fallback KinLab auth token read after KIN_REMOTE_BEARER_TOKEN |
 | `KIN_REMOTE_BASE_URL` | url | *(unset)* | operational | KinLab base URL for remote and federation calls |

--- a/llms-install.md
+++ b/llms-install.md
@@ -241,13 +241,15 @@ names which gate ruled.
 ### One thing to tell the user before they judge the answers
 
 `kin setup status` prints a `Retrieval quality profile` line naming the profile serving
-queries and which retrieval levers are on. A stock install serves `compat-v0`, which is the
-default on purpose and keeps the historical ranking behavior. `KIN_PROFILE` selects a
-profile, and `accuracy-v1` is the opt-in candidate shape. Two facts matter if you change it.
+queries and which retrieval levers are on. A stock install serves `accuracy-v2`, the
+measured-accuracy default: `semantic_locate` and `kin locate` both answer from the fused
+multi-signal pipeline, entity fusion and the lexical parity floor are on, and the
+cross-encoder reranker stays off. `KIN_PROFILE` selects a different profile: `accuracy-v1`
+adds the budget-gated cross-encoder when its model is already cached, and `compat-v0` keeps
+the pre-profile lever defaults as an A/B escape hatch. Two facts matter if you change it.
 The profile is read by the process that serves queries, so it has to be set where the daemon
 starts and not on the MCP client entry, and a daemon already running has to be restarted
-under it. And `accuracy-v1` stays opt-in because it has not graduated on measurement, so
-treat it as a comparison to run rather than a fix to apply.
+under it.
 
 ## Step 6: stop the daemon when you are done
 

--- a/scripts/validate-retrieval-mf16.sh
+++ b/scripts/validate-retrieval-mf16.sh
@@ -12,16 +12,20 @@
 # result or release evidence.
 #
 # What it compares (same 16 frozen tasks, same model config, temp0/seed0):
-#   arm A  KIN_PROFILE=compat-v0   — pre-profile behavior (cosine semantic_locate)
-#   arm B  KIN_PROFILE=accuracy-v1 — fused semantic_locate + accuracy defaults
+#   arm A  KIN_PROFILE=compat-v0:   pre-profile lever defaults
+#   arm B  KIN_PROFILE=accuracy-v1: accuracy levers plus the conditional cross-encoder
+# Routing is profile-independent: semantic_locate serves the fused pipeline in
+# BOTH arms, exactly like kin locate, so this A/B isolates the lever sets. The
+# cosine arm is reachable only per call via pipeline:"cosine".
 #
 # Metrics to read from the scorer output, A vs B:
 #   - gold files surfaced %          (diagnostic north star: was 39%)
 #   - retrieval_miss / traversal_pruned counts (was 28/31 of fixable misses)
 #   - file precision / recall / F1, symbol R, line R
 #   - declared-vs-surfaced conversion, total tokens per task
-#   - per-hit `routing` field distribution (fused-v1 vs cosine-v0) as an
-#     arm-integrity check, and `degradations` frequencies
+#   - per-hit `routing` field distribution (fused-v1 expected in BOTH arms;
+#     cosine-v0 only where a call forced pipeline:"cosine") and `degradations`
+#     frequencies
 #
 # Prerequisites the operator must satisfy first (fail-loud checks below):
 #   1. Rebuild ALL binaries from the branch under test (CLI + daemon + bench
@@ -64,8 +68,8 @@ plan "      output:    $OUTPUT_DIR/mf16_accuracy_v1.jsonl (+ _turns/_results)"
 plan ""
 plan "[5/5] score both with the official scorer; read the paired deltas:"
 plan "      gold-surfaced %, traversal_pruned count, file P/R/F1, symbol R,"
-plan "      line R, conversion, tokens/task; check per-hit routing field says"
-plan "      fused-v1 only in arm B; collect degradations[] frequencies."
+plan "      line R, conversion, tokens/task; check the per-hit routing field"
+plan "      says fused-v1 in both arms; collect degradations[] frequencies."
 plan ""
 plan "optional per-call A/B without switching profiles: pass"
 plan "      pipeline:\"cosine\" / pipeline:\"fused\" on semantic_locate calls."


### PR DESCRIPTION
An agent calling `semantic_locate` now gets what a human typing `kin locate` has always gotten. The MCP tool's default route is the fused multi-signal pipeline on every profile, the same ranking `POST /locate` serves, and the legacy cosine ranking stays reachable per call via `pipeline:"cosine"` for A/B comparison. On the 0525 battery's 23-symbol probe set the cosine default scored 0/23 at rank one where the fused pipeline scored 20/23 (non-citable dev-box measurement, `.kin-coord/reports/profile-default-decision-20260814.md`).

The shipped default profile flips from compat-v0 to accuracy-v2, a new version minted per the profile module's own rule that lever flips land as a new version rather than changing what an existing pin means. accuracy-v2 is accuracy-v1's lever set (entity fusion, lexical parity floor, calibrated 0.625 embedding seed floor, promotion-only rerank blend, 1500ms rerank budget) with the cross-encoder reranker off unconditionally. That implements the founder ruling within the module's law: the accuracy levers graduate to default, and the reranker's do-not-flip verdict is affirmed (one lateral top-1 change in 55 probes for +54% latency and +1.3GB resident). Returning false explicitly, rather than keeping accuracy-v1's cached-model condition, also protects installs that prefetched the model under earlier doctor advice from silently starting to pay for it. An accuracy-v1 pin keeps the conditional reranker it always had, and compat-v0 keeps the historical lever defaults as the A/B escape hatch.

`kin doctor` now agrees with the shipped default. A stock install reports Healthy with no remediation; the advice to set accuracy-v1 and prefetch the 1.1GB reranker model is gone; a lever-off profile someone chose still warns and points back at accuracy-v2. KIN_PROFILE stays env-only, an exported profile still wins, and the new default lands when a daemon restarts under the new binary.

Tests pin all three decisions: the default variant with every lever value including reranker-off under the cached-model-plus-resident-daemon condition, fused routing under an explicit compat-v0 environment, and doctor emitting no advice that contradicts the shipped default even with the reranker model cached.

Closes FIR-2321
