### PR TITLE
Answer MCP handshake frames before the daemon binds; park a supervisor-stopped reconcile loop

### DIFF
--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -20,6 +20,16 @@ use std::pin::Pin;
 /// server starts anyway and each `tools/call` fails loud with a structured,
 /// actionable error (see `kin_mcp::daemon_delegate::daemon_unavailable_tool_result`)
 /// instead of the process silently never having started at all.
+///
+/// Answer early, load behind (FIR-2316): the stdio loop starts before the
+/// daemon binding rather than after it. Resolving the repo daemon can spawn
+/// one, and a cold start on a flagship-scale store takes minutes; awaiting it
+/// here meant zero stdout frames for that whole window, without even the
+/// `initialize` response, which no handshake probe or client timeout survives.
+/// The binding now runs on a background task that publishes into a
+/// [`kin_mcp::StartupDaemonBinding`]; `initialize` and `tools/list` answer
+/// immediately, and a `tools/call` that arrives before the binding settles is
+/// answered honestly that the daemon is still starting.
 pub async fn start(
     global: bool,
     repo: Option<PathBuf>,
@@ -43,51 +53,6 @@ pub async fn start(
         }
     }
 
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let mut bound_at_start = match bind_daemon_for_repo_dir(&cwd).await {
-        Ok(daemon_url) => {
-            eprintln!("{}", session_authority_notice());
-            eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
-            true
-        }
-        Err(reason) => {
-            if !global {
-                eprintln!(
-                    "Kin MCP: no repository bound at startup ({reason}). If the MCP client \
-                     advertises workspace roots, Kin binds to the open repository after \
-                     initialization; otherwise run `kin init .`, relaunch inside a Kin \
-                     repository, or pass --repo <path> (or set KIN_MCP_REPO=<path>)."
-                );
-            } else {
-                eprintln!("Kin MCP: the launch directory bound no repository ({reason}).");
-            }
-            false
-        }
-    };
-
-    // Registry mode: a launch directory that is no repository is the normal
-    // case, not a failure. Resolve the startup repository from the global
-    // registry instead, but never by guessing between several, which would
-    // answer about a codebase nobody named.
-    //
-    // An operator pin that failed to bind is never rescued this way. Falling
-    // through to the registry there would serve whichever repository the
-    // registry happens to name while the operator asked for a specific one:
-    // the same wrong-repository answer the roots binder refuses, reached
-    // through the registry door instead.
-    if registry_should_resolve(global, bound_at_start, repo_override.is_some()) {
-        bound_at_start = bind_from_registry().await;
-    } else if global && !bound_at_start {
-        if let Some(pinned) = &repo_override {
-            eprintln!(
-                "Kin MCP: --repo/KIN_MCP_REPO pins {}, which did not bind. Registry mode will not \
-                 substitute another repository for a pin; fix the pinned repository or drop the \
-                 pin.",
-                pinned.display()
-            );
-        }
-    }
-
     let mut config = build_mcp_start_config();
     let resolved_profile = resolve_tool_profile(
         tool_profile.as_deref(),
@@ -103,6 +68,8 @@ pub async fn start(
         );
     }
 
+    let startup = kin_mcp::StartupDaemonBinding::new();
+
     // The stdio server always binds through the MCP client's advertised
     // workspace roots: late, when nothing bound from --repo/KIN_MCP_REPO/cwd
     // (how editors that launch MCP servers from $HOME — Cursor, Windsurf, ... —
@@ -115,11 +82,16 @@ pub async fn start(
     // follows the client to another repository. It still refuses to answer for
     // one: the binder reports the disagreement and the server fails loud, rather
     // than serving the pinned repository's graph for a workspace the client
-    // moved away from.
-    let pinned_by_operator = repo_override.is_some() && bound_at_start;
+    // moved away from. With the startup binding running behind the loop, whether
+    // the pin bound is only known once it settles, so the binder reads it from
+    // the shared handle at each invocation.
+    let binder_startup = std::sync::Arc::clone(&startup);
     let repo_binder: Option<kin_mcp::RepoBinder> = Some(Box::new(
         move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<kin_mcp::BoundRepo>> + Send>> {
-            Box::pin(bind_first_kin_repo(roots, pinned_by_operator))
+            let startup = std::sync::Arc::clone(&binder_startup);
+            Box::pin(async move {
+                bind_first_kin_repo(roots, startup.pinned_by_operator()).await
+            })
         },
     ));
 
@@ -128,11 +100,102 @@ pub async fn start(
     // a revived daemon joins supervisor routing like an autostarted one.
     crate::daemon_client::install_spawn_registrar();
 
-    kin_mcp::run_stdio_daemon(config, repo_binder)
-        .await
-        .map_err(|e| anyhow::anyhow!("MCP server error: {}", e))?;
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let bind_task = tokio::spawn(run_startup_binding(
+        global,
+        repo_override,
+        cwd,
+        std::sync::Arc::clone(&startup),
+    ));
 
-    Ok(())
+    let served = kin_mcp::run_stdio_daemon(config, repo_binder, Some(startup))
+        .await
+        .map_err(|e| anyhow::anyhow!("MCP server error: {}", e));
+
+    // The client closed stdin, so this server is done. A daemon spawn already
+    // in flight is detached and survives on its own by design, so the next
+    // session finds it warm; only the wait is abandoned.
+    bind_task.abort();
+
+    served
+}
+
+/// The startup daemon binding `start` used to run inline, now driven behind
+/// the stdio loop. Publishes every outcome into `startup` so the server can
+/// answer `tools/call` honestly while this is still in flight.
+async fn run_startup_binding(
+    global: bool,
+    repo_override: Option<PathBuf>,
+    cwd: PathBuf,
+    startup: std::sync::Arc<kin_mcp::StartupDaemonBinding>,
+) {
+    // Name the repository being bound before the slow work starts, so the
+    // still-starting report can say how far that daemon's startup has come.
+    // The probe closure defers to the daemon-lifecycle IO boundary; this
+    // module and the transport crate stay free of filesystem primitives.
+    let discovered = kin_core::KinLayout::discover(&cwd);
+    if let Some(layout) = &discovered {
+        let kin_root = layout.root().to_path_buf();
+        startup.set_phase_probe(Box::new(move || {
+            crate::daemon_client::daemon_startup_phase(&kin_root)
+        }));
+    }
+
+    let unbound_reason = match bind_daemon_for_repo_dir(&cwd).await {
+        Ok(daemon_url) => {
+            eprintln!("{}", session_authority_notice());
+            eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
+            let root = discovered
+                .as_ref()
+                .map(|layout| canonical_path(layout.working_dir()))
+                .unwrap_or(cwd);
+            startup.resolve_bound(
+                kin_mcp::BoundRepo { root, daemon_url },
+                repo_override.is_some(),
+            );
+            return;
+        }
+        Err(reason) => {
+            if !global {
+                eprintln!(
+                    "Kin MCP: no repository bound at startup ({reason}). If the MCP client \
+                     advertises workspace roots, Kin binds to the open repository after \
+                     initialization; otherwise run `kin init .`, relaunch inside a Kin \
+                     repository, or pass --repo <path> (or set KIN_MCP_REPO=<path>)."
+                );
+            } else {
+                eprintln!("Kin MCP: the launch directory bound no repository ({reason}).");
+            }
+            reason
+        }
+    };
+
+    // Registry mode: a launch directory that is no repository is the normal
+    // case, not a failure. Resolve the startup repository from the global
+    // registry instead, but never by guessing between several, which would
+    // answer about a codebase nobody named.
+    //
+    // An operator pin that failed to bind is never rescued this way. Falling
+    // through to the registry there would serve whichever repository the
+    // registry happens to name while the operator asked for a specific one:
+    // the same wrong-repository answer the roots binder refuses, reached
+    // through the registry door instead.
+    if registry_should_resolve(global, false, repo_override.is_some()) {
+        if let Some(bound) = bind_from_registry(&startup).await {
+            startup.resolve_bound(bound, false);
+            return;
+        }
+    } else if global {
+        if let Some(pinned) = &repo_override {
+            eprintln!(
+                "Kin MCP: --repo/KIN_MCP_REPO pins {}, which did not bind. Registry mode will not \
+                 substitute another repository for a pin; fix the pinned repository or drop the \
+                 pin.",
+                pinned.display()
+            );
+        }
+    }
+    startup.resolve_unbound(unbound_reason);
 }
 
 // ── Tool profile ────────────────────────────────────────────────────────
@@ -346,8 +409,8 @@ pub(crate) fn registry_startup_choice(
 }
 
 /// Bind the startup repository from the global registry, reporting why when it
-/// cannot. Returns whether a repository is bound.
-async fn bind_from_registry() -> bool {
+/// cannot. Returns the bound repository, or `None` when nothing bound.
+async fn bind_from_registry(startup: &kin_mcp::StartupDaemonBinding) -> Option<kin_mcp::BoundRepo> {
     let registry = match kin_core::registry::KinRegistry::load() {
         Ok(registry) => registry,
         Err(error) => {
@@ -356,7 +419,7 @@ async fn bind_from_registry() -> bool {
                  will fail loud until a repository binds through --repo, KIN_MCP_REPO, or the \
                  client's workspace roots."
             );
-            return false;
+            return None;
         }
     };
 
@@ -367,7 +430,7 @@ async fn bind_from_registry() -> bool {
                  writes a registry entry. Pass --repo <path> (or set KIN_MCP_REPO=<path>) to \
                  serve a repository directly."
             );
-            false
+            None
         }
         RegistryStartupChoice::Ambiguous(ids) => {
             eprintln!(
@@ -377,37 +440,50 @@ async fn bind_from_registry() -> bool {
                 ids.len(),
                 ids.join(", ")
             );
-            false
+            None
         }
-        RegistryStartupChoice::Single(path) => match bind_daemon_for_repo_dir(&path).await {
-            Ok(daemon_url) => {
-                // Match the roots path: the daemon delegate reads the
-                // per-install loopback token from <root>/.kin/daemon.token
-                // relative to the process working directory.
-                if let Err(err) = std::env::set_current_dir(&path) {
+        RegistryStartupChoice::Single(path) => {
+            // Retarget the still-starting report at the registry repository:
+            // this is the daemon whose startup the report now describes.
+            if let Some(layout) = kin_core::KinLayout::discover(&path) {
+                let kin_root = layout.root().to_path_buf();
+                startup.set_phase_probe(Box::new(move || {
+                    crate::daemon_client::daemon_startup_phase(&kin_root)
+                }));
+            }
+            match bind_daemon_for_repo_dir(&path).await {
+                Ok(daemon_url) => {
+                    // Match the roots path: the daemon delegate reads the
+                    // per-install loopback token from <root>/.kin/daemon.token
+                    // relative to the process working directory.
+                    if let Err(err) = std::env::set_current_dir(&path) {
+                        eprintln!(
+                            "Kin MCP: bound {daemon_url} but could not switch cwd to {} ({err}); \
+                             tool auth will fall back to KIN_DAEMON_AUTH_TOKEN if set.",
+                            path.display()
+                        );
+                    }
+                    eprintln!("{}", session_authority_notice());
                     eprintln!(
-                        "Kin MCP: bound {daemon_url} but could not switch cwd to {} ({err}); \
-                         tool auth will fall back to KIN_DAEMON_AUTH_TOKEN if set.",
+                        "Kin MCP: registry mode bound the only registered repository at {} (daemon \
+                         {daemon_url})",
                         path.display()
                     );
+                    Some(kin_mcp::BoundRepo {
+                        root: canonical_path(&path),
+                        daemon_url,
+                    })
                 }
-                eprintln!("{}", session_authority_notice());
-                eprintln!(
-                    "Kin MCP: registry mode bound the only registered repository at {} (daemon \
-                     {daemon_url})",
-                    path.display()
-                );
-                true
+                Err(reason) => {
+                    eprintln!(
+                        "Kin MCP: registry mode could not bind the only registered repository at {} \
+                         ({reason}); tool calls will fail loud until one binds.",
+                        path.display()
+                    );
+                    None
+                }
             }
-            Err(reason) => {
-                eprintln!(
-                    "Kin MCP: registry mode could not bind the only registered repository at {} \
-                     ({reason}); tool calls will fail loud until one binds.",
-                    path.display()
-                );
-                false
-            }
-        },
+        }
     }
 }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -3827,6 +3827,23 @@ pub fn repo_daemon_recorded_endpoint(kin_root: &Path) -> (Option<u32>, Option<u1
     (read_pid_file(kin_root), read_port_file(kin_root))
 }
 
+/// One line saying how far a starting repo daemon has come, read from its
+/// recorded lifecycle markers alone: the daemon writes `daemon.pid` when its
+/// process comes up and `daemon.port` only once it is listening.
+///
+/// This is the phase string the MCP answer-early path (FIR-2316) folds into
+/// its honest still-starting `tools/call` answer. It lives here, in the
+/// declared daemon-lifecycle IO boundary, because the transport crate and the
+/// `kin mcp` launcher deliberately carry no filesystem primitive at all; they
+/// receive this as an injected probe.
+pub fn daemon_startup_phase(kin_root: &Path) -> &'static str {
+    match repo_daemon_recorded_endpoint(kin_root) {
+        (_, Some(_)) => "phase: the daemon is listening and finishing readiness checks",
+        (Some(_), None) => "phase: the daemon process is up and loading the repository graph",
+        (None, None) => "phase: resolving or spawning the repo daemon process",
+    }
+}
+
 /// The (pid, port) recorded for the per-user supervisor, read from its
 /// `supervisor.{pid,port}` files with no liveness probe. Either component is
 /// `None` when its file is absent or unparseable.
@@ -7132,6 +7149,30 @@ mod urlencoding {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The startup-phase line the MCP answer-early path injects must track the
+    /// daemon's lifecycle markers: pid file means the process is up and
+    /// loading, port file means it is listening, neither means it is still
+    /// being resolved or spawned.
+    #[test]
+    fn daemon_startup_phase_tracks_the_lifecycle_markers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kin_root = tmp.path();
+        assert!(
+            daemon_startup_phase(kin_root).contains("resolving or spawning"),
+            "no markers is the resolve/spawn phase"
+        );
+        std::fs::write(kin_root.join(kin_daemon_spawn::PID_FILE_NAME), "12345").unwrap();
+        assert!(
+            daemon_startup_phase(kin_root).contains("loading the repository graph"),
+            "a pid file with no port file is the graph-load phase"
+        );
+        std::fs::write(kin_root.join(kin_daemon_spawn::PORT_FILE_NAME), "50000").unwrap();
+        assert!(
+            daemon_startup_phase(kin_root).contains("finishing readiness checks"),
+            "a published port is the readiness phase"
+        );
+    }
 
     #[test]
     fn windows_daemon_candidates_use_the_target_platform_executable_name() {

--- a/crates/kin-cli/tests/mcp_stdio_contract.rs
+++ b/crates/kin-cli/tests/mcp_stdio_contract.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The MCP stdio contract with no daemon anywhere (FIR-2316).
+//!
+//! `kin mcp start` used to await its repo daemon binding before reading a
+//! byte of stdio, so a cold flagship-scale start meant minutes of complete
+//! silence against handshake probes budgeted in seconds, without even the
+//! `initialize` response. These tests drive the real binary with the update
+//! watchdog's exact four-frame session and no daemon at all (`KIN_NO_DAEMON`
+//! plus an isolated registry guarantee nothing can be spawned or found), and
+//! require every frame answered under a tight bound. The slow-bind case, a
+//! binding that stays pending while frames arrive, is covered
+//! deterministically in `kin-mcp`'s server tests; what this binary-level test
+//! pins is that the served transport never needs a daemon to hold the
+//! handshake contract.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::{Child, Stdio};
+use std::time::{Duration, Instant};
+
+mod common;
+
+/// Wall-clock bound for the whole four-frame session. Orders of magnitude
+/// above the millisecond-scale expectation, and far below the minutes a
+/// daemon-coupled handshake stalls for: a regression to the pre-loop await
+/// shape fails this bound, it does not merely slow the suite.
+const FOUR_FRAME_BOUND: Duration = Duration::from_secs(30);
+
+/// The update watchdog's probe session: initialize, the initialized
+/// notification, tools/list, and one graph-backed tools/call.
+fn probe_frames() -> String {
+    [
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"kin-mcp-contract-test","version":"0"}}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"kin_graph_status","arguments":{}}}"#,
+    ]
+    .join("\n")
+        + "\n"
+}
+
+struct McpRun {
+    responses: Vec<serde_json::Value>,
+    stderr: String,
+    elapsed: Duration,
+}
+
+/// Run `kin mcp start` in `dir` with a fully controlled environment, feed it
+/// the probe session, and collect every stdout response under the bound.
+///
+/// The environment is cleared and rebuilt rather than scrubbed: an inherited
+/// `KIN_DAEMON_URL` or `KIN_MCP_REPO` from the developer's shell would change
+/// what this test proves, and `KIN_NO_DAEMON=1` plus an isolated registry and
+/// HOME guarantee no daemon can be spawned or discovered.
+fn run_probe_session(dir: &Path, home: &Path) -> McpRun {
+    let started = Instant::now();
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["mcp", "start"])
+        .current_dir(dir)
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("TMPDIR", std::env::temp_dir())
+        .env("KIN_NO_DAEMON", "1")
+        .env("KIN_VFS_DISABLE", "1")
+        .env("KIN_REGISTRY_PATH", home.join("registry.toml"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn kin mcp start");
+
+    // Write the whole session and close stdin, exactly as the watchdog's
+    // heredoc does; the server answers each frame and exits at EOF.
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(probe_frames().as_bytes())
+        .expect("write probe frames");
+
+    // Drain both pipes concurrently: tools/list alone can exceed the pipe
+    // buffer, and a reader that waits for exit first deadlocks against a
+    // writer blocked on a full pipe.
+    let mut stdout_pipe = child.stdout.take().expect("piped stdout");
+    let stdout_reader = std::thread::spawn(move || {
+        let mut collected = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut collected);
+        collected
+    });
+    let mut stderr_pipe = child.stderr.take().expect("piped stderr");
+    let stderr_reader = std::thread::spawn(move || {
+        let mut collected = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut collected);
+        collected
+    });
+
+    let status = wait_bounded(&mut child, started + FOUR_FRAME_BOUND);
+    let stdout = stdout_reader.join().expect("join stdout reader");
+    let stderr =
+        String::from_utf8_lossy(&stderr_reader.join().expect("join stderr reader")).into_owned();
+    let elapsed = started.elapsed();
+
+    let status = status.unwrap_or_else(|| {
+        panic!(
+            "kin mcp start answered nothing within {FOUR_FRAME_BOUND:?}: the stdio loop is \
+             blocked behind the daemon binding again (FIR-2316); stderr:\n{stderr}"
+        )
+    });
+    assert!(
+        status.success(),
+        "kin mcp start exited with {status}; stderr:\n{stderr}"
+    );
+
+    let responses = String::from_utf8(stdout)
+        .expect("stdout is UTF-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("stdout lines are JSON-RPC"))
+        .collect();
+    McpRun {
+        responses,
+        stderr,
+        elapsed,
+    }
+}
+
+/// Wait for the child under a deadline; kill it at expiry and return `None`.
+fn wait_bounded(child: &mut Child, deadline: Instant) -> Option<std::process::ExitStatus> {
+    loop {
+        if let Some(status) = child.try_wait().expect("poll kin mcp start") {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn response_with_id(run: &McpRun, id: u64) -> &serde_json::Value {
+    run.responses
+        .iter()
+        .find(|value| value.get("id").and_then(|v| v.as_u64()) == Some(id))
+        .unwrap_or_else(|| {
+            panic!(
+                "no response with id {id}; got {:#?}; stderr:\n{}",
+                run.responses, run.stderr
+            )
+        })
+}
+
+fn assert_four_frame_contract(run: &McpRun) {
+    assert!(
+        run.elapsed < FOUR_FRAME_BOUND,
+        "the probe session took {:?} against a {FOUR_FRAME_BOUND:?} bound",
+        run.elapsed
+    );
+    let initialize = response_with_id(run, 1);
+    assert!(
+        initialize.pointer("/result/serverInfo/name").is_some(),
+        "initialize must answer with server info: {initialize:#?}"
+    );
+    let tools = response_with_id(run, 2);
+    let tool_count = tools
+        .pointer("/result/tools")
+        .and_then(|tools| tools.as_array())
+        .map(|tools| tools.len())
+        .unwrap_or(0);
+    assert!(
+        tool_count > 0,
+        "tools/list must serve the tool surface with no daemon: {tools:#?}"
+    );
+
+    // The graph-backed call is answered with a structured error naming the
+    // situation, never with silence or a dead process.
+    let call = response_with_id(run, 3);
+    let content = call
+        .pointer("/result/content/0/text")
+        .and_then(|text| text.as_str())
+        .unwrap_or_else(|| panic!("tools/call must carry a content block: {call:#?}"));
+    assert_eq!(
+        call.pointer("/result/isError").and_then(|v| v.as_bool()),
+        Some(true),
+        "with no daemon anywhere the graph call is an error result: {call:#?}"
+    );
+    assert!(
+        content.contains("daemon") || content.contains("repository"),
+        "the error must name what is missing: {content}"
+    );
+}
+
+/// The global-entry shape: launched from a directory that is no repository.
+#[test]
+fn the_four_frame_probe_is_answered_with_no_repository_and_no_daemon() {
+    let root = tempfile::tempdir().expect("temp root");
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+    let plain = root.path().join("not-a-repo");
+    std::fs::create_dir_all(&plain).expect("create launch dir");
+
+    let run = run_probe_session(&plain, &home);
+    assert_four_frame_contract(&run);
+}
+
+/// The watchdog-probe shape: launched inside a real Kin repository whose
+/// daemon does not exist and may not be spawned.
+#[test]
+fn the_four_frame_probe_is_answered_inside_a_repository_whose_daemon_is_absent() {
+    let root = tempfile::tempdir().expect("temp root");
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+    // Kin-native init requires an empty directory; it will not derive
+    // authority from pre-existing filesystem contents.
+    let repo = root.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let init = common::Command::new(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(&repo)
+        .env("HOME", &home)
+        .env("KIN_NO_DAEMON", "1")
+        .env("KIN_REGISTRY_PATH", home.join("registry.toml"))
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let run = run_probe_session(&repo, &home);
+    assert_four_frame_contract(&run);
+}

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2758,6 +2758,13 @@ async fn select_with_signals(
     }
 
     let (completed, result) = tokio::select! {
+        // NOTE: this arm shuts the daemon down, so the reconciliation loop
+        // must only exit for reasons that end the daemon: the cancel signal,
+        // or a real startup/runtime error. A background-work supervisor stop
+        // parks the loop inside `run_loop` instead of exiting it, precisely
+        // because reaching this arm cancels the API task and every other
+        // task, the opposite of the stop announcement's "the daemon keeps
+        // serving" (FIR-2317).
         result = &mut loop_handle => {
             info!("reconciliation loop exited");
             let _ = cancel_tx.send(true);
@@ -2893,6 +2900,13 @@ async fn select_with_signals(
     }
 
     let (completed, result) = tokio::select! {
+        // NOTE: this arm shuts the daemon down, so the reconciliation loop
+        // must only exit for reasons that end the daemon: the cancel signal,
+        // or a real startup/runtime error. A background-work supervisor stop
+        // parks the loop inside `run_loop` instead of exiting it, precisely
+        // because reaching this arm cancels the API task and every other
+        // task, the opposite of the stop announcement's "the daemon keeps
+        // serving" (FIR-2317).
         result = &mut loop_handle => {
             info!("reconciliation loop exited");
             let _ = cancel_tx.send(true);

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info, warn};
 use crate::error::{DaemonError, Result};
 use crate::state::{
     ChangeType, DaemonEvent, DaemonState, LspEnrichmentRequest, ProjectionChangedSet, RECON_IDLE,
-    RECON_PROCESSING,
+    RECON_PARKED, RECON_PROCESSING,
 };
 
 pub(crate) const DISABLE_FILESYSTEM_RECONCILE_ENV: &str = "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE";
@@ -1246,6 +1246,94 @@ fn reconcile_error_earns_retry(error: &kin_reconcile::ReconcileError) -> bool {
     )
 }
 
+/// Sweep expired coordination intents and record every automatic release
+/// durably, under the same cross-surface gate used by registration and graph
+/// apply.
+///
+/// Called once per reconcile tick, and kept alive by the parked loop after a
+/// supervisor stop: intents are locks, and a daemon that keeps serving must
+/// keep expiring them whether or not admission still runs.
+async fn sweep_expired_intents(state: &DaemonState) {
+    let _coordination = state.coordination_gate.lock().await;
+    let mode = state.coordination_mode().as_str().to_string();
+    match state
+        .coordinator
+        .sweep_expired_intents_with_reservation(|intent| {
+            state
+                .record_coordination_event(crate::state::CoordinationEventDraft {
+                    event: "intent_release",
+                    outcome: "pending:expired".to_string(),
+                    session_id: Some(intent.session_id.to_string()),
+                    intent_id: Some(intent.intent_id.to_string()),
+                    intent_ids: vec![intent.intent_id.to_string()],
+                    transaction_id: None,
+                    scopes: intent.scopes.iter().map(crate::api::format_scope).collect(),
+                    enforcement_mode: mode.clone(),
+                    blocking_intent_ids: Vec::new(),
+                })
+                .map(|_| ())
+        }) {
+        Ok(reaped) => {
+            for intent in &reaped {
+                let _ = state.record_coordination_event(crate::state::CoordinationEventDraft {
+                    event: "intent_release",
+                    outcome: "expired".to_string(),
+                    session_id: Some(intent.session_id.to_string()),
+                    intent_id: Some(intent.intent_id.to_string()),
+                    intent_ids: vec![intent.intent_id.to_string()],
+                    transaction_id: None,
+                    scopes: intent.scopes.iter().map(crate::api::format_scope).collect(),
+                    enforcement_mode: mode.clone(),
+                    blocking_intent_ids: Vec::new(),
+                });
+            }
+            if !reaped.is_empty() {
+                debug!(reaped = reaped.len(), "swept expired intents");
+            }
+        }
+        Err(error) => {
+            state.mark_coordination_evidence_incomplete(format!(
+                "expired-intent sweep failed after reservation may have been written: {error}"
+            ));
+        }
+    }
+}
+
+/// What the reconciliation loop becomes after the background-work supervisor
+/// stops its pass: parked, not exited.
+///
+/// The loop's exit is one of the daemon's shutdown arms, so exiting on a
+/// supervisor stop tore down the API task and every other task with it,
+/// directly contradicting the stop announcement's "the daemon keeps serving"
+/// (FIR-2317). Parking keeps the task alive doing only the coordination
+/// housekeeping the daemon still owes, and ends on the daemon's own shutdown
+/// signal. Admission stays stopped until a daemon restart clears the
+/// in-memory halt, which is the "a restart retries it" the announcement
+/// promises.
+async fn park_reconcile_loop(
+    state: &DaemonState,
+    mut cancel: tokio::sync::watch::Receiver<bool>,
+    interval: Duration,
+) -> Result<()> {
+    // A zero poll interval must not turn the parked loop into the very
+    // CPU-spending spin the supervisor just stopped.
+    let interval = interval.max(Duration::from_millis(200));
+    loop {
+        if *cancel.borrow() {
+            state
+                .reconciliation_status
+                .store(RECON_IDLE, Ordering::Relaxed);
+            info!("reconciliation loop shutting down");
+            return Ok(());
+        }
+        sweep_expired_intents(state).await;
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = cancel.changed() => {}
+        }
+    }
+}
+
 /// Run the reconciliation loop until the cancellation token fires.
 ///
 /// This is the main loop of the daemon. It:
@@ -1355,69 +1443,36 @@ pub async fn run_loop(
         // taken, so nothing is abandoned mid-transaction. Graph truth is
         // untouched and the daemon keeps serving it; what stops is the automatic
         // tracking of working-copy edits, which the announced reason says.
+        //
+        // Parking, not exiting, is what keeps that announcement true: this
+        // loop's exit is a shutdown arm in the daemon's task supervision, so
+        // returning here cancelled the API task and took the whole daemon down
+        // twenty seconds after it promised to keep serving (FIR-2317). The
+        // parked loop sheds the watcher and the admission machinery, keeps the
+        // expired-intent sweep alive so coordination locks still expire, and
+        // ends only on the daemon's own shutdown. The halt is in-memory state,
+        // so a daemon restart retries the pass, exactly as announced.
         if pass.halted() {
             state
                 .reconciliation_status
-                .store(RECON_IDLE, Ordering::Relaxed);
+                .store(RECON_PARKED, Ordering::Relaxed);
             error!(
                 reason = pass.halt_reason().unwrap_or_default(),
-                "reconciliation loop stopped by the background-work supervisor"
+                "reconciliation loop stopped by the background-work supervisor; parking it while \
+                 the daemon keeps serving (a daemon restart retries the pass)"
             );
-            break;
+            pass.idle();
+            // A parked loop owes nothing, whatever its ladder still held.
+            pass.set_deferred(false, Instant::now());
+            // Shed the admission machinery: the watcher would keep buffering
+            // events nothing will ever drain.
+            drop(watcher);
+            drop(pending_events);
+            drop(retry_lane);
+            return park_reconcile_loop(&state, cancel, interval).await;
         }
 
-        // Sweep under the same cross-surface gate used by registration and
-        // graph apply, then record every automatic release durably.
-        {
-            let _coordination = state.coordination_gate.lock().await;
-            let mode = state.coordination_mode().as_str().to_string();
-            match state
-                .coordinator
-                .sweep_expired_intents_with_reservation(|intent| {
-                    state
-                        .record_coordination_event(crate::state::CoordinationEventDraft {
-                            event: "intent_release",
-                            outcome: "pending:expired".to_string(),
-                            session_id: Some(intent.session_id.to_string()),
-                            intent_id: Some(intent.intent_id.to_string()),
-                            intent_ids: vec![intent.intent_id.to_string()],
-                            transaction_id: None,
-                            scopes: intent.scopes.iter().map(crate::api::format_scope).collect(),
-                            enforcement_mode: mode.clone(),
-                            blocking_intent_ids: Vec::new(),
-                        })
-                        .map(|_| ())
-                }) {
-                Ok(reaped) => {
-                    for intent in &reaped {
-                        let _ =
-                            state.record_coordination_event(crate::state::CoordinationEventDraft {
-                                event: "intent_release",
-                                outcome: "expired".to_string(),
-                                session_id: Some(intent.session_id.to_string()),
-                                intent_id: Some(intent.intent_id.to_string()),
-                                intent_ids: vec![intent.intent_id.to_string()],
-                                transaction_id: None,
-                                scopes: intent
-                                    .scopes
-                                    .iter()
-                                    .map(crate::api::format_scope)
-                                    .collect(),
-                                enforcement_mode: mode.clone(),
-                                blocking_intent_ids: Vec::new(),
-                            });
-                    }
-                    if !reaped.is_empty() {
-                        debug!(reaped = reaped.len(), "swept expired intents");
-                    }
-                }
-                Err(error) => {
-                    state.mark_coordination_evidence_incomplete(format!(
-                        "expired-intent sweep failed after reservation may have been written: {error}"
-                    ));
-                }
-            }
-        }
+        sweep_expired_intents(&state).await;
 
         // Collect retries first and real watcher notifications second. Dedup once per tick,
         // only when something new arrived; a real remove/recreate therefore supersedes a
@@ -2329,6 +2384,90 @@ mod tests {
             std::env::var_os("KIN_ALLOW_MASS_DELETION"),
             mass_delete_before,
             "graph-only mode must not set or clear the mass-deletion escape hatch"
+        );
+    }
+
+    /// FIR-2317: a background-work supervisor stop parks the reconciliation
+    /// loop; it must not exit the loop task. In the daemon, the loop task's
+    /// exit is a shutdown arm that cancels the API task and drains everything,
+    /// so an exit here is exactly the "stopped a stalled pass, lost the whole
+    /// daemon" failure, twenty seconds after announcing "the daemon keeps
+    /// serving".
+    #[tokio::test]
+    async fn a_supervisor_stop_parks_the_loop_instead_of_exiting_it() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        // The supervisor's verdict, delivered before the loop starts so its
+        // first checkpoint observes it.
+        state
+            .background_work
+            .pass(crate::background_work::PASS_RECONCILE)
+            .halt("test: the reconcile pass was stopped by the supervisor");
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let mut handle = tokio::spawn(run_loop(
+            Arc::clone(&state),
+            LoopConfig::default(),
+            cancel_rx,
+        ));
+
+        // Wait for the loop to reach its checkpoint and park. The parked
+        // status is the observable that separates "parked" from "not yet
+        // scheduled", so this poll cannot pass vacuously on a slow machine.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while state.reconciliation_status.load(Ordering::Relaxed) != RECON_PARKED {
+            assert!(
+                !handle.is_finished(),
+                "the reconciliation loop exited on a supervisor stop; in the daemon this \
+                 cancels the API task and takes the whole daemon down (FIR-2317)"
+            );
+            assert!(
+                Instant::now() < deadline,
+                "the loop never reached its supervisor-stop checkpoint"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            state.reconciliation_status_str(),
+            "parked-by-supervisor",
+            "status surfaces must report the stop, not describe the loop as idle"
+        );
+
+        // Parked is not exited: the task must still be alive after the
+        // checkpoint has provably run.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !handle.is_finished(),
+            "the parked loop must stay alive until the daemon itself shuts down"
+        );
+
+        // The daemon's own shutdown still ends the parked loop cleanly.
+        cancel_tx.send(true).unwrap();
+        let joined = tokio::time::timeout(Duration::from_secs(30), &mut handle)
+            .await
+            .expect("a parked reconciliation loop must still exit on shutdown")
+            .expect("the parked loop task must not panic");
+        joined.expect("the parked loop must exit cleanly");
+        assert_eq!(
+            state.reconciliation_status.load(Ordering::Relaxed),
+            RECON_IDLE,
+            "shutdown returns the status to idle"
+        );
+
+        // The halt is in-memory supervisor state, which is what makes the
+        // announcement's "a restart retries it" true: a fresh daemon process
+        // starts with an unhalted pass.
+        drop(handle);
+        drop(state);
+        let reopened = kin_core::KinLayout::discover(repo.path())
+            .expect("the repository layout must still be discoverable");
+        let restarted = DaemonState::open(reopened).expect("a fresh daemon state must open");
+        assert!(
+            !restarted
+                .background_work
+                .pass(crate::background_work::PASS_RECONCILE)
+                .halted(),
+            "a restarted daemon must retry the reconcile pass"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -85,6 +85,11 @@ impl ChangeStore for ProspectiveChangeStore<'_> {
 /// Reconciliation loop status values.
 pub const RECON_IDLE: u8 = 0;
 pub const RECON_PROCESSING: u8 = 1;
+/// The background-work supervisor stopped the reconcile pass and the loop is
+/// parked: no admission runs until a daemon restart, while the daemon itself
+/// keeps serving. Distinct from `RECON_IDLE` so status surfaces report the
+/// stop instead of describing a stopped loop as merely quiet.
+pub const RECON_PARKED: u8 = 2;
 
 /// Flush a directory entry after an atomic namespace update where the host
 /// supports opening directories as files. Windows rejects
@@ -5193,6 +5198,7 @@ impl DaemonState {
     pub fn reconciliation_status_str(&self) -> &'static str {
         match self.reconciliation_status.load(Ordering::Relaxed) {
             RECON_PROCESSING => "processing",
+            RECON_PARKED => "parked-by-supervisor",
             _ => "idle",
         }
     }

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod negative;
 pub mod server;
 pub mod session;
+pub mod startup_binding;
 pub mod tools;
 pub mod types;
 
@@ -27,6 +28,7 @@ pub use session::{
     CoordinationSurfaceCoverage, CoordinationWritePreflight, IntentRegistrationAttempt,
     McpMutationOperation, McpMutationPayload, McpTransaction, SessionRegistry,
 };
+pub use startup_binding::{StartupBindingState, StartupDaemonBinding};
 pub use tools::{
     agent_default_tool_names, benchmark_tool_names, context_bench_tool_names, tool_definitions,
 };

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -17,6 +17,7 @@ use crate::envelope::{self, Envelope};
 use crate::error::{McpError, Result};
 use crate::handlers::{handle_tool_call, RequestRepositoryAuthority};
 use crate::session::SessionRegistry;
+use crate::startup_binding::{StartupBindingState, StartupDaemonBinding};
 use crate::tools::tool_definitions;
 use crate::types::*;
 
@@ -198,6 +199,7 @@ const ROOTS_REQUEST_ID: &str = "kin-mcp-roots-list";
 pub async fn run_stdio_daemon(
     config: McpServerConfig,
     repo_binder: Option<RepoBinder>,
+    startup: Option<std::sync::Arc<StartupDaemonBinding>>,
 ) -> Result<()> {
     if !config.session_authority_mode.requires_daemon() {
         return Err(McpError::Other(
@@ -215,6 +217,7 @@ pub async fn run_stdio_daemon(
         config,
         repo_binder,
         bound_daemon_url_from_env(),
+        startup,
     )
     .await
 }
@@ -236,6 +239,7 @@ async fn run_stdio_daemon_over<R, W>(
     config: McpServerConfig,
     repo_binder: Option<RepoBinder>,
     bound_daemon_url: Option<String>,
+    startup: Option<std::sync::Arc<StartupDaemonBinding>>,
 ) -> Result<()>
 where
     R: AsyncBufRead + Unpin,
@@ -253,6 +257,18 @@ where
     let mut binding = RepoBindingState::started_with(bound_daemon_url);
 
     while let Some((message, framed)) = read_stdio_message(&mut *reader).await? {
+        // The launcher's startup binding runs behind this loop so `initialize`
+        // and `tools/list` are answered immediately. Once it settles with a
+        // bound daemon, fold that into the roots-binding bookkeeping so a
+        // later roots change compares against the repository actually served.
+        if let Some(startup) = startup.as_ref() {
+            if !binding.is_bound() {
+                if let StartupBindingState::Bound(bound) = startup.snapshot() {
+                    binding.bind(bound);
+                }
+            }
+        }
+
         // Peek at the raw JSON so we can distinguish the client's requests and
         // notifications from the `roots/list` response we may have sent: a
         // response carries no `method`, which the strongly-typed
@@ -262,6 +278,31 @@ where
 
             if method == Some("initialize") {
                 client_supports_roots = value.pointer("/params/capabilities/roots").is_some();
+            }
+
+            // A `tools/call` racing the launcher's startup binding gets a
+            // bounded moment for a warm daemon to bind, then an honest
+            // still-starting answer: never minutes of silence, and never a
+            // remedy-flavored "no daemon" error while one is on its way up.
+            if method == Some("tools/call") {
+                if let Some(startup) = startup.as_ref() {
+                    if !startup
+                        .wait_until_settled(TOOLS_CALL_STARTUP_BIND_GRACE)
+                        .await
+                    {
+                        if let Some(response) = startup_pending_response(&value, startup) {
+                            let response_json =
+                                serde_json::to_string(&response).map_err(McpError::Json)?;
+                            write_stdio_message(&mut *writer, &response_json, framed).await?;
+                        }
+                        continue;
+                    }
+                    if !binding.is_bound() {
+                        if let StartupBindingState::Bound(bound) = startup.snapshot() {
+                            binding.bind(bound);
+                        }
+                    }
+                }
             }
 
             // The client moved to a workspace we could not bind. Refuse every
@@ -477,6 +518,37 @@ impl WorkspaceMismatch {
              from it (or with --repo <path> / KIN_MCP_REPO=<path>)."
         )
     }
+}
+
+/// How long a `tools/call` waits for the launcher's startup daemon binding to
+/// settle before answering that the daemon is still starting.
+///
+/// A warm daemon binds in well under a second, so a call racing the bind gets
+/// its real answer inside this window; a cold flagship-scale start takes
+/// minutes and no defensible grace covers it, which is exactly when the honest
+/// still-starting answer is owed. Kept well under common MCP client per-call
+/// timeouts (60 s) and under the update watchdog's 30 s whole-probe budget.
+const TOOLS_CALL_STARTUP_BIND_GRACE: Duration = Duration::from_secs(10);
+
+/// Structured answer for a `tools/call` that arrived while the launcher's
+/// startup binding is still pending. `None` for a malformed call with no id,
+/// which has no response channel; the caller still drops the call rather than
+/// forwarding it.
+fn startup_pending_response(
+    request: &serde_json::Value,
+    startup: &StartupDaemonBinding,
+) -> Option<JsonRpcResponse> {
+    let id = request.get("id").filter(|id| !id.is_null())?.clone();
+    let tool = request
+        .pointer("/params/name")
+        .and_then(|name| name.as_str())
+        .unwrap_or("this tool");
+    let result = ToolCallResult::error(startup.starting_report(tool));
+    let enveloped = envelope::finalize(result, Envelope::daemon_unreachable(), tool);
+    Some(JsonRpcResponse::success(
+        Some(id),
+        serde_json::to_value(&enveloped).unwrap_or_default(),
+    ))
 }
 
 /// How long an unanswered `roots/list` suppresses another one. A client that
@@ -1984,6 +2056,15 @@ mod tests {
         repo_binder: Option<RepoBinder>,
         bound_daemon_url: Option<String>,
     ) -> Vec<serde_json::Value> {
+        drive_daemon_loop_with_startup(client_messages, repo_binder, bound_daemon_url, None).await
+    }
+
+    async fn drive_daemon_loop_with_startup(
+        client_messages: &[serde_json::Value],
+        repo_binder: Option<RepoBinder>,
+        bound_daemon_url: Option<String>,
+        startup: Option<std::sync::Arc<StartupDaemonBinding>>,
+    ) -> Vec<serde_json::Value> {
         let mut input = String::new();
         for message in client_messages {
             input.push_str(&message.to_string());
@@ -2002,6 +2083,7 @@ mod tests {
             config,
             repo_binder,
             bound_daemon_url,
+            startup,
         )
         .await
         .expect("stdio loop must drain the scripted client session");
@@ -2294,6 +2376,148 @@ mod tests {
         assert!(
             text.contains("not enabled in this MCP profile"),
             "an empty roots list must not be treated as a workspace switch: {text}"
+        );
+    }
+
+    /// The answer-early contract (FIR-2316): the handshake never waits on the
+    /// daemon. With the startup binding pending forever (the shape of a cold
+    /// flagship-scale daemon start), `initialize` and `tools/list` are still
+    /// answered from this process.
+    #[tokio::test]
+    async fn initialize_and_tools_list_answer_while_the_startup_binding_is_pending() {
+        let startup = StartupDaemonBinding::new();
+
+        let responses = drive_daemon_loop_with_startup(
+            &[
+                serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+            ],
+            None,
+            None,
+            Some(startup),
+        )
+        .await;
+
+        let initialize = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(1))
+            .expect("initialize must be answered while the daemon binding is pending");
+        assert!(
+            initialize.pointer("/result/serverInfo/name").is_some(),
+            "initialize must carry the ordinary result: {initialize:#?}"
+        );
+        let tools_list = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(2))
+            .expect("tools/list must be answered while the daemon binding is pending");
+        assert!(
+            tools_list.pointer("/result/tools").is_some(),
+            "tools/list must carry the ordinary result: {tools_list:#?}"
+        );
+    }
+
+    /// A `tools/call` racing a binding that never settles gets the honest
+    /// still-starting answer once the bounded grace elapses: not silence, and
+    /// not the fall-through refusal this config would otherwise produce (the
+    /// empty allow-list answers "not enabled in this MCP profile", so reaching
+    /// that text would prove the guard never ran).
+    #[tokio::test(start_paused = true)]
+    async fn a_tool_call_during_a_pending_binding_answers_that_the_daemon_is_starting() {
+        let startup = StartupDaemonBinding::new();
+
+        let responses = drive_daemon_loop_with_startup(
+            &[
+                serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+                tool_call(3, "kin_graph_status"),
+            ],
+            None,
+            None,
+            Some(startup),
+        )
+        .await;
+
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(3))
+            .expect("a tool call during startup binding must be answered, not dropped");
+        let text = tool_error_text(answer);
+        assert!(
+            text.contains("still starting") && text.contains("kin_graph_status"),
+            "the answer must say the daemon is starting and name the tool: {text}"
+        );
+        assert!(
+            text.contains("retry"),
+            "the remedy is retrying, not remediation: {text}"
+        );
+        assert!(
+            !text.contains("not enabled in this MCP profile"),
+            "the still-starting guard must answer before the fall-through path: {text}"
+        );
+    }
+
+    /// Once the binding settles without a daemon, tool calls fall through to
+    /// the ordinary handling instead of reporting a startup that is over.
+    #[tokio::test]
+    async fn a_tool_call_after_the_binding_settles_unbound_falls_through() {
+        let startup = StartupDaemonBinding::new();
+        startup.resolve_unbound("not a Kin repository");
+
+        let responses = drive_daemon_loop_with_startup(
+            &[
+                serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+                tool_call(4, "semantic_locate"),
+            ],
+            None,
+            None,
+            Some(startup),
+        )
+        .await;
+
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(4))
+            .expect("the tool call must be answered");
+        let text = tool_error_text(answer);
+        assert!(
+            !text.contains("still starting"),
+            "a settled binding must not be reported as still starting: {text}"
+        );
+        assert!(
+            text.contains("not enabled in this MCP profile"),
+            "a settled-unbound binding falls through to the ordinary handling: {text}"
+        );
+    }
+
+    /// A startup binding that settles bound folds into the roots bookkeeping:
+    /// the server then behaves as bound, so it does not keep asking a
+    /// roots-capable client for a workspace it already serves.
+    #[tokio::test]
+    async fn a_bound_startup_binding_folds_into_the_roots_bookkeeping() {
+        let startup = StartupDaemonBinding::new();
+        startup.resolve_bound(bound_repo("/repo/a", "http://127.0.0.1:4111"), false);
+        let (binder, calls) = ScriptedBinder::install(vec![]);
+
+        let responses = drive_daemon_loop_with_startup(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+            ],
+            Some(binder),
+            None,
+            Some(startup),
+        )
+        .await;
+
+        assert!(
+            roots_requests(&responses).is_empty(),
+            "a server whose startup binding bound must not keep requesting workspace roots: \
+             {responses:#?}"
+        );
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "the binder must not run while the startup binding already bound"
         );
     }
 }

--- a/crates/kin-mcp/src/startup_binding.rs
+++ b/crates/kin-mcp/src/startup_binding.rs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The daemon binding a launcher performs in the background at startup.
+//!
+//! `kin mcp start` used to resolve (and, cold, spawn and wait for) its repo
+//! daemon before reading a single byte of stdio, so a client saw no frames at
+//! all until the daemon served, without even the `initialize` response. On a
+//! flagship-scale store that is minutes of silence against handshake probes
+//! measured in seconds. The stdio server needs no daemon for `initialize` or
+//! `tools/list`; only `tools/call` does.
+//!
+//! This type is the seam between the two: the launcher starts the stdio loop
+//! immediately, runs the binding on a background task, and publishes its
+//! progress here. The server consults it on `tools/call`, giving a
+//! fast-settling bind a bounded moment, then answering honestly that the
+//! daemon is still starting instead of hanging or failing as if no daemon
+//! could ever exist.
+//!
+//! This crate is an answer surface under the zero-file-search rule and carries
+//! no filesystem primitive. The startup-phase detail in the still-starting
+//! report comes from a probe the launcher injects; the daemon-lifecycle IO
+//! behind that probe lives in the launcher's declared IO boundary.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::server::BoundRepo;
+
+/// Where the launcher's startup daemon binding currently stands.
+#[derive(Debug, Clone)]
+pub enum StartupBindingState {
+    /// The binding task is still resolving, spawning, or waiting on a daemon.
+    Pending,
+    /// A daemon is bound and `tools/call` forwarding can proceed.
+    Bound(BoundRepo),
+    /// The binding settled without a daemon. `tools/call` falls through to the
+    /// ordinary daemon-unavailable handling, which names the remedy.
+    Unbound {
+        /// Why nothing bound, for the launcher's stderr log; tool results keep
+        /// using the standard unavailable message, which is remedy-focused.
+        #[allow(dead_code)]
+        reason: String,
+    },
+}
+
+/// How the launcher answers "how far has the starting daemon come" for the
+/// still-starting report. Injected rather than computed here: the phase is
+/// read from the daemon's lifecycle markers, and that filesystem IO belongs to
+/// the launcher's daemon-lifecycle boundary, not to this crate.
+pub type StartupPhaseProbe = Box<dyn Fn() -> &'static str + Send + Sync>;
+
+/// Handle shared between the launcher's background binding task and the stdio
+/// server loop.
+///
+/// The launcher creates it `Pending`, hands one clone to the binding task and
+/// one to the server, and the task settles it exactly once. The server only
+/// ever reads it, plus a bounded wait so a warm daemon that binds in
+/// milliseconds is never reported as still starting.
+pub struct StartupDaemonBinding {
+    state: tokio::sync::watch::Sender<StartupBindingState>,
+    /// The launcher-injected startup-phase probe, once the binding task knows
+    /// which repository it is binding.
+    phase_probe: Mutex<Option<StartupPhaseProbe>>,
+    /// Whether an operator pin (`--repo`/`KIN_MCP_REPO`) bound successfully.
+    /// The workspace-roots binder must not repoint such a binding, and with the
+    /// bind running behind the loop this is only known once it settles.
+    pinned_by_operator: AtomicBool,
+    began: Instant,
+}
+
+impl std::fmt::Debug for StartupDaemonBinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StartupDaemonBinding")
+            .field("state", &*self.state.borrow())
+            .field("pinned_by_operator", &self.pinned_by_operator())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StartupDaemonBinding {
+    pub fn new() -> std::sync::Arc<Self> {
+        let (state, _) = tokio::sync::watch::channel(StartupBindingState::Pending);
+        std::sync::Arc::new(Self {
+            state,
+            phase_probe: Mutex::new(None),
+            pinned_by_operator: AtomicBool::new(false),
+            began: Instant::now(),
+        })
+    }
+
+    /// Install the launcher's startup-phase probe for the repository being
+    /// bound, so the not-ready report can say how far that daemon's startup
+    /// has come. Re-installable: registry mode retargets the report when it
+    /// picks a different repository than the launch directory.
+    pub fn set_phase_probe(&self, probe: StartupPhaseProbe) {
+        if let Ok(mut guard) = self.phase_probe.lock() {
+            *guard = Some(probe);
+        }
+    }
+
+    /// Settle the binding with a bound daemon. `pinned_by_operator` marks a
+    /// successful `--repo`/`KIN_MCP_REPO` bind, which workspace roots must
+    /// never repoint.
+    ///
+    /// `send_replace`, not `send`: a plain watch send fails when no receiver
+    /// is subscribed, and this channel routinely has none, because the server
+    /// only subscribes while a `tools/call` is actually waiting. A settle must
+    /// never be lost to that.
+    pub fn resolve_bound(&self, bound: BoundRepo, pinned_by_operator: bool) {
+        self.pinned_by_operator
+            .store(pinned_by_operator, Ordering::Release);
+        self.state.send_replace(StartupBindingState::Bound(bound));
+    }
+
+    /// Settle the binding without a daemon.
+    pub fn resolve_unbound(&self, reason: impl Into<String>) {
+        self.state.send_replace(StartupBindingState::Unbound {
+            reason: reason.into(),
+        });
+    }
+
+    pub fn pinned_by_operator(&self) -> bool {
+        self.pinned_by_operator.load(Ordering::Acquire)
+    }
+
+    /// The current state, cloned out of the watch channel.
+    pub fn snapshot(&self) -> StartupBindingState {
+        self.state.borrow().clone()
+    }
+
+    fn is_settled(&self) -> bool {
+        !matches!(*self.state.borrow(), StartupBindingState::Pending)
+    }
+
+    /// Wait up to `grace` for the binding to settle. Returns whether it did.
+    ///
+    /// The grace exists for the warm case: a daemon that is already serving
+    /// binds in well under a second, and a `tools/call` racing that bind must
+    /// get its real answer, not a spurious "still starting". A cold start does
+    /// not fit any reasonable grace and is reported honestly instead.
+    pub async fn wait_until_settled(&self, grace: Duration) -> bool {
+        if self.is_settled() {
+            return true;
+        }
+        let mut receiver = self.state.subscribe();
+        let settled = tokio::time::timeout(grace, async {
+            loop {
+                if !matches!(*receiver.borrow_and_update(), StartupBindingState::Pending) {
+                    return;
+                }
+                if receiver.changed().await.is_err() {
+                    // The sender lives in this same struct, so this arm is
+                    // unreachable while `self` is alive; return rather than
+                    // spin if it ever is not.
+                    return;
+                }
+            }
+        })
+        .await;
+        settled.is_ok() && self.is_settled()
+    }
+
+    /// The honest account of a `tools/call` that arrived while the binding is
+    /// still pending: what is happening, how long it has been happening, and
+    /// what the caller should do (retry, not remediate).
+    pub fn starting_report(&self, tool: &str) -> String {
+        let phase = self.startup_phase();
+        let elapsed = self.began.elapsed().as_secs();
+        format!(
+            "kin-mcp cannot answer '{tool}' yet: the repo daemon is still starting \
+             ({phase}; {elapsed}s so far). The MCP transport is up and `initialize` and \
+             `tools/list` are served; retry this call once the daemon is ready. Large \
+             repositories can take minutes on a fully cold start. This is startup latency, \
+             not a failure: do not restart the MCP server or re-run `kin init`."
+        )
+    }
+
+    /// The daemon's startup phase from the launcher's injected probe, or the
+    /// resolve phase while no probe is installed (nothing has named a
+    /// repository to bind yet).
+    fn startup_phase(&self) -> &'static str {
+        if let Ok(guard) = self.phase_probe.lock() {
+            if let Some(probe) = guard.as_ref() {
+                return probe();
+            }
+        }
+        "phase: resolving which repository daemon to bind"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[tokio::test(start_paused = true)]
+    async fn a_pending_binding_reports_not_settled_after_the_grace() {
+        let binding = StartupDaemonBinding::new();
+        assert!(
+            !binding.wait_until_settled(Duration::from_secs(10)).await,
+            "a binding nobody settles must report unsettled once the grace elapses"
+        );
+        assert!(matches!(binding.snapshot(), StartupBindingState::Pending));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_binding_that_settles_mid_grace_is_seen_settling() {
+        let binding = StartupDaemonBinding::new();
+        let waiter = std::sync::Arc::clone(&binding);
+        let wait =
+            tokio::spawn(async move { waiter.wait_until_settled(Duration::from_secs(10)).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        binding.resolve_bound(
+            BoundRepo {
+                root: PathBuf::from("/repo"),
+                daemon_url: "http://127.0.0.1:4242".to_string(),
+            },
+            true,
+        );
+        assert!(
+            wait.await.unwrap(),
+            "a settle during the grace must be observed as settled, not timed out"
+        );
+        assert!(binding.pinned_by_operator());
+        assert!(matches!(
+            binding.snapshot(),
+            StartupBindingState::Bound(BoundRepo { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_already_settled_binding_waits_for_nothing() {
+        let binding = StartupDaemonBinding::new();
+        binding.resolve_unbound("not a Kin repository");
+        let began = Instant::now();
+        assert!(binding.wait_until_settled(Duration::from_secs(30)).await);
+        assert!(
+            began.elapsed() < Duration::from_secs(5),
+            "a settled binding must answer immediately, not sit out the grace"
+        );
+    }
+
+    #[test]
+    fn the_starting_report_carries_the_injected_phase() {
+        let binding = StartupDaemonBinding::new();
+        // Before a probe is installed, the report still explains itself.
+        let report = binding.starting_report("kin_graph_status");
+        assert!(
+            report.contains("resolving which repository"),
+            "with no probe the report carries the resolve phase: {report}"
+        );
+        assert!(
+            report.contains("kin_graph_status") && report.contains("retry"),
+            "the report must name the tool and the retry remedy: {report}"
+        );
+        assert!(
+            report.contains("not a failure"),
+            "the report must say this is startup latency, not a defect: {report}"
+        );
+
+        // The launcher's probe is read at report time, so the phase moves as
+        // the daemon's startup does, not as of when the probe was installed.
+        let phase = std::sync::Arc::new(Mutex::new(
+            "phase: the daemon process is up and loading the repository graph",
+        ));
+        let probe_phase = std::sync::Arc::clone(&phase);
+        binding.set_phase_probe(Box::new(move || *probe_phase.lock().unwrap()));
+        assert!(binding
+            .starting_report("kin_graph_status")
+            .contains("loading the repository graph"));
+
+        *phase.lock().unwrap() = "phase: the daemon is listening and finishing readiness checks";
+        assert!(binding
+            .starting_report("kin_graph_status")
+            .contains("finishing readiness checks"));
+    }
+}


### PR DESCRIPTION
An agent calling `semantic_locate` now gets what a human typing `kin locate` has always gotten. The MCP tool's default route is the fused multi-signal pipeline on every profile, the same ranking `POST /locate` serves, and the legacy cosine ranking stays reachable per call via `pipeline:"cosine"` for A/B comparison. On the 0525 battery's 23-symbol probe set the cosine default scored 0/23 at rank one where the fused pipeline scored 20/23 (non-citable dev-box measurement, `.kin-coord/reports/profile-default-decision-20260814.md`).

The shipped default profile flips from compat-v0 to accuracy-v2, a new version minted per the profile module's own rule that lever flips land as a new version rather than changing what an existing pin means. accuracy-v2 is accuracy-v1's lever set (entity fusion, lexical parity floor, calibrated 0.625 embedding seed floor, promotion-only rerank blend, 1500ms rerank budget) with the cross-encoder reranker off unconditionally. That implements the founder ruling within the module's law: the accuracy levers graduate to default, and the reranker's do-not-flip verdict is affirmed (one lateral top-1 change in 55 probes for +54% latency and +1.3GB resident). Returning false explicitly, rather than keeping accuracy-v1's cached-model condition, also protects installs that prefetched the model under earlier doctor advice from silently starting to pay for it. An accuracy-v1 pin keeps the conditional reranker it always had, and compat-v0 keeps the historical lever defaults as the A/B escape hatch.

`kin doctor` now agrees with the shipped default. A stock install reports Healthy with no remediation; the advice to set accuracy-v1 and prefetch the 1.1GB reranker model is gone; a lever-off profile someone chose still warns and points back at accuracy-v2. KIN_PROFILE stays env-only, an exported profile still wins, and the new default lands when a daemon restarts under the new binary.

Tests pin all three decisions: the default variant with every lever value including reranker-off under the cached-model-plus-resident-daemon condition, fused routing under an explicit compat-v0 environment, and doctor emitting no advice that contradicts the shipped default even with the reranker model cached.

Closes FIR-2321
