### PR TITLE
Skip policy-excluded proposals instead of failing the whole tree admission

### DIFF
--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -307,6 +307,56 @@ pub struct ReconcileHealth {
     /// which no admission can represent.
     #[serde(default)]
     pub unsupported_path_count: u64,
+    /// Untracked host paths the graph-owned admission policy excluded from the
+    /// most recent complete walk.
+    ///
+    /// Separate from `ignored_path_count` because the reader's next action is
+    /// different: that count sends them to `.kinignore` in the working copy,
+    /// this one to the `.gitignore`/`.kinignore` blobs the repository tracks and
+    /// to the frozen local overlay. It is also the count that used to be zero
+    /// while every one of those paths failed the entire admission (FIR-2346).
+    #[serde(default)]
+    pub policy_excluded_path_count: u64,
+    /// Why the reconciliation loop is parked, when it is.
+    ///
+    /// The reconcile status string reads `parked-by-supervisor` and said
+    /// nothing else, so the only account of why lived in a log line from
+    /// whenever it happened. Absent on a loop that is running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parked: Option<ReconcileParked>,
+}
+
+/// The background-work supervisor's account of a parked reconciliation loop.
+///
+/// Every field is what the supervisor already had when it stopped the pass. It
+/// is published beside the status string so `parked-by-supervisor` names its own
+/// cause: the reason it announced, and the two readings that produced it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconcileParked {
+    /// The reason the supervisor announced when it stopped the pass.
+    pub reason: String,
+    /// Units of work the pass had durably recorded when it was stopped. The
+    /// number the stall verdict was reached on: a pass is stalled by having
+    /// held the CPU without advancing this.
+    #[serde(default)]
+    pub progress: u64,
+    /// Seconds the pass had been working without interruption. Absent once the
+    /// park cleared the working stretch, which is the ordinary case after a
+    /// stop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_seconds: Option<u64>,
+    /// Seconds since `progress` last advanced. Absent when it never did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress_age_seconds: Option<u64>,
+    /// Seconds the pass has owed deferred work. A livelock's own clock: it ages
+    /// while the loop keeps re-deferring paths it may not admit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_seconds: Option<u64>,
+    /// The configured stall threshold this verdict was reached against, in
+    /// seconds. Stated so a reader knows whether the numbers above are near the
+    /// limit or past it without going to find the constant.
+    #[serde(default)]
+    pub stall_threshold_seconds: u64,
 }
 
 impl ReconcileHealth {
@@ -323,6 +373,22 @@ impl ReconcileHealth {
     /// the limit or merely a number.
     pub fn degraded_reasons(&self) -> Vec<String> {
         let mut reasons = Vec::new();
+        // First, because it outranks every other reading here: a parked loop is
+        // not admitting anything at all, so whatever the counters below say
+        // about the last attempt, there is no next one until the daemon
+        // restarts.
+        if let Some(parked) = &self.parked {
+            let progress_age = match parked.progress_age_seconds {
+                Some(age) => format!("last advanced {age}s ago"),
+                None => "never advanced".to_string(),
+            };
+            reasons.push(format!(
+                "the reconciliation loop is parked by the background-work supervisor and admits \
+                 nothing until the daemon restarts: {} (progress {} units, {progress_age}, stall \
+                 threshold {}s)",
+                parked.reason, parked.progress, parked.stall_threshold_seconds
+            ));
+        }
         if self.admission_failure_streak >= ADMISSION_FAILURE_STREAK_ATTENTION {
             let since = match self.last_admission_success_age_seconds {
                 Some(age) => format!("last succeeded {age}s ago"),
@@ -406,12 +472,21 @@ impl ReconcileHealth {
                 self.untracked_path_count
             ));
         }
-        if self.ignored_path_count > 0 || self.unsupported_path_count > 0 {
+        if self.ignored_path_count > 0
+            || self.unsupported_path_count > 0
+            || self.policy_excluded_path_count > 0
+        {
             let mut excluded = Vec::new();
             if self.ignored_path_count > 0 {
                 excluded.push(format!(
                     "{} excluded by the ignore rules",
                     self.ignored_path_count
+                ));
+            }
+            if self.policy_excluded_path_count > 0 {
+                excluded.push(format!(
+                    "{} excluded by the repository's graph-owned admission policy",
+                    self.policy_excluded_path_count
                 ));
             }
             if self.unsupported_path_count > 0 {
@@ -422,8 +497,8 @@ impl ReconcileHealth {
             }
             notices.push(format!(
                 "The last complete walk left host content unobserved: {}. Nothing admits these, so \
-                 a file missing from here is missing on purpose; check .kinignore before waiting \
-                 on it.",
+                 a file missing from here is missing on purpose; check .kinignore and the \
+                 repository's tracked .gitignore rules before waiting on it.",
                 excluded.join(", ")
             ));
         }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2574,7 +2574,7 @@ async fn health(
     let sampled_at = std::time::Instant::now();
     let background_passes = state.background_work.reports(sampled_at);
     let background_pass_stopped = state.background_work.any_stopped();
-    let reconcile = state.background_work.reconcile().report(sampled_at);
+    let reconcile = state.background_work.reconcile_report(sampled_at);
     let reconcile_degraded = reconcile.degraded();
     // Surface graph-safety + derived-index health in the top-level status so an
     // operator or client polling /health sees a non-"ok" signal when the daemon
@@ -3459,8 +3459,7 @@ async fn command_graph(
         &request,
         &state
             .background_work
-            .reconcile()
-            .report(std::time::Instant::now()),
+            .reconcile_report(std::time::Instant::now()),
         &embedding_runtime,
     )
     .map_err(internal_error)?;

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -310,6 +310,35 @@ impl BackgroundPass {
         self.lock().progress
     }
 
+    /// This pass's park, with the readings the verdict was reached on, or
+    /// `None` while it is running.
+    ///
+    /// Read under one lock so the reason and the counts beside it describe the
+    /// same instant. `stall_threshold` travels with them because a park is only
+    /// legible against the limit it was measured by.
+    fn parked_report(
+        &self,
+        now: Instant,
+        stall_threshold: Duration,
+    ) -> Option<kin_cli::commands::resources::ReconcileParked> {
+        let inner = self.lock();
+        let reason = inner.halt.clone()?;
+        Some(kin_cli::commands::resources::ReconcileParked {
+            reason,
+            progress: inner.progress,
+            working_seconds: inner
+                .working_since
+                .map(|since| now.saturating_duration_since(since).as_secs()),
+            progress_age_seconds: inner
+                .progress_at
+                .map(|at| now.saturating_duration_since(at).as_secs()),
+            deferred_seconds: inner
+                .deferred_since
+                .map(|since| now.saturating_duration_since(since).as_secs()),
+            stall_threshold_seconds: stall_threshold.as_secs(),
+        })
+    }
+
     fn report(&self, now: Instant) -> BackgroundPassReport {
         let inner = self.lock();
         // `working` outranks `waiting_deferred`: a pass burning CPU on this tick
@@ -413,6 +442,22 @@ impl BackgroundWorkSupervisor {
     /// The reconcile loop's probe handle, for the loop to record into.
     pub fn reconcile(&self) -> &ReconcileProbes {
         &self.reconcile
+    }
+
+    /// The reconcile loop's complete account of itself, park included.
+    ///
+    /// The probes know what the loop admitted and dropped; only the supervisor
+    /// knows whether it stopped the pass. Assembled here rather than by each
+    /// surface, because a surface that reads the probes alone publishes a
+    /// parked loop as an ordinary quiet one, and the status string beside it
+    /// says `parked-by-supervisor` with nothing to explain it. Every disclosure
+    /// this daemon builds goes through here.
+    pub fn reconcile_report(&self, now: Instant) -> ReconcileHealth {
+        let mut report = self.reconcile.report(now);
+        report.parked = self
+            .registered(PASS_RECONCILE)
+            .and_then(|pass| pass.parked_report(now, self.stall_threshold));
+        report
     }
 
     fn passes(
@@ -567,14 +612,14 @@ impl BackgroundWorkSupervisor {
             // not one, so the caller that can see both fills this in.
             authority_loads: None,
             passes: self.reports(now),
-            reconcile: self.reconcile.report(now),
+            reconcile: self.reconcile_report(now),
         }
     }
 
     /// Whether the reconcile loop's own account of itself is degraded. Drives
     /// the `attention` health status beside `any_stopped`.
     pub fn reconcile_degraded(&self, now: Instant) -> bool {
-        self.reconcile.report(now).degraded()
+        self.reconcile_report(now).degraded()
     }
 }
 
@@ -683,6 +728,15 @@ pub struct ExcludedHostContent {
     pub ignored: u64,
     /// Untracked leaves outside Kin's regular-file and symbolic-link tree.
     pub unsupported: u64,
+    /// Untracked entries the graph-owned admission policy excluded.
+    ///
+    /// Counted apart from `ignored` because they answer different questions. A
+    /// path in `ignored` is named by this repository's `.kinignore` or a
+    /// built-in default, which an operator edits in the working copy. A path
+    /// here is excluded by the durable policy compiled from the tree's
+    /// `.gitignore`/`.kinignore` blobs and the frozen local overlay, and it is
+    /// the set that used to fail the whole admission instead of being skipped.
+    pub policy_excluded: u64,
 }
 
 /// How many untracked paths a disclosure names outright.
@@ -799,6 +853,8 @@ impl ReconcileProbes {
             untracked_paths_sample: inner.untracked_paths_sample.clone(),
             ignored_path_count: inner.excluded.ignored,
             unsupported_path_count: inner.excluded.unsupported,
+            policy_excluded_path_count: inner.excluded.policy_excluded,
+            parked: None,
         }
     }
 }

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1213,6 +1213,7 @@ mod tests {
         let scan = kin_index::scan_repository_preserving_graph_only(
             &source,
             &ignore,
+            None,
             tracked_paths.iter(),
             graph_only_paths.iter(),
         )

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -156,6 +156,15 @@ struct ExactTreeAdmission {
     deltas: Vec<TreeDelta>,
     changed_paths: BTreeSet<RepoPath>,
     semantic_events: Vec<FileEvent>,
+    /// The exact admission policy this pass planned against.
+    ///
+    /// Carried back so the reconcile loop can drop host events for paths the
+    /// policy excludes without paying a second authority load per tick. The
+    /// loop's copy is therefore one pass old, which is the right staleness for
+    /// what it decides: dropping an event is advisory, admission still enforces
+    /// the policy exactly, and a rule written this tick takes effect on the
+    /// next one instead of on the one that wrote it.
+    policy: Option<kin_index::ResolvedAdmissionMatcher>,
 }
 
 fn canonicalize_host_parent_preserving_leaf(path: &Path) -> std::io::Result<PathBuf> {
@@ -347,6 +356,32 @@ fn event_is_beneath_graph_only_member(state: &DaemonState, event: &FileEvent) ->
     }
 }
 
+/// Whether the graph-owned admission policy excludes the path this event names,
+/// and graph truth does not already track it.
+///
+/// The exact test the walk and the authority boundary both apply, asked of one
+/// host notification. `policy` is the last resolved one; before the first
+/// admission of a daemon's life there is none and nothing is dropped.
+fn event_is_policy_excluded(
+    state: &DaemonState,
+    policy: Option<&kin_index::ResolvedAdmissionMatcher>,
+    event: &FileEvent,
+) -> bool {
+    let Some(policy) = policy else {
+        return false;
+    };
+    let path = match event {
+        FileEvent::Changed(path) | FileEvent::Removed(path) => path,
+    };
+    let Ok(Some(repo_path)) = repo_path(path, state.layout.working_dir()) else {
+        return false;
+    };
+    if state.graph.artifact_id_at_path(&repo_path).is_some() {
+        return false;
+    }
+    policy.decide(&repo_path, false, false).is_ignored()
+}
+
 fn is_within_graph_only_member(state: &DaemonState, path: &RepoPath) -> Result<bool> {
     for artifact in state.graph.resolved_tree().artifacts_by_path() {
         if kin_core::source_projection_disposition(&artifact.path, artifact.entry)?
@@ -417,13 +452,35 @@ fn mass_deletion_refused(removed: u64, total_graph_files: u64) -> DaemonError {
     ))
 }
 
-/// Read the repository roots the next observation will be planned against.
-pub(crate) fn current_authority_roots(state: &DaemonState) -> Result<kin_model::RootBundle> {
+/// Read the authority roots an admission plans against and the exact admission
+/// policy that authority will judge it by, from one open.
+///
+/// One open rather than two because the pair has to be coherent: planning a
+/// tree against one generation's roots and filtering it through another
+/// generation's rules would leave the walk proposing paths the publication is
+/// about to refuse, which is the failure this reads the policy to avoid.
+///
+/// A repository with no local workspace — a hosted snapshot daemon — has no
+/// policy to resolve and reports `None`. Nothing is filtered in that case, and
+/// nothing is published from a host walk there either.
+pub(crate) fn current_authority_admission(
+    state: &DaemonState,
+) -> Result<(
+    kin_model::RootBundle,
+    Option<kin_index::ResolvedAdmissionMatcher>,
+)> {
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     let roots = authority.read_authority().roots().clone();
-    Ok(roots)
+    let policy = authority
+        .workspace_admission_snapshot(
+            authority_context.repository_id(),
+            &authority_context.workspace_id(),
+        )
+        .map_err(DaemonError::Graph)?
+        .map(|snapshot| snapshot.matcher);
+    Ok((roots, policy))
 }
 
 /// What one complete walk declined to observe, taken from its own diagnostics.
@@ -437,7 +494,33 @@ fn excluded_host_content(
     crate::background_work::ExcludedHostContent {
         ignored: diagnostics.ignored_untracked_entries as u64,
         unsupported: diagnostics.unsupported_untracked_entries as u64,
+        policy_excluded: diagnostics.policy_excluded_untracked_entries as u64,
     }
+}
+
+/// Say once per pass what the graph-owned policy kept out of it.
+///
+/// Once per pass and bounded, not once per path: the founder's daemon logged
+/// the same refusal continuously, and a walk that meets a churning excluded
+/// directory would reproduce that at debug if it named every leaf. The count is
+/// complete and the sample is what makes the rule recognizable.
+fn announce_policy_exclusions(scan: &kin_index::CompleteRepositoryScan) {
+    let excluded = scan.diagnostics().policy_excluded_untracked_entries;
+    if excluded == 0 {
+        return;
+    }
+    let sample = scan
+        .policy_excluded_paths_sample()
+        .iter()
+        .map(|path| path.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    debug!(
+        count = excluded,
+        sample = %sample,
+        "the graph-owned admission policy excludes these untracked host paths; \
+         they were skipped rather than proposed"
+    );
 }
 
 /// Report whether one repository path was named by an observation, either
@@ -493,7 +576,7 @@ fn exact_tree_admission(
     // Publication compare-and-swaps on this bundle, so a repository that moves
     // while the host walk is running fails the whole admission instead of
     // having its desired tree replanned onto the newer authority.
-    let expected_roots = current_authority_roots(state)?;
+    let (expected_roots, policy) = current_authority_admission(state)?;
     let previous = state.graph.resolved_tree();
     let tracked_paths = previous
         .artifacts_by_path()
@@ -540,11 +623,13 @@ fn exact_tree_admission(
         kin_index::scan_repository_preserving_graph_only(
             working_dir,
             &ignore,
+            policy.as_ref(),
             scanned_tracked.into_iter(),
             graph_only_paths.iter(),
         )
     })
     .map_err(kin_index::IndexError::from)?;
+    announce_policy_exclusions(&scan);
     let mut observed =
         crate::mcp_commit::timed_commit_phase("observe_tree_and_stage_blobs", || {
             crate::commit_deltas::observed_tree_from_complete_scan(&state.blobs, &scan, &previous)
@@ -712,6 +797,7 @@ fn exact_tree_admission(
         deltas,
         changed_paths,
         semantic_events: dedup_file_events(semantic_events),
+        policy,
     })
 }
 
@@ -1525,6 +1611,11 @@ pub async fn run_loop(
     // larger than `batch_size` is deferred instead of silently discarded.
     let mut pending_events: VecDeque<FileEvent> = VecDeque::new();
     let mut backlog_warning_active = false;
+    // The admission policy the last complete pass planned against, kept so the
+    // event filter below costs no authority load of its own. `None` until the
+    // first pass resolves one, which is the safe direction: nothing is dropped
+    // and the pass itself still enforces the policy exactly.
+    let mut graph_owned_policy: Option<kin_index::ResolvedAdmissionMatcher> = None;
 
     // Register with the self-limit supervisor. Registered here rather than at
     // daemon start so a repository that never runs this loop — filesystem
@@ -1614,6 +1705,33 @@ pub async fn run_loop(
             retry_lane.forget(path);
             false
         });
+        // A path the graph-owned admission policy excludes is dropped for the
+        // same reason and with more force. Authority would refuse to admit it,
+        // and that refusal is not per-path: it fails the whole exact-tree
+        // admission, so one churning excluded file used to defer every other
+        // path in the working copy and admit nothing (FIR-2346). Even with the
+        // walk no longer proposing it, waking the tick on such an event would
+        // still buy a complete working-copy admission that can only conclude
+        // there is nothing to do, and a working stretch that records no
+        // progress is what the supervisor eventually parks the loop for. So the
+        // event never schedules work, and it ends whatever ladder the path had:
+        // the rules exclude it, so no retry can ever reach a different answer.
+        let mut policy_excluded_events = 0usize;
+        incoming_events.retain(|event| {
+            if !event_is_policy_excluded(&state, graph_owned_policy.as_ref(), event) {
+                return true;
+            }
+            let (FileEvent::Changed(path) | FileEvent::Removed(path)) = event;
+            retry_lane.forget(path);
+            policy_excluded_events += 1;
+            false
+        });
+        if policy_excluded_events > 0 {
+            debug!(
+                count = policy_excluded_events,
+                "dropped host events for paths the graph-owned admission policy excludes"
+            );
+        }
         // A path already waiting out a ladder step is not looked at again until
         // that step elapses, whichever queue its next notification arrived on.
         // The retry is already owed and re-reads whatever the file then holds, so
@@ -1738,6 +1856,7 @@ pub async fn run_loop(
                     &state.layout,
                     state.graph.resolved_tree().len() as u64,
                 );
+                graph_owned_policy.clone_from(&admission.policy);
                 admission
             }
             Err(error) => {
@@ -4458,6 +4577,241 @@ mod tests {
         // resetting the graph.
         assert!(tree_entry(&state, "keep.rs").is_some());
         assert_eq!(entity_ids_for(&state, "keep.rs"), kept_entities);
+    }
+
+    /// Establish a repository whose graph-owned admission policy excludes
+    /// `.claude/`, the way every real one does: the rule file is tracked before
+    /// the excluded content exists.
+    ///
+    /// A repository imported from Git resolves its policy from the `.gitignore`
+    /// blobs the import carried, so the rules are in force before the daemon's
+    /// first ambient pass. This fixture reproduces that state rather than
+    /// asserting anything about it.
+    async fn repository_with_policy_excluding_claude(root: &Path, state: &DaemonState) {
+        std::fs::write(root.join(".gitignore"), b".claude/\n").unwrap();
+        std::fs::write(root.join("keep.rs"), b"pub fn kept() -> u32 { 1 }\n").unwrap();
+        sync_filesystem_with_graph(state).await.unwrap();
+        assert!(
+            tree_entry(state, ".gitignore").is_some(),
+            "the fixture never admitted its own rule file, so no policy is in force"
+        );
+    }
+
+    /// A dirty subtree the graph-owned policy excludes admits the rest of the
+    /// tree instead of failing the whole admission.
+    ///
+    /// The scanner reads `.kinignore` and its built-in defaults; the durable
+    /// admission policy is compiled from every `.gitignore` and `.kinignore`
+    /// blob in the tree plus the frozen local overlay. A path only the second
+    /// one excludes was proposed by the walk and refused at the authority
+    /// boundary, and that refusal fails the entire exact-tree admission, so one
+    /// churning agent lock file left every other file in the working copy
+    /// unadmitted and the store answered from nothing (FIR-2346).
+    ///
+    /// The nested checkout under the excluded directory is the shape that
+    /// produced it on the founder's machine: a git worktree whose `.git` file
+    /// is control metadata while everything beside it is ordinary content.
+    #[tokio::test]
+    async fn a_dirty_policy_excluded_subtree_admits_the_rest_of_the_tree() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        repository_with_policy_excluding_claude(&root, &state).await;
+
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), b"pub fn library() -> u32 { 2 }\n").unwrap();
+        std::fs::create_dir_all(root.join(".claude/worktrees/lane-a/src")).unwrap();
+        std::fs::write(root.join(".claude/scheduled_tasks.lock"), b"held\n").unwrap();
+        std::fs::write(
+            root.join(".claude/worktrees/lane-a/.git"),
+            b"gitdir: ../../../.git/worktrees/lane-a\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(".claude/worktrees/lane-a/src/dirty.rs"),
+            b"pub fn dirty() -> u32 { 3 }\n",
+        )
+        .unwrap();
+
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        assert!(
+            tree_entry(&state, "src/lib.rs").is_some(),
+            "an excluded subtree left an ordinary file unadmitted"
+        );
+        assert!(
+            tree_entry(&state, "keep.rs").is_some(),
+            "the file admitted before the excluded subtree appeared was dropped"
+        );
+        assert!(tree_entry(&state, ".gitignore").is_some());
+        assert!(
+            tree_entry(&state, ".claude/scheduled_tasks.lock").is_none(),
+            "a policy-excluded path reached repository truth"
+        );
+        assert!(tree_entry(&state, ".claude/worktrees/lane-a/src/dirty.rs").is_none());
+
+        // The walk declined to observe them rather than silently finding
+        // nothing, and it says how many. An operator reading a missing file
+        // gets an answer instead of a quiet tree.
+        let excluded = state
+            .background_work
+            .reconcile()
+            .report(Instant::now())
+            .policy_excluded_path_count;
+        assert!(
+            excluded > 0,
+            "the pass skipped policy-excluded content without disclosing any of it"
+        );
+    }
+
+    /// Churn under an excluded path is not work, and the loop must not spend a
+    /// working stretch on it.
+    ///
+    /// Every excluded notification used to schedule a complete working-copy
+    /// admission that could only conclude there was nothing to admit, which is
+    /// a working stretch that records no progress. Ten minutes of that is what
+    /// the supervisor parks a pass for, and it parked the founder's store at
+    /// zero entities while the loop was doing exactly what it should.
+    #[tokio::test]
+    async fn continuous_excluded_churn_never_reaches_the_admission_path() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        repository_with_policy_excluding_claude(&root, &state).await;
+
+        let (_, policy) = current_authority_admission(&state).unwrap();
+        let policy = policy.expect("a local workspace resolves an admission policy");
+        std::fs::create_dir_all(root.join(".claude/worktrees/lane-a")).unwrap();
+        std::fs::write(root.join(".claude/scheduled_tasks.lock"), b"held\n").unwrap();
+        std::fs::write(root.join("src.rs"), b"pub fn src() -> u32 { 4 }\n").unwrap();
+
+        let excluded = FileEvent::Changed(root.join(".claude/scheduled_tasks.lock"));
+        assert!(
+            event_is_policy_excluded(&state, Some(&policy), &excluded),
+            "a churning excluded path still schedules a complete admission"
+        );
+        assert!(event_is_policy_excluded(
+            &state,
+            Some(&policy),
+            &FileEvent::Changed(root.join(".claude/worktrees/lane-a/head")),
+        ));
+
+        // Two-sided, or the predicate could be "drop everything". Ordinary
+        // content still reaches the admission path, and so does a tracked path
+        // even when the rules would exclude it today.
+        assert!(!event_is_policy_excluded(
+            &state,
+            Some(&policy),
+            &FileEvent::Changed(root.join("src.rs")),
+        ));
+        assert!(!event_is_policy_excluded(
+            &state,
+            Some(&policy),
+            &FileEvent::Changed(root.join("keep.rs")),
+        ));
+        // Before the first pass of a daemon's life there is no resolved policy,
+        // and nothing may be dropped on the strength of not having one.
+        assert!(!event_is_policy_excluded(&state, None, &excluded));
+    }
+
+    /// A pass making real progress is never stalled by excluded churn beside
+    /// it.
+    ///
+    /// The supervisor's verdict is the half that decides whether the store
+    /// survives, so it is exercised directly rather than inferred from the
+    /// filter above: excluded notifications arrive continuously for well past
+    /// the stall threshold while the loop keeps admitting, and the sweep must
+    /// leave the pass running.
+    #[test]
+    fn excluded_churn_beside_real_progress_never_parks_the_pass() {
+        let supervisor = crate::background_work::BackgroundWorkSupervisor::new(
+            Duration::from_secs(600),
+        );
+        let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
+        let start = Instant::now();
+
+        // Twenty minutes of ticks. Each one admits something real while
+        // excluded paths churn beside it, which is the working copy of anyone
+        // running an agent in their repository.
+        let mut now = start;
+        for tick in 0..120 {
+            now = start + Duration::from_secs(tick * 10);
+            pass.working(now);
+            pass.advanced(1, now);
+            assert!(
+                supervisor.sweep(now).is_empty(),
+                "a pass that is admitting was parked at tick {tick}"
+            );
+        }
+        assert!(!pass.halted());
+        assert!(supervisor.reconcile_report(now).parked.is_none());
+
+        // The other side: with the same clock and no progress, the sweep does
+        // stop it. Without this the assertions above would hold for a
+        // supervisor that never parks anything.
+        let starved = crate::background_work::BackgroundWorkSupervisor::new(
+            Duration::from_secs(600),
+        );
+        let starved_pass = starved.pass(crate::background_work::PASS_RECONCILE);
+        starved_pass.working(start);
+        assert!(starved.sweep(start + Duration::from_secs(1_200)).len() == 1);
+        assert!(starved_pass.halted());
+    }
+
+    /// The park names its own cause wherever the status string appears.
+    ///
+    /// `parked-by-supervisor` was the whole account a surface gave, and the
+    /// reason lived only in a log line from whenever it happened. The
+    /// supervisor already held the reason and the readings behind it.
+    #[test]
+    fn a_parked_reconcile_pass_publishes_its_reason_and_its_counts() {
+        let supervisor = crate::background_work::BackgroundWorkSupervisor::new(
+            Duration::from_secs(600),
+        );
+        let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
+        let start = Instant::now();
+        pass.working(start);
+        pass.advanced(3, start);
+        pass.set_deferred(true, start);
+        let stopped = supervisor.sweep(start + Duration::from_secs(1_050));
+        assert_eq!(stopped.len(), 1);
+
+        let report = supervisor.reconcile_report(start + Duration::from_secs(1_050));
+        let parked = report.parked.clone().expect("a parked pass reports its park");
+        assert!(parked.reason.contains("without recording any progress"));
+        assert_eq!(parked.progress, 3);
+        assert_eq!(parked.stall_threshold_seconds, 600);
+        assert_eq!(parked.progress_age_seconds, Some(1_050));
+        assert_eq!(parked.deferred_seconds, Some(1_050));
+        assert!(
+            report
+                .degraded_reasons()
+                .iter()
+                .any(|reason| reason.contains("parked by the background-work supervisor")),
+            "a parked loop reported no degraded reason: {:?}",
+            report.degraded_reasons()
+        );
+
+        // It serializes, because every surface that carries it is JSON, and it
+        // stays absent on a healthy loop rather than serializing an empty park.
+        let encoded = serde_json::to_value(&report).unwrap();
+        assert_eq!(encoded["parked"]["progress"], 3);
+        assert_eq!(encoded["parked"]["stall_threshold_seconds"], 600);
+        assert!(encoded["parked"]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("was stopped"));
+        let decoded: kin_cli::commands::resources::ReconcileHealth =
+            serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.parked, report.parked);
+
+        let healthy = crate::background_work::BackgroundWorkSupervisor::new(
+            Duration::from_secs(600),
+        );
+        healthy.pass(crate::background_work::PASS_RECONCILE);
+        let healthy_report = healthy.reconcile_report(start);
+        assert!(healthy_report.parked.is_none());
+        assert!(serde_json::to_value(&healthy_report).unwrap()["parked"].is_null());
     }
 
     /// A rule wide enough to empty the repository is refused, not obeyed.

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -4633,11 +4633,19 @@ mod tests {
         )
         .unwrap();
 
+        // The pass completing at all is what proves nothing was deferred: a
+        // deferral is only reachable from the failure arm this admission used
+        // to take, where the loop defers every path in the batch and admits
+        // none of them.
         sync_filesystem_with_graph(&state).await.unwrap();
 
         assert!(
             tree_entry(&state, "src/lib.rs").is_some(),
             "an excluded subtree left an ordinary file unadmitted"
+        );
+        assert!(
+            !entity_ids_for(&state, "src/lib.rs").is_empty(),
+            "the pass admitted a tree it derived no semantics from, which is no progress"
         );
         assert!(
             tree_entry(&state, "keep.rs").is_some(),
@@ -4724,9 +4732,8 @@ mod tests {
     /// leave the pass running.
     #[test]
     fn excluded_churn_beside_real_progress_never_parks_the_pass() {
-        let supervisor = crate::background_work::BackgroundWorkSupervisor::new(
-            Duration::from_secs(600),
-        );
+        let supervisor =
+            crate::background_work::BackgroundWorkSupervisor::new(Duration::from_secs(600));
         let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
         let start = Instant::now();
 
@@ -4749,9 +4756,8 @@ mod tests {
         // The other side: with the same clock and no progress, the sweep does
         // stop it. Without this the assertions above would hold for a
         // supervisor that never parks anything.
-        let starved = crate::background_work::BackgroundWorkSupervisor::new(
-            Duration::from_secs(600),
-        );
+        let starved =
+            crate::background_work::BackgroundWorkSupervisor::new(Duration::from_secs(600));
         let starved_pass = starved.pass(crate::background_work::PASS_RECONCILE);
         starved_pass.working(start);
         assert!(starved.sweep(start + Duration::from_secs(1_200)).len() == 1);
@@ -4765,9 +4771,8 @@ mod tests {
     /// supervisor already held the reason and the readings behind it.
     #[test]
     fn a_parked_reconcile_pass_publishes_its_reason_and_its_counts() {
-        let supervisor = crate::background_work::BackgroundWorkSupervisor::new(
-            Duration::from_secs(600),
-        );
+        let supervisor =
+            crate::background_work::BackgroundWorkSupervisor::new(Duration::from_secs(600));
         let pass = supervisor.pass(crate::background_work::PASS_RECONCILE);
         let start = Instant::now();
         pass.working(start);
@@ -4777,7 +4782,10 @@ mod tests {
         assert_eq!(stopped.len(), 1);
 
         let report = supervisor.reconcile_report(start + Duration::from_secs(1_050));
-        let parked = report.parked.clone().expect("a parked pass reports its park");
+        let parked = report
+            .parked
+            .clone()
+            .expect("a parked pass reports its park");
         assert!(parked.reason.contains("without recording any progress"));
         assert_eq!(parked.progress, 3);
         assert_eq!(parked.stall_threshold_seconds, 600);
@@ -4805,9 +4813,8 @@ mod tests {
             serde_json::from_value(encoded).unwrap();
         assert_eq!(decoded.parked, report.parked);
 
-        let healthy = crate::background_work::BackgroundWorkSupervisor::new(
-            Duration::from_secs(600),
-        );
+        let healthy =
+            crate::background_work::BackgroundWorkSupervisor::new(Duration::from_secs(600));
         healthy.pass(crate::background_work::PASS_RECONCILE);
         let healthy_report = healthy.reconcile_report(start);
         assert!(healthy_report.parked.is_none());

--- a/crates/kin-daemon/src/repository_admit.rs
+++ b/crates/kin-daemon/src/repository_admit.rs
@@ -232,7 +232,11 @@ async fn run_pass(state: &DaemonState) -> Result<AdmitResponse> {
         entities_after: after.entities,
         embeddings_indexed: embeddings.indexed,
         embeddings_total: embeddings.total,
-        reconcile: probes.report(now),
+        // Read through the supervisor rather than off the probes, so an
+        // explicit admission run against a store whose ambient loop is parked
+        // says so. The probes alone report a quiet loop and a parked one
+        // identically.
+        reconcile: state.background_work.reconcile_report(now),
         admitted: failure.is_none(),
         failure,
     };

--- a/crates/kin-daemon/src/repository_purge.rs
+++ b/crates/kin-daemon/src/repository_purge.rs
@@ -99,14 +99,17 @@ pub(crate) fn execute(
         });
     }
 
-    let expected_roots = crate::loop_runner::current_authority_roots(state)?;
+    let (expected_roots, policy) = crate::loop_runner::current_authority_admission(state)?;
     let retained_tracked = tracked
         .iter()
         .filter(|path| !purge_set.contains(*path))
         .collect::<Vec<&RepoPath>>();
+    // A purge publishes the tree its own walk observed, so it is judged by the
+    // same admission policy and must not propose what that policy excludes.
     let scan = kin_index::scan_repository_preserving_graph_only(
         working_dir,
         &ignore,
+        policy.as_ref(),
         retained_tracked.into_iter(),
         graph_only.iter(),
     )

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -46,6 +46,8 @@ use kin_model::RepoPath;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+use crate::admission::ResolvedAdmissionMatcher;
+
 /// Exact materialization kind observed at a host filesystem boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScannedEntryKind {
@@ -81,6 +83,15 @@ pub struct RepositoryScanDiagnostics {
     /// Imported graph-only members preserved without inferring identity from
     /// their host materialization.
     pub graph_only_entries_preserved: usize,
+    /// Untracked entries the graph-owned admission policy excludes.
+    ///
+    /// Counted apart from `ignored_untracked_entries` because the two rule sets
+    /// are different objects: that one is this repository's `.kinignore` and the
+    /// built-in defaults, and this one is the durable policy compiled from every
+    /// `.gitignore`/`.kinignore` blob in the tree plus the frozen local overlay.
+    /// A path only the second excludes used to be proposed by the walk and
+    /// refused at the authority boundary, which failed the whole admission.
+    pub policy_excluded_untracked_entries: usize,
     pub content_bytes_read: u64,
 }
 
@@ -128,6 +139,7 @@ pub struct CompleteRepositoryScan {
     entries: BTreeMap<RepoPath, ScannedRepositoryEntry>,
     graph_only_paths: BTreeSet<RepoPath>,
     unverified_ignored_paths: BTreeSet<RepoPath>,
+    policy_excluded_sample: Vec<RepoPath>,
     diagnostics: RepositoryScanDiagnostics,
     completion: CompleteScanToken,
 }
@@ -161,6 +173,17 @@ impl CompleteRepositoryScan {
 
     pub const fn completion(&self) -> CompleteScanToken {
         self.completion
+    }
+
+    /// A bounded sample of the untracked paths the graph-owned admission
+    /// policy excluded from this walk.
+    ///
+    /// Bounded because an excluded directory is skipped whole and its leaves
+    /// are never counted individually, but a policy that names many separate
+    /// files still could. The count in the diagnostics is complete; this names
+    /// enough of it for an operator to recognize which rule is at work.
+    pub fn policy_excluded_paths_sample(&self) -> &[RepoPath] {
+        &self.policy_excluded_sample
     }
 
     /// Tracked paths the effective ignore rules excluded from observation.
@@ -693,6 +716,7 @@ pub fn scan_repository<'a>(
     scan_repository_preserving_graph_only(
         root,
         ignore,
+        None,
         tracked_paths,
         std::iter::empty::<&'a RepoPath>(),
     )
@@ -703,9 +727,28 @@ pub fn scan_repository<'a>(
 /// `graph_only_paths` currently carries imported Gitlinks. Their identity is
 /// owned by graph/import truth; a host directory is neither evidence for a
 /// Gitlink nor permission to expand its checkout into sibling Kin artifacts.
+///
+/// `policy` is the repository's compiled graph-owned admission policy, and a
+/// caller that is about to publish what this walk proposes must pass it. The
+/// two rule sets are genuinely different: `ignore` is this repository's
+/// `.kinignore` plus the built-in defaults, read from the working copy with
+/// literal component matching, while the policy is compiled at the durable
+/// authority boundary from every `.gitignore` and `.kinignore` blob in the
+/// tree plus the frozen local overlay, with gitwildmatch semantics. Proposing
+/// an untracked path the policy excludes is not a survivable disagreement:
+/// authority refuses that one artifact and the refusal fails the entire
+/// exact-tree admission, so the walk that proposed it admits nothing at all
+/// (FIR-2346). Passing `None` keeps the legacy behavior for callers that do not
+/// publish, such as coverage reports and purge previews.
+///
+/// Only untracked paths are judged against it, which is exactly the boundary
+/// authority itself applies: an artifact the repository already tracks is
+/// admitted regardless of what the policy says today, and retracting it is a
+/// separate, announced decision made against graph truth rather than here.
 pub fn scan_repository_preserving_graph_only<'a>(
     root: &Path,
     ignore: &RepositoryIgnore,
+    policy: Option<&ResolvedAdmissionMatcher>,
     tracked_paths: impl IntoIterator<Item = &'a RepoPath>,
     graph_only_paths: impl IntoIterator<Item = &'a RepoPath>,
 ) -> Result<CompleteRepositoryScan, IncompleteRepositoryScan> {
@@ -734,9 +777,11 @@ pub fn scan_repository_preserving_graph_only<'a>(
     let mut scanner = Scanner {
         root,
         ignore,
+        policy,
         tracked_paths,
         graph_only_paths,
         unverified_ignored_paths,
+        policy_excluded_sample: Vec::new(),
         entries: BTreeMap::new(),
         diagnostics: RepositoryScanDiagnostics::default(),
     };
@@ -748,17 +793,24 @@ pub fn scan_repository_preserving_graph_only<'a>(
         entries: scanner.entries,
         graph_only_paths: scanner.graph_only_paths,
         unverified_ignored_paths: scanner.unverified_ignored_paths,
+        policy_excluded_sample: scanner.policy_excluded_sample,
         diagnostics: scanner.diagnostics,
         completion: CompleteScanToken { _private: () },
     })
 }
 
+/// How many policy-excluded paths one walk names outright. See
+/// [`CompleteRepositoryScan::policy_excluded_paths_sample`].
+const POLICY_EXCLUDED_SAMPLE_LIMIT: usize = 8;
+
 struct Scanner<'a> {
     root: &'a Path,
     ignore: &'a RepositoryIgnore,
+    policy: Option<&'a ResolvedAdmissionMatcher>,
     tracked_paths: BTreeSet<RepoPath>,
     graph_only_paths: BTreeSet<RepoPath>,
     unverified_ignored_paths: BTreeSet<RepoPath>,
+    policy_excluded_sample: Vec<RepoPath>,
     entries: BTreeMap<RepoPath, ScannedRepositoryEntry>,
     diagnostics: RepositoryScanDiagnostics,
 }
@@ -780,6 +832,26 @@ impl Scanner<'_> {
     /// paying a full pass over that set for every entry it inspected. Repository
     /// paths order by their bytes, so every descendant of `path` sorts after it
     /// and before the first path that does not begin with those bytes.
+    /// Whether the graph-owned admission policy excludes an untracked `path`.
+    ///
+    /// Records a bounded sample as it goes, so the pass that skipped a path can
+    /// name it once rather than leaving an operator to guess which rule fired.
+    /// `true` is only ever returned for a path this walk is about to skip, so
+    /// the sample and the count describe the same set.
+    fn policy_excludes_untracked(&mut self, path: &RepoPath, is_dir: bool) -> bool {
+        let Some(policy) = self.policy else {
+            return false;
+        };
+        if !policy.decide(path, is_dir, false).is_ignored() {
+            return false;
+        }
+        self.diagnostics.policy_excluded_untracked_entries += 1;
+        if self.policy_excluded_sample.len() < POLICY_EXCLUDED_SAMPLE_LIMIT {
+            self.policy_excluded_sample.push(path.clone());
+        }
+        true
+    }
+
     fn is_tracked_or_contains_tracked(&self, path: &RepoPath) -> bool {
         let prefix = path.as_bytes();
         self.tracked_paths
@@ -827,6 +899,19 @@ impl Scanner<'_> {
                     self.diagnostics.ignored_untracked_entries += 1;
                     continue;
                 }
+                // A directory the durable policy excludes is skipped whole, and
+                // gitwildmatch semantics are why that is exact rather than
+                // merely convenient: a rule beneath an excluded ancestor cannot
+                // re-admit anything under it, so nothing down there could ever
+                // be admitted and descending would only cost the reads. Graph
+                // truth still outranks the rules, so a directory holding a
+                // tracked path is walked and only its untracked leaves are
+                // skipped below.
+                if !self.is_tracked_or_contains_tracked(&repo_path)
+                    && self.policy_excludes_untracked(&repo_path, true)
+                {
+                    continue;
+                }
                 self.walk(&host_path)?;
                 continue;
             }
@@ -840,6 +925,16 @@ impl Scanner<'_> {
                 if !self.unverified_ignored_paths.contains(&repo_path) {
                     self.diagnostics.ignored_untracked_entries += 1;
                 }
+                continue;
+            }
+
+            // An untracked leaf the durable policy excludes. Nothing opens it,
+            // for the same reason nothing opens an ignored one: proposing it
+            // would be refused at the authority boundary, and that refusal is
+            // not survivable, it fails the whole tree admission.
+            if !self.tracked_paths.contains(&repo_path)
+                && self.policy_excludes_untracked(&repo_path, false)
+            {
                 continue;
             }
 
@@ -1657,9 +1752,11 @@ mod tests {
         let scanner = Scanner {
             root,
             ignore: &ignore,
+            policy: None,
             tracked_paths: BTreeSet::new(),
             graph_only_paths: BTreeSet::new(),
             unverified_ignored_paths: BTreeSet::new(),
+            policy_excluded_sample: Vec::new(),
             entries: BTreeMap::new(),
             diagnostics: RepositoryScanDiagnostics::default(),
         };
@@ -1691,6 +1788,7 @@ mod tests {
         let scan = scan_repository_preserving_graph_only(
             root,
             &RepositoryIgnore::default(),
+            None,
             [&gitlink],
             [&gitlink],
         )
@@ -1705,6 +1803,7 @@ mod tests {
         let deinitialized = scan_repository_preserving_graph_only(
             root,
             &RepositoryIgnore::default(),
+            None,
             [&gitlink],
             [&gitlink],
         )
@@ -1842,9 +1941,11 @@ mod tests {
         let scanner = Scanner {
             root,
             ignore: &ignore,
+            policy: None,
             tracked_paths: BTreeSet::new(),
             graph_only_paths: BTreeSet::new(),
             unverified_ignored_paths: BTreeSet::new(),
+            policy_excluded_sample: Vec::new(),
             entries: BTreeMap::new(),
             diagnostics: RepositoryScanDiagnostics::default(),
         };

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -1218,6 +1218,132 @@ mod tests {
         scan_repository(root, &ignore, std::iter::empty()).unwrap()
     }
 
+    /// Compile one graph-owned policy from rule bytes, as the durable authority
+    /// boundary compiles the repository's own.
+    fn graph_owned_policy(rules: &str) -> ResolvedAdmissionMatcher {
+        ResolvedAdmissionMatcher::compile(
+            crate::admission::AdmissionCase::Sensitive,
+            vec![crate::admission::ResolvedAdmissionRuleSet::from_bytes(
+                crate::admission::AdmissionRuleSource::Shared {
+                    source_path: path(".gitignore"),
+                },
+                0,
+                None,
+                rules.as_bytes().to_vec(),
+            )],
+        )
+        .unwrap()
+    }
+
+    /// The walk skips what the graph-owned policy excludes, and does not read
+    /// it on the way.
+    ///
+    /// Proposing one of these paths is refused at the authority boundary, and
+    /// the refusal fails the whole exact-tree admission rather than that one
+    /// artifact (FIR-2346). Skipping it is therefore not an optimization. The
+    /// byte counter is asserted because an excluded subtree that is walked and
+    /// hashed anyway still costs the machine everything the skip exists to
+    /// save, which is what a churning agent worktree under an excluded
+    /// directory does on every pass.
+    #[test]
+    fn the_graph_owned_policy_prunes_untracked_paths_before_they_are_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join(".claude/worktrees/lane-a/src")).unwrap();
+        fs::write(root.join(".claude/scheduled_tasks.lock"), b"held").unwrap();
+        fs::write(
+            root.join(".claude/worktrees/lane-a/src/dirty.rs"),
+            vec![b'x'; 4096],
+        )
+        .unwrap();
+        fs::write(root.join("keep.rs"), b"fn keep() {}").unwrap();
+        let ignore = RepositoryIgnore::default();
+        let policy = graph_owned_policy(".claude/\n");
+
+        let scan = scan_repository_preserving_graph_only(
+            root,
+            &ignore,
+            Some(&policy),
+            std::iter::empty(),
+            std::iter::empty(),
+        )
+        .unwrap();
+
+        assert!(scan.entry(&path("keep.rs")).is_some());
+        assert!(scan.entry(&path(".claude/scheduled_tasks.lock")).is_none());
+        assert!(scan
+            .entry(&path(".claude/worktrees/lane-a/src/dirty.rs"))
+            .is_none());
+        assert_eq!(scan.diagnostics().policy_excluded_untracked_entries, 1);
+        assert_eq!(
+            scan.policy_excluded_paths_sample(),
+            [path(".claude")],
+            "the excluded directory is named once rather than every leaf beneath it"
+        );
+        assert!(
+            scan.diagnostics().content_bytes_read < 4096,
+            "the excluded subtree was read: {} bytes",
+            scan.diagnostics().content_bytes_read
+        );
+
+        // Two-sided. Without the policy the same walk really does reach and
+        // read all of it, so the assertions above describe the policy rather
+        // than a fixture that was never walkable.
+        let everything = scan_repository_preserving_graph_only(
+            root,
+            &ignore,
+            None,
+            std::iter::empty(),
+            std::iter::empty(),
+        )
+        .unwrap();
+        assert!(everything
+            .entry(&path(".claude/worktrees/lane-a/src/dirty.rs"))
+            .is_some());
+        assert_eq!(
+            everything.diagnostics().policy_excluded_untracked_entries,
+            0
+        );
+        assert!(everything.diagnostics().content_bytes_read > 4096);
+    }
+
+    /// Graph truth outranks the policy for a path the repository already
+    /// tracks, exactly as the authority boundary ranks them.
+    ///
+    /// Authority admits a tracked artifact whatever the rules say today, so a
+    /// walk that dropped it would report it absent and infer a removal from
+    /// that. Untracking such a path is a separate announced decision.
+    #[test]
+    fn a_tracked_path_survives_a_policy_that_would_exclude_it_today() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("vendor/lib")).unwrap();
+        fs::write(root.join("vendor/lib/tracked.rs"), b"fn tracked() {}").unwrap();
+        fs::write(root.join("vendor/lib/fresh.rs"), b"fn fresh() {}").unwrap();
+        let tracked = path("vendor/lib/tracked.rs");
+        let ignore = RepositoryIgnore::default();
+        let policy = graph_owned_policy("vendor/\n");
+
+        let scan = scan_repository_preserving_graph_only(
+            root,
+            &ignore,
+            Some(&policy),
+            [&tracked],
+            std::iter::empty(),
+        )
+        .unwrap();
+
+        assert!(
+            scan.entry(&tracked).is_some(),
+            "a tracked artifact was dropped by a rule that only governs admission"
+        );
+        assert!(scan.missing_tracked_paths([&tracked]).is_empty());
+        assert!(
+            scan.entry(&path("vendor/lib/fresh.rs")).is_none(),
+            "an untracked path under the excluded directory was admitted"
+        );
+    }
+
     /// Membership stays independent of parser support, hidden names, and
     /// vendoring. Only control metadata and derived output are excluded, and
     /// `build`/`out`/`vendor` stay admitted because those names are ambiguous.


### PR DESCRIPTION
Two rule sets decided whether a host path could become repository truth, and they
were never introduced to each other. The exact-tree walk read the repository's root
`.kinignore` plus a built-in default list, matched literally by path component. Repository
authority judged what that walk proposed against the graph-owned admission policy kin-db
compiles from every `.gitignore` and `.kinignore` blob in the tree plus the frozen local
overlay, with gitwildmatch semantics.

A path the second one excluded and the first one admitted was therefore proposed and then
refused, and the refusal is not scoped to that artifact: it fails the whole transaction.
The reconcile loop deferred every path in the batch to the retry lane and admitted none of
them, the pass recorded zero progress however much work it did, and after the stall
threshold the background-work supervisor parked it. One churning agent lock file under an
excluded directory was enough to leave a whole working copy unadmitted and a store
answering from nothing.

The walk now takes the same compiled policy and skips untracked paths it excludes, pruning
an excluded directory whole rather than descending into it and hashing what it holds. Only
untracked paths are judged, which is exactly the boundary authority applies, so nothing is
retracted here; retraction remains a separate announced decision made against graph truth.
Roots and policy come from one authority open, so a tree can never be planned against one
generation and filtered by another. A purge publishes its own walk and takes the same
filter.

Host events for excluded paths no longer schedule work either. Each one bought a complete
working-copy admission that could only conclude there was nothing to admit, and a working
stretch that records no progress is what the supervisor parks a pass for. The matcher used
is the one the last pass resolved, so the filter costs no authority load of its own.

Fail-loud is intact. A proposal the policy admits that then fails verification still fails
the pass exactly as before; only a proposal the policy excludes is skipped, announced once
per pass at debug with the count and a bounded sample rather than once per file.

The park now names its own cause. `reconciliation_status` read `parked-by-supervisor` and
said nothing else, so the only account of why lived in a log line from whenever it
happened. The reconcile disclosure gains an optional `parked` object carrying the reason,
the progress the verdict was reached on, the working and deferred stretches, and the stall
threshold, filled by the supervisor because it is the only thing that knows both the probes
and the passes. It reaches `/health`, `/commands/resources`, `kin graph status` detail, and
the `kin admit` report, and a parked loop is a degraded reason rather than a quiet one. The
count of host paths the policy excluded is disclosed beside the ignored count.

Zero File-Search Authority is untouched: this is ingestion-boundary IO, and the change
makes the walk read strictly less of the host, never more.

Tests: a fixture repository whose policy excludes `.claude/` admits every other file while
a dirty nested git worktree churns beneath it, and fails on `main` with the exact
`InvalidOperation` this fixes; continuous excluded churn never reaches the admission path,
two-sided against ordinary and tracked paths; a pass making real progress beside that churn
survives twenty minutes of supervisor sweeps while a starved pass on the same clock is
still parked; the park round-trips through JSON and stays absent on a healthy loop; and at
the scanner level the excluded subtree is proven unread by its byte counter, while a tracked
path under the same rule still scans.

Known residual, verified rather than assumed: kin-db derives the successor policy from the
desired tree and verifies that same transaction against it, so a pass that admits a new or
changed rule file in the same tick as untracked content that rule newly excludes still fails
wholesale. The pre-scan filter cannot see it, because the policy in force does not yet
contain the rule the pass is about to publish. Every repository imported from Git with at
least one commit has its rules in force before the daemon's first pass and is covered here;
the exposed cases are an import with no base commit, a native init on a non-Git directory
carrying a `.gitignore`, and a rule file edited while the daemon was down beside matching
untracked content. Closing it belongs at the layer that holds the successor policy at
verification time.

Closes FIR-2346
