### PR TITLE
Name the wedged commit deferral on every status surface

### DIFF
--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -324,6 +324,10 @@ pub struct ReconcileHealth {
     /// whenever it happened. Absent on a loop that is running.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parked: Option<ReconcileParked>,
+    /// The derived graph is holding an exact tree repository authority never
+    /// accepted, and only a restart clears it. Absent on every other daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_tree_wedge: Option<DeferredTreeWedge>,
 }
 
 /// The background-work supervisor's account of a parked reconciliation loop.
@@ -359,6 +363,36 @@ pub struct ReconcileParked {
     pub stall_threshold_seconds: u64,
 }
 
+/// A commit deferral that could not be closed, and the publication error that
+/// left it open.
+///
+/// The commit path admits the working copy without publishing its tree, so one
+/// repository-authority successor carries both the admitted tree and the change.
+/// A commit that never reaches authority publishes that tree standalone on its
+/// way out. When that publication fails too, the derived graph is left holding a
+/// tree authority never accepted: every later admission plans out of the graph's
+/// tree and is refused against the older authority tree, and it stays that way
+/// until the daemon restarts and rebuilds the graph from authority.
+///
+/// It takes two failures where the second is an authority write that had just
+/// succeeded under the same gate, so it is rare by construction. What it was not
+/// was legible: the only account lived in one error log, while every status
+/// surface kept reporting a daemon that was merely failing its admissions.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeferredTreeWedge {
+    /// The restoring publication's error, verbatim. The one fact that separates
+    /// a wedge from the ordinary refusals that follow it.
+    pub error: String,
+    /// Seconds since the wedge was recorded. Monotonic, so a wall-clock
+    /// adjustment cannot shrink it.
+    #[serde(default)]
+    pub age_seconds: u64,
+    /// Wall-clock time the wedge was recorded, RFC 3339, for lining the state up
+    /// against the daemon log that carries the failing commit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+}
+
 impl ReconcileHealth {
     /// Every reason this reconcile state is degraded, worst first, empty when
     /// it is not.
@@ -373,7 +407,21 @@ impl ReconcileHealth {
     /// the limit or merely a number.
     pub fn degraded_reasons(&self) -> Vec<String> {
         let mut reasons = Vec::new();
-        // First, because it outranks every other reading here: a parked loop is
+        // First of all, because it outranks even a park: a parked loop resumes
+        // on the next daemon, while this one refuses every admission it is
+        // handed until an operator restarts it, and the counters below record
+        // exactly those refusals without naming what causes them.
+        if let Some(wedge) = &self.deferred_tree_wedge {
+            reasons.push(format!(
+                "restart required, commit deferral wedged: a commit failed {}s ago and the \
+                 publication restoring its deferred tree failed too, so the derived graph holds an \
+                 exact tree repository authority never accepted and every later admission is \
+                 refused against the mismatched tree until this daemon restarts; restoring \
+                 publication error: {}",
+                wedge.age_seconds, wedge.error
+            ));
+        }
+        // Next, because it outranks every other reading here: a parked loop is
         // not admitting anything at all, so whatever the counters below say
         // about the last attempt, there is no next one until the daemon
         // restarts.
@@ -1004,6 +1052,104 @@ mod tests {
         };
         assert!(stuck.degraded());
         assert!(stuck.degraded_reasons()[0].contains(&BACKLOG_STALE_SECONDS.to_string()));
+    }
+
+    /// A wedged commit deferral has to say the two things a reader acts on:
+    /// that a restart is what clears it, and what the publication actually
+    /// failed with. Without the first, an operator waits for a loop that will
+    /// never admit again; without the second, the only account of the cause is a
+    /// log line from whenever it happened.
+    #[test]
+    fn a_wedged_commit_deferral_names_the_restart_and_the_publication_error() {
+        let wedged = ReconcileHealth {
+            deferred_tree_wedge: Some(DeferredTreeWedge {
+                error: "repository authority moved after the complete workspace observation was \
+                        planned"
+                    .to_string(),
+                age_seconds: 96,
+                at: Some("2026-08-17T09:00:00+00:00".to_string()),
+            }),
+            ..Default::default()
+        };
+        let reasons = wedged.degraded_reasons();
+        assert_eq!(reasons.len(), 1, "one fault, one reason: {reasons:?}");
+        let reason = &reasons[0];
+        assert!(
+            reason.contains("restart required, commit deferral wedged"),
+            "the recovery an operator has to perform is the headline: {reason}"
+        );
+        assert!(
+            reason.contains("repository authority moved"),
+            "the daemon's own publication error, not a summary invented here: {reason}"
+        );
+        assert!(
+            reason.contains("96"),
+            "how long the daemon has been wedged is what separates it from a \
+             refusal that just happened: {reason}"
+        );
+        assert!(wedged.degraded());
+
+        // It outranks the park, because a parked loop resumes on the next daemon
+        // and this one refuses whatever it is handed until then.
+        let both = ReconcileHealth {
+            parked: Some(ReconcileParked {
+                reason: "no progress".to_string(),
+                ..Default::default()
+            }),
+            ..wedged.clone()
+        };
+        assert_eq!(both.degraded_reasons().len(), 2);
+        assert!(
+            both.degraded_reasons()[0].contains("commit deferral wedged"),
+            "{:?}",
+            both.degraded_reasons()
+        );
+
+        // The falsification: the identical daemon with nothing wedged is healthy
+        // and serializes no wedge at all, so a surface reading the field cannot
+        // mistake an additive absence for a state it failed to check.
+        let healthy = ReconcileHealth {
+            deferred_tree_wedge: None,
+            ..wedged.clone()
+        };
+        assert!(!healthy.degraded(), "{:?}", healthy.degraded_reasons());
+        assert!(serde_json::to_value(&healthy).unwrap()["deferred_tree_wedge"].is_null());
+    }
+
+    /// The wedge crosses the wire intact. Every surface but the daemon's own
+    /// reads this through JSON, so a field that degraded a daemon in process and
+    /// vanished on the way out would leave `/health`, `kin graph status`, and
+    /// `kin doctor` reporting the healthy answer they reported before.
+    #[test]
+    fn a_wedge_round_trips_through_json_and_reaches_the_rendered_lines() {
+        let wedged = ReconcileHealth {
+            deferred_tree_wedge: Some(DeferredTreeWedge {
+                error: "workspace generation exhausted".to_string(),
+                age_seconds: 12,
+                at: Some("2026-08-17T09:00:00+00:00".to_string()),
+            }),
+            ..Default::default()
+        };
+        let encoded = serde_json::to_value(&wedged).unwrap();
+        assert_eq!(
+            encoded["deferred_tree_wedge"]["error"],
+            "workspace generation exhausted"
+        );
+        assert_eq!(encoded["deferred_tree_wedge"]["age_seconds"], 12);
+        let decoded: ReconcileHealth = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded, wedged);
+
+        let lines = render_reconcile_lines(&wedged);
+        assert!(
+            lines.iter().any(|line| line.contains("Reconcile degraded")
+                && line.contains("restart required, commit deferral wedged")),
+            "the wedge has to reach the text surface: {lines:?}"
+        );
+        assert_eq!(
+            render_reconcile_lines(&ReconcileHealth::default()).len(),
+            1,
+            "a daemon with nothing wedged prints no extra line"
+        );
     }
 
     /// The reconcile line is rendered whether or not anything is wrong. A

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4650,7 +4650,17 @@ async fn command_commit(
     .map_err(internal_error)?;
 
     match command_commit_after_admission(&state, request, deferred_tree.as_ref()) {
-        Ok(response) => Ok(response),
+        Ok(response) => {
+            // A transaction that reached authority carried the tree the graph
+            // holds with it, which is the divergence an earlier unclosed
+            // deferral left behind. The admission above plans out of the graph's
+            // tree, so a still-wedged daemon could not have got this far.
+            state
+                .background_work
+                .reconcile()
+                .clear_deferred_tree_wedge();
+            Ok(response)
+        }
         Err(error) => {
             if let Some(admitted) = deferred_tree {
                 crate::loop_runner::publish_deferred_tree_after_failure(&state, &admitted);
@@ -19177,6 +19187,64 @@ mod tests {
         );
     }
 
+    /// A commit that reaches authority clears a wedge, because its transaction
+    /// carried the graph's tree across.
+    ///
+    /// The other half of the deferral's own contract. A commit that fails
+    /// publishes its deferred tree standalone, and a failure there wedges the
+    /// daemon; a commit that succeeds is the same transition arriving by the
+    /// intended door, so the divergence a wedge names cannot survive it. Without
+    /// this the flag would be a one-way latch that a daemon carried until
+    /// restart even after the state had resolved.
+    #[cfg(unix)]
+    #[tokio::test]
+    // Commit phases are emitted at debug level when they are fast, and the
+    // level a `tracing` event is filtered by is a process-global hint. A test
+    // that captures those events therefore cannot run beside one that emits
+    // them, so every test on either side of that shares this group.
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_commit_that_reaches_authority_clears_a_recorded_wedge() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        std::fs::write(
+            repo.path().join("recovered.rs"),
+            b"pub fn recovered() -> u32 { 1 }\n",
+        )
+        .unwrap();
+        state
+            .background_work
+            .reconcile()
+            .record_deferred_tree_wedge(
+                "an earlier restoring publication failed",
+                std::time::Instant::now(),
+            );
+        assert!(
+            state
+                .background_work
+                .reconcile_report(std::time::Instant::now())
+                .degraded(),
+            "the fixture must start wedged, or the assertion below proves nothing"
+        );
+
+        let app = router(Arc::clone(&state));
+        commit_through_api(
+            &app,
+            kin_model::OperationId::new(),
+            "publish through the deferral's own transaction",
+        )
+        .await;
+
+        let report = state
+            .background_work
+            .reconcile_report(std::time::Instant::now());
+        assert!(
+            report.deferred_tree_wedge.is_none(),
+            "a commit that published cannot leave the graph ahead of authority"
+        );
+        assert!(!report.degraded(), "{:?}", report.degraded_reasons());
+    }
+
     #[tokio::test]
     async fn graph_only_command_commit_fails_before_filesystem_delta_computation() {
         let state = test_state();
@@ -24420,6 +24488,72 @@ mod tests {
             Some("src/lib.rs: parser rejected the transaction")
         );
         assert!(json.reconcile.last_error_at.is_some());
+    }
+
+    /// A wedged commit deferral end to end on `/health`, and the recovery that
+    /// clears it.
+    ///
+    /// The daemon is not merely failing admissions here: the derived graph holds
+    /// a tree repository authority never accepted, so every admission is refused
+    /// against the mismatched tree until this process restarts. `/health`,
+    /// `kin graph status`, `kin admit`, and `kin doctor` all answer from this
+    /// one payload, so a wedged daemon that answered `ok` here would read as
+    /// healthy on every surface a reader has.
+    ///
+    /// The wedge is recorded on the probes rather than driven through a failing
+    /// commit, the same way the failing-admission tests above plant a streak.
+    /// The double failure itself is driven at the seam that produces it, in
+    /// `loop_runner`.
+    #[tokio::test]
+    async fn health_names_a_wedged_commit_deferral_and_an_admission_clears_it() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        install_working_copy_file(&state, "docs/notes.md", b"notes\n", false);
+        state
+            .background_work
+            .reconcile()
+            .record_deferred_tree_wedge(
+                "repository authority moved after the complete workspace observation was planned",
+                std::time::Instant::now(),
+            );
+
+        let json = health_json(Arc::clone(&state)).await;
+        assert_eq!(
+            json.status, "attention",
+            "a daemon that cannot admit again until it restarts must not answer ok"
+        );
+        let wedge = json
+            .reconcile
+            .deferred_tree_wedge
+            .as_ref()
+            .expect("the wedge must cross the wire, not merely exist in the daemon");
+        assert!(wedge.error.contains("repository authority moved"));
+        assert!(wedge.at.is_some());
+        assert!(
+            json.reconcile.degraded_reasons().iter().any(|reason| {
+                reason.contains("restart required, commit deferral wedged")
+                    && reason.contains("repository authority moved")
+            }),
+            "the reason must name the recovery and carry the error: {:?}",
+            json.reconcile.degraded_reasons()
+        );
+
+        // The operator's recovery is a complete admission, and `kin admit` is
+        // the surface they run it from, so its own report is where they check
+        // whether it worked.
+        let app = router(Arc::clone(&state));
+        let (_, response) = admit_through_api(&app).await;
+        assert_eq!(response["report"]["admitted"], json!(true));
+        assert!(
+            response["report"]["reconcile"]["deferred_tree_wedge"].is_null(),
+            "the admission that cleared the wedge still reported one: {response}"
+        );
+
+        let json = health_json(state).await;
+        assert_eq!(json.status, "ok");
+        assert!(json.reconcile.deferred_tree_wedge.is_none());
     }
 
     /// The two-sided floor. A daemon that has reconciled nothing at all is the

--- a/crates/kin-daemon/src/background_work.rs
+++ b/crates/kin-daemon/src/background_work.rs
@@ -710,6 +710,12 @@ struct ReconcileProbesInner {
     untracked_paths_sample: Vec<String>,
     /// What the most recent complete walk deliberately did not observe.
     excluded: ExcludedHostContent,
+    /// The publication error that left a commit's deferred tree unpublished.
+    ///
+    /// Held beside the admission counters because it is what explains them: once
+    /// it is set, every admission failure recorded below is a refusal against
+    /// the mismatched tree rather than an independent fault.
+    deferred_tree_wedge: Option<RecordedFault>,
 }
 
 /// Host content one complete walk declined to observe at all.
@@ -776,6 +782,34 @@ impl ReconcileProbes {
         let mut inner = self.lock();
         inner.admission_failure_streak = 0;
         inner.last_admission_success = Some(RecordedFault::new(String::new(), now));
+        // A complete admission that succeeded is proof the graph's tree reached
+        // repository authority, which is exactly the divergence a wedge names.
+        // Clearing it here rather than on a timer means the state can only leave
+        // the surfaces by being resolved.
+        inner.deferred_tree_wedge = None;
+    }
+
+    /// A commit's deferred tree was left unpublished because the publication
+    /// restoring it failed as well.
+    ///
+    /// The daemon is not merely failing admissions at this point: the derived
+    /// graph holds a tree repository authority never accepted, so every later
+    /// admission is refused against the mismatched tree until this process
+    /// restarts. Recorded rather than logged alone, because the log line is
+    /// gone by the time anyone reads a status surface.
+    pub fn record_deferred_tree_wedge(&self, error: impl std::fmt::Display, now: Instant) {
+        let mut inner = self.lock();
+        inner.deferred_tree_wedge = Some(RecordedFault::new(error.to_string(), now));
+    }
+
+    /// Repository authority accepted the tree the graph holds again.
+    ///
+    /// The counterpart to [`Self::record_deferred_tree_wedge`], for the paths
+    /// that resolve the divergence without going through a complete admission:
+    /// a later deferral whose restoring publication succeeds, and a commit whose
+    /// own transaction carries the tree across.
+    pub fn clear_deferred_tree_wedge(&self) {
+        self.lock().deferred_tree_wedge = None;
     }
 
     /// Whether the loop finished a tick still holding work.
@@ -855,6 +889,13 @@ impl ReconcileProbes {
             unsupported_path_count: inner.excluded.unsupported,
             policy_excluded_path_count: inner.excluded.policy_excluded,
             parked: None,
+            deferred_tree_wedge: inner.deferred_tree_wedge.as_ref().map(|fault| {
+                kin_cli::commands::resources::DeferredTreeWedge {
+                    error: fault.message.clone(),
+                    age_seconds: age(fault),
+                    at: Some(fault.wall_clock.to_rfc3339()),
+                }
+            }),
         }
     }
 }
@@ -1371,6 +1412,60 @@ mod tests {
             !report.degraded(),
             "a loop that is admitting again is not degraded"
         );
+    }
+
+    /// A wedged commit deferral survives every later failure and clears on the
+    /// one event that resolves it.
+    ///
+    /// Both halves are load-bearing. A wedged daemon goes on failing admissions
+    /// forever, and each of those failures is a consequence of the wedge rather
+    /// than a fresh cause, so a record that any later fault overwrote would
+    /// erase the one line naming the restart. A record nothing could clear would
+    /// be worse: the state does end, on a complete admission that succeeds, and
+    /// a surface that kept reporting it would teach a reader to ignore it.
+    #[test]
+    fn a_wedged_deferral_outlives_later_failures_and_clears_on_a_successful_admission() {
+        let probes = ReconcileProbes::default();
+        let base = Instant::now();
+        probes.record_deferred_tree_wedge(
+            "repository authority moved after the complete workspace observation was planned",
+            at(base, 10),
+        );
+
+        let report = probes.report(at(base, 70));
+        let wedge = report
+            .deferred_tree_wedge
+            .as_ref()
+            .expect("a wedged daemon reports its wedge");
+        assert!(
+            wedge.error.contains("repository authority moved"),
+            "the publication's own error is what a reader acts on: {wedge:?}"
+        );
+        assert_eq!(wedge.age_seconds, 60);
+        assert!(
+            wedge.at.is_some(),
+            "a wall-clock stamp is what lines this up against the daemon log"
+        );
+        assert!(report.degraded());
+
+        // The refusals that follow are the wedge, not new information, and they
+        // must not displace it.
+        for step in 1..=4 {
+            probes.record_admission_failure(
+                "the complete workspace observation was planned against a tree that is not this \
+                 workspace's authority tree",
+                at(base, 100 + step * 10),
+            );
+        }
+        assert!(probes.report(at(base, 200)).deferred_tree_wedge.is_some());
+
+        probes.record_admission_success(at(base, 300));
+        let recovered = probes.report(at(base, 300));
+        assert!(
+            recovered.deferred_tree_wedge.is_none(),
+            "an admission that succeeded is proof the graph's tree reached authority"
+        );
+        assert!(!recovered.degraded(), "{:?}", recovered.degraded_reasons());
     }
 
     /// A dropped reconcile event leaves one path's enrichment stale until that

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -3126,6 +3126,209 @@ mod tests {
         );
     }
 
+    /// Move repository authority while a caller is holding an open deferral.
+    ///
+    /// Publishes `desired` as this workspace's tree through the same seam every
+    /// admission publishes through, which advances the authority roots the
+    /// deferral was planned against. Nothing else has to cooperate to produce
+    /// the double failure: the deferral's own publication compare-and-swaps on
+    /// those roots and refuses rather than replanning a stale desired tree onto
+    /// newer authority, which is exactly what a concurrent authority write does
+    /// to it in production.
+    fn publish_authority_tree_out_of_band(state: &DaemonState, desired: kin_model::ResolvedTree) {
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+                .unwrap();
+        let (expected_roots, previous_tree) = {
+            let authority = context.open().unwrap();
+            let lease = authority.read_authority();
+            let previous = lease
+                .metadata()
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == context.workspace_id())
+                .map(|workspace| workspace.tree.clone())
+                .unwrap_or_default();
+            (lease.roots().clone(), previous)
+        };
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            state.layout.working_dir(),
+            expected_roots,
+            previous_tree,
+            desired,
+        );
+        crate::repository_commit::publish_workspace_tree(
+            state.blobs.as_ref(),
+            &context,
+            &admitted,
+            kin_model::OperationId::new(),
+            kin_model::AuthorId::new("out-of-band-authority-writer"),
+        )
+        .expect("the fixture's own authority write must succeed")
+        .expect("it has to move authority, or the deferral below would still publish cleanly");
+    }
+
+    /// The double failure, and the record that is the only account a status
+    /// surface gets of it.
+    ///
+    /// A commit that fails publishes its deferred tree standalone on the way
+    /// out. When that publication fails too, the derived graph is left holding a
+    /// tree repository authority never accepted, every later admission is
+    /// refused against the mismatched tree, and only a restart clears it. It was
+    /// logged once at error level and named on no surface at all, so an operator
+    /// watching admissions refuse had nothing telling them the daemon itself was
+    /// what needed restarting.
+    #[test]
+    // Commit phases are emitted at debug level when they are fast, and the
+    // level a `tracing` event is filtered by is a process-global hint. A test
+    // that captures those events therefore cannot run beside one that emits
+    // them, so every test on either side of that shares this group.
+    #[serial_test::serial(commit_phase_capture)]
+    fn a_failed_restoring_publication_wedges_the_daemon_and_says_so() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(repo.path().join("base.rs"), b"pub fn base() -> u32 { 1 }\n").unwrap();
+        exact_tree_admission(&state, None, TreePublication::Standalone).unwrap();
+        let baseline = authority_generation(&state);
+
+        std::fs::write(
+            repo.path().join("carried.rs"),
+            b"pub fn carried() -> u32 { 2 }\n",
+        )
+        .unwrap();
+        let admission =
+            exact_tree_admission(&state, None, TreePublication::DeferredToCaller).unwrap();
+        let deferred = admission
+            .deferred_tree
+            .expect("the admission defers its transition to this caller");
+        assert_eq!(
+            authority_generation(&state),
+            baseline,
+            "nothing may be published while the deferral is open"
+        );
+        assert!(
+            state
+                .background_work
+                .reconcile_report(Instant::now())
+                .deferred_tree_wedge
+                .is_none(),
+            "the fixture reported a wedge before one happened"
+        );
+
+        // The second failure. Authority moves under the open deferral, so the
+        // publication that would restore it has no valid transition left.
+        publish_authority_tree_out_of_band(&state, kin_model::ResolvedTree::default());
+        publish_deferred_tree_after_failure(&state, &deferred);
+
+        let report = state.background_work.reconcile_report(Instant::now());
+        let wedge = report
+            .deferred_tree_wedge
+            .as_ref()
+            .expect("the double failure must reach the surfaces that answer for this daemon");
+        assert!(
+            wedge.error.contains("repository authority moved"),
+            "the publication's own error is what names the cause: {wedge:?}"
+        );
+        assert!(
+            wedge.at.is_some(),
+            "a wall-clock stamp is what lines this up against the daemon log"
+        );
+        let reasons = report.degraded_reasons();
+        assert!(
+            reasons.iter().any(|reason| {
+                reason.contains("restart required, commit deferral wedged")
+                    && reason.contains(&wedge.error)
+            }),
+            "a wedged daemon must name the restart and carry the error: {reasons:?}"
+        );
+        assert!(report.degraded(), "a wedged daemon is not a healthy one");
+
+        // The state that reason describes is real rather than cosmetic. The
+        // graph holds a tree authority never accepted, so the next admission
+        // with anything to publish is refused against the mismatched tree, which
+        // is what an operator watches happen with no explanation attached.
+        std::fs::write(
+            repo.path().join("later.rs"),
+            b"pub fn later() -> u32 { 3 }\n",
+        )
+        .unwrap();
+        let refusal = exact_tree_admission(&state, None, TreePublication::Standalone)
+            .expect_err("a wedged daemon must refuse the next admission rather than publish it");
+        assert!(
+            refusal
+                .to_string()
+                .contains("not this workspace's authority tree"),
+            "the refusal must name the mismatch the wedge describes: {refusal}"
+        );
+    }
+
+    /// The falsification, and the ordinary case beside it. A commit that fails
+    /// is routine, and the publication restoring its deferred tree normally
+    /// succeeds, leaving exactly the state a standalone admission would have.
+    /// A flag that fired on the single failure would report every failed commit
+    /// as a daemon needing a restart.
+    #[test]
+    // Commit phases are emitted at debug level when they are fast, and the
+    // level a `tracing` event is filtered by is a process-global hint. A test
+    // that captures those events therefore cannot run beside one that emits
+    // them, so every test on either side of that shares this group.
+    #[serial_test::serial(commit_phase_capture)]
+    fn a_restored_deferral_leaves_nothing_wedged_and_clears_an_earlier_wedge() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            repo.path().join("restored.rs"),
+            b"pub fn restored() -> u32 { 1 }\n",
+        )
+        .unwrap();
+        let admission =
+            exact_tree_admission(&state, None, TreePublication::DeferredToCaller).unwrap();
+        let deferred = admission
+            .deferred_tree
+            .expect("the admission defers its transition to this caller");
+
+        publish_deferred_tree_after_failure(&state, &deferred);
+
+        let report = state.background_work.reconcile_report(Instant::now());
+        assert!(
+            report.deferred_tree_wedge.is_none(),
+            "a deferral that closed is not a wedge: {:?}",
+            report.deferred_tree_wedge
+        );
+        assert!(!report.degraded(), "{:?}", report.degraded_reasons());
+        assert!(
+            serde_json::to_value(&report).unwrap()["deferred_tree_wedge"].is_null(),
+            "a healthy daemon must serialize no wedge field at all"
+        );
+
+        // A daemon carrying an earlier wedge is cleared by a deferral that does
+        // close. Publishing planned against the authority tree and advanced it,
+        // which a graph running ahead of authority cannot do.
+        state
+            .background_work
+            .reconcile()
+            .record_deferred_tree_wedge("an earlier restoring publication failed", Instant::now());
+        std::fs::write(
+            repo.path().join("second.rs"),
+            b"pub fn second() -> u32 { 2 }\n",
+        )
+        .unwrap();
+        let admission =
+            exact_tree_admission(&state, None, TreePublication::DeferredToCaller).unwrap();
+        let deferred = admission
+            .deferred_tree
+            .expect("the admission defers its transition to this caller");
+        publish_deferred_tree_after_failure(&state, &deferred);
+        assert!(
+            state
+                .background_work
+                .reconcile_report(Instant::now())
+                .deferred_tree_wedge
+                .is_none(),
+            "a publication that reached authority resolves the divergence a wedge names"
+        );
+    }
+
     /// A collapsed commit publishes the tree its own walk proved, or none.
     ///
     /// The completion proof rides along as a value only a finished walk can
@@ -5314,17 +5517,40 @@ async fn sync_filesystem_with_graph_publishing(
 /// later admission raises stays loud, because a daemon whose graph outruns
 /// authority must be restarted to rebuild the graph rather than keep answering
 /// from it.
+///
+/// The error log is not the whole disclosure. It is written once, at the moment
+/// of the failure, and every status surface afterwards showed a daemon whose
+/// admissions happened to be failing, which is what a wedged daemon and a merely
+/// unlucky one look like from the outside. The state is recorded on the
+/// reconcile probes as well, so `/health`, `/commands/resources`, `kin graph
+/// status`, `kin admit`, and `kin doctor` all name the restart rather than
+/// leaving a reader to infer it from a refusal.
 pub(crate) fn publish_deferred_tree_after_failure(
     state: &DaemonState,
     admitted: &crate::repository_commit::AdmittedWorkspaceTree,
 ) {
-    if let Err(error) = publish_exact_workspace_tree(state, admitted) {
-        error!(
-            error = %error,
-            "failed to publish the deferred exact workspace tree after the carrying transaction \
-             did not reach authority; the derived graph is ahead of repository authority and this \
-             daemon must be restarted before it can admit again"
-        );
+    match publish_exact_workspace_tree(state, admitted) {
+        Ok(_) => {
+            // The deferral closed, so whatever earlier one did not is resolved:
+            // this publication planned against the authority tree it just
+            // advanced, which a graph running ahead of authority cannot do.
+            state
+                .background_work
+                .reconcile()
+                .clear_deferred_tree_wedge();
+        }
+        Err(error) => {
+            error!(
+                error = %error,
+                "failed to publish the deferred exact workspace tree after the carrying transaction \
+                 did not reach authority; the derived graph is ahead of repository authority and this \
+                 daemon must be restarted before it can admit again"
+            );
+            state
+                .background_work
+                .reconcile()
+                .record_deferred_tree_wedge(&error, Instant::now());
+        }
     }
 }
 


### PR DESCRIPTION
A commit admits the working copy without publishing its tree, so one
repository-authority successor carries both the admitted tree and the change, and
a commit that never reaches authority publishes that tree standalone on its way
out. When that restoring publication fails too, the derived graph is left holding
a tree authority never accepted: every later admission plans out of the graph's
tree and is refused against the older authority tree, and it stays that way until
the daemon restarts and rebuilds the graph from authority.

The state was legible only in one error log line written at the moment it
happened. Afterwards `/health` answered with a daemon whose admissions were
failing, which is exactly what an unlucky daemon looks like too, so an operator
watched refusals accumulate with nothing saying the daemon itself was what needed
restarting.

The reconcile disclosure gains an optional `deferred_tree_wedge` object carrying
the restoring publication's error verbatim, how long the daemon has been wedged,
and a wall-clock stamp for lining it up against the log. It reaches `/health`,
`/commands/resources`, `kin graph status` detail, the `kin admit` report, and
`kin doctor`, all of which answer from one `ReconcileHealth` and its shared
`degraded_reasons`, and a wedged daemon answers `attention` rather than `ok`. The
reason leads with the recovery, "restart required, commit deferral wedged", and
outranks the park: a parked loop resumes on the next daemon, while this one
refuses whatever it is handed until an operator restarts it.

The field is additive in the style the park established. It serializes only when
set, defaults on decode, and a healthy daemon's payload is byte-identical to what
it published before.

It clears rather than latching, on each event that proves the graph's tree
reached authority: a complete admission that succeeds, a later deferral whose
restoring publication does close, and a commit whose own transaction carries the
tree across. The admission failures recorded in between never displace it,
because each of those is the wedge rather than a fresh cause.

Tests drive the double failure at the seam that produces it. A deferring
admission takes the tree, authority moves out of band underneath the open
deferral, and the restoring publication is refused for planning against stale
roots; the wedge appears with that error and the degraded reason names the
restart. The same test then writes another file and watches the next admission
refuse against the mismatched tree, so the record describes a real state rather
than a flag. The falsification is the ordinary case beside it: a commit that
fails and restores cleanly leaves nothing wedged and serializes no field at all.
Probe-level tests pin that later failures do not displace the record and that a
success clears it, and the API tests pin `/health` turning `attention`, the
`kin admit` report showing it cleared, and a commit that reaches authority
clearing it.

Each new test was falsified against a canary build with the record and the
degraded reason removed: the seam test fails at the wedge that never arrives, the
health test fails on `attention`, the commit test fails at its own wedged
precondition, and the probe test fails on `degraded()`. The control test passes
either way, which is what it is for.

Zero File-Search Authority is untouched: this adds no filesystem read of any
kind, only a record on the in-memory reconcile probes.

The full local gate is green on this branch: all 5715 workspace tests pass
alongside doctests, `cargo fmt --check`, the CI clippy allowlist under
`-D warnings`, and both zero-file-search scanners.

Closes FIR-2349
