### PR TITLE
Pin kin-db 0.7.27 and flip the reopen test to per-key salvage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.23"
+version = "0.7.27"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9daa5bc4ba8a3a9edeeb859116b216a682fbcb5b461bbe77231baba3ddc2d192"
+checksum = "787ad7149aa2d2c78d01bdeda128254e1f92d8ae8d96bfbcc9f4fbf89493b36f"
 dependencies = [
  "bincode",
  "bstr",
@@ -6625,7 +6625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.23", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.27", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -8670,11 +8670,15 @@ mod tests {
         );
     }
 
-    /// A sidecar bound to a graph that has since moved on describes entities
-    /// this store no longer has, so it is refused and announced too.
+    /// A sidecar bound to a graph that has since moved on is salvaged per
+    /// key: every vector whose entity truth is unchanged is reused, only the
+    /// genuinely new key is missing, and nothing is announced as discarded.
+    /// The whole-index refusal this test used to pin was the FIR-2325 defect;
+    /// kin-db 0.7.24 replaced it with per-key salvage, and the corrupted-format
+    /// case above still proves a real refusal stays loud.
     #[test]
     #[cfg(feature = "vector")]
-    fn an_index_bound_to_stale_graph_truth_is_refused_and_announced() {
+    fn an_index_bound_to_drifted_graph_truth_is_salvaged_per_key() {
         let repo_dir = tempfile::tempdir().unwrap();
         let layout = KinLayout::new(repo_dir.path().join(".kin"));
         let graph = store_with_persisted_vector_index(&layout, None);
@@ -8685,15 +8689,18 @@ mod tests {
 
         let discarded = DaemonState::load_validated_vector_index(&layout, graph.as_ref());
 
-        let reason = discarded.expect("a refused sidecar must be announced, not dropped silently");
-        assert!(
-            reason.contains("graph.kvec") && reason.contains("no longer matches"),
-            "the announcement must name what was discarded and why: {reason}"
-        );
         assert_eq!(
-            graph.embedding_status().indexed,
-            0,
-            "an index bound to stale graph truth must not be installed"
+            discarded, None,
+            "a salvageable sidecar must be reused, not announced as discarded"
+        );
+        let status = graph.embedding_status();
+        assert_eq!(
+            status.indexed, 1,
+            "the persisted vector whose entity truth is unchanged must survive the reopen"
+        );
+        assert!(
+            status.total >= 2,
+            "graph truth must still owe a vector for the entity added after the index"
         );
     }
 


### PR DESCRIPTION
Ships the wave train to the product. kin now resolves kin-db 0.7.27, carrying the four wave releases: 0.7.24 salvages a drifted vector sidecar per key instead of discarding it on reopen, 0.7.25 shares one replay decode across successor preparation so publication stops paying for the whole store per commit, 0.7.26 discloses artifact embedding ids dropped for missing enrichment records, and 0.7.27 materializes workspace snapshots without whole-snapshot copies.

The daemon test pinning the old whole-index refusal flips to the salvage contract per the FIR-2325 handoff: an index bound to drifted graph truth is reused per key, only the genuinely new entity stays missing, and nothing is announced as discarded. The corrupted-format test keeps proving a real refusal stays loud.

Gate: full workspace suite green on the lane worktree (5680 passed, doctests included, no tracked-lock contamination). The lock entry keeps its sparse registry source and checksum.

Refs FIR-2322, FIR-2324, FIR-2325, FIR-2326.