### PR TITLE
Model JavaScript and TypeScript receivers, classes and requires as a graph

### DIFF
--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -46,6 +46,7 @@ impl LanguageAdapter for JavaScriptAdapter {
         let mut relations = Vec::new();
         let mut imports = Vec::new();
         let mut tests = Vec::new();
+        let mut owners = JsOwners::default();
         let root = tree.root_node();
         let mut cursor = root.walk();
 
@@ -67,19 +68,24 @@ impl LanguageAdapter for JavaScriptAdapter {
         }
 
         for child in root.children(&mut cursor) {
-            extract_js_node(&child, source, file_id, &mut entities, &mut relations);
+            extract_js_node(
+                &child,
+                source,
+                file_id,
+                &mut entities,
+                &mut relations,
+                &mut owners,
+            );
             if let Some(import_like) = extract_js_import_like(&child, source) {
                 imports.push(import_like);
             }
             // Extract CommonJS require() calls as imports
-            if child.kind() == "lexical_declaration" || child.kind() == "variable_declaration" {
-                if let Some(import) = extract_require_import(&child, source) {
-                    imports.push(import);
-                }
-            }
+            collect_js_require_imports(&child, source, &mut imports);
             // Detect describe/it/test calls (Jest/Vitest/Mocha)
             extract_js_tests_from_node(&child, source, &mut tests);
         }
+
+        owners.finish(&mut entities);
 
         // Build import lookup: local_name -> module_path
         let import_map: std::collections::HashMap<&str, &str> = imports
@@ -113,12 +119,67 @@ impl LanguageAdapter for JavaScriptAdapter {
     }
 }
 
+/// Receivers that own member-assigned methods: `View.prototype.lookup = ...`,
+/// `res.status = ...`, `const utils = { parse() {} }`.
+///
+/// Such a receiver is a class in all but syntax — a constructor function
+/// carrying `prototype` members, or a prototype object built by
+/// `Object.create` — so it is kinded [`EntityKind::Class`] once extraction
+/// finishes. That kind is also what puts an `Owner.method` call on the linker's
+/// receiver-method and inheritance tiers, which only fire for a class-like
+/// owner.
+#[derive(Default)]
+pub(super) struct JsOwners {
+    names: std::collections::BTreeSet<String>,
+    /// A stand-in binding for a receiver that never declared one in this file
+    /// (`app.foo = ...` where `app` came from elsewhere). Only pushed when no
+    /// real entity claims the name, so every `Contains` edge keeps a resolvable
+    /// source.
+    synthesized: Vec<ExtractedEntity>,
+}
+
+impl JsOwners {
+    pub(super) fn record(
+        &mut self,
+        name: &str,
+        site: &tree_sitter::Node,
+        source: &[u8],
+        file_id: &FilePathId,
+    ) {
+        if self.names.insert(name.to_string()) {
+            self.synthesized.push(ExtractedEntity {
+                kind: EntityKind::Class,
+                name: name.to_string(),
+                signature: format!("object {name}"),
+                visibility: Visibility::Public,
+                doc_summary: None,
+                fingerprint: compute_fingerprint(site, source),
+                span: span_from_node(site, file_id),
+            });
+        }
+    }
+
+    pub(super) fn finish(self, entities: &mut Vec<ExtractedEntity>) {
+        for name in &self.names {
+            if let Some(existing) = entities.iter_mut().find(|entity| &entity.name == name) {
+                existing.kind = EntityKind::Class;
+            }
+        }
+        for candidate in self.synthesized {
+            if !entities.iter().any(|entity| entity.name == candidate.name) {
+                entities.push(candidate);
+            }
+        }
+    }
+}
+
 fn extract_js_node(
     node: &tree_sitter::Node,
     source: &[u8],
     file_id: &FilePathId,
     entities: &mut Vec<ExtractedEntity>,
     relations: &mut Vec<ExtractedRelation>,
+    owners: &mut JsOwners,
 ) {
     match node.kind() {
         "function_declaration" | "function" => {
@@ -140,83 +201,13 @@ fn extract_js_node(
         "class_declaration" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::Class,
-                    name: name.clone(),
-                    signature: node_signature(node, source),
-                    visibility: detect_js_visibility(node),
-                    doc_summary: extract_preceding_comment(node, source),
-                    fingerprint: compute_fingerprint(node, source),
-                    span: span_from_node(node, file_id),
-                });
-
-                // Extract Extends relation for class inheritance.
-                // tree-sitter-javascript: class_declaration → class_heritage → identifier
-                {
-                    let mut heritage_cursor = node.walk();
-                    for child in node.children(&mut heritage_cursor) {
-                        if child.kind() == "class_heritage" {
-                            // Inside class_heritage, find the named identifier (skip "extends" keyword)
-                            let mut hc = child.walk();
-                            for hchild in child.children(&mut hc) {
-                                if hchild.is_named() && hchild.kind() == "identifier" {
-                                    let parent_name =
-                                        hchild.utf8_text(source).unwrap_or("").to_string();
-                                    if !parent_name.is_empty() {
-                                        relations.push(ExtractedRelation {
-                                            receiver: None,
-                                            call_shape: None,
-                                            kind: kin_model::RelationKind::Extends,
-                                            src_name: name.clone(),
-                                            dst_name: parent_name,
-                                            import_source: None,
-                                        });
-                                    }
-                                    break;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                }
-
-                // Recurse into class body
-                if let Some(body) = node.child_by_field_name("body") {
-                    let mut body_cursor = body.walk();
-                    for member in body.children(&mut body_cursor) {
-                        if member.kind() == "method_definition" {
-                            if let Some(mn) = member.child_by_field_name("name") {
-                                let method_name = mn.utf8_text(source).unwrap_or("").to_string();
-                                let qualified = format!("{}.{}", name, method_name);
-                                entities.push(ExtractedEntity {
-                                    kind: EntityKind::Method,
-                                    name: qualified.clone(),
-                                    signature: node_signature(&member, source),
-                                    visibility: Visibility::Public,
-                                    doc_summary: extract_preceding_comment(&member, source),
-                                    fingerprint: compute_fingerprint(&member, source),
-                                    span: span_from_node(&member, file_id),
-                                });
-                                relations.push(ExtractedRelation {
-                                    receiver: None,
-                                    call_shape: None,
-                                    kind: kin_model::RelationKind::Contains,
-                                    src_name: name.clone(),
-                                    dst_name: qualified.clone(),
-                                    import_source: None,
-                                });
-                                // Extract calls within method body
-                                extract_calls_from_context(&member, source, &qualified, relations);
-                            }
-                        }
-                    }
-                }
+                extract_js_class_like(node, &name, source, file_id, entities, relations);
             }
         }
         "expression_statement" => {
             // Handle prototype method assignments: obj.method = function() {}
             // and module.exports = function name() {}
-            extract_js_assignment_function(node, source, file_id, entities, relations);
+            extract_js_assignment_function(node, source, file_id, entities, relations, owners);
         }
         "lexical_declaration" | "variable_declaration" => {
             let mut decl_cursor = node.walk();
@@ -232,6 +223,35 @@ fn extract_js_node(
                 };
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
                 let value_node = declarator.child_by_field_name("value");
+
+                // A `require(...)` binding is a dependency line, not a constant.
+                // It is already carried as a `FileImport` with its specifiers,
+                // and emitting a Constant beside it doubled every dependency
+                // into the entity set: on express those bindings were the bulk
+                // of the 451 constants that buried 133 functions.
+                if value_node
+                    .as_ref()
+                    .is_some_and(|value| js_require_target(value, source).is_some())
+                {
+                    continue;
+                }
+
+                // `const Foo = class extends Bar {}` is a class declaration
+                // wearing a binding; model it as the class it is.
+                if let Some(class_value) = value_node.filter(|value| value.kind() == "class") {
+                    if !name.is_empty() {
+                        extract_js_class_like(
+                            &class_value,
+                            &name,
+                            source,
+                            file_id,
+                            entities,
+                            relations,
+                        );
+                    }
+                    continue;
+                }
+
                 let is_function_like = value_node.as_ref().is_some_and(is_js_function_like_node);
                 let kind = if is_function_like {
                     EntityKind::Function
@@ -258,7 +278,7 @@ fn extract_js_node(
                 }
                 entities.push(ExtractedEntity {
                     kind,
-                    name,
+                    name: name.clone(),
                     signature: node_signature(&declarator, source),
                     visibility: detect_js_visibility(node),
                     doc_summary: extract_preceding_comment(node, source),
@@ -268,6 +288,13 @@ fn extract_js_node(
                 if let Some(value_node) = value_node.filter(is_js_function_like_node) {
                     let context_name = name_node.utf8_text(source).unwrap_or("");
                     extract_calls_from_context(&value_node, source, context_name, relations);
+                }
+                // `const utils = { parse() {}, print: () => {} }` is a namespace
+                // object whose function properties are the methods it owns.
+                if let Some(object) = value_node.filter(|value| value.kind() == "object") {
+                    extract_js_object_methods(
+                        &object, &name, source, file_id, entities, relations, owners,
+                    );
                 }
             }
         }
@@ -279,7 +306,7 @@ fn extract_js_node(
                 if child.kind() == "default" || child.utf8_text(source).unwrap_or("") == "default" {
                     has_default = true;
                 }
-                extract_js_node(&child, source, file_id, entities, relations);
+                extract_js_node(&child, source, file_id, entities, relations, owners);
             }
             // If this is a default export and recursion didn't create any entities,
             // create a synthetic "default" entity so the linker can resolve
@@ -450,13 +477,55 @@ fn extract_assignment_lhs_name(lhs: &tree_sitter::Node, source: &[u8]) -> String
     }
 }
 
-/// Extract function entities from assignment expressions like `app.init = function() {}`.
-fn extract_js_assignment_function(
+/// Split a `member_expression` assignment target into its receiver path and the
+/// property being assigned: `res.status` -> (`res`, `status`),
+/// `View.prototype.lookup` -> (`View.prototype`, `lookup`).
+fn split_member_lhs(lhs: &tree_sitter::Node, source: &[u8]) -> Option<(String, String)> {
+    let object = lhs.child_by_field_name("object")?;
+    let property = lhs.child_by_field_name("property")?;
+    Some((
+        object.utf8_text(source).ok()?.to_string(),
+        property.utf8_text(source).ok()?.to_string(),
+    ))
+}
+
+/// The entity that owns a member assignment, or `None` when the receiver is a
+/// module-export namespace, a runtime global, or a path this adapter does not
+/// model.
+///
+/// `Foo.prototype` and `Foo` name the same owner: `Foo.prototype.bar` and
+/// `Foo.bar` are both reached as `bar` on a `Foo`, and collapsing them yields
+/// the `Owner.method` key the linker already resolves for Python and C++.
+/// `module.exports` and `exports` are the module's public surface rather than an
+/// object with methods, so their members stay module-level functions.
+pub(super) fn js_method_owner(receiver_path: &str) -> Option<&str> {
+    let base = receiver_path
+        .strip_suffix(".prototype")
+        .unwrap_or(receiver_path);
+    if base.is_empty()
+        || base.contains('.')
+        || matches!(
+            base,
+            "module" | "exports" | "this" | "window" | "global" | "globalThis" | "self"
+        )
+    {
+        return None;
+    }
+    base.chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+        .then_some(base)
+}
+
+/// Extract entities from a top-level assignment statement:
+/// `res.status = function status() {}`, `res.set = res.header = function() {}`,
+/// `View.prototype.lookup = function() {}`, `module.exports = { a() {} }`.
+pub(super) fn extract_js_assignment_function(
     node: &tree_sitter::Node,
     source: &[u8],
     file_id: &FilePathId,
     entities: &mut Vec<ExtractedEntity>,
     relations: &mut Vec<ExtractedRelation>,
+    owners: &mut JsOwners,
 ) {
     // Find the assignment_expression child
     let assign = {
@@ -470,51 +539,335 @@ fn extract_js_assignment_function(
         }
         found
     };
-    let assign = match assign {
-        Some(a) => a,
-        None => return,
+    let Some(assign) = assign else {
+        return;
     };
-    let lhs = match assign.child_by_field_name("left") {
-        Some(l) => l,
-        None => return,
+
+    // Unwrap a chained assignment so every target on the chain is modeled.
+    // `res.contentType = res.type = function contentType(t) {}` defines both
+    // names; reading only the outermost right-hand side sees another assignment
+    // and records neither.
+    let mut targets = Vec::new();
+    let mut current = assign;
+    let value = loop {
+        let (Some(lhs), Some(rhs)) = (
+            current.child_by_field_name("left"),
+            current.child_by_field_name("right"),
+        ) else {
+            return;
+        };
+        targets.push(lhs);
+        if rhs.kind() == "assignment_expression" {
+            current = rhs;
+        } else {
+            break rhs;
+        }
     };
-    let rhs = match assign.child_by_field_name("right") {
-        Some(r) => r,
-        None => return,
-    };
-    let rhs_kind = rhs.kind();
-    let is_function_rhs = matches!(
-        rhs_kind,
-        "function_expression" | "function" | "arrow_function" | "generator_function"
-    );
-    if !is_function_rhs {
+
+    for lhs in targets {
+        extract_js_assignment_target(
+            node, &lhs, &value, source, file_id, entities, relations, owners,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn extract_js_assignment_target(
+    stmt: &tree_sitter::Node,
+    lhs: &tree_sitter::Node,
+    value: &tree_sitter::Node,
+    source: &[u8],
+    file_id: &FilePathId,
+    entities: &mut Vec<ExtractedEntity>,
+    relations: &mut Vec<ExtractedRelation>,
+    owners: &mut JsOwners,
+) {
+    let member = (lhs.kind() == "member_expression")
+        .then(|| split_member_lhs(lhs, source))
+        .flatten();
+
+    // A receiver that is not the module-export namespace owns what is assigned
+    // to it: `res.status = function () {}` is a method on `res`, the shape
+    // express-era JavaScript uses instead of an ES class.
+    if let Some((receiver_path, property)) = &member {
+        if let Some(owner) = js_method_owner(receiver_path) {
+            if is_js_function_like_node(value) && !property.is_empty() {
+                let qualified = format!("{owner}.{property}");
+                owners.record(owner, lhs, source, file_id);
+                entities.push(ExtractedEntity {
+                    kind: EntityKind::Method,
+                    name: qualified.clone(),
+                    signature: node_signature(stmt, source),
+                    visibility: Visibility::Public,
+                    doc_summary: extract_preceding_comment(stmt, source),
+                    fingerprint: compute_fingerprint(stmt, source),
+                    span: span_from_node(stmt, file_id),
+                });
+                relations.push(ExtractedRelation {
+                    receiver: None,
+                    call_shape: None,
+                    kind: kin_model::RelationKind::Contains,
+                    src_name: owner.to_string(),
+                    dst_name: qualified.clone(),
+                    import_source: None,
+                });
+                extract_calls_from_context(value, source, &qualified, relations);
+            }
+            return;
+        }
+
+        // `module.exports = { parse() {}, print() {} }` is the CommonJS way of
+        // exporting a set of functions. Give each property its own entity so
+        // `require('./m').parse` has something to bind to.
+        if value.kind() == "object" && matches!(receiver_path.as_str(), "module" | "exports") {
+            for (property_name, function_node) in js_object_literal_methods(value, source) {
+                entities.push(ExtractedEntity {
+                    kind: EntityKind::Function,
+                    name: property_name.clone(),
+                    signature: node_signature(&function_node, source),
+                    visibility: Visibility::Public,
+                    doc_summary: extract_preceding_comment(&function_node, source),
+                    fingerprint: compute_fingerprint(&function_node, source),
+                    span: span_from_node(&function_node, file_id),
+                });
+                extract_calls_from_context(&function_node, source, &property_name, relations);
+            }
+            return;
+        }
+    }
+
+    if !is_js_function_like_node(value) {
         return;
     }
     // Determine the entity name: prefer the function's own name, fall back to LHS property
-    let name = if matches!(
-        rhs_kind,
+    let name = matches!(
+        value.kind(),
         "function_expression" | "function" | "generator_function"
-    ) {
-        rhs.child_by_field_name("name")
+    )
+    .then(|| {
+        value
+            .child_by_field_name("name")
             .and_then(|n| n.utf8_text(source).ok())
             .map(|s| s.to_string())
-    } else {
-        None
-    };
-    let name = name.unwrap_or_else(|| extract_assignment_lhs_name(&lhs, source));
+    })
+    .flatten()
+    .unwrap_or_else(|| extract_assignment_lhs_name(lhs, source));
     if name.is_empty() {
         return;
     }
     entities.push(ExtractedEntity {
         kind: EntityKind::Function,
         name: name.clone(),
-        signature: node_signature(node, source),
+        signature: node_signature(stmt, source),
         visibility: Visibility::Public,
+        doc_summary: extract_preceding_comment(stmt, source),
+        fingerprint: compute_fingerprint(stmt, source),
+        span: span_from_node(stmt, file_id),
+    });
+    extract_calls_from_context(value, source, &name, relations);
+}
+
+/// The function-valued properties of an object literal, as
+/// (property name, function node) pairs. Covers shorthand methods (`a() {}`),
+/// function-expression properties (`a: function () {}`) and arrow properties
+/// (`a: () => {}`).
+pub(super) fn js_object_literal_methods<'a>(
+    object: &tree_sitter::Node<'a>,
+    source: &[u8],
+) -> Vec<(String, tree_sitter::Node<'a>)> {
+    let mut found = Vec::new();
+    let mut cursor = object.walk();
+    for child in object.children(&mut cursor) {
+        match child.kind() {
+            "method_definition" => {
+                if let Some(name) = child
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                {
+                    if !name.is_empty() {
+                        found.push((name.to_string(), child));
+                    }
+                }
+            }
+            "pair" => {
+                let (Some(key), Some(value)) = (
+                    child.child_by_field_name("key"),
+                    child.child_by_field_name("value"),
+                ) else {
+                    continue;
+                };
+                if !is_js_function_like_node(&value) {
+                    continue;
+                }
+                let name = key
+                    .utf8_text(source)
+                    .unwrap_or("")
+                    .trim_matches(|c| c == '"' || c == '\'' || c == '`')
+                    .to_string();
+                if !name.is_empty() {
+                    found.push((name, value));
+                }
+            }
+            _ => {}
+        }
+    }
+    found
+}
+
+/// Emit `Method` entities and `Contains` edges for the function properties of a
+/// named object literal (`const utils = { parse() {} }` -> `utils.parse`).
+#[allow(clippy::too_many_arguments)]
+pub(super) fn extract_js_object_methods(
+    object: &tree_sitter::Node,
+    owner: &str,
+    source: &[u8],
+    file_id: &FilePathId,
+    entities: &mut Vec<ExtractedEntity>,
+    relations: &mut Vec<ExtractedRelation>,
+    owners: &mut JsOwners,
+) {
+    if js_method_owner(owner).is_none() {
+        return;
+    }
+    for (property_name, function_node) in js_object_literal_methods(object, source) {
+        let qualified = format!("{owner}.{property_name}");
+        owners.record(owner, object, source, file_id);
+        entities.push(ExtractedEntity {
+            kind: EntityKind::Method,
+            name: qualified.clone(),
+            signature: node_signature(&function_node, source),
+            visibility: Visibility::Public,
+            doc_summary: extract_preceding_comment(&function_node, source),
+            fingerprint: compute_fingerprint(&function_node, source),
+            span: span_from_node(&function_node, file_id),
+        });
+        relations.push(ExtractedRelation {
+            receiver: None,
+            call_shape: None,
+            kind: kin_model::RelationKind::Contains,
+            src_name: owner.to_string(),
+            dst_name: qualified.clone(),
+            import_source: None,
+        });
+        extract_calls_from_context(&function_node, source, &qualified, relations);
+    }
+}
+
+/// Extract a class entity, its `Extends` edge, and its members. Shared by
+/// `class Foo {}` and `const Foo = class {}`, which differ only in where the
+/// name comes from.
+fn extract_js_class_like(
+    node: &tree_sitter::Node,
+    name: &str,
+    source: &[u8],
+    file_id: &FilePathId,
+    entities: &mut Vec<ExtractedEntity>,
+    relations: &mut Vec<ExtractedRelation>,
+) {
+    entities.push(ExtractedEntity {
+        kind: EntityKind::Class,
+        name: name.to_string(),
+        signature: node_signature(node, source),
+        visibility: detect_js_visibility(node),
         doc_summary: extract_preceding_comment(node, source),
         fingerprint: compute_fingerprint(node, source),
         span: span_from_node(node, file_id),
     });
-    extract_calls_from_context(&rhs, source, &name, relations);
+
+    // Extract Extends relation for class inheritance.
+    // tree-sitter-javascript: class_declaration → class_heritage → <expression>.
+    // The base may be a bare identifier (`extends Animal`), a namespace member
+    // (`extends React.Component`) or a mixin call (`extends mixin(Base)`); each
+    // reduces to the rightmost identifier, which is the name the linker resolves.
+    let mut heritage_cursor = node.walk();
+    for child in node.children(&mut heritage_cursor) {
+        if child.kind() != "class_heritage" {
+            continue;
+        }
+        let mut hc = child.walk();
+        for hchild in child.children(&mut hc) {
+            let Some(parent_name) = js_heritage_name(&hchild, source) else {
+                continue;
+            };
+            relations.push(ExtractedRelation {
+                receiver: None,
+                call_shape: None,
+                kind: kin_model::RelationKind::Extends,
+                src_name: name.to_string(),
+                dst_name: parent_name,
+                import_source: None,
+            });
+            break;
+        }
+        break;
+    }
+
+    let Some(body) = node.child_by_field_name("body") else {
+        return;
+    };
+    let mut body_cursor = body.walk();
+    for member in body.children(&mut body_cursor) {
+        // `method_definition` covers methods, getters, setters and static
+        // members. `field_definition` is a method only when its value is a
+        // function (`handleClick = () => {}`, the React class-property form);
+        // a data field is not a callable and stays out of the graph.
+        let is_callable_field = member.kind() == "field_definition"
+            && member
+                .child_by_field_name("value")
+                .as_ref()
+                .is_some_and(is_js_function_like_node);
+        if member.kind() != "method_definition" && !is_callable_field {
+            continue;
+        }
+        let Some(method_name) = member
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(source).ok())
+            .filter(|n| !n.is_empty())
+        else {
+            continue;
+        };
+        let qualified = format!("{name}.{method_name}");
+        entities.push(ExtractedEntity {
+            kind: EntityKind::Method,
+            name: qualified.clone(),
+            signature: node_signature(&member, source),
+            visibility: Visibility::Public,
+            doc_summary: extract_preceding_comment(&member, source),
+            fingerprint: compute_fingerprint(&member, source),
+            span: span_from_node(&member, file_id),
+        });
+        relations.push(ExtractedRelation {
+            receiver: None,
+            call_shape: None,
+            kind: kin_model::RelationKind::Contains,
+            src_name: name.to_string(),
+            dst_name: qualified.clone(),
+            import_source: None,
+        });
+        // Extract calls within method body
+        extract_calls_from_context(&member, source, &qualified, relations);
+    }
+}
+
+/// The name a `class_heritage` child contributes to an `Extends` edge: the
+/// rightmost identifier of the base expression, or `None` for the `extends`
+/// keyword and other unnamed nodes.
+pub(super) fn js_heritage_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if !node.is_named() {
+        return None;
+    }
+    match node.kind() {
+        "identifier" => Some(node.utf8_text(source).ok()?.to_string()),
+        "member_expression" => Some(
+            node.child_by_field_name("property")?
+                .utf8_text(source)
+                .ok()?
+                .to_string(),
+        ),
+        "call_expression" => js_heritage_name(&node.child_by_field_name("function")?, source),
+        _ => None,
+    }
+    .filter(|name| !name.is_empty())
 }
 
 fn detect_js_visibility(node: &tree_sitter::Node) -> Visibility {
@@ -784,55 +1137,191 @@ fn extract_single_import_name(node: &tree_sitter::Node, source: &[u8]) -> Option
     })
 }
 
-/// Extract CommonJS require() call as a FileImport.
-/// Handles patterns like `const foo = require('./bar')`.
-fn extract_require_import(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImport> {
-    // Walk into variable_declarator children
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "variable_declarator" {
-            let var_name = child
-                .child_by_field_name("name")
-                .and_then(|n| n.utf8_text(source).ok())
-                .unwrap_or("")
+/// The module a `require(...)` expression names, plus the member picked off it.
+///
+/// Covers the three shapes a CommonJS dependency line actually takes:
+/// `require('m')`, `require('m').x` (a named export bound directly) and
+/// `require('m')(args)` (a module that is itself a factory). Anything else is
+/// not a require expression.
+pub(super) fn js_require_target(
+    node: &tree_sitter::Node,
+    source: &[u8],
+) -> Option<(String, Option<String>)> {
+    match node.kind() {
+        "call_expression" => {
+            let function = node.child_by_field_name("function")?;
+            if function.kind() == "identifier" && function.utf8_text(source).ok()? == "require" {
+                let arguments = node.child_by_field_name("arguments")?;
+                let mut cursor = arguments.walk();
+                let literal = arguments
+                    .children(&mut cursor)
+                    .find(|arg| arg.kind() == "string")?;
+                let module_path = literal
+                    .utf8_text(source)
+                    .ok()?
+                    .trim_matches(|c| c == '\'' || c == '"' || c == '`')
+                    .to_string();
+                return (!module_path.is_empty()).then_some((module_path, None));
+            }
+            // `require('depd')('express')` still binds that module to the name.
+            js_require_target(&function, source).map(|(module_path, _)| (module_path, None))
+        }
+        "member_expression" => {
+            let object = node.child_by_field_name("object")?;
+            let (module_path, _) = js_require_target(&object, source)?;
+            let member = node
+                .child_by_field_name("property")?
+                .utf8_text(source)
+                .ok()?
                 .to_string();
+            Some((module_path, (!member.is_empty()).then_some(member)))
+        }
+        _ => None,
+    }
+}
 
-            // Check if the value is a call_expression with callee "require"
-            if let Some(value) = child.child_by_field_name("value") {
-                if value.kind() == "call_expression" {
-                    if let Some(callee) = value.child(0) {
-                        let callee_text = callee.utf8_text(source).unwrap_or("");
-                        if callee_text == "require" {
-                            // Extract the argument (module path)
-                            if let Some(args) = value.child_by_field_name("arguments") {
-                                let mut args_cursor = args.walk();
-                                for arg in args.children(&mut args_cursor) {
-                                    if arg.kind() == "string" {
-                                        let module_path = arg
-                                            .utf8_text(source)
-                                            .unwrap_or("")
-                                            .trim_matches(|c| c == '\'' || c == '"')
-                                            .to_string();
-                                        if !module_path.is_empty() && !var_name.is_empty() {
-                                            return Some(FileImport {
-                                                module_path,
-                                                specifiers: vec![ImportedName {
-                                                    local_name: var_name,
-                                                    original_name: None,
-                                                    is_default: true,
-                                                }],
-                                            });
-                                        }
-                                    }
-                                }
-                            }
+/// The specifiers a require binding contributes: one for an identifier target,
+/// one per destructured key for `const { a, b: c } = require('m')`.
+fn js_require_specifiers(
+    name: &tree_sitter::Node,
+    member: Option<&str>,
+    source: &[u8],
+) -> Vec<ImportedName> {
+    match name.kind() {
+        "identifier" => {
+            let local_name = name.utf8_text(source).unwrap_or("").to_string();
+            if local_name.is_empty() {
+                return Vec::new();
+            }
+            vec![ImportedName {
+                local_name,
+                original_name: member.map(str::to_string),
+                is_default: member.is_none(),
+            }]
+        }
+        "object_pattern" => {
+            let mut specifiers = Vec::new();
+            let mut cursor = name.walk();
+            for child in name.children(&mut cursor) {
+                match child.kind() {
+                    "shorthand_property_identifier_pattern" => {
+                        let local_name = child.utf8_text(source).unwrap_or("").to_string();
+                        if !local_name.is_empty() {
+                            specifiers.push(ImportedName {
+                                local_name,
+                                original_name: None,
+                                is_default: false,
+                            });
                         }
                     }
+                    "pair_pattern" => {
+                        let original_name = child
+                            .child_by_field_name("key")
+                            .and_then(|n| n.utf8_text(source).ok())
+                            .unwrap_or("")
+                            .to_string();
+                        let local_name = child
+                            .child_by_field_name("value")
+                            .and_then(|n| n.utf8_text(source).ok())
+                            .unwrap_or("")
+                            .to_string();
+                        if !original_name.is_empty() && !local_name.is_empty() {
+                            specifiers.push(ImportedName {
+                                local_name,
+                                original_name: Some(original_name),
+                                is_default: false,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            specifiers
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Record every CommonJS `require(...)` in a top-level statement as a
+/// [`FileImport`].
+///
+/// ESM `import` is handled by `extract_js_import`; this is the half of the
+/// import surface express-era JavaScript actually uses, and cross-file
+/// resolution has no binding to work with without it.
+pub(super) fn collect_js_require_imports(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    imports: &mut Vec<FileImport>,
+) {
+    match node.kind() {
+        "lexical_declaration" | "variable_declaration" => {
+            let mut cursor = node.walk();
+            for declarator in node.children(&mut cursor) {
+                if declarator.kind() != "variable_declarator" {
+                    continue;
+                }
+                let (Some(name), Some(value)) = (
+                    declarator.child_by_field_name("name"),
+                    declarator.child_by_field_name("value"),
+                ) else {
+                    continue;
+                };
+                let Some((module_path, member)) = js_require_target(&value, source) else {
+                    continue;
+                };
+                let specifiers = js_require_specifiers(&name, member.as_deref(), source);
+                if !specifiers.is_empty() {
+                    imports.push(FileImport {
+                        module_path,
+                        specifiers,
+                    });
                 }
             }
         }
+        "expression_statement" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                match child.kind() {
+                    // `exports.static = require('serve-static')` re-exports a dependency.
+                    "assignment_expression" => {
+                        let (Some(lhs), Some(rhs)) = (
+                            child.child_by_field_name("left"),
+                            child.child_by_field_name("right"),
+                        ) else {
+                            continue;
+                        };
+                        let Some((module_path, member)) = js_require_target(&rhs, source) else {
+                            continue;
+                        };
+                        let local_name = extract_assignment_lhs_name(&lhs, source);
+                        if local_name.is_empty() {
+                            continue;
+                        }
+                        imports.push(FileImport {
+                            module_path,
+                            specifiers: vec![ImportedName {
+                                local_name,
+                                is_default: member.is_none(),
+                                original_name: member,
+                            }],
+                        });
+                    }
+                    // A bare `require('./polyfill')` is a side-effect dependency:
+                    // it binds no name, but the file still depends on that module.
+                    "call_expression" => {
+                        if let Some((module_path, _)) = js_require_target(&child, source) {
+                            imports.push(FileImport {
+                                module_path,
+                                specifiers: Vec::new(),
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
     }
-    None
 }
 
 /// Detect Jest/Vitest/Mocha test calls in JS: `test(...)`, `it(...)`, `describe(...)`.
@@ -1029,18 +1518,41 @@ mod tests {
     #[test]
     fn parse_js_prototype_method_named() {
         // app.init = function init() { ... }
+        //
+        // Contract: a function assigned to a receiver is that receiver's
+        // METHOD, named `receiver.property` and contained by the receiver —
+        // not a free function named after the right-hand side. The right-hand
+        // name is an internal recursion label; `app.init` is how the method is
+        // reached, and it is the key the linker resolves an `Owner.method`
+        // call against.
         let adapter = JavaScriptAdapter;
         let source = b"app.init = function init() { console.log('starting'); };";
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let funcs: Vec<_> = output
+        let methods: Vec<_> = output
             .entities
             .iter()
-            .filter(|e| e.kind == EntityKind::Function)
+            .filter(|e| e.kind == EntityKind::Method)
             .collect();
-        assert_eq!(funcs.len(), 1, "expected 1 function, got {:?}", funcs);
-        assert_eq!(funcs[0].name, "init");
+        assert_eq!(methods.len(), 1, "expected 1 method, got {:?}", methods);
+        assert_eq!(methods[0].name, "app.init");
+        // The receiver becomes the class-like owner that holds the method.
+        let owners: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Class)
+            .map(|e| e.name.as_str())
+            .collect();
+        assert_eq!(owners, vec!["app"]);
+        let contains: Vec<_> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Contains)
+            .collect();
+        assert_eq!(contains.len(), 1);
+        assert_eq!(contains[0].src_name, "app");
+        assert_eq!(contains[0].dst_name, "app.init");
     }
 
     #[test]
@@ -1051,13 +1563,156 @@ mod tests {
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let funcs: Vec<_> = output
+        let methods: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Method)
+            .collect();
+        assert_eq!(methods.len(), 1, "expected 1 method, got {:?}", methods);
+        assert_eq!(methods[0].name, "res.status");
+    }
+
+    #[test]
+    fn parse_js_prototype_assignment_owns_the_constructor() {
+        // `View.prototype.lookup = ...` is a method on `View`, not on a
+        // separate `View.prototype` object: `Foo.prototype.bar` and `Foo.bar`
+        // are both reached as `bar` on a `Foo`, so both collapse to the same
+        // `Owner.method` key.
+        let adapter = JavaScriptAdapter;
+        let source = b"function View(name) { this.name = name; }\nView.prototype.lookup = function lookup(n) { return n; };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert!(
+            named.contains(&(EntityKind::Class, "View")),
+            "a constructor carrying prototype methods is class-like, got {named:?}"
+        );
+        assert!(
+            named.contains(&(EntityKind::Method, "View.lookup")),
+            "expected View.lookup method, got {named:?}"
+        );
+        let contains: Vec<_> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Contains)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(contains, vec![("View", "View.lookup")]);
+    }
+
+    #[test]
+    fn parse_js_chained_member_assignment_defines_every_target() {
+        // `res.set = res.header = function header() {}` defines BOTH names.
+        // Reading only the outermost right-hand side sees another assignment
+        // and records neither.
+        let adapter = JavaScriptAdapter;
+        let source = b"res.set =\nres.header = function header(field, val) { return this; };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut methods: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Method)
+            .map(|e| e.name.as_str())
+            .collect();
+        methods.sort_unstable();
+        assert_eq!(methods, vec!["res.header", "res.set"]);
+    }
+
+    #[test]
+    fn parse_js_module_exports_object_yields_one_function_per_property() {
+        // `module.exports = { parse() {}, print: () => {} }` is the CommonJS
+        // way of exporting a set of functions. `module.exports` is the module's
+        // public surface rather than an object with methods, so its properties
+        // stay module-level functions that `require('./m').parse` can bind to.
+        let adapter = JavaScriptAdapter;
+        let source =
+            b"module.exports = { parse(input) { return scan(input); }, print: (x) => emit(x) };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut funcs: Vec<&str> = output
             .entities
             .iter()
             .filter(|e| e.kind == EntityKind::Function)
+            .map(|e| e.name.as_str())
             .collect();
-        assert_eq!(funcs.len(), 1, "expected 1 function, got {:?}", funcs);
-        assert_eq!(funcs[0].name, "status");
+        funcs.sort_unstable();
+        assert_eq!(funcs, vec!["parse", "print"]);
+        let calls: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Calls)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert!(calls.contains(&("parse", "scan")), "got {calls:?}");
+        assert!(calls.contains(&("print", "emit")), "got {calls:?}");
+    }
+
+    #[test]
+    fn parse_js_require_binding_is_an_import_not_a_constant() {
+        // A `require(...)` binding is a dependency line, already carried as a
+        // FileImport. Emitting a Constant beside it doubled every dependency
+        // into the entity set: on express those bindings were the bulk of the
+        // 451 constants that buried 133 functions.
+        let adapter = JavaScriptAdapter;
+        let source = br#"
+var contentDisposition = require('content-disposition');
+var { METHODS } = require('node:http');
+var isAbsolute = require('node:path').isAbsolute;
+var deprecate = require('depd')('express');
+require('./polyfill');
+exports.static = require('serve-static');
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        assert!(
+            output.entities.is_empty(),
+            "require bindings must not produce entities, got {:?}",
+            output
+                .entities
+                .iter()
+                .map(|e| (e.kind, e.name.as_str()))
+                .collect::<Vec<_>>()
+        );
+
+        let by_module: Vec<(&str, Vec<&str>)> = output
+            .imports
+            .iter()
+            .map(|imp| {
+                (
+                    imp.module_path.as_str(),
+                    imp.specifiers
+                        .iter()
+                        .map(|s| s.local_name.as_str())
+                        .collect(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            by_module,
+            vec![
+                ("content-disposition", vec!["contentDisposition"]),
+                ("node:http", vec!["METHODS"]),
+                ("node:path", vec!["isAbsolute"]),
+                ("depd", vec!["deprecate"]),
+                ("./polyfill", Vec::new()),
+                ("serve-static", vec!["static"]),
+            ]
+        );
+        // `require('m').x` binds the named export `x`, not the module default.
+        let member = &output.imports[2].specifiers[0];
+        assert_eq!(member.original_name.as_deref(), Some("isAbsolute"));
+        assert!(!member.is_default);
     }
 
     #[test]
@@ -1118,19 +1773,27 @@ mod tests {
 
     #[test]
     fn parse_js_arrow_function_assignment() {
-        // app.handler = (req, res) => { ... }
+        // app.handler = (req, res) => { ... } — an arrow assigned to a receiver
+        // is that receiver's method, same as a function expression.
         let adapter = JavaScriptAdapter;
         let source = b"app.handler = (req, res) => { res.send('ok'); };";
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let funcs: Vec<_> = output
+        let methods: Vec<_> = output
             .entities
             .iter()
-            .filter(|e| e.kind == EntityKind::Function)
+            .filter(|e| e.kind == EntityKind::Method)
             .collect();
-        assert_eq!(funcs.len(), 1, "expected 1 function, got {:?}", funcs);
-        assert_eq!(funcs[0].name, "handler");
+        assert_eq!(methods.len(), 1, "expected 1 method, got {:?}", methods);
+        assert_eq!(methods[0].name, "app.handler");
+        let calls: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Calls)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(calls, vec![("app.handler", "send")]);
     }
 
     #[test]
@@ -1319,22 +1982,35 @@ mod tests {
     #[test]
     fn parse_js_exported_object_with_callback_kept() {
         let adapter = JavaScriptAdapter;
-        // Object literals with function-like children are meaningful code
+        // Object literals with function-like children are meaningful code.
+        //
+        // Contract: such a literal is a namespace object, so it is kinded
+        // Class and each function property becomes a Method it contains. That
+        // is the kind the linker's receiver-method tier requires; a Constant
+        // owner would leave `handlers.onClick` unreachable as a call target.
         let source = b"export const handlers = { onClick: () => console.log('click') };";
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let constants: Vec<_> = output
+        let named: Vec<(EntityKind, &str)> = output
             .entities
             .iter()
-            .filter(|e| e.kind == EntityKind::Constant)
+            .map(|e| (e.kind, e.name.as_str()))
             .collect();
         assert_eq!(
-            constants.len(),
-            1,
-            "object literals with callbacks should be kept"
+            named,
+            vec![
+                (EntityKind::Class, "handlers"),
+                (EntityKind::Method, "handlers.onClick"),
+            ]
         );
-        assert_eq!(constants[0].name, "handlers");
+        let contains: Vec<_> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Contains)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(contains, vec![("handlers", "handlers.onClick")]);
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -810,17 +810,25 @@ fn extract_js_class_like(
         // `method_definition` covers methods, getters, setters and static
         // members. `field_definition` is a method only when its value is a
         // function (`handleClick = () => {}`, the React class-property form);
-        // a data field is not a callable and stays out of the graph.
-        let is_callable_field = member.kind() == "field_definition"
-            && member
-                .child_by_field_name("value")
-                .as_ref()
-                .is_some_and(is_js_function_like_node);
-        if member.kind() != "method_definition" && !is_callable_field {
-            continue;
-        }
-        let Some(method_name) = member
-            .child_by_field_name("name")
+        // a data field is not a callable and stays out of the graph. The
+        // grammar gives `field_definition` no `name`/`value` fields, so its
+        // parts are read positionally: the property first, the initializer last.
+        let name_node = match member.kind() {
+            "method_definition" => member.child_by_field_name("name"),
+            "field_definition" => {
+                let mut field_cursor = member.walk();
+                let parts: Vec<tree_sitter::Node> =
+                    member.named_children(&mut field_cursor).collect();
+                match parts.last() {
+                    Some(initializer) if is_js_function_like_node(initializer) => {
+                        parts.first().copied()
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+        let Some(method_name) = name_node
             .and_then(|n| n.utf8_text(source).ok())
             .filter(|n| !n.is_empty())
         else {
@@ -1862,6 +1870,75 @@ exports.static = require('serve-static');
             .specifiers
             .iter()
             .any(|spec| spec.local_name == "*"));
+    }
+
+    #[test]
+    fn parse_js_class_expression_binding() {
+        // `const Foo = class extends Bar {}` is a class declaration wearing a
+        // binding; it must produce the same shape as `class Foo extends Bar {}`.
+        let adapter = JavaScriptAdapter;
+        let source = b"const Timer = class extends Base { start() { return tick(); } };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert_eq!(
+            named,
+            vec![
+                (EntityKind::Class, "Timer"),
+                (EntityKind::Method, "Timer.start"),
+            ]
+        );
+        let extends: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Extends)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(extends, vec![("Timer", "Base")]);
+    }
+
+    #[test]
+    fn parse_js_class_extends_namespace_member() {
+        // `extends React.Component` reduces to the rightmost identifier, which
+        // is the name the linker resolves. Reading the whole member expression
+        // yields `React.Component`, which matches no entity.
+        let adapter = JavaScriptAdapter;
+        let source = b"class Panel extends React.Component { render() {} }";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let extends: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Extends)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(extends, vec![("Panel", "Component")]);
+    }
+
+    #[test]
+    fn parse_js_class_field_arrow_is_a_method() {
+        // The React class-property form `handleClick = () => {}` is a callable
+        // member; a data field is not and stays out of the graph.
+        let adapter = JavaScriptAdapter;
+        let source =
+            b"class Panel { state = { open: false }; handleClick = (e) => { this.toggle(e); } }";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let methods: Vec<&str> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Method)
+            .map(|e| e.name.as_str())
+            .collect();
+        assert_eq!(methods, vec!["Panel.handleClick"]);
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -161,7 +161,16 @@ impl JsOwners {
 
     pub(super) fn finish(self, entities: &mut Vec<ExtractedEntity>) {
         for name in &self.names {
-            if let Some(existing) = entities.iter_mut().find(|entity| &entity.name == name) {
+            // The file's `Module` node can carry the receiver's name when an
+            // `index.js` sits in a directory of that name. Leave it as a module
+            // and let it hold the `Contains` edge: rekinding it would claim the
+            // file is a class, and pushing a second entity beside it would give
+            // one file two entities under one name, which the linker's
+            // (file, name) index cannot tell apart.
+            if let Some(existing) = entities
+                .iter_mut()
+                .find(|entity| &entity.name == name && entity.kind != EntityKind::Module)
+            {
                 existing.kind = EntityKind::Class;
             }
         }
@@ -2149,6 +2158,41 @@ exports.static = require('serve-static');
             1,
             "export default <identifier> should create a 'default' entity"
         );
+    }
+
+    #[test]
+    fn receiver_named_like_the_index_module_keeps_one_entity() {
+        // `router/index.js` assigning to a receiver called `router` collides
+        // with the directory-named Module entity. One file must not hold two
+        // entities under one name: the linker indexes on (file, name) and
+        // cannot tell them apart.
+        let adapter = JavaScriptAdapter;
+        let source = b"router.handle = function handle(req) { return req; };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("lib/router/index.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert_eq!(
+            named,
+            vec![
+                (EntityKind::Module, "router"),
+                (EntityKind::Method, "router.handle"),
+            ],
+            "the module keeps its kind and no second `router` is added"
+        );
+        // The Contains edge still resolves, against the module node.
+        let contains: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Contains)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(contains, vec![("router", "router.handle")]);
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -122,9 +122,9 @@ impl LanguageAdapter for JavaScriptAdapter {
 /// Receivers that own member-assigned methods: `View.prototype.lookup = ...`,
 /// `res.status = ...`, `const utils = { parse() {} }`.
 ///
-/// Such a receiver is a class in all but syntax — a constructor function
-/// carrying `prototype` members, or a prototype object built by
-/// `Object.create` — so it is kinded [`EntityKind::Class`] once extraction
+/// Such a receiver is a class in all but syntax. It is either a constructor
+/// function carrying `prototype` members or a prototype object built by
+/// `Object.create`, so it is kinded [`EntityKind::Class`] once extraction
 /// finishes. That kind is also what puts an `Owner.method` call on the linker's
 /// receiver-method and inheritance tiers, which only fire for a class-like
 /// owner.
@@ -1528,11 +1528,11 @@ mod tests {
         // app.init = function init() { ... }
         //
         // Contract: a function assigned to a receiver is that receiver's
-        // METHOD, named `receiver.property` and contained by the receiver —
-        // not a free function named after the right-hand side. The right-hand
-        // name is an internal recursion label; `app.init` is how the method is
-        // reached, and it is the key the linker resolves an `Owner.method`
-        // call against.
+        // METHOD, named `receiver.property` and contained by the receiver,
+        // rather than a free function named after the right-hand side. The
+        // right-hand name is an internal recursion label. `app.init` is how the
+        // method is reached, and it is the key the linker resolves an
+        // `Owner.method` call against.
         let adapter = JavaScriptAdapter;
         let source = b"app.init = function init() { console.log('starting'); };";
         let tree = adapter.parse(source).unwrap();
@@ -1781,8 +1781,9 @@ exports.static = require('serve-static');
 
     #[test]
     fn parse_js_arrow_function_assignment() {
-        // app.handler = (req, res) => { ... } — an arrow assigned to a receiver
-        // is that receiver's method, same as a function expression.
+        // app.handler = (req, res) => { ... }
+        // An arrow assigned to a receiver is that receiver's method, same as a
+        // function expression.
         let adapter = JavaScriptAdapter;
         let source = b"app.handler = (req, res) => { res.send('ok'); };";
         let tree = adapter.parse(source).unwrap();

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -1232,6 +1232,93 @@ export class Dog extends Animal implements Pet {
     }
 
     #[test]
+    fn ts_require_binding_is_an_import_not_a_constant() {
+        // TypeScript files in Node packages still use CommonJS. The adapter
+        // recognized no `require` shape at all before, so every dependency line
+        // became a Constant and none reached the import surface.
+        let adapter = TypeScriptAdapter;
+        let source = br#"
+const contentType = require('content-type');
+const { METHODS } = require('node:http');
+const isAbsolute = require('node:path').isAbsolute;
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        assert!(
+            output.entities.is_empty(),
+            "require bindings must not produce entities, got {:?}",
+            output
+                .entities
+                .iter()
+                .map(|e| (e.kind, e.name.as_str()))
+                .collect::<Vec<_>>()
+        );
+        let modules: Vec<&str> = output
+            .imports
+            .iter()
+            .map(|i| i.module_path.as_str())
+            .collect();
+        assert_eq!(modules, vec!["content-type", "node:http", "node:path"]);
+    }
+
+    #[test]
+    fn ts_receiver_assignment_is_a_method() {
+        // `Foo.prototype.bar = function () {}` in a .ts file is the same shape
+        // as in a .js file and must extract identically.
+        let adapter = TypeScriptAdapter;
+        let source = b"function View(name: string) { this.name = name; }\nView.prototype.lookup = function lookup(n: string) { return n; };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert!(named.contains(&(EntityKind::Class, "View")), "{named:?}");
+        assert!(
+            named.contains(&(EntityKind::Method, "View.lookup")),
+            "{named:?}"
+        );
+        let contains: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Contains)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(contains, vec![("View", "View.lookup")]);
+    }
+
+    #[test]
+    fn ts_class_expression_binding() {
+        let adapter = TypeScriptAdapter;
+        let source = b"const Timer = class extends Base { start(): void { tick(); } };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.ts");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert_eq!(
+            named,
+            vec![
+                (EntityKind::Class, "Timer"),
+                (EntityKind::Method, "Timer.start"),
+            ]
+        );
+        let extends: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Extends)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(extends, vec![("Timer", "Base")]);
+    }
+
+    #[test]
     fn keep_object_literal_with_callbacks() {
         let adapter = TypeScriptAdapter;
         // Object literals containing function-like nodes are meaningful code.

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -12,6 +12,14 @@ use crate::extract::{
     ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport, ImportedName,
     ParseOutput,
 };
+// TypeScript is a superset of JavaScript, so the CommonJS import surface,
+// receiver-method assignment forms and object-literal methods parse to the same
+// nodes in both grammars. Sharing them keeps the two adapters from drifting into
+// different answers for the same source.
+use super::javascript::{
+    collect_js_require_imports, extract_js_assignment_function, extract_js_object_methods,
+    js_heritage_name, js_require_target, JsOwners,
+};
 
 pub struct TypeScriptAdapter;
 
@@ -46,6 +54,7 @@ impl LanguageAdapter for TypeScriptAdapter {
         let mut relations = Vec::new();
         let mut imports = Vec::new();
         let mut tests = Vec::new();
+        let mut owners = JsOwners::default();
         let root = tree.root_node();
         let mut cursor = root.walk();
 
@@ -67,13 +76,24 @@ impl LanguageAdapter for TypeScriptAdapter {
         }
 
         for child in root.children(&mut cursor) {
-            extract_ts_node(&child, source, file_id, &mut entities, &mut relations);
+            extract_ts_node(
+                &child,
+                source,
+                file_id,
+                &mut entities,
+                &mut relations,
+                &mut owners,
+            );
             if let Some(import_like) = extract_ts_import_like(&child, source) {
                 imports.push(import_like);
             }
+            // Extract CommonJS require() calls as imports
+            collect_js_require_imports(&child, source, &mut imports);
             // Detect describe/it/test calls (Jest/Vitest/Mocha)
             extract_js_tests(&child, source, &mut tests);
         }
+
+        owners.finish(&mut entities);
 
         // Build import lookup: local_name -> module_path
         let import_map: std::collections::HashMap<&str, &str> = imports
@@ -113,6 +133,7 @@ fn extract_ts_node(
     file_id: &FilePathId,
     entities: &mut Vec<ExtractedEntity>,
     relations: &mut Vec<ExtractedRelation>,
+    owners: &mut JsOwners,
 ) {
     match node.kind() {
         "function_declaration" | "function" => {
@@ -136,29 +157,7 @@ fn extract_ts_node(
         "class_declaration" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
-                let sig = node_signature(node, source);
-                entities.push(ExtractedEntity {
-                    kind: EntityKind::Class,
-                    name: name.clone(),
-                    signature: sig,
-                    visibility: detect_ts_visibility(node, source),
-                    doc_summary: extract_preceding_comment(node, source),
-                    fingerprint: compute_fingerprint(node, source),
-                    span: span_from_node(node, file_id),
-                });
-
-                // Extract heritage (extends/implements)
-                extract_ts_heritage(node, source, &name, relations);
-
-                // Recurse into class body for methods
-                if let Some(body) = node.child_by_field_name("body") {
-                    let mut cursor = body.walk();
-                    for member in body.children(&mut cursor) {
-                        extract_ts_class_member(
-                            &member, source, file_id, &name, entities, relations,
-                        );
-                    }
-                }
+                extract_ts_class_like(node, &name, source, file_id, entities, relations);
             }
         }
         "interface_declaration" => {
@@ -240,6 +239,12 @@ fn extract_ts_node(
                 }
             }
         }
+        "expression_statement" => {
+            // Prototype and receiver method assignments (`Foo.prototype.bar =
+            // function () {}`) plus `module.exports = ...`. TypeScript files in
+            // Node packages still carry these CommonJS shapes.
+            extract_js_assignment_function(node, source, file_id, entities, relations, owners);
+        }
         "lexical_declaration" | "variable_declaration" => {
             let mut decl_cursor = node.walk();
             for declarator in node.children(&mut decl_cursor) {
@@ -247,6 +252,34 @@ fn extract_ts_node(
                     if let Some(name_node) = declarator.child_by_field_name("name") {
                         let name = name_node.utf8_text(source).unwrap_or("").to_string();
                         let value_node = declarator.child_by_field_name("value");
+
+                        // A `require(...)` binding is a dependency line, not a
+                        // constant; it is already carried as a `FileImport`.
+                        if value_node
+                            .as_ref()
+                            .is_some_and(|value| js_require_target(value, source).is_some())
+                        {
+                            continue;
+                        }
+
+                        // `const Foo = class extends Bar {}` is a class
+                        // declaration wearing a binding.
+                        if let Some(class_value) =
+                            value_node.filter(|value| value.kind() == "class")
+                        {
+                            if !name.is_empty() {
+                                extract_ts_class_like(
+                                    &class_value,
+                                    &name,
+                                    source,
+                                    file_id,
+                                    entities,
+                                    relations,
+                                );
+                            }
+                            continue;
+                        }
+
                         let kind = if value_node.as_ref().is_some_and(is_ts_function_like_node) {
                             EntityKind::Function
                         } else {
@@ -267,7 +300,7 @@ fn extract_ts_node(
                         }
                         entities.push(ExtractedEntity {
                             kind,
-                            name,
+                            name: name.clone(),
                             signature: node_signature(&declarator, source),
                             visibility: detect_ts_visibility(node, source),
                             doc_summary: extract_preceding_comment(node, source),
@@ -283,6 +316,13 @@ fn extract_ts_node(
                                 relations,
                             );
                         }
+                        // `const utils = { parse() {} }` is a namespace object
+                        // whose function properties are the methods it owns.
+                        if let Some(object) = value_node.filter(|value| value.kind() == "object") {
+                            extract_js_object_methods(
+                                &object, &name, source, file_id, entities, relations, owners,
+                            );
+                        }
                     }
                 }
             }
@@ -296,7 +336,7 @@ fn extract_ts_node(
                 if child.kind() == "default" || child.utf8_text(source).unwrap_or("") == "default" {
                     has_default = true;
                 }
-                extract_ts_node(&child, source, file_id, entities, relations);
+                extract_ts_node(&child, source, file_id, entities, relations, owners);
             }
             // If this is a default export and recursion didn't create any entities,
             // create a synthetic "default" entity so the linker can resolve
@@ -334,6 +374,39 @@ fn extract_ts_node(
         }
         "import_statement" => {}
         _ => {}
+    }
+}
+
+/// Extract a class entity, its heritage edges, and its members. Shared by
+/// `class Foo {}` and `const Foo = class {}`, which differ only in where the
+/// name comes from.
+fn extract_ts_class_like(
+    node: &tree_sitter::Node,
+    name: &str,
+    source: &[u8],
+    file_id: &FilePathId,
+    entities: &mut Vec<ExtractedEntity>,
+    relations: &mut Vec<ExtractedRelation>,
+) {
+    entities.push(ExtractedEntity {
+        kind: EntityKind::Class,
+        name: name.to_string(),
+        signature: node_signature(node, source),
+        visibility: detect_ts_visibility(node, source),
+        doc_summary: extract_preceding_comment(node, source),
+        fingerprint: compute_fingerprint(node, source),
+        span: span_from_node(node, file_id),
+    });
+
+    // Extract heritage (extends/implements)
+    extract_ts_heritage(node, source, name, relations);
+
+    // Recurse into class body for methods
+    if let Some(body) = node.child_by_field_name("body") {
+        let mut cursor = body.walk();
+        for member in body.children(&mut cursor) {
+            extract_ts_class_member(&member, source, file_id, name, entities, relations);
+        }
     }
 }
 
@@ -523,18 +596,23 @@ fn extract_ts_heritage(
             for clause in child.children(&mut heritage_cursor) {
                 match clause.kind() {
                     "extends_clause" => {
-                        if let Some(value) = clause.child(1) {
-                            let parent = value.utf8_text(source).unwrap_or("").to_string();
-                            if !parent.is_empty() {
-                                relations.push(ExtractedRelation {
-                                    receiver: None,
-                                    call_shape: None,
-                                    kind: kin_model::RelationKind::Extends,
-                                    src_name: class_name.to_string(),
-                                    dst_name: parent,
-                                    import_source: None,
-                                });
-                            }
+                        // The base may be a bare identifier, a namespace member
+                        // (`extends React.Component`) or a mixin call; each
+                        // reduces to the rightmost identifier, which is the name
+                        // the linker resolves. A generic base
+                        // (`extends Base<T>`) keeps only `Base`.
+                        if let Some(parent) = clause
+                            .child(1)
+                            .and_then(|value| js_heritage_name(&value, source))
+                        {
+                            relations.push(ExtractedRelation {
+                                receiver: None,
+                                call_shape: None,
+                                kind: kin_model::RelationKind::Extends,
+                                src_name: class_name.to_string(),
+                                dst_name: parent,
+                                import_source: None,
+                            });
                         }
                     }
                     "implements_clause" => {
@@ -1156,23 +1234,28 @@ export class Dog extends Animal implements Pet {
     #[test]
     fn keep_object_literal_with_callbacks() {
         let adapter = TypeScriptAdapter;
-        // Object literals containing function-like nodes are meaningful code
+        // Object literals containing function-like nodes are meaningful code.
+        //
+        // Contract (shared with the JavaScript adapter): such a literal is a
+        // namespace object, so it is kinded Class and each function property
+        // becomes a Method it contains.
         let source = b"export const handlers = { onClick: () => console.log('click') };";
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.ts");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
 
-        let constants: Vec<_> = output
+        let named: Vec<(EntityKind, &str)> = output
             .entities
             .iter()
-            .filter(|e| e.kind == EntityKind::Constant)
+            .map(|e| (e.kind, e.name.as_str()))
             .collect();
         assert_eq!(
-            constants.len(),
-            1,
-            "object literals with callbacks should be kept"
+            named,
+            vec![
+                (EntityKind::Class, "handlers"),
+                (EntityKind::Method, "handlers.onClick"),
+            ]
         );
-        assert_eq!(constants[0].name, "handlers");
     }
 
     #[test]

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -425,6 +425,193 @@ fn kotlin_signature_should_exclude_body() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// JavaScript / TypeScript relational shape.
+//
+// A `kin init` of express on 0.5.36 produced 613 entities and 211 relations —
+// 0.34 per entity, no Contains, no Extends, no Method or Class kind, and 451 of
+// the 613 entities Constants. Python on a comparable repo produced 2.64
+// relations per entity. The two fixtures below carry every JavaScript shape
+// that gap came from, and assert edge DENSITY as well as presence so a
+// regression that halves the relational graph fails rather than passing on a
+// surviving sample.
+// ---------------------------------------------------------------------------
+
+/// Every relational JavaScript shape in one file: an ES class with methods and
+/// a base, a constructor with a prototype method, a receiver-object method, a
+/// namespace object literal, a const-bound arrow, a CommonJS export and an ESM
+/// export.
+const RELATIONAL_JS: &str = r#"
+import { helper } from './helper';
+const format = require('./format');
+
+export class Service extends Base {
+  run() { return format(helper(this.id)); }
+  stop() { return format(helper(this.id)); }
+}
+
+function View(name) { this.name = normalize(trim(name)); }
+View.prototype.lookup = function lookup(n) { return format(helper(n)); };
+
+res.status = function status(code) { return format(validate(code)); };
+res.set = res.header = function header(field) { return format(trim(field)); };
+
+const utils = {
+  parse(input) { return format(helper(input)); },
+  print: (x) => format(trim(x)),
+};
+
+const build = (spec) => format(normalize(spec));
+
+module.exports = { boot() { return format(helper(0)); } };
+
+export const NAME = 'service';
+"#;
+
+/// The TypeScript mirror of [`RELATIONAL_JS`]. The two adapters share the
+/// CommonJS import surface, the receiver-assignment forms and the
+/// object-literal method extraction, so a divergence here means one adapter
+/// answers a question about the same source differently from the other.
+const RELATIONAL_TS: &str = r#"
+import { helper } from './helper';
+const format = require('./format');
+
+export class Service extends Base {
+  run(): number { return format(helper(this.id)); }
+  stop(): number { return format(helper(this.id)); }
+}
+
+function View(name: string) { this.name = normalize(trim(name)); }
+View.prototype.lookup = function lookup(n: string) { return format(helper(n)); };
+
+res.status = function status(code: number) { return format(validate(code)); };
+res.set = res.header = function header(field: string) { return format(trim(field)); };
+
+const utils = {
+  parse(input: string) { return format(helper(input)); },
+  print: (x: string) => format(trim(x)),
+};
+
+const build = (spec: string) => format(normalize(spec));
+
+module.exports = { boot() { return format(helper(0)); } };
+
+export const NAME = 'service';
+"#;
+
+/// Assert the relational contract both adapters must satisfy on their fixture.
+fn assert_relational_shape(out: &ParseOutput, lang: &str) {
+    let named: Vec<(EntityKind, &str)> = out
+        .entities
+        .iter()
+        .map(|e| (e.kind, e.name.as_str()))
+        .collect();
+    let expected = [
+        // ES class, its methods, and the constructor-plus-prototype form —
+        // both are classes with methods, and the graph must not tell them apart.
+        (EntityKind::Class, "Service"),
+        (EntityKind::Method, "Service.run"),
+        (EntityKind::Method, "Service.stop"),
+        (EntityKind::Class, "View"),
+        (EntityKind::Method, "View.lookup"),
+        // A receiver object owns what is assigned to it, and a chained
+        // assignment defines every target on the chain.
+        (EntityKind::Class, "res"),
+        (EntityKind::Method, "res.status"),
+        (EntityKind::Method, "res.set"),
+        (EntityKind::Method, "res.header"),
+        // A namespace object literal owns its function properties.
+        (EntityKind::Class, "utils"),
+        (EntityKind::Method, "utils.parse"),
+        (EntityKind::Method, "utils.print"),
+        // A const-bound arrow is a Function, never a Constant.
+        (EntityKind::Function, "build"),
+        // `module.exports = { ... }` exports one function per property.
+        (EntityKind::Function, "boot"),
+        // A scalar named export stays a Constant.
+        (EntityKind::Constant, "NAME"),
+    ];
+    for want in expected {
+        assert!(
+            named.contains(&want),
+            "{lang}: missing {want:?}; have {named:?}"
+        );
+    }
+
+    let contains: std::collections::BTreeSet<(&str, &str)> = out
+        .relations
+        .iter()
+        .filter(|r| r.kind == kin_model::RelationKind::Contains)
+        .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+        .collect();
+    for want in [
+        ("Service", "Service.run"),
+        ("Service", "Service.stop"),
+        ("View", "View.lookup"),
+        ("res", "res.status"),
+        ("res", "res.set"),
+        ("res", "res.header"),
+        ("utils", "utils.parse"),
+        ("utils", "utils.print"),
+    ] {
+        assert!(
+            contains.contains(&want),
+            "{lang}: missing Contains {want:?}; have {contains:?}"
+        );
+    }
+
+    let extends: Vec<(&str, &str)> = out
+        .relations
+        .iter()
+        .filter(|r| r.kind == kin_model::RelationKind::Extends)
+        .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+        .collect();
+    assert_eq!(extends, vec![("Service", "Base")], "{lang}: Extends");
+
+    // Both the ESM `import` and the CommonJS `require` reach the import
+    // surface; cross-file resolution has no binding to work with otherwise.
+    let modules: std::collections::BTreeSet<&str> =
+        out.imports.iter().map(|i| i.module_path.as_str()).collect();
+    assert!(
+        modules.contains("./helper") && modules.contains("./format"),
+        "{lang}: expected both ESM and CommonJS imports, got {modules:?}"
+    );
+    // A require binding is a dependency line, not an entity.
+    assert!(
+        !named.iter().any(|(_, n)| *n == "format"),
+        "{lang}: require binding must not become an entity; have {named:?}"
+    );
+
+    // Density, not just presence: express measured 0.34 relations per entity
+    // against Python's 2.64. Asserting the ratio is what makes a regression
+    // that halves the edge count fail on a fixture that still contains every
+    // expected name.
+    let density = out.relations.len() as f64 / out.entities.len() as f64;
+    assert!(
+        density >= 2.0,
+        "{lang}: {} relations over {} entities is {density:.2} per entity, \
+         below the 2.0 floor this fixture must clear",
+        out.relations.len(),
+        out.entities.len()
+    );
+}
+
+#[test]
+fn javascript_relational_shape() {
+    assert_relational_shape(
+        &extract(&JavaScriptAdapter, "service.js", RELATIONAL_JS),
+        "javascript",
+    );
+}
+
+#[test]
+fn typescript_relational_shape() {
+    assert_relational_shape(
+        &extract(&TypeScriptAdapter, "service.ts", RELATIONAL_TS),
+        "typescript",
+    );
+}
+
 #[test]
 #[ignore = "YELLOW: Ruby empty-body method keeps a trailing `end` in the signature (`def helper end`) because there is no `body` field to cut before"]
 fn ruby_empty_body_method_signature_should_exclude_end() {

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -428,7 +428,7 @@ fn kotlin_signature_should_exclude_body() {
 // ---------------------------------------------------------------------------
 // JavaScript / TypeScript relational shape.
 //
-// A `kin init` of express on 0.5.36 produced 613 entities and 211 relations —
+// A `kin init` of express on 0.5.36 produced 613 entities and 211 relations:
 // 0.34 per entity, no Contains, no Extends, no Method or Class kind, and 451 of
 // the 613 entities Constants. Python on a comparable repo produced 2.64
 // relations per entity. The two fixtures below carry every JavaScript shape
@@ -507,8 +507,8 @@ fn assert_relational_shape(out: &ParseOutput, lang: &str) {
         .map(|e| (e.kind, e.name.as_str()))
         .collect();
     let expected = [
-        // ES class, its methods, and the constructor-plus-prototype form —
-        // both are classes with methods, and the graph must not tell them apart.
+        // ES class, its methods, and the constructor-plus-prototype form.
+        // Both are classes with methods, and the graph must not tell them apart.
         (EntityKind::Class, "Service"),
         (EntityKind::Method, "Service.run"),
         (EntityKind::Method, "Service.stop"),


### PR DESCRIPTION
A `kin init` of expressjs/express produced 613 entities and 211 relations: 0.34
per entity, no Contains, no Extends, no Method or Class kind, and 451 of the 613
entities Constants. Python on a comparable repo produced 2.64 relations per
entity with Method, Class, Contains and Extends all populated. The JavaScript
graph was a symbol list; the Python graph was a call graph.

Reproduced exactly by driving the adapter over all 141 express JS files: 613
entities, 451/133/29 Constant/Function/Module, 0.93 raw relations per entity.
After this change, same checkout: 235 entities, 672 relations, 2.86 per entity,
Class 11, Method 63, Contains 63 where all three were zero, Constants down to
50 and imports up from 305 to 396.

The ticket named the wrong cause and the code already did what item 3 asked. A
`const fn = function () {}` binding was classified Function before this change.
Three other gaps produced the reported shape.

A function assigned to a receiver was recorded as a free function named after
its right-hand side. express is written in the prototype-object style, so
`res.status = function status(code)` and its twenty-two siblings became orphan
functions with nothing joining them to `res` and nothing marking them methods.
express contains no ES classes at all, which is why the class path that already
existed never fired. A receiver now owns what is assigned to it: the method is
named `receiver.property`, the receiver is kinded Class, and a Contains edge
joins them. The kind is load-bearing rather than cosmetic, because the linker's
receiver-method and inheritance tiers only fire when the owner half of an
`Owner.method` name is class-like. Recall does not drop from the rename, since
the linker indexes every entity under its bare leaf as well as its full name.
`Foo.prototype.bar` and `Foo.bar` collapse to one owner, as both are reached as
`bar` on a `Foo`. A chained assignment now defines every target on the chain
rather than none, which recovers `res.set`/`res.header`,
`res.contentType`/`res.type` and `req.get`/`req.header`. `module.exports` and
`exports` stay the module's public surface, so their members remain module-level
functions, and an object literal exported that way yields one function per
property.

Object literals with function properties and class expressions bound to a const
were not modeled at all; both now produce the same Class plus Method plus
Contains shape. Class bodies pick up function-valued fields, which is the React
class-property form, while a data field stays out because it is not callable. A
base named through a namespace member or a mixin call resolves to its rightmost
identifier, so `extends React.Component` links to `Component` instead of being
dropped in JavaScript or kept as an unmatchable string in TypeScript.

A require binding was recorded as a Constant beside the FileImport it already
produced, which is where most of the 451 came from: express has 305 dependency
lines and every one was counted twice. It is now only an import, and the
collector covers destructuring, member access on the required module, an invoked
module, a bare side-effect require, a re-export assignment and every declarator
in a multi-declarator statement, none of which were recognized before.
`require('m').x` binds as the named export `x` rather than as a default.

TypeScript shares the CommonJS import surface, the receiver-assignment forms and
the object-literal method extraction rather than re-implementing them, so the
two adapters cannot drift into different answers about the same source.
TypeScript previously had no expression-statement handling and no require
handling at all.

Left for the tickets that own them, and stated so the next reader does not
mistake absence for oversight: `this.foo()` receiver qualification and
`call_shape` belong to FIR-2360, which owns per-edge confidence, and changing
the call side here would collide with that work; the call-coverage negative
marker belongs with FIR-2358, since flipping it changes readiness signalling
across every JavaScript repo; extraction still walks top-level statements only,
so a method assigned inside an IIFE stays invisible.

Tests assert relations-per-entity on the fixture, not only presence, so a
regression that halves edge density fails on a fixture that still contains every
expected name. Each assertion was falsified by reverting its behavior in the
source and confirming the guard fires, including the density floor in isolation,
which the Contains-presence assertion would otherwise mask.

Closes FIR-2362
