### PR TITLE
Create missing artifact enrichment records at embed time and ship kin-db 0.7.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.21"
+version = "0.7.23"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2a6c754f946db0f26e836ba0c6c9a0e7fd416f7324c0b0d09692d3dd888f0933"
+checksum = "9daa5bc4ba8a3a9edeeb859116b216a682fbcb5b461bbe77231baba3ddc2d192"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.21", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.23", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6015,6 +6015,19 @@ async fn embed(
             // save_snapshot() acquires persist_lock internally; the non-reentrant std
             // Mutex self-deadlocks if we hold persist_lock across this call (this was
             // the daemon embed hang — the worker wedged here before embedding started).
+            // An explicit embed is the operator asking for full retrieval
+            // coverage, so create any enrichment records bulk admission never
+            // wrote before counting what there is to embed. Without them the
+            // artifact denominator reads zero and the pass honestly reports
+            // "+0 artifacts" on a store full of tracked files.
+            match crate::loop_runner::ensure_non_entity_enrichment_coverage(&state_for_embed) {
+                Ok(created) if created > 0 => state_for_embed.bump_version(),
+                Ok(_) => {}
+                Err(error) => tracing::warn!(
+                    error = %error,
+                    "enrichment coverage reconcile failed before embed; artifact coverage may be short"
+                ),
+            }
             state_for_embed
                 .save_snapshot()
                 .map_err(|error| format!("embed pre-persist save failed: {error:#}"))?;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1070,6 +1070,109 @@ fn persist_non_entity_enrichment(
     }
 }
 
+/// Create the missing non-entity enrichment records for the current resolved
+/// tree, reading bodies from the repository CAS.
+///
+/// Bulk admission (`kin init` importing a Git repository) derives entities for
+/// parser-supported sources and stops there: no shallow, structured, or opaque
+/// record is written for any other tracked file. Every downstream artifact
+/// surface keys on those records — `artifact_count()`, the artifact embedding
+/// queue, the text index that feeds lexical artifact candidacy — so a store
+/// born from bulk admission reports "+0 artifacts" on `kin embed` and can never
+/// rank an artifact, while `kin status` counts the same files as tracked. The
+/// live reconcile loop only enriches paths that produce file events, which an
+/// unchanged imported tree never does.
+///
+/// This pass is strictly additive: a path is skipped when any enrichment facet
+/// already exists for it (including an entity-source layout), when its current
+/// bytes classify as entity source, or when its tree entry carries no blob
+/// body. It never deletes or replaces a facet, so drift between an existing
+/// record and tree truth stays the reconcile loop's job. Bodies come from the
+/// repository CAS, never from the working filesystem.
+///
+/// Returns how many records were created. Callers that receive a nonzero count
+/// own bumping the state version so the records persist with the next snapshot.
+///
+/// Gated with its only runtime caller, the embed request handler: a build
+/// without embedding support has no surface that asks for this coverage, and
+/// an uncalled function fails the deny-warnings build on exactly those
+/// feature subsets.
+#[cfg(feature = "embeddings")]
+pub(crate) fn ensure_non_entity_enrichment_coverage(state: &DaemonState) -> Result<usize> {
+    let tree = state.graph.resolved_tree();
+    let pipeline = IndexPipeline::new();
+    let mut created = 0usize;
+    let mut unreadable = 0usize;
+
+    for artifact in tree.artifacts() {
+        if !matches!(artifact.entry, TreeEntry::Blob { .. }) {
+            continue;
+        }
+        let Some(hash) = artifact.entry.blob_identity() else {
+            continue;
+        };
+        let Some(path) = artifact.path.as_utf8() else {
+            // Non-UTF-8 paths stay byte-exact tree truth with no UTF-8
+            // enrichment surface, same as the live reconcile loop.
+            continue;
+        };
+        let file_id = FilePathId::new(path);
+
+        if state.graph.get_shallow_file(&file_id)?.is_some()
+            || state.graph.get_structured_artifact(&file_id)?.is_some()
+            || state.graph.get_opaque_artifact(&file_id)?.is_some()
+            || state.graph.get_file_layout(&file_id)?.is_some()
+        {
+            continue;
+        }
+
+        let content = match state.blobs.read(&hash) {
+            Ok(content) => content,
+            Err(error) => {
+                // A missing derived body must not fail daemon startup; CAS
+                // hydration owns repairing it, and the next pass retries.
+                unreadable += 1;
+                debug!(
+                    file = %file_id,
+                    error = %error,
+                    "enrichment coverage pass could not read tracked body from CAS"
+                );
+                continue;
+            }
+        };
+
+        if FileClassifier::classify_with_content(Path::new(path), &content)
+            == FileClassification::EntitySource
+        {
+            continue;
+        }
+
+        match pipeline.index_any_content(&file_id, &content, hash) {
+            Ok(indexed) => match persist_non_entity_enrichment(state, indexed) {
+                Ok(_) => created += 1,
+                Err(error) => warn!(
+                    file = %file_id,
+                    error = %error,
+                    "enrichment coverage pass could not persist facet"
+                ),
+            },
+            Err(error) => warn!(
+                file = %file_id,
+                error = %error,
+                "enrichment coverage pass could not enrich tracked body"
+            ),
+        }
+    }
+
+    if created > 0 || unreadable > 0 {
+        info!(
+            created,
+            unreadable, "enrichment coverage pass created missing non-entity records"
+        );
+    }
+    Ok(created)
+}
+
 /// Deferrals of one path before its log line escalates from debug to warn.
 ///
 /// A file saved while the pass is reading it defers once and reconciles on the
@@ -3123,6 +3226,73 @@ mod tests {
             .unwrap()
             .is_none());
         assert!(tree_entry(&state, "src/change.rs").is_some());
+    }
+
+    /// A store born from bulk admission holds tree truth with no non-entity
+    /// enrichment records, so nothing feeds the artifact embedding queue or the
+    /// artifact text index and `kin embed` honestly reports "+0 artifacts".
+    /// The coverage pass must recreate exactly the missing records from CAS
+    /// bodies, leave entity sources alone, and be idempotent.
+    #[cfg(feature = "embeddings")]
+    #[tokio::test]
+    async fn coverage_pass_recreates_missing_records_and_feeds_the_artifact_queue() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            repo.path().join("AGENTS.md"),
+            "# Doctrine\n\nChecks That Cannot Fail live here, past any preview cap.\n",
+        )
+        .unwrap();
+        std::fs::write(repo.path().join("main.py"), "def fail():\n    return 1\n").unwrap();
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        let doc_id = FilePathId::new("AGENTS.md");
+        assert!(state.graph.get_opaque_artifact(&doc_id).unwrap().is_some());
+
+        // Deleting the record reproduces the shape bulk admission leaves
+        // behind: the tree tracks the file, no enrichment facet exists.
+        state.graph.delete_opaque_artifact(&doc_id).unwrap();
+        assert_eq!(state.graph.artifact_count(), 0);
+        assert!(tree_entry(&state, "AGENTS.md").is_some());
+
+        let created = ensure_non_entity_enrichment_coverage(&state).unwrap();
+        assert_eq!(
+            created, 1,
+            "the doc regains its record; the entity source must not gain one"
+        );
+        let record = state
+            .graph
+            .get_opaque_artifact(&doc_id)
+            .unwrap()
+            .expect("coverage pass recreates the opaque record");
+        assert!(
+            record
+                .text_preview
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Checks That Cannot Fail"),
+            "recreated record must retain the body text retrieval indexes"
+        );
+        assert!(state
+            .graph
+            .get_opaque_artifact(&FilePathId::new("main.py"))
+            .unwrap()
+            .is_none());
+        assert_eq!(state.graph.artifact_count(), 1);
+
+        assert_eq!(
+            ensure_non_entity_enrichment_coverage(&state).unwrap(),
+            0,
+            "a second pass over full coverage creates nothing"
+        );
+
+        // The recreated record is exactly what the artifact embedding queue
+        // keys on, so the backfill can now see the file.
+        state.graph.queue_missing_artifacts_for_embedding();
+        assert!(
+            state.graph.pending_artifact_embeddings() >= 1,
+            "recreated record must enter the artifact embedding backfill"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
A docs store can now answer for its own content: `kin embed` embeds its tracked
artifacts instead of reporting "+0 artifacts", and artifact rows reach retrieval with
`id_space: artifact`. Battery R4 failed on v0.5.25 with the candidacy fix (kin#760) and
the text-retention fix (kin#802) both aboard, because two independent gaps remained, and
this change closes both.

First, a store born from bulk admission held no non-entity enrichment records at all.
`kin init`'s semantic import derives entities for parser-supported sources and stops;
shallow/structured/opaque records are only written by the daemon's live file-event
paths, which an unchanged imported tree never triggers. Every artifact surface keys on
those records: the embed denominator (`artifact_count`), the artifact backfill
(`collect_artifact_ids`), the doc builder (`artifact_embedding_doc`), and the text index
that feeds locate's artifact candidacy. An explicit embed request now reconciles that
coverage before counting what there is to embed: a strictly additive pass creates the
missing records for the current resolved tree from repository CAS bodies. A path with
any existing facet or an entity-source classification is left alone, so the pass can
never delete or replace a facet, and a second pass over full coverage creates nothing.

The reconcile deliberately does not run on daemon startup. Opening a store must not
rewrite its graph truth: the retrieval-authority hash covers the enrichment maps, so a
sidecar stamped before the records existed would go stale on the next save cycle, and
the prepared-state suite catches exactly that (a startup variant of this change made
`prepared_state_publish_and_materialize_preserve_indexed_state` report one truthfully
owed artifact vector). At embed time the pre-embed snapshot save and the embed pass
itself re-stamp the derived sidecars in the same breath that moves the hash, and the
whole prepared_state_json suite passes unmodified.

Second, the kin-db pin moves =0.7.21 to =0.7.23, re-locked from the registry. 0.7.21's
staged embed pipeline destroyed any artifact key reaching the unified queue (drained,
never formatted, never embedded, never requeued); kin-db#184 fixed that in 0.7.23, and
no shipping kin has carried it. The bump also ships kin-db#183, which stops a healthy
store's every call from warning about retired entity keys with a false `kin embed`
remedy (FIR-2201's counter fix; its remedy strings in kin have their own emitters and
are not touched here).

Verified end to end on a scratch docs-shaped store (126-file kin-ecosystem clone):
same 126-file corpus, same commands, pre-fix
binaries then this branch's binaries. Pre-fix: `Pass 1: +253 entities, +0 artifacts`,
"Full coverage" claimed with zero artifacts, and 125 of 125 admitted regular files
disclosed as having no query-facing enrichment facet. With this change: `Pass 1: +256
entities, +64 artifacts`, 320/320 indexed with 0 pending, facet-less files down to 9
(symlink-shaped tree entries, still disclosed), and MCP `semantic_locate` on the fused
pipeline returns the AGENTS.md artifact labeled `id_space: artifact` for the doctrine
probe "Checks That Cannot Fail" (rank 19 of 22 at limit 50, alongside two more artifact
rows). Artifact hits still rank below entity hits on doctrine phrases; where artifacts
should sit in the fused ranking is a ranking-weights question left to the read-path
work, and this PR keeps to candidacy, embedding, and labeling.

A unit test pins the reconcile: records recreated from CAS with retained body text,
entity sources untouched, idempotent re-run, and recreated records entering the
artifact embedding backfill.

Closes FIR-2326
