### PR TITLE
Bound trace_data_flow's own response, order its fan-out by relevance, and give every step one shape

### DIFF
--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -34,31 +34,16 @@ const DEFAULT_LIMIT_PER_STEP: usize = 5;
 const MAX_LIMIT_PER_STEP: usize = 25;
 const MAX_TOTAL_STEPS: usize = 200;
 
-/// Serialized characters one response may occupy before the tool cuts its own
-/// payload.
+/// Serialized characters one response may occupy before this walk cuts its own
+/// payload, and the floor and ceiling a caller may move it to.
 ///
-/// Every other bound here shapes the WALK, and none of them bounds the ANSWER: a
-/// walk inside all of them returned 228,413 characters over 2,453 lines from a
-/// 777-entity repository, because 106 steps each inlined a full body, and the
-/// client refused the result outright. A refused result is worse than a
-/// truncated one, since a caller gets neither the chain nor a way to ask for
-/// less, so the tool now measures what it is about to return and cuts bodies
-/// before edges to fit.
-///
-/// Sized against the tool-result ceilings agent clients actually apply, which
-/// are counted in tokens; at roughly 3.5 characters per token of JSON-wrapped
-/// source this leaves headroom under a 25k-token cap for the envelope a caller
-/// wraps around it.
-pub const DEFAULT_MAX_RESPONSE_CHARS: usize = 80_000;
-
-/// Floor for a caller-supplied budget. Below this the envelope alone does not
-/// fit, so a smaller number could only be honoured by returning nothing.
-const MIN_MAX_RESPONSE_CHARS: usize = 2_000;
-
-/// Ceiling for a caller-supplied budget. A caller with a larger window may raise
-/// the bound, but not to unbounded: the daemon serving this has other callers,
-/// and a response nothing can read is not worth building.
-const MAX_MAX_RESPONSE_CHARS: usize = 400_000;
+/// Read from `kin_mcp` rather than restated here: both arms of this one tool have
+/// to promise the same bound, and the arm that serves a generic graph store lives
+/// there. A refused result is worse than a truncated one, since a caller gets
+/// neither the chain nor a way to ask for less, which is why the number exists at
+/// all — see the definition for what it was measured against.
+pub use kin_mcp::handlers::common::TRACE_DEFAULT_MAX_RESPONSE_CHARS as DEFAULT_MAX_RESPONSE_CHARS;
+use kin_mcp::handlers::common::{trace_response_budget, TRACE_DISCLOSURE_RESERVE_CHARS};
 
 /// Wall-clock ceiling for one trace walk.
 ///
@@ -332,9 +317,7 @@ impl TraceDataFlowRequest {
     }
 
     fn budget_chars(&self) -> usize {
-        self.max_response_chars
-            .unwrap_or(DEFAULT_MAX_RESPONSE_CHARS)
-            .clamp(MIN_MAX_RESPONSE_CHARS, MAX_MAX_RESPONSE_CHARS)
+        trace_response_budget(self.max_response_chars)
     }
 }
 
@@ -1052,13 +1035,6 @@ fn entity_record(entity: &Entity, source: Option<&GraphSourceRecord>) -> TraceEn
     }
 }
 
-/// Characters held back from the budget for the disclosure a cut adds.
-///
-/// A response cut to exactly its ceiling and then told to explain the cut is
-/// over its ceiling again, by the length of the explanation. Reserving the room
-/// first is what makes the bound hold for the payload that actually ships.
-const DISCLOSURE_RESERVE_CHARS: usize = 1_500;
-
 /// Serialized size of a response, measured the way it will be sent.
 ///
 /// Both surfaces that return this — the CLI's `println!` and the daemon's MCP
@@ -1087,7 +1063,7 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
     if measure_response(response) <= ceiling {
         return;
     }
-    let target = ceiling.saturating_sub(DISCLOSURE_RESERVE_CHARS);
+    let target = ceiling.saturating_sub(TRACE_DISCLOSURE_RESERVE_CHARS);
 
     let mut bodies_omitted = 0usize;
     for step in &mut response.chain {
@@ -2084,6 +2060,7 @@ mod tests {
                 step: index,
                 role: "callee".to_string(),
                 relation_kind: "Calls".to_string(),
+                resolution: RelationResolution::TypeResolved.as_str().to_string(),
                 parent_step: index.saturating_sub(1),
                 depth: 1,
                 entity: record,

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -815,7 +815,10 @@ pub fn build_trace_data_flow_response_within(
                     (focal_entity.id.to_string(), focal_entity.name.clone())
                 } else {
                     let step = &chain[node.step - 1];
-                    (step.entity.entity_id.clone(), step.entity.entity_name.clone())
+                    (
+                        step.entity.entity_id.clone(),
+                        step.entity.entity_name.clone(),
+                    )
                 };
                 clipped_steps.push(TraceFanoutClip {
                     step: node.step,
@@ -835,8 +838,7 @@ pub fn build_trace_data_flow_response_within(
                 let candidate_external =
                     kin_ranking::entity_ranking::trace_entity_is_external(&candidate.entity);
                 if let Some(&existing) = name_index.get(candidate.entity.name.as_str()) {
-                    let existing_external =
-                        existing > 0 && chain[existing - 1].entity.external;
+                    let existing_external = existing > 0 && chain[existing - 1].entity.external;
                     if candidate_external {
                         // A record for this name is already in the response.
                         // A second, location-less one adds no information and
@@ -850,9 +852,7 @@ pub fn build_trace_data_flow_response_within(
                         // Fill it in with the record the graph does own rather
                         // than admitting one symbol twice.
                         let source = bodies_included
-                            .then(|| {
-                                source_record_or_none(projection.as_ref(), &candidate.entity)
-                            })
+                            .then(|| source_record_or_none(projection.as_ref(), &candidate.entity))
                             .flatten();
                         let promoted = &mut chain[existing - 1];
                         promoted.entity = entity_record(&candidate.entity, source.as_ref());
@@ -862,8 +862,11 @@ pub fn build_trace_data_flow_response_within(
                         // replaced it does, so it re-enters the frontier at the
                         // depth it already sits at.
                         if promoted.depth < depth {
-                            next_frontier
-                                .push(FrontierNode::at(existing, promoted.depth, &candidate.entity));
+                            next_frontier.push(FrontierNode::at(
+                                existing,
+                                promoted.depth,
+                                &candidate.entity,
+                            ));
                         }
                         continue;
                     }
@@ -1152,7 +1155,10 @@ fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
     } else {
         "bodies_omitted"
     };
-    let cut = match (bodies_omitted + usize::from(focal_body_omitted), steps_omitted) {
+    let cut = match (
+        bodies_omitted + usize::from(focal_body_omitted),
+        steps_omitted,
+    ) {
         (bodies, 0) => format!("{bodies} inlined bodies were dropped"),
         (0, steps) => format!("{steps} steps were dropped from the end of the chain"),
         (bodies, steps) => format!(
@@ -2180,10 +2186,7 @@ mod tests {
             .iter()
             .all(|step| step.step <= kept && step.parent_step <= kept));
         assert!(
-            response
-                .clipped_steps
-                .iter()
-                .all(|clip| clip.step <= kept),
+            response.clipped_steps.iter().all(|clip| clip.step <= kept),
             "a clip must not name a step the response dropped"
         );
         let cut = response

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -19,7 +19,7 @@ use anyhow::{Context, Result};
 use kin_index::RelationResolution;
 use kin_model::{Entity, EntityId, EntityStore, GraphNodeId, RelationKind};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use crate::commands::graph::{graph_source_record_from, GraphSourceRecord};
@@ -33,6 +33,32 @@ const MAX_DEPTH: usize = 8;
 const DEFAULT_LIMIT_PER_STEP: usize = 5;
 const MAX_LIMIT_PER_STEP: usize = 25;
 const MAX_TOTAL_STEPS: usize = 200;
+
+/// Serialized characters one response may occupy before the tool cuts its own
+/// payload.
+///
+/// Every other bound here shapes the WALK, and none of them bounds the ANSWER: a
+/// walk inside all of them returned 228,413 characters over 2,453 lines from a
+/// 777-entity repository, because 106 steps each inlined a full body, and the
+/// client refused the result outright. A refused result is worse than a
+/// truncated one, since a caller gets neither the chain nor a way to ask for
+/// less, so the tool now measures what it is about to return and cuts bodies
+/// before edges to fit.
+///
+/// Sized against the tool-result ceilings agent clients actually apply, which
+/// are counted in tokens; at roughly 3.5 characters per token of JSON-wrapped
+/// source this leaves headroom under a 25k-token cap for the envelope a caller
+/// wraps around it.
+pub const DEFAULT_MAX_RESPONSE_CHARS: usize = 80_000;
+
+/// Floor for a caller-supplied budget. Below this the envelope alone does not
+/// fit, so a smaller number could only be honoured by returning nothing.
+const MIN_MAX_RESPONSE_CHARS: usize = 2_000;
+
+/// Ceiling for a caller-supplied budget. A caller with a larger window may raise
+/// the bound, but not to unbounded: the daemon serving this has other callers,
+/// and a response nothing can read is not worth building.
+const MAX_MAX_RESPONSE_CHARS: usize = 400_000;
 
 /// Wall-clock ceiling for one trace walk.
 ///
@@ -288,6 +314,70 @@ pub struct TraceDataFlowRequest {
     /// Maximum number of relations expanded per step (default 5, capped at 25).
     #[serde(default)]
     pub limit_per_step: Option<usize>,
+    /// Inline each step's source body (default true). `false` returns the SHAPE
+    /// of the chain — names, kinds, roles, spans, and edges — at a fraction of
+    /// the size, which is what a caller asking "what does this reach" wants.
+    #[serde(default)]
+    pub include_body: Option<bool>,
+    /// Serialized characters this response may occupy (default
+    /// [`DEFAULT_MAX_RESPONSE_CHARS`]). The tool cuts bodies, and only then
+    /// steps, to stay inside it, and says so in `degradations`.
+    #[serde(default)]
+    pub max_response_chars: Option<usize>,
+}
+
+impl TraceDataFlowRequest {
+    fn bodies_included(&self) -> bool {
+        self.include_body.unwrap_or(true)
+    }
+
+    fn budget_chars(&self) -> usize {
+        self.max_response_chars
+            .unwrap_or(DEFAULT_MAX_RESPONSE_CHARS)
+            .clamp(MIN_MAX_RESPONSE_CHARS, MAX_MAX_RESPONSE_CHARS)
+    }
+}
+
+/// One entity as a trace reports it, with the same keys whether the graph owns a
+/// location for it or holds it only as a reference target.
+///
+/// Flattened into its step rather than nested, so the step keys a consumer
+/// already parses (`entity_id`, `entity_name`, `entity_kind`, `entity_file`) are
+/// unchanged, and the span, signature, and body that used to live in a
+/// sometimes-absent nested record sit beside them as explicit nulls.
+///
+/// The absent-record shape is what this replaces. 16 of 106 steps in one
+/// measured response carried `entity_name` and `entity_kind` with no file, no
+/// line, and no body, so one array held two different key sets and broke its
+/// consumer's parser twice. Nothing is invented to fix that: a symbol the graph
+/// owns no file for still reports null for every field it has no answer for, and
+/// says which case it is in `external`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceEntityRecord {
+    pub entity_id: String,
+    pub entity_name: String,
+    pub entity_kind: String,
+    /// `source`, `test`, `external`, … — the role the per-step relevance order
+    /// reads, so a caller can see why a test callee lost a slot to a source one.
+    pub entity_role: String,
+    pub entity_file: Option<String>,
+    /// True when the graph holds no file for this symbol: an import another
+    /// repository defines, a builtin, or an alias split off its definition. Such
+    /// a record carries identity and nothing else, and the nulls beside it are
+    /// facts about the graph rather than a failed read.
+    pub external: bool,
+    /// 1-based inclusive presentation lines, from the entity's own span. Present
+    /// without a body, because a span is what makes a shape query actionable.
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+    pub signature: Option<String>,
+    /// Inlined source, or null when bodies were not requested, could not be
+    /// read, or were dropped to fit the response budget. `bodies_included` and
+    /// `degradations` on the response say which.
+    pub body: Option<String>,
+    /// Whether the span that cut `body` was proven to describe those exact bytes.
+    /// Null whenever no body was served, since the pairing is what it describes.
+    pub span_coherence: Option<String>,
 }
 
 /// One step in the data-flow chain.
@@ -314,44 +404,96 @@ pub struct TraceStep {
     /// Depth from the focal (1 = direct neighbor of focal, 2 = neighbor of
     /// neighbor, etc.).
     pub depth: usize,
-    /// Source record for this entity, including the inlined body. Optional
-    /// because some entities (external symbols, headers without spans) may
-    /// not be readable from the graph.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entity: Option<GraphSourceRecord>,
-    /// Fallback fields for entities without a readable body. Always present
-    /// so the consumer can render even when `entity` is None.
+    /// This step's identity, location, and (when served) body.
+    #[serde(flatten)]
+    pub entity: TraceEntityRecord,
+    /// True when THIS node's own fan-out was cut by `limit_per_step`, so the
+    /// chain below it is partial. A top-level flag cannot say this: the measured
+    /// response reported `truncated: true` once for 106 steps, which named no
+    /// node and left every step indistinguishable from a complete one.
+    pub fanout_truncated: bool,
+    /// How many of this node's neighbors the cap dropped. Re-query this node
+    /// with a wider `limit_per_step` to recover exactly them.
+    pub fanout_dropped: usize,
+}
+
+/// A node whose fan-out the per-step cap clipped, listed so a caller can repair
+/// the chain without scanning every step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceFanoutClip {
+    /// Step index of the clipped node; `0` is the focal entity.
+    pub step: usize,
     pub entity_id: String,
     pub entity_name: String,
-    pub entity_kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entity_file: Option<String>,
+    pub dropped_callees: usize,
+    pub dropped_callers: usize,
+    /// The cap that did the clipping, so the remedy is a number the caller can
+    /// raise rather than a guess.
+    pub limit_per_step: usize,
 }
 
 /// Response from the trace-data-flow primitive.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceDataFlowResponse {
-    /// Focal entity. When the entity has a readable body, the record is
-    /// populated; otherwise the fallback identity fields below are used.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Focal entity's source record. Present when a body was requested and
+    /// readable, null otherwise; `focal_*` below always carry its identity, and
+    /// `focal_span` its location, in both modes.
     pub focal: Option<GraphSourceRecord>,
     pub focal_id: String,
     pub focal_name: String,
     pub focal_kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub focal_file: Option<String>,
+    /// The focal in the same shape every step uses, so a consumer can read the
+    /// whole response through one record type. Carries the focal's span and
+    /// signature even when no body was served.
+    pub focal_entity: TraceEntityRecord,
     /// Direction that was traversed.
     pub direction: String,
     /// Depth that was traversed.
     pub depth: usize,
+    /// The per-step fan-out cap this walk applied, echoed because it is what a
+    /// caller raises to recover a clipped step.
+    pub limit_per_step: usize,
+    /// Whether step bodies were inlined. False when the caller asked for the
+    /// chain's shape, and also when the response budget dropped them.
+    pub bodies_included: bool,
     /// The ordered chain of steps reached from the focal. Already deduplicated
-    /// (each entity appears at most once).
+    /// (each entity appears at most once), ordered per node by relevance rather
+    /// than by whatever order the relation table returned.
     pub chain: Vec<TraceStep>,
     /// Total number of steps in the chain (excludes the focal).
     pub total_steps: usize,
     /// True when the traversal was cut off because per-step or total caps
     /// were hit. Lets callers detect when they need to widen the limit.
+    ///
+    /// Bodies dropped to fit the response budget do NOT set this: the chain and
+    /// its edges are complete in that case, and `bodies_included` plus a
+    /// `response_budget` degradation report the cut. Steps dropped to fit the
+    /// budget DO set it, because those are edges the caller did not receive.
     pub truncated: bool,
+    /// Every node whose fan-out the per-step cap clipped, with the count it
+    /// dropped. Empty — and omitted — for a walk that expanded every neighbor it
+    /// reached.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub clipped_steps: Vec<TraceFanoutClip>,
+    /// Step bodies the response budget dropped, and steps it dropped after that.
+    /// Both zero — and omitted — for a response that fit as built.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub bodies_omitted: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub steps_omitted: usize,
+    /// File-less duplicates of a symbol the graph also holds with a file, merged
+    /// into the located record so one symbol carries one identity in one
+    /// response. Zero — and omitted — when no name arrived both ways.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub external_identities_merged: usize,
+    /// The ceiling this response was measured against, echoed so a caller that
+    /// wants more (or less) knows the name and the number to send.
+    ///
+    /// The response's own size is deliberately not a field here: writing it in
+    /// changes it, so the number would be wrong by however many digits it took to
+    /// say. A caller measuring the payload it received is measuring the truth.
+    pub max_response_chars: usize,
     /// Every work bound that cut this walk short, in the same machine-readable
     /// shape `semantic_locate` reports retrieval degradation in. Empty — and
     /// omitted from the payload — for a walk that finished inside every bound,
@@ -360,13 +502,19 @@ pub struct TraceDataFlowResponse {
     pub degradations: Vec<RetrievalDegradation>,
 }
 
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
+
 /// CLI entry: `kin trace-data-flow --focal <e> [--depth N] [--direction D]
-/// [--limit-per-step M]`.
+/// [--limit-per-step M] [--no-bodies] [--max-response-chars C]`.
 pub async fn run_seeded(
     focal: String,
     depth: Option<usize>,
     direction: Option<String>,
     limit_per_step: Option<usize>,
+    include_body: Option<bool>,
+    max_response_chars: Option<usize>,
 ) -> Result<()> {
     let direction = match direction {
         Some(value) => Some(TraceDirection::parse(&value)?),
@@ -377,6 +525,8 @@ pub async fn run_seeded(
         depth,
         direction,
         limit_per_step,
+        include_body,
+        max_response_chars,
     };
     let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_trace_data_flow(&layout, &request).await?;
@@ -440,6 +590,7 @@ pub fn build_trace_data_flow_response_within(
         .limit_per_step
         .unwrap_or(DEFAULT_LIMIT_PER_STEP)
         .clamp(1, MAX_LIMIT_PER_STEP);
+    let bodies_included = request.bodies_included();
 
     let focal_entity = match resolve_trace_focal(graph, trimmed)? {
         Some(entity) => entity,
@@ -485,7 +636,12 @@ pub fn build_trace_data_flow_response_within(
 
     // Try to load the focal source record. Failures (missing span, OOB blob)
     // degrade gracefully to the identity-only payload — the chain still works.
-    let focal_record = source_record_or_none(projection.as_ref(), &focal_entity);
+    // Read once and shared by both focal shapes, so asking for the focal in two
+    // shapes never costs two body reads.
+    let focal_record = bodies_included
+        .then(|| source_record_or_none(projection.as_ref(), &focal_entity))
+        .flatten();
+    let focal_entity_record = entity_record(&focal_entity, focal_record.as_ref());
 
     let reference_kinds = [
         RelationKind::Calls,
@@ -497,18 +653,34 @@ pub fn build_trace_data_flow_response_within(
     let mut chain: Vec<TraceStep> = Vec::new();
     let mut visited: HashSet<EntityId> = HashSet::new();
     visited.insert(focal_entity.id);
+    // Which step already stands for a symbol NAME.
+    //
+    // `visited` cannot answer this: an import alias and the function it aliases
+    // are two entities with two ids, so id-dedup admitted `cookiejar_from_dict`
+    // twice in one measured response — once located in cookies.py and once as a
+    // file-less Module — and the same symbol read as both admitted and external
+    // depending on which edge reached it.
+    //
+    // Seeded with the focal only when the graph owns a file for it. An admitted
+    // focal makes a file-less twin redundant; a file-less focal must not be
+    // rewritten into an entity the caller did not ask about.
+    let mut name_index: HashMap<String, usize> = HashMap::new();
+    if focal_entity.file_origin.is_some() {
+        name_index.insert(focal_entity.name.clone(), 0);
+    }
+    let mut external_identities_merged = 0usize;
+    let mut clipped_steps: Vec<TraceFanoutClip> = Vec::new();
     let mut truncated = false;
     let mut stop = TraceStop::Exhausted;
 
-    // Frontier: (parent_step, parent_entity, parent_depth).
-    let mut frontier: Vec<(usize, EntityId, usize)> = vec![(0, focal_entity.id, 0)];
-    let mut next_frontier: Vec<(usize, EntityId, usize)>;
+    let mut frontier: Vec<FrontierNode> = vec![FrontierNode::rooted(&focal_entity)];
+    let mut next_frontier: Vec<FrontierNode>;
 
     'walk: while !frontier.is_empty() {
         next_frontier = Vec::new();
 
-        for (parent_step, parent_id, parent_depth) in frontier.drain(..) {
-            if parent_depth >= depth {
+        for node in frontier.drain(..) {
+            if node.depth >= depth {
                 continue;
             }
 
@@ -522,7 +694,7 @@ pub fn build_trace_data_flow_response_within(
             }
 
             let relations = graph
-                .get_all_relations_for_entity(&parent_id)
+                .get_all_relations_for_entity(&node.id)
                 .context("read relations for trace step")?;
 
             // Expand outgoing edges (parent calls these) when direction allows.
@@ -530,10 +702,18 @@ pub fn build_trace_data_flow_response_within(
             // Expand incoming edges (these call parent) when direction allows.
             let want_callers = matches!(direction, TraceDirection::Callers | TraceDirection::Both);
 
-            // Independent budgets per direction so `direction=both` doesn't
-            // starve callers when callees are listed first (or vice versa).
-            let mut callee_count = 0usize;
-            let mut caller_count = 0usize;
+            // Every neighbor this node offers is collected BEFORE any is kept.
+            //
+            // The per-step cap is a choice between candidates, and a loop that
+            // admitted as it read had no candidates to choose between: it kept
+            // whichever the relation table listed first. On the measured trace
+            // that cost the answer — `resolve_redirects` kept `SupportsRead.read`
+            // and `HTTPAdapter.close` while dropping `get_redirect_target` and
+            // `rebuild_method`, the two functions that decide whether a redirect
+            // exists and what method replays it, both of which sit in its own
+            // file and were in the graph the whole time.
+            let mut candidates: Vec<FanoutCandidate> = Vec::new();
+            let mut candidate_index: HashMap<(EntityId, &'static str), usize> = HashMap::new();
             for rel in &relations {
                 if let Some(reason) = meter.charge_edge() {
                     stop = reason;
@@ -550,77 +730,171 @@ pub fn build_trace_data_flow_response_within(
 
                 // Decide which side of the relation is the "next" node.
                 let (next_id, role) = if want_callees
-                    && src_entity == Some(parent_id)
+                    && src_entity == Some(node.id)
                     && dst_entity.is_some()
-                    && dst_entity != Some(parent_id)
+                    && dst_entity != Some(node.id)
                 {
                     (dst_entity.unwrap(), "callee")
                 } else if want_callers
-                    && dst_entity == Some(parent_id)
+                    && dst_entity == Some(node.id)
                     && src_entity.is_some()
-                    && src_entity != Some(parent_id)
+                    && src_entity != Some(node.id)
                 {
                     (src_entity.unwrap(), "caller")
                 } else {
                     continue;
                 };
 
-                // Independent per-direction budget — cap callees and callers
-                // separately so `direction=both` doesn't starve one side.
-                // Check budget BEFORE marking visited so the next relation
-                // (potentially in the other direction) can still consider
-                // this entity if appropriate.
-                if role == "callee" && callee_count >= limit_per_step {
-                    truncated = true;
-                    continue;
-                }
-                if role == "caller" && caller_count >= limit_per_step {
-                    truncated = true;
+                // Already in the chain by another edge. Not a candidate, and not
+                // a drop either: the caller has the node, so counting it as
+                // dropped would send them re-querying for something they hold.
+                if visited.contains(&next_id) {
                     continue;
                 }
 
-                if !visited.insert(next_id) {
-                    continue;
+                match candidate_index.get(&(next_id, role)) {
+                    // The same neighbor reached twice, by two edges of different
+                    // kinds or confidences. One step, described by the stronger
+                    // edge, rather than one candidate per edge.
+                    Some(&existing) => {
+                        let candidate: &mut FanoutCandidate = &mut candidates[existing];
+                        let stronger = kin_ranking::entity_ranking::trace_relation_rank(rel.kind)
+                            > kin_ranking::entity_ranking::trace_relation_rank(
+                                candidate.relation_kind,
+                            )
+                            || (rel.kind == candidate.relation_kind
+                                && rel.confidence > candidate.confidence);
+                        if stronger {
+                            candidate.relation_kind = rel.kind;
+                            candidate.confidence = rel.confidence;
+                            candidate.resolution = RelationResolution::of(rel);
+                        }
+                    }
+                    None => {
+                        let Some(entity) = graph
+                            .get_entity(&next_id)
+                            .context("load trace step entity")?
+                        else {
+                            continue;
+                        };
+                        candidate_index.insert((next_id, role), candidates.len());
+                        candidates.push(FanoutCandidate {
+                            entity,
+                            role,
+                            relation_kind: rel.kind,
+                            confidence: rel.confidence,
+                            resolution: RelationResolution::of(rel),
+                        });
+                    }
                 }
+            }
 
-                if role == "callee" {
-                    callee_count += 1;
+            // Independent budgets per direction so `direction=both` doesn't
+            // starve callers when callees are listed first (or vice versa).
+            let (mut callees, mut callers): (Vec<FanoutCandidate>, Vec<FanoutCandidate>) =
+                candidates.into_iter().partition(|c| c.role == "callee");
+            sort_by_relevance(&mut callees, &node);
+            sort_by_relevance(&mut callers, &node);
+            let dropped_callees = callees.len().saturating_sub(limit_per_step);
+            let dropped_callers = callers.len().saturating_sub(limit_per_step);
+            callees.truncate(limit_per_step);
+            callers.truncate(limit_per_step);
+
+            // Localize the cut on the node it happened at. A single top-level
+            // flag names no node, so a caller cannot tell a complete step from a
+            // clipped one and cannot repair either.
+            if dropped_callees + dropped_callers > 0 {
+                truncated = true;
+                let dropped = dropped_callees + dropped_callers;
+                if node.step > 0 {
+                    let step = &mut chain[node.step - 1];
+                    step.fanout_truncated = true;
+                    step.fanout_dropped = step.fanout_dropped.saturating_add(dropped);
+                }
+                let (entity_id, entity_name) = if node.step == 0 {
+                    (focal_entity.id.to_string(), focal_entity.name.clone())
                 } else {
-                    caller_count += 1;
-                }
+                    let step = &chain[node.step - 1];
+                    (step.entity.entity_id.clone(), step.entity.entity_name.clone())
+                };
+                clipped_steps.push(TraceFanoutClip {
+                    step: node.step,
+                    entity_id,
+                    entity_name,
+                    dropped_callees,
+                    dropped_callers,
+                    limit_per_step,
+                });
+            }
 
+            for candidate in callees.into_iter().chain(callers) {
                 if chain.len() >= MAX_TOTAL_STEPS {
                     truncated = true;
                     break;
                 }
+                let candidate_external =
+                    kin_ranking::entity_ranking::trace_entity_is_external(&candidate.entity);
+                if let Some(&existing) = name_index.get(candidate.entity.name.as_str()) {
+                    let existing_external =
+                        existing > 0 && chain[existing - 1].entity.external;
+                    if candidate_external {
+                        // A record for this name is already in the response.
+                        // A second, location-less one adds no information and
+                        // gives the symbol a second identity.
+                        visited.insert(candidate.entity.id);
+                        external_identities_merged += 1;
+                        continue;
+                    }
+                    if existing_external {
+                        // The placeholder arrived first, by a different edge.
+                        // Fill it in with the record the graph does own rather
+                        // than admitting one symbol twice.
+                        let source = bodies_included
+                            .then(|| {
+                                source_record_or_none(projection.as_ref(), &candidate.entity)
+                            })
+                            .flatten();
+                        let promoted = &mut chain[existing - 1];
+                        promoted.entity = entity_record(&candidate.entity, source.as_ref());
+                        visited.insert(candidate.entity.id);
+                        external_identities_merged += 1;
+                        // The placeholder had no edges to walk; the record that
+                        // replaced it does, so it re-enters the frontier at the
+                        // depth it already sits at.
+                        if promoted.depth < depth {
+                            next_frontier
+                                .push(FrontierNode::at(existing, promoted.depth, &candidate.entity));
+                        }
+                        continue;
+                    }
+                }
+                if !visited.insert(candidate.entity.id) {
+                    continue;
+                }
 
-                let next_entity = match graph
-                    .get_entity(&next_id)
-                    .context("load trace step entity")?
-                {
-                    Some(entity) => entity,
-                    None => continue,
-                };
-                let next_record = source_record_or_none(projection.as_ref(), &next_entity);
-                let next_depth = parent_depth + 1;
+                let source = bodies_included
+                    .then(|| source_record_or_none(projection.as_ref(), &candidate.entity))
+                    .flatten();
+                let next_depth = node.depth + 1;
                 let step_index = chain.len() + 1;
+                name_index
+                    .entry(candidate.entity.name.clone())
+                    .or_insert(step_index);
 
                 chain.push(TraceStep {
                     step: step_index,
-                    role: role.to_string(),
-                    relation_kind: format!("{:?}", rel.kind),
-                    resolution: RelationResolution::of(&rel).as_str().to_string(),
-                    parent_step,
+                    role: candidate.role.to_string(),
+                    relation_kind: format!("{:?}", candidate.relation_kind),
+                    resolution: candidate.resolution.as_str().to_string(),
+                    parent_step: node.step,
                     depth: next_depth,
-                    entity: next_record,
-                    entity_id: next_entity.id.to_string(),
-                    entity_name: next_entity.name.clone(),
-                    entity_kind: format!("{:?}", next_entity.kind),
-                    entity_file: next_entity.file_origin.as_ref().map(|p| p.0.clone()),
+                    entity: entity_record(&candidate.entity, source.as_ref()),
+                    fanout_truncated: false,
+                    fanout_dropped: 0,
                 });
 
                 if next_depth < depth {
-                    next_frontier.push((step_index, next_id, next_depth));
+                    next_frontier.push(FrontierNode::at(step_index, next_depth, &candidate.entity));
                 }
             }
 
@@ -646,19 +920,261 @@ pub fn build_trace_data_flow_response_within(
         record_trace_stop(&mut degradations, stop, &meter, chain.len());
     }
 
-    Ok(TraceDataFlowResponse {
+    let mut response = TraceDataFlowResponse {
         focal: focal_record,
         focal_id: focal_entity.id.to_string(),
         focal_name: focal_entity.name.clone(),
         focal_kind: format!("{:?}", focal_entity.kind),
         focal_file: focal_entity.file_origin.as_ref().map(|p| p.0.clone()),
+        focal_entity: focal_entity_record,
         direction: direction.as_str().to_string(),
         depth,
+        limit_per_step,
+        bodies_included,
         total_steps: chain.len(),
         chain,
         truncated,
+        clipped_steps,
+        bodies_omitted: 0,
+        steps_omitted: 0,
+        external_identities_merged,
+        max_response_chars: request.budget_chars(),
         degradations,
-    })
+    };
+    enforce_response_budget(&mut response);
+    Ok(response)
+}
+
+/// One node of the walk, carrying the file and directory its fan-out is scored
+/// against.
+///
+/// The parent's own location travels with it rather than being re-read per
+/// expansion, and relevance is measured against IT rather than against the
+/// focal: at depth 3 the focal's directory says nothing about which of a distant
+/// node's callees continue the chain.
+struct FrontierNode {
+    /// Step index of this node; `0` is the focal.
+    step: usize,
+    id: EntityId,
+    depth: usize,
+    file: Option<String>,
+    dir: Option<String>,
+}
+
+impl FrontierNode {
+    fn at(step: usize, depth: usize, entity: &Entity) -> Self {
+        Self {
+            step,
+            id: entity.id,
+            depth,
+            file: entity.file_origin.as_ref().map(|path| path.0.clone()),
+            dir: kin_ranking::entity_ranking::entity_directory(entity),
+        }
+    }
+
+    fn rooted(entity: &Entity) -> Self {
+        Self::at(0, 0, entity)
+    }
+}
+
+/// One neighbor a node offers, before the per-step cap decides whether it is
+/// kept.
+struct FanoutCandidate {
+    entity: Entity,
+    role: &'static str,
+    relation_kind: RelationKind,
+    confidence: f32,
+    /// Classification of the edge this candidate is currently described by.
+    /// It moves with `relation_kind` and `confidence` when a stronger edge to
+    /// the same neighbor replaces them, so the step reports what the edge it
+    /// names actually proved.
+    resolution: RelationResolution,
+}
+
+/// Order one side of a node's fan-out by relevance, most relevant first.
+///
+/// Ties break on name and then id so the same store returns the same chain every
+/// run: a reproducible answer is worth more than a marginally better one that
+/// moves under the caller.
+fn sort_by_relevance(candidates: &mut [FanoutCandidate], node: &FrontierNode) {
+    candidates.sort_by(|left, right| {
+        let left_score = kin_ranking::entity_ranking::trace_fanout_score(
+            &left.entity,
+            left.relation_kind,
+            node.file.as_deref(),
+            node.dir.as_deref(),
+            left.confidence,
+        );
+        let right_score = kin_ranking::entity_ranking::trace_fanout_score(
+            &right.entity,
+            right.relation_kind,
+            node.file.as_deref(),
+            node.dir.as_deref(),
+            right.confidence,
+        );
+        right_score
+            .cmp(&left_score)
+            .then_with(|| left.entity.name.cmp(&right.entity.name))
+            .then_with(|| left.entity.id.0.cmp(&right.entity.id.0))
+    });
+}
+
+/// The one record shape every entity in a trace is reported in.
+///
+/// `source` is the body read, already attempted by the caller (or skipped
+/// entirely for a shape query). When it is absent the span still comes from the
+/// entity's own graph span, because a caller asking for the shape of a chain
+/// still needs to know where each step lives.
+fn entity_record(entity: &Entity, source: Option<&GraphSourceRecord>) -> TraceEntityRecord {
+    let (start_line, end_line) = match (source, entity.span.as_ref()) {
+        (Some(record), _) => (Some(record.start_line), Some(record.end_line)),
+        (None, Some(span)) => {
+            let (start, end) = kin_mcp::handlers::common::presentation_span_lines(span);
+            (Some(start), Some(end))
+        }
+        (None, None) => (None, None),
+    };
+    TraceEntityRecord {
+        entity_id: entity.id.to_string(),
+        entity_name: entity.name.clone(),
+        entity_kind: format!("{:?}", entity.kind),
+        entity_role: format!("{:?}", entity.role).to_lowercase(),
+        entity_file: entity.file_origin.as_ref().map(|path| path.0.clone()),
+        external: kin_ranking::entity_ranking::trace_entity_is_external(entity),
+        start_line,
+        end_line,
+        signature: (!entity.signature.is_empty()).then(|| entity.signature.clone()),
+        body: source.map(|record| record.body.clone()),
+        span_coherence: source.map(|record| record.span_coherence.clone()),
+    }
+}
+
+/// Characters held back from the budget for the disclosure a cut adds.
+///
+/// A response cut to exactly its ceiling and then told to explain the cut is
+/// over its ceiling again, by the length of the explanation. Reserving the room
+/// first is what makes the bound hold for the payload that actually ships.
+const DISCLOSURE_RESERVE_CHARS: usize = 1_500;
+
+/// Serialized size of a response, measured the way it will be sent.
+///
+/// Both surfaces that return this — the CLI's `println!` and the daemon's MCP
+/// text result — serialize it pretty-printed, so the budget is charged for the
+/// indentation the caller receives rather than for a compact form nobody sends.
+fn measure_response(response: &TraceDataFlowResponse) -> usize {
+    serde_json::to_string_pretty(response).map_or(usize::MAX, |json| json.len())
+}
+
+/// Bound the response the tool is about to return, cutting BODIES before EDGES.
+///
+/// The defect this closes: a walk inside every work bound produced 228,413
+/// characters and the client refused the whole result, so the caller received
+/// neither the chain nor a usable error and recovered by parsing a spill file
+/// with a script. A tool that can measure its own output has no excuse for
+/// that.
+///
+/// The cut order is the priority order. A chain with every edge and no source
+/// still answers "what does this reach"; a chain missing edges answers a
+/// different, smaller question, and a caller cannot tell which question was
+/// answered unless the cut says so. Bodies go first, then the focal's body, then
+/// steps from the tail — a suffix, because the chain is discovery-ordered, so
+/// removing the end never orphans a surviving step's parent.
+fn enforce_response_budget(response: &mut TraceDataFlowResponse) {
+    let ceiling = response.max_response_chars;
+    if measure_response(response) <= ceiling {
+        return;
+    }
+    let target = ceiling.saturating_sub(DISCLOSURE_RESERVE_CHARS);
+
+    let mut bodies_omitted = 0usize;
+    for step in &mut response.chain {
+        if step.entity.body.take().is_some() {
+            step.entity.span_coherence = None;
+            bodies_omitted += 1;
+        }
+    }
+    if bodies_omitted > 0 {
+        response.bodies_included = false;
+        response.bodies_omitted = bodies_omitted;
+    }
+
+    let mut focal_body_omitted = false;
+    if measure_response(response) > target && response.focal.take().is_some() {
+        response.focal_entity.body = None;
+        response.focal_entity.span_coherence = None;
+        response.bodies_included = false;
+        focal_body_omitted = true;
+    }
+
+    let mut steps_omitted = 0usize;
+    if measure_response(response) > target {
+        // Bisected rather than popped one step at a time: the same answer, in a
+        // handful of serializations instead of one per dropped step.
+        let full = std::mem::take(&mut response.chain);
+        let mut kept = 0usize;
+        let mut low = 0usize;
+        let mut high = full.len();
+        while low <= high {
+            let mid = (low + high) / 2;
+            response.chain = full[..mid].to_vec();
+            response.total_steps = mid;
+            if measure_response(response) <= target {
+                kept = mid;
+                low = mid + 1;
+            } else if mid == 0 {
+                break;
+            } else {
+                high = mid - 1;
+            }
+        }
+        steps_omitted = full.len() - kept;
+        response.chain = full[..kept].to_vec();
+        response.total_steps = kept;
+        response.steps_omitted = steps_omitted;
+        if steps_omitted > 0 {
+            // Dropped steps are edges the caller did not receive, which is what
+            // this flag has always meant. Dropped bodies are not.
+            response.truncated = true;
+            // A clip recorded against a step that is no longer here would send a
+            // caller re-querying a node the response does not name.
+            let kept_steps = response.chain.len();
+            response
+                .clipped_steps
+                .retain(|clip| clip.step <= kept_steps);
+        }
+    }
+
+    if bodies_omitted == 0 && !focal_body_omitted && steps_omitted == 0 {
+        return;
+    }
+    let reason = if steps_omitted > 0 {
+        "steps_omitted"
+    } else {
+        "bodies_omitted"
+    };
+    let cut = match (bodies_omitted + usize::from(focal_body_omitted), steps_omitted) {
+        (bodies, 0) => format!("{bodies} inlined bodies were dropped"),
+        (0, steps) => format!("{steps} steps were dropped from the end of the chain"),
+        (bodies, steps) => format!(
+            "{bodies} inlined bodies were dropped, and {steps} steps after that were dropped from \
+             the end of the chain"
+        ),
+    };
+    record_degradation(
+        &mut response.degradations,
+        RetrievalDegradation {
+            component: "response_budget".to_string(),
+            reason: reason.to_string(),
+            detail: format!(
+                "the response exceeded its {ceiling}-character budget, so {cut}; bodies are cut \
+                 before edges, so the chain's shape survives a cut that its source cannot"
+            ),
+            remediation: "ask for the shape directly with include_body: false, or narrow the walk \
+                          with a smaller depth or limit_per_step; raise max_response_chars only if \
+                          the caller's own result limit accepts a larger payload"
+                .to_string(),
+        },
+    );
 }
 
 /// What a trace answers when the focal it was given resolves to nothing.
@@ -807,6 +1323,8 @@ mod tests {
                 depth: None,
                 direction: None,
                 limit_per_step: None,
+                include_body: None,
+                max_response_chars: None,
             },
         )
         .unwrap_err();
@@ -828,6 +1346,8 @@ mod tests {
                 depth: None,
                 direction: None,
                 limit_per_step: None,
+                include_body: None,
+                max_response_chars: None,
             },
         )
         .unwrap_err();
@@ -875,6 +1395,8 @@ mod tests {
                 depth: Some(2),
                 direction: Some(TraceDirection::Calls),
                 limit_per_step: Some(5),
+                include_body: None,
+                max_response_chars: None,
             },
         )
         .unwrap();
@@ -892,7 +1414,7 @@ mod tests {
         let leaf_step = response
             .chain
             .iter()
-            .find(|s| s.entity_id == leaf_id.to_string())
+            .find(|s| s.entity.entity_id == leaf_id.to_string())
             .expect("leaf must be reached at depth 2");
         assert_eq!(leaf_step.depth, 2);
         assert!(leaf_step.parent_step >= 1, "leaf's parent must be a step");
@@ -930,6 +1452,8 @@ mod tests {
                 depth: Some(1),
                 direction: Some(TraceDirection::Callers),
                 limit_per_step: Some(5),
+                include_body: None,
+                max_response_chars: None,
             },
         )
         .unwrap();
@@ -943,7 +1467,7 @@ mod tests {
         let names: Vec<_> = response
             .chain
             .iter()
-            .map(|s| s.entity_name.clone())
+            .map(|s| s.entity.entity_name.clone())
             .collect();
         assert!(names.contains(&"caller_a".to_string()));
         assert!(names.contains(&"caller_b".to_string()));
@@ -974,6 +1498,8 @@ mod tests {
                 depth: Some(1),
                 direction: Some(TraceDirection::Calls),
                 limit_per_step: Some(3),
+                include_body: None,
+                max_response_chars: None,
             },
         )
         .unwrap();
@@ -1006,6 +1532,8 @@ mod tests {
             depth: Some(2),
             direction: Some(TraceDirection::Calls),
             limit_per_step: Some(5),
+            include_body: None,
+            max_response_chars: None,
         }
     }
 
@@ -1126,7 +1654,7 @@ mod tests {
 
         assert_eq!(response.total_steps, 3);
         assert!(
-            response.chain.iter().all(|step| step.entity.is_none()),
+            response.chain.iter().all(|step| step.entity.body.is_none()),
             "no body is readable through an absent authority"
         );
         assert!(
@@ -1191,6 +1719,8 @@ mod tests {
             depth: Some(2),
             direction: Some(TraceDirection::Calls),
             limit_per_step: Some(25),
+            include_body: None,
+            max_response_chars: None,
         };
 
         let uncancelled = build_trace_data_flow_response_within(

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -1270,7 +1270,18 @@ mod tests {
                 stability_score: 1.0,
             },
             file_origin: Some(FilePathId::new(file)),
-            span: None,
+            // A span, because a shape query's whole value is names plus
+            // locations: a fixture with none cannot tell a compact response that
+            // kept its spans from one that dropped them.
+            span: Some(kin_model::entity::SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 32,
+                start_line: 9,
+                start_col: 0,
+                end_line: 19,
+                end_col: 1,
+            }),
             signature: format!("fn {name}()"),
             visibility: Visibility::Public,
             role: EntityRole::Source,
@@ -1280,6 +1291,40 @@ mod tests {
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    /// The shape a symbol the graph owns no file for actually has: identity, no
+    /// location, no span, and (in the measured repository) `Module` kind.
+    fn make_external_entity(name: &str) -> Entity {
+        let mut entity = make_entity(name, "unused");
+        entity.kind = EntityKind::Module;
+        entity.file_origin = None;
+        entity.span = None;
+        entity
+    }
+
+    fn trace_request(
+        focal: &EntityId,
+        depth: usize,
+        direction: TraceDirection,
+        limit_per_step: usize,
+    ) -> TraceDataFlowRequest {
+        TraceDataFlowRequest {
+            focal: focal.to_string(),
+            depth: Some(depth),
+            direction: Some(direction),
+            limit_per_step: Some(limit_per_step),
+            include_body: None,
+            max_response_chars: None,
+        }
+    }
+
+    fn step_names(response: &TraceDataFlowResponse) -> Vec<String> {
+        response
+            .chain
+            .iter()
+            .map(|step| step.entity.entity_name.clone())
+            .collect()
     }
 
     fn make_relation(src: EntityId, dst: EntityId, kind: RelationKind) -> Relation {
@@ -1758,6 +1803,607 @@ mod tests {
             cancelled.total_steps,
             uncancelled.total_steps
         );
+    }
+
+    /// The measured inversion, as a fixture: `resolve_redirects` fanning out
+    /// wider than its cap, where which callees matter is knowable from the graph
+    /// alone.
+    ///
+    /// Two of its callees sit in its own file and decide the redirect (the two
+    /// the shipped cap dropped); the others are a distant adapter method, a test
+    /// helper, and a file-less import placeholder (three the shipped cap kept).
+    fn redirect_graph() -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("resolve_redirects", "src/requests/sessions.py");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+
+        let mut callees = vec![
+            make_entity("get_redirect_target", "src/requests/sessions.py"),
+            make_entity("rebuild_method", "src/requests/sessions.py"),
+            make_entity("HTTPAdapter.close", "src/requests/adapters.py"),
+        ];
+        let mut harness = make_entity("RedirectSession.send", "tests/test_requests.py");
+        harness.role = EntityRole::Test;
+        callees.push(harness);
+        callees.push(make_external_entity("urljoin"));
+
+        for callee in &callees {
+            graph.upsert_entity(callee).unwrap();
+            graph
+                .upsert_relation(&make_relation(focal_id, callee.id, RelationKind::Calls))
+                .unwrap();
+        }
+        (graph, focal_id)
+    }
+
+    #[test]
+    fn the_per_step_cap_keeps_the_callees_that_continue_the_chain() {
+        let (graph, focal_id) = redirect_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 2),
+        )
+        .unwrap();
+
+        let mut kept = step_names(&response);
+        kept.sort();
+        assert_eq!(
+            kept,
+            vec![
+                "get_redirect_target".to_string(),
+                "rebuild_method".to_string()
+            ],
+            "a two-wide cap must keep the two located source callees in the expanded node's own \
+             file, not a distant method, a test double, or a file-less placeholder"
+        );
+    }
+
+    #[test]
+    fn a_clipped_fan_out_says_which_node_was_clipped_and_how_much_it_dropped() {
+        let (graph, focal_id) = redirect_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 2),
+        )
+        .unwrap();
+
+        assert!(response.truncated);
+        assert_eq!(
+            response.clipped_steps.len(),
+            1,
+            "exactly one node fanned out here: {:?}",
+            response.clipped_steps
+        );
+        let clip = &response.clipped_steps[0];
+        assert_eq!(clip.step, 0, "the focal is step 0");
+        assert_eq!(clip.entity_name, "resolve_redirects");
+        assert_eq!(
+            clip.dropped_callees, 3,
+            "five candidates minus a two-wide cap is three dropped"
+        );
+        assert_eq!(clip.dropped_callers, 0);
+        assert_eq!(
+            clip.limit_per_step, 2,
+            "the clip names the cap a caller would raise"
+        );
+    }
+
+    /// The repair path the top-level flag could not support: a clipped node that
+    /// is not the focal has to carry its own truncation, or a caller cannot tell
+    /// which of 106 steps to re-query.
+    #[test]
+    fn a_clipped_step_carries_its_own_truncation_flag_and_count() {
+        let graph = InMemoryGraph::new();
+        let (_t, binding) = empty_binding();
+
+        let focal = make_entity("Session.send", "src/requests/sessions.py");
+        let mid = make_entity("resolve_redirects", "src/requests/sessions.py");
+        let focal_id = focal.id;
+        let mid_id = mid.id;
+        graph.upsert_entity(&focal).unwrap();
+        graph.upsert_entity(&mid).unwrap();
+        graph
+            .upsert_relation(&make_relation(focal_id, mid_id, RelationKind::Calls))
+            .unwrap();
+        for index in 0..3 {
+            let leaf = make_entity(&format!("rebuild_{index}"), "src/requests/sessions.py");
+            graph.upsert_entity(&leaf).unwrap();
+            graph
+                .upsert_relation(&make_relation(mid_id, leaf.id, RelationKind::Calls))
+                .unwrap();
+        }
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 2, TraceDirection::Calls, 1),
+        )
+        .unwrap();
+
+        let mid_step = response
+            .chain
+            .iter()
+            .find(|step| step.entity.entity_name == "resolve_redirects")
+            .expect("the mid node must be in the chain");
+        assert!(
+            mid_step.fanout_truncated,
+            "the node whose fan-out was cut must say so on itself"
+        );
+        assert_eq!(
+            mid_step.fanout_dropped, 2,
+            "three callees under a one-wide cap drops two"
+        );
+        let unclipped = response
+            .chain
+            .iter()
+            .find(|step| step.entity.entity_name.starts_with("rebuild_"))
+            .expect("the kept leaf must be in the chain");
+        assert!(
+            !unclipped.fanout_truncated && unclipped.fanout_dropped == 0,
+            "a step whose fan-out was complete must be distinguishable from a clipped one"
+        );
+        assert!(
+            response
+                .clipped_steps
+                .iter()
+                .any(|clip| clip.step == mid_step.step && clip.dropped_callees == 2),
+            "the clip list must name the step: {:?}",
+            response.clipped_steps
+        );
+    }
+
+    /// A walk that expands every neighbor it reaches must be byte-identical to
+    /// the one before per-step clip reporting existed.
+    #[test]
+    fn an_unclipped_walk_reports_no_clip_at_all() {
+        let (graph, focal_id) = hub_graph(3);
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 2, TraceDirection::Calls, 5),
+        )
+        .unwrap();
+
+        assert!(!response.truncated);
+        assert!(response.clipped_steps.is_empty());
+        assert!(response.chain.iter().all(|step| !step.fanout_truncated));
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(
+            json.get("clipped_steps").is_none(),
+            "an unaffected walk must not carry the field at all"
+        );
+    }
+
+    #[test]
+    fn compact_mode_keeps_every_edge_and_span_while_inlining_no_body() {
+        let (graph, focal_id) = redirect_graph();
+        let (_t, binding) = empty_binding();
+
+        let mut request = trace_request(&focal_id, 1, TraceDirection::Calls, 25);
+        let with_bodies = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &request,
+        )
+        .unwrap();
+        request.include_body = Some(false);
+        let compact = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &request,
+        )
+        .unwrap();
+
+        assert_eq!(
+            compact.total_steps, with_bodies.total_steps,
+            "asking for the shape must not change which edges are walked"
+        );
+        assert_eq!(step_names(&compact), step_names(&with_bodies));
+        assert!(!compact.bodies_included);
+        assert!(compact.focal.is_none());
+        assert!(compact.chain.iter().all(|step| step.entity.body.is_none()));
+        // The point of the mode: shape, not silence. Every located step still
+        // reports where it is.
+        assert!(compact
+            .chain
+            .iter()
+            .filter(|step| !step.entity.external)
+            .all(|step| step.entity.entity_file.is_some()
+                && step.entity.start_line == Some(10)
+                && step.entity.end_line == Some(20)
+                && step.entity.signature.is_some()));
+        assert_eq!(
+            compact.focal_entity.start_line,
+            Some(10),
+            "the focal keeps its span in a shape query too"
+        );
+    }
+
+    /// The regression a character count is the only guard against: a change that
+    /// re-inlines bodies on a shape query is invisible to every assertion about
+    /// chain contents.
+    #[test]
+    fn a_compact_trace_stays_far_under_its_budget() {
+        let (graph, focal_id) = hub_graph(120);
+        let (_t, binding) = empty_binding();
+
+        let mut request = trace_request(&focal_id, 1, TraceDirection::Calls, 25);
+        request.include_body = Some(false);
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &request,
+        )
+        .unwrap();
+
+        assert_eq!(response.total_steps, 25, "the fixture must produce a chain");
+        let json = serde_json::to_string_pretty(&response).unwrap();
+        assert!(
+            json.len() <= response.max_response_chars,
+            "a response must fit the budget it reports: {} chars against {}",
+            json.len(),
+            response.max_response_chars
+        );
+        assert!(
+            !json.contains("\"body\": \""),
+            "a shape query must carry no inlined body"
+        );
+        assert!(
+            json.len() < 20_000,
+            "25 steps of shape are small; {} chars means bodies or per-step bloat crept back in",
+            json.len()
+        );
+    }
+
+    /// A response is refused whole or not at all, so the tool bounds its own
+    /// payload rather than discovering the ceiling at the client.
+    fn fat_response(steps: usize, body_chars: usize) -> TraceDataFlowResponse {
+        let entity = make_entity("focal", "src/focal.rs");
+        let mut chain = Vec::new();
+        for index in 1..=steps {
+            let step_entity = make_entity(&format!("step_{index}"), "src/step.rs");
+            let mut record = entity_record(&step_entity, None);
+            record.body = Some("x".repeat(body_chars));
+            record.span_coherence = Some("verified".to_string());
+            chain.push(TraceStep {
+                step: index,
+                role: "callee".to_string(),
+                relation_kind: "Calls".to_string(),
+                parent_step: index.saturating_sub(1),
+                depth: 1,
+                entity: record,
+                fanout_truncated: false,
+                fanout_dropped: 0,
+            });
+        }
+        TraceDataFlowResponse {
+            focal: None,
+            focal_id: entity.id.to_string(),
+            focal_name: entity.name.clone(),
+            focal_kind: "Function".to_string(),
+            focal_file: Some("src/focal.rs".to_string()),
+            focal_entity: entity_record(&entity, None),
+            direction: "calls".to_string(),
+            depth: 1,
+            limit_per_step: 25,
+            bodies_included: true,
+            total_steps: chain.len(),
+            chain,
+            truncated: false,
+            clipped_steps: Vec::new(),
+            bodies_omitted: 0,
+            steps_omitted: 0,
+            external_identities_merged: 0,
+            max_response_chars: DEFAULT_MAX_RESPONSE_CHARS,
+            degradations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn the_response_budget_cuts_bodies_before_it_cuts_edges() {
+        let mut response = fat_response(40, 4_000);
+        assert!(
+            serde_json::to_string_pretty(&response).unwrap().len() > response.max_response_chars,
+            "the fixture must start over budget or this proves nothing"
+        );
+
+        enforce_response_budget(&mut response);
+
+        assert_eq!(
+            response.total_steps, 40,
+            "every edge survives a cut that bodies can absorb"
+        );
+        assert_eq!(response.bodies_omitted, 40);
+        assert_eq!(response.steps_omitted, 0);
+        assert!(!response.bodies_included);
+        assert!(
+            !response.truncated,
+            "dropping bodies leaves the chain complete, so the chain-truncation flag must stay off"
+        );
+        assert!(response.chain.iter().all(|step| step.entity.body.is_none()
+            && step.entity.span_coherence.is_none()
+            && step.entity.entity_file.is_some()));
+        let cut = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "response_budget")
+            .expect("a cut must be disclosed, not silently applied");
+        assert_eq!(cut.reason, "bodies_omitted");
+        assert!(cut.detail.contains("40"), "the cut states its own numbers");
+        assert!(!cut.remediation.is_empty());
+        assert!(
+            serde_json::to_string_pretty(&response).unwrap().len() <= response.max_response_chars,
+            "the payload must end up inside the budget it reports"
+        );
+    }
+
+    #[test]
+    fn the_response_budget_drops_steps_only_after_every_body_and_says_so() {
+        let mut response = fat_response(200, 2_000);
+        response.max_response_chars = 8_000;
+        response.clipped_steps.push(TraceFanoutClip {
+            step: 199,
+            entity_id: "late".to_string(),
+            entity_name: "step_199".to_string(),
+            dropped_callees: 4,
+            dropped_callers: 0,
+            limit_per_step: 25,
+        });
+
+        enforce_response_budget(&mut response);
+
+        assert_eq!(response.bodies_omitted, 200, "bodies go first, all of them");
+        assert!(
+            response.steps_omitted > 0,
+            "a budget no body-free chain can meet must drop steps too"
+        );
+        assert_eq!(response.total_steps, response.chain.len());
+        assert_eq!(response.total_steps + response.steps_omitted, 200);
+        assert!(
+            response.truncated,
+            "dropped steps are edges the caller did not receive"
+        );
+        // The chain that survives is a prefix, so no surviving step points at a
+        // parent the response no longer contains.
+        let kept = response.chain.len();
+        assert!(response
+            .chain
+            .iter()
+            .all(|step| step.step <= kept && step.parent_step <= kept));
+        assert!(
+            response
+                .clipped_steps
+                .iter()
+                .all(|clip| clip.step <= kept),
+            "a clip must not name a step the response dropped"
+        );
+        let cut = response
+            .degradations
+            .iter()
+            .find(|d| d.component == "response_budget")
+            .expect("the cut must be disclosed");
+        assert_eq!(cut.reason, "steps_omitted");
+        assert!(
+            serde_json::to_string_pretty(&response).unwrap().len() <= response.max_response_chars,
+            "the payload must end up inside the budget it reports"
+        );
+    }
+
+    #[test]
+    fn a_response_that_fits_is_left_exactly_as_built() {
+        let mut response = fat_response(2, 100);
+        let before = serde_json::to_string_pretty(&response).unwrap();
+
+        enforce_response_budget(&mut response);
+
+        assert_eq!(
+            serde_json::to_string_pretty(&response).unwrap(),
+            before,
+            "a response inside its budget must be byte-identical after enforcement"
+        );
+        assert!(response.bodies_included);
+        assert_eq!(response.bodies_omitted, 0);
+        assert_eq!(response.steps_omitted, 0);
+    }
+
+    /// One symbol, two entities: the located definition and a file-less alias of
+    /// the same name. The measured response admitted both, so
+    /// `cookiejar_from_dict` was simultaneously a real entity in cookies.py and
+    /// an external Module, depending on which edge reached it.
+    #[test]
+    fn a_name_the_graph_holds_both_ways_yields_one_identity() {
+        let graph = InMemoryGraph::new();
+        let (_t, binding) = empty_binding();
+
+        let focal = make_entity("Session.prepare_request", "src/requests/sessions.py");
+        let admitted = make_entity("cookiejar_from_dict", "src/requests/cookies.py");
+        let alias = make_external_entity("cookiejar_from_dict");
+        let focal_id = focal.id;
+        let admitted_id = admitted.id;
+        let alias_id = alias.id;
+        assert_ne!(admitted_id, alias_id, "the graph holds two entities here");
+
+        for entity in [&focal, &admitted, &alias] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        graph
+            .upsert_relation(&make_relation(focal_id, admitted_id, RelationKind::Calls))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation(focal_id, alias_id, RelationKind::Calls))
+            .unwrap();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 25),
+        )
+        .unwrap();
+
+        let carrying: Vec<&TraceStep> = response
+            .chain
+            .iter()
+            .filter(|step| step.entity.entity_name == "cookiejar_from_dict")
+            .collect();
+        assert_eq!(
+            carrying.len(),
+            1,
+            "one symbol, one step: {:?}",
+            step_names(&response)
+        );
+        assert_eq!(
+            carrying[0].entity.entity_id,
+            admitted_id.to_string(),
+            "the located record wins over the placeholder"
+        );
+        assert!(!carrying[0].entity.external);
+        assert_eq!(response.external_identities_merged, 1);
+    }
+
+    /// The same rule when the placeholder is reached FIRST, by a different edge:
+    /// the located record fills it in rather than adding a second identity.
+    #[test]
+    fn a_placeholder_reached_first_is_filled_in_by_the_located_record() {
+        let graph = InMemoryGraph::new();
+        let (_t, binding) = empty_binding();
+
+        let focal = make_entity("Session.request", "src/requests/sessions.py");
+        let mid = make_entity("Session.prepare_request", "src/requests/sessions.py");
+        let alias = make_external_entity("cookiejar_from_dict");
+        let admitted = make_entity("cookiejar_from_dict", "src/requests/cookies.py");
+        let focal_id = focal.id;
+        let mid_id = mid.id;
+        let alias_id = alias.id;
+        let admitted_id = admitted.id;
+
+        for entity in [&focal, &mid, &alias, &admitted] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        // depth 1: the placeholder and the mid node. depth 2: the located record,
+        // reached through the mid node.
+        graph
+            .upsert_relation(&make_relation(focal_id, alias_id, RelationKind::Calls))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation(focal_id, mid_id, RelationKind::Calls))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation(mid_id, admitted_id, RelationKind::Calls))
+            .unwrap();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 3, TraceDirection::Calls, 25),
+        )
+        .unwrap();
+
+        let carrying: Vec<&TraceStep> = response
+            .chain
+            .iter()
+            .filter(|step| step.entity.entity_name == "cookiejar_from_dict")
+            .collect();
+        assert_eq!(
+            carrying.len(),
+            1,
+            "the placeholder must be filled in, not doubled: {:?}",
+            step_names(&response)
+        );
+        assert_eq!(carrying[0].entity.entity_id, admitted_id.to_string());
+        assert!(!carrying[0].entity.external);
+        assert_eq!(
+            carrying[0].entity.entity_file.as_deref(),
+            Some("src/requests/cookies.py")
+        );
+        assert_eq!(response.external_identities_merged, 1);
+        assert_ne!(
+            alias_id.to_string(),
+            carrying[0].entity.entity_id,
+            "the placeholder's id must not be what the response reports"
+        );
+    }
+
+    /// The parser break, asserted structurally: one array, one key set, whatever
+    /// the graph knows about each symbol.
+    #[test]
+    fn every_step_carries_the_same_keys_admitted_or_external() {
+        let (graph, focal_id) = redirect_graph();
+        let (_t, binding) = empty_binding();
+
+        let response = build_trace_data_flow_response(
+            &RequestRepositoryAuthority::pinned(binding.clone()),
+            &graph,
+            &trace_request(&focal_id, 1, TraceDirection::Calls, 25),
+        )
+        .unwrap();
+        assert!(
+            response.chain.iter().any(|step| step.entity.external),
+            "the fixture must include a file-less symbol or this proves nothing"
+        );
+        assert!(
+            response.chain.iter().any(|step| !step.entity.external),
+            "and a located one"
+        );
+
+        let json = serde_json::to_value(&response).unwrap();
+        let steps = json["chain"].as_array().unwrap();
+        let expected: Vec<String> = steps[0]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in [
+            "step",
+            "role",
+            "relation_kind",
+            "parent_step",
+            "depth",
+            "entity_id",
+            "entity_name",
+            "entity_kind",
+            "entity_role",
+            "entity_file",
+            "external",
+            "start_line",
+            "end_line",
+            "signature",
+            "body",
+            "span_coherence",
+            "fanout_truncated",
+            "fanout_dropped",
+        ] {
+            assert!(
+                expected.contains(&key.to_string()),
+                "a step must carry '{key}': {expected:?}"
+            );
+        }
+        for step in steps {
+            let keys: Vec<String> = step.as_object().unwrap().keys().cloned().collect();
+            assert_eq!(
+                keys, expected,
+                "every step must carry the same keys; this one differs: {step}"
+            );
+        }
+        // Not inventing data is the other half: the placeholder's location fields
+        // are present and null rather than absent.
+        let external = steps
+            .iter()
+            .find(|step| step["external"] == serde_json::Value::Bool(true))
+            .unwrap();
+        assert!(external["entity_file"].is_null());
+        assert!(external["start_line"].is_null());
+        assert!(external["end_line"].is_null());
+        assert!(external["entity_name"].is_string());
     }
 
     #[test]

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -506,6 +506,14 @@ enum Command {
         /// Max relations expanded per step (default 5, capped at 25).
         #[arg(long = "limit-per-step", value_name = "M")]
         limit_per_step: Option<usize>,
+        /// Return the chain's shape — names, kinds, roles, spans, edges —
+        /// without inlining any source body.
+        #[arg(long = "no-bodies", default_value_t = false)]
+        no_bodies: bool,
+        /// Serialized characters this response may occupy before the tool cuts
+        /// bodies, and then steps, to fit (default 80000).
+        #[arg(long = "max-response-chars", value_name = "C")]
+        max_response_chars: Option<usize>,
     },
     /// Show this repository's recorded cross-repo dependencies
     Deps {
@@ -2870,9 +2878,18 @@ fn main() -> Result<()> {
                     depth,
                     direction,
                     limit_per_step,
+                    no_bodies,
+                    max_response_chars,
                 } => {
-                    commands::trace_data_flow::run_seeded(focal, depth, direction, limit_per_step)
-                        .await
+                    commands::trace_data_flow::run_seeded(
+                        focal,
+                        depth,
+                        direction,
+                        limit_per_step,
+                        no_bodies.then_some(false),
+                        max_response_chars,
+                    )
+                    .await
                 }
                 Command::Deps { all, json } => commands::deps::run(all, json).await,
                 Command::Xref { entity } => commands::xref::run(entity).await,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8179,6 +8179,26 @@ async fn mcp_tools_call(
             .get("direction")
             .and_then(serde_json::Value::as_str)
             .map(|s| s.to_string());
+        // `compact: true` is the same request as `include_body: false`, and an
+        // agent that learned the spelling from another tool here should not get a
+        // 228k-character response because it used that one. An explicit
+        // `include_body` wins, so the two can never disagree silently.
+        let include_body = request
+            .arguments
+            .get("include_body")
+            .and_then(serde_json::Value::as_bool)
+            .or_else(|| {
+                request
+                    .arguments
+                    .get("compact")
+                    .and_then(serde_json::Value::as_bool)
+                    .map(|compact| !compact)
+            });
+        let max_response_chars = request
+            .arguments
+            .get("max_response_chars")
+            .and_then(serde_json::Value::as_u64)
+            .map(|v| v as usize);
         let Some(focal) = focal else {
             return Ok(Json(kin_mcp::ToolCallResult::error(
                 "missing required parameter: focal".to_string(),
@@ -8208,6 +8228,8 @@ async fn mcp_tools_call(
             depth,
             direction: parsed_direction,
             limit_per_step,
+            include_body,
+            max_response_chars,
         };
         let repository_authority = match require_mcp_command_repository_authority(&state) {
             Ok(authority) => authority,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -29210,6 +29210,259 @@ mod tests {
         );
     }
 
+    /// The raw text of a tool result, for the assertions that are about SIZE.
+    ///
+    /// `call_mcp_tool` hands back parsed JSON, and a parse discards the only
+    /// number a token-overflow defect is measured in. This is the payload the
+    /// client would have refused.
+    async fn call_mcp_tool_text(
+        app: Router,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> String {
+        let response = app
+            .oneshot(
+                Request::post("/mcp/tools/call")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "name": name, "arguments": arguments }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4 * 1024 * 1024)
+            .await
+            .unwrap();
+        let result: kin_mcp::ToolCallResult = serde_json::from_slice(&body).unwrap();
+        assert_ne!(result.is_error, Some(true), "{name} errored: {result:?}");
+        mcp_result_text(&result)
+    }
+
+    /// A trace fixture whose bodies are real: `steps` source entities with
+    /// projectable spans, chained focal -> next -> next, each body wide enough
+    /// that inlining it is measurable.
+    ///
+    /// The defect this supports is about size, so a fixture of one-line bodies
+    /// would make every size assertion vacuous.
+    fn install_trace_chain(state: &Arc<DaemonState>, steps: usize) -> Vec<EntityId> {
+        let ids: Vec<EntityId> = (0..steps)
+            .map(|index| {
+                let path = format!("src/hop{index}.py");
+                let filler = "    # a line of body that costs real characters\n".repeat(30);
+                let source = format!("def hop{index}(request):\n{filler}    return {index}\n");
+                install_source_entity(state, &format!("hop{index}"), &path, &source)
+            })
+            .collect();
+        for window in ids.windows(2) {
+            state
+                .graph
+                .upsert_relation(&kin_model::relation::Relation {
+                    id: kin_model::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(window[0]),
+                    dst: GraphNodeId::Entity(window[1]),
+                    confidence: 1.0,
+                    origin: kin_model::relation::RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: vec![],
+                })
+                .unwrap();
+        }
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        ids
+    }
+
+    /// A shape query is the cheap call, and it is cheap because it carries no
+    /// source — not because it walks less.
+    ///
+    /// The measured defect: `depth: 4, limit_per_step: 8` returned 228,413
+    /// characters and the client refused the whole result, because every one of
+    /// 106 steps inlined a full body and the tool had no way to be asked for the
+    /// chain's shape. This asserts on real projected bodies, so a regression that
+    /// re-inlines them fails on the character count rather than passing a chain
+    /// comparison that cannot see source at all.
+    #[tokio::test]
+    async fn a_trace_shape_query_keeps_every_edge_and_carries_no_body() {
+        let state = test_state();
+        let ids = install_trace_chain(&state, 5);
+        let app = router(Arc::clone(&state));
+
+        let with_bodies = call_mcp_tool_text(
+            app.clone(),
+            "trace_data_flow",
+            json!({ "focal": ids[0].to_string(), "depth": 4, "direction": "calls" }),
+        )
+        .await;
+        let compact = call_mcp_tool_text(
+            app.clone(),
+            "trace_data_flow",
+            json!({
+                "focal": ids[0].to_string(),
+                "depth": 4,
+                "direction": "calls",
+                "include_body": false,
+            }),
+        )
+        .await;
+
+        let full: serde_json::Value = serde_json::from_str(&with_bodies).unwrap();
+        let shape: serde_json::Value = serde_json::from_str(&compact).unwrap();
+
+        // Non-vacuity: the default call must actually have inlined graph-owned
+        // source, or "no bodies" below is a fact about the fixture.
+        assert_eq!(full["bodies_included"], json!(true));
+        assert!(
+            full["chain"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|step| step["body"].as_str().is_some_and(|body| body.len() > 500)),
+            "the default call must inline a real body per step: {with_bodies}"
+        );
+
+        assert_eq!(
+            shape["total_steps"], full["total_steps"],
+            "asking for the shape must not change which edges are walked"
+        );
+        assert_eq!(shape["bodies_included"], json!(false));
+        assert!(
+            shape["chain"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|step| step["body"].is_null()
+                    && step["entity_file"].as_str().is_some()
+                    && step["start_line"].as_u64().is_some()),
+            "a shape query keeps names, spans, and edges and drops only source: {compact}"
+        );
+        assert!(
+            shape["focal"].is_null() && shape["focal_entity"]["start_line"].as_u64().is_some(),
+            "the focal is a body too, and its span outlives it: {compact}"
+        );
+        assert!(
+            compact.len() * 3 < with_bodies.len(),
+            "a shape query must be a fraction of the size: {} vs {} chars",
+            compact.len(),
+            with_bodies.len()
+        );
+    }
+
+    /// `compact: true` is the same request as `include_body: false`.
+    ///
+    /// An agent that learned the spelling from another tool on this surface must
+    /// not be handed a 228k-character response for using it.
+    #[tokio::test]
+    async fn compact_is_the_same_request_as_include_body_false() {
+        let state = test_state();
+        let ids = install_trace_chain(&state, 4);
+        let app = router(Arc::clone(&state));
+
+        let by_compact = call_mcp_tool(
+            app.clone(),
+            "trace_data_flow",
+            json!({ "focal": ids[0].to_string(), "depth": 3, "compact": true }),
+        )
+        .await;
+        let by_include_body = call_mcp_tool(
+            app.clone(),
+            "trace_data_flow",
+            json!({ "focal": ids[0].to_string(), "depth": 3, "include_body": false }),
+        )
+        .await;
+        assert_eq!(by_compact, by_include_body);
+        assert_eq!(by_compact["bodies_included"], json!(false));
+
+        // An explicit include_body wins over the alias, so the two can never
+        // disagree silently.
+        let conflicting = call_mcp_tool(
+            app,
+            "trace_data_flow",
+            json!({
+                "focal": ids[0].to_string(),
+                "depth": 3,
+                "compact": true,
+                "include_body": true,
+            }),
+        )
+        .await;
+        assert_eq!(conflicting["bodies_included"], json!(true));
+    }
+
+    /// The tool bounds its own payload, and cuts bodies before edges.
+    ///
+    /// This is the defect end to end: a walk inside every work bound whose
+    /// RESULT does not fit. The response now measures itself and returns a
+    /// complete chain without source rather than a full chain the caller never
+    /// receives.
+    #[tokio::test]
+    async fn a_trace_over_its_budget_drops_bodies_and_keeps_every_edge() {
+        const BUDGET: usize = 6_000;
+        let state = test_state();
+        let ids = install_trace_chain(&state, 6);
+        let app = router(Arc::clone(&state));
+
+        let unbounded = call_mcp_tool_text(
+            app.clone(),
+            "trace_data_flow",
+            json!({ "focal": ids[0].to_string(), "depth": 5, "direction": "calls" }),
+        )
+        .await;
+        assert!(
+            unbounded.len() > BUDGET,
+            "the fixture must exceed the budget under test or this proves nothing: {} chars",
+            unbounded.len()
+        );
+        let full: serde_json::Value = serde_json::from_str(&unbounded).unwrap();
+
+        let bounded = call_mcp_tool_text(
+            app,
+            "trace_data_flow",
+            json!({
+                "focal": ids[0].to_string(),
+                "depth": 5,
+                "direction": "calls",
+                "max_response_chars": BUDGET,
+            }),
+        )
+        .await;
+        let cut: serde_json::Value = serde_json::from_str(&bounded).unwrap();
+
+        assert!(
+            bounded.len() <= BUDGET,
+            "the tool must return what it promised to fit: {} chars against {BUDGET}",
+            bounded.len()
+        );
+        assert_eq!(
+            cut["total_steps"], full["total_steps"],
+            "bodies are cut before edges, so the chain survives a cut its source does not"
+        );
+        assert_eq!(cut["bodies_included"], json!(false));
+        assert!(cut["bodies_omitted"].as_u64().unwrap_or(0) > 0);
+        assert_eq!(
+            cut["truncated"], json!(false),
+            "a chain that lost only bodies is not a truncated chain"
+        );
+        let disclosure = cut["degradations"]
+            .as_array()
+            .expect("a cut must be disclosed")
+            .iter()
+            .find(|entry| entry["component"] == json!("response_budget"))
+            .expect("the cut must name itself");
+        assert_eq!(disclosure["reason"], json!("bodies_omitted"));
+        assert!(
+            disclosure["remediation"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("include_body"),
+            "the remediation must name the parameter that avoids the cut: {disclosure}"
+        );
+    }
+
     /// A publication boundary forces a fresh, fully validating load on this
     /// wrapper too.
     ///

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -29215,11 +29215,7 @@ mod tests {
     /// `call_mcp_tool` hands back parsed JSON, and a parse discards the only
     /// number a token-overflow defect is measured in. This is the payload the
     /// client would have refused.
-    async fn call_mcp_tool_text(
-        app: Router,
-        name: &str,
-        arguments: serde_json::Value,
-    ) -> String {
+    async fn call_mcp_tool_text(app: Router, name: &str, arguments: serde_json::Value) -> String {
         let response = app
             .oneshot(
                 Request::post("/mcp/tools/call")
@@ -29444,7 +29440,8 @@ mod tests {
         assert_eq!(cut["bodies_included"], json!(false));
         assert!(cut["bodies_omitted"].as_u64().unwrap_or(0) > 0);
         assert_eq!(
-            cut["truncated"], json!(false),
+            cut["truncated"],
+            json!(false),
             "a chain that lost only bodies is not a truncated chain"
         );
         let disclosure = cut["degradations"]

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -401,6 +401,49 @@ pub use kin_ranking::entity_ranking::{
     trace_callee_score, trace_entity_is_external, trace_fanout_score, trace_relation_rank,
 };
 
+/// Serialized characters one trace response may occupy before the tool cuts its
+/// own payload.
+///
+/// Every other bound on a trace shapes the WALK, and none of them bounds the
+/// ANSWER: a walk inside all of them returned 228,413 characters over 2,453
+/// lines from a 777-entity repository and the client refused the whole result,
+/// so the caller got neither the chain nor a way to ask for less.
+///
+/// Sized against the tool-result ceilings agent clients actually apply, which
+/// are counted in tokens; at roughly 3.5 characters per token of JSON-wrapped
+/// source this leaves headroom under a 25k-token cap for the envelope the MCP
+/// path wraps around this payload.
+///
+/// Defined here rather than beside either walk because BOTH walks serve this one
+/// tool — the generic-store arm in `handlers::entities` and the body-inlining
+/// arm in `kin_cli::commands::trace_data_flow`, which reads these through this
+/// module. Two definitions would let one arm promise a bound the other does not
+/// keep.
+pub const TRACE_DEFAULT_MAX_RESPONSE_CHARS: usize = 80_000;
+
+/// Floor for a caller-supplied budget. Below this the envelope alone does not
+/// fit, so a smaller number could only be honoured by returning nothing.
+pub const TRACE_MIN_MAX_RESPONSE_CHARS: usize = 2_000;
+
+/// Ceiling for a caller-supplied budget. A caller with a larger window may raise
+/// the bound, but not to unbounded: the daemon serving this has other callers,
+/// and a response nothing can read is not worth building.
+pub const TRACE_MAX_MAX_RESPONSE_CHARS: usize = 400_000;
+
+/// Characters held back from the budget for the disclosure a cut adds.
+///
+/// A response cut to exactly its ceiling and then told to explain the cut is
+/// over its ceiling again, by the length of the explanation. Reserving the room
+/// first is what makes the bound hold for the payload that actually ships.
+pub const TRACE_DISCLOSURE_RESERVE_CHARS: usize = 1_500;
+
+/// The budget a trace request asks for, clamped to what this tool will serve.
+pub fn trace_response_budget(requested: Option<usize>) -> usize {
+    requested
+        .unwrap_or(TRACE_DEFAULT_MAX_RESPONSE_CHARS)
+        .clamp(TRACE_MIN_MAX_RESPONSE_CHARS, TRACE_MAX_MAX_RESPONSE_CHARS)
+}
+
 pub fn next_trace_step<G: GraphStore>(
     store: &G,
     current: &Entity,

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -397,7 +397,9 @@ pub fn is_trace_function(entity: &Entity) -> bool {
     matches!(entity.kind, EntityKind::Function | EntityKind::Method)
 }
 
-pub use kin_ranking::entity_ranking::{trace_callee_score, trace_relation_rank};
+pub use kin_ranking::entity_ranking::{
+    trace_callee_score, trace_entity_is_external, trace_fanout_score, trace_relation_rank,
+};
 
 pub fn next_trace_step<G: GraphStore>(
     store: &G,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2446,8 +2446,18 @@ by entity_id or by exact name. Reach for it when you need to follow a path \"wha
 this call, and what do those call?\" or \"trace this value back to its source\" and want \
 the chain in traversal order, not a bag of neighbors. Its value is that the whole walk \
 happens substrate-side and comes back as one structured response, so you don't loop \
-get_entity_source per hop and exhaust your tool-call budget. Tune depth and \
-limit_per_step to control breadth; results flag when they were truncated. \
+get_entity_source per hop and exhaust your tool-call budget. Ask for the chain's SHAPE with \
+include_body=false (names, kinds, roles, spans, edges, no source) — that is the cheap call, and \
+the one to reach for unless you mean to read the code. The response bounds its own size \
+(max_response_chars) and cuts bodies before edges, so it is never refused for being too large; \
+any cut is reported in `degradations` with the numbers. Tune depth and limit_per_step to control \
+breadth: the per-step cap keeps the most relevant neighbors (located over file-less, source over \
+test, Calls over Imports over References, the expanded node's own file first) rather than \
+whatever order the relation table returned, and any node whose fan-out was cut carries \
+`fanout_truncated` with `fanout_dropped`, listed together under `clipped_steps`, so you can \
+re-query exactly that node with a wider limit_per_step. Every step reports the same keys: a \
+symbol the graph owns no file for carries explicit nulls plus `external: true` rather than a \
+shorter record, and one symbol never appears both located and file-less in one response. \
 When the chain comes back empty, the additive `negative` object's `safe_to_conclude_absent` \
 flag says whether \"no flow from here\" is authoritative or merely \"not indexed yet\", and its \
 `subject` scopes the absence to the direction that was walked, so an empty 'callers' result is \
@@ -2458,6 +2468,140 @@ resolution miss rather than reporting an empty chain. \
 Each step carries `resolution` for the edge that reached it: `type_resolved`, \
 `import_scoped`, or `name_only`. A chain is only as trustworthy as its weakest hop, so a \
 `name_only` step means the flow it claims may not exist at all.";
+
+/// One node of a trace walk, carrying the file and directory its fan-out is
+/// scored against.
+///
+/// Relevance is measured against the node being EXPANDED rather than the focal:
+/// at depth 3 the focal's directory says nothing about which of a distant node's
+/// callees continue the chain.
+struct TraceFrontierNode {
+    /// Step index of this node; `0` is the focal.
+    step: usize,
+    id: kin_model::ids::EntityId,
+    depth: usize,
+    file: Option<String>,
+    dir: Option<String>,
+}
+
+impl TraceFrontierNode {
+    fn at(step: usize, depth: usize, entity: &kin_model::entity::Entity) -> Self {
+        Self {
+            step,
+            id: entity.id,
+            depth,
+            file: entity.file_origin.as_ref().map(|path| path.0.clone()),
+            dir: kin_ranking::entity_ranking::entity_directory(entity),
+        }
+    }
+
+    fn rooted(entity: &kin_model::entity::Entity) -> Self {
+        Self::at(0, 0, entity)
+    }
+}
+
+/// One neighbor a node offers, before the per-step cap decides whether it is
+/// kept.
+struct TraceFanoutCandidate {
+    entity: kin_model::entity::Entity,
+    role: &'static str,
+    relation_kind: RelationKind,
+    confidence: f32,
+    /// Classification of the edge this candidate is currently described by.
+    /// It moves with `relation_kind` and `confidence` when a stronger edge to
+    /// the same neighbor replaces them, so the step reports what the edge it
+    /// names actually proved.
+    resolution: RelationResolution,
+}
+
+/// Order one side of a node's fan-out by relevance, most relevant first, with
+/// name and id tiebreaks so the same store returns the same chain every run.
+fn sort_trace_candidates(candidates: &mut [TraceFanoutCandidate], node: &TraceFrontierNode) {
+    candidates.sort_by(|left, right| {
+        let left_score = trace_fanout_score(
+            &left.entity,
+            left.relation_kind,
+            node.file.as_deref(),
+            node.dir.as_deref(),
+            left.confidence,
+        );
+        let right_score = trace_fanout_score(
+            &right.entity,
+            right.relation_kind,
+            node.file.as_deref(),
+            node.dir.as_deref(),
+            right.confidence,
+        );
+        right_score
+            .cmp(&left_score)
+            .then_with(|| left.entity.name.cmp(&right.entity.name))
+            .then_with(|| left.entity.id.0.cmp(&right.entity.id.0))
+    });
+}
+
+/// The one record shape every entity in a trace is reported in: the same keys
+/// whether the graph owns a location for the symbol or holds it only as a
+/// reference target, with explicit nulls and an `external` marker instead of a
+/// shorter object.
+///
+/// This arm serves no bodies — it answers from a generic graph store with no
+/// repository authority to project source through — so `body` is null on every
+/// record here and `bodies_included` on the response says so.
+fn trace_entity_value(entity: &kin_model::entity::Entity) -> serde_json::Value {
+    let (start_line, end_line) = match entity.span.as_ref() {
+        Some(span) => {
+            let (start, end) = presentation_span_lines(span);
+            (Some(start), Some(end))
+        }
+        None => (None, None),
+    };
+    serde_json::json!({
+        "entity_id": entity.id.to_string(),
+        "entity_name": entity.name.clone(),
+        "entity_kind": format!("{:?}", entity.kind),
+        "entity_role": format!("{:?}", entity.role).to_lowercase(),
+        "entity_file": entity.file_origin.as_ref().map(|path| path.to_string()),
+        "external": trace_entity_is_external(entity),
+        "start_line": start_line,
+        "end_line": end_line,
+        "signature": (!entity.signature.is_empty()).then(|| entity.signature.clone()),
+        "body": serde_json::Value::Null,
+        "span_coherence": serde_json::Value::Null,
+    })
+}
+
+/// One chain step: its edge, its depth, its entity record, and its own fan-out
+/// truncation, flat so every step carries one key set.
+fn trace_step_value(
+    step: usize,
+    role: &str,
+    relation_kind: &str,
+    resolution: &str,
+    parent_step: usize,
+    depth: usize,
+    entity: &kin_model::entity::Entity,
+) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "step": step,
+        "role": role,
+        "relation_kind": relation_kind,
+        // How the edge INTO this step was resolved. A chain is only as
+        // trustworthy as its weakest hop, and a `name_only` hop means the flow
+        // may not exist at all.
+        "resolution": resolution,
+        "parent_step": parent_step,
+        "depth": depth,
+        "fanout_truncated": false,
+        "fanout_dropped": 0,
+    });
+    let record = trace_entity_value(entity);
+    if let (Some(target), Some(source)) = (value.as_object_mut(), record.as_object()) {
+        for (key, entry) in source {
+            target.insert(key.clone(), entry.clone());
+        }
+    }
+    value
+}
 
 /// Trace the actual call/data-flow chain rooted at a focal entity.
 ///
@@ -2533,23 +2677,40 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     let mut visited: std::collections::HashSet<kin_model::ids::EntityId> =
         std::collections::HashSet::new();
     visited.insert(focal_entity.id);
+    // Which step already stands for a symbol NAME, so an import alias and the
+    // function it aliases never arrive as two identities for one symbol. Seeded
+    // with the focal only when the graph owns a file for it.
+    let mut name_index: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    if focal_entity.file_origin.is_some() {
+        name_index.insert(focal_entity.name.clone(), 0);
+    }
+    let mut external_identities_merged = 0usize;
+    let mut clipped_steps: Vec<serde_json::Value> = Vec::new();
     let mut truncated = false;
 
-    let mut frontier: Vec<(usize, kin_model::ids::EntityId, usize)> = vec![(0, focal_entity.id, 0)];
+    // Frontier: (step, entity, depth, file, dir) — the expanded node's own
+    // location travels with it, because relevance is scored against the node
+    // being expanded rather than against the focal.
+    let mut frontier: Vec<TraceFrontierNode> = vec![TraceFrontierNode::rooted(&focal_entity)];
 
     while !frontier.is_empty() {
-        let mut next_frontier: Vec<(usize, kin_model::ids::EntityId, usize)> = Vec::new();
-        for (parent_step, parent_id, parent_depth) in frontier.drain(..) {
-            if parent_depth >= depth {
+        let mut next_frontier: Vec<TraceFrontierNode> = Vec::new();
+        for node in frontier.drain(..) {
+            if node.depth >= depth {
                 continue;
             }
             let relations = store
-                .get_all_relations_for_entity(&parent_id)
+                .get_all_relations_for_entity(&node.id)
                 .map_err(McpError::graph)?;
-            // Independent per-direction budgets so `direction=both` doesn't
-            // starve one side when relations are emitted in either order.
-            let mut callee_count = 0usize;
-            let mut caller_count = 0usize;
+            // Every neighbor is collected before any is kept: a per-step cap is
+            // a choice between candidates, and a loop that admits as it reads
+            // keeps whatever the relation table listed first.
+            let mut candidates: Vec<TraceFanoutCandidate> = Vec::new();
+            let mut candidate_index: std::collections::HashMap<
+                (kin_model::ids::EntityId, &'static str),
+                usize,
+            > = std::collections::HashMap::new();
             for rel in &relations {
                 if !allowed.contains(&rel.kind) {
                     continue;
@@ -2560,66 +2721,164 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     _ => None,
                 };
                 let (next_id, role) = if want_callees
-                    && src_entity == Some(parent_id)
+                    && src_entity == Some(node.id)
                     && dst_entity.is_some()
-                    && dst_entity != Some(parent_id)
+                    && dst_entity != Some(node.id)
                 {
                     (dst_entity.unwrap(), "callee")
                 } else if want_callers
-                    && dst_entity == Some(parent_id)
+                    && dst_entity == Some(node.id)
                     && src_entity.is_some()
-                    && src_entity != Some(parent_id)
+                    && src_entity != Some(node.id)
                 {
                     (src_entity.unwrap(), "caller")
                 } else {
                     continue;
                 };
 
-                if role == "callee" && callee_count >= limit_per_step {
-                    truncated = true;
-                    continue;
-                }
-                if role == "caller" && caller_count >= limit_per_step {
-                    truncated = true;
+                // Already in the chain by another edge: not a candidate, and not
+                // a drop either.
+                if visited.contains(&next_id) {
                     continue;
                 }
 
-                if !visited.insert(next_id) {
-                    continue;
+                match candidate_index.get(&(next_id, role)) {
+                    Some(&existing) => {
+                        let candidate: &mut TraceFanoutCandidate = &mut candidates[existing];
+                        let stronger = trace_relation_rank(rel.kind)
+                            > trace_relation_rank(candidate.relation_kind)
+                            || (rel.kind == candidate.relation_kind
+                                && rel.confidence > candidate.confidence);
+                        if stronger {
+                            candidate.relation_kind = rel.kind;
+                            candidate.confidence = rel.confidence;
+                            candidate.resolution = RelationResolution::of(rel);
+                        }
+                    }
+                    None => {
+                        let Some(entity) = store.get_entity(&next_id).map_err(McpError::graph)?
+                        else {
+                            continue;
+                        };
+                        candidate_index.insert((next_id, role), candidates.len());
+                        candidates.push(TraceFanoutCandidate {
+                            entity,
+                            role,
+                            relation_kind: rel.kind,
+                            confidence: rel.confidence,
+                            resolution: RelationResolution::of(rel),
+                        });
+                    }
                 }
-                if role == "callee" {
-                    callee_count += 1;
+            }
+
+            // Independent per-direction budgets so `direction=both` doesn't
+            // starve one side when relations are emitted in either order.
+            let (mut callees, mut callers): (
+                Vec<TraceFanoutCandidate>,
+                Vec<TraceFanoutCandidate>,
+            ) = candidates.into_iter().partition(|c| c.role == "callee");
+            sort_trace_candidates(&mut callees, &node);
+            sort_trace_candidates(&mut callers, &node);
+            let dropped_callees = callees.len().saturating_sub(limit_per_step);
+            let dropped_callers = callers.len().saturating_sub(limit_per_step);
+            callees.truncate(limit_per_step);
+            callers.truncate(limit_per_step);
+
+            if dropped_callees + dropped_callers > 0 {
+                truncated = true;
+                let dropped = dropped_callees + dropped_callers;
+                let (entity_id, entity_name) = if node.step == 0 {
+                    (focal_entity.id.to_string(), focal_entity.name.clone())
                 } else {
-                    caller_count += 1;
-                }
+                    let step = &mut chain[node.step - 1];
+                    step["fanout_truncated"] = serde_json::Value::Bool(true);
+                    let already = step["fanout_dropped"].as_u64().unwrap_or(0);
+                    step["fanout_dropped"] =
+                        serde_json::Value::from(already.saturating_add(dropped as u64));
+                    (
+                        step["entity_id"].as_str().unwrap_or_default().to_string(),
+                        step["entity_name"].as_str().unwrap_or_default().to_string(),
+                    )
+                };
+                clipped_steps.push(serde_json::json!({
+                    "step": node.step,
+                    "entity_id": entity_id,
+                    "entity_name": entity_name,
+                    "dropped_callees": dropped_callees,
+                    "dropped_callers": dropped_callers,
+                    "limit_per_step": limit_per_step,
+                }));
+            }
+
+            for candidate in callees.into_iter().chain(callers) {
                 if chain.len() >= MAX_TOTAL_STEPS {
                     truncated = true;
                     break;
                 }
-                let next_entity = match store.get_entity(&next_id).map_err(McpError::graph)? {
-                    Some(entity) => entity,
-                    None => continue,
-                };
-                let next_depth = parent_depth + 1;
+                let candidate_external = trace_entity_is_external(&candidate.entity);
+                if let Some(&existing) = name_index.get(candidate.entity.name.as_str()) {
+                    let existing_external = existing > 0
+                        && chain[existing - 1]["external"].as_bool().unwrap_or(false);
+                    if candidate_external {
+                        visited.insert(candidate.entity.id);
+                        external_identities_merged += 1;
+                        continue;
+                    }
+                    if existing_external {
+                        // Fill the placeholder in with the record the graph owns,
+                        // rather than admitting one symbol under two identities.
+                        let promoted_depth =
+                            chain[existing - 1]["depth"].as_u64().unwrap_or(0) as usize;
+                        let promoted = trace_step_value(
+                            existing,
+                            chain[existing - 1]["role"].as_str().unwrap_or("callee"),
+                            chain[existing - 1]["relation_kind"]
+                                .as_str()
+                                .unwrap_or("Calls"),
+                            chain[existing - 1]["resolution"]
+                                .as_str()
+                                .unwrap_or_else(|| RelationResolution::NameOnly.as_str()),
+                            chain[existing - 1]["parent_step"].as_u64().unwrap_or(0) as usize,
+                            promoted_depth,
+                            &candidate.entity,
+                        );
+                        chain[existing - 1] = promoted;
+                        visited.insert(candidate.entity.id);
+                        external_identities_merged += 1;
+                        if promoted_depth < depth {
+                            next_frontier.push(TraceFrontierNode::at(
+                                existing,
+                                promoted_depth,
+                                &candidate.entity,
+                            ));
+                        }
+                        continue;
+                    }
+                }
+                if !visited.insert(candidate.entity.id) {
+                    continue;
+                }
+                let next_depth = node.depth + 1;
                 let step_index = chain.len() + 1;
-                chain.push(serde_json::json!({
-                    "step": step_index,
-                    "role": role,
-                    "relation_kind": format!("{:?}", rel.kind),
-                    // How the edge INTO this step was resolved. A chain is only
-                    // as trustworthy as its weakest hop, and a `name_only` hop
-                    // means the flow may not exist at all.
-                    "resolution": RelationResolution::of(&rel).as_str(),
-                    "parent_step": parent_step,
-                    "depth": next_depth,
-                    "entity_id": next_entity.id.to_string(),
-                    "entity_name": next_entity.name,
-                    "entity_kind": format!("{:?}", next_entity.kind),
-                    "entity_file": next_entity.file_origin.as_ref().map(|p| p.to_string()),
-                    "signature": (!next_entity.signature.is_empty()).then_some(next_entity.signature),
-                }));
+                name_index
+                    .entry(candidate.entity.name.clone())
+                    .or_insert(step_index);
+                chain.push(trace_step_value(
+                    step_index,
+                    candidate.role,
+                    &format!("{:?}", candidate.relation_kind),
+                    candidate.resolution.as_str(),
+                    node.step,
+                    next_depth,
+                    &candidate.entity,
+                ));
                 if next_depth < depth {
-                    next_frontier.push((step_index, next_id, next_depth));
+                    next_frontier.push(TraceFrontierNode::at(
+                        step_index,
+                        next_depth,
+                        &candidate.entity,
+                    ));
                 }
             }
             if chain.len() >= MAX_TOTAL_STEPS {
@@ -2648,11 +2907,17 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     });
     let mut result = serde_json::json!({
         "focal_id": focal_entity.id.to_string(),
-        "focal_name": focal_entity.name,
+        "focal_name": focal_entity.name.clone(),
         "focal_kind": format!("{:?}", focal_entity.kind),
         "focal_file": focal_entity.file_origin.as_ref().map(|p| p.to_string()),
+        "focal_entity": trace_entity_value(&focal_entity),
         "direction": direction,
         "depth": depth,
+        "limit_per_step": limit_per_step,
+        // This arm reads no bodies at all: it answers from a generic graph store,
+        // with no repository authority to project source through. Stating it
+        // keeps `include_body` from reading as honoured here.
+        "bodies_included": false,
         "chain": chain,
         "total_steps": total_steps,
         "truncated": truncated,
@@ -2663,6 +2928,12 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     });
     if let Some(edge_coverage) = edge_coverage {
         result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    }
+    if !clipped_steps.is_empty() {
+        result["clipped_steps"] = serde_json::Value::Array(clipped_steps);
+    }
+    if external_identities_merged > 0 {
+        result["external_identities_merged"] = serde_json::Value::from(external_identities_merged);
     }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2603,6 +2603,88 @@ fn trace_step_value(
     value
 }
 
+/// Bound this arm's payload, dropping steps from the TAIL of the chain until it
+/// fits, and disclosing the cut.
+///
+/// This arm serves no bodies, so it has none to cut first: what it can shed is
+/// steps. It still needs the bound, because 200 steps of identity, span, and
+/// signature is a six-figure character count on their own, and a response the
+/// client refuses is worse than a short one — the caller gets neither the chain
+/// nor a way to ask for less.
+///
+/// A suffix is what makes the cut safe: the chain is discovery-ordered, so
+/// children always sit after their parents and removing the end never orphans a
+/// surviving step's `parent_step`.
+fn bound_trace_payload(result: &mut serde_json::Value, max_chars: usize) {
+    fn measure(value: &serde_json::Value) -> usize {
+        serde_json::to_string_pretty(value).map_or(usize::MAX, |json| json.len())
+    }
+    if measure(result) <= max_chars {
+        return;
+    }
+    let target = max_chars.saturating_sub(TRACE_DISCLOSURE_RESERVE_CHARS);
+    let full: Vec<serde_json::Value> = result["chain"].as_array().cloned().unwrap_or_default();
+
+    // Bisected rather than popped one step at a time: the same answer, in a
+    // handful of serializations instead of one per dropped step.
+    let mut kept = 0usize;
+    let mut low = 0usize;
+    let mut high = full.len();
+    while low <= high {
+        let mid = (low + high) / 2;
+        result["chain"] = serde_json::Value::Array(full[..mid].to_vec());
+        result["total_steps"] = serde_json::Value::from(mid);
+        if measure(result) <= target {
+            kept = mid;
+            low = mid + 1;
+        } else if mid == 0 {
+            break;
+        } else {
+            high = mid - 1;
+        }
+    }
+    result["chain"] = serde_json::Value::Array(full[..kept].to_vec());
+    result["total_steps"] = serde_json::Value::from(kept);
+
+    let omitted = full.len() - kept;
+    if omitted == 0 {
+        return;
+    }
+    result["steps_omitted"] = serde_json::Value::from(omitted);
+    // Dropped steps are edges the caller did not receive, which is what this flag
+    // has always meant.
+    result["truncated"] = serde_json::Value::Bool(true);
+    // A clip naming a step the response no longer carries would send a caller
+    // re-querying a node it cannot see.
+    if let Some(clips) = result
+        .get_mut("clipped_steps")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        clips.retain(|clip| clip["step"].as_u64().unwrap_or(0) as usize <= kept);
+    }
+    let disclosure = serde_json::json!({
+        "component": "response_budget",
+        "reason": "steps_omitted",
+        "detail": format!(
+            "the response exceeded its {max_chars}-character budget, so {omitted} steps were \
+             dropped from the end of the chain; this arm inlines no bodies, so steps are all it \
+             can shed"
+        ),
+        "remediation": "narrow the walk with a smaller depth or limit_per_step, or raise \
+                        max_response_chars if the caller's own result limit accepts a larger \
+                        payload",
+    });
+    // Appended rather than assigned: another producer may already have disclosed
+    // something about this same answer.
+    match result
+        .get_mut("degradations")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        Some(existing) => existing.push(disclosure),
+        None => result["degradations"] = serde_json::Value::Array(vec![disclosure]),
+    }
+}
+
 /// Trace the actual call/data-flow chain rooted at a focal entity.
 ///
 /// Walks Calls/Imports/References relations from the focal in the requested
@@ -2932,6 +3014,13 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     if external_identities_merged > 0 {
         result["external_identities_merged"] = serde_json::Value::from(external_identities_merged);
     }
+    let max_response_chars = trace_response_budget(
+        args.get("max_response_chars")
+            .and_then(serde_json::Value::as_u64)
+            .map(|value| value as usize),
+    );
+    result["max_response_chars"] = serde_json::Value::from(max_response_chars);
+    bound_trace_payload(&mut result, max_response_chars);
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -5002,6 +5091,223 @@ mod tests {
         store
             .upsert_relation(&make_relation(caller.id, callee.id, RelationKind::Calls))
             .unwrap();
+    }
+
+    /// `trace_data_flow` on this arm, with whatever arguments a test needs, and
+    /// no envelope: these assert on the handler's own payload.
+    fn traced_payload(
+        store: &InMemoryGraph,
+        args: &[(&str, serde_json::Value)],
+    ) -> serde_json::Value {
+        let mut arguments = HashMap::new();
+        for (key, value) in args {
+            arguments.insert((*key).to_string(), value.clone());
+        }
+        parsed_response(&handle_trace_data_flow(&arguments, store).unwrap())
+    }
+
+    /// The measured fan-out inversion on this arm: a node whose callees include
+    /// two in its own file, a distant method, a test double, and a file-less
+    /// import placeholder.
+    fn trace_fanout_store() -> (InMemoryGraph, EntityId) {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("resolve_redirects", "src/requests/sessions.py");
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+
+        let mut candidates = vec![
+            make_entity("get_redirect_target", "src/requests/sessions.py"),
+            make_entity("rebuild_method", "src/requests/sessions.py"),
+            make_entity("HTTPAdapter.close", "src/requests/adapters.py"),
+        ];
+        let mut harness = make_entity("RedirectSession.send", "tests/test_requests.py");
+        harness.role = EntityRole::Test;
+        candidates.push(harness);
+        let mut placeholder = make_entity("urljoin", "unused");
+        placeholder.kind = EntityKind::Module;
+        placeholder.file_origin = None;
+        candidates.push(placeholder);
+
+        for candidate in &candidates {
+            store.upsert_entity(candidate).unwrap();
+            store
+                .upsert_relation(&make_relation(focal_id, candidate.id, RelationKind::Calls))
+                .unwrap();
+        }
+        (store, focal_id)
+    }
+
+    /// This arm serves the tool whenever the MCP server answers from an
+    /// in-process store rather than delegating to the daemon, so it owes the same
+    /// per-step cap behavior. A cap that kept whatever the relation table listed
+    /// first dropped the two callees that decide the redirect.
+    #[test]
+    fn trace_data_flow_offline_cap_keeps_the_callees_that_continue_the_chain() {
+        let (store, focal_id) = trace_fanout_store();
+        let response = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(2)),
+            ],
+        );
+
+        let mut kept: Vec<String> = response["chain"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|step| step["entity_name"].as_str().unwrap().to_string())
+            .collect();
+        kept.sort();
+        assert_eq!(
+            kept,
+            vec![
+                "get_redirect_target".to_string(),
+                "rebuild_method".to_string()
+            ],
+            "the located source callees in the expanded node's own file must win the two slots"
+        );
+        assert_eq!(response["truncated"], serde_json::json!(true));
+        let clip = &response["clipped_steps"][0];
+        assert_eq!(clip["step"], serde_json::json!(0), "the focal is step 0");
+        assert_eq!(clip["dropped_callees"], serde_json::json!(3));
+        assert_eq!(clip["limit_per_step"], serde_json::json!(2));
+    }
+
+    /// One array, one key set, and one identity per symbol — on this arm too.
+    #[test]
+    fn trace_data_flow_offline_reports_one_shape_and_one_identity() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("Session.prepare_request", "src/requests/sessions.py");
+        let admitted = make_entity("cookiejar_from_dict", "src/requests/cookies.py");
+        let mut alias = make_entity("cookiejar_from_dict", "unused");
+        alias.kind = EntityKind::Module;
+        alias.file_origin = None;
+        let mut placeholder = make_entity("urlparse", "unused");
+        placeholder.kind = EntityKind::Module;
+        placeholder.file_origin = None;
+        let focal_id = focal.id;
+        let admitted_id = admitted.id;
+
+        for entity in [&focal, &admitted, &alias, &placeholder] {
+            store.upsert_entity(entity).unwrap();
+        }
+        for target in [admitted.id, alias.id, placeholder.id] {
+            store
+                .upsert_relation(&make_relation(focal_id, target, RelationKind::Calls))
+                .unwrap();
+        }
+
+        let response = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(25)),
+            ],
+        );
+
+        let steps = response["chain"].as_array().unwrap();
+        let cookiejar: Vec<&serde_json::Value> = steps
+            .iter()
+            .filter(|step| step["entity_name"] == serde_json::json!("cookiejar_from_dict"))
+            .collect();
+        assert_eq!(cookiejar.len(), 1, "one symbol, one step: {response}");
+        assert_eq!(
+            cookiejar[0]["entity_id"],
+            serde_json::json!(admitted_id.to_string()),
+            "the located record wins over the placeholder"
+        );
+        assert_eq!(response["external_identities_merged"], serde_json::json!(1));
+
+        // The file-less import is kept, because nothing located stands for it,
+        // and it carries the same keys with explicit nulls.
+        let external = steps
+            .iter()
+            .find(|step| step["external"] == serde_json::json!(true))
+            .expect("the file-less import must still be reported");
+        assert!(external["entity_file"].is_null() && external["start_line"].is_null());
+        let expected: Vec<String> = steps[0].as_object().unwrap().keys().cloned().collect();
+        for step in steps {
+            let keys: Vec<String> = step.as_object().unwrap().keys().cloned().collect();
+            assert_eq!(keys, expected, "every step carries the same keys: {step}");
+        }
+    }
+
+    /// This arm inlines no bodies, so what it can shed is steps — and it must,
+    /// because 200 steps of identity and signature is a six-figure character
+    /// count on its own.
+    #[test]
+    fn trace_data_flow_offline_bounds_its_own_payload() {
+        const BUDGET: usize = 4_000;
+        let store = InMemoryGraph::new();
+        let focal = make_entity("hub", "src/hub.rs");
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+        for index in 0..25 {
+            let callee = make_entity(&format!("callee_{index}"), &format!("src/c{index}.rs"));
+            store.upsert_entity(&callee).unwrap();
+            store
+                .upsert_relation(&make_relation(focal_id, callee.id, RelationKind::Calls))
+                .unwrap();
+        }
+
+        let unbounded = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(25)),
+            ],
+        );
+        assert_eq!(unbounded["total_steps"], serde_json::json!(25));
+        let unbounded_chars = serde_json::to_string_pretty(&unbounded).unwrap().len();
+        assert!(
+            unbounded_chars > BUDGET,
+            "the fixture must exceed the budget under test: {unbounded_chars} chars"
+        );
+
+        let bounded = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("calls")),
+                ("depth", serde_json::json!(1)),
+                ("limit_per_step", serde_json::json!(25)),
+                ("max_response_chars", serde_json::json!(BUDGET)),
+            ],
+        );
+        let bounded_chars = serde_json::to_string_pretty(&bounded).unwrap().len();
+        assert!(
+            bounded_chars <= BUDGET,
+            "the tool must return what it promised to fit: {bounded_chars} chars against {BUDGET}"
+        );
+        let kept = bounded["total_steps"].as_u64().unwrap() as usize;
+        assert!(kept > 0, "a bound is not a refusal: {bounded}");
+        assert_eq!(
+            bounded["steps_omitted"].as_u64().unwrap() as usize + kept,
+            25
+        );
+        assert_eq!(
+            bounded["truncated"],
+            serde_json::json!(true),
+            "dropped steps are edges the caller did not receive"
+        );
+        // A prefix, so no surviving step points at a parent that was dropped.
+        for step in bounded["chain"].as_array().unwrap() {
+            assert!(step["parent_step"].as_u64().unwrap() as usize <= kept);
+        }
+        let disclosure = bounded["degradations"]
+            .as_array()
+            .expect("a cut must be disclosed")
+            .iter()
+            .find(|entry| entry["component"] == serde_json::json!("response_budget"))
+            .expect("the cut must name itself");
+        assert_eq!(disclosure["reason"], serde_json::json!("steps_omitted"));
     }
 
     /// The authoritative side of the trace absence: a focal that is in the

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2680,8 +2680,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     // Which step already stands for a symbol NAME, so an import alias and the
     // function it aliases never arrive as two identities for one symbol. Seeded
     // with the focal only when the graph owns a file for it.
-    let mut name_index: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::new();
+    let mut name_index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     if focal_entity.file_origin.is_some() {
         name_index.insert(focal_entity.name.clone(), 0);
     }
@@ -2774,10 +2773,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
 
             // Independent per-direction budgets so `direction=both` doesn't
             // starve one side when relations are emitted in either order.
-            let (mut callees, mut callers): (
-                Vec<TraceFanoutCandidate>,
-                Vec<TraceFanoutCandidate>,
-            ) = candidates.into_iter().partition(|c| c.role == "callee");
+            let (mut callees, mut callers): (Vec<TraceFanoutCandidate>, Vec<TraceFanoutCandidate>) =
+                candidates.into_iter().partition(|c| c.role == "callee");
             sort_trace_candidates(&mut callees, &node);
             sort_trace_candidates(&mut callers, &node);
             let dropped_callees = callees.len().saturating_sub(limit_per_step);
@@ -2818,8 +2815,8 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 }
                 let candidate_external = trace_entity_is_external(&candidate.entity);
                 if let Some(&existing) = name_index.get(candidate.entity.name.as_str()) {
-                    let existing_external = existing > 0
-                        && chain[existing - 1]["external"].as_bool().unwrap_or(false);
+                    let existing_external =
+                        existing > 0 && chain[existing - 1]["external"].as_bool().unwrap_or(false);
                     if candidate_external {
                         visited.insert(candidate.entity.id);
                         external_identities_merged += 1;

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -364,7 +364,24 @@ fn registered_tools() -> ToolsListResult {
                             "description": "Direction of traversal: 'calls' walks outgoing edges (focal -> callees), 'callers' walks incoming edges (callers -> focal), 'both' merges. Default 'both'.",
                             "default": "both"
                         },
-                        "limit_per_step": { "type": "integer", "description": "Max relations expanded per step (default 5, capped at 25)", "default": 5, "minimum": 1, "maximum": 25 }
+                        "limit_per_step": { "type": "integer", "description": "Max relations expanded per step (default 5, capped at 25). Kept by relevance, not by relation order; a step whose fan-out was cut says so with the count it dropped.", "default": 5, "minimum": 1, "maximum": 25 },
+                        "include_body": {
+                            "type": "boolean",
+                            "description": "Inline each step's source body (default true). Pass false to ask for the SHAPE of the chain — names, kinds, roles, spans, edges — which is a fraction of the size and is what you want unless you intend to read the code.",
+                            "default": true
+                        },
+                        "compact": {
+                            "type": "boolean",
+                            "description": "Alias for include_body: false. Ignored when include_body is given explicitly.",
+                            "default": false
+                        },
+                        "max_response_chars": {
+                            "type": "integer",
+                            "description": "Serialized characters this response may occupy (default 80000). The tool enforces it itself, dropping bodies before edges and reporting the cut in degradations, so a result is never refused for size.",
+                            "default": 80000,
+                            "minimum": 2000,
+                            "maximum": 400000
+                        }
                     },
                     "required": ["focal"]
                 }),

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -288,6 +288,106 @@ pub fn trace_callee_score(
     )
 }
 
+/// True when the graph holds this entity as a reference target it owns no
+/// location for: an imported symbol another repository defines, a builtin, or an
+/// import alias the extractor split off the definition.
+///
+/// Keyed on the file origin rather than on [`EntityRole::External`], because the
+/// two disagree in both directions and only the file decides what a caller can
+/// do with the record. A vendored dependency's entities are `External` by role
+/// and carry real files, so they are addressable; the file-less placeholders
+/// measured in a converted Python repository were `Module`-kinded with the
+/// default `Source` role. A record with no file has no span, so no body, no
+/// line, and nothing to open.
+pub fn trace_entity_is_external(entity: &Entity) -> bool {
+    entity.file_origin.is_none()
+}
+
+/// How much a role earns a scarce fan-out slot when a step has more candidates
+/// than it may keep.
+///
+/// Test code is not noise, but a per-step cap is a choice between candidates,
+/// and a caller asking what a function calls means its production callees before
+/// the harness that exercises them. Measured on a converted `psf/requests`: the
+/// six-wide caller cap on `HTTPAdapter.send` kept five `TestRequests` methods
+/// and a test server while dropping `Session.send` and
+/// `HTTPDigestAuth.handle_401`, the only two real callers, so the same graph
+/// answered "who calls this" with five tests or two source functions depending
+/// on which tool trimmed what.
+fn trace_role_rank(role: &EntityRole) -> usize {
+    match role {
+        EntityRole::Source => 4,
+        EntityRole::Vendored | EntityRole::External => 3,
+        EntityRole::Generated => 2,
+        EntityRole::Test => 1,
+        EntityRole::Docs => 0,
+    }
+}
+
+/// The comparable relevance key for one fan-out candidate. Higher is kept.
+pub type TraceFanoutScore = (
+    bool,
+    usize,
+    usize,
+    bool,
+    bool,
+    usize,
+    u32,
+    std::cmp::Reverse<usize>,
+);
+
+/// Relevance of one candidate against the other candidates of the SAME step, so
+/// a per-step cap keeps the chain rather than whatever order the relation table
+/// happened to return.
+///
+/// Compared as a tuple, most significant first:
+/// 1. the graph holds a location for it (a file-less placeholder never takes a
+///    slot from a symbol a caller can open)
+/// 2. role rank (source over test; see [`trace_role_rank`])
+/// 3. relation rank (Calls over Imports over References)
+/// 4. declared in the same FILE as the node being expanded
+/// 5. declared in the same DIRECTORY as it
+/// 6. declaration kind rank (functions and methods over constants)
+/// 7. the edge's own confidence
+/// 8. shorter name, which only ever breaks a tie the seven signals above left
+///
+/// `parent_file` and `parent_dir` describe the node whose fan-out is being cut,
+/// not the focal: locality is what makes a chain readable, and at depth 3 the
+/// focal's directory says nothing about which of a distant node's callees
+/// continue the path. On the measured trace this is the signal that decides:
+/// `resolve_redirects` dropped `get_redirect_target` and `rebuild_method`, both
+/// in its own file, in favour of `SupportsRead.read` and `HTTPAdapter.close`.
+pub fn trace_fanout_score(
+    entity: &Entity,
+    relation_kind: RelationKind,
+    parent_file: Option<&str>,
+    parent_dir: Option<&str>,
+    confidence: f32,
+) -> TraceFanoutScore {
+    let same_file = parent_file
+        .zip(entity.file_origin.as_ref())
+        .map(|(parent, file)| parent == file.0.as_str())
+        .unwrap_or(false);
+    let same_dir = parent_dir
+        .zip(entity_directory(entity).as_deref())
+        .map(|(parent, dir)| parent == dir)
+        .unwrap_or(false);
+    // Quantized because the key is compared with `Ord` and `f32` is not. Three
+    // decimals keep every confidence the graph records distinguishable while
+    // staying immune to the last-bit noise of a float that was multiplied out.
+    let confidence = (confidence.clamp(0.0, 1.0) * 1000.0).round() as u32;
+    (
+        !trace_entity_is_external(entity),
+        trace_role_rank(&entity.role),
+        trace_relation_rank(relation_kind),
+        same_file,
+        same_dir,
+        declaration_kind_rank(&entity.kind),
+        confidence,
+        std::cmp::Reverse(entity.name.len()),
+    )
+}
+
 /// Compute a composite score for trace constant selection.
 pub fn trace_constant_score(entity: &Entity, focal_dir: Option<&str>) -> (bool, bool, usize) {
     let same_dir = focal_dir
@@ -387,6 +487,122 @@ mod tests {
         let rels = vec![relation(RelationKind::Calls, caller, method)];
         assert_eq!(containing_owner_id(&method, &rels), None);
         assert_eq!(containing_owner_id(&method, &[]), None);
+    }
+
+    fn fanout_entity(name: &str, file: Option<&str>) -> Entity {
+        use kin_model::entity::{EntityMetadata, FingerprintAlgorithm, SemanticFingerprint};
+        use kin_model::ids::{FilePathId, Hash256, LanguageId};
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Python,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: file.map(FilePathId::new),
+            span: None,
+            signature: format!("def {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn score(entity: &Entity) -> TraceFanoutScore {
+        trace_fanout_score(
+            entity,
+            RelationKind::Calls,
+            Some("src/requests/sessions.py"),
+            Some("src/requests"),
+            1.0,
+        )
+    }
+
+    #[test]
+    fn a_located_callee_outranks_a_file_less_placeholder() {
+        let admitted = fanout_entity("get_redirect_target", Some("src/requests/sessions.py"));
+        let placeholder = fanout_entity("urljoin", None);
+        assert!(trace_entity_is_external(&placeholder));
+        assert!(!trace_entity_is_external(&admitted));
+        assert!(score(&admitted) > score(&placeholder));
+    }
+
+    #[test]
+    fn a_source_callee_outranks_a_test_one() {
+        let source = fanout_entity("Session.send", Some("src/requests/sessions.py"));
+        let mut test = fanout_entity("TestRequests.test_send", Some("tests/test_requests.py"));
+        test.role = EntityRole::Test;
+        assert!(score(&source) > score(&test));
+    }
+
+    #[test]
+    fn a_callee_in_the_expanded_node_s_own_file_outranks_a_distant_one() {
+        // The measured inversion: `resolve_redirects` kept `HTTPAdapter.close`
+        // (adapters.py) and dropped `rebuild_method`, which sits beside it.
+        let neighbour = fanout_entity("rebuild_method", Some("src/requests/sessions.py"));
+        let distant = fanout_entity("HTTPAdapter.close", Some("src/requests/adapters.py"));
+        assert!(score(&neighbour) > score(&distant));
+    }
+
+    #[test]
+    fn a_call_edge_outranks_a_reference_edge_to_the_same_kind_of_callee() {
+        let entity = fanout_entity("rebuild_proxies", Some("src/requests/sessions.py"));
+        let called = trace_fanout_score(
+            &entity,
+            RelationKind::Calls,
+            Some("src/requests/sessions.py"),
+            Some("src/requests"),
+            1.0,
+        );
+        let referenced = trace_fanout_score(
+            &entity,
+            RelationKind::References,
+            Some("src/requests/sessions.py"),
+            Some("src/requests"),
+            1.0,
+        );
+        assert!(called > referenced);
+    }
+
+    #[test]
+    fn a_more_confident_edge_outranks_a_guessed_one() {
+        let entity = fanout_entity("rebuild_auth", Some("src/requests/sessions.py"));
+        let certain = trace_fanout_score(
+            &entity,
+            RelationKind::Calls,
+            Some("src/requests/sessions.py"),
+            Some("src/requests"),
+            1.0,
+        );
+        let guessed = trace_fanout_score(
+            &entity,
+            RelationKind::Calls,
+            Some("src/requests/sessions.py"),
+            Some("src/requests"),
+            0.4,
+        );
+        assert!(certain > guessed);
+    }
+
+    /// A vendored dependency carries real files, so it is addressable and must
+    /// not be scored as a placeholder the way a file-less import alias is.
+    #[test]
+    fn a_vendored_entity_with_a_file_is_not_external() {
+        let mut vendored = fanout_entity("urllib3.connectionpool", Some("vendor/urllib3/pool.py"));
+        vendored.role = EntityRole::External;
+        assert!(!trace_entity_is_external(&vendored));
+        let placeholder = fanout_entity("urllib3.connectionpool", None);
+        assert!(score(&vendored) > score(&placeholder));
     }
 
     #[test]


### PR DESCRIPTION
`trace_data_flow` returned a result its own client refused. Measured on a converted
`psf/requests` (777 entities), `depth: 4, limit_per_step: 8` produced 228,413 characters over
2,453 lines and was rejected for exceeding the token limit, because all 106 steps inlined a
full source body and nothing measured the payload. The caller recovered by parsing a spill
file with a script, in a tool whose stated purpose is avoiding round trips. Four defects, all
in one answer.

**The result did not fit, and there was no way to ask for less.** `include_body: false` now
returns the SHAPE of a chain: names, kinds, roles, spans, signatures, and every edge, with no
body anywhere including the focal's. On the MCP surface `compact: true` means the same thing,
because an agent that learned that spelling from `bulk_check_references` on this same surface
should not be handed a 228k-character response for using it; an explicit `include_body` wins
over the alias so the two can never disagree silently. The CLI carries `--no-bodies`.

The default stays `include_body: true` on purpose. The budget below is what makes that safe: a
default call whose bodies do not fit now degrades to a complete chain without them and says
so, where before it overflowed. Flipping the default would silently strip bodies from every
caller that fits today, which is a change with no defect behind it.

**The tool now bounds its own response, and cuts bodies before edges.**
`max_response_chars` (default 80,000, clamped to 2,000..400,000) is enforced inside the walk,
measured with the same pretty serialization both surfaces use, so the budget is charged for
the payload a caller receives rather than a compact form nobody sends. It cuts in priority
order. Step bodies go first. The focal's body goes next. Only then does it drop steps, from
the tail of the chain, bisected rather than popped one at a time. A suffix is what makes that
last stage safe, because the chain is discovery-ordered and removing the end never orphans a
surviving step's parent. Dropped bodies do NOT set `truncated`, since every edge is still
there; dropped steps do, because those are edges the caller did not receive. Either cut is
disclosed through the `degradations` channel `semantic_locate` already uses, with the counts
and the parameter that avoids it, and `bodies_included` says which mode the caller got.

Both arms of the tool are bound on one shared ceiling. The daemon special-cases the
body-inlining walk in `kin-cli`; the MCP server answers from an in-process store through the
generic walk in `kin-mcp`, which inlines no bodies and so looked safe, while 200 steps of
identity, span, and signature is a six-figure character count with no source in it. The
default, floor, ceiling, and disclosure reserve now live in `kin-mcp`'s common handlers, which
`kin-cli` already depends on, because two definitions would let one arm promise a bound the
other does not keep.

**The per-step cap now keeps the callees that continue the chain.** It used to keep whichever
neighbors the relation table listed first, which is not a choice at all: `resolve_redirects`
kept `SupportsRead.read` and `HTTPAdapter.close` while dropping `get_redirect_target` and
`rebuild_method`, the two functions that decide whether a redirect exists and what method
replays it, both in its own file and both in the graph the whole time. The same defect
inverted a caller query in the same session, where a six-wide cap on `HTTPAdapter.send` kept
five test methods and a test server and dropped `Session.send` and
`HTTPDigestAuth.handle_401`, the only two real callers. Each node now collects every candidate
before any is kept and ranks them by `kin_ranking::entity_ranking::trace_fanout_score`: a
located symbol over a file-less placeholder, source over test, Calls over Imports over
References, the expanded node's own file, then its directory, then declaration kind, then the
edge's confidence, with name and id tiebreaks so the same store returns the same chain every
run. Scored against the node being expanded rather than the focal, because at depth 3 the
focal's directory says nothing about which of a distant node's callees continue the path.

**Truncation is localized.** `truncated: true` used to sit at the top level for 106 steps,
naming no node, so a caller could not tell a complete step from a clipped one and could not
repair either. Every step now carries `fanout_truncated` and `fanout_dropped`, and the
response carries `clipped_steps`: one entry per clipped node with its step index, identity,
dropped callees, dropped callers, and the `limit_per_step` that did the clipping, which is the
number a caller raises to recover exactly what was dropped.

**Every step carries one key set.** `entity` was an optional nested record, so 16 of 106 steps
arrived with a shorter shape and broke the consumer's parser twice. The record is flattened
into each step, keeping the keys a consumer already parses and adding the span, signature,
body, `span_coherence`, `entity_role`, and `external` beside them as explicit nulls where the
graph has no answer. Nothing is invented: a symbol the graph owns no file for reports null for
its location and says so with `external: true`. The focal is reported in the same shape under
`focal_entity`, so its span survives a shape query.

**One symbol now has one identity.** `cookiejar_from_dict` arrived twice in the measured
response, once located in cookies.py and once as a file-less Module, because dedup was by
entity id and an import alias is a second entity with a second id. A name index beside
`visited` now drops a file-less candidate whose name is already in the response, and fills a
file-less step in with the located record when that arrives later, re-entering the frontier at
its own depth since the placeholder had no edges to walk and the record replacing it does.
Merging is by exact name and only when one record has no file at all, which is the narrowest
rule that fixes the measured case; `external_identities_merged` reports it.

Fifteen new tests, each falsified by restoring the behavior it guards. Three of them run
through the MCP route against a fixture whose bodies are really projected from graph-owned
truth and measure the RAW result text, which is the only unit the overflow was ever reported
in; the kin-cli fixture's authority is unopenable, so a size claim proved only there would be
vacuous. One asserts a character count, because a change that re-inlines bodies on a shape
query is invisible to every assertion about chain contents. Two more assert the other
direction: a response inside its budget is byte-identical after enforcement, and a walk that
expanded every neighbor carries none of the new clip fields at all.

Closes FIR-2361
