### PR TITLE
Fix four fresh-install papercuts: venv admission, context-pack budget, and the MCP roots refusal

### DIFF
--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -71,7 +71,7 @@ pub use repository::{
     should_track_host_relative_path, tracked_paths_covered_by_ignore,
     tracked_paths_retracted_by_ignore, CompleteRepositoryScan, CompleteScanToken,
     IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore, RepositoryScanDiagnostics,
-    ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
+    ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES, PYTHON_VIRTUALENV_MARKER,
 };
 pub use support::{compute_coverage_report, CoverageReport};
 pub use watcher::{FileEvent, FileWatcher};

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -9,7 +9,9 @@
 //! metadata is inherently excluded, and the compiler/packager output named by
 //! [`DEFAULT_IGNORED_NAMES`] is excluded by default because the graph is the
 //! system of record for source truth, not for derived bytes that any build
-//! reproduces.
+//! reproduces. A Python virtual environment is excluded by the same default on
+//! different evidence: it is recognized by [`PYTHON_VIRTUALENV_MARKER`] rather
+//! than by its directory name, which no rule could predict.
 //!
 //! An ignore rule is a statement about IO, not only about membership. Nothing
 //! the effective rules exclude is opened, read, hashed, or verified here, and
@@ -233,6 +235,11 @@ impl CompleteRepositoryScan {
 /// so in its `.kinignore`. The rule for adding an entry here is that the name
 /// must be unambiguously derived output across the ecosystems that use it.
 ///
+/// `venv` and `env` are the same problem and get a different answer:
+/// [`PYTHON_VIRTUALENV_MARKER`] recognizes a virtual environment by the file
+/// PEP 405 requires it to carry, so an environment is excluded whatever it was
+/// named while an ordinary directory sharing the name stays admitted.
+///
 /// A `!` rule re-admits anything here, and re-admission is scoped: it cancels
 /// only the rules matching at or above its own boundary, so `!target` does not
 /// also re-admit `target/node_modules`.
@@ -242,6 +249,8 @@ pub const DEFAULT_IGNORED_NAMES: &[&str] = &[
     "target",
     // Package-manager dependency trees.
     "node_modules",
+    "bower_components",
+    "__pypackages__",
     // JavaScript and Python packaging output.
     "dist",
     // Python bytecode and environment/tool caches.
@@ -253,6 +262,7 @@ pub const DEFAULT_IGNORED_NAMES: &[&str] = &[
     ".mypy_cache",
     ".ruff_cache",
     ".ipynb_checkpoints",
+    ".eggs",
     // JavaScript framework and bundler caches.
     ".next",
     ".nuxt",
@@ -268,6 +278,25 @@ pub const DEFAULT_IGNORED_NAMES: &[&str] = &[
     // Finder metadata.
     ".DS_Store",
 ];
+
+/// The file PEP 405 requires at the root of every Python virtual environment.
+///
+/// A name list cannot answer this one. `python3 -m venv <name>` takes the name
+/// from its caller, `.venv` and `venv` and `env` are all in common use, and two
+/// of those three routinely name ordinary source directories, so excluding them
+/// by name would either miss real environments or delete real code from the
+/// graph. The marker is the interpreter's own declaration that a directory is a
+/// materialized environment rather than authored source, and `python3 -m venv`
+/// writes it before it installs anything, so a fresh environment is recognized
+/// on the first walk that sees it and never races the live watcher for the
+/// semantic graph.
+///
+/// The check is scoped to untracked directories a walk is about to descend
+/// into, so it can only decline to admit something new. It never retracts
+/// graph-owned truth, which is why the host-blind retraction predicate in
+/// [`tracked_paths_retracted_by_ignore`] does not consult it and cannot drift
+/// from it: for a tracked path this rule is inert by construction.
+pub const PYTHON_VIRTUALENV_MARKER: &str = "pyvenv.cfg";
 
 /// Roots already warned about a missing `.kinignore` in this process.
 static WARNED_ROOTS: std::sync::OnceLock<std::sync::Mutex<BTreeSet<PathBuf>>> =
@@ -432,9 +461,10 @@ impl RepositoryIgnore {
         }
         Some(format!(
             "no .kinignore: admission is running on {} built-in default excludes \
-             ({}). Derived output outside those names will be ingested as \
-             repository truth. Write a .kinignore to state this repository's \
-             rules, and use `!name` to re-admit a default.",
+             ({}), plus any directory carrying a {PYTHON_VIRTUALENV_MARKER}. \
+             Derived output outside those names will be ingested as repository \
+             truth. Write a .kinignore to state this repository's rules, and use \
+             `!name` to re-admit a default.",
             DEFAULT_IGNORED_NAMES.len(),
             DEFAULT_IGNORED_NAMES.join(", ")
         ))
@@ -501,6 +531,17 @@ impl RepositoryIgnore {
         let bytes = path.as_bytes();
         let floor = self.readmit_floor(bytes).unwrap_or(0);
         Self::rules_match_below(&self.names, &self.prefixes, bytes, floor)
+    }
+
+    /// Whether a `!` rule re-admits `path` itself or an ancestor of it.
+    ///
+    /// This is how a repository overrides an exclusion that no pattern could
+    /// have named, such as the virtual-environment marker: `!venv` in
+    /// `.kinignore` re-admits that environment whole. A rule pointing strictly
+    /// deeper is not an override of the boundary above it, so it does not
+    /// count here.
+    pub fn readmits(&self, path: &RepoPath) -> bool {
+        self.readmit_floor(path.as_bytes()).is_some()
     }
 
     /// Whether the walk must descend into an otherwise-excluded `directory`
@@ -785,7 +826,7 @@ pub fn scan_repository_preserving_graph_only<'a>(
         entries: BTreeMap::new(),
         diagnostics: RepositoryScanDiagnostics::default(),
     };
-    scanner.walk(root)?;
+    scanner.walk(root, false)?;
     scanner.diagnostics.admitted_entries = scanner.entries.len();
     scanner.diagnostics.graph_only_entries_preserved = scanner.graph_only_paths.len();
     scanner.diagnostics.ignored_tracked_entries_unverified = scanner.unverified_ignored_paths.len();
@@ -852,6 +893,16 @@ impl Scanner<'_> {
         true
     }
 
+    /// Whether `directory` is a Python virtual environment this walk declines
+    /// to admit.
+    ///
+    /// The re-admission test comes first so an operator override costs no host
+    /// IO, and so the answer for a directory the repository re-admitted is the
+    /// same whether or not the marker happens to be there.
+    fn excludes_python_virtualenv(&self, repo_path: &RepoPath, host_path: &Path) -> bool {
+        !self.ignore.readmits(repo_path) && host_path.join(PYTHON_VIRTUALENV_MARKER).is_file()
+    }
+
     fn is_tracked_or_contains_tracked(&self, path: &RepoPath) -> bool {
         let prefix = path.as_bytes();
         self.tracked_paths
@@ -860,7 +911,16 @@ impl Scanner<'_> {
             .any(|tracked| tracked == path || tracked.as_bytes()[prefix.len()..].starts_with(b"/"))
     }
 
-    fn walk(&mut self, directory: &Path) -> Result<(), IncompleteRepositoryScan> {
+    /// `within_excluded_environment` marks a descent that only happened because
+    /// graph truth tracks something below an excluded Python environment. The
+    /// walk reaches those tracked paths and admits nothing else on the way, so
+    /// one file committed into an environment before this rule existed cannot
+    /// re-open the whole site-packages tree behind it.
+    fn walk(
+        &mut self,
+        directory: &Path,
+        within_excluded_environment: bool,
+    ) -> Result<(), IncompleteRepositoryScan> {
         self.diagnostics.directories_visited += 1;
         let entries = fs::read_dir(directory)
             .map_err(|error| self.fail(directory, "read directory", error))?;
@@ -892,10 +952,8 @@ impl Scanner<'_> {
             let ignored = self.ignore.matches(&repo_path);
 
             if file_type.is_dir() {
-                if ignored
-                    && !self.is_tracked_or_contains_tracked(&repo_path)
-                    && !self.ignore.readmits_below(&repo_path)
-                {
+                let holds_tracked = self.is_tracked_or_contains_tracked(&repo_path);
+                if ignored && !holds_tracked && !self.ignore.readmits_below(&repo_path) {
                     self.diagnostics.ignored_untracked_entries += 1;
                     continue;
                 }
@@ -907,12 +965,38 @@ impl Scanner<'_> {
                 // truth still outranks the rules, so a directory holding a
                 // tracked path is walked and only its untracked leaves are
                 // skipped below.
-                if !self.is_tracked_or_contains_tracked(&repo_path)
-                    && self.policy_excludes_untracked(&repo_path, true)
-                {
+                if !holds_tracked && self.policy_excludes_untracked(&repo_path, true) {
                     continue;
                 }
-                self.walk(&host_path)?;
+                // A materialized Python environment, recognized by the marker
+                // its interpreter writes rather than by a name anyone chose.
+                // Skipped whole for the same reason a policy-excluded directory
+                // is: nothing beneath an excluded environment is authored
+                // source, so descending would only cost the reads. Re-admitting
+                // the environment directory itself (`!venv`) is the override,
+                // and it is checked before the host is touched at all.
+                let excluded_environment = self.excludes_python_virtualenv(&repo_path, &host_path);
+                if (excluded_environment || within_excluded_environment) && !holds_tracked {
+                    self.diagnostics.ignored_untracked_entries += 1;
+                    continue;
+                }
+                self.walk(
+                    &host_path,
+                    within_excluded_environment || excluded_environment,
+                )?;
+                continue;
+            }
+
+            // A leaf inside an excluded environment, reached only because graph
+            // truth tracks something down here. Tracked identity is observed as
+            // it always is; everything else stays out, so the descent admits
+            // exactly what it came for. Checked before `ignored` handling so a
+            // tracked path can never fall into the counter for an untracked one.
+            if within_excluded_environment
+                && !self.tracked_paths.contains(&repo_path)
+                && !self.ignore.readmits(&repo_path)
+            {
+                self.diagnostics.ignored_untracked_entries += 1;
                 continue;
             }
 
@@ -1612,6 +1696,141 @@ mod tests {
             );
         }
         assert_eq!(everything.len(), derived.len() + 1);
+    }
+
+    /// Materialize the directory `python3 -m venv <name>` produces, down to the
+    /// marker file PEP 405 requires and a plausible site-packages leaf.
+    fn create_virtualenv(root: &Path, name: &str) {
+        let env = root.join(name);
+        fs::create_dir_all(env.join("lib/python3.11/site-packages/pytest")).unwrap();
+        fs::create_dir_all(env.join("bin")).unwrap();
+        fs::write(
+            env.join(PYTHON_VIRTUALENV_MARKER),
+            b"home = /usr/bin\nversion = 3.11.2\n",
+        )
+        .unwrap();
+        fs::write(env.join("bin/activate"), b"# activate").unwrap();
+        fs::write(
+            env.join("lib/python3.11/site-packages/pytest/__init__.py"),
+            b"__version__ = '9.1.1'",
+        )
+        .unwrap();
+    }
+
+    /// A fresh repository with no user action of any kind must keep a virtual
+    /// environment out of the graph, whichever of the three common names its
+    /// author used. `.venv` is covered by name; `venv` and `env` are names that
+    /// also occur as ordinary source directories, so only the marker can tell
+    /// the two apart.
+    #[test]
+    fn a_freshly_created_virtualenv_is_excluded_without_any_user_action() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for name in [".venv", "venv", "env"] {
+            create_virtualenv(root, name);
+        }
+        fs::write(root.join("app.py"), b"print('hi')").unwrap();
+
+        // No .kinignore, no .gitignore: exactly what `kin init` leaves behind.
+        let admitted = scan(root);
+        assert!(admitted.entry(&path("app.py")).is_some());
+        for name in [".venv", "venv", "env"] {
+            assert!(
+                admitted
+                    .entry(&path(&format!("{name}/bin/activate")))
+                    .is_none(),
+                "{name} leaked into the graph"
+            );
+            assert!(
+                admitted
+                    .entry(&path(&format!(
+                        "{name}/lib/python3.11/site-packages/pytest/__init__.py"
+                    )))
+                    .is_none(),
+                "{name} site-packages leaked into the graph"
+            );
+        }
+        assert_eq!(
+            admitted.len(),
+            1,
+            "only the authored file belongs in the graph: {:?}",
+            admitted.paths().collect::<Vec<_>>()
+        );
+
+        // Two-sided: the same names WITHOUT the marker are ordinary source and
+        // stay admitted, so the assertions above describe the marker rather
+        // than a name list that would have deleted real code.
+        let sources = tempfile::tempdir().unwrap();
+        let sources = sources.path();
+        for name in ["venv", "env"] {
+            fs::create_dir_all(sources.join(name)).unwrap();
+            fs::write(sources.join(name).join("__init__.py"), b"# real source").unwrap();
+        }
+        let admitted = scan(sources);
+        assert!(admitted.entry(&path("venv/__init__.py")).is_some());
+        assert!(admitted.entry(&path("env/__init__.py")).is_some());
+    }
+
+    /// The escape hatch has to reach an exclusion no pattern named, or a
+    /// repository that deliberately tracks a checked-in environment has no way
+    /// back. `!venv` in `.kinignore` re-admits the environment whole.
+    #[test]
+    fn a_readmit_rule_overrides_the_virtualenv_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        create_virtualenv(root, "venv");
+        create_virtualenv(root, "tools/env");
+
+        fs::write(root.join(".kinignore"), b"!venv\n").unwrap();
+        let ignore = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &ignore, std::iter::empty()).unwrap();
+        assert!(
+            scan.entry(&path("venv/bin/activate")).is_some(),
+            "!venv did not re-admit the environment it names"
+        );
+        assert!(
+            scan.entry(&path("tools/env/bin/activate")).is_none(),
+            "re-admitting one environment must not re-admit the others"
+        );
+
+        // Falsification: drop the rule and the same fixture loses the tree.
+        fs::write(root.join(".kinignore"), b"# nothing re-admitted\n").unwrap();
+        let none = RepositoryIgnore::load(root).unwrap();
+        let scan = scan_repository(root, &none, std::iter::empty()).unwrap();
+        assert!(scan.entry(&path("venv/bin/activate")).is_none());
+    }
+
+    /// Graph truth outranks the marker exactly as it outranks every other
+    /// admission rule: a repository that already tracks a path inside an
+    /// environment keeps observing it, so the rule can never turn into a silent
+    /// retraction of what the graph already owns.
+    #[test]
+    fn the_virtualenv_marker_never_retracts_already_tracked_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        create_virtualenv(root, "venv");
+        let tracked = path("venv/bin/activate");
+
+        let ignore = RepositoryIgnore::default();
+        let scan = scan_repository(root, &ignore, [&tracked]).unwrap();
+        assert!(
+            scan.entry(&tracked).is_some(),
+            "a tracked path was dropped by a rule that only governs admission"
+        );
+        assert!(scan.missing_tracked_paths([&tracked]).is_empty());
+        assert!(
+            tracked_paths_retracted_by_ignore(&ignore, [&tracked], std::iter::empty()).is_empty(),
+            "the marker must not appear in the retraction predicate"
+        );
+
+        // Reaching the tracked path must not re-open the environment around it.
+        // One file committed into a venv before this rule existed would
+        // otherwise drag all of site-packages back in on every pass.
+        assert_eq!(
+            scan.paths().collect::<Vec<_>>(),
+            [&tracked],
+            "the descent admitted more than the tracked path it came for"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/artifacts.rs
+++ b/crates/kin-mcp/src/handlers/artifacts.rs
@@ -56,6 +56,11 @@ or content-addressed blob is missing. It never reads the working directory.";
 /// wants to correlate against `kin log`, a formula, or another tool's input has
 /// to be reassembled by hand first.
 ///
+/// Shared with the provenance seam in `common`, so the one encoding covers
+/// every agent-facing payload that carries a tree entry rather than only this
+/// tool's. `get_context_pack` is fitted to a token budget and was spending it
+/// on one such array per dependency.
+///
 /// The tag and field names mirror [`TreeEntry`] exactly, so only the encoding of
 /// the ids changes. Rendering is `Display`, which is lowercase hex and the same
 /// spelling `Hash256::from_hex` parses, so what this prints round-trips.
@@ -69,7 +74,7 @@ or content-addressed blob is missing. It never reads the working directory.";
 /// being thrown away.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-enum TreeEntryWire {
+pub(crate) enum TreeEntryWire {
     Blob {
         hash: String,
         executable: bool,

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1308,6 +1308,13 @@ pub struct ExactEntitySource {
 /// Every body-serving surface routes through this, so the shape cannot drift
 /// between `get_entity_source`, `get_entity`, and the context pack the way the
 /// snippet field name did between the two `semantic_locate` arms.
+///
+/// Every content-addressed id here is hex, never the model's own byte-array
+/// serialization. A `Hash256` derives `Serialize` over `[u8; 32]`, so a change
+/// id reached an agent as 32 decimal numbers: about four times the bytes of the
+/// hex it stands for, and not the spelling any Kin surface parses back. This
+/// seam is per-dependency in a context pack, which is documented as fitted to a
+/// token budget, so the waste scaled with the pack.
 pub fn source_provenance_fields(
     source: &ExactEntitySource,
 ) -> serde_json::Map<String, serde_json::Value> {
@@ -1318,7 +1325,10 @@ pub fn source_provenance_fields(
     );
     match &source.provenance {
         SourceProvenance::Committed { change_id } => {
-            fields.insert("source_change_id".into(), serde_json::json!(change_id));
+            fields.insert(
+                "source_change_id".into(),
+                serde_json::json!(change_id.to_string()),
+            );
         }
         SourceProvenance::Workspace {
             tree_hash,
@@ -1333,7 +1343,10 @@ pub fn source_provenance_fields(
                 serde_json::json!(tree_hash.to_string()),
             );
             fields.insert("workspace_generation".into(), serde_json::json!(generation));
-            fields.insert("base_change_id".into(), serde_json::json!(base_change_id));
+            fields.insert(
+                "base_change_id".into(),
+                serde_json::json!(base_change_id.to_string()),
+            );
         }
     }
     fields.insert(
@@ -1342,7 +1355,10 @@ pub fn source_provenance_fields(
     );
     fields.insert("artifact_id".into(), serde_json::json!(source.artifact_id));
     fields.insert("artifact_path".into(), serde_json::json!(source.path));
-    fields.insert("artifact_entry".into(), serde_json::json!(source.entry));
+    fields.insert(
+        "artifact_entry".into(),
+        serde_json::json!(super::artifacts::TreeEntryWire::from(source.entry)),
+    );
     fields
 }
 

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2819,6 +2819,85 @@ mod tests {
         );
     }
 
+    /// Name every array of 20 or more numbers under `value`.
+    ///
+    /// That is the shape a `Hash256` (32) or a sha1 `GitObjectId` (20) takes
+    /// when it reaches an agent through the model's derived `Serialize`. No
+    /// legitimate field in a retrieval payload is a long run of bare integers,
+    /// so the shape itself is the defect and no field name has to be enumerated
+    /// for a new one to be caught.
+    fn decimal_byte_arrays(value: &serde_json::Value, at: &str, found: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Array(items) => {
+                if items.len() >= 20 && items.iter().all(serde_json::Value::is_number) {
+                    found.push(format!("{at} ({} numbers)", items.len()));
+                }
+                for (index, item) in items.iter().enumerate() {
+                    decimal_byte_arrays(item, &format!("{at}[{index}]"), found);
+                }
+            }
+            serde_json::Value::Object(fields) => {
+                for (key, item) in fields {
+                    decimal_byte_arrays(item, &format!("{at}.{key}"), found);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// `get_context_pack` is documented as fitted to a token budget, and it was
+    /// spending that budget on `artifact_entry.hash` and `base_change_id`
+    /// serialized as 32-element decimal arrays, one number per line when the
+    /// response is pretty-printed. Hex costs a quarter of that and is the only
+    /// spelling Kin's own inputs parse back.
+    #[test]
+    fn a_context_pack_never_spends_its_budget_on_decimal_byte_arrays() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "export function budgeted_probe_5c1a(value: number): boolean {\n  return value > 0;\n}\n";
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
+
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let sessions = SessionRegistry::new();
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(entity.id.to_string()),
+        )]);
+
+        let value = tool_result_json(
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap(),
+        );
+
+        // Positive control first: the pack really does carry the fields this
+        // test is about, so a payload that simply lost them cannot pass.
+        // Dependencies render through the same seam as the focal, so covering
+        // the focal covers every entry the pack can hold.
+        let hash = value["focal_entity"]["artifact_entry"]["hash"]
+            .as_str()
+            .unwrap_or_else(|| panic!("the pack must carry the focal artifact entry: {value}"));
+        assert_eq!(hash.len(), 64, "a blob hash is 64 hex characters: {hash}");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "the blob hash must be hex: {hash}"
+        );
+
+        let mut found = Vec::new();
+        decimal_byte_arrays(&value, "context_pack", &mut found);
+        assert!(
+            found.is_empty(),
+            "the pack spends its token budget on decimal byte arrays at {found:?}: {value}"
+        );
+    }
+
     /// Stand-in for the context builder's token-accounting projection, so the
     /// tests above assert against the exact text that used to leak into `body`.
     fn project_full_body_stub(entity: &Entity) -> String {

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -306,15 +306,34 @@ where
             }
 
             // The client moved to a workspace we could not bind. Refuse every
-            // tool call until a later roots change lands on a Kin repository:
-            // answering from the repository the client left would return a
-            // confident, well-formed result about the wrong codebase.
+            // tool call until the root becomes bindable: answering from the
+            // repository the client left would return a confident, well-formed
+            // result about the wrong codebase.
+            //
+            // The verdict is re-derived here rather than read out of the state
+            // it was recorded in. It was computed once, when the roots changed,
+            // and nothing about the announced root is fixed: `kin init` can run
+            // there, a mount can appear, a container path can be made to exist.
+            // A cached refusal outlives every one of those, so a server that
+            // was right at roots-change time keeps refusing a workspace it
+            // could now serve, and the only recovery is restarting the process.
+            // Re-binding costs nothing that matters, because every call in this
+            // state is being refused anyway.
             if method == Some("tools/call") && binding.is_mismatched() {
-                if let Some(response) = binding.repo_mismatch_response(&value) {
-                    let response_json = serde_json::to_string(&response).map_err(McpError::Json)?;
-                    write_stdio_message(&mut *writer, &response_json, framed).await?;
+                if let Some(binder) = repo_binder.as_ref() {
+                    let roots = binding.mismatched_roots();
+                    if !roots.is_empty() {
+                        apply_workspace_roots(binder, roots, &mut binding).await;
+                    }
                 }
-                continue;
+                if binding.is_mismatched() {
+                    if let Some(response) = binding.repo_mismatch_response(&value) {
+                        let response_json =
+                            serde_json::to_string(&response).map_err(McpError::Json)?;
+                        write_stdio_message(&mut *writer, &response_json, framed).await?;
+                    }
+                    continue;
+                }
             }
 
             // Our own `roots/list` response returning from the client: bind the
@@ -478,6 +497,18 @@ impl RepoBindingState {
         });
     }
 
+    /// The roots the client announced that this server could not bind.
+    ///
+    /// Empty when nothing is mismatched. Handed back so a later call can put
+    /// the same roots through the binder again instead of trusting a verdict
+    /// reached before anything on the host had a chance to change.
+    fn mismatched_roots(&self) -> Vec<PathBuf> {
+        self.mismatch
+            .as_ref()
+            .map(|mismatch| mismatch.requested_roots.clone())
+            .unwrap_or_default()
+    }
+
     /// Structured refusal for a `tools/call` that arrived while the client's
     /// workspace and this server's binding disagree. `None` for a malformed
     /// call with no id, which has no response channel — the caller still drops
@@ -514,8 +545,8 @@ impl WorkspaceMismatch {
             "kin-mcp refuses '{tool}': the MCP client's workspace roots changed to [{requested}], \
              and none of them is a Kin repository this server can bind, so Kin is still bound to \
              {bound}. Answering would return a confident result about a repository you are no \
-             longer looking at. Run `kin init .` in the new workspace, or restart the MCP server \
-             from it (or with --repo <path> / KIN_MCP_REPO=<path>)."
+             longer looking at. Run `kin init .` in the new workspace, or restart the MCP \
+             server from it (or with --repo <path> / KIN_MCP_REPO=<path>)."
         )
     }
 }
@@ -2185,8 +2216,12 @@ mod tests {
     #[tokio::test]
     async fn tool_calls_fail_loud_when_the_new_workspace_cannot_be_bound() {
         // Bind repo A, then switch to a workspace with no bindable Kin repo.
-        let (binder, _calls) = ScriptedBinder::install(vec![
+        // The third outcome is the tool call's own re-check, which must find
+        // the root still unbindable and leave the refusal exactly as it was:
+        // re-checking changes when the verdict is taken, never what it is.
+        let (binder, calls) = ScriptedBinder::install(vec![
             Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            None,
             None,
         ]);
 
@@ -2216,6 +2251,63 @@ mod tests {
         assert!(
             text.contains("/repo/a"),
             "refusal must name the repository still bound: {text}"
+        );
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            3,
+            "the tool call must re-check the root before refusing"
+        );
+    }
+
+    /// The refusal was computed when the roots changed and then cached, so a
+    /// root that became bindable afterwards kept being refused for the life of
+    /// the process. The reported shape: a container registration whose
+    /// announced host path was made to exist, with no way to restart the
+    /// client's MCP server.
+    #[tokio::test]
+    async fn a_root_that_becomes_bindable_self_heals_on_the_next_tool_call() {
+        let (binder, calls) = ScriptedBinder::install(vec![
+            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            None,
+            Some(bound_repo("/host/path", "http://127.0.0.1:4222")),
+        ]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/repo/a"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/host/path"]),
+                // No roots change and no restart in between: only the host
+                // changed under a root the client already announced.
+                tool_call(21, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+        )
+        .await;
+
+        let calls = calls.lock().unwrap().clone();
+        assert_eq!(
+            calls.len(),
+            3,
+            "the tool call must put the recorded roots through the binder again: {calls:?}"
+        );
+        assert_eq!(
+            calls[2],
+            vec![PathBuf::from("/host/path")],
+            "the re-check must use the roots the client announced, not invent new ones"
+        );
+
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(21))
+            .expect("the tool call must be answered");
+        let text = tool_error_text(answer);
+        assert!(
+            text.contains("not enabled in this MCP profile"),
+            "a root that became bindable must clear the refusal without a restart: {text}"
         );
     }
 

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -280,6 +280,13 @@ where
                 client_supports_roots = value.pointer("/params/capabilities/roots").is_some();
             }
 
+            // Whether `--repo`/`KIN_MCP_REPO` pinned this server's repository.
+            // Read per message rather than once: the startup binding settles
+            // behind this loop, so the pin is not knowable when it starts.
+            let repo_pinned = startup
+                .as_ref()
+                .is_some_and(|startup| startup.pinned_by_operator());
+
             // A `tools/call` racing the launcher's startup binding gets a
             // bounded moment for a warm daemon to bind, then an honest
             // still-starting answer: never minutes of silence, and never a
@@ -323,7 +330,7 @@ where
                 if let Some(binder) = repo_binder.as_ref() {
                     let roots = binding.mismatched_roots();
                     if !roots.is_empty() {
-                        apply_workspace_roots(binder, roots, &mut binding).await;
+                        apply_workspace_roots(binder, roots, &mut binding, repo_pinned).await;
                     }
                 }
                 if binding.is_mismatched() {
@@ -343,8 +350,13 @@ where
             {
                 roots_request_state.complete();
                 if let Some(binder) = repo_binder.as_ref() {
-                    apply_workspace_roots(binder, parse_workspace_roots(&value), &mut binding)
-                        .await;
+                    apply_workspace_roots(
+                        binder,
+                        parse_workspace_roots(&value),
+                        &mut binding,
+                        repo_pinned,
+                    )
+                    .await;
                 }
                 continue;
             }
@@ -390,6 +402,7 @@ async fn apply_workspace_roots(
     binder: &RepoBinder,
     roots: Vec<PathBuf>,
     binding: &mut RepoBindingState,
+    repo_pinned: bool,
 ) {
     if roots.is_empty() {
         // No open folder is not the same as a different folder: there is no
@@ -421,7 +434,7 @@ async fn apply_workspace_roots(
                 "kin-mcp: the client's workspace roots changed to a workspace with no bindable Kin \
                  repository; refusing tool calls instead of answering from the previous repository"
             );
-            binding.mark_mismatch(roots);
+            binding.mark_mismatch(roots, repo_pinned);
         }
         None => {
             tracing::info!("kin-mcp: no Kin repository among the client's workspace roots");
@@ -457,6 +470,9 @@ struct RepoBindingState {
 struct WorkspaceMismatch {
     bound_repo: Option<PathBuf>,
     requested_roots: Vec<PathBuf>,
+    /// Whether `--repo`/`KIN_MCP_REPO` pinned this server's repository, which
+    /// decides which remedies the refusal is allowed to offer.
+    repo_pinned: bool,
 }
 
 impl RepoBindingState {
@@ -490,10 +506,11 @@ impl RepoBindingState {
         self.mismatch = None;
     }
 
-    fn mark_mismatch(&mut self, requested_roots: Vec<PathBuf>) {
+    fn mark_mismatch(&mut self, requested_roots: Vec<PathBuf>, repo_pinned: bool) {
         self.mismatch = Some(WorkspaceMismatch {
             bound_repo: self.repo_root.clone(),
             requested_roots,
+            repo_pinned,
         });
     }
 
@@ -545,9 +562,30 @@ impl WorkspaceMismatch {
             "kin-mcp refuses '{tool}': the MCP client's workspace roots changed to [{requested}], \
              and none of them is a Kin repository this server can bind, so Kin is still bound to \
              {bound}. Answering would return a confident result about a repository you are no \
-             longer looking at. Run `kin init .` in the new workspace, or restart the MCP \
-             server from it (or with --repo <path> / KIN_MCP_REPO=<path>)."
+             longer looking at. {}",
+            self.remedy()
         )
+    }
+
+    /// The fixes that actually apply to this server.
+    ///
+    /// A repo-bound server is not offered `kin init .`, and the omission is the
+    /// point rather than brevity. `--repo`/`KIN_MCP_REPO` is how a server is
+    /// registered against a repository it reaches over a boundary the client
+    /// does not share: a docker-exec registration, a remote checkout. The path
+    /// the client announces is then a HOST path this process may never be able
+    /// to see, so running `kin init` there does not repair the mismatch. It
+    /// creates a second, empty repository beside the real one and leaves the
+    /// refusal exactly where it was.
+    fn remedy(&self) -> &'static str {
+        if self.repo_pinned {
+            "This server is pinned by --repo / KIN_MCP_REPO, so point the pin at the repository \
+             you are working in and restart the MCP server, or open that repository's own path \
+             in your client."
+        } else {
+            "Run `kin init .` in the new workspace, or restart the MCP server from it (or with \
+             --repo <path> / KIN_MCP_REPO=<path>)."
+        }
     }
 }
 
@@ -1975,7 +2013,7 @@ mod tests {
             "a settled binding must not re-ask on every trigger"
         );
 
-        binding.mark_mismatch(vec![PathBuf::from("/elsewhere")]);
+        binding.mark_mismatch(vec![PathBuf::from("/elsewhere")], false);
         assert!(
             binding.wants_workspace_roots(),
             "bound to a repository the client left is no better than unbound"
@@ -2308,6 +2346,70 @@ mod tests {
         assert!(
             text.contains("not enabled in this MCP profile"),
             "a root that became bindable must clear the refusal without a restart: {text}"
+        );
+    }
+
+    /// Drive the loop with an operator pin that bound at startup, then move the
+    /// client to a root this server cannot bind, and return the refusal text.
+    async fn pinned_workspace_refusal(repo_pinned: bool) -> String {
+        let startup = StartupDaemonBinding::new();
+        startup.resolve_bound(
+            bound_repo("/repo/pinned", "http://127.0.0.1:4111"),
+            repo_pinned,
+        );
+        // Two `None`s: the roots change that records the mismatch, and the
+        // tool call's own re-check.
+        let (binder, _calls) = ScriptedBinder::install(vec![None, None]);
+
+        let responses = drive_daemon_loop_with_startup(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/host/only/path"]),
+                tool_call(31, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+            Some(startup),
+        )
+        .await;
+
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(31))
+            .expect("the tool call must be answered");
+        tool_error_text(answer)
+    }
+
+    /// `kin init .` is wrong advice for a repo-bound server, and wrong in the
+    /// expensive direction: the announced root is a host path a docker-exec or
+    /// remote registration may never be able to see, so following the hint
+    /// creates a second empty repository beside the real one and leaves the
+    /// refusal in place.
+    #[tokio::test]
+    async fn a_repo_bound_refusal_does_not_suggest_kin_init() {
+        let pinned = pinned_workspace_refusal(true).await;
+        assert!(
+            !pinned.contains("kin init"),
+            "a repo-bound server must not send the user to create a second repository: {pinned}"
+        );
+        assert!(
+            pinned.contains("--repo") && pinned.contains("KIN_MCP_REPO"),
+            "the remedy that does apply must survive: {pinned}"
+        );
+        assert!(
+            pinned.contains("semantic_locate") && pinned.contains("/host/only/path"),
+            "the refusal must still name the tool and the workspace: {pinned}"
+        );
+
+        // Falsification: an unpinned server reaches the same refusal by the
+        // same path and still gets the suggestion, so the assertion above
+        // describes the pin rather than a message that lost the text for
+        // everyone.
+        let unpinned = pinned_workspace_refusal(false).await;
+        assert!(
+            unpinned.contains("kin init"),
+            "an unpinned server can genuinely init the workspace it is looking at: {unpinned}"
         );
     }
 


### PR DESCRIPTION
Four independent papercuts a stranger hit on a fresh install of shipped
0.5.36, each a separate commit so any one can be reverted alone.

**Default ignores: a venv no longer races the live watcher.** Kin
inherits only `.gitignore`, and the watcher indexes on write rather than
on commit, so `python3 -m venv .venv` inside a Kin repository raced it
for the semantic graph. `.venv` was already a built-in default, but
`venv` and `env` are just as common and both also name ordinary source
directories, so no name list covers them without deleting real code from
the graph. An environment is now recognized by `pyvenv.cfg`, the file
PEP 405 requires at its root and that `python3 -m venv` writes before it
installs anything: excluded whatever it was named, on the first walk
that sees it, with no user action. `!name` in `.kinignore` re-admits one
whole, and the re-admission test runs before the host is touched, so an
override costs no IO. The rule only ever declines to admit something
new, so it can never retract graph-owned truth, and a descent that
happens only because graph truth tracks a path inside an environment
admits that path and nothing else. `bower_components`,
`__pypackages__`, and `.eggs` join the built-in defaults on the standing
rule for that list; `build`, `out`, and `vendor` stay admitted.

**Context pack budget: content-addressed ids are hex.** `Hash256`
derives `Serialize` over `[u8; 32]`, so every dependency in a pack
carried `artifact_entry.hash` and `base_change_id` as 32-element decimal
arrays, one number per line when pretty-printed. That is about four
times the bytes of the hex it stands for, in a tool documented as fitted
to a token budget, and it is not the spelling any Kin surface parses
back: `kin_artifact_read`'s own `source_change_id` input contract is a
64-character hex string. `source_provenance_fields` is the single seam
every body-serving surface routes through, so the fix covers
`get_entity_source`, `get_entity_sources`, `get_entity`, and both the
focal entity and every dependency of a context pack. Tree entries reuse
the hex wire type `kin_artifact_read` already had. The test walks a real
context pack and fails on any array of twenty or more bare numbers,
which is the shape a `Hash256` or a sha1 `GitObjectId` takes on the
wire, so a newly added id is caught without updating the test.

**MCP roots refusal self-heals.** When the client announces a workspace
root the server cannot bind, it correctly refuses every tool call rather
than answering about the repository the client left. But the verdict was
computed once, at roots-change time, and cached, so the refusal outlived
the condition that produced it: `kin init` can run there, a mount can
appear, a container path can be made to exist, and the user kept being
refused for the life of a process the client owns. The recorded roots go
back through the binder on the next tool call. Fail-closed is unchanged
and now asserted: a root still unbindable is re-marked and refused
exactly as before.

**Wrong remediation dropped for a repo-bound server.** That refusal
advised `kin init .` in the new workspace, which is actively wrong when
`--repo`/`KIN_MCP_REPO` pinned the server. That pin is how a server is
registered against a repository it reaches over a boundary the client
does not share, so the announced root is a host path this process may
never see; following the advice creates a second, empty repository and
leaves the refusal in place. A pinned server is now offered only the
remedies that apply to it, and the `--repo` half survives. Its unpinned
twin still gets the suggestion, which the test asserts so the text
cannot have simply vanished for everyone.

Gates, all from the lane worktree at `chore/lane-fir2359-papercuts-kin`:
`kin-dev local-test kin` green at 5714 tests, `cargo fmt --all --check`
clean, the CI clippy allowlist under `RUSTFLAGS=-D warnings` clean, both
zero-file-search scanners passing, and the runtime-boundary and
private-repo-coupling checks passing.

Not fixed here, and named because it is the same defect one layer over:
`entity_response_json` serializes a whole `Entity`, so `get_entity`
still emits four fingerprint hashes and `created_in` as decimal byte
arrays. That shape is declared by the tracked cross-process contract
(`packages/boundary-contracts/schemas/entity.schema.json` refs
`kin://contracts/hash256`, "Serialized as a 32-element byte array"), so
changing it is a boundary-contract decision rather than a papercut, and
it belongs in its own ticket with the editor and VFS consumers in scope.

Closes FIR-2359
