### PR TITLE
Resolve Python imports across files and disclose the cross-file coverage that remains

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -254,6 +254,84 @@ fn embedding_coverage_is_measured(_graph: &kin_db::InMemoryGraph) -> bool {
     true
 }
 
+/// Language servers this build can actually enrich with, and the binaries that
+/// provide them.
+///
+/// Two facts have to hold together for a reference edge to exist: the daemon
+/// wires an adapter for the language, and a server binary is installed. The
+/// binary names mirror `kin_lsp::discovery::KNOWN_SERVERS` for exactly the
+/// languages `kin_core::cross_file_coverage::ENRICHABLE_LANGUAGES` names;
+/// probing them here rather than through `discover_servers` keeps the daemon's
+/// status path off a subprocess, since discovery runs `--version` on every
+/// server it finds.
+pub(crate) const LANGUAGE_SERVER_BINARIES: &[(kin_model::LanguageId, &[&str])] = &[
+    (kin_model::LanguageId::Rust, &["rust-analyzer"]),
+    (
+        kin_model::LanguageId::Python,
+        &["pyright-langserver", "pylsp"],
+    ),
+];
+
+/// Languages whose enrichment server is installed on this host.
+pub(crate) fn installed_language_servers() -> HashSet<kin_model::LanguageId> {
+    LANGUAGE_SERVER_BINARIES
+        .iter()
+        .filter(|(_, binaries)| binaries.iter().any(|binary| which::which(binary).is_ok()))
+        .map(|(language, _)| *language)
+        .collect()
+}
+
+/// Measure how much of this graph's knowledge crosses a file boundary, and why
+/// the rest does not.
+///
+/// Artifact-level import edges are not reachable from an entity-rooted
+/// traversal, so they are derived as the difference between the graph-wide
+/// count of a kind and the entity-rooted count the caller already has.
+fn cross_file_coverage(
+    graph: &kin_db::InMemoryGraph,
+    entities: &[Entity],
+    entity_relation_counts: &HashMap<RelationKind, usize>,
+    cross_file_by_language: &HashMap<kin_model::LanguageId, usize>,
+    entity_relations: usize,
+    cross_file_relations: usize,
+) -> kin_core::cross_file_coverage::CrossFileCoverage {
+    let stats = graph.graph_stats();
+    let artifact_import_relations: usize = [RelationKind::Imports, RelationKind::Includes]
+        .into_iter()
+        .map(|kind| {
+            let graph_wide = stats
+                .relation_counts
+                .get(&format!("{kind:?}"))
+                .copied()
+                .unwrap_or(0);
+            let entity_rooted = entity_relation_counts.get(&kind).copied().unwrap_or(0);
+            graph_wide.saturating_sub(entity_rooted)
+        })
+        .sum();
+
+    // Entities without a file origin are external reference targets this
+    // repository does not own; counting their language would report coverage
+    // for a language the repository holds no source in.
+    let mut entities_by_language: HashMap<kin_model::LanguageId, usize> = HashMap::new();
+    for entity in entities.iter().filter(|e| e.file_origin.is_some()) {
+        *entities_by_language.entry(entity.language).or_insert(0) += 1;
+    }
+
+    kin_core::cross_file_coverage::CrossFileCoverage::assemble(
+        entity_relations,
+        cross_file_relations,
+        artifact_import_relations,
+        entities_by_language.into_iter().map(|(language, count)| {
+            (
+                language,
+                count,
+                cross_file_by_language.get(&language).copied().unwrap_or(0),
+            )
+        }),
+        &installed_language_servers(),
+    )
+}
+
 fn build_graph_status_response(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
@@ -307,11 +385,40 @@ fn build_graph_status_response(
     let mut relation_counts: HashMap<RelationKind, usize> = HashMap::new();
     let mut seen_relation_ids = HashSet::new();
     let mut total_relations = 0usize;
+    // Whether an edge crosses a file boundary is the fact that decides whether
+    // this graph can answer what calls what, and it is invisible in the
+    // relation-kind histogram: a `Calls` total says nothing about how many of
+    // those calls left the file they were written in. Both endpoints are
+    // resolved through the entity's own file origin, so an edge is only counted
+    // as cross-file when the graph knows both files and they differ.
+    let origin_by_entity: HashMap<kin_model::EntityId, (&str, kin_model::LanguageId)> = entities
+        .iter()
+        .filter_map(|e| {
+            e.file_origin
+                .as_ref()
+                .map(|file| (e.id, (file.0.as_str(), e.language)))
+        })
+        .collect();
+    let mut cross_file_relations = 0usize;
+    let mut cross_file_by_language: HashMap<kin_model::LanguageId, usize> = HashMap::new();
     for e in &entities {
         for rel in graph.get_all_relations_for_entity(&e.id)? {
             if seen_relation_ids.insert(rel.id) {
                 *relation_counts.entry(rel.kind).or_insert(0) += 1;
                 total_relations += 1;
+                let crossing =
+                    rel.src
+                        .as_entity()
+                        .zip(rel.dst.as_entity())
+                        .and_then(|(src, dst)| {
+                            let (src_file, src_language) = origin_by_entity.get(&src)?;
+                            let (dst_file, _) = origin_by_entity.get(&dst)?;
+                            (src_file != dst_file).then_some(*src_language)
+                        });
+                if let Some(src_language) = crossing {
+                    cross_file_relations += 1;
+                    *cross_file_by_language.entry(src_language).or_insert(0) += 1;
+                }
             }
         }
     }
@@ -374,6 +481,22 @@ fn build_graph_status_response(
         "Entity-to-entity relation kinds: {}",
         rel_parts.join(", ")
     ));
+
+    // Cross-file coverage, stated beside the kind breakdown the reader just
+    // saw. A kind histogram cannot say whether any edge leaves its own file,
+    // and a graph that answers nothing across a file boundary looks identical
+    // to a healthy one at this level of detail.
+    lines.extend(
+        cross_file_coverage(
+            graph,
+            &entities,
+            &relation_counts,
+            &cross_file_by_language,
+            total_relations,
+            cross_file_relations,
+        )
+        .disclosure_lines(),
+    );
 
     // Kind distribution
     let mut kind_pairs: Vec<_> = kind_counts.iter().collect();
@@ -1569,6 +1692,87 @@ mod tests {
                 .iter()
                 .any(|line| line.starts_with("Relations: ") || line.contains("  |  Relations: ")),
             "{:?}",
+            response.lines
+        );
+    }
+
+    fn test_entity_in_file(name: &str, file: &str) -> Entity {
+        let mut entity = test_entity(name);
+        entity.file_origin = Some(kin_model::FilePathId::new(file));
+        entity
+    }
+
+    /// A graph whose every edge stays inside one file must say so.
+    ///
+    /// This is the state the isolation experiment found and the kind histogram
+    /// cannot express: `Calls: 8` reads identically whether those calls reach
+    /// another module or none of them do.
+    #[test]
+    fn graph_status_names_a_graph_whose_edges_never_leave_their_file() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let caller = test_entity_in_file("ingest_note", "storage.py");
+        let callee = test_entity_in_file("normalize", "storage.py");
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        graph
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+
+        let response =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
+
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.starts_with("Cross-file entity relations: 0 of 1")),
+            "the cross-file count belongs beside the kind breakdown: {:?}",
+            response.lines
+        );
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.contains("no relation in this graph crosses a file boundary")),
+            "a graph that cannot leave a file must state it: {:?}",
+            response.lines
+        );
+    }
+
+    /// The counterpart: one edge across a file boundary withdraws the claim.
+    /// Without this, the test above would still pass if the disclosure were
+    /// printed unconditionally, which would make it decoration rather than a
+    /// measurement.
+    #[test]
+    fn graph_status_withdraws_the_shortfall_once_an_edge_crosses_files() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let caller = test_entity_in_file("ingest_note", "storage.py");
+        let callee = test_entity_in_file("parse_note", "parsing.py");
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        graph
+            .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
+            .unwrap();
+
+        let response =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
+
+        assert!(
+            response
+                .lines
+                .iter()
+                .any(|line| line.starts_with("Cross-file entity relations: 1 of 1")),
+            "{:?}",
+            response.lines
+        );
+        assert!(
+            !response
+                .lines
+                .iter()
+                .any(|line| line.contains("no relation in this graph crosses a file boundary")),
+            "a graph that does cross files must not be told it cannot: {:?}",
             response.lines
         );
     }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -170,6 +170,7 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_semantic_query_readiness().await);
     checks.push(check_background_work().await);
     checks.push(check_retrieval_profile());
+    checks.push(check_cross_file_enrichment());
     checks.push(check_update_policy());
     checks.push(check_binary_assessment_load());
 
@@ -2109,6 +2110,74 @@ async fn check_semantic_query_readiness() -> HealthCheck {
     semantic_query_health_from_runtime(&daemon_url, &response.embed_runtime)
 }
 
+/// Report whether cross-file reference edges can be produced on this host.
+///
+/// Reference and override edges are not derivable from a single-file parse:
+/// they need a resolved program, which Kin gets from an external language
+/// server. On a host with none installed the graph simply never gains that edge
+/// class, and until this row existed the only trace was a relation count a
+/// reader had to already know the expected value of. The row names the language
+/// and the missing binary so the gap is a fact on the page rather than an
+/// inference from a ratio.
+///
+/// It reports `Stale` rather than `Missing`: the graph still answers, with
+/// import and call edges resolved from source, so this degrades an install
+/// without breaking it.
+fn check_cross_file_enrichment() -> HealthCheck {
+    cross_file_enrichment_check(&crate::commands::graph::installed_language_servers())
+}
+
+/// The verdict half of [`check_cross_file_enrichment`], over an explicit set of
+/// installed servers so both outcomes can be exercised on any host.
+fn cross_file_enrichment_check(
+    installed: &std::collections::HashSet<kin_model::LanguageId>,
+) -> HealthCheck {
+    let mut available: Vec<String> = Vec::new();
+    let mut missing: Vec<String> = Vec::new();
+    for (language, binaries) in crate::commands::graph::LANGUAGE_SERVER_BINARIES {
+        if installed.contains(language) {
+            available.push(language.to_string());
+        } else {
+            missing.push(format!("{language} ({})", binaries.join(" or ")));
+        }
+    }
+
+    if missing.is_empty() {
+        return HealthCheck::new(
+            "cross_file_enrichment",
+            "Cross-file reference edges",
+            HealthStatus::Healthy,
+            format!("language server found for {}", available.join(", ")),
+        );
+    }
+
+    let detail = format!(
+        "cross-file reference and override edges unavailable: no language server found for {}",
+        missing.join(", ")
+    );
+    HealthCheck::new(
+        "cross_file_enrichment",
+        "Cross-file reference edges",
+        HealthStatus::Stale,
+        // Say what still works. A row that reports only the loss reads as "the
+        // graph knows nothing across files", and import-bound calls are
+        // resolved from source with no language server involved at all.
+        format!(
+            "{detail}; import and call edges are still resolved from source. Languages outside \
+             {} gain no reference edges in this build either",
+            crate::commands::graph::LANGUAGE_SERVER_BINARIES
+                .iter()
+                .map(|(language, _)| language.to_string())
+                .collect::<Vec<_>>()
+                .join("/")
+        ),
+    )
+    .with_manual_fix(
+        "install a language server for the named language (for example `npm i -g pyright` or \
+         `rustup component add rust-analyzer`), then restart the daemon",
+    )
+}
+
 /// Report the active retrieval quality profile and the effective lever set,
 /// so an operator can see at a glance whether they are getting full
 /// retrieval capability — and why not, when a lever is off.
@@ -2211,6 +2280,61 @@ mod tests {
     use super::*;
     use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
+
+    /// A host with no language server must be told which language lost which
+    /// edge class, and told it in words rather than as a low relation count.
+    #[test]
+    fn doctor_names_the_language_whose_missing_server_costs_cross_file_edges() {
+        let check = cross_file_enrichment_check(&std::collections::HashSet::new());
+
+        assert!(matches!(check.status, HealthStatus::Stale));
+        assert!(
+            check.detail.contains("no language server found for"),
+            "{}",
+            check.detail
+        );
+        assert!(check.detail.contains("python"), "{}", check.detail);
+        assert!(
+            check.detail.contains("pyright-langserver"),
+            "{}",
+            check.detail
+        );
+        assert!(
+            check
+                .detail
+                .contains("import and call edges are still resolved from source"),
+            "the row must not read as a total loss: {}",
+            check.detail
+        );
+        assert!(check.manual_fix.is_some());
+    }
+
+    /// The counterpart, so the row above cannot be an unconditional warning:
+    /// with every wired language's server installed there is no gap to report.
+    #[test]
+    fn doctor_reports_no_gap_once_every_wired_language_server_is_installed() {
+        let installed: std::collections::HashSet<kin_model::LanguageId> =
+            crate::commands::graph::LANGUAGE_SERVER_BINARIES
+                .iter()
+                .map(|(language, _)| *language)
+                .collect();
+        let check = cross_file_enrichment_check(&installed);
+
+        assert!(matches!(check.status, HealthStatus::Healthy));
+        assert!(!check.detail.contains("unavailable"), "{}", check.detail);
+    }
+
+    /// A `Stale` row needs attention without failing readiness. A missing
+    /// language server degrades a working install; calling it a failure would
+    /// turn `kin doctor` red on every host that never installed one.
+    #[test]
+    fn a_missing_language_server_needs_attention_without_blocking_readiness() {
+        let check = cross_file_enrichment_check(&std::collections::HashSet::new());
+        assert!(!blocks_readiness(&check));
+        let report = assemble_health_report("test".to_string(), vec![check]);
+        assert!(report.healthy);
+        assert_eq!(report.summary().attention, 1);
+    }
 
     fn write_file(path: &Path, bytes: &[u8]) {
         use std::io::Write;

--- a/crates/kin-core/src/cross_file_coverage.rs
+++ b/crates/kin-core/src/cross_file_coverage.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! How much of a graph's knowledge crosses a file boundary, and why the rest
+//! does not.
+//!
+//! A graph whose edges all stay inside one file cannot answer what calls what,
+//! which is the whole claim the semantic substrate makes over text search. That
+//! shortfall used to be invisible: every status surface reported the graph
+//! healthy, and the only trace was a relations-per-entity ratio a reader had to
+//! know the expected value of. This module measures the shortfall from graph
+//! truth and names the two mechanisms that cause it, so a surface can disclose
+//! it instead of leaving it to be inferred.
+//!
+//! Nothing here probes the filesystem or the process table. Callers supply the
+//! entity/relation counts they already hold and the set of languages whose
+//! language server they found, and the assessment is a pure function of those.
+//! That keeps one vocabulary, the serialized `cross_file_coverage` object,
+//! shared by `kin doctor`, `kin graph status`, and the retrieval envelope that
+//! decides whether an empty result is safe to call an absence.
+
+use std::collections::HashSet;
+
+use kin_model::LanguageId;
+use serde::{Deserialize, Serialize};
+
+/// Languages this build can enrich with language-server evidence.
+///
+/// Reference, override, and type-use edges are not derivable from a
+/// single-file parse: they need a resolved program, which Kin gets from an
+/// external language server. The daemon wires an adapter for exactly these
+/// languages, so every other language carries no such edge by construction, no
+/// matter what is installed on the host.
+pub const ENRICHABLE_LANGUAGES: &[LanguageId] = &[LanguageId::Rust, LanguageId::Python];
+
+/// Whether cross-file reference evidence is available for one language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReferenceEnrichment {
+    /// An adapter is wired and its language server was found.
+    Available,
+    /// An adapter is wired but no language server for it is installed, so
+    /// reference and override edges cannot be produced on this host.
+    NoLanguageServer,
+    /// This build wires no adapter for the language, so reference and override
+    /// edges are unavailable regardless of what is installed.
+    Unsupported,
+}
+
+impl ReferenceEnrichment {
+    /// Whether this state should be surfaced as needing attention.
+    ///
+    /// A missing language server is a host gap an operator can close.
+    /// `Unsupported` is a property of the build, and a row a reader can do
+    /// nothing about is noise rather than a finding.
+    pub fn is_actionable_gap(&self) -> bool {
+        matches!(self, ReferenceEnrichment::NoLanguageServer)
+    }
+}
+
+/// Whether the language server for `language` can enrich this host's graph.
+pub fn reference_enrichment_for(
+    language: LanguageId,
+    servers_found: &HashSet<LanguageId>,
+) -> ReferenceEnrichment {
+    if !ENRICHABLE_LANGUAGES.contains(&language) {
+        return ReferenceEnrichment::Unsupported;
+    }
+    if servers_found.contains(&language) {
+        ReferenceEnrichment::Available
+    } else {
+        ReferenceEnrichment::NoLanguageServer
+    }
+}
+
+/// Measured cross-file coverage for one language in the graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LanguageCoverage {
+    pub language: String,
+    pub entities: usize,
+    /// Entity-to-entity relations whose source entity is in this language and
+    /// whose endpoints live in different files.
+    pub cross_file_relations: usize,
+    pub reference_enrichment: ReferenceEnrichment,
+}
+
+/// Cross-file coverage of a graph, measured rather than assumed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossFileCoverage {
+    /// Entity-to-entity relations counted, both endpoints resolved to entities.
+    pub entity_relations: usize,
+    /// How many of those cross a file boundary.
+    pub cross_file_entity_relations: usize,
+    /// Artifact-to-artifact import and include edges.
+    pub artifact_import_relations: usize,
+    /// One entry per language the graph actually holds entities for, ordered by
+    /// entity count so the language a reader cares about leads.
+    pub languages: Vec<LanguageCoverage>,
+}
+
+impl CrossFileCoverage {
+    /// Assemble a report from counts the caller measured against graph truth.
+    ///
+    /// `per_language` carries `(language, entities, cross_file_relations)`.
+    pub fn assemble(
+        entity_relations: usize,
+        cross_file_entity_relations: usize,
+        artifact_import_relations: usize,
+        per_language: impl IntoIterator<Item = (LanguageId, usize, usize)>,
+        servers_found: &HashSet<LanguageId>,
+    ) -> Self {
+        let mut languages: Vec<LanguageCoverage> = per_language
+            .into_iter()
+            .map(
+                |(language, entities, cross_file_relations)| LanguageCoverage {
+                    language: language.to_string(),
+                    entities,
+                    cross_file_relations,
+                    reference_enrichment: reference_enrichment_for(language, servers_found),
+                },
+            )
+            .collect();
+        languages.sort_by(|a, b| {
+            b.entities
+                .cmp(&a.entities)
+                .then_with(|| a.language.cmp(&b.language))
+        });
+        Self {
+            entity_relations,
+            cross_file_entity_relations,
+            artifact_import_relations,
+            languages,
+        }
+    }
+
+    /// Whether the graph holds entities but no edge between two files.
+    ///
+    /// This is the state the ratio used to hide. It is deliberately keyed on a
+    /// hard zero: a graph with even one cross-file edge is answering the
+    /// question, and how well it answers is a recall question this counter
+    /// cannot settle.
+    pub fn holds_no_cross_file_edges(&self) -> bool {
+        self.entity_relations > 0 && self.cross_file_entity_relations == 0
+    }
+
+    /// Languages whose missing language server an operator could install.
+    pub fn languages_missing_a_language_server(&self) -> Vec<&str> {
+        self.languages
+            .iter()
+            .filter(|coverage| coverage.reference_enrichment.is_actionable_gap())
+            .map(|coverage| coverage.language.as_str())
+            .collect()
+    }
+
+    /// Whether any surface should present this as needing attention.
+    pub fn needs_attention(&self) -> bool {
+        self.holds_no_cross_file_edges() || !self.languages_missing_a_language_server().is_empty()
+    }
+
+    /// Human disclosure for a status surface, one statement per line.
+    ///
+    /// Every line states a measured count or a probed absence. None of them
+    /// asserts the graph is complete, because nothing measured here can say so.
+    pub fn disclosure_lines(&self) -> Vec<String> {
+        let mut lines = vec![format!(
+            "Cross-file entity relations: {} of {} ({} artifact import/include edges)",
+            self.cross_file_entity_relations, self.entity_relations, self.artifact_import_relations
+        )];
+
+        if self.holds_no_cross_file_edges() {
+            lines.push(
+                "  no relation in this graph crosses a file boundary, so `find_references` and \
+                 `trace_data_flow` cannot leave the file they start in"
+                    .to_string(),
+            );
+        }
+
+        let missing = self.languages_missing_a_language_server();
+        if !missing.is_empty() {
+            lines.push(format!(
+                "  cross-file reference and override edges unavailable for {}: no language server found",
+                missing.join(", ")
+            ));
+        }
+
+        let unsupported: Vec<&str> = self
+            .languages
+            .iter()
+            .filter(|coverage| {
+                coverage.reference_enrichment == ReferenceEnrichment::Unsupported
+                    && coverage.entities > 0
+            })
+            .map(|coverage| coverage.language.as_str())
+            .collect();
+        if !unsupported.is_empty() {
+            lines.push(format!(
+                "  cross-file reference and override edges unsupported for {}: this build wires no language-server adapter",
+                unsupported.join(", ")
+            ));
+        }
+
+        lines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn servers(found: &[LanguageId]) -> HashSet<LanguageId> {
+        found.iter().copied().collect()
+    }
+
+    #[test]
+    fn a_wired_language_without_its_server_is_an_actionable_gap() {
+        assert_eq!(
+            reference_enrichment_for(LanguageId::Python, &servers(&[])),
+            ReferenceEnrichment::NoLanguageServer
+        );
+        assert_eq!(
+            reference_enrichment_for(LanguageId::Python, &servers(&[LanguageId::Python])),
+            ReferenceEnrichment::Available
+        );
+    }
+
+    #[test]
+    fn an_unwired_language_stays_unsupported_even_with_a_server_installed() {
+        // gopls on PATH does not give Go reference edges, because no adapter
+        // consumes it. Reporting Available here would promise edges that can
+        // never appear.
+        assert_eq!(
+            reference_enrichment_for(LanguageId::Go, &servers(&[LanguageId::Go])),
+            ReferenceEnrichment::Unsupported
+        );
+        assert!(!ReferenceEnrichment::Unsupported.is_actionable_gap());
+    }
+
+    #[test]
+    fn a_graph_with_only_same_file_edges_is_disclosed_not_inferred() {
+        let coverage = CrossFileCoverage::assemble(
+            17,
+            0,
+            0,
+            [(LanguageId::Python, 15, 0)],
+            &servers(&[LanguageId::Python]),
+        );
+        assert!(coverage.holds_no_cross_file_edges());
+        assert!(coverage.needs_attention());
+        let disclosure = coverage.disclosure_lines().join("\n");
+        assert!(
+            disclosure.contains("no relation in this graph crosses a file boundary"),
+            "the shortfall must be stated, not left to a ratio: {disclosure}"
+        );
+    }
+
+    #[test]
+    fn a_graph_that_crosses_files_makes_no_shortfall_claim() {
+        let coverage = CrossFileCoverage::assemble(
+            17,
+            6,
+            3,
+            [(LanguageId::Python, 15, 6)],
+            &servers(&[LanguageId::Python]),
+        );
+        assert!(!coverage.holds_no_cross_file_edges());
+        assert!(!coverage.needs_attention());
+        let disclosure = coverage.disclosure_lines().join("\n");
+        assert!(disclosure.contains("6 of 17"));
+        assert!(!disclosure.contains("no relation in this graph"));
+    }
+
+    #[test]
+    fn a_missing_language_server_is_named_with_its_language() {
+        let coverage =
+            CrossFileCoverage::assemble(40, 12, 4, [(LanguageId::Python, 15, 12)], &servers(&[]));
+        assert_eq!(
+            coverage.languages_missing_a_language_server(),
+            vec!["python"]
+        );
+        assert!(coverage.needs_attention());
+        assert!(coverage
+            .disclosure_lines()
+            .join("\n")
+            .contains("unavailable for python: no language server found"));
+    }
+
+    #[test]
+    fn languages_lead_with_the_one_holding_the_most_entities() {
+        let coverage = CrossFileCoverage::assemble(
+            0,
+            0,
+            0,
+            [
+                (LanguageId::Python, 3, 0),
+                (LanguageId::Rust, 90, 40),
+                (LanguageId::Go, 3, 1),
+            ],
+            &servers(&[LanguageId::Rust]),
+        );
+        let order: Vec<&str> = coverage
+            .languages
+            .iter()
+            .map(|c| c.language.as_str())
+            .collect();
+        assert_eq!(order, vec!["rust", "go", "python"]);
+    }
+
+    #[test]
+    fn the_report_round_trips_as_the_cross_file_coverage_object() {
+        let coverage =
+            CrossFileCoverage::assemble(17, 0, 0, [(LanguageId::Python, 15, 0)], &servers(&[]));
+        let json = serde_json::to_string(&coverage).expect("serializes");
+        assert!(json.contains("\"reference_enrichment\":\"no_language_server\""));
+        let parsed: CrossFileCoverage = serde_json::from_str(&json).expect("round trips");
+        assert_eq!(parsed, coverage);
+    }
+}

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod assistant;
 pub mod assistant_sync;
 pub mod behavior_env;
 pub mod config;
+pub mod cross_file_coverage;
 pub mod dependencies;
 pub mod diff;
 pub mod disambiguation;

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -3170,6 +3170,19 @@ fn resolve_module_path<S>(
 where
     S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
 {
+    // Python module paths are dotted, not path-shaped, in both directions:
+    // `app.parsing` names `app/parsing.py` and `.parsing` names a sibling
+    // module inside the importer's own package. Neither shape survives the
+    // generic branches below — the relative branch would join `.parsing` onto
+    // the importer's directory as a literal path segment, and the non-relative
+    // branch only knows header, JS package, Java, and Go layouts. So every
+    // Python import fell through unresolved, which cost the graph its
+    // artifact-level `Imports` edges and left every imported call to the blind
+    // name fallback.
+    if is_python_source_path(importer_path) {
+        return resolve_python_module_import(importer_path, module_path, known_files);
+    }
+
     if module_path.starts_with('.') {
         // Relative import resolution
         let importer = Path::new(importer_path);
@@ -3211,6 +3224,108 @@ where
             // Go module resolution: github.com/org/repo/v2/pkg/foo → pkg/foo/*.go
             .or_else(|| resolve_go_module_import(module_path, known_files))
     }
+}
+
+/// Source extensions a Python module name can materialize as.
+const PYTHON_MODULE_EXTENSIONS: &[&str] = &["py", "pyi"];
+
+/// Source roots an absolute Python import is resolved against, in the order a
+/// repository normally puts them on `sys.path`.
+///
+/// Deliberately short. A repo-wide suffix search would find a same-named module
+/// anywhere in the tree and bind the import to it, which is a guess wearing the
+/// costume of a resolution; an import that names no module at one of these roots
+/// stays unresolved instead.
+const PYTHON_SOURCE_ROOTS: &[&str] = &["", "src"];
+
+fn is_python_source_path(path: &str) -> bool {
+    matches!(path.rsplit('.').next(), Some("py" | "pyi"))
+}
+
+/// Resolve a Python import to the repo-local file that defines it.
+///
+/// Handles the two shapes the adapter emits: an absolute dotted path
+/// (`app.parsing`) resolved against the repository's source roots, and a
+/// relative one (`.parsing`, `..util.text`) resolved against the importer's own
+/// package, where each leading dot beyond the first climbs one package.
+///
+/// Both shapes only ever name files the caller already knows about, so an
+/// import of a third-party or standard-library module resolves to nothing and
+/// is left to the external-reference tier. When more than one source root
+/// answers the same module the import is ambiguous and stays unresolved: a
+/// fabricated edge is worse than a missing one.
+fn resolve_python_module_import<S>(
+    importer_path: &str,
+    module_path: &str,
+    known_files: &HashSet<S>,
+) -> Option<String>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    let level = module_path.chars().take_while(|c| *c == '.').count();
+    let segments: Vec<&str> = module_path[level..]
+        .split('.')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+
+    if level > 0 {
+        let mut base = parent_dir(importer_path).to_string();
+        for _ in 1..level {
+            if base.is_empty() {
+                // More leading dots than there are packages above the importer.
+                return None;
+            }
+            base = parent_dir(&base).to_string();
+        }
+        return python_module_file(&base, &segments, known_files);
+    }
+
+    let mut hit: Option<String> = None;
+    for root in PYTHON_SOURCE_ROOTS {
+        let Some(candidate) = python_module_file(root, &segments, known_files) else {
+            continue;
+        };
+        match &hit {
+            Some(existing) if *existing != candidate => return None,
+            Some(_) => {}
+            None => hit = Some(candidate),
+        }
+    }
+    hit
+}
+
+/// The file a dotted module name resolves to under one source root, preferring
+/// a module (`pkg/mod.py`) over a package (`pkg/mod/__init__.py`).
+///
+/// An empty segment list names the base package itself (`from . import sibling`),
+/// which can only be that package's `__init__`.
+fn python_module_file<S>(base: &str, segments: &[&str], known_files: &HashSet<S>) -> Option<String>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    let joined = segments.join("/");
+    let prefix = match (base.is_empty(), joined.is_empty()) {
+        (true, true) => return None,
+        (true, false) => joined,
+        (false, true) => base.to_string(),
+        (false, false) => format!("{base}/{joined}"),
+    };
+
+    if !segments.is_empty() {
+        for ext in PYTHON_MODULE_EXTENSIONS {
+            let candidate = format!("{prefix}.{ext}");
+            if known_files.contains(candidate.as_str()) {
+                return Some(candidate);
+            }
+        }
+    }
+    for ext in PYTHON_MODULE_EXTENSIONS {
+        let candidate = format!("{prefix}/__init__.{ext}");
+        if known_files.contains(candidate.as_str()) {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn resolve_repo_local_header<S>(module_path: &str, known_files: &HashSet<S>) -> Option<String>

--- a/crates/kin-index/tests/python_import_linking.rs
+++ b/crates/kin-index/tests/python_import_linking.rs
@@ -22,7 +22,9 @@ fn parse_with(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> FileParse
     let file_id = FilePathId::new(path);
     let bytes = src.as_bytes();
     let tree = adapter.parse(bytes).expect("fixture parses");
-    let output = adapter.extract(&tree, bytes, &file_id).expect("fixture extracts");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
     let entities: Vec<Entity> = output
         .entities
         .into_iter()

--- a/crates/kin-index/tests/python_import_linking.rs
+++ b/crates/kin-index/tests/python_import_linking.rs
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file linking of Python and JavaScript imports through the real parser.
+//!
+//! Python module paths are dotted (`app.parsing`, `.parsing`), not path-shaped,
+//! so the linker's generic module resolution never mapped them onto a repo file:
+//! Python graphs carried no artifact-level `Imports` edge at all, and every
+//! imported call fell through to the blind name fallback, which drops the edge
+//! the moment two modules define the same name. These tests drive real adapters
+//! into the real linker and pin both halves: the import edge exists, the call
+//! binds to the module it was imported from, and an unimported ambiguous name
+//! still resolves to nothing rather than to a guess.
+
+use std::collections::{HashMap, HashSet};
+
+use kin_index::{link_cross_file as link_cross_file_with_identities, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityId, FilePathId, GraphNodeId, Relation, RelationKind};
+use kin_parser::{JavaScriptAdapter, LanguageAdapter, PythonAdapter};
+
+fn parse_with(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> FileParseData {
+    let file_id = FilePathId::new(path);
+    let bytes = src.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("fixture extracts");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+type ArtifactIds = HashMap<String, ArtifactId>;
+
+/// Link and return both the relations and the identity map, so artifact-level
+/// import edges can be asserted by path rather than by opaque identity.
+fn link_with_identities(files: &[FileParseData]) -> (Vec<Relation>, ArtifactIds) {
+    let artifact_ids: ArtifactIds = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file_with_identities(files, &artifact_ids)
+        .expect("every fixture file has an explicitly assigned artifact identity");
+    (relations, artifact_ids)
+}
+
+fn link(files: &[FileParseData]) -> Vec<Relation> {
+    link_with_identities(files).0
+}
+
+fn artifact_import_paths(
+    relations: &[Relation],
+    artifact_ids: &ArtifactIds,
+) -> HashSet<(String, String)> {
+    let path_of = |node: &GraphNodeId| -> Option<String> {
+        match node {
+            GraphNodeId::Artifact(id) => artifact_ids
+                .iter()
+                .find(|(_, candidate)| *candidate == id)
+                .map(|(path, _)| path.clone()),
+            _ => None,
+        }
+    };
+    relations
+        .iter()
+        .filter(|rel| rel.kind == RelationKind::Imports)
+        .filter_map(|rel| Some((path_of(&rel.src)?, path_of(&rel.dst)?)))
+        .collect()
+}
+
+fn entity_id_in(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+fn call_confidence(relations: &[Relation], src: EntityId, dst: EntityId) -> Option<f32> {
+    relations
+        .iter()
+        .find(|rel| {
+            rel.kind == RelationKind::Calls
+                && rel.src == GraphNodeId::Entity(src)
+                && rel.dst == GraphNodeId::Entity(dst)
+        })
+        .map(|rel| rel.confidence)
+}
+
+fn parsing_module(path: &str) -> FileParseData {
+    parse_with(
+        &PythonAdapter,
+        path,
+        "def parse_note(path):\n    return {}\n",
+    )
+}
+
+/// Confidence the linker records when a call resolves through the importing
+/// file's own import declaration (tier (b) of `linker::resolve_one_file`).
+///
+/// Asserting the confidence, not merely the edge, is what keeps these tests
+/// falsifiable: the blind cross-file name fallback reaches the same entity at
+/// 0.7 in the single-definition fixtures, so an edge alone cannot tell import
+/// resolution apart from a lucky name match.
+const IMPORT_RESOLVED_CONFIDENCE: f32 = 0.95;
+
+#[test]
+fn flat_python_absolute_import_produces_an_artifact_import_edge() {
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "storage.py",
+            "from parsing import parse_note\n\n\nclass Database:\n    def ingest_note(self, path):\n        return parse_note(path)\n",
+        ),
+        parsing_module("parsing.py"),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids)
+            .contains(&("storage.py".to_string(), "parsing.py".to_string())),
+        "`from parsing import parse_note` must produce storage.py -> parsing.py Imports"
+    );
+
+    let caller = entity_id_in(&files, "storage.py", "Database.ingest_note");
+    let callee = entity_id_in(&files, "parsing.py", "parse_note");
+    assert_eq!(
+        call_confidence(&relations, caller, callee),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the call must bind through its import, not through the blind name fallback"
+    );
+}
+
+#[test]
+fn python_package_relative_import_resolves_to_the_sibling_module() {
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "app/storage.py",
+            "from .parsing import parse_note\n\n\ndef ingest_note(path):\n    return parse_note(path)\n",
+        ),
+        parsing_module("app/parsing.py"),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids)
+            .contains(&("app/storage.py".to_string(), "app/parsing.py".to_string())),
+        "`from .parsing import ...` names the importer's own package, not a path segment"
+    );
+    let caller = entity_id_in(&files, "app/storage.py", "ingest_note");
+    let callee = entity_id_in(&files, "app/parsing.py", "parse_note");
+    assert_eq!(
+        call_confidence(&relations, caller, callee),
+        Some(IMPORT_RESOLVED_CONFIDENCE)
+    );
+}
+
+#[test]
+fn python_dotted_package_import_resolves_through_the_repo_root() {
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "app/storage.py",
+            "from app.parsing import parse_note\n\n\ndef ingest_note(path):\n    return parse_note(path)\n",
+        ),
+        parsing_module("app/parsing.py"),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids)
+            .contains(&("app/storage.py".to_string(), "app/parsing.py".to_string())),
+        "a dotted absolute import resolves against the repository root"
+    );
+}
+
+#[test]
+fn python_package_import_resolves_to_its_init_module() {
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "app/storage.py",
+            "from app.parsing import parse_note\n\n\ndef ingest_note(path):\n    return parse_note(path)\n",
+        ),
+        parsing_module("app/parsing/__init__.py"),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids).contains(&(
+            "app/storage.py".to_string(),
+            "app/parsing/__init__.py".to_string()
+        )),
+        "a package import resolves to the package's __init__ module"
+    );
+}
+
+#[test]
+fn python_src_layout_absolute_import_resolves() {
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "src/app/storage.py",
+            "from app.parsing import parse_note\n\n\ndef ingest_note(path):\n    return parse_note(path)\n",
+        ),
+        parsing_module("src/app/parsing.py"),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids).contains(&(
+            "src/app/storage.py".to_string(),
+            "src/app/parsing.py".to_string()
+        )),
+        "a src/ layout is a source root a repository-local import resolves against"
+    );
+}
+
+#[test]
+fn a_third_party_python_import_resolves_to_nothing_local() {
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "storage.py",
+            "from requests import get\n\n\ndef fetch(url):\n    return get(url)\n",
+        ),
+        parsing_module("parsing.py"),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids).is_empty(),
+        "an import that names no repo-local module must not resolve to one"
+    );
+}
+
+#[test]
+fn an_import_bound_call_binds_to_the_imported_module_not_the_same_named_twin() {
+    // `parse_note` is defined twice. The import says which one this call means;
+    // before import resolution the name bucket was ambiguous and the call was
+    // recorded as an unresolvable external reference instead.
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "storage.py",
+            "from parsing import parse_note\n\n\ndef ingest_note(path):\n    return parse_note(path)\n",
+        ),
+        parsing_module("parsing.py"),
+        parse_with(
+            &PythonAdapter,
+            "legacy.py",
+            "def parse_note(path):\n    return None\n",
+        ),
+    ];
+    let relations = link(&files);
+
+    let caller = entity_id_in(&files, "storage.py", "ingest_note");
+    let imported = entity_id_in(&files, "parsing.py", "parse_note");
+    let twin = entity_id_in(&files, "legacy.py", "parse_note");
+
+    assert_eq!(
+        call_confidence(&relations, caller, imported),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the imported definition is the one this call reaches"
+    );
+    assert!(
+        call_confidence(&relations, caller, twin).is_none(),
+        "the same-named definition in an unimported module must not be linked"
+    );
+}
+
+#[test]
+fn an_unimported_ambiguous_name_is_left_unresolved() {
+    // No import binds `parse_note` here, and two modules define it. Nothing in
+    // the source says which one runs, so the linker must emit no call edge to
+    // either rather than pick one.
+    let files = vec![
+        parse_with(
+            &PythonAdapter,
+            "storage.py",
+            "def ingest_note(path):\n    return parse_note(path)\n",
+        ),
+        parsing_module("parsing.py"),
+        parse_with(
+            &PythonAdapter,
+            "legacy.py",
+            "def parse_note(path):\n    return None\n",
+        ),
+    ];
+    let relations = link(&files);
+
+    let caller = entity_id_in(&files, "storage.py", "ingest_note");
+    for module in ["parsing.py", "legacy.py"] {
+        let candidate = entity_id_in(&files, module, "parse_note");
+        assert!(
+            call_confidence(&relations, caller, candidate).is_none(),
+            "an ambiguous unimported name must not be bound to {module}"
+        );
+    }
+}
+
+#[test]
+fn javascript_relative_import_produces_an_artifact_import_edge() {
+    let files = vec![
+        parse_with(
+            &JavaScriptAdapter,
+            "storage.js",
+            "import { parseNote } from './parsing.js';\nexport function ingestNote(p) { return parseNote(p); }\n",
+        ),
+        parse_with(
+            &JavaScriptAdapter,
+            "parsing.js",
+            "export function parseNote(p) { return {}; }\n",
+        ),
+    ];
+    let (relations, artifact_ids) = link_with_identities(&files);
+
+    assert!(
+        artifact_import_paths(&relations, &artifact_ids)
+            .contains(&("storage.js".to_string(), "parsing.js".to_string())),
+        "a relative JavaScript import produces storage.js -> parsing.js Imports"
+    );
+
+    let caller = entity_id_in(&files, "storage.js", "ingestNote");
+    let callee = entity_id_in(&files, "parsing.js", "parseNote");
+    assert!(
+        call_confidence(&relations, caller, callee).is_some(),
+        "the imported call resolves across the file boundary"
+    );
+}
+
+#[test]
+fn javascript_same_named_twin_does_not_steal_an_imported_call() {
+    let files = vec![
+        parse_with(
+            &JavaScriptAdapter,
+            "storage.js",
+            "import { parseNote } from './parsing.js';\nexport function ingestNote(p) { return parseNote(p); }\n",
+        ),
+        parse_with(
+            &JavaScriptAdapter,
+            "parsing.js",
+            "export function parseNote(p) { return {}; }\n",
+        ),
+        parse_with(
+            &JavaScriptAdapter,
+            "legacy.js",
+            "export function parseNote(p) { return null; }\n",
+        ),
+    ];
+    let relations = link(&files);
+
+    let caller = entity_id_in(&files, "storage.js", "ingestNote");
+    let imported = entity_id_in(&files, "parsing.js", "parseNote");
+    let twin = entity_id_in(&files, "legacy.js", "parseNote");
+    assert!(call_confidence(&relations, caller, imported).is_some());
+    assert!(
+        call_confidence(&relations, caller, twin).is_none(),
+        "the unimported twin must not be linked"
+    );
+}


### PR DESCRIPTION
Two mechanisms kept a fresh-install graph from knowing what calls what across
a file boundary. This PR fixes one of them and makes the other visible instead
of leaving it to be inferred from a relations-per-entity ratio.

**Python imports never resolved to a repository file.** Python module paths are
dotted rather than path-shaped in both directions: `app.parsing` names a module
under a source root and `.parsing` names a sibling inside the importer's own
package. Neither shape survived `resolve_module_path` in the cross-file linker.
The relative branch joined `.parsing` onto the importer's directory as a literal
path segment, and the non-relative branch only knew header, JS package, Java, and
Go layouts. Every Python import therefore resolved to nothing: Python graphs
carried no artifact-level `Imports` edge at all, and an imported call fell
through to the blind cross-file name match. Measured on a two-file fixture
through the real adapter and the real linker, that fallback bound the call at
0.7 when exactly one module defined the name, and bound nothing at all once a
second module defined it too, minting a cross-repo external-reference placeholder
for a call whose target sat in the same repository. That is the reported
`find_references` zero.

Absolute imports now resolve against the repository's source roots and relative
ones against the importer's own package, climbing one package per leading dot
beyond the first. Only files the linker already knows can be named, so a
third-party or standard-library import still resolves to nothing, and an import
answered by more than one source root is left unresolved rather than bound to a
guess.

**Where a gap remains, it is now stated.** `kin graph status` counts, from graph
truth, how many entity-to-entity relations have endpoints in different files and
prints it beside the relation-kind breakdown with the artifact import total. A
graph holding entities but no cross-file edge says so outright and names what it
costs: `find_references` and `trace_data_flow` cannot leave the file they start
in. `kin doctor` gains a `cross_file_enrichment` row, because reference and
override edges come from language-server evidence rather than a single-file
parse; the row names the language and the binaries that would provide it, says
that import and call edges are still resolved from source, and reports Stale
rather than Missing, since a missing server degrades an install without breaking
it.

Both surfaces speak one vocabulary, `kin_core::cross_file_coverage`, whose
serialized `cross_file_coverage` object carries the same measurement for the
retrieval envelope that decides whether an empty result is safe to report as an
absence.

**Not fixed here, and now measurable:** the live ingest path never runs the
cross-file linker at all. `resolve_relations` in the index pipeline matches a
relation's source and destination against only the parsed file's own entities,
pushes every cross-file candidate onto `unresolved_relations`, and the reconciler
that consumes the indexed file never reads that field. The whole-tree linker runs
only when `kin init` imports an existing git history, so a file written after
init gains no cross-file edge from parsing however well its imports resolve. The
disclosure this PR adds is what makes that state legible on a fresh install; the
fix belongs in its own change.

Part of FIR-2354
