### PR TITLE
Name every dark span on the CLI commit path

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4626,24 +4626,33 @@ async fn command_commit(
     // Hold one uninterrupted graph-authority gate across forced filesystem
     // admission, change construction, and branch publication. The sync helper
     // deliberately does not re-lock this non-reentrant mutex.
-    let _coordination = state.coordination_gate.lock().await;
-    crate::loop_runner::sync_filesystem_with_graph_under_coordination(&state)
-        .await
-        .map_err(internal_error)?;
+    let _coordination = crate::mcp_commit::timed_commit_phase_async(
+        "coordination_gate_wait",
+        state.coordination_gate.lock(),
+    )
+    .await;
+    crate::mcp_commit::timed_commit_phase_async(
+        "forced_filesystem_admission",
+        crate::loop_runner::sync_filesystem_with_graph_under_coordination(&state),
+    )
+    .await
+    .map_err(internal_error)?;
 
     let graph = &*state.graph;
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
             .map_err(repository_commit_error)?;
-    let plan = crate::repository_commit::plan_native_commit(
-        graph,
-        state.blobs.as_ref(),
-        &authority_context,
-        request.operation_id,
-        request.timestamp,
-        kin_model::AuthorId::new(kin_core::whoami()),
-        request.message,
-    )
+    let plan = crate::mcp_commit::timed_commit_phase("plan_transaction", || {
+        crate::repository_commit::plan_native_commit(
+            graph,
+            state.blobs.as_ref(),
+            &authority_context,
+            request.operation_id,
+            request.timestamp,
+            kin_model::AuthorId::new(kin_core::whoami()),
+            request.message,
+        )
+    })
     .map_err(repository_commit_error)?;
     let change_id = plan.change.id;
     let branch_name = plan.branch.clone();
@@ -4721,9 +4730,10 @@ async fn command_commit(
     // The repository transaction is durable authority. The in-process graph is
     // a derived query view; install the exact immutable change only after the
     // authority CAS succeeds.
-    graph
-        .create_change(&committed.change)
-        .map_err(internal_error)?;
+    crate::mcp_commit::timed_commit_phase("install_live_graph", || {
+        graph.create_change(&committed.change)
+    })
+    .map_err(internal_error)?;
     state.bump_version();
     state.emit_event(DaemonEvent::GraphRootChanged {
         old_root_hash: None,
@@ -19085,6 +19095,147 @@ mod tests {
                 .snapshot_generation
                 .load(std::sync::atomic::Ordering::Relaxed),
             generation_before
+        );
+    }
+
+    /// Every span the CLI commit path spends before durable publication names
+    /// itself in the log.
+    ///
+    /// The finalize after publication already reported its steps, so the wall a
+    /// user waits was attributable only from its tail backwards. Everything in
+    /// front of it, the coordination gate, the forced filesystem admission it
+    /// guards, transaction planning, and the live-graph install, ran silent,
+    /// which left a slow commit blamable on any of them and disprovable against
+    /// none. This drives one real commit through the router under a capture
+    /// subscriber and reads the phase lines back, so a span that stops
+    /// reporting fails here rather than reappearing as an unexplained gap.
+    ///
+    /// The names are asserted because the proof parser keys on them. A fabricated
+    /// name is checked too: without it a capture that silently collected nothing
+    /// would satisfy every membership assertion it was given.
+    #[tokio::test]
+    async fn the_cli_commit_path_names_every_phase_it_spends() {
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        #[derive(Default)]
+        struct Captured {
+            phases: Vec<String>,
+            malformed: Vec<String>,
+        }
+
+        struct CaptureLayer(Arc<std::sync::Mutex<Captured>>);
+
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                #[derive(Default)]
+                struct Read {
+                    phase: Option<String>,
+                    message: Option<String>,
+                    elapsed_ms: bool,
+                }
+                impl tracing::field::Visit for Read {
+                    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                        if field.name() == "phase" {
+                            self.phase = Some(value.to_string());
+                        }
+                    }
+                    fn record_debug(
+                        &mut self,
+                        field: &tracing::field::Field,
+                        value: &dyn std::fmt::Debug,
+                    ) {
+                        match field.name() {
+                            "message" => self.message = Some(format!("{value:?}")),
+                            "elapsed_ms" => self.elapsed_ms = true,
+                            _ => {}
+                        }
+                    }
+                }
+
+                let mut read = Read::default();
+                event.record(&mut read);
+                let message = read.message.unwrap_or_default();
+                if message != "commit phase" && message != "slow commit phase" {
+                    return;
+                }
+                let mut captured = self.0.lock().unwrap();
+                match read.phase {
+                    // The proof parser reads `phase=` and `elapsed_ms=` off these
+                    // two needles, so a line carrying one without the other is a
+                    // parse failure and is collected as such rather than dropped.
+                    Some(phase) if read.elapsed_ms => captured.phases.push(phase),
+                    other => captured.malformed.push(format!("{message}: {other:?}")),
+                }
+            }
+        }
+
+        let state = test_state();
+        let root = state.layout.working_dir();
+        std::fs::write(root.join("attributable.rs"), b"pub fn attributable() {}\n").unwrap();
+        let app = router(Arc::clone(&state));
+
+        let captured = Arc::new(std::sync::Mutex::new(Captured::default()));
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer(Arc::clone(&captured)));
+        let response = {
+            let _default = tracing::subscriber::set_default(subscriber);
+            app.oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "message": "attribute the commit wall"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        };
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        let captured = std::mem::take(&mut *captured.lock().unwrap());
+        assert!(
+            captured.malformed.is_empty(),
+            "every commit phase line must carry both phase and elapsed_ms: {:?}",
+            captured.malformed
+        );
+        for phase in [
+            "coordination_gate_wait",
+            "forced_filesystem_admission",
+            "scan_working_copy",
+            "observe_tree_and_stage_blobs",
+            "publish_workspace_admission",
+            "plan_transaction",
+            "plan_snapshot_clone",
+            "plan_diff_semantics",
+            "plan_compute_deltas",
+            "plan_derive_admission_policy",
+            "install_live_graph",
+        ] {
+            assert!(
+                captured.phases.iter().any(|captured| captured == phase),
+                "the commit path must name the {phase} phase; captured {:?}",
+                captured.phases
+            );
+        }
+        assert!(
+            !captured
+                .phases
+                .iter()
+                .any(|phase| phase == "phase_this_commit_never_spends"),
+            "a phase the path never runs must not be reported; captured {:?}",
+            captured.phases
         );
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -536,15 +536,19 @@ fn exact_tree_admission(
         .iter()
         .filter(|path| !retracted_paths.contains(*path))
         .collect::<Vec<&RepoPath>>();
-    let scan = kin_index::scan_repository_preserving_graph_only(
-        working_dir,
-        &ignore,
-        scanned_tracked.into_iter(),
-        graph_only_paths.iter(),
-    )
+    let scan = crate::mcp_commit::timed_commit_phase("scan_working_copy", || {
+        kin_index::scan_repository_preserving_graph_only(
+            working_dir,
+            &ignore,
+            scanned_tracked.into_iter(),
+            graph_only_paths.iter(),
+        )
+    })
     .map_err(kin_index::IndexError::from)?;
     let mut observed =
-        crate::commit_deltas::observed_tree_from_complete_scan(&state.blobs, &scan, &previous)?;
+        crate::mcp_commit::timed_commit_phase("observe_tree_and_stage_blobs", || {
+            crate::commit_deltas::observed_tree_from_complete_scan(&state.blobs, &scan, &previous)
+        })?;
     if let Some(observation) = observation {
         for artifact in previous.artifacts_by_path() {
             if observation_covers_path(observation, &artifact.path) {
@@ -658,7 +662,9 @@ fn exact_tree_admission(
             previous.clone(),
             desired_tree,
         );
-        let _ = publish_exact_workspace_tree(state, &admitted)?;
+        let _ = crate::mcp_commit::timed_commit_phase("publish_workspace_admission", || {
+            publish_exact_workspace_tree(state, &admitted)
+        })?;
         // Authority has committed the removal, so the entities derived from
         // those paths go before the graph is asked to match. kin-db refuses a
         // tree transition that leaves an entity on a path the staged tree no

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1554,6 +1554,31 @@ pub(crate) fn timed_commit_phase<T>(phase: &'static str, work: impl FnOnce() -> 
     outcome
 }
 
+/// Time one awaited phase of the commit and report it exactly as the blocking
+/// helper does.
+///
+/// The CLI commit path opens with two phases that cannot be measured by a
+/// closure: waiting on the coordination gate, and the forced filesystem
+/// admission that runs under it. Both are `async`, and a phase that is skipped
+/// because it does not fit the helper's shape is a phase the wall time hides.
+/// The elapsed span covers suspension as well as work, which is the point for a
+/// gate wait: the queue behind a held lock is the cost being attributed.
+pub(crate) async fn timed_commit_phase_async<T>(
+    phase: &'static str,
+    work: impl std::future::Future<Output = T>,
+) -> T {
+    let started = std::time::Instant::now();
+    let outcome = work.await;
+    let elapsed = started.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    if elapsed >= SLOW_FINALIZE_STEP {
+        tracing::info!(phase, elapsed_ms, "slow commit phase");
+    } else {
+        tracing::debug!(phase, elapsed_ms, "commit phase");
+    }
+    outcome
+}
+
 fn finalize_committed_transaction(
     state: &Arc<DaemonState>,
     sessions: &kin_mcp::SessionRegistry,

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -773,36 +773,46 @@ fn plan_native_commit_inner(
                     "repository authority has no graph snapshot for workspace {workspace_id}"
                 ))
             })?;
-    let desired_workspace_graph = graph.to_snapshot();
-    let workspace_semantic_delta = kin_core::diff_workspace_semantics(
-        &authority_workspace_graph.entities,
-        &authority_workspace_graph.relations,
-        &desired_workspace_graph.entities,
-        &desired_workspace_graph.relations,
-    )?;
-    let deltas = compute_deltas_vs_repository_authority(graph, lease.snapshot(), parent.as_ref())?;
+    let desired_workspace_graph =
+        crate::mcp_commit::timed_commit_phase("plan_snapshot_clone", || graph.to_snapshot());
+    let workspace_semantic_delta =
+        crate::mcp_commit::timed_commit_phase("plan_diff_semantics", || {
+            kin_core::diff_workspace_semantics(
+                &authority_workspace_graph.entities,
+                &authority_workspace_graph.relations,
+                &desired_workspace_graph.entities,
+                &desired_workspace_graph.relations,
+            )
+        })?;
+    let deltas = crate::mcp_commit::timed_commit_phase("plan_compute_deltas", || {
+        compute_deltas_vs_repository_authority(graph, lease.snapshot(), parent.as_ref())
+    })?;
     let mut source_lengths = std::collections::BTreeMap::new();
-    let (shared_policy, admission_policy_delta) = SharedAdmissionPolicy::derive_from_tree(
-        parent_policy.as_ref(),
-        &deltas.expected_tree,
-        |hash| {
-            if let Some(length) = source_lengths.get(&hash) {
-                return Ok(*length);
-            }
-            let source = read_publishable_source(blobs, &authority, hash).map_err(|error| {
-                ModelError::InvalidOperation(format!(
-                    "{error}, while deriving the graph-owned admission policy"
-                ))
-            })?;
-            let length = u64::try_from(source.body().len()).map_err(|_| {
-                ModelError::InvalidOperation(format!(
-                    "graph-owned admission source {hash} exceeds u64"
-                ))
-            })?;
-            source_lengths.insert(hash, length);
-            Ok(length)
-        },
-    )?;
+    let (shared_policy, admission_policy_delta) =
+        crate::mcp_commit::timed_commit_phase("plan_derive_admission_policy", || {
+            SharedAdmissionPolicy::derive_from_tree(
+                parent_policy.as_ref(),
+                &deltas.expected_tree,
+                |hash| {
+                    if let Some(length) = source_lengths.get(&hash) {
+                        return Ok(*length);
+                    }
+                    let source =
+                        read_publishable_source(blobs, &authority, hash).map_err(|error| {
+                            ModelError::InvalidOperation(format!(
+                                "{error}, while deriving the graph-owned admission policy"
+                            ))
+                        })?;
+                    let length = u64::try_from(source.body().len()).map_err(|_| {
+                        ModelError::InvalidOperation(format!(
+                            "graph-owned admission source {hash} exceeds u64"
+                        ))
+                    })?;
+                    source_lengths.insert(hash, length);
+                    Ok(length)
+                },
+            )
+        })?;
 
     // Settled here, not before planning: the message may have to name what this
     // change carried in, and that set is not known until the published tree


### PR DESCRIPTION
The finalize after durable publication already reported its own steps, so the wall a `kin commit` costs was attributable only from its tail backwards. Everything in front of it ran silent. A caller queues on the coordination gate, then holds it across the forced filesystem admission, all of transaction planning, and the live-graph install after the authority CAS, with no line in the log for any of that stretch. A slow commit could be blamed on any of them and disproved against none.

Each of those spans reports now, through the same `timed_commit_phase` helper the post-publication steps already use, so the emitted shape is unchanged: `phase=` and `elapsed_ms=` under the `commit phase` needle below 500ms and `slow commit phase` at or above it. No existing phase is renamed and no logic moves. Every wrapped call keeps the arguments, ordering, result, and error path it had.

`/commands/commit` names `coordination_gate_wait`, `forced_filesystem_admission`, `plan_transaction`, and `install_live_graph`. The exact-tree admission under it names `scan_working_copy`, `observe_tree_and_stage_blobs`, and `publish_workspace_admission`, which the ambient reconcile tick reports too; the lines carry their own names, so a tick and a commit stay distinguishable in one log. Planning breaks down further into `plan_snapshot_clone`, `plan_diff_semantics`, `plan_compute_deltas`, and `plan_derive_admission_policy`, because one `plan_transaction` number cannot say whether a graph clone or a whole-tree policy derivation spent it.

Two of those spans are `async` and no closure can measure them, so `timed_commit_phase_async` sits beside the blocking helper and reports identically. Its elapsed span covers suspension as well as work, which is the point for a gate wait: the queue behind a held lock is the cost being attributed.

A router test drives one real commit and reads the phase lines back, asserting every name appears and that each line carries both `phase` and `elapsed_ms`, since the proof parser keys on that pair. It asserts no duration. A fabricated phase name is checked absent as well, because a capture that collected nothing would otherwise satisfy every membership assertion it was given. The test was proven able to fail: reverting the `install_live_graph` wrapper alone fails it by name.

Closes FIR-2345
