### PR TITLE
Stand the ambient reconcile tick down for a commit already inside the daemon

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -29822,5 +29822,4 @@ mod tests {
             "the committed file must be graph-owned after the single successor"
         );
     }
-
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -29716,4 +29716,111 @@ mod tests {
             );
         }
     }
+
+    /// The write-then-commit cadence pays for one repository-authority
+    /// successor, not two.
+    ///
+    /// An agent writes a file and commits it immediately. The watcher
+    /// notification reaches the reconcile loop first, so an ambient tick admits
+    /// the file and publishes a successor for it, and the commit that arrives a
+    /// moment later admits the same working copy and publishes a second one.
+    /// Both are O(store): on the store this was measured against, the tick's
+    /// publication was 11.7 seconds and a second ~189MB snapshot write for a
+    /// one-line change.
+    ///
+    /// The race is composed here rather than hoped for. The tick's admission
+    /// runs while a commit is inside the daemon, which is exactly what the
+    /// daemon's own ordering produces: the commit announces itself at the top of
+    /// its handler and then waits on the coordination gate the tick is holding.
+    /// One generation for the pair is the whole acceptance, and the graph-owned
+    /// assertion is what stops a tick that published nothing AND admitted
+    /// nothing from passing it.
+    #[cfg(unix)]
+    #[tokio::test]
+    // Commit phases are emitted at debug level when they are fast, and the
+    // level a `tracing` event is filtered by is a process-global hint. A test
+    // that captures those events therefore cannot run beside one that emits
+    // them, so every test on either side of that shares this group.
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_tick_racing_a_commit_publishes_one_authority_successor_between_them() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        std::fs::write(
+            repo.path().join("raced.rs"),
+            b"pub fn raced() -> u32 { 1 }\n",
+        )
+        .unwrap();
+        let repo_path = kin_model::RepoPath::from_utf8("raced.rs").unwrap();
+
+        let before = crate::loop_runner::current_authority_admission(&state)
+            .unwrap()
+            .0
+            .generation;
+
+        // The tick, with the commit already inside the daemon.
+        let observation =
+            std::iter::once(repo_path.clone()).collect::<std::collections::BTreeSet<_>>();
+        let pending = state.pending_commits.announce();
+        let yielded = crate::loop_runner::ambient_admission_for_test(&state, &observation).unwrap();
+        assert!(
+            yielded,
+            "the tick must stand its publication down for the commit that is waiting on the gate"
+        );
+        drop(pending);
+
+        // The commit, which admits the working copy itself and carries the tree
+        // in the transaction that publishes its change.
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "message": "publish the raced file through one successor"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "commit must succeed: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["file_count"].as_u64().unwrap() >= 1,
+            "the commit must carry the file the tick declined to publish: {json}"
+        );
+
+        let after = crate::loop_runner::current_authority_admission(&state)
+            .unwrap()
+            .0
+            .generation;
+        assert_eq!(
+            after - before,
+            1,
+            "one edit committed once must prepare and persist exactly one \
+             repository-authority successor, whichever pass observed it first"
+        );
+        assert!(
+            state
+                .graph
+                .resolved_tree()
+                .artifact_at_path(&repo_path)
+                .is_some(),
+            "the committed file must be graph-owned after the single successor"
+        );
+    }
+
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4622,6 +4622,16 @@ async fn command_commit(
         ));
     }
 
+    // Announce this commit before anything else, and keep announcing it until
+    // the handler returns. The ambient reconcile tick reads this and stands its
+    // own publication down, because the admission below sweeps the whole working
+    // copy and the transaction after it carries the resulting tree: a tick that
+    // publishes first pays a complete O(store) publication for a tree this
+    // commit is about to publish anyway.
+    //
+    // Before the gate, not after it. A tick that already holds the gate is still
+    // deciding whether to publish, and it decides by reading this.
+    let _pending_commit = state.pending_commits.announce();
     // Hold one uninterrupted graph-authority gate across forced filesystem
     // admission, change construction, and branch publication. The sync helper
     // deliberately does not re-lock this non-reentrant mutex.

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -124,6 +124,7 @@ pub mod lifecycle;
 mod local_repository_authority;
 pub mod loop_runner;
 mod mcp_commit;
+mod pending_commits;
 pub mod replica_adoption;
 mod repository_admit;
 mod repository_branch;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -170,14 +170,46 @@ struct ExactTreeAdmission {
     /// the caller can publish it standalone if its own transaction never
     /// reaches authority.
     deferred_tree: Option<crate::repository_commit::AdmittedWorkspaceTree>,
+    /// The pass derived a transition and then stood down for a commit that had
+    /// entered the daemon while it worked. Nothing was published and nothing was
+    /// applied to the derived graph, so the caller must treat this pass as not
+    /// having happened and let the commit admit the working copy itself.
+    yielded_to_pending_commit: bool,
+}
+
+impl ExactTreeAdmission {
+    /// A pass that stood down for a commit already inside the daemon.
+    ///
+    /// It carries no deltas because it admitted nothing: the transition it
+    /// derived was dropped unpublished, so reporting it would name work that
+    /// never crossed authority.
+    fn yielded(policy: Option<kin_index::ResolvedAdmissionMatcher>) -> Self {
+        Self {
+            deltas: Vec::new(),
+            changed_paths: BTreeSet::new(),
+            semantic_events: Vec::new(),
+            policy,
+            deferred_tree: None,
+            yielded_to_pending_commit: true,
+        }
+    }
 }
 
 /// Where an admitted exact tree crosses repository authority.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TreePublication {
     /// The admission publishes its own repository-authority successor. This is
-    /// the ambient watcher path and every explicit standalone admission.
+    /// every explicit standalone admission.
     Standalone,
+    /// [`Standalone`](Self::Standalone), unless a commit entered the daemon
+    /// before this pass reached its publication, in which case the pass stands
+    /// down and publishes nothing.
+    ///
+    /// The ambient watcher path. A commit forces its own complete admission of
+    /// the working copy and carries the resulting tree inside the transaction
+    /// that publishes its change, so a tick that publishes first buys nothing
+    /// and costs one whole O(store) publication.
+    StandaloneUnlessACommitIsWaiting,
     /// The caller carries the tree transition in its own transaction. Nothing
     /// is published here, so the caller owns the interval in which the derived
     /// graph holds a tree repository authority has not yet accepted.
@@ -426,6 +458,7 @@ pub(crate) fn publish_exact_workspace_tree(
 ) -> Result<Option<u64>> {
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
+    let started = Instant::now();
     let Some(admission) = crate::repository_commit::publish_workspace_tree(
         state.blobs.as_ref(),
         &authority_context,
@@ -436,6 +469,9 @@ pub(crate) fn publish_exact_workspace_tree(
     else {
         return Ok(None);
     };
+    // What this cost is what the reconcile tick is deciding whether to spend, so
+    // it is measured here rather than modelled from the store's size.
+    state.record_authority_publication(started.elapsed());
     state.record_repository_authority_commit(admission.receipt.generation)?;
     info!(
         workspace = %admission.workspace_id,
@@ -781,8 +817,29 @@ fn exact_tree_admission(
         // as a standalone admission does.
         let defer = publication == TreePublication::DeferredToCaller
             && !transition_touches_graph_only_member(&deltas)?;
+        // The last point at which standing down is free, and the last one at
+        // which it is possible. Everything above derived a transition and wrote
+        // nothing that outlives this call; everything below crosses
+        // repository authority or advances the derived graph, and a pass that
+        // stopped between them would leave the graph carrying a tree authority
+        // never accepted.
+        //
+        // The commit that this defers to may have arrived a moment ago, while
+        // this pass was walking the working copy. It will admit the same paths
+        // itself — its own admission is unbounded by any observation — so
+        // nothing is lost by dropping this transition on the floor, and the
+        // whole point is that the commit publishes once for both.
+        let yields = publication == TreePublication::StandaloneUnlessACommitIsWaiting
+            && state.pending_commits.any();
         if defer {
             deferred_tree = Some(admitted);
+        } else if yields {
+            debug!(
+                deltas = deltas.len(),
+                "standing this ambient admission down for a commit already inside the daemon; \
+                 its transaction carries the tree"
+            );
+            return Ok(ExactTreeAdmission::yielded(policy));
         } else {
             // The phase stays on the standalone path, which is the path that
             // still spends it. A deferring caller reports its own publication
@@ -841,6 +898,7 @@ fn exact_tree_admission(
         semantic_events: dedup_file_events(semantic_events),
         policy,
         deferred_tree,
+        yielded_to_pending_commit: false,
     })
 }
 
@@ -1556,6 +1614,104 @@ async fn sweep_expired_intents(state: &DaemonState) {
     }
 }
 
+/// How many consecutive rounds the reconcile tick may stand down for commits
+/// before it admits regardless.
+///
+/// A backstop rather than a hot path. A commit that is announcing itself is
+/// either holding the coordination gate or queued on it, so a tick that
+/// proceeds past this bound does not race that commit: it queues on the same
+/// gate, and by the time it gets there the commit has admitted the whole
+/// working copy and the tick finds nothing left to publish. What the bound
+/// actually protects against is a client that keeps a commit handler inside the
+/// daemon without ever reaching authority — the tick must not hold its own
+/// admission for that forever, whatever else is wrong.
+///
+/// Eight rounds is under a second at the daemon's default cadence, and it is
+/// several orders of magnitude longer than the gap between a commit announcing
+/// itself and reaching the gate, which is the gap this yield exists to cover.
+const MAX_CONSECUTIVE_COMMIT_YIELDS: u32 = 8;
+
+/// The largest share of a publication that is worth spending to avoid one.
+const COMMIT_YIELD_GRACE_SHARE: u32 = 8;
+
+/// The largest number of poll intervals a tick will hold off for.
+const COMMIT_YIELD_GRACE_INTERVALS: u32 = 5;
+
+/// The upper bound on holding off, whatever the other two say.
+const COMMIT_YIELD_GRACE_CEILING: Duration = Duration::from_secs(1);
+
+/// How long a tick holds off before publishing, waiting to see whether a commit
+/// is about to make its publication redundant.
+///
+/// The window matters because the two arrive together by construction: an agent
+/// writes a file and runs `kin commit` in the same breath, the watcher
+/// notification reaches this loop first, and the commit's own process is still
+/// starting up. On the run this was measured against, the tick reached its
+/// publication roughly 150ms before the commit reached the daemon, and then
+/// spent 11.7 seconds publishing a tree the commit published again immediately
+/// afterwards.
+///
+/// The wait is bounded three ways, because it is only ever worth a fraction of
+/// what it saves. At most an eighth of what the last publication cost, so a
+/// repository whose publications are microseconds waits microseconds and one
+/// whose publications are seconds waits meaningfully. At most five poll
+/// intervals, so a loop configured to react faster holds off proportionally
+/// less. And never more than a second.
+///
+/// A daemon that has not published yet has no measurement to scale by, so it
+/// uses the interval bound alone. That is the protective direction on purpose:
+/// the first publication of a process is exactly the one whose cost is unknown.
+fn commit_yield_grace(state: &DaemonState, interval: Duration) -> Duration {
+    let ceiling = interval
+        .saturating_mul(COMMIT_YIELD_GRACE_INTERVALS)
+        .min(COMMIT_YIELD_GRACE_CEILING);
+    match state.last_authority_publication() {
+        Some(last) => (last / COMMIT_YIELD_GRACE_SHARE).min(ceiling),
+        None => ceiling,
+    }
+}
+
+/// Report whether this reconcile round should stand down for a commit.
+///
+/// True when one is already inside the daemon, or when one arrives while this
+/// waits out [`commit_yield_grace`]. A commit admits the whole working copy
+/// itself and carries the resulting tree in the transaction that publishes its
+/// change, so a round that stands down loses no observation: its events stay
+/// queued, and the next round either finds them already admitted or admits them
+/// itself.
+///
+/// The wait holds no lock. It happens before the round takes the coordination
+/// gate, so the commit it is waiting for is never waiting on it.
+async fn wait_out_imminent_commit(
+    state: &DaemonState,
+    interval: Duration,
+    consecutive_yields: u32,
+) -> bool {
+    if consecutive_yields >= MAX_CONSECUTIVE_COMMIT_YIELDS {
+        return false;
+    }
+    // Registered before the count is read, so a commit that announces itself in
+    // between wakes this wait rather than falling between the two.
+    let arrival = state.pending_commits.arrival();
+    tokio::pin!(arrival);
+    arrival.as_mut().enable();
+    if state.pending_commits.any() {
+        return true;
+    }
+    let grace = commit_yield_grace(state, interval);
+    if grace.is_zero() {
+        return false;
+    }
+    tokio::select! {
+        _ = arrival => {}
+        _ = tokio::time::sleep(grace) => {}
+    }
+    // Read again rather than assuming the wakeup was an arrival: a commit that
+    // announced itself and finished inside the grace has already admitted this
+    // working copy, and there is nothing left to stand down for.
+    state.pending_commits.any()
+}
+
 /// What the reconciliation loop becomes after the background-work supervisor
 /// stops its pass: parked, not exited.
 ///
@@ -1678,6 +1834,10 @@ pub async fn run_loop(
     // first pass resolves one, which is the safe direction: nothing is dropped
     // and the pass itself still enforces the policy exactly.
     let mut graph_owned_policy: Option<kin_index::ResolvedAdmissionMatcher> = None;
+    // Rounds stood down in a row for commits, reset by every round that admits.
+    // Bounded by MAX_CONSECUTIVE_COMMIT_YIELDS so a commit that never leaves the
+    // daemon cannot hold ambient admission off forever.
+    let mut commit_yields: u32 = 0;
 
     // Register with the self-limit supervisor. Registered here rather than at
     // daemon start so a repository that never runs this loop — filesystem
@@ -1843,6 +2003,34 @@ pub async fn run_loop(
             continue;
         }
 
+        // Stand this round down for a commit that is already inside the daemon,
+        // or for one that announces itself while this waits. A commit forces a
+        // complete admission of the working copy and carries the resulting tree
+        // in the transaction that publishes its change, so a tick that publishes
+        // first buys nothing and costs one whole O(store) publication. The
+        // agent-shaped cadence — write a file, commit it immediately — puts the
+        // watcher notification and the commit within a few hundred milliseconds
+        // of each other, and the tick wins that race almost every time.
+        //
+        // Nothing is lost by standing down: the events stay in the queue and no
+        // path is deferred, because a yield is not a failure and must not feed
+        // the retry ladder. The working stretch is deliberately not ended here
+        // either. This path is bounded, and a stretch cleared on a path the loop
+        // keeps reaching is a stretch the supervisor can no longer measure.
+        if wait_out_imminent_commit(&state, interval, commit_yields).await {
+            commit_yields += 1;
+            debug!(
+                consecutive = commit_yields,
+                pending = pending_events.len(),
+                "holding this reconcile round for a commit inside the daemon"
+            );
+            tokio::select! {
+                _ = tokio::time::sleep(interval) => {}
+                _ = cancel.changed() => {}
+            }
+            continue;
+        }
+
         state
             .reconciliation_status
             .store(RECON_PROCESSING, Ordering::Relaxed);
@@ -1911,9 +2099,32 @@ pub async fn run_loop(
         let exact_admission = match exact_tree_admission(
             &state,
             Some(&observation),
-            TreePublication::Standalone,
+            TreePublication::StandaloneUnlessACommitIsWaiting,
         ) {
+            // A commit entered the daemon while this pass was walking the
+            // working copy, so the pass derived a transition and published
+            // nothing. Its events go back on the queue rather than into the
+            // retry ladder: nothing failed, and the next round will find them
+            // either already admitted by the commit or still owed.
+            Ok(admission) if admission.yielded_to_pending_commit => {
+                commit_yields += 1;
+                drop(graph_mutation);
+                drop(reconciler);
+                drop(coordination);
+                enqueue_file_events(&mut pending_events, watcher_batch);
+                debug!(
+                    consecutive = commit_yields,
+                    "stood this reconcile round down at its publication for a commit inside \
+                     the daemon"
+                );
+                state
+                    .reconciliation_status
+                    .store(RECON_IDLE, Ordering::Relaxed);
+                tokio::time::sleep(interval).await;
+                continue;
+            }
             Ok(admission) => {
+                commit_yields = 0;
                 state
                     .background_work
                     .reconcile()

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -826,8 +826,8 @@ fn exact_tree_admission(
         //
         // The commit that this defers to may have arrived a moment ago, while
         // this pass was walking the working copy. It will admit the same paths
-        // itself — its own admission is unbounded by any observation — so
-        // nothing is lost by dropping this transition on the floor, and the
+        // itself, because its own admission is unbounded by any observation.
+        // Nothing is lost by dropping this transition on the floor, and the
         // whole point is that the commit publishes once for both.
         let yields = publication == TreePublication::StandaloneUnlessACommitIsWaiting
             && state.pending_commits.any();
@@ -900,6 +900,26 @@ fn exact_tree_admission(
         deferred_tree,
         yielded_to_pending_commit: false,
     })
+}
+
+/// Run one ambient reconcile round's admission the way the loop runs it, and
+/// report whether it stood down for a commit.
+///
+/// The loop itself is a watcher, a batcher, and a retry ladder wrapped around
+/// this one call, none of which the commit race is about. This is the seam a
+/// test drives so the race can be composed in a fixed order instead of hoped
+/// for.
+#[cfg(test)]
+pub(crate) fn ambient_admission_for_test(
+    state: &DaemonState,
+    observation: &BTreeSet<RepoPath>,
+) -> Result<bool> {
+    exact_tree_admission(
+        state,
+        Some(observation),
+        TreePublication::StandaloneUnlessACommitIsWaiting,
+    )
+    .map(|admission| admission.yielded_to_pending_commit)
 }
 
 /// Report whether one planned exact-tree transition moves a repository member
@@ -1623,7 +1643,7 @@ async fn sweep_expired_intents(state: &DaemonState) {
 /// gate, and by the time it gets there the commit has admitted the whole
 /// working copy and the tick finds nothing left to publish. What the bound
 /// actually protects against is a client that keeps a commit handler inside the
-/// daemon without ever reaching authority — the tick must not hold its own
+/// daemon without ever reaching authority. The tick must not hold its own
 /// admission for that forever, whatever else is wrong.
 ///
 /// Eight rounds is under a second at the daemon's default cadence, and it is
@@ -2008,9 +2028,10 @@ pub async fn run_loop(
         // complete admission of the working copy and carries the resulting tree
         // in the transaction that publishes its change, so a tick that publishes
         // first buys nothing and costs one whole O(store) publication. The
-        // agent-shaped cadence — write a file, commit it immediately — puts the
-        // watcher notification and the commit within a few hundred milliseconds
-        // of each other, and the tick wins that race almost every time.
+        // agent-shaped cadence, write a file and commit it immediately, puts
+        // the watcher notification and the commit within a few hundred
+        // milliseconds of each other, and the tick wins that race almost every
+        // time.
         //
         // Nothing is lost by standing down: the events stay in the queue and no
         // path is deferred, because a yield is not a failure and must not feed
@@ -5640,6 +5661,258 @@ mod tests {
         }
         source.into_bytes()
     }
+
+    /// The ambient tick with nothing else in the daemon publishes exactly as it
+    /// did before it learned to stand down. Its mode is the only thing that
+    /// changed, and a mode that skipped a publication on a quiet daemon would
+    /// leave every observed write outside repository authority.
+    #[test]
+    // Commit phases are emitted at debug level when they are fast, and the
+    // level a `tracing` event is filtered by is a process-global hint. A test
+    // that captures those events therefore cannot run beside one that emits
+    // them, so every test on either side of that shares this group.
+    #[serial_test::serial(commit_phase_capture)]
+    fn an_ambient_tick_with_no_commit_in_flight_publishes_its_own_successor() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            repo.path().join("quiet.rs"),
+            b"pub fn quiet() -> u32 { 1 }\n",
+        )
+        .unwrap();
+        let repo_path = test_repo_path("quiet.rs");
+        let observation = std::iter::once(repo_path.clone()).collect::<BTreeSet<_>>();
+
+        let before = authority_generation(&state);
+        let admission = exact_tree_admission(
+            &state,
+            Some(&observation),
+            TreePublication::StandaloneUnlessACommitIsWaiting,
+        )
+        .unwrap();
+
+        assert!(
+            !admission.yielded_to_pending_commit,
+            "there is no commit to stand down for"
+        );
+        assert!(
+            !admission.deltas.is_empty(),
+            "the observed write must be admitted"
+        );
+        assert_eq!(
+            authority_generation(&state) - before,
+            1,
+            "a tick with no commit in flight publishes exactly one successor"
+        );
+        assert!(
+            state
+                .graph
+                .resolved_tree()
+                .artifact_at_path(&repo_path)
+                .is_some(),
+            "the derived graph carries the admitted path"
+        );
+    }
+
+    /// The racing shape, decided the way it is decided in the daemon: the tick
+    /// reaches its publication while a commit is inside the daemon, and stands
+    /// down.
+    ///
+    /// What it must leave behind is a pass that never happened. Publishing is
+    /// the cost being avoided, so the generation must not move; but a tick that
+    /// skipped only the publication and still applied its transition would leave
+    /// the derived graph carrying a tree repository authority never accepted,
+    /// and every later admission plans out of that tree and is refused against
+    /// the older one. So the graph must not carry the path either.
+    #[test]
+    // Commit phases are emitted at debug level when they are fast, and the
+    // level a `tracing` event is filtered by is a process-global hint. A test
+    // that captures those events therefore cannot run beside one that emits
+    // them, so every test on either side of that shares this group.
+    #[serial_test::serial(commit_phase_capture)]
+    fn a_tick_that_meets_a_commit_at_its_publication_publishes_nothing() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        std::fs::write(
+            repo.path().join("raced.rs"),
+            b"pub fn raced() -> u32 { 1 }\n",
+        )
+        .unwrap();
+        let repo_path = test_repo_path("raced.rs");
+        let observation = std::iter::once(repo_path.clone()).collect::<BTreeSet<_>>();
+
+        let before = authority_generation(&state);
+        let commit = state.pending_commits.announce();
+        let admission = exact_tree_admission(
+            &state,
+            Some(&observation),
+            TreePublication::StandaloneUnlessACommitIsWaiting,
+        )
+        .unwrap();
+
+        assert!(
+            admission.yielded_to_pending_commit,
+            "a commit inside the daemon must take this tick's publication"
+        );
+        assert!(
+            admission.deltas.is_empty(),
+            "a pass that admitted nothing must report nothing admitted"
+        );
+        assert_eq!(
+            authority_generation(&state),
+            before,
+            "standing down must cost no repository-authority successor"
+        );
+        assert!(
+            state
+                .graph
+                .resolved_tree()
+                .artifact_at_path(&repo_path)
+                .is_none(),
+            "the derived graph must not run ahead of the authority the tick declined to move"
+        );
+
+        // The commit leaves, and the same tick admits normally again.
+        drop(commit);
+        let admission = exact_tree_admission(
+            &state,
+            Some(&observation),
+            TreePublication::StandaloneUnlessACommitIsWaiting,
+        )
+        .unwrap();
+        assert!(
+            !admission.yielded_to_pending_commit,
+            "the daemon is quiet again, so the next round admits"
+        );
+        assert_eq!(
+            authority_generation(&state) - before,
+            1,
+            "one successor for the file, published by whichever pass got to it"
+        );
+    }
+
+    /// A commit already inside the daemon takes the round with no wait at all.
+    #[tokio::test]
+    async fn a_round_stands_down_for_a_commit_that_is_already_inside_the_daemon() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let _commit = state.pending_commits.announce();
+
+        assert!(
+            wait_out_imminent_commit(&state, Duration::from_secs(3600), 0).await,
+            "a commit inside the daemon is read directly, not waited for"
+        );
+    }
+
+    /// A quiet daemon waits out the grace and then admits. The grace is what
+    /// makes the yield reach the real cadence, because the commit's own
+    /// process is still starting when the watcher notification lands. A round
+    /// that refused to wait at all would only ever catch a commit that arrived
+    /// during the walk.
+    #[tokio::test]
+    async fn a_round_waits_out_the_grace_and_then_admits_when_no_commit_arrives() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+
+        let started = std::time::Instant::now();
+        assert!(
+            !wait_out_imminent_commit(&state, Duration::from_millis(2), 0).await,
+            "no commit arrived, so the round admits"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the wait is bounded by the grace, not by the arrival it hoped for"
+        );
+    }
+
+    /// A commit that announces itself during the grace still takes the round.
+    /// This is the shape the defect was measured in: the tick reached its
+    /// publication about 150ms before the commit reached the daemon.
+    #[tokio::test]
+    async fn a_round_stands_down_for_a_commit_that_arrives_during_the_grace() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+
+        let announcing = Arc::clone(&state);
+        let arriving = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _commit = announcing.pending_commits.announce();
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        // A 200ms poll interval puts the grace at its one-second ceiling, which
+        // is fifty times the arrival above.
+        assert!(
+            wait_out_imminent_commit(&state, Duration::from_millis(200), 0).await,
+            "a commit that arrives inside the grace takes the round"
+        );
+        arriving.abort();
+    }
+
+    /// The starvation bound. A commit that is announcing itself is holding the
+    /// coordination gate or queued on it, so a round that proceeds past the
+    /// bound queues behind it rather than racing it. What must not be possible
+    /// is a client that keeps a commit handler inside the daemon without ever
+    /// reaching authority holding ambient admission off forever.
+    #[tokio::test]
+    async fn consecutive_yields_are_bounded_so_a_permanent_commit_cannot_suppress_admission() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let _never_leaves = state.pending_commits.announce();
+
+        for round in 0..MAX_CONSECUTIVE_COMMIT_YIELDS {
+            assert!(
+                wait_out_imminent_commit(&state, Duration::from_millis(2), round).await,
+                "round {round} is within the bound and stands down"
+            );
+        }
+        assert!(
+            !wait_out_imminent_commit(
+                &state,
+                Duration::from_millis(2),
+                MAX_CONSECUTIVE_COMMIT_YIELDS
+            )
+            .await,
+            "past the bound the round admits, however loudly a commit is still announcing itself"
+        );
+    }
+
+    /// The grace is worth a fraction of what it protects, never a fixed price.
+    /// A repository whose publications are microseconds must not spend half a
+    /// second holding off from one.
+    #[test]
+    fn the_grace_scales_with_what_a_publication_actually_costs() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let interval = Duration::from_millis(100);
+
+        assert_eq!(
+            commit_yield_grace(&state, interval),
+            interval * COMMIT_YIELD_GRACE_INTERVALS,
+            "a daemon that has never published has no measurement to scale by and uses the \
+             interval bound"
+        );
+
+        state.record_authority_publication(Duration::from_micros(400));
+        assert_eq!(
+            commit_yield_grace(&state, interval),
+            Duration::from_micros(50),
+            "a publication measured in microseconds is not worth a wait measured in \
+             milliseconds"
+        );
+
+        state.record_authority_publication(Duration::from_secs(12));
+        assert_eq!(
+            commit_yield_grace(&state, interval),
+            interval * COMMIT_YIELD_GRACE_INTERVALS,
+            "an eighth of twelve seconds is more than the interval bound allows"
+        );
+        assert!(
+            commit_yield_grace(&state, Duration::from_secs(60)) <= COMMIT_YIELD_GRACE_CEILING,
+            "no poll cadence may turn the grace into a stall"
+        );
+    }
+
 }
 
 /// Decide whether a filesystem-sync tick's bulk deletions should be WITHHELD as

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -909,7 +909,10 @@ fn exact_tree_admission(
 /// this one call, none of which the commit race is about. This is the seam a
 /// test drives so the race can be composed in a fixed order instead of hoped
 /// for.
-#[cfg(test)]
+// Gated to match its only caller, the unix-only race test in `api`: a helper
+// whose callers are platform-gated is dead code on every other platform, and
+// the CI gate compiles with `-D warnings`.
+#[cfg(all(test, unix))]
 pub(crate) fn ambient_admission_for_test(
     state: &DaemonState,
     observation: &BTreeSet<RepoPath>,
@@ -5912,7 +5915,6 @@ mod tests {
             "no poll cadence may turn the grace into a stall"
         );
     }
-
 }
 
 /// Decide whether a filesystem-sync tick's bulk deletions should be WITHHELD as

--- a/crates/kin-daemon/src/pending_commits.rs
+++ b/crates/kin-daemon/src/pending_commits.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Commits that have entered this daemon and have not left it yet.
+//!
+//! The ambient reconcile tick and `/commands/commit` both admit the working
+//! copy, and both publish a repository-authority successor to do it. Preparing
+//! that successor and persisting the store are O(store) on every commit, so the
+//! two of them running back to back costs one whole publication more than the
+//! edit needed: the tick publishes the file, and the commit publishes it again
+//! inside its own transaction moments later.
+//!
+//! This is how the tick learns that the second half of that pair is already on
+//! its way. A commit announces itself the moment its handler is entered, before
+//! it waits on the coordination gate, and stops announcing when the handler
+//! returns. The tick reads that and holds off, because a commit admits the whole
+//! working copy itself and carries the tree in the same transaction that
+//! publishes its change.
+//!
+//! The counter is not the gate's waiter count. A `tokio::sync::Mutex` does not
+//! expose one, and it would answer a narrower question anyway: a commit that has
+//! entered the daemon but has not reached the gate yet is exactly as certain to
+//! publish as one already queued on it.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::sync::Notify;
+
+/// Commits currently inside this daemon, and a wakeup for whoever is waiting on
+/// one to arrive.
+#[derive(Debug, Default)]
+pub(crate) struct PendingCommits {
+    inside: AtomicUsize,
+    arrived: Notify,
+}
+
+impl PendingCommits {
+    /// Announce one commit for as long as the returned guard is held.
+    ///
+    /// Take it at the top of the handler, before any lock: the point of the
+    /// announcement is to be readable by a tick that has not started publishing
+    /// yet, and every microsecond spent before it is announced is a microsecond
+    /// in which the tick can commit to a publication this commit makes
+    /// redundant.
+    pub(crate) fn announce(&self) -> PendingCommit<'_> {
+        self.inside.fetch_add(1, Ordering::SeqCst);
+        // Wakes whoever is already waiting. A wakeup that finds nobody is
+        // dropped rather than stored, which is why a waiter registers its
+        // interest before it reads the count rather than after.
+        self.arrived.notify_waiters();
+        PendingCommit { commits: self }
+    }
+
+    /// Whether any commit is inside the daemon right now.
+    pub(crate) fn any(&self) -> bool {
+        self.inside.load(Ordering::SeqCst) > 0
+    }
+
+    /// A future that completes when a commit announces itself.
+    ///
+    /// Enable it (`Notified::enable`) before reading [`any`](Self::any), so a
+    /// commit that arrives between the read and the wait still wakes the
+    /// waiter instead of being missed by both.
+    pub(crate) fn arrival(&self) -> tokio::sync::futures::Notified<'_> {
+        self.arrived.notified()
+    }
+}
+
+/// One commit's announcement, withdrawn when this is dropped.
+#[derive(Debug)]
+pub(crate) struct PendingCommit<'a> {
+    commits: &'a PendingCommits,
+}
+
+impl Drop for PendingCommit<'_> {
+    fn drop(&mut self) {
+        self.commits.inside.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_commit_is_announced_for_exactly_as_long_as_its_guard_lives() {
+        let commits = PendingCommits::default();
+        assert!(!commits.any(), "an idle daemon announces no commit");
+        {
+            let _commit = commits.announce();
+            assert!(commits.any(), "an entered commit announces itself");
+        }
+        assert!(
+            !commits.any(),
+            "a commit that left the daemon must stop announcing itself, or the tick \
+             would hold off forever for a commit that already finished"
+        );
+    }
+
+    #[test]
+    fn concurrent_commits_are_counted_rather_than_flagged() {
+        let commits = PendingCommits::default();
+        let first = commits.announce();
+        let second = commits.announce();
+        drop(first);
+        assert!(
+            commits.any(),
+            "the second commit is still inside the daemon; a bare flag would have been \
+             cleared by the first one leaving"
+        );
+        drop(second);
+        assert!(!commits.any());
+    }
+
+    #[tokio::test]
+    async fn a_waiter_that_enabled_its_interest_first_cannot_miss_an_arrival() {
+        let commits = PendingCommits::default();
+        let arrival = commits.arrival();
+        tokio::pin!(arrival);
+        arrival.as_mut().enable();
+        assert!(!commits.any(), "nothing has arrived yet");
+
+        let _commit = commits.announce();
+        tokio::time::timeout(std::time::Duration::from_secs(5), arrival)
+            .await
+            .expect("an announcement must wake a waiter that registered before reading");
+        assert!(commits.any());
+    }
+}

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1278,6 +1278,18 @@ pub struct DaemonState {
     /// so it is pre-existing content rather than something ambient observation
     /// saw arrive, however late the watcher event naming it drains.
     pub retired_graph_only_members: crate::graph_only_members::RetiredGraphOnlyMembers,
+    /// Commits inside this daemon right now. The ambient reconcile tick reads it
+    /// to avoid publishing a repository-authority successor for a working copy a
+    /// commit is already on its way to admit and publish itself.
+    pub(crate) pending_commits: crate::pending_commits::PendingCommits,
+    /// How long this daemon's last exact-tree publication took, in microseconds,
+    /// or zero when it has not published one yet.
+    ///
+    /// Read by the reconcile tick to size how long it is worth holding off for
+    /// an imminent commit: the wait is only ever worth a fraction of the
+    /// publication it might save, and that publication is O(store), so its cost
+    /// is measured rather than assumed.
+    last_authority_publication_micros: AtomicU64,
     /// True when the background embedding worker has permanently stopped (it
     /// exhausted its consecutive-panic budget). The graph/locate/reconcile
     /// surfaces keep serving — embeddings are a DERIVED index — but the vector
@@ -2299,6 +2311,8 @@ impl DaemonState {
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             retired_graph_only_members: Default::default(),
+            pending_commits: Default::default(),
+            last_authority_publication_micros: AtomicU64::new(0),
             embed_worker_failed: AtomicBool::new(false),
             derived_views_stale: RwLock::new(None),
             mcp_transactions: Mutex::new(HashMap::new()),
@@ -2518,6 +2532,8 @@ impl DaemonState {
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             retired_graph_only_members: Default::default(),
+            pending_commits: Default::default(),
+            last_authority_publication_micros: AtomicU64::new(0),
             embed_worker_failed: AtomicBool::new(false),
             derived_views_stale: RwLock::new(None),
             mcp_transactions: Mutex::new(HashMap::new()),
@@ -4999,6 +5015,29 @@ impl DaemonState {
     /// as a daemon-health signal.
     pub fn is_mass_deletion_blocked(&self) -> bool {
         self.mass_deletion_blocked.load(Ordering::Relaxed)
+    }
+
+    /// Record what one exact-tree publication cost.
+    ///
+    /// Microseconds rather than milliseconds because a publication on a small
+    /// repository is well under a millisecond, and the reading that matters
+    /// most is the cheap one: it is what tells the reconcile tick that holding
+    /// off for an imminent commit would cost more than the publication it could
+    /// save.
+    pub(crate) fn record_authority_publication(&self, elapsed: Duration) {
+        self.last_authority_publication_micros.store(
+            u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX).max(1),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// What this daemon's last exact-tree publication cost, or `None` when it
+    /// has not published one yet.
+    pub(crate) fn last_authority_publication(&self) -> Option<Duration> {
+        match self.last_authority_publication_micros.load(Ordering::Relaxed) {
+            0 => None,
+            micros => Some(Duration::from_micros(micros)),
+        }
     }
 
     /// Duration since the last successful save.

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5026,7 +5026,9 @@ impl DaemonState {
     /// save.
     pub(crate) fn record_authority_publication(&self, elapsed: Duration) {
         self.last_authority_publication_micros.store(
-            u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX).max(1),
+            u64::try_from(elapsed.as_micros())
+                .unwrap_or(u64::MAX)
+                .max(1),
             Ordering::Relaxed,
         );
     }
@@ -5034,7 +5036,10 @@ impl DaemonState {
     /// What this daemon's last exact-tree publication cost, or `None` when it
     /// has not published one yet.
     pub(crate) fn last_authority_publication(&self) -> Option<Duration> {
-        match self.last_authority_publication_micros.load(Ordering::Relaxed) {
+        match self
+            .last_authority_publication_micros
+            .load(Ordering::Relaxed)
+        {
             0 => None,
             micros => Some(Duration::from_micros(micros)),
         }


### PR DESCRIPTION
An agent writes a file and commits it in the same breath. The watcher
notification reaches the reconcile loop first, so the ambient tick admits the
file and publishes a repository-authority successor for it, and the commit that
arrives a moment later admits the same working copy and publishes a second one.
Both are O(store). On the v0.5.36 gauntlet's 189MB store that was one 11.7s
publication followed by another ~189MB snapshot write, for a one-line change.
kin#854 collapsed the commit's own pair into one publication. This is the pair
formed by the tick and the commit.

What makes the tick's half redundant is that a commit forces a complete
admission of the working copy, unbounded by any observation, and carries the
resulting tree inside the transaction that publishes its change. So a tick that
publishes first buys nothing, and it now reads whether a commit is inside the
daemon and stands its round down when one is.

`/commands/commit` announces itself as its first statement, before it waits on
the coordination gate, and keeps announcing until the handler returns. The tick
reads that at two points: before it takes the gate, and again at its
publication. The second is the last point at which standing down is possible.
Everything above it derived a transition and wrote nothing durable; everything
below either crosses repository authority or applies the transition to the
derived graph, and a tick that stopped between them would leave the graph
carrying a tree authority never accepted.

A tick that finds no commit waits a bounded moment for one, and that wait is
what makes this reach the measured cadence rather than a corner of it. On the
gauntlet run the commit's `coordination_gate_wait` was 0ms, so the commit had
not entered its handler while the tick held the gate. Reconstructing from the
phase table, its own process was still resolving the daemon and would have
arrived about 150ms after the tick's publication decision. A flag read with no
wait only catches a commit that arrives inside the tick's 35ms scan window.

The wait is bounded three ways, because it is only ever worth a fraction of what
it saves. At most an eighth of what this daemon's last publication actually
cost, so a repository whose publications are 400 microseconds waits 50 and never
notices one. At most five poll intervals, which is 500ms at the daemon's default
cadence and proportionally less for a loop configured to react faster. Never
more than a second. A daemon that has not published yet uses the interval bound
alone, which is the protective direction: the first publication of a process is
exactly the one whose cost is unknown. The default 500ms is about three times
the 150ms the measured instance needed.

Consecutive yields are bounded at eight, and the reason that number is safe is
worth stating. A commit that is announcing itself is either holding the
coordination gate or queued on it, and `tokio::sync::Mutex` is FIFO-fair, so a
tick that proceeds past the bound does not race that commit. It queues on the
same gate, and by the time it gets there the commit has admitted the whole
working copy and the tick finds nothing left to publish. The bound is a backstop
against a client that keeps a commit handler inside the daemon without ever
reaching authority. Ambient admission must not be holdable off forever by that.
A steady stream of successful commits cannot starve unrelated paths either,
because each commit's forced admission sweeps them itself.

Tests, each falsified rather than merely passed. The racing shape is composed in
a fixed order instead of hoped for: the tick's admission runs while a commit is
inside the daemon, and the pair leaves exactly one authority generation with the
committed file graph-owned. Standing down is asserted to publish nothing and to
apply nothing, so the graph cannot outrun authority. The standalone tick still
publishes exactly one successor with no commit in flight, and the FIR-2347 pins
are untouched. With the yield disabled both racing tests fail on the yield
assertion, with the grace zeroed the arrives-during-the-grace test fails, and
with the bound removed the starvation test fails on its final round.

Not claimed: any wall-clock measurement. No daemon, store, or gauntlet ran in
this lane, and the 150ms figure is reconstructed from the published phase table
rather than observed directly. The remaining single publication per commit is
FIR-2347 directions 1 and 3 and is untouched. The MCP transactional commit path
never forces a filesystem admission, so it never formed this pair and does not
announce itself.

Closes FIR-2350
