### PR TITLE
Pin kin-db 0.7.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.27"
+version = "0.7.29"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "787ad7149aa2d2c78d01bdeda128254e1f92d8ae8d96bfbcc9f4fbf89493b36f"
+checksum = "89bd923bb4da06c47e57e457e48de765d019d17ffd613ef719344d7e9519bab7"
 dependencies = [
  "bincode",
  "bstr",
@@ -6625,7 +6625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.27", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.29", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Carries the prepared workspace query-state serve (kin-db#190, FIR-2334) and the single-resolution workspace base path (kin-db#191, FIR-2347 direction 1) into the kin binary. The pin moves =0.7.27 to =0.7.29 with the registry source and checksum preserved; exactly one package moved in the lock. Both kin-db changes are additive or internal: the two new StorageBackend methods carry default bodies and kin implements the trait nowhere.