### PR TITLE
Auto-update by default, an unattended executor, and a no-spawn MCP probe

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -170,9 +170,36 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_semantic_query_readiness().await);
     checks.push(check_background_work().await);
     checks.push(check_retrieval_profile());
+    checks.push(check_update_policy());
     checks.push(check_binary_assessment_load());
 
     assemble_health_report(env::consts::OS.to_string(), checks)
+}
+
+/// Report the active update policy and where it came from.
+///
+/// Always healthy: every policy is a legitimate preference, and the check
+/// exists so the doctor surface states which one governs this machine now
+/// that the default installs unattended (FIR-2342). The inherited default and
+/// a recorded choice are named apart, because only the first moves when the
+/// shipped default changes.
+fn check_update_policy() -> HealthCheck {
+    let (policy, recorded) = crate::commands::update::active_update_policy_for_doctor();
+    let name = crate::commands::update::policy_name(policy);
+    let source = if recorded {
+        "recorded in ~/.kin/update.toml"
+    } else {
+        "the default; no recorded choice"
+    };
+    HealthCheck::new(
+        "update_policy",
+        "Update policy",
+        HealthStatus::Healthy,
+        format!(
+            "{name} ({source}); auto installs unattended through the gated executor. Change with \
+             `kin update --set-policy auto|prompt|manual`."
+        ),
+    )
 }
 
 /// macOS assesses each never-before-seen binary on first launch. Cold cargo

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -30,11 +30,27 @@ use std::pin::Pin;
 /// [`kin_mcp::StartupDaemonBinding`]; `initialize` and `tools/list` answer
 /// immediately, and a `tools/call` that arrives before the binding settles is
 /// answered honestly that the daemon is still starting.
+///
+/// `--no-spawn` is the probe contract (FIR-2341): this server binds only a
+/// daemon that is already serving and never starts one, neither in the
+/// startup binding nor through tool-call revival. It is carried as the
+/// process-wide `KIN_NO_DAEMON=1` rather than as plumbing through every
+/// resolution path, because every daemon-starting seam in this binary already
+/// honors that variable, and a flag that covered fewer of them than the
+/// variable does would be a probe mode with a spawn path left inside it.
 pub async fn start(
     global: bool,
     repo: Option<PathBuf>,
     tool_profile: Option<String>,
+    no_spawn: bool,
 ) -> Result<()> {
+    if no_spawn {
+        std::env::set_var("KIN_NO_DAEMON", "1");
+        eprintln!(
+            "Kin MCP: --no-spawn is set; this server will bind an already-running daemon but \
+             never start one, and graph tool calls without a running daemon fail loud."
+        );
+    }
     let repo_override = resolve_repo_override(repo);
     if let Some(repo_dir) = &repo_override {
         if global {

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -254,9 +254,17 @@ fn channel_name(channel: Channel) -> &'static str {
 ///
 /// Updating is not a background detail here. Kin's binaries sit under live
 /// agent sessions, daemons part-way through embedding, MCP servers bound into
-/// running CLIs, and VFS shims mapped into other processes. Swapping bytes out
-/// from under all of that without being asked is the mechanism that produces
-/// the stale-runtime drift the watchdog then reports, so the default is to ask.
+/// running CLIs, and VFS shims mapped into other processes. What makes an
+/// unattended swap survivable is not asking first. It is the machinery around
+/// the install: the activity gates and bounded deferral decide when, the
+/// preflight stops every managed serving executable before bytes move, the
+/// restart fence forces the new binary to acknowledge, and stores reopen
+/// through per-key salvage. With that machinery in place, the default is to
+/// install (founder ruling, 2026-08-15): a machine that silently falls
+/// releases behind is the failure mode that actually happened: the founder's
+/// install sat eight releases stale until the drift itself helped take the
+/// machine down (FIR-2342). `kin update --set-policy prompt|manual` remains
+/// the opt-out.
 #[derive(
     Clone,
     Copy,
@@ -270,22 +278,44 @@ fn channel_name(channel: Channel) -> &'static str {
 )]
 #[serde(rename_all = "lowercase")]
 pub enum UpdatePolicy {
-    /// Install unattended, but only when the machine is provably idle. The
-    /// default is not this: a silent swap under live sessions is exactly the
-    /// failure this policy exists to bound.
+    /// Install unattended through the gated executor. The default: a missing
+    /// or policy-less `update.toml` means auto, in this binary and in the
+    /// update watchdog's shell parser, which must stay in lockstep.
+    #[default]
     Auto,
     /// Notify with the remedy attached and install when the person says so.
-    #[default]
     Prompt,
     /// Never notify about an available update. Checks still run.
     Manual,
 }
 
-fn policy_name(policy: UpdatePolicy) -> &'static str {
+pub(crate) fn policy_name(policy: UpdatePolicy) -> &'static str {
     match policy {
         UpdatePolicy::Auto => "auto",
         UpdatePolicy::Prompt => "prompt",
         UpdatePolicy::Manual => "manual",
+    }
+}
+
+/// The active update policy plus whether a person recorded it, for the doctor
+/// surface. Inherited-default and recorded-choice are different answers: the
+/// first moves with the shipped default (auto since FIR-2342), the second
+/// never moves except by `kin update --set-policy`.
+pub(crate) fn active_update_policy_for_doctor() -> (UpdatePolicy, bool) {
+    #[derive(serde::Deserialize)]
+    struct PolicyProbe {
+        policy: Option<UpdatePolicy>,
+    }
+    let Ok(kin_home) = crate::commands::setup::kin_dir() else {
+        return (UpdatePolicy::default(), false);
+    };
+    let recorded = std::fs::read_to_string(kin_home.join("update.toml"))
+        .ok()
+        .and_then(|text| toml::from_str::<PolicyProbe>(&text).ok())
+        .and_then(|probe| probe.policy);
+    match recorded {
+        Some(policy) => (policy, true),
+        None => (UpdatePolicy::default(), false),
     }
 }
 
@@ -555,13 +585,20 @@ fn set_update_policy(policy: UpdatePolicy) -> Result<()> {
         policy_name(policy),
         policy_name(stored.policy)
     );
-    if policy != UpdatePolicy::Prompt {
-        println!(
-            "Recorded, not yet enforced: every mode behaves as prompt today. The recorded \
-             choice takes effect when the notifier honors it; unattended installs will run \
-             only when no agent session, managed Kin process, or part-way indexing job is \
-             detected, and Kin asks instead when that cannot be determined."
-        );
+    match policy {
+        UpdatePolicy::Auto => println!(
+            "Unattended installs run through `kin update --unattended` (the update watchdog \
+             invokes it): they wait for a moment with no managed Kin process or agent session, \
+             defer at most {UNATTENDED_DEFERRAL_WINDOW_HOURS}h, and always stop managed \
+             processes, install, and acknowledge the restart fence as one chain."
+        ),
+        UpdatePolicy::Prompt => {
+            println!("Kin will notify with the remedy attached and install only when told to.")
+        }
+        UpdatePolicy::Manual => println!(
+            "Kin will not notify about available updates. Checks still run and `kin update` \
+             still works when invoked."
+        ),
     }
     Ok(())
 }
@@ -798,12 +835,17 @@ pub async fn run(
     set_policy: Option<UpdatePolicy>,
     apply: bool,
     dry_run: bool,
+    unattended: bool,
+    force_window: bool,
 ) -> Result<()> {
     // Setting the policy is a preference write and nothing else. It runs before
     // any expectation parsing, network client, or install-root inspection so
     // that changing how updates arrive never depends on one being available.
     if let Some(policy) = set_policy {
         return set_update_policy(policy);
+    }
+    if unattended {
+        return run_unattended(force_window).await;
     }
     if dry_run && !apply {
         anyhow::bail!("--dry-run describes what --apply would do; pass both or neither");
@@ -1323,6 +1365,493 @@ fn registry_authority_preflight() -> Result<()> {
             "update preflight refused unsafe local registry authority; no release bytes were downloaded: {error}"
         )
     })
+}
+
+// ── Unattended executor ─────────────────────────────────────────────────────
+//
+// `kin update --unattended` is the executor behind the auto policy (FIR-2342):
+// the update watchdog invokes it on drift, it decides through
+// `decide_auto_update`, and on Proceed it runs the same
+// stop → install → acknowledge → repair chain a person triggers with
+// `kin update --apply`. Its stdout contract is one JSON object on the final
+// line, the same serialization appended to `$KIN_HOME/update-ledger.jsonl`,
+// so the caller and the artifact trail read one encoding.
+
+/// How long unattended updating may keep deferring to activity gates before
+/// the caller is entitled to force the window. The bound implements the
+/// founder ruling that agent sessions alone do not block forever: on a fleet
+/// machine `external_sessions` is true around the clock, so pure gating means
+/// never, and never is what left the incident machine eight releases stale.
+pub const UNATTENDED_DEFERRAL_WINDOW_HOURS: u64 = 24;
+
+const UNATTENDED_SCHEMA: &str = "kin.update-unattended.v1";
+const UNATTENDED_DEFERRAL_SCHEMA_VERSION: u32 = 1;
+
+fn unattended_deferral_path(kin_home: &Path) -> PathBuf {
+    kin_home.join("update-deferral.json")
+}
+
+fn update_ledger_path(kin_home: &Path) -> PathBuf {
+    kin_home.join("update-ledger.jsonl")
+}
+
+/// When unattended updating first found itself blocked, persisted so the
+/// deferral clock survives the six-hourly watchdog processes that read it.
+/// The clock deliberately does not reset when a newer release appears while
+/// blocked: the bound is on how long this machine stays behind, and a fleet
+/// shipping several releases a day would otherwise never converge.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct UnattendedDeferral {
+    schema_version: u32,
+    first_blocked_at: String,
+    first_blocked_at_unix_seconds: u64,
+    reason: String,
+    latest_version_seen: String,
+}
+
+/// One line of the update ledger, and byte-for-byte the final stdout line of
+/// `kin update --unattended`. `decision` records what the gate said
+/// (`proceed`, `prompt`, `silent`, or `forced-proceed`); `outcome` records
+/// what actually happened (`applied`, `deferred`, `silent`, `current`, or
+/// `failed`). `window_seconds` republishes the deferral bound so the caller
+/// compares `blocked_seconds` against the executor's own constant instead of
+/// carrying a second copy of it.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct UnattendedLedgerEntry {
+    schema: String,
+    at: String,
+    policy: String,
+    decision: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    forced: bool,
+    from_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    to_version: Option<String>,
+    update_available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_blocked_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    blocked_seconds: Option<u64>,
+    window_seconds: u64,
+    steps: Vec<String>,
+    outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl UnattendedLedgerEntry {
+    fn begin(policy: UpdatePolicy, forced: bool) -> Self {
+        Self {
+            schema: UNATTENDED_SCHEMA.to_string(),
+            at: chrono::Utc::now().to_rfc3339(),
+            policy: policy_name(policy).to_string(),
+            decision: String::new(),
+            reason: None,
+            forced,
+            from_version: CURRENT_VERSION.to_string(),
+            to_version: None,
+            update_available: false,
+            first_blocked_at: None,
+            blocked_seconds: None,
+            window_seconds: UNATTENDED_DEFERRAL_WINDOW_HOURS * 3600,
+            steps: Vec::new(),
+            outcome: String::new(),
+            error: None,
+        }
+    }
+}
+
+fn load_unattended_deferral(kin_home: &Path) -> Option<UnattendedDeferral> {
+    let bytes = fs::read(unattended_deferral_path(kin_home)).ok()?;
+    match serde_json::from_slice(&bytes) {
+        Ok(state) => Some(state),
+        Err(error) => {
+            // An unreadable state file restarts the clock, which defers longer
+            // rather than forcing earlier, which is the safe direction, but it must
+            // say so, because a clock that silently restarts reads exactly
+            // like one that never started.
+            eprintln!(
+                "Note: {} is unreadable ({error}); the deferral clock restarts from now.",
+                unattended_deferral_path(kin_home).display()
+            );
+            None
+        }
+    }
+}
+
+/// Record the first blocked moment, or return the one already recorded.
+fn record_unattended_blocked(
+    kin_home: &Path,
+    reason: &str,
+    latest_version: &str,
+) -> Result<UnattendedDeferral> {
+    if let Some(existing) = load_unattended_deferral(kin_home) {
+        return Ok(existing);
+    }
+    let now = chrono::Utc::now();
+    let state = UnattendedDeferral {
+        schema_version: UNATTENDED_DEFERRAL_SCHEMA_VERSION,
+        first_blocked_at: now.to_rfc3339(),
+        first_blocked_at_unix_seconds: now.timestamp().max(0) as u64,
+        reason: reason.to_string(),
+        latest_version_seen: latest_version.to_string(),
+    };
+    let bytes = serde_json::to_vec_pretty(&state).context("serialize unattended deferral state")?;
+    let path = unattended_deferral_path(kin_home);
+    let staged = kin_home.join(format!(".update-deferral.tmp.{}", std::process::id()));
+    {
+        let mut options = fs::OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&staged)
+            .with_context(|| format!("stage unattended deferral state at {}", staged.display()))?;
+        file.write_all(&bytes)
+            .context("write unattended deferral state")?;
+    }
+    fs::rename(&staged, &path)
+        .with_context(|| format!("persist unattended deferral state at {}", path.display()))?;
+    Ok(state)
+}
+
+/// Forget the deferral clock. Called when the machine converges (an apply
+/// succeeded, or nothing needs applying), so the next blocked stretch starts
+/// its own window.
+fn clear_unattended_deferral(kin_home: &Path) {
+    let path = unattended_deferral_path(kin_home);
+    if let Err(error) = fs::remove_file(&path) {
+        if error.kind() != io::ErrorKind::NotFound {
+            eprintln!("Note: could not clear {} ({error}).", path.display());
+        }
+    }
+}
+
+/// Append one entry to `$KIN_HOME/update-ledger.jsonl`. Append-only by
+/// construction: the file is opened `O_APPEND` and each entry is a single
+/// line, so concurrent writers interleave whole records rather than bytes.
+fn append_update_ledger(kin_home: &Path, entry: &UnattendedLedgerEntry) -> Result<()> {
+    let path = update_ledger_path(kin_home);
+    let mut options = fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&path)
+        .with_context(|| format!("open update ledger at {}", path.display()))?;
+    let mut line = serde_json::to_vec(entry).context("serialize update ledger entry")?;
+    line.push(b'\n');
+    file.write_all(&line)
+        .with_context(|| format!("append update ledger at {}", path.display()))
+}
+
+/// Deliver the run's one record: append it to the ledger and print it as the
+/// final stdout line. Ledger delivery failure is reported and never converts
+/// the run's real outcome into a failure: by this point the outcome already
+/// happened.
+fn conclude_unattended(kin_home: &Path, entry: &UnattendedLedgerEntry) {
+    if let Err(error) = append_update_ledger(kin_home, entry) {
+        eprintln!("Note: could not append the update ledger: {error:#}");
+    }
+    match serde_json::to_string(entry) {
+        Ok(line) => println!("{line}"),
+        Err(error) => eprintln!("Note: could not serialize the unattended report: {error}"),
+    }
+}
+
+/// What this machine is doing right now, observed from the process table with
+/// the same matcher the update preflight refuses on, so the executor can
+/// never believe idle a machine the preflight would reject.
+///
+/// Gate semantics under policy auto (FIR-2342), stated once here:
+/// - `external_sessions`: a managed MCP serving process is alive, the stdio
+///   transport an agent session holds open. Defers the install; never blocks
+///   it forever, because the caller passes `--force-window` once the bounded
+///   deferral window is spent.
+/// - `managed_runtimes_active`: a managed daemon or VFS server is alive.
+///   Same deferral semantics; the orchestrated stop makes the forced path
+///   safe by stopping them cooperatively before any byte moves.
+/// - `work_in_flight`: work executing inside a store is only observable
+///   through a live daemon, and a live daemon already defers through
+///   `managed_runtimes_active`. With no daemon running nothing is executing,
+///   and pending-but-paused work resumes under the new binary through per-key
+///   salvage, so this probe reports `false` rather than opening a store to
+///   ask. Opening one spawns the exact heavy daemon the probe rules exist to
+///   avoid (FIR-2341).
+/// - `readable`: whether this scan ran at all. The scan is a synchronous
+///   process-table walk that either returns or the process errors before
+///   constructing an answer, so a constructed `MachineActivity` is always a
+///   read one.
+fn probe_machine_activity(kin_home: &Path, spec: &[ComponentSpec]) -> MachineActivity {
+    let mut system = System::new_all();
+    system.refresh_all();
+    let mut managed_runtimes_active = false;
+    let mut external_sessions = false;
+    for (kind, _, _) in scan_active_managed_runtimes(&system, kin_home, spec) {
+        match kind {
+            RuntimeKind::Mcp => external_sessions = true,
+            RuntimeKind::Daemon | RuntimeKind::Vfs => managed_runtimes_active = true,
+        }
+    }
+    MachineActivity {
+        managed_runtimes_active,
+        external_sessions,
+        work_in_flight: false,
+        readable: true,
+    }
+}
+
+/// Stop every managed serving executable so the unattended chain can run,
+/// instead of refusing the way the interactive preflight does.
+///
+/// Safety, in order:
+/// 1. The cooperative machine-scope sweep full uninstall already uses
+///    (workers first, supervisor last, incarnation-bound); the same
+///    reasoning applies: the update replaces the binaries every daemon on
+///    this box serves from.
+/// 2. Managed serving processes the sweep does not own (MCP stdio servers
+///    agents hold open, VFS servers) get SIGTERM. The scan matches only
+///    executables of the managed install, so nothing outside Kin's own set
+///    can be signaled, and every one of them restarts on demand (agents
+///    respawn their MCP servers, daemons autostart on next use), so the cost
+///    is a reconnect, never data: stores reopen through per-key salvage and
+///    the restart fence forces the new binary to acknowledge.
+/// 3. A bounded drain (the daemon's own shutdown escalation force-exits
+///    ~25 s after TERM, so the bound clears it), then anything still serving
+///    fails the run loudly. Updating under a live managed process is never
+///    attempted; the interactive preflight's fences all still run behind
+///    this.
+async fn stop_managed_runtimes_for_update(
+    kin_home: &Path,
+    spec: &[ComponentSpec],
+) -> Result<Vec<String>> {
+    let mut actions = Vec::new();
+    match crate::commands::daemon::stop_all_quiet().await {
+        Ok(()) => actions.push("stopped managed daemons and supervisor cooperatively".to_string()),
+        // The sweep failing (no supervisor to talk to, a worker already gone)
+        // is not the verdict; the drain scan below is. Record what it said.
+        Err(error) => actions.push(format!("cooperative daemon stop reported: {error:#}")),
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(35);
+    let mut signaled: HashSet<u32> = HashSet::new();
+    loop {
+        let mut system = System::new_all();
+        system.refresh_all();
+        let residual = scan_active_managed_runtimes(&system, kin_home, spec);
+        if residual.is_empty() {
+            return Ok(actions);
+        }
+        #[cfg(unix)]
+        for (kind, component, pid) in &residual {
+            if signaled.insert(*pid) {
+                // SAFETY: plain signal delivery to a pid this scan just
+                // matched against the managed install's own executables.
+                let rc = unsafe { libc::kill(*pid as libc::pid_t, libc::SIGTERM) };
+                if rc == 0 {
+                    actions.push(format!(
+                        "sent SIGTERM to managed {} {} (pid {pid})",
+                        kind.label(),
+                        component
+                    ));
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = &mut signaled;
+        if std::time::Instant::now() >= deadline {
+            let survivors = residual
+                .iter()
+                .map(|(kind, component, pid)| format!("{} {} (pid {pid})", kind.label(), component))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "managed serving executables survived the unattended stop: {survivors}; nothing \
+                 was installed"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Whether an unattended run may apply. Pure, so the force-window rule is
+/// testable without a network or a process table.
+///
+/// `--force-window` overrides only the activity gates under policy auto, the
+/// executor's own caution, which the founder ruling bounds at
+/// [`UNATTENDED_DEFERRAL_WINDOW_HOURS`]. A recorded `prompt` or `manual`
+/// policy is a person's explicit choice about being asked, and no window
+/// makes an explicit choice expire.
+fn unattended_may_proceed(
+    policy: UpdatePolicy,
+    decision: &AutoDecision,
+    force_window: bool,
+) -> bool {
+    matches!(decision, AutoDecision::Proceed)
+        || (force_window
+            && policy == UpdatePolicy::Auto
+            && matches!(decision, AutoDecision::Prompt(_)))
+}
+
+/// The exact chain `kin update --apply` runs, callable from the executor.
+async fn run_apply_chain() -> Result<()> {
+    run_update_flow(
+        false,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        Vec::new(),
+        true,
+        false,
+    )
+    .await?;
+    run_chain_tail()
+}
+
+/// `kin update --unattended [--force-window]`: evaluate the auto-update
+/// decision against live machine activity and act on it, reporting one
+/// machine-readable record (see [`UnattendedLedgerEntry`]).
+///
+/// `--force-window` applies despite the activity gates, and exists for
+/// exactly one caller shape: the watchdog observing `blocked_seconds >=
+/// window_seconds` in a previous deferred record. It never overrides a
+/// recorded `prompt` or `manual` policy: those are a person's explicit
+/// choice about being asked, while the gates are the executor's own caution,
+/// which is what the ruling bounds.
+pub async fn run_unattended(force_window: bool) -> Result<()> {
+    let requested_home = crate::commands::setup::kin_dir()?;
+    let kin_home = validate_existing_install_root(&requested_home)?;
+    let spec = platform_bundle_spec(std::env::consts::OS)?;
+    ensure_mutating_update_supported(std::env::consts::OS, false)?;
+    registry_authority_preflight()?;
+
+    let config = UpdateConfig::load_from(&kin_home);
+    let policy = config.policy;
+    let channel = effective_channel(None, config.channel);
+    let mut entry = UnattendedLedgerEntry::begin(policy, force_window);
+
+    // Read-only availability check; failures here are real failures the
+    // caller must see, and they still leave a ledger line behind.
+    let availability = async {
+        let client = build_update_http_client()?;
+        let release = resolve_release(&client, channel).await?;
+        parse_release_version(&release.tag_name)
+    }
+    .await;
+    let latest_version = match availability {
+        Ok(version) => version,
+        Err(error) => {
+            // No gate ran, so there is no decision to record; the outcome is
+            // the whole story.
+            entry.decision = "none".to_string();
+            entry.outcome = "failed".to_string();
+            entry.error = Some(format!("{error:#}"));
+            conclude_unattended(&kin_home, &entry);
+            return Err(error.context("unattended update could not resolve the latest release"));
+        }
+    };
+    let latest = latest_version.to_string();
+    let current_version = parse_release_version(CURRENT_VERSION)?;
+    let update_available = latest_version > current_version;
+    entry.update_available = update_available;
+    let chain_needed = update_available
+        || restart_pending_path(&kin_home).exists()
+        || mcp_repair_pending_path(&kin_home).exists();
+
+    if !chain_needed {
+        clear_unattended_deferral(&kin_home);
+        entry.decision = "current".to_string();
+        entry.outcome = "current".to_string();
+        conclude_unattended(&kin_home, &entry);
+        return Ok(());
+    }
+
+    let activity = probe_machine_activity(&kin_home, spec);
+    let decision = decide_auto_update(policy, activity);
+    entry.reason = decision.reason().map(str::to_string);
+    let proceed = unattended_may_proceed(policy, &decision, force_window);
+
+    if !proceed {
+        match decision {
+            AutoDecision::Silent(_) => {
+                entry.decision = "silent".to_string();
+                entry.outcome = "silent".to_string();
+            }
+            _ => {
+                entry.decision = "prompt".to_string();
+                entry.outcome = "deferred".to_string();
+                let reason = decision.reason().unwrap_or("blocked");
+                match record_unattended_blocked(&kin_home, reason, &latest) {
+                    Ok(state) => {
+                        let now = chrono::Utc::now().timestamp().max(0) as u64;
+                        entry.blocked_seconds =
+                            Some(now.saturating_sub(state.first_blocked_at_unix_seconds));
+                        entry.first_blocked_at = Some(state.first_blocked_at);
+                    }
+                    Err(error) => {
+                        // A deferral that cannot be recorded still defers, but
+                        // the caller must know the clock is not running.
+                        entry.error = Some(format!("deferral state not persisted: {error:#}"));
+                    }
+                }
+            }
+        }
+        conclude_unattended(&kin_home, &entry);
+        return Ok(());
+    }
+
+    entry.decision = if matches!(decision, AutoDecision::Proceed) {
+        "proceed".to_string()
+    } else {
+        "forced-proceed".to_string()
+    };
+    if let Some(state) = load_unattended_deferral(&kin_home) {
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        entry.blocked_seconds = Some(now.saturating_sub(state.first_blocked_at_unix_seconds));
+        entry.first_blocked_at = Some(state.first_blocked_at);
+    }
+
+    match stop_managed_runtimes_for_update(&kin_home, spec).await {
+        Ok(actions) => entry.steps.extend(actions),
+        Err(error) => {
+            entry.outcome = "failed".to_string();
+            entry.error = Some(format!("{error:#}"));
+            conclude_unattended(&kin_home, &entry);
+            return Err(error);
+        }
+    }
+
+    entry.to_version = update_available.then(|| latest.clone());
+    match run_apply_chain().await {
+        Ok(()) => {
+            entry.steps.extend(
+                ChainStep::ORDER
+                    .iter()
+                    .map(|step| step.describe().to_string()),
+            );
+            entry.outcome = "applied".to_string();
+            clear_unattended_deferral(&kin_home);
+            conclude_unattended(&kin_home, &entry);
+            Ok(())
+        }
+        Err(error) => {
+            entry.outcome = "failed".to_string();
+            entry.error = Some(format!("{error:#}"));
+            conclude_unattended(&kin_home, &entry);
+            Err(error)
+        }
+    }
 }
 
 fn report_successful_install(
@@ -10702,6 +11231,53 @@ fn runtime_executable_diagnostic(
     })
 }
 
+/// Every live pid currently serving `component` as `kind`. This is the one
+/// matcher, shared by the fail-closed preflight (`reject_active_managed_runtime`),
+/// the unattended activity probe, and the unattended stop's drain scan, so all
+/// three answer from the same definition of "a managed serving executable".
+fn collect_active_managed_runtime_pids(
+    system: &System,
+    kin_home: &Path,
+    kind: RuntimeKind,
+    component: ComponentSpec,
+) -> Vec<u32> {
+    let managed_path = component_path(kin_home, component);
+    let managed = managed_path.canonicalize().unwrap_or(managed_path);
+    let mut pids = Vec::new();
+    for (pid, process) in system.processes() {
+        let pid = pid.as_u32();
+        let command = process_command(process);
+        let matched =
+            process.exe().is_some_and(|executable| {
+                process_path_matches_component(pid, executable, &managed, kin_home, component)
+            }) || argv0_matches_component(&command, process.cwd(), &managed, kin_home, component);
+        if matched && is_managed_serving_process(kind, component.name, &command) {
+            pids.push(pid);
+        }
+    }
+    pids
+}
+
+/// Every managed serving process on the machine, across all runtime kinds.
+fn scan_active_managed_runtimes(
+    system: &System,
+    kin_home: &Path,
+    spec: &[ComponentSpec],
+) -> Vec<(RuntimeKind, &'static str, u32)> {
+    let mut active = Vec::new();
+    for kind in [RuntimeKind::Daemon, RuntimeKind::Mcp, RuntimeKind::Vfs] {
+        for component in spec
+            .iter()
+            .filter(|component| runtime_component_matches(kind, component.name))
+        {
+            for pid in collect_active_managed_runtime_pids(system, kin_home, kind, *component) {
+                active.push((kind, component.name, pid));
+            }
+        }
+    }
+    active
+}
+
 fn reject_active_managed_runtime(
     system: &System,
     kin_home: &Path,
@@ -10715,41 +11291,38 @@ fn reject_active_managed_runtime(
         .with_context(|| format!("managed {} runtime component is missing", kind.label()))?;
     let managed_path = component_path(kin_home, *component);
     let managed = managed_path.canonicalize().unwrap_or(managed_path);
-    for (pid, process) in system.processes() {
-        let pid = pid.as_u32();
-        let command = process_command(process);
-        let matched =
-            process.exe().is_some_and(|executable| {
-                process_path_matches_component(pid, executable, &managed, kin_home, *component)
-            }) || argv0_matches_component(&command, process.cwd(), &managed, kin_home, *component);
-        if !matched || !is_managed_serving_process(kind, component_name, &command) {
-            continue;
-        }
-        let executable = process.exe().with_context(|| {
+    let Some(pid) = collect_active_managed_runtime_pids(system, kin_home, kind, *component)
+        .first()
+        .copied()
+    else {
+        return Ok(());
+    };
+    let executable = system
+        .process(Pid::from_u32(pid))
+        .and_then(|process| process.exe())
+        .with_context(|| {
             format!(
                 "active managed {} PID {pid} has no observable mapped executable path",
                 kind.label()
             )
         })?;
-        let evidence = runtime_executable_diagnostic(pid, executable).with_context(|| {
-            format!(
-                "cannot capture fail-closed executable diagnostics for active managed {} PID {pid}",
-                kind.label()
-            )
-        })?;
-        anyhow::bail!(
-            "active managed {} PID {pid} reports executable {} ({}: {}, object {}:{}, {} bytes, SHA-256 {}); stop it before self-update. This diagnostic never authorizes runtime convergence",
-            kind.label(),
-            managed.display(),
-            evidence.scope,
-            evidence.path.display(),
-            evidence.object.namespace,
-            evidence.object.file,
-            evidence.identity.size_bytes,
-            evidence.identity.sha256
-        );
-    }
-    Ok(())
+    let evidence = runtime_executable_diagnostic(pid, executable).with_context(|| {
+        format!(
+            "cannot capture fail-closed executable diagnostics for active managed {} PID {pid}",
+            kind.label()
+        )
+    })?;
+    anyhow::bail!(
+        "active managed {} PID {pid} reports executable {} ({}: {}, object {}:{}, {} bytes, SHA-256 {}); stop it before self-update. This diagnostic never authorizes runtime convergence",
+        kind.label(),
+        managed.display(),
+        evidence.scope,
+        evidence.path.display(),
+        evidence.object.namespace,
+        evidence.object.file,
+        evidence.identity.size_bytes,
+        evidence.identity.sha256
+    );
 }
 
 fn ensure_no_active_managed_runtimes(kin_home: &Path, spec: &[ComponentSpec]) -> Result<()> {
@@ -15845,6 +16418,8 @@ cwd = {:?}
             None,
             false,
             false,
+            false,
+            false,
         )
         .await
         .expect_err("check-only must report, not recover, a stale transaction");
@@ -18534,17 +19109,149 @@ cwd = {:?}
     }
 
     #[test]
-    fn the_default_policy_asks_before_swapping_bytes() {
+    fn the_default_policy_installs_unattended_on_an_idle_machine() {
         // The default decides what happens on every install that never sets a
-        // policy, which is all of them. Kin's binaries sit under live agent
-        // sessions and mapped VFS shims, so the default has to be the one that
-        // does not move them without being asked.
-        assert_eq!(UpdatePolicy::default(), UpdatePolicy::Prompt);
+        // policy, which is all of them. Founder ruling 2026-08-15 (FIR-2342):
+        // a machine left alone converges to current on its own, because the
+        // machine that silently fell eight releases behind is the one that
+        // ended in a crash loop. The safety lives in the gates and the chain,
+        // not in asking first, and the gates are asserted right below.
+        assert_eq!(UpdatePolicy::default(), UpdatePolicy::Auto);
         assert_eq!(
             decide_auto_update(UpdatePolicy::default(), idle_machine()),
-            AutoDecision::Prompt("update policy is prompt"),
-            "an idle machine on the default policy must still ask"
+            AutoDecision::Proceed,
+            "an idle machine on the default policy must converge unattended"
         );
+        // A machine that predates the flip and recorded prompt keeps prompt:
+        // the flip changes the default, never a recorded choice.
+        assert_eq!(
+            decide_auto_update(UpdatePolicy::Prompt, idle_machine()),
+            AutoDecision::Prompt("update policy is prompt"),
+            "a recorded prompt policy must be untouched by the default flip"
+        );
+    }
+
+    #[test]
+    fn the_force_window_overrides_activity_gates_and_never_a_recorded_policy() {
+        let busy = MachineActivity {
+            external_sessions: true,
+            ..idle_machine()
+        };
+        // The rule the ruling bounds: activity gates defer, and the caller
+        // may force them once the window is spent.
+        let blocked = decide_auto_update(UpdatePolicy::Auto, busy);
+        assert!(!unattended_may_proceed(UpdatePolicy::Auto, &blocked, false));
+        assert!(unattended_may_proceed(UpdatePolicy::Auto, &blocked, true));
+        // An unreadable machine is also an activity gate, and the ruling
+        // says the window bounds it too: after 24h blocked, apply anyway,
+        // trusting the fence and salvage.
+        let unreadable = decide_auto_update(
+            UpdatePolicy::Auto,
+            MachineActivity {
+                readable: false,
+                ..idle_machine()
+            },
+        );
+        assert!(unattended_may_proceed(
+            UpdatePolicy::Auto,
+            &unreadable,
+            true
+        ));
+        // A recorded human policy never expires into an install.
+        let prompt_policy = decide_auto_update(UpdatePolicy::Prompt, idle_machine());
+        assert!(!unattended_may_proceed(
+            UpdatePolicy::Prompt,
+            &prompt_policy,
+            true
+        ));
+        let manual_policy = decide_auto_update(UpdatePolicy::Manual, idle_machine());
+        assert!(!unattended_may_proceed(
+            UpdatePolicy::Manual,
+            &manual_policy,
+            true
+        ));
+        // And an idle machine proceeds with no force at all.
+        assert!(unattended_may_proceed(
+            UpdatePolicy::Auto,
+            &AutoDecision::Proceed,
+            false
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn the_deferral_clock_starts_once_and_survives_reruns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        assert!(load_unattended_deferral(home).is_none());
+        let first = record_unattended_blocked(home, "an agent or user session is open", "0.9.9")
+            .expect("record the first blocked moment");
+        // A later blocked run must read the SAME first-blocked moment, or the
+        // 24h window restarts on every watchdog cycle and never elapses.
+        let second =
+            record_unattended_blocked(home, "a different reason", "1.0.0").expect("reread");
+        assert_eq!(first.first_blocked_at, second.first_blocked_at);
+        assert_eq!(
+            second.reason, "an agent or user session is open",
+            "the recorded first reason is the fact; later reasons never rewrite it"
+        );
+
+        clear_unattended_deferral(home);
+        assert!(
+            load_unattended_deferral(home).is_none(),
+            "convergence must forget the clock so the next stretch starts its own window"
+        );
+        // Clearing an already-clear state is a no-op, not an error.
+        clear_unattended_deferral(home);
+    }
+
+    #[test]
+    fn the_update_ledger_is_append_only_lines_of_the_report_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        let mut first = UnattendedLedgerEntry::begin(UpdatePolicy::Auto, false);
+        first.decision = "prompt".to_string();
+        first.outcome = "deferred".to_string();
+        first.reason = Some("an agent or user session is open".to_string());
+        append_update_ledger(home, &first).expect("append first entry");
+
+        let mut second = UnattendedLedgerEntry::begin(UpdatePolicy::Auto, true);
+        second.decision = "forced-proceed".to_string();
+        second.outcome = "applied".to_string();
+        second.to_version = Some("9.9.9".to_string());
+        second.steps = vec!["stopped managed daemons and supervisor cooperatively".to_string()];
+        append_update_ledger(home, &second).expect("append second entry");
+
+        let text = std::fs::read_to_string(update_ledger_path(home)).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "one line per action, in order: {text}");
+        let parsed_first: UnattendedLedgerEntry = serde_json::from_str(lines[0]).unwrap();
+        let parsed_second: UnattendedLedgerEntry = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(parsed_first.outcome, "deferred");
+        assert_eq!(parsed_second.outcome, "applied");
+        assert_eq!(parsed_second.to_version.as_deref(), Some("9.9.9"));
+        assert_eq!(parsed_first.schema, UNATTENDED_SCHEMA);
+        assert_eq!(
+            parsed_first.window_seconds,
+            UNATTENDED_DEFERRAL_WINDOW_HOURS * 3600,
+            "the caller compares blocked_seconds against the executor's own bound"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(update_ledger_path(home))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                mode, 0o600,
+                "the ledger is operator state, not world-readable"
+            );
+        }
     }
 
     #[test]
@@ -18700,10 +19407,20 @@ cwd = {:?}
         // A missing/empty config deserializes to the stable default.
         let empty: UpdateConfig = toml::from_str("").unwrap();
         assert_eq!(empty.channel, Channel::Stable);
-        // Every install that predates the policy has a config carrying only a
-        // channel, and each one must read as prompt rather than as auto.
+        assert_eq!(
+            empty.policy,
+            UpdatePolicy::Auto,
+            "a machine with no recorded policy inherits the auto default (FIR-2342)"
+        );
+        // A config carrying only a channel never recorded a policy choice, so
+        // it inherits the default like a missing file does, which is what
+        // "existing installs inherit the default on their next binary" means.
+        // A recorded policy, by contrast, is never moved by the flip.
         let channel_only: UpdateConfig = toml::from_str("channel = \"alpha\"").unwrap();
-        assert_eq!(channel_only.policy, UpdatePolicy::Prompt);
+        assert_eq!(channel_only.policy, UpdatePolicy::Auto);
+        let recorded_prompt: UpdateConfig =
+            toml::from_str("channel = \"alpha\"\npolicy = \"prompt\"").unwrap();
+        assert_eq!(recorded_prompt.policy, UpdatePolicy::Prompt);
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -6535,6 +6535,20 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         }
     }
 
+    // Everything past this point is spawn authority. `KIN_NO_DAEMON` is the
+    // process-wide no-spawn contract (the probe mode behind `kin mcp start
+    // --no-spawn` and the update watchdog's checks), and every caller that
+    // honors it gates earlier, so reaching here under it is already a bug;
+    // refusing here makes the invariant hold at the chokepoint instead of at
+    // each caller. An already-running supervisor was returned above, so this
+    // refusal costs a probe nothing it was entitled to.
+    if is_transient_bool_env("KIN_NO_DAEMON") {
+        bail!(
+            "KIN_NO_DAEMON is set and no supervisor is running, so none may be started; unset \
+             KIN_NO_DAEMON (or drop --no-spawn) to let kin start one"
+        );
+    }
+
     // Validate the binary's explicit protocol acknowledgement before taking
     // cleanup or spawn authority. In particular, an immutable base daemon is
     // rejected here and is never started under a marker it cannot adopt.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1023,10 +1023,12 @@ enum Command {
         )]
         runtime_sessions: Vec<String>,
         /// Set how an available update should reach this machine and exit.
-        /// `prompt` (the default) notifies with the remedy attached and waits
-        /// to be told. `auto` and `manual` are recorded preferences whose
-        /// enforcement has not shipped: today every mode behaves as `prompt`,
-        /// and the recorded choice takes effect when the notifier honors it.
+        /// `auto` (the default) installs unattended through the gated
+        /// executor: it waits for a moment with no managed Kin process or
+        /// agent session, defers at most a bounded window, and runs the full
+        /// stop-install-acknowledge chain. `prompt` notifies with the remedy
+        /// attached and waits to be told. `manual` never notifies; checks
+        /// still run.
         #[arg(
             long,
             value_enum,
@@ -1052,6 +1054,33 @@ enum Command {
         /// With --apply: print the ordered steps and change nothing.
         #[arg(long, requires = "apply")]
         dry_run: bool,
+        /// Run the unattended executor (what the update watchdog invokes on a
+        /// stale install with policy auto): evaluate the machine-activity
+        /// gates, and on proceed stop every managed Kin process cooperatively
+        /// and run the full --apply chain. Blocked runs persist a deferral
+        /// clock instead of installing. The final stdout line is one JSON
+        /// record (also appended to ~/.kin/update-ledger.jsonl) carrying the
+        /// decision, reason, blocked_seconds, and window_seconds.
+        #[arg(long, conflicts_with_all = [
+            "skip_verify",
+            "channel",
+            "expect_version",
+            "expect_sha",
+            "expect_archive_sha256",
+            "check_only",
+            "json",
+            "ack_restart",
+            "set_policy",
+            "apply",
+            "dry_run"
+        ])]
+        unattended: bool,
+        /// With --unattended: apply despite the activity gates. For the
+        /// watchdog once a deferred record shows blocked_seconds >=
+        /// window_seconds (24h). Never overrides a recorded prompt or manual
+        /// policy, only the executor's own activity gates.
+        #[arg(long, requires = "unattended")]
+        force_window: bool,
     },
     /// Show or manage the global Kin repository registry
     Registry {
@@ -1704,6 +1733,14 @@ enum McpAction {
         /// KIN_MCP_TOOL_PROFILE.
         #[arg(long = "tool-profile", value_name = "PROFILE")]
         tool_profile: Option<String>,
+        /// Never start or revive a daemon from this server: bind only a daemon
+        /// that is already running, and answer graph tool calls with an honest
+        /// "no daemon is running" error otherwise. This is the probe mode for
+        /// watchdogs and boot-time checks (equivalent to KIN_NO_DAEMON=1): the
+        /// MCP handshake and tool list are served in full, and nothing heavy
+        /// is ever spawned by the check itself.
+        #[arg(long)]
+        no_spawn: bool,
     },
 }
 
@@ -2882,7 +2919,8 @@ fn main() -> Result<()> {
                         global,
                         repo,
                         tool_profile,
-                    } => commands::mcp::start(global, repo, tool_profile).await,
+                        no_spawn,
+                    } => commands::mcp::start(global, repo, tool_profile, no_spawn).await,
                 },
                 Command::Auth { action } => match action {
                     AuthAction::Login {
@@ -3272,6 +3310,8 @@ fn main() -> Result<()> {
                     set_policy,
                     apply,
                     dry_run,
+                    unattended,
+                    force_window,
                 } => {
                     commands::update::run(
                         skip_verify,
@@ -3286,6 +3326,8 @@ fn main() -> Result<()> {
                         set_policy,
                         apply,
                         dry_run,
+                        unattended,
+                        force_window,
                     )
                     .await
                 }

--- a/crates/kin-cli/tests/mcp_stdio_contract.rs
+++ b/crates/kin-cli/tests/mcp_stdio_contract.rs
@@ -55,18 +55,38 @@ struct McpRun {
 /// what this test proves, and `KIN_NO_DAEMON=1` plus an isolated registry and
 /// HOME guarantee no daemon can be spawned or discovered.
 fn run_probe_session(dir: &Path, home: &Path) -> McpRun {
+    run_configured_probe_session(dir, home, &[], &[("KIN_NO_DAEMON", "1".into())])
+}
+
+/// [`run_probe_session`] with the no-spawn contract carried explicitly by the
+/// caller (as `--no-spawn`, as `KIN_NO_DAEMON`, or deliberately as neither),
+/// plus whatever extra environment the fixture needs (`KIN_DAEMON_URL`,
+/// `KIN_DAEMON_BIN`). The spawn-control tests need all three shapes, and a
+/// helper that always injected the env var could never run its own positive
+/// control.
+fn run_configured_probe_session(
+    dir: &Path,
+    home: &Path,
+    extra_args: &[&str],
+    extra_env: &[(&str, std::ffi::OsString)],
+) -> McpRun {
     let started = Instant::now();
-    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_kin"))
+    let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_kin"));
+    command
         .args(["mcp", "start"])
+        .args(extra_args)
         .current_dir(dir)
         .env_clear()
         .env("PATH", std::env::var_os("PATH").unwrap_or_default())
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env("TMPDIR", std::env::temp_dir())
-        .env("KIN_NO_DAEMON", "1")
         .env("KIN_VFS_DISABLE", "1")
-        .env("KIN_REGISTRY_PATH", home.join("registry.toml"))
+        .env("KIN_REGISTRY_PATH", home.join("registry.toml"));
+    for (name, value) in extra_env {
+        command.env(name, value);
+    }
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -237,4 +257,131 @@ fn the_four_frame_probe_is_answered_inside_a_repository_whose_daemon_is_absent()
 
     let run = run_probe_session(&repo, &home);
     assert_four_frame_contract(&run);
+}
+
+/// The boot-incident shape (FIR-2341), replayed: a repository whose daemon
+/// died with its pid/port record left behind, probed by a session bound to the
+/// dead daemon's URL. Before the no-spawn contract covered revival, this exact
+/// session started a fresh daemon from inside the probe, the mechanism behind
+/// the 2026-08-15 boot spawn storm.
+///
+/// The spawn detector is a stub `kin-daemon` injected through `KIN_DAEMON_BIN`
+/// that records every invocation to a marker file. The positive control runs
+/// the identical session without `--no-spawn` and requires the marker to
+/// appear, which is what proves the detector can see a spawn at all; only then
+/// does the absent marker under `--no-spawn` mean zero daemon processes rather
+/// than a check that cannot fail. Unix-only because the stub is a shell script.
+#[cfg(unix)]
+#[test]
+fn a_no_spawn_probe_over_a_dead_daemon_record_spawns_nothing() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let root = tempfile::tempdir().expect("temp root");
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+    let repo = root.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let init = common::Command::new(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(&repo)
+        .env("HOME", &home)
+        .env("KIN_NO_DAEMON", "1")
+        .env("KIN_REGISTRY_PATH", home.join("registry.toml"))
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // A pid that provably belonged to a real process and provably no longer
+    // does: reap a child and record its pid.
+    let dead_pid = {
+        let mut child = std::process::Command::new("/usr/bin/true")
+            .spawn()
+            .or_else(|_| std::process::Command::new("/bin/true").spawn())
+            .expect("spawn short-lived child");
+        let pid = child.id();
+        child.wait().expect("reap short-lived child");
+        pid
+    };
+    // A loopback port that was free at selection time: bind, read, release.
+    let dead_port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve a loopback port");
+        listener.local_addr().expect("read reserved port").port()
+    };
+    let kin_dir = repo.join(".kin");
+    std::fs::write(
+        kin_dir.join(kin_daemon_spawn::PID_FILE_NAME),
+        dead_pid.to_string(),
+    )
+    .expect("plant stale pid record");
+    std::fs::write(
+        kin_dir.join(kin_daemon_spawn::PORT_FILE_NAME),
+        dead_port.to_string(),
+    )
+    .expect("plant stale port record");
+
+    // The stub daemon: records its invocation and exits, so a run that spawns
+    // leaves evidence and leaves no process behind.
+    let marker = root.path().join("daemon-spawned.marker");
+    let stub = root.path().join("kin-daemon-stub");
+    std::fs::write(
+        &stub,
+        format!("#!/bin/sh\necho \"$@\" >> '{}'\nexit 7\n", marker.display()),
+    )
+    .expect("write stub daemon");
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+        .expect("mark stub executable");
+
+    let fixture_env = |ready_timeout: Option<&str>| {
+        let mut env: Vec<(&str, std::ffi::OsString)> = vec![
+            (
+                "KIN_DAEMON_URL",
+                format!("http://127.0.0.1:{dead_port}").into(),
+            ),
+            ("KIN_DAEMON_BIN", stub.clone().into_os_string()),
+        ];
+        if let Some(secs) = ready_timeout {
+            env.push(("KIN_DAEMON_READY_TIMEOUT_SECS", secs.into()));
+        }
+        env
+    };
+
+    // The claim: under --no-spawn the whole session answers and nothing is
+    // started. The tools/call error must name KIN_NO_DAEMON, which proves the
+    // binding settled, the dead daemon was observed, and revival was consulted
+    // and refused. Without that assertion, an early failure anywhere on the
+    // path would also leave the marker absent and the test would prove nothing.
+    let no_spawn = run_configured_probe_session(&repo, &home, &["--no-spawn"], &fixture_env(None));
+    assert_four_frame_contract(&no_spawn);
+    let refusal = response_with_id(&no_spawn, 3)
+        .pointer("/result/content/0/text")
+        .and_then(|text| text.as_str())
+        .expect("tools/call carries a content block")
+        .to_string();
+    assert!(
+        refusal.contains("KIN_NO_DAEMON"),
+        "the no-spawn refusal must reach the tool answer: {refusal}"
+    );
+    assert!(
+        !marker.exists(),
+        "--no-spawn probe invoked the daemon binary: {}",
+        std::fs::read_to_string(&marker).unwrap_or_default()
+    );
+
+    // Positive control: the identical session without --no-spawn must reach
+    // the stub, proving the marker detects spawns. The short ready timeout
+    // bounds the supervisor-spawn arm should binary validation ever start
+    // accepting the stub.
+    let unrestricted = run_configured_probe_session(&repo, &home, &[], &fixture_env(Some("2")));
+    assert_four_frame_contract(&unrestricted);
+    assert!(
+        marker.exists(),
+        "the control run must spawn the stub daemon, or the marker check cannot fail; stderr:\n{}",
+        unrestricted.stderr
+    );
 }

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -272,7 +272,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_CONTENT_MODE", kind: Kind::OneOf(&["deny"]), default: "", sensitivity: Sensitivity::Operational, summary: "content projection mode; 'deny' restricts native content" },
     EnvVarSpec { name: "KIN_DISCOVERY_MODE", kind: Kind::OneOf(&["deny"]), default: "", sensitivity: Sensitivity::Operational, summary: "filesystem discovery mode; 'deny' forces graph-only discovery" },
     EnvVarSpec { name: "KIN_NO_KEYRING", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "skip the OS keyring for credential storage" },
-    EnvVarSpec { name: "KIN_NO_DAEMON", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "force in-process execution instead of the daemon" },
+    EnvVarSpec { name: "KIN_NO_DAEMON", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "never start or revive a daemon; bind only an already-running one (the probe contract behind `kin mcp start --no-spawn`)" },
     EnvVarSpec { name: "KIN_ALLOW_OFFLINE_RESTORE", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "allow restoring a backup without remote verification" },
     EnvVarSpec { name: "KIN_ALLOW_PARENT_STORE", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "allow discovering a store in a parent directory" },
     EnvVarSpec { name: "KIN_BINARY_PATH", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "override the kin binary path for bench dispatch" },

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -699,6 +699,23 @@ fn configured_managed_install_root() -> Option<std::path::PathBuf> {
     kin_core::layout::global_home_kin_dir()
 }
 
+/// Whether `KIN_NO_DAEMON` forbids this process from starting daemon processes.
+///
+/// Same accepted spellings as the CLI's transient-bool reader, so the one
+/// contract ("this process spawns no daemon") cannot mean different things on
+/// the two sides of the transport. The revival path consults it because
+/// revival is a spawn: a scheduled probe that sets `KIN_NO_DAEMON` and then
+/// issues a `tools/call` against a dead daemon's recorded route would
+/// otherwise start a full daemon from inside the "no daemon" session, which
+/// is exactly the boot-time spawn storm of the 2026-08-15 incident
+/// (FIR-2341).
+fn no_daemon_spawns_requested() -> bool {
+    std::env::var("KIN_NO_DAEMON")
+        .ok()
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
 /// Spawn a fresh daemon and wait for it to pass `/health`.
 ///
 /// Uses the MCP-path idle timeout (30 min) unless the user has set
@@ -714,6 +731,19 @@ fn configured_managed_install_root() -> Option<std::path::PathBuf> {
 /// never cleared a stale port record, and never registered the daemon it
 /// started with the supervisor.
 async fn revive_mcp_daemon() -> Result<String, String> {
+    // The no-spawn contract is checked before any revival work, including the
+    // lock: a probe session must be able to observe "the daemon is dead" as an
+    // honest answer without this path quietly replacing the daemon it was
+    // asked about. Nothing is spawned, nothing is cleared, nothing is
+    // registered.
+    if no_daemon_spawns_requested() {
+        return Err(
+            "KIN_NO_DAEMON is set, so this session reports the dead daemon instead of \
+             starting a replacement; unset KIN_NO_DAEMON (or drop --no-spawn) and re-run \
+             to let kin start one"
+                .to_string(),
+        );
+    }
     // Serialize revival across concurrent tool calls. Every forwarded request
     // now reaches this path, so a dead daemon can be observed by several calls
     // at once; without this each would spawn its own daemon and all but one
@@ -1731,6 +1761,29 @@ mod tests {
         assert_eq!(
             find_mcp_daemon_binary_from(None, Some(&executable), None),
             Some(daemon)
+        );
+    }
+
+    /// The no-spawn contract, at the one place in this crate that can start a
+    /// process. With `KIN_NO_DAEMON` set, revival must refuse before doing any
+    /// work (the refusal happens ahead of binary discovery, record clearing,
+    /// and the spawn itself), and the refusal must name the variable so the
+    /// honest "daemon is dead" answer teaches the remedy. This is the guard
+    /// FIR-2341 demanded: a probe session that may not spawn cannot have its
+    /// own tools/call revive the daemon it is probing.
+    #[tokio::test]
+    async fn revival_refuses_to_spawn_under_kin_no_daemon() {
+        let _guard = kin_core::test_env::EnvVarGuard::set("KIN_NO_DAEMON", "1");
+        let refusal = revive_mcp_daemon()
+            .await
+            .expect_err("revival must refuse under KIN_NO_DAEMON");
+        assert!(
+            refusal.contains("KIN_NO_DAEMON"),
+            "the refusal must name the contract that produced it: {refusal}"
+        );
+        assert!(
+            refusal.contains("no-spawn") || refusal.contains("unset"),
+            "the refusal must name the remedy: {refusal}"
         );
     }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1208,6 +1208,7 @@ kin mcp start [options]
 | `--global` |  | Run in global mode, serving all registered repos from ~/.kin/registry.toml |
 | `--repo <path>` |  | Bind this server to a specific Kin repository instead of relying on the launching process's working directory. Overrides KIN_MCP_REPO. Use this for a global agent-CLI MCP entry that may launch outside any Kin repository (e.g. an umbrella workspace root). |
 | `--tool-profile <profile>` |  | Tool surface to serve: `agent-default` (the curated agent belt, and the default), `full` (every tool, roughly 12k extra tokens of schemas per session), `benchmark`, or `context-bench`. Overrides KIN_MCP_TOOL_PROFILE. |
+| `--no-spawn` |  | Never start or revive a daemon from this server: bind only a daemon that is already running, and answer graph tool calls with an honest "no daemon is running" error otherwise. This is the probe mode for watchdogs and boot-time checks (equivalent to KIN_NO_DAEMON=1): the MCP handshake and tool list are served in full, and nothing heavy is ever spawned by the check itself. |
 
 ### `kin assistant`
 
@@ -2589,9 +2590,11 @@ kin update [options]
 | `--json` |  | Emit the check-only result as JSON. |
 | `--ack-restart` |  | Verify the durable restart fence and exact installed binary identities for the release awaiting acknowledgement. Legacy markers may additionally require explicit replacement-session evidence. |
 | `--runtime-session <kind=pid>` |  | Legacy-marker live replacement proof: `daemon=PID`, `mcp=PID`, or `vfs=PID`. New stop-before-update markers reject these arguments and require no replacement session evidence. Repeatable. |
-| `--set-policy <policy>` |  | Set how an available update should reach this machine and exit. `prompt` (the default) notifies with the remedy attached and waits to be told. `auto` and `manual` are recorded preferences whose enforcement has not shipped: today every mode behaves as `prompt`, and the recorded choice takes effect when the notifier honors it. |
+| `--set-policy <policy>` |  | Set how an available update should reach this machine and exit. `auto` (the default) installs unattended through the gated executor: it waits for a moment with no managed Kin process or agent session, defers at most a bounded window, and runs the full stop-install-acknowledge chain. `prompt` notifies with the remedy attached and waits to be told. `manual` never notifies; checks still run. |
 | `--apply` |  | Bring this machine current in one gesture: install the release, acknowledge the restart fence, and repair agent configs, in that order. This is what the update notification's button runs. |
 | `--dry-run` |  | With --apply: print the ordered steps and change nothing. |
+| `--unattended` |  | Run the unattended executor (what the update watchdog invokes on a stale install with policy auto): evaluate the machine-activity gates, and on proceed stop every managed Kin process cooperatively and run the full --apply chain. Blocked runs persist a deferral clock instead of installing. The final stdout line is one JSON record (also appended to ~/.kin/update-ledger.jsonl) carrying the decision, reason, blocked_seconds, and window_seconds. |
+| `--force-window` |  | With --unattended: apply despite the activity gates. For the watchdog once a deferred record shows blocked_seconds >= window_seconds (24h). Never overrides a recorded prompt or manual policy, only the executor's own activity gates. |
 
 ### `kin completions`
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -58,7 +58,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_BUILD_GRAPH_TIMEOUT_SECS` | seconds>=0 | 60 | operational | timeout for building a historical ref-view graph |
 | `KIN_BYPASS_EMBEDDING_COVERAGE_CHECK` | bool | false | correctness | bypass the embedding-coverage correctness gate |
 | `KIN_DISABLE_SPINE` | bool | false | correctness | disable the spine federation layer, narrowing retrieval scope |
-| `KIN_NO_DAEMON` | bool | false | operational | force in-process execution instead of the daemon |
+| `KIN_NO_DAEMON` | bool | false | operational | never start or revive a daemon; bind only an already-running one (the probe contract behind `kin mcp start --no-spawn`) |
 | `KIN_NO_KEYRING` | bool | false | operational | skip the OS keyring for credential storage |
 | `KIN_NO_VFS` | bool | false | operational | kin-vfs shim projection bypass: set to 1 to skip VFS initialization and exec the real binary directly (only the literal '1' bypasses), default off |
 | `KIN_ORG_ID` | string | *(unset)* | operational | organization id for federation/remote |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -564,8 +564,10 @@ setups should use `@kinlab/kin`, which includes the same MCP server as `kin mcp 
 The Kin daemon is the canonical authority for graph truth and auto-starts as needed for
 normal use. The escape hatches:
 
-- `KIN_NO_DAEMON=1`: disable daemon auto-start (use only an already-running daemon or
-  `KIN_DAEMON_URL`).
+- `KIN_NO_DAEMON=1`: never start or revive a daemon (use only an already-running daemon or
+  `KIN_DAEMON_URL`). This is the probe contract: `kin mcp start --no-spawn` sets it so
+  scheduled and boot-time checks can hold the full MCP handshake while provably spawning
+  nothing, and graph calls without a running daemon fail loud instead of starting one.
 - `KIN_DAEMON_URL`: point the CLI at an explicit daemon endpoint.
 - `KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN=1`: offline/admin escape hatch that lets the read-only
   in-process commands fall back to reading the local `.kin` snapshot directly. It is never


### PR DESCRIPTION
Kin now updates itself by default. A missing or policy-less `update.toml` means policy auto, in this binary and in the update watchdog's parser together, and the new `kin update --unattended` executor is what the watchdog invokes when an install falls behind. It evaluates the machine-activity gates against the live process table with the same matcher the update preflight refuses on, and on proceed it stops every managed Kin process cooperatively instead of refusing, runs the full install, restart-fence acknowledgement, and config-repair chain, and reports one machine-readable record as its final stdout line, appended verbatim to `~/.kin/update-ledger.jsonl`. Blocked runs persist a first-blocked clock; the caller passes `--force-window` once the executor's own 24h window is spent, and the flag overrides only the activity gates, never a recorded prompt or manual policy. `kin update --set-policy prompt|manual` stays the opt-out, and `kin doctor` now reports the active policy and whether it was recorded or inherited.

The probe half of the 2026-08-15 boot incident closes in the same change. `kin mcp start --no-spawn` (equivalent to `KIN_NO_DAEMON=1`) holds the full MCP handshake while provably starting nothing: the tool-call revival path and the supervisor spawn chokepoint both refuse under the contract with the reason in the answer. A new binary-level test replays the incident shape, a stale daemon record plus a dead bound URL, and proves zero daemon processes are created, with a positive control showing the identical session without the flag does reach the spawn.

Release notes: existing installs inherit the auto default on their next binary; machines that recorded prompt or manual keep their choice. Safety is unchanged in kind and stronger in order: the preflight still proves managed serving executables quiescent before bytes move, the restart fence still forces the new binary to acknowledge, and stores still reopen through per-key salvage.

Closes FIR-2342
Refs FIR-2341
