### PR TITLE
Pin kin-db 0.7.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.29"
+version = "0.7.31"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "89bd923bb4da06c47e57e457e48de765d019d17ffd613ef719344d7e9519bab7"
+checksum = "67d0045bdd2c3aa4f3fb0acbc055bb0a7df5e02a17cb12eb49c107d02a54bc6c"
 dependencies = [
  "bincode",
  "bstr",
@@ -6625,7 +6625,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.29", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.31", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -2288,16 +2288,25 @@ mod tests {
         assert_eq!(lease.snapshot().changes.len(), 1);
     }
 
+    /// An exclusion rule takes effect from the generation AFTER the one that
+    /// publishes it, so the transaction introducing a rule is judged by the
+    /// policy already in force rather than by the one it is about to install.
+    /// The contract is stated on kin-db's `judging_shared_policy`; this is its
+    /// kin-side half, and it is deliberately the inverse of what this test
+    /// asserted before kin-db 0.7.30. Judging a transaction by its own new rule
+    /// livelocked: the rule file could never land, because landing it required
+    /// admitting content the unlanded rule already excluded, and every retry
+    /// failed identically.
     #[test]
-    fn ignored_new_artifact_is_rejected_without_partial_authority() {
+    fn a_rule_and_the_content_it_will_exclude_land_together_then_the_rule_bites() {
         let root = tempfile::tempdir().unwrap();
         let init = kin_core::init(root.path()).unwrap();
         let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
         let graph = kin_db::InMemoryGraph::new();
-        add_artifact(&graph, &blobs, b".gitignore", b"secret.txt\n", |hash| {
+        add_artifact(&graph, &blobs, b".gitignore", b"*.secret\n", |hash| {
             TreeEntry::blob(hash, false)
         });
-        add_artifact(&graph, &blobs, b"secret.txt", b"not admitted\n", |hash| {
+        add_artifact(&graph, &blobs, b"one.secret", b"not admitted\n", |hash| {
             TreeEntry::blob(hash, false)
         });
         let plan = plan_native_commit(
@@ -2307,26 +2316,52 @@ mod tests {
             OperationId::new(),
             fixed_timestamp(),
             AuthorId::new("dogfood"),
-            "must fail admission".to_string(),
+            "publish the rule beside the content it will exclude".to_string(),
         )
         .unwrap();
-        let error = commit_native_plan(&init.layout, &blobs, plan).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("excluded by the exact graph-owned admission policy"));
+        commit_native_plan(&init.layout, &blobs, plan).unwrap();
 
         let authority = reopen(&init);
         let lease = authority.read_authority();
-        assert_eq!(lease.roots().generation, 1);
-        assert!(lease.snapshot().changes.is_empty());
+        assert_eq!(lease.roots().generation, 2);
+        assert_eq!(lease.snapshot().changes.len(), 1);
         let workspace = lease
             .metadata()
             .workspaces
             .iter()
             .find(|workspace| workspace.workspace_id == init.workspace_id)
             .unwrap();
-        assert!(workspace.tree.is_empty());
-        assert!(lease.metadata().ref_state.refs.is_empty());
+        assert_eq!(workspace.tree.len(), 2);
+        drop(lease);
+        drop(authority);
+
+        // The rule is in force from here, so the next new path under it is
+        // refused, and refused without moving authority.
+        add_artifact(&graph, &blobs, b"two.secret", b"also secret\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("dogfood"),
+            "must fail admission under the rule now in force".to_string(),
+        )
+        .unwrap();
+        let error = commit_native_plan(&init.layout, &blobs, plan).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("excluded by the exact graph-owned admission policy"),
+            "unexpected error: {error}"
+        );
+
+        let authority = reopen(&init);
+        let lease = authority.read_authority();
+        assert_eq!(lease.roots().generation, 2);
+        assert_eq!(lease.snapshot().changes.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Carries two kin-db fixes into the kin binary. kin-db#192 judges a transaction by the exclusion rules already in force rather than the ones it publishes, which closes the livelock where admitting a new .gitignore beside newly-excluded untracked content failed wholesale on every retry (FIR-2348). kin-db#193 releases the vector index slot before saving the sidecar, which is the layer-1 half of the stall that was misattributed to graph re-derivation: the commit was waiting on a lock held by a full HNSW rebuild, not rebuilding anything itself (FIR-2351; the kin-vector half is FIR-2367).

The pin moves =0.7.29 to =0.7.31 with the registry source and checksum preserved; exactly one package moved in the lock.