### PR TITLE
Stop the supervisor reaping a daemon that has a commit in flight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,6 +3257,8 @@ dependencies = [
  "fs2",
  "libc",
  "pretty_assertions",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -3,21 +3,34 @@
 
 use anyhow::{Context, Result};
 
+use super::commit_progress::{daemon_death_explanation, PhaseTail, AUTHORITY_NOT_GIT_NOTE};
+
 pub async fn run(message: String, quiet: bool) -> Result<()> {
     let layout = crate::commands::require_repository_layout()?;
 
-    let result = run_daemon_commit(&layout, &message).await?;
+    let result = run_daemon_commit(&layout, &message, quiet).await?;
     if !quiet {
-        println!(
-            "Created semantic change {} on branch '{}' ({} entities, {} relations, {} artifacts)",
-            result.change_id,
-            result.branch,
-            result.entity_count,
-            result.relation_count,
-            result.file_count
-        );
+        println!("{}", render_commit_summary(&result));
     }
     Ok(())
+}
+
+/// What a successful `kin commit` prints.
+///
+/// The second line is said every time, because the surprise is permanent: the
+/// working tree this change came from stays dirty and `git log` never moves.
+/// Without it a brownfield user commits all day and reads `git status` as proof
+/// that nothing happened.
+fn render_commit_summary(result: &DaemonCommitResult) -> String {
+    format!(
+        "Created semantic change {} on branch '{}' ({} entities, {} relations, {} artifacts)\n{}",
+        result.change_id,
+        result.branch,
+        result.entity_count,
+        result.relation_count,
+        result.file_count,
+        AUTHORITY_NOT_GIT_NOTE,
+    )
 }
 
 /// Result from the daemon-owned native commit transaction.
@@ -35,9 +48,13 @@ struct DaemonCommitResult {
     file_count: usize,
 }
 
+/// How often the phase tail is read while the commit request is outstanding.
+const PHASE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(400);
+
 async fn run_daemon_commit(
     layout: &kin_core::KinLayout,
     message: &str,
+    quiet: bool,
 ) -> Result<DaemonCommitResult> {
     let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
         .await?
@@ -65,10 +82,24 @@ async fn run_daemon_commit(
         request = request.bearer_auth(token);
     }
 
-    let response = request
-        .send()
-        .await
-        .context("send daemon-owned native commit request")?;
+    let kin_root = layout.root().to_path_buf();
+    // Opened before the request so the first phase the daemon enters is already
+    // inside the window this reads.
+    let mut tail = PhaseTail::open(&kin_root);
+    let response = stream_phases_while(quiet, &mut tail, request.send()).await;
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            // A transport error names a socket. When the daemon was killed with
+            // this request in flight, the socket is the symptom and the killer
+            // left the cause in the repository.
+            return match daemon_death_explanation(&kin_root) {
+                Some(cause) => Err(anyhow::Error::new(error).context(cause)),
+                None => Err(anyhow::Error::new(error))
+                    .context("send daemon-owned native commit request"),
+            };
+        }
+    };
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
@@ -78,4 +109,156 @@ async fn run_daemon_commit(
         .json()
         .await
         .context("decode daemon native commit response")
+}
+
+/// Await `work`, printing the phases the daemon reaches while it runs.
+///
+/// The daemon names each phase into `.kin/daemon.log` as it enters and leaves
+/// it, and a commit-in-flight beat keeps naming the running one, so the caller
+/// sees the same attribution the log carries instead of two to three minutes of
+/// nothing.
+async fn stream_phases_while<F: std::future::Future>(
+    quiet: bool,
+    tail: &mut PhaseTail,
+    work: F,
+) -> F::Output {
+    if quiet {
+        return work.await;
+    }
+    let mut progress = crate::progress::Progress::stderr();
+    let outcome =
+        drive_phases_while(tail, work, |phase| progress.update(format_args!("{phase}"))).await;
+    progress.finish();
+    outcome
+}
+
+/// The streaming loop, with the sink injected.
+///
+/// Separated from the terminal writer so a test can assert the thing that
+/// actually matters — that phases reach the caller *while* the commit is still
+/// running — rather than only that they reach it eventually. A version that
+/// collected everything and printed it at the end would satisfy any assertion
+/// made on the finished output and would fix nothing.
+async fn drive_phases_while<F: std::future::Future>(
+    tail: &mut PhaseTail,
+    work: F,
+    mut emit: impl FnMut(&str),
+) -> F::Output {
+    let mut ticker = tokio::time::interval(PHASE_POLL_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    tokio::pin!(work);
+    let outcome = loop {
+        tokio::select! {
+            outcome = &mut work => break outcome,
+            _ = ticker.tick() => {
+                for phase in tail.poll() {
+                    emit(&phase);
+                }
+            }
+        }
+    };
+    // Drain whatever the daemon wrote between the last tick and the reply, so
+    // the phase that finished the commit is reported like every other one.
+    for phase in tail.poll() {
+        emit(&phase);
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn append(path: &std::path::Path, text: &str) {
+        use std::io::Write as _;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        file.write_all(text.as_bytes()).unwrap();
+    }
+
+    /// A commit that takes two to three minutes printed nothing for all of it,
+    /// so a working commit and a hung one looked identical — which is how a
+    /// commit that had already been dead for 20 seconds still looked fine.
+    ///
+    /// The assertion is ordering, not presence: every phase must land before the
+    /// request resolves. Falsify by moving the `tail.poll()` loop out of the
+    /// select and running it only after `work` completes; the phases then all
+    /// arrive after `request-finished` and the position check fails.
+    #[tokio::test]
+    async fn commit_phases_reach_the_caller_while_the_request_is_still_outstanding() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("daemon.log");
+        std::fs::write(&log, "").unwrap();
+        let mut tail = PhaseTail::open(dir.path());
+
+        let seen = Rc::new(RefCell::new(Vec::<String>::new()));
+        let recorder = Rc::clone(&seen);
+        let slow_commit = async {
+            for phase in ["publish_workspace_admission", "plan_transaction"] {
+                append(
+                    &log,
+                    &format!(
+                        "INFO kin_daemon::commit_liveness: commit phase in progress \
+                         phase=\"{phase}\" elapsed_ms=5000\n"
+                    ),
+                );
+                tokio::time::sleep(PHASE_POLL_INTERVAL * 2).await;
+            }
+            recorder.borrow_mut().push("request-finished".to_string());
+        };
+
+        let sink = Rc::clone(&seen);
+        drive_phases_while(&mut tail, slow_commit, |phase| {
+            sink.borrow_mut().push(phase.to_string())
+        })
+        .await;
+
+        let seen = seen.borrow();
+        let finished = seen
+            .iter()
+            .position(|line| line == "request-finished")
+            .expect("the request must have completed");
+        assert!(
+            finished > 0,
+            "at least one phase must print before the reply: {seen:?}"
+        );
+        for phase in ["publish_workspace_admission", "plan_transaction"] {
+            let at = seen
+                .iter()
+                .position(|line| line.starts_with(phase))
+                .unwrap_or_else(|| panic!("phase {phase} was never shown: {seen:?}"));
+            assert!(
+                at < finished,
+                "phase {phase} reached the caller only after the reply: {seen:?}"
+            );
+        }
+    }
+
+    /// `kin commit` is not a git commit and nothing said so, while `git status`
+    /// stayed dirty forever afterward.
+    #[test]
+    fn a_successful_commit_says_the_change_is_in_kin_authority_and_not_in_git() {
+        let summary = render_commit_summary(&DaemonCommitResult {
+            change_id: "9ade4452cd80".to_string(),
+            branch: "refs/heads/main".to_string(),
+            entity_count: 0,
+            relation_count: 0,
+            file_count: 1,
+        });
+        assert!(
+            summary.contains("Created semantic change 9ade4452cd80"),
+            "{summary}"
+        );
+        assert!(summary.contains("not in git"), "{summary}");
+        assert!(
+            summary.contains("git status"),
+            "the note must name the surface that keeps disagreeing: {summary}"
+        );
+        assert!(summary.contains("kin eject"), "{summary}");
+    }
 }

--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What `kin commit` shows while the daemon is committing, and what it says
+//! when the daemon dies underneath it.
+//!
+//! A comment-only commit on a converted repository costs two to three minutes,
+//! and for all of it the CLI printed nothing at all. The daemon was naming every
+//! phase it entered the whole time, into `.kin/daemon.log`, so the information
+//! existed and simply never reached the person waiting: silence and a hang were
+//! indistinguishable, which is how a commit that had been running for 172
+//! seconds was read as working right up to the moment it failed.
+//!
+//! The phases arrive by reading the log the daemon already writes rather than by
+//! asking the daemon for them. That matters for the case this exists to cover: a
+//! daemon deep in a synchronous commit has no runtime worker free to answer a
+//! progress request, so a polling endpoint would go quiet exactly when the
+//! caller most needs to see something. The file keeps growing regardless.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+/// One phase line lifted out of the daemon log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhaseLine {
+    pub phase: String,
+    /// Milliseconds the phase has run, when the line reported them.
+    pub elapsed_ms: Option<u64>,
+}
+
+impl PhaseLine {
+    /// How the phase reads on the caller's terminal.
+    pub fn render(&self) -> String {
+        match self.elapsed_ms {
+            Some(ms) if ms >= 1000 => format!("{} ({:.1}s)", self.phase, ms as f64 / 1000.0),
+            Some(ms) => format!("{} ({ms}ms)", self.phase),
+            None => format!("{}...", self.phase),
+        }
+    }
+}
+
+/// Drop ANSI escape sequences from a log line.
+///
+/// The daemon's `tracing` formatter colors field names, so the bytes between a
+/// name and its value are not what a naive match expects: a byte-level search
+/// for `phase=` fails on a line that visibly contains it. Stripping first is
+/// what makes the parse below able to fire at all.
+pub fn strip_ansi(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            out.push(ch);
+            continue;
+        }
+        if chars.peek() == Some(&'[') {
+            chars.next();
+            for escape in chars.by_ref() {
+                if escape.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Messages whose lines carry a commit phase worth showing.
+const PHASE_MESSAGES: [&str; 3] = [
+    "slow commit phase",
+    "commit phase in progress",
+    "commit phase",
+];
+
+/// Lift a commit phase out of one daemon-log line, if it holds one.
+pub fn parse_phase_line(raw: &str) -> Option<PhaseLine> {
+    let line = strip_ansi(raw);
+    if !PHASE_MESSAGES.iter().any(|message| line.contains(message)) {
+        return None;
+    }
+    let phase = field_value(&line, "phase")?;
+    let elapsed_ms = field_value(&line, "elapsed_ms").and_then(|value| value.parse().ok());
+    Some(PhaseLine { phase, elapsed_ms })
+}
+
+/// Read `name=value` or `name="value"` out of an already-stripped log line.
+fn field_value(line: &str, name: &str) -> Option<String> {
+    let needle = format!("{name}=");
+    let mut from = 0usize;
+    while let Some(offset) = line[from..].find(&needle) {
+        let start = from + offset;
+        // Reject a suffix match such as `phase_elapsed_ms=` matching `ms=`: the
+        // character before the name must not itself be part of a longer name.
+        let boundary_ok = start == 0
+            || !line[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|ch| ch.is_alphanumeric() || ch == '_');
+        let rest = &line[start + needle.len()..];
+        if boundary_ok {
+            return Some(match rest.strip_prefix('"') {
+                Some(quoted) => quoted.split('"').next()?.to_string(),
+                None => rest
+                    .split(|ch: char| ch.is_whitespace())
+                    .next()?
+                    .to_string(),
+            });
+        }
+        from = start + needle.len();
+    }
+    None
+}
+
+/// A cursor over the daemon log that yields phases as the daemon reaches them.
+///
+/// Opened at the log's current length so a commit never replays the phases of
+/// the one before it.
+pub struct PhaseTail {
+    path: PathBuf,
+    offset: u64,
+    pending: String,
+    last_rendered: Option<String>,
+}
+
+impl PhaseTail {
+    /// Start tailing `<kin_root>/daemon.log` from wherever it currently ends.
+    pub fn open(kin_root: &Path) -> Self {
+        let path = kin_root.join("daemon.log");
+        let offset = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
+        Self {
+            path,
+            offset,
+            pending: String::new(),
+            last_rendered: None,
+        }
+    }
+
+    /// Every phase written since the last call, deduplicated so a beat that
+    /// repeats an unchanged phase does not repeat a line on the terminal.
+    pub fn poll(&mut self) -> Vec<String> {
+        let Ok(mut file) = std::fs::File::open(&self.path) else {
+            return Vec::new();
+        };
+        if file.seek(SeekFrom::Start(self.offset)).is_err() {
+            return Vec::new();
+        }
+        let mut fresh = String::new();
+        let Ok(read) = file.read_to_string(&mut fresh) else {
+            return Vec::new();
+        };
+        self.offset += read as u64;
+        self.pending.push_str(&fresh);
+
+        let mut rendered = Vec::new();
+        while let Some(newline) = self.pending.find('\n') {
+            let line: String = self.pending.drain(..=newline).collect();
+            let Some(phase) = parse_phase_line(&line) else {
+                continue;
+            };
+            let text = phase.render();
+            if self.last_rendered.as_deref() == Some(text.as_str()) {
+                continue;
+            }
+            self.last_rendered = Some(text.clone());
+            rendered.push(text);
+        }
+        rendered
+    }
+}
+
+/// Explain a commit that failed at the transport, when the daemon is why.
+///
+/// The failure this covers reads, verbatim, as `error sending request ... /
+/// connection closed before message completed`, which describes a socket and
+/// says nothing about a daemon that was SIGKILLed with the caller's transaction
+/// in flight. The killer leaves a note in the repository it emptied, so the
+/// answer is on disk; this is the CLI reading it back.
+pub fn daemon_death_explanation(kin_root: &Path) -> Option<String> {
+    let note = kin_daemon_spawn::read_daemon_death_note(kin_root)?;
+    Some(format!(
+        "the daemon serving this repository was terminated while the request was in flight: {}. \
+         Its log is {}; the change was not recorded.",
+        note.summary(),
+        kin_root.join("daemon.log").display()
+    ))
+}
+
+/// The line a `kin commit` prints after recording a change.
+///
+/// `kin commit` is not a git commit, and until now nothing said so: the working
+/// tree it just committed from stays dirty forever, `git log` never moves, and
+/// in a brownfield repository whose CI, hooks and reviewers all read git that
+/// reads as a commit that silently did nothing.
+pub const AUTHORITY_NOT_GIT_NOTE: &str = "Recorded in Kin authority, not in git — `git status` \
+                                          stays dirty until you run `kin eject` or push this \
+                                          branch to a Kin remote.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_phase_survives_the_ansi_escapes_the_daemon_writes_between_name_and_value() {
+        // The exact shape a colored `tracing` line takes: the field name is
+        // wrapped in escapes, so `phase="` is not a substring of the raw bytes.
+        let raw = "2026-08-17T11:41:56.123Z  INFO kin_daemon::mcp_commit: slow commit phase \
+                   \u{1b}[3mphase\u{1b}[0m\u{1b}[2m=\u{1b}[0m\"publish_workspace_admission\" \
+                   \u{1b}[3melapsed_ms\u{1b}[0m\u{1b}[2m=\u{1b}[0m85776";
+        assert!(
+            !raw.contains("phase=\""),
+            "the fixture must actually carry the escapes this parse exists for"
+        );
+        let parsed = parse_phase_line(raw).expect("a phase line must survive its own coloring");
+        assert_eq!(parsed.phase, "publish_workspace_admission");
+        assert_eq!(parsed.elapsed_ms, Some(85776));
+        assert_eq!(parsed.render(), "publish_workspace_admission (85.8s)");
+    }
+
+    #[test]
+    fn a_line_that_is_not_a_commit_phase_yields_nothing() {
+        assert!(parse_phase_line("INFO kin_daemon: daemon is up and ready").is_none());
+        assert!(
+            parse_phase_line(
+                "INFO kin_db::storage::history_replay: validating repository history, 6730 \
+                 changes phase=\"git_projection_replay\""
+            )
+            .is_none(),
+            "only the daemon's own commit-phase messages are shown, so an unrelated `phase=` \
+             field cannot masquerade as commit progress"
+        );
+    }
+
+    #[test]
+    fn an_in_progress_beat_renders_without_a_completion_time() {
+        let parsed = parse_phase_line(
+            "INFO kin_daemon::commit_liveness: commit phase in progress \
+             phase=\"git_projection_replay\" elapsed_ms=20000",
+        )
+        .expect("an in-progress beat is a phase line");
+        assert_eq!(parsed.render(), "git_projection_replay (20.0s)");
+    }
+
+    #[test]
+    fn the_tail_starts_at_the_end_so_a_commit_never_replays_the_last_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("daemon.log");
+        std::fs::write(
+            &log,
+            "INFO kin_daemon::mcp_commit: slow commit phase phase=\"older_commit\" \
+             elapsed_ms=1000\n",
+        )
+        .unwrap();
+
+        let mut tail = PhaseTail::open(dir.path());
+        assert!(tail.poll().is_empty(), "history is not this commit's news");
+
+        append(
+            &log,
+            "INFO kin_daemon::mcp_commit: slow commit phase phase=\"plan_transaction\" \
+             elapsed_ms=27960\n",
+        );
+        assert_eq!(tail.poll(), vec!["plan_transaction (28.0s)".to_string()]);
+    }
+
+    #[test]
+    fn a_repeated_beat_on_one_phase_does_not_repeat_a_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("daemon.log");
+        std::fs::write(&log, "").unwrap();
+        let mut tail = PhaseTail::open(dir.path());
+
+        let beat = "INFO kin_daemon::commit_liveness: commit phase in progress \
+                    phase=\"publish_workspace_admission\" elapsed_ms=5000\n";
+        append(&log, beat);
+        assert_eq!(
+            tail.poll(),
+            vec!["publish_workspace_admission (5.0s)".to_string()]
+        );
+        append(&log, beat);
+        assert!(tail.poll().is_empty());
+
+        append(
+            &log,
+            "INFO kin_daemon::commit_liveness: commit phase in progress \
+             phase=\"publish_workspace_admission\" elapsed_ms=10000\n",
+        );
+        assert_eq!(
+            tail.poll(),
+            vec!["publish_workspace_admission (10.0s)".to_string()],
+            "a phase that is still running must keep reporting that it is"
+        );
+    }
+
+    #[test]
+    fn a_partial_line_is_held_until_it_is_whole() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("daemon.log");
+        std::fs::write(&log, "").unwrap();
+        let mut tail = PhaseTail::open(dir.path());
+
+        append(
+            &log,
+            "INFO kin_daemon::mcp_commit: slow commit phase phase=\"pl",
+        );
+        assert!(
+            tail.poll().is_empty(),
+            "half a phase name must never be printed as a phase"
+        );
+        append(&log, "an_transaction\" elapsed_ms=27960\n");
+        assert_eq!(tail.poll(), vec!["plan_transaction (28.0s)".to_string()]);
+    }
+
+    #[test]
+    fn a_transport_failure_reports_the_daemon_death_behind_it() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            daemon_death_explanation(dir.path()).is_none(),
+            "no note means no claim about why anything died"
+        );
+
+        kin_daemon_spawn::write_daemon_death_note(
+            dir.path(),
+            &kin_daemon_spawn::DaemonDeathNote {
+                pid: 387,
+                killed_by: "kin-supervisor-reaper".to_string(),
+                reason: "reaping misbehaving repo daemon: OrphanedUnreachableStalled".to_string(),
+                in_flight: Some("commit in phase publish_workspace_admission for 86s".to_string()),
+                at: "2026-08-17T11:43:00Z".to_string(),
+            },
+        );
+        let explanation =
+            daemon_death_explanation(dir.path()).expect("a note explains the failure");
+        assert!(
+            explanation.contains("kin-supervisor-reaper"),
+            "{explanation}"
+        );
+        assert!(explanation.contains("daemon.log"), "{explanation}");
+        assert!(
+            explanation.contains("the change was not recorded"),
+            "{explanation}"
+        );
+    }
+
+    fn append(path: &Path, text: &str) {
+        use std::io::Write as _;
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(text.as_bytes()).unwrap();
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod checkout;
 pub mod clone;
 pub mod cochange;
 pub mod commit;
+pub mod commit_progress;
 pub mod conflicts;
 pub mod context;
 pub mod contextbench_locate;

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7128,6 +7128,10 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url)
         .await
         .map_err(AutoStartError::spawn)?;
+    // A death note explains the outage that made this spawn necessary, and
+    // nothing after it. Left in place it would be quoted as the cause of the
+    // next unrelated transport failure.
+    kin_daemon_spawn::clear_daemon_death_note(kin_root);
     info!(daemon = %base_url, "daemon is up and ready");
     Ok(base_url)
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -6721,6 +6721,9 @@ pub async fn ensure_supervisor_running() -> Result<String> {
             "supervisor became healthy without acknowledging the exact startup generation",
         );
     }
+    // A supervisor is the same binary under `--supervisor`, so an unreaped one
+    // prints as `[kin-daemon] <defunct>` exactly like a repo daemon does.
+    kin_daemon_spawn::adopt_detached_daemon_child(child);
     info!(supervisor = %base_url, "supervisor is up and ready");
     Ok(base_url)
 }
@@ -7112,12 +7115,16 @@ pub async fn ensure_daemon_running_with_idle_timeout(
 
     let timeout_secs = daemon_ready_timeout_secs();
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
-    let base_url = wait_for_daemon_ready(kin_root, &mut child, deadline, log_offset)
-        .await
-        .map_err(|error| match error {
-            DaemonReadinessError::Failed(error) => AutoStartError::spawn(format!("{error:#}")),
-            DaemonReadinessError::Timeout(detail) => AutoStartError::StartupTimeout(detail),
-        })?;
+    let readiness = wait_for_daemon_ready(kin_root, &mut child, deadline, log_offset).await;
+    // The daemon outlives this call either way, and this process may outlive the
+    // daemon: `kin mcp start` reaches here for a whole agent session. Dropping
+    // the handle waits on nothing, so hand it to the reaper before the borrow
+    // ends rather than leaving a corpse behind for the session's duration.
+    kin_daemon_spawn::adopt_detached_daemon_child(child);
+    let base_url = readiness.map_err(|error| match error {
+        DaemonReadinessError::Failed(error) => AutoStartError::spawn(format!("{error:#}")),
+        DaemonReadinessError::Timeout(detail) => AutoStartError::StartupTimeout(detail),
+    })?;
     register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url)
         .await
         .map_err(AutoStartError::spawn)?;

--- a/crates/kin-daemon-spawn/Cargo.toml
+++ b/crates/kin-daemon-spawn/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 
 [dependencies]
 fs2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3353,6 +3353,102 @@ pub async fn register_started_daemon(kin_root: &Path, daemon_url: &str) -> Resul
 mod tests {
     use super::*;
 
+    /// Whether the OS still has an entry for this pid. A zombie answers yes for
+    /// as long as its parent lives without waiting on it, so this is exactly the
+    /// observable that separates a reaped child from an unreaped corpse: an
+    /// unadopted child would answer yes here forever.
+    ///
+    /// Gated to match its only caller, which is `#[cfg(unix)]` — an ungated
+    /// helper whose callers are all gated is dead code on the other platform and
+    /// fails the `-D warnings` leg there.
+    #[cfg(unix)]
+    fn process_entry_exists(pid: u32) -> bool {
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    /// Six `[kin-daemon] <defunct>` entries accumulated in one brownfield agent
+    /// session. Every spawn path calls `setsid` and then relies on the launcher
+    /// exiting so init inherits and waits on the daemon; `setsid` does not change
+    /// the parent pid, so under `kin mcp start` — which reaches a daemon spawn on
+    /// binding, on rebinding, and on every tool call that revives one — the
+    /// launcher stays the parent and dropping the handle waits on nothing.
+    ///
+    /// Falsify by replacing the `adopt_detached_daemon_child` call with `drop`:
+    /// every pid then answers `kill(pid, 0)` until this process exits and the
+    /// loop below runs to its deadline.
+    #[cfg(unix)]
+    #[test]
+    fn adopted_daemon_children_are_reaped_rather_than_left_defunct() {
+        const RESTARTS: usize = 6;
+        let mut pids = Vec::with_capacity(RESTARTS);
+        for _ in 0..RESTARTS {
+            let child = std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg("exit 0")
+                .spawn()
+                .expect("spawn a short-lived stand-in for a daemon");
+            pids.push(child.id());
+            adopt_detached_daemon_child(child);
+        }
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let unreaped: Vec<u32> = pids
+                .iter()
+                .copied()
+                .filter(|pid| process_entry_exists(*pid))
+                .collect();
+            if unreaped.is_empty() {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "{} of {RESTARTS} adopted children were still in the process table after 10s: \
+                 {unreaped:?}",
+                unreaped.len()
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    #[test]
+    fn a_death_note_round_trips_and_names_the_work_that_was_lost() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_daemon_death_note(dir.path()).is_none());
+
+        let note = DaemonDeathNote {
+            pid: 387,
+            killed_by: "kin-supervisor-reaper".to_string(),
+            reason: "reaping misbehaving repo daemon: OrphanedUnreachableStalled".to_string(),
+            in_flight: Some("commit in phase publish_workspace_admission for 86s".to_string()),
+            at: "2026-08-17T11:43:00Z".to_string(),
+        };
+        write_daemon_death_note(dir.path(), &note);
+
+        let read = read_daemon_death_note(dir.path()).expect("a written note must read back");
+        assert_eq!(read.pid, 387);
+        assert!(read.summary().contains("OrphanedUnreachableStalled"));
+        assert!(
+            read.summary().contains("publish_workspace_admission"),
+            "the note must name the work that was interrupted: {}",
+            read.summary()
+        );
+
+        clear_daemon_death_note(dir.path());
+        assert!(
+            read_daemon_death_note(dir.path()).is_none(),
+            "a cleared note must not be blamed for the next outage"
+        );
+    }
+
+    #[test]
+    fn a_supervisor_reason_reaches_the_log_an_operator_opens() {
+        let dir = tempfile::tempdir().unwrap();
+        append_to_daemon_log(dir.path(), "kin-daemon TERMINATED BY SUPERVISOR: because");
+        let log = std::fs::read_to_string(dir.path().join("daemon.log")).unwrap();
+        assert!(log.contains("TERMINATED BY SUPERVISOR: because"), "{log}");
+    }
+
     // These are intentionally cross-platform. The permanent native-Windows
     // authority leg selects this name prefix so Windows proves the same
     // shared/exclusive lease and retired-root contract as Unix.

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -74,6 +74,92 @@ pub const PORT_FILE_NAME: &str = "daemon.port";
 /// File the daemon writes its PID into as part of endpoint publication.
 pub const PID_FILE_NAME: &str = "daemon.pid";
 
+/// File whoever ends a daemon from outside writes its reason into.
+pub const DEATH_FILE_NAME: &str = "daemon.death";
+
+/// Why a daemon stopped, recorded by the process that stopped it.
+///
+/// A daemon killed from outside cannot log its own cause: the reaper's SIGTERM
+/// grace is shorter than the daemon's own shutdown, so the SIGKILL that follows
+/// lands while the tokio arm that would print a shutdown line is still unpolled.
+/// Everything the killer knew therefore went to the killer's log, and the log an
+/// operator actually opens — `.kin/daemon.log` — simply stopped mid-line. This
+/// carries that reason back to the repository the daemon served, so both the CLI
+/// reporting a failed request and `kin doctor` can say what happened instead of
+/// quoting a transport error.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DaemonDeathNote {
+    /// The daemon that was ended.
+    pub pid: u32,
+    /// What ended it, e.g. `kin-supervisor-reaper`.
+    pub killed_by: String,
+    /// The deciding condition, in the killer's own words.
+    pub reason: String,
+    /// What the daemon was doing, when the killer could tell.
+    pub in_flight: Option<String>,
+    /// RFC 3339 timestamp of the decision.
+    pub at: String,
+}
+
+impl DaemonDeathNote {
+    /// One line an operator can read without parsing anything.
+    pub fn summary(&self) -> String {
+        match &self.in_flight {
+            Some(work) => format!(
+                "{} ended pid {} at {}: {} (in flight: {})",
+                self.killed_by, self.pid, self.at, self.reason, work
+            ),
+            None => format!(
+                "{} ended pid {} at {}: {}",
+                self.killed_by, self.pid, self.at, self.reason
+            ),
+        }
+    }
+}
+
+/// Record why a daemon was ended, in the repository it served.
+///
+/// Best effort by construction: the caller is about to signal a process, and a
+/// note it could not write must never stop that from happening.
+pub fn write_daemon_death_note(kin_root: &Path, note: &DaemonDeathNote) {
+    let Ok(body) = serde_json::to_string(note) else {
+        return;
+    };
+    let tmp = kin_root.join(format!("{DEATH_FILE_NAME}.tmp"));
+    if fs::write(&tmp, body).is_ok() && fs::rename(&tmp, kin_root.join(DEATH_FILE_NAME)).is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+/// Read the death note left for `kin_root`, if one is there.
+pub fn read_daemon_death_note(kin_root: &Path) -> Option<DaemonDeathNote> {
+    let raw = fs::read_to_string(kin_root.join(DEATH_FILE_NAME)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Clear a death note. A daemon that comes up successfully calls this, so a note
+/// never outlives the outage it describes and gets blamed for the next one.
+pub fn clear_daemon_death_note(kin_root: &Path) {
+    let _ = fs::remove_file(kin_root.join(DEATH_FILE_NAME));
+}
+
+/// Append a line to the repo daemon's own log.
+///
+/// The one place a killer can put its reason where the operator will look. The
+/// daemon holds this file open in append mode and is about to stop writing to
+/// it, so an extra append races nothing.
+pub fn append_to_daemon_log(kin_root: &Path, line: &str) {
+    use std::io::Write as _;
+    let Ok(mut log) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(kin_root.join("daemon.log"))
+    else {
+        return;
+    };
+    let _ = writeln!(log, "{line}");
+}
+
 /// Shared install-mutation lease for spawn paths that cannot depend on
 /// `kin-cli` (most importantly MCP daemon revival). Full uninstall takes the
 /// same `<KIN_HOME>/update.lock` exclusively before stopping processes and
@@ -3002,6 +3088,78 @@ pub fn terminate_if_proven_dead(
     let _ = child.kill();
     let _ = child.wait();
     true
+}
+
+/// How often the detached-daemon reaper asks whether an adopted child has
+/// exited. Cheap: `try_wait` is one `waitpid(WNOHANG)` per adopted handle.
+const DETACHED_DAEMON_REAP_POLL: Duration = Duration::from_millis(250);
+
+/// Hand a started, detached daemon to a reaper that waits on it.
+///
+/// Every spawn path here calls `setsid`, and every spawn path then relies on
+/// the launcher exiting: once it does the daemon reparents to init, and init
+/// waits on it. `setsid` starts a new session and process group and does not
+/// change the parent pid, so the arrangement only holds while the launcher is
+/// short-lived. Under a launcher that outlives the daemon it does not hold at
+/// all, and dropping a [`std::process::Child`] waits on nothing, so the daemon
+/// stays in the process table as `[kin-daemon] <defunct>` from the moment it
+/// dies until the launcher does.
+///
+/// That launcher exists: `kin mcp start` runs for a whole agent session and
+/// reaches a daemon spawn on startup binding, on every workspace rebind, and on
+/// every tool call that revives one, while the supervisor's reaper and redeploy
+/// paths end daemons underneath it. Six corpses accumulated in one brownfield
+/// session that way.
+///
+/// Adoption transfers the handle to a named background thread that polls it to
+/// completion. It never signals the child, because the caller has no evidence
+/// the daemon should stop: this collects an exit status and nothing else.
+/// Failing to start the thread is not fatal — the handle is dropped, which is
+/// exactly the behavior every caller had before.
+pub fn adopt_detached_daemon_child(child: std::process::Child) {
+    let Some(reaper) = detached_daemon_reaper() else {
+        return;
+    };
+    let _ = reaper.send(child);
+}
+
+/// The process-wide sender for [`adopt_detached_daemon_child`], started on first
+/// use. `None` once thread creation has failed, so a failed start is not retried
+/// per spawn.
+fn detached_daemon_reaper() -> Option<std::sync::mpsc::Sender<std::process::Child>> {
+    static REAPER: OnceLock<Option<std::sync::mpsc::Sender<std::process::Child>>> = OnceLock::new();
+    REAPER
+        .get_or_init(|| {
+            let (sender, receiver) = std::sync::mpsc::channel::<std::process::Child>();
+            std::thread::Builder::new()
+                .name("kin-detached-daemon-reaper".to_string())
+                .spawn(move || detached_daemon_reaper_loop(receiver))
+                .ok()
+                .map(|_handle| sender)
+        })
+        .clone()
+}
+
+/// Poll every adopted child until it is reaped.
+///
+/// A handle is retired on `Ok(Some(status))` (the child was waited on here) and
+/// on `Err(_)` (nobody can wait on it any more, most often because something
+/// else already did). `Ok(None)` means still running, which for a healthy daemon
+/// is the case for as long as it serves.
+fn detached_daemon_reaper_loop(receiver: std::sync::mpsc::Receiver<std::process::Child>) {
+    let mut adopted: Vec<std::process::Child> = Vec::new();
+    loop {
+        match receiver.recv_timeout(DETACHED_DAEMON_REAP_POLL) {
+            Ok(child) => adopted.push(child),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) if adopted.is_empty() => return,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {}
+        }
+        while let Ok(child) = receiver.try_recv() {
+            adopted.push(child);
+        }
+        adopted.retain_mut(|child| matches!(child.try_wait(), Ok(None)));
+    }
 }
 
 /// Coarse process liveness, fail-closed on anything indeterminate.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4641,7 +4641,8 @@ async fn command_commit(
     // `daemon.log`, also stalls behind a phase that logs only when it finishes.
     // The marker and its beat are what make a busy daemon distinguishable from a
     // wedged one.
-    let _transaction = crate::commit_liveness::TransactionGuard::open(state.layout.root(), "commit");
+    let _transaction =
+        crate::commit_liveness::TransactionGuard::open(state.layout.root(), "commit");
     // Hold one uninterrupted graph-authority gate across forced filesystem
     // admission, change construction, and branch publication. The sync helper
     // deliberately does not re-lock this non-reentrant mutex.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4632,6 +4632,16 @@ async fn command_commit(
     // Before the gate, not after it. A tick that already holds the gate is still
     // deciding whether to publish, and it decides by reading this.
     let _pending_commit = state.pending_commits.announce();
+
+    // Publish that this daemon has a write transaction open, on a path that
+    // survives the runtime having no worker free to answer anything. The commit
+    // below is synchronous work on a runtime worker, so `/health` — the only
+    // question the supervisor's reaper asks before killing a daemon — can go
+    // unanswered for the whole commit while the reaper's other signal, growth in
+    // `daemon.log`, also stalls behind a phase that logs only when it finishes.
+    // The marker and its beat are what make a busy daemon distinguishable from a
+    // wedged one.
+    let _transaction = crate::commit_liveness::TransactionGuard::open(state.layout.root(), "commit");
     // Hold one uninterrupted graph-authority gate across forced filesystem
     // admission, change construction, and branch publication. The sync helper
     // deliberately does not re-lock this non-reentrant mutex.
@@ -8491,6 +8501,10 @@ async fn mcp_tools_call(
             )
             .await
         } else if request.name == "kin_transaction_commit" {
+            // Synchronous authority work on a runtime worker, exactly like the
+            // CLI commit path, so it publishes the same mid-transaction proof.
+            let _transaction =
+                crate::commit_liveness::TransactionGuard::open(state.layout.root(), "commit");
             Ok(crate::mcp_commit::commit_exact_transaction(
                 &state,
                 &sessions,

--- a/crates/kin-daemon/src/commit_liveness.rs
+++ b/crates/kin-daemon/src/commit_liveness.rs
@@ -213,11 +213,9 @@ fn ensure_beat_thread() {
     STARTED.get_or_init(|| {
         let _ = std::thread::Builder::new()
             .name("kin-transaction-beat".to_string())
-            .spawn(|| {
-                loop {
-                    std::thread::sleep(BEAT_INTERVAL);
-                    publish_beat();
-                }
+            .spawn(|| loop {
+                std::thread::sleep(BEAT_INTERVAL);
+                publish_beat();
             });
     });
 }

--- a/crates/kin-daemon/src/commit_liveness.rs
+++ b/crates/kin-daemon/src/commit_liveness.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Proof that a daemon is mid-transaction, published where a killer can read it.
+//!
+//! The supervisor's rogue-daemon reaper decides whether a daemon is doing real
+//! work by asking `/health` and reading `active_request_count` off the answer.
+//! That question can only be answered by a daemon with a free runtime worker,
+//! and the commit path is synchronous work on a runtime worker holding the
+//! coordination gate, so the one daemon state the guard exists to protect is
+//! the one state in which the guard cannot fire. Its fallback signal is growth
+//! in `.kin/daemon.log`, and commit phases are timed by closures that log only
+//! once the closure returns, so a single 86-second phase writes nothing for its
+//! whole duration and reads as 86 seconds of no progress.
+//!
+//! Both halves failed together on a converted psf/requests store: a one-file
+//! docstring commit was SIGKILLed 172 seconds in, leaving no shutdown line, no
+//! panic, a stale endpoint record and an unexplained end to the log.
+//!
+//! This module publishes the missing fact on a path that does not depend on the
+//! runtime being schedulable at all. A dedicated OS thread rewrites
+//! `.kin/daemon.transaction` on a fixed beat while a transaction is open and
+//! names the running phase in the log as it goes, so a reader gets a positive
+//! statement — this pid, this operation, this phase, beating as of this second
+//! — instead of inferring wedged-ness from silence.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// File a daemon publishes its open transaction into, beside the endpoint
+/// record it already publishes.
+pub const TRANSACTION_FILE_NAME: &str = "daemon.transaction";
+
+/// How often the beat thread republishes the marker and names the running phase.
+///
+/// The reaper sweeps every 15s and needs four consecutive sweeps with no log
+/// growth, so a 5s beat puts at least two lines in the log per sweep and the
+/// stall streak can never accumulate while a transaction is open.
+const BEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How long a published beat stays trustworthy.
+///
+/// Twelve missed beats. A daemon whose OS thread has not been scheduled for a
+/// minute is wedged in a way this marker should not shield, and the reap that
+/// follows says so explicitly rather than treating the marker as absent.
+pub const BEAT_STALE_AFTER: Duration = Duration::from_secs(60);
+
+/// What one daemon publishes about the transaction it currently has open.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OpenTransaction {
+    /// The daemon that owns this transaction. A marker naming a different pid
+    /// than the daemon being judged is a leftover and shields nobody.
+    pub pid: u32,
+    /// Which write path is open, e.g. `commit`.
+    pub operation: String,
+    /// Phase currently running, when one has been entered.
+    pub phase: Option<String>,
+    /// Wall seconds since the transaction opened.
+    pub elapsed_secs: u64,
+    /// Wall seconds since the running phase was entered.
+    pub phase_elapsed_secs: u64,
+    /// Unix seconds at the last beat. Freshness is decided against this.
+    pub beat_unix: u64,
+}
+
+/// How a reader should treat a daemon's transaction marker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransactionLiveness {
+    /// No marker, or one belonging to a different pid.
+    None,
+    /// A marker this daemon published, beating within [`BEAT_STALE_AFTER`].
+    Open(Box<OpenTransactionSummary>),
+    /// A marker this daemon published whose beat has gone quiet. The daemon is
+    /// wedged rather than merely busy, and anything that ends it must say so.
+    Stale(Box<OpenTransactionSummary>),
+}
+
+/// The part of an open transaction a reader reports back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenTransactionSummary {
+    pub operation: String,
+    pub phase: String,
+    pub elapsed_secs: u64,
+    pub beat_age_secs: u64,
+}
+
+impl std::fmt::Display for OpenTransactionSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} in phase {} for {}s (last beat {}s ago)",
+            self.operation, self.phase, self.elapsed_secs, self.beat_age_secs
+        )
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs())
+        .unwrap_or(0)
+}
+
+/// Path of the marker for a repository working directory.
+pub fn transaction_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(".kin").join(TRANSACTION_FILE_NAME)
+}
+
+/// Classify what `repo_root`'s marker says about the daemon running as `pid`.
+///
+/// Deliberately one-directional in the same sense the endpoint-ownership read
+/// is: `Open` is positive proof of work in flight, and every other outcome — no
+/// file, an unreadable file, a marker naming another pid — is merely the absence
+/// of proof. Callers use it to withhold a kill, never to authorize one.
+pub fn transaction_liveness(repo_root: &Path, pid: u32) -> TransactionLiveness {
+    let Ok(raw) = std::fs::read_to_string(transaction_path(repo_root)) else {
+        return TransactionLiveness::None;
+    };
+    let Ok(open) = serde_json::from_str::<OpenTransaction>(&raw) else {
+        return TransactionLiveness::None;
+    };
+    if open.pid != pid {
+        return TransactionLiveness::None;
+    }
+    let beat_age_secs = unix_now().saturating_sub(open.beat_unix);
+    let summary = Box::new(OpenTransactionSummary {
+        operation: open.operation,
+        phase: open.phase.unwrap_or_else(|| "starting".to_string()),
+        elapsed_secs: open.elapsed_secs,
+        beat_age_secs,
+    });
+    if beat_age_secs > BEAT_STALE_AFTER.as_secs() {
+        TransactionLiveness::Stale(summary)
+    } else {
+        TransactionLiveness::Open(summary)
+    }
+}
+
+/// The transaction this process currently has open, shared with the beat thread.
+struct ActiveTransaction {
+    kin_root: PathBuf,
+    operation: &'static str,
+    opened: std::time::Instant,
+    phase: Option<&'static str>,
+    phase_entered: std::time::Instant,
+}
+
+impl ActiveTransaction {
+    fn record(&self) -> OpenTransaction {
+        OpenTransaction {
+            pid: std::process::id(),
+            operation: self.operation.to_string(),
+            phase: self.phase.map(str::to_string),
+            elapsed_secs: self.opened.elapsed().as_secs(),
+            phase_elapsed_secs: self.phase_entered.elapsed().as_secs(),
+            beat_unix: unix_now(),
+        }
+    }
+}
+
+fn active() -> &'static Mutex<Option<ActiveTransaction>> {
+    static ACTIVE: OnceLock<Mutex<Option<ActiveTransaction>>> = OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(None))
+}
+
+/// Publish the marker for whatever is currently open. A no-op when nothing is.
+fn publish_beat() {
+    let Ok(guard) = active().lock() else {
+        return;
+    };
+    let Some(transaction) = guard.as_ref() else {
+        return;
+    };
+    let record = transaction.record();
+    let kin_root = transaction.kin_root.clone();
+    let phase = transaction.phase;
+    let phase_elapsed_ms = transaction.phase_entered.elapsed().as_millis();
+    drop(guard);
+
+    write_marker(&kin_root, &record);
+    // The reaper's other signal is byte growth in this repo's `daemon.log`, and
+    // this line is what makes a long phase grow it. It carries the same `phase`
+    // and `elapsed_ms` fields the completion lines carry, so one parser reads
+    // the phase table whether a phase has finished or is still running.
+    if let Some(phase) = phase {
+        tracing::info!(
+            phase,
+            elapsed_ms = phase_elapsed_ms,
+            "commit phase in progress"
+        );
+    }
+}
+
+fn write_marker(kin_root: &Path, record: &OpenTransaction) {
+    let Ok(body) = serde_json::to_string(record) else {
+        return;
+    };
+    let path = kin_root.join(TRANSACTION_FILE_NAME);
+    let tmp = kin_root.join(format!("{TRANSACTION_FILE_NAME}.tmp"));
+    if std::fs::write(&tmp, body).is_ok() && std::fs::rename(&tmp, &path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+/// Start the beat thread once per process.
+///
+/// A plain OS thread, never a task: the whole point is to keep publishing while
+/// the runtime has no worker free to poll anything, which is the exact state
+/// that made the daemon look dead.
+fn ensure_beat_thread() {
+    static STARTED: OnceLock<()> = OnceLock::new();
+    STARTED.get_or_init(|| {
+        let _ = std::thread::Builder::new()
+            .name("kin-transaction-beat".to_string())
+            .spawn(|| {
+                loop {
+                    std::thread::sleep(BEAT_INTERVAL);
+                    publish_beat();
+                }
+            });
+    });
+}
+
+/// An open transaction, published for as long as this value lives.
+///
+/// Dropping it retires the marker. A daemon killed mid-transaction never drops
+/// it, which is the intended asymmetry: the leftover marker is what tells the
+/// next reader the daemon died with work in flight.
+pub struct TransactionGuard {
+    kin_root: PathBuf,
+}
+
+impl TransactionGuard {
+    /// Open a transaction marker for `kin_root` (the `.kin` directory).
+    pub fn open(kin_root: &Path, operation: &'static str) -> Self {
+        let now = std::time::Instant::now();
+        if let Ok(mut guard) = active().lock() {
+            *guard = Some(ActiveTransaction {
+                kin_root: kin_root.to_path_buf(),
+                operation,
+                opened: now,
+                phase: None,
+                phase_entered: now,
+            });
+        }
+        ensure_beat_thread();
+        publish_beat();
+        Self {
+            kin_root: kin_root.to_path_buf(),
+        }
+    }
+}
+
+impl Drop for TransactionGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = active().lock() {
+            *guard = None;
+        }
+        let _ = std::fs::remove_file(self.kin_root.join(TRANSACTION_FILE_NAME));
+    }
+}
+
+/// Name the phase the open transaction has just entered.
+///
+/// Called by the commit phase timers, which already know the name. Nothing
+/// happens when no transaction is open, so the timers stay usable from paths
+/// that do not publish a marker.
+pub fn enter_phase(phase: &'static str) {
+    let Ok(mut guard) = active().lock() else {
+        return;
+    };
+    if let Some(transaction) = guard.as_mut() {
+        transaction.phase = Some(phase);
+        transaction.phase_entered = std::time::Instant::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo_with_kin(dir: &Path) -> PathBuf {
+        let kin_root = dir.join(".kin");
+        std::fs::create_dir_all(&kin_root).unwrap();
+        kin_root
+    }
+
+    #[test]
+    fn an_open_transaction_reads_as_open_for_its_own_pid_and_absent_for_another() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_root = repo_with_kin(dir.path());
+        let guard = TransactionGuard::open(&kin_root, "commit");
+        enter_phase("plan_transaction");
+        publish_beat();
+
+        let pid = std::process::id();
+        match transaction_liveness(dir.path(), pid) {
+            TransactionLiveness::Open(summary) => {
+                assert_eq!(summary.operation, "commit");
+                assert_eq!(summary.phase, "plan_transaction");
+            }
+            other => panic!("expected an open transaction, got {other:?}"),
+        }
+        // A marker naming a different daemon must shield nobody: it is the
+        // leftover of a process that already died, and treating it as live is
+        // how a marker turns into a permanent immunity.
+        assert_eq!(
+            transaction_liveness(dir.path(), pid.wrapping_add(1)),
+            TransactionLiveness::None
+        );
+
+        drop(guard);
+        assert_eq!(
+            transaction_liveness(dir.path(), pid),
+            TransactionLiveness::None,
+            "a closed transaction must retire its marker"
+        );
+    }
+
+    #[test]
+    fn a_beat_older_than_the_stale_bound_reads_as_stale_rather_than_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_root = repo_with_kin(dir.path());
+        let pid = std::process::id();
+        let record = OpenTransaction {
+            pid,
+            operation: "commit".to_string(),
+            phase: Some("git_projection_replay".to_string()),
+            elapsed_secs: 400,
+            phase_elapsed_secs: 300,
+            beat_unix: unix_now().saturating_sub(BEAT_STALE_AFTER.as_secs() + 5),
+        };
+        write_marker(&kin_root, &record);
+
+        match transaction_liveness(dir.path(), pid) {
+            TransactionLiveness::Stale(summary) => {
+                assert_eq!(summary.phase, "git_projection_replay");
+                assert!(summary.beat_age_secs > BEAT_STALE_AFTER.as_secs());
+            }
+            other => panic!("expected a stale transaction, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unreadable_or_absent_marker_never_reads_as_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_root = repo_with_kin(dir.path());
+        let pid = std::process::id();
+        assert_eq!(
+            transaction_liveness(dir.path(), pid),
+            TransactionLiveness::None
+        );
+        std::fs::write(kin_root.join(TRANSACTION_FILE_NAME), b"not json at all").unwrap();
+        assert_eq!(
+            transaction_liveness(dir.path(), pid),
+            TransactionLiveness::None
+        );
+    }
+}

--- a/crates/kin-daemon/src/commit_liveness.rs
+++ b/crates/kin-daemon/src/commit_liveness.rs
@@ -139,6 +139,12 @@ pub fn transaction_liveness(repo_root: &Path, pid: u32) -> TransactionLiveness {
 
 /// The transaction this process currently has open, shared with the beat thread.
 struct ActiveTransaction {
+    /// Identifies which guard installed this. A guard retires the marker only
+    /// when the slot still holds its own token, so an outer guard dropping
+    /// after an inner one took the slot cannot silence a transaction that is
+    /// still running — which would put the daemon straight back into the state
+    /// this module exists to make visible.
+    token: u64,
     kin_root: PathBuf,
     operation: &'static str,
     opened: std::time::Instant,
@@ -226,15 +232,19 @@ fn ensure_beat_thread() {
 /// it, which is the intended asymmetry: the leftover marker is what tells the
 /// next reader the daemon died with work in flight.
 pub struct TransactionGuard {
+    token: u64,
     kin_root: PathBuf,
 }
 
 impl TransactionGuard {
     /// Open a transaction marker for `kin_root` (the `.kin` directory).
     pub fn open(kin_root: &Path, operation: &'static str) -> Self {
+        static NEXT_TOKEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        let token = NEXT_TOKEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let now = std::time::Instant::now();
         if let Ok(mut guard) = active().lock() {
             *guard = Some(ActiveTransaction {
+                token,
                 kin_root: kin_root.to_path_buf(),
                 operation,
                 opened: now,
@@ -245,6 +255,7 @@ impl TransactionGuard {
         ensure_beat_thread();
         publish_beat();
         Self {
+            token,
             kin_root: kin_root.to_path_buf(),
         }
     }
@@ -252,10 +263,22 @@ impl TransactionGuard {
 
 impl Drop for TransactionGuard {
     fn drop(&mut self) {
-        if let Ok(mut guard) = active().lock() {
-            *guard = None;
+        let owned = match active().lock() {
+            Ok(mut guard) => {
+                let owned = guard.as_ref().is_some_and(|open| open.token == self.token);
+                if owned {
+                    *guard = None;
+                }
+                owned
+            }
+            Err(_) => false,
+        };
+        // Leave the marker alone when a later transaction owns the slot: it is
+        // that transaction's proof of life now, and clearing it would blind the
+        // reaper to a commit that is still running.
+        if owned {
+            let _ = std::fs::remove_file(self.kin_root.join(TRANSACTION_FILE_NAME));
         }
-        let _ = std::fs::remove_file(self.kin_root.join(TRANSACTION_FILE_NAME));
     }
 }
 
@@ -284,7 +307,12 @@ mod tests {
         kin_root
     }
 
+    // The open transaction lives in one process-wide slot, so two tests holding
+    // guards at once write each other's phases. Production serializes commits
+    // behind the coordination gate; the test binary does not, so these share a
+    // group. Every test that opens a `TransactionGuard` belongs in it.
     #[test]
+    #[serial_test::serial(commit_transaction_marker)]
     fn an_open_transaction_reads_as_open_for_its_own_pid_and_absent_for_another() {
         let dir = tempfile::tempdir().unwrap();
         let kin_root = repo_with_kin(dir.path());
@@ -313,6 +341,35 @@ mod tests {
             transaction_liveness(dir.path(), pid),
             TransactionLiveness::None,
             "a closed transaction must retire its marker"
+        );
+    }
+
+    /// A guard retires only its own transaction. Without the token an outer
+    /// guard dropping after an inner one took the slot would clear the marker of
+    /// a commit that is still running, putting the daemon back into exactly the
+    /// unreachable-and-apparently-stalled state that gets it killed.
+    #[test]
+    #[serial_test::serial(commit_transaction_marker)]
+    fn dropping_an_outer_guard_never_retires_a_later_transactions_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_root = repo_with_kin(dir.path());
+        let pid = std::process::id();
+
+        let outer = TransactionGuard::open(&kin_root, "commit");
+        let inner = TransactionGuard::open(&kin_root, "commit");
+        drop(outer);
+        assert!(
+            matches!(
+                transaction_liveness(dir.path(), pid),
+                TransactionLiveness::Open(_)
+            ),
+            "the transaction still running must still be published"
+        );
+
+        drop(inner);
+        assert_eq!(
+            transaction_liveness(dir.path(), pid),
+            TransactionLiveness::None
         );
     }
 

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -117,6 +117,7 @@
 pub mod api;
 pub mod background_work;
 pub mod commit_deltas;
+pub mod commit_liveness;
 pub mod daemon;
 pub mod error;
 pub mod graph_only_members;

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -1030,6 +1030,38 @@ pub fn remove_daemon_files_if_current_process(kin_root: &Path) {
     })
 }
 
+/// Retire an endpoint whose recorded owner this caller has proved is dead.
+///
+/// A daemon killed from outside never retires its own endpoint: retirement runs
+/// after the shutdown select returns, and a SIGKILLed process never gets there.
+/// The record then keeps naming a dead pid as the live owner of the repository,
+/// which is what left `kin doctor` reporting a STALE daemon with its endpoint
+/// record still on disk after a supervisor reap.
+///
+/// Returns whether anything was removed. Removal requires the record to still
+/// name `owner_pid` and that pid to be gone; a record naming a live process, a
+/// successor that republished, or nobody identifiable is left alone. That keeps
+/// this in the same direction the rest of this module runs in — proof authorizes
+/// destruction, absence of proof never does.
+pub fn retire_endpoint_of_dead_owner(kin_root: &Path, owner_pid: u32) -> bool {
+    without_blocking_runtime_worker(|| {
+        let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
+            tracing::warn!(
+                repo = %kin_root.display(),
+                "preserving daemon endpoint because lifecycle authority is unavailable"
+            );
+            return false;
+        };
+        match endpoint_ownership(kin_root) {
+            EndpointOwnership::OtherProcess { pid, live: false } if pid == owner_pid => {
+                remove_endpoint_components(kin_root);
+                true
+            }
+            _ => false,
+        }
+    })
+}
+
 /// Is the process with this PID alive?
 fn is_process_alive(pid: u32) -> bool {
     kin_cli::daemon_client::is_process_alive(pid)

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -4490,6 +4490,78 @@ mod tests {
         assert_eq!(endpoint_ownership(root), EndpointOwnership::Unattributed);
     }
 
+    /// A pid the OS has finished with, obtained by starting a process and
+    /// waiting on it rather than by picking a number and hoping.
+    fn a_pid_that_is_gone() -> u32 {
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("exit 0")
+            .spawn()
+            .expect("spawn a process to outlive");
+        let pid = child.id();
+        child.wait().expect("wait for it to exit");
+        pid
+    }
+
+    /// A daemon SIGKILLed by the supervisor's reaper retires nothing of its own:
+    /// endpoint retirement runs after the shutdown select returns and a killed
+    /// process never gets there. `kin doctor` then read STALE with the record
+    /// still on disk, which is a reading that does not match reality — the
+    /// endpoint names a live owner that is dead. The killer knows it is dead, so
+    /// the killer clears it.
+    #[test]
+    fn the_endpoint_of_a_daemon_proved_dead_is_retired_by_whoever_killed_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let dead = a_pid_that_is_gone();
+
+        std::fs::write(root.join("daemon.pid"), dead.to_string()).unwrap();
+        std::fs::write(root.join("daemon.port"), "39603").unwrap();
+        assert_eq!(
+            endpoint_ownership(root),
+            EndpointOwnership::OtherProcess {
+                pid: dead,
+                live: false
+            }
+        );
+
+        assert!(retire_endpoint_of_dead_owner(root, dead));
+        assert_eq!(
+            endpoint_ownership(root),
+            EndpointOwnership::Absent,
+            "doctor must read the same absence the killer created"
+        );
+        assert!(!root.join("daemon.port").exists());
+    }
+
+    /// The retirement is proof-gated in both directions it can be wrong: a
+    /// record naming a live daemon, and a record naming a successor rather than
+    /// the pid that was killed. Either would strand a working repository.
+    #[test]
+    fn retiring_a_dead_owners_endpoint_refuses_a_live_owner_or_a_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // pid 1 is always alive.
+        std::fs::write(root.join("daemon.pid"), "1").unwrap();
+        std::fs::write(root.join("daemon.port"), "39603").unwrap();
+        assert!(
+            !retire_endpoint_of_dead_owner(root, 1),
+            "a live owner's endpoint is never destroyed"
+        );
+        assert!(root.join("daemon.pid").exists());
+
+        // A successor republished under a different pid: the killed daemon's
+        // number no longer owns this endpoint and clearing it would strand the
+        // daemon that does.
+        let dead = a_pid_that_is_gone();
+        assert!(
+            !retire_endpoint_of_dead_owner(root, dead),
+            "an endpoint naming somebody else is left where it is"
+        );
+        assert!(root.join("daemon.pid").exists());
+    }
+
     #[test]
     fn a_stray_owner_record_alone_publishes_nothing() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1543,6 +1543,7 @@ fn timed_finalize_step<T>(step: &'static str, work: impl FnOnce() -> T) -> T {
 /// spent it instead of leaving the reply gap unexplained.
 pub(crate) fn timed_commit_phase<T>(phase: &'static str, work: impl FnOnce() -> T) -> T {
     let started = std::time::Instant::now();
+    crate::commit_liveness::enter_phase(phase);
     let outcome = work();
     let elapsed = started.elapsed();
     let elapsed_ms = elapsed.as_millis();
@@ -1568,6 +1569,7 @@ pub(crate) async fn timed_commit_phase_async<T>(
     work: impl std::future::Future<Output = T>,
 ) -> T {
     let started = std::time::Instant::now();
+    crate::commit_liveness::enter_phase(phase);
     let outcome = work.await;
     let elapsed = started.elapsed();
     let elapsed_ms = elapsed.as_millis();

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::state::DaemonState;
@@ -1731,6 +1731,10 @@ struct DaemonObservation {
     /// The deployed binary was rebuilt after this process started — it is running
     /// stale code and is a redeploy candidate.
     stale_binary: bool,
+    /// What this daemon publishes about a write transaction it has open. Read
+    /// from disk rather than from `/health`, because the state this protects is
+    /// exactly the state in which `/health` cannot be answered.
+    transaction: crate::commit_liveness::TransactionLiveness,
 }
 
 /// Decide what to do with a discovered daemon: reap a demonstrably-misbehaving
@@ -1769,6 +1773,22 @@ fn classify_daemon(obs: &DaemonObservation, policy: &ReapPolicy) -> DaemonDecisi
         &obs.health,
         DaemonHealth::Healthy(activity) if activity.has_clients || activity.reconciling
     );
+
+    // Absolute guard, second half: a daemon that has published a beating write
+    // transaction is doing real work whether or not it can say so over HTTP.
+    // The guard above reads `has_clients` off a `/health` body, so it can only
+    // fire for a daemon with a runtime worker free to produce one — and a commit
+    // is synchronous work on a runtime worker holding the coordination gate. The
+    // one state the busy guard exists to protect was therefore the one state it
+    // could not observe, which is how a 172-second commit was SIGKILLed with its
+    // client still waiting. This reads the daemon's own on-disk claim instead,
+    // and never adopts a stale one (see `Stale` below).
+    if matches!(
+        obs.transaction,
+        crate::commit_liveness::TransactionLiveness::Open(_)
+    ) {
+        return DaemonDecision::Keep;
+    }
 
     if !active {
         // (a) Safe criterion, always on: orphaned and the daemon ANSWERED its
@@ -2035,6 +2055,10 @@ async fn reaper_sweep(
                 .unwrap_or(0),
             registry: registry_relation,
             stale_binary,
+            transaction: crate::commit_liveness::transaction_liveness(
+                Path::new(&daemon.repo_root),
+                daemon.pid,
+            ),
         };
         match classify_daemon(&observation, &policy) {
             DaemonDecision::Reap(reason) => {
@@ -2272,10 +2296,35 @@ async fn graceful_terminate(pid: u32, repo_root: &str, action: &str, reason: &st
         reason,
         "{action} (SIGTERM)"
     );
+    // Say it in the victim's own log before signalling, because everything below
+    // this line is written to the supervisor's log and the operator opens
+    // `.kin/daemon.log`. Without this the daemon's log just stops: a SIGKILL
+    // prints nothing, and the daemon's own SIGTERM handler is a tokio arm a
+    // saturated runtime never polls, so neither signal leaves a trace there.
+    let kin_root = Path::new(repo_root).join(".kin");
+    let in_flight = match crate::commit_liveness::transaction_liveness(Path::new(repo_root), pid) {
+        crate::commit_liveness::TransactionLiveness::Open(summary)
+        | crate::commit_liveness::TransactionLiveness::Stale(summary) => Some(summary.to_string()),
+        crate::commit_liveness::TransactionLiveness::None => None,
+    };
+    let note = kin_daemon_spawn::DaemonDeathNote {
+        pid,
+        killed_by: "kin-supervisor-reaper".to_string(),
+        reason: format!("{action}: {reason}"),
+        in_flight,
+        at: chrono::Utc::now().to_rfc3339(),
+    };
+    kin_daemon_spawn::append_to_daemon_log(
+        &kin_root,
+        &format!("kin-daemon TERMINATED BY SUPERVISOR: {}", note.summary()),
+    );
+    kin_daemon_spawn::write_daemon_death_note(&kin_root, &note);
+
     unsafe {
         libc::kill(pid as libc::pid_t, libc::SIGTERM);
     }
     let start = Instant::now();
+    let mut killed = false;
     while start.elapsed() < REAPER_SIGTERM_GRACE {
         if !is_process_alive(pid) {
             info!(
@@ -2283,6 +2332,7 @@ async fn graceful_terminate(pid: u32, repo_root: &str, action: &str, reason: &st
                 repo = %repo_root,
                 "daemon exited gracefully after SIGTERM"
             );
+            retire_endpoint_of_terminated_daemon(&kin_root, pid);
             return;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -2297,6 +2347,43 @@ async fn graceful_terminate(pid: u32, repo_root: &str, action: &str, reason: &st
         unsafe {
             libc::kill(pid as libc::pid_t, libc::SIGKILL);
         }
+        killed = true;
+    }
+    if killed {
+        // A SIGKILLed daemon retires nothing: endpoint retirement runs after the
+        // shutdown select returns, which it never does. Left alone, `daemon.pid`
+        // keeps naming a dead daemon as the live owner of this repo, which is
+        // what `kin doctor` reported as STALE with the record still on disk. The
+        // killer knows the daemon is gone, so the killer clears it.
+        let settled = Instant::now();
+        while settled.elapsed() < REAPER_SIGTERM_GRACE && is_process_alive(pid) {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        retire_endpoint_of_terminated_daemon(&kin_root, pid);
+    }
+}
+
+/// Clear the endpoint record of a daemon this supervisor just ended.
+///
+/// Refuses on anything short of proof: the record must still name that exact
+/// pid, and that pid must be gone. A record naming a live process, a successor,
+/// or nobody identifiable is left exactly where it is.
+#[cfg(unix)]
+fn retire_endpoint_of_terminated_daemon(kin_root: &Path, pid: u32) {
+    if is_process_alive(pid) {
+        return;
+    }
+    match crate::lifecycle::retire_endpoint_of_dead_owner(kin_root, pid) {
+        true => info!(
+            pid,
+            kin_root = %kin_root.display(),
+            "retired the endpoint record of a terminated daemon"
+        ),
+        false => warn!(
+            pid,
+            kin_root = %kin_root.display(),
+            "left the endpoint record in place: it no longer names the terminated daemon"
+        ),
     }
 }
 
@@ -2312,10 +2399,26 @@ async fn reap_daemon(observation: &DaemonObservation, reason: ReapReason) {
         DaemonHealth::Unreachable => "unreachable",
         DaemonHealth::Unknown => "unknown",
     };
-    let context = format!(
+    let mut context = format!(
         "{reason:?} (probe={probe}, cpu_pinned_sweeps={}, stall_sweeps={})",
         observation.cpu_pinned_sweeps, observation.stall_sweeps
     );
+    // A daemon that opened a write transaction and then stopped beating it is
+    // wedged rather than busy, and ending it may cost a caller its commit. That
+    // is a decision worth taking, not one worth taking quietly: it is the only
+    // reap that names an interrupted transaction, and it says so at error level
+    // with the phase the daemon died in.
+    if let crate::commit_liveness::TransactionLiveness::Stale(summary) = &observation.transaction {
+        context = format!("{context} (abandoned transaction: {summary})");
+        error!(
+            pid = observation.pid,
+            repo = %observation.repo_root,
+            transaction = %summary,
+            reason = ?reason,
+            "reaping a daemon that has a write transaction open; its beat went stale, so it is \
+             wedged rather than busy — the caller waiting on this transaction will lose it"
+        );
+    }
     graceful_terminate(
         observation.pid,
         &observation.repo_root,
@@ -2712,6 +2815,17 @@ mod tests {
             stall_sweeps: 0,
             registry: RegistryRelation::RegisteredSelf,
             stale_binary: false,
+            transaction: crate::commit_liveness::TransactionLiveness::None,
+        }
+    }
+
+    /// A daemon mid-commit, as its own on-disk marker reports it.
+    fn committing(beat_age_secs: u64) -> crate::commit_liveness::OpenTransactionSummary {
+        crate::commit_liveness::OpenTransactionSummary {
+            operation: "commit".to_string(),
+            phase: "publish_workspace_admission".to_string(),
+            elapsed_secs: 86,
+            beat_age_secs,
         }
     }
 
@@ -2720,6 +2834,80 @@ mod tests {
             has_clients,
             reconciling,
         })
+    }
+
+    /// The regression this whole marker exists for.
+    ///
+    /// A one-file docstring commit on a converted psf/requests store was
+    /// SIGKILLed 172 seconds in, with the client still waiting on the request.
+    /// Every gate the reaper checked was satisfied by a HEALTHY commit: the
+    /// daemon is orphaned because `setsid` reparents every detached daemon to
+    /// init, it is unreachable because the commit is synchronous work on a
+    /// runtime worker so `/health` misses its 2s deadline, and it is stalled
+    /// because a commit phase logs only when it finishes and one phase ran 85.8s
+    /// against a 60s stall window. The `has_clients` guard that should have
+    /// stopped this reads a `/health` body, which by construction does not exist
+    /// for an unreachable daemon.
+    ///
+    /// So the decision is made against the daemon's own published claim instead,
+    /// and this asserts across every reap criterion at once — including the
+    /// duplicate-twin path, which carries no stall grace and fires on the very
+    /// first sweep.
+    #[test]
+    fn reaper_never_reaps_a_daemon_that_is_beating_an_open_transaction() {
+        for (health, registry) in [
+            (DaemonHealth::Unreachable, RegistryRelation::RegisteredSelf),
+            (DaemonHealth::Unhealthy, RegistryRelation::RegisteredSelf),
+            (DaemonHealth::Unreachable, RegistryRelation::LiveTwin),
+            (DaemonHealth::Unknown, RegistryRelation::LiveTwin),
+        ] {
+            let mut obs = observation(health.clone(), true);
+            obs.registry = registry;
+            obs.stall_sweeps = REAPER_STALL_SWEEPS * 10;
+            obs.cpu_pinned_sweeps = 100;
+            obs.stale_binary = true;
+            obs.transaction =
+                crate::commit_liveness::TransactionLiveness::Open(Box::new(committing(0)));
+            assert_eq!(
+                classify_daemon(&obs, &ReapPolicy::default()),
+                DaemonDecision::Keep,
+                "a daemon beating an open transaction must survive {health:?}/{registry:?}"
+            );
+        }
+    }
+
+    /// The marker must not become permanent immunity.
+    ///
+    /// A daemon that opened a transaction and then stopped beating it is wedged
+    /// rather than busy: the beat runs on a dedicated OS thread precisely so
+    /// runtime saturation cannot silence it, so a minute of silence is evidence
+    /// about the process, not about the workload. Reaping resumes, and
+    /// `reap_daemon` says at error level that it is ending a transaction.
+    #[test]
+    fn a_transaction_whose_beat_went_stale_stops_shielding_the_daemon() {
+        let mut obs = observation(DaemonHealth::Unreachable, true);
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
+        obs.transaction = crate::commit_liveness::TransactionLiveness::Stale(Box::new(committing(
+            crate::commit_liveness::BEAT_STALE_AFTER.as_secs() + 30,
+        )));
+        assert_eq!(
+            classify_daemon(&obs, &ReapPolicy::default()),
+            DaemonDecision::Reap(ReapReason::OrphanedUnreachableStalled)
+        );
+    }
+
+    /// A marker left by some earlier daemon shields nobody: `transaction_liveness`
+    /// only reports `Open` for the pid being judged, so a leftover file cannot
+    /// make a repository permanently unreapable.
+    #[test]
+    fn an_absent_transaction_marker_leaves_every_reap_criterion_as_it_was() {
+        let mut obs = observation(DaemonHealth::Unreachable, true);
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
+        assert_eq!(
+            classify_daemon(&obs, &ReapPolicy::default()),
+            DaemonDecision::Reap(ReapReason::OrphanedUnreachableStalled),
+            "without a marker the pre-existing criteria must be untouched"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -28,7 +28,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
+#[cfg(unix)]
+use tracing::error;
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::state::DaemonState;

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1184,12 +1184,32 @@ async fn revive_mcp_daemon() -> Result<String, String> {
         .spawn()
         .map_err(|e| format!("MCP revival: spawn kin-daemon failed: {e}"))?;
 
+    let revived = await_revived_daemon(&kin_dir, &mut child).await;
+    // This process is an MCP server: it runs for the whole agent session and
+    // reaches this path on every tool call that finds a dead daemon. `setsid`
+    // does not change the parent pid, so a daemon started here stays this
+    // process's child, and dropping the handle would leave it `<defunct>` from
+    // the moment it dies until the session ends. Adopt it on every outcome —
+    // the startup failures below leave a daemon running on purpose too.
+    kin_daemon_spawn::adopt_detached_daemon_child(child);
+    revived
+}
+
+/// Wait for a just-started MCP daemon to report its port and serve health.
+///
+/// Split from the spawn so the child handle outlives every exit this can take
+/// and reaches the reaper once, rather than being dropped down one of five
+/// returns.
+async fn await_revived_daemon(
+    kin_dir: &std::path::Path,
+    child: &mut std::process::Child,
+) -> Result<String, String> {
     // The daemon binds :0 and publishes the port it actually got. There is no
     // fallback: a revival that cannot learn the real port has no daemon to
     // talk to, and addressing a default port would reach whatever else is
     // listening there.
     let port_deadline = tokio::time::Instant::now() + Duration::from_secs(15);
-    let port = kin_daemon_spawn::await_reported_port(&kin_dir, &mut child, port_deadline)
+    let port = kin_daemon_spawn::await_reported_port(kin_dir, child, port_deadline)
         .await
         .map_err(|e| format!("MCP revival: {e}"))?;
 
@@ -1207,7 +1227,7 @@ async fn revive_mcp_daemon() -> Result<String, String> {
                 // A daemon the supervisor does not know about is unroutable to
                 // every other client, so registration is part of starting one.
                 if let Err(error) =
-                    kin_daemon_spawn::register_started_daemon(&kin_dir, &new_base).await
+                    kin_daemon_spawn::register_started_daemon(kin_dir, &new_base).await
                 {
                     tracing::warn!(
                         url = %new_base,
@@ -1226,7 +1246,7 @@ async fn revive_mcp_daemon() -> Result<String, String> {
 
         // The child reporting a port then failing to serve is still a startup
         // in progress; only its death is evidence against it.
-        if let Ok(disposition) = kin_daemon_spawn::startup_disposition(&mut child) {
+        if let Ok(disposition) = kin_daemon_spawn::startup_disposition(child) {
             if let kin_daemon_spawn::StartupDisposition::Exited(status) = disposition {
                 return Err(format!(
                     "MCP revival: daemon exited during startup with status {status} (port {port})"

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -8,7 +8,7 @@
     },
     {
       "file": "crates/kin-mcp/src/daemon_delegate.rs",
-      "reason": "Daemon-reachability boundary: this module forwards MCP tool calls to the daemon, which is the graph authority. Every filesystem touch here is about reaching that authority, never about answering in its place — no tool result derives from any of them. Three classes, each pinned to its whole expression: (1) the loopback bearer token at <kin_dir>/daemon.token, read so the forwarded request can authenticate; (2) repo binding, walking up from the working directory for the .kin layout marker to locate that token, which precedes any graph consult because it decides which daemon to talk to; (3) revival, resolving and spawning the known kin-daemon executable via KIN_DAEMON_BIN, the current exe's directory, the cargo target dir, and PATH, a `which` equivalent open-coded to avoid the dependency. The head-generation marker is the daemon's own published counter and only keys a within-session memo; a missing marker reads as generation 0, which costs cross-generation invalidation and never substitutes for a graph answer. Pinned rather than whole-file so any newly added filesystem primitive or subprocess in this module fails the guard",
+      "reason": "Daemon-reachability boundary: this module forwards MCP tool calls to the daemon, which is the graph authority. Every filesystem touch here is about reaching that authority, never about answering in its place — no tool result derives from any of them. Three classes, each pinned to its whole expression: (1) the loopback bearer token at <kin_dir>/daemon.token, read so the forwarded request can authenticate; (2) repo binding, walking up from the working directory for the .kin layout marker to locate that token, which precedes any graph consult because it decides which daemon to talk to; (3) revival, resolving and spawning the known kin-daemon executable via KIN_DAEMON_BIN, the current exe's directory, the cargo target dir, and PATH, a `which` equivalent open-coded to avoid the dependency. The head-generation marker is the daemon's own published counter and only keys a within-session memo; a missing marker reads as generation 0, which costs cross-generation invalidation and never substitutes for a graph answer. Pinned rather than whole-file so any newly added filesystem primitive or subprocess in this module fails the guard The revival wait is split into its own helper so the spawned child handle outlives every exit it can take and reaches the detached-daemon reaper exactly once; its `&mut std::process::Child` parameter is process-lifecycle plumbing with no answer surface.",
       "owner": "kin-mcp",
       "expiration": "2026-12-31",
       "allow_match": [
@@ -20,7 +20,8 @@
         "if target_sibling.exists()",
         "if candidate.exists()",
         "cmd.stdout(std::process::Stdio::null());",
-        "cmd.stderr(std::process::Stdio::null());"
+        "cmd.stderr(std::process::Stdio::null());",
+        "child: &mut std::process::Child,"
       ]
     },
     {
@@ -64,7 +65,7 @@
     },
     {
       "file": "crates/kin-cli/src/commands/health.rs",
-      "reason": "Install-diagnostic boundary: kin health reports on the local installation, so the environment is its subject rather than a source of semantic answers. The line this pin enforces is that environment probes are a diagnostic boundary while repo-content reads are not, and every pinned expression was checked against it individually. Four classes: (1) install artifacts \u2014 the kin-daemon binary beside the current exe or in the cargo target dir, the VFS shim's metadata and its four-byte object header, the shell hook, the editor extensions directory; (2) environment config \u2014 the shell rc, and the AI-client MCP configs for Claude, Cursor, Codex and Antigravity, which are read to check the kin server entry and never for their surrounding content; (3) repo binding \u2014 the layout-discovered repository root is compared against the repository argument recorded in client config, and that root is first resolved to its canonical form, because the config writers record the canonicalized path and an unresolved root makes the check reject setup's own write wherever the two forms differ, which is every Windows install (the \\?\\ verbatim prefix) and any symlinked ancestor. The resolution takes a path already produced by layout discovery, reads no repository content, and its result is only ever compared, never returned as an answer. The setup-ledger fingerprint check belongs to this same class: it re-reads the client config bytes setup itself wrote to prove the on-disk entry is still the recorded one, and probes the recorded repository's existence before trusting the record, both feeding a comparison and never an answer; (4) a projection audit \u2014 read_dir over .kin/runs listing session workspaces left materialized. That last one is a filesystem read by necessity rather than by shortcut: it detects materialized state that reconcile has not reclaimed, and a graph that believed those sessions closed would report nothing, which is the exact failure the check exists to catch, so the traversal audits the projection against graph truth instead of standing in for it. Semantic readiness itself comes from daemon-owned embedding state, not sidecar presence. A fifth class, host assessment: two absolute-path subprocess probes (pgrep for the syspolicyd pid, ps for its CPU share) sample the macOS binary-assessment daemon so a saturated assessor is named as the cause of machine-wide launch stalls instead of surfacing as random tool hangs; they read scheduler state about the host, never repository content, and no output feeds a semantic answer. A sixth class, severity discrimination: four probes that decide whether a check reports a failure or reports nothing wrong, each testing for the presence of an artifact rather than reading one. The kin-vfs driver beside the managed binaries separates a shim the installer deliberately removed on a host that cannot run projection from a shim missing where projection is installed. The repository's daemon endpoint record separates a repository no daemon has ever started for from one whose daemon left its record behind unreachable. A .kin entry the layout already refused separates a partial or corrupt repository from a directory that simply is not one, and it is a probe for the marker directory, never a read of anything inside it; the layout, not this probe, decides what a repository is, and it has already answered before the probe runs. The fourth resolves two paths to their canonical form so the managed toolchain directory can be recognized as itself rather than as a repository someone failed to initialize, which is the same comparison-only use as class (3) and returns no answer. None of the four reads repository source content, and each exists so a correct install stops being reported as broken. No pinned expression reads repository source content. Pinned rather than whole-file so this module is falsifiable at every site and any newly added filesystem primitive fails the guard",
+      "reason": "Install-diagnostic boundary: kin health reports on the local installation, so the environment is its subject rather than a source of semantic answers. The line this pin enforces is that environment probes are a diagnostic boundary while repo-content reads are not, and every pinned expression was checked against it individually. Four classes: (1) install artifacts — the kin-daemon binary beside the current exe or in the cargo target dir, the VFS shim's metadata and its four-byte object header, the shell hook, the editor extensions directory; (2) environment config — the shell rc, and the AI-client MCP configs for Claude, Cursor, Codex and Antigravity, which are read to check the kin server entry and never for their surrounding content; (3) repo binding — the layout-discovered repository root is compared against the repository argument recorded in client config, and that root is first resolved to its canonical form, because the config writers record the canonicalized path and an unresolved root makes the check reject setup's own write wherever the two forms differ, which is every Windows install (the \\?\\ verbatim prefix) and any symlinked ancestor. The resolution takes a path already produced by layout discovery, reads no repository content, and its result is only ever compared, never returned as an answer. The setup-ledger fingerprint check belongs to this same class: it re-reads the client config bytes setup itself wrote to prove the on-disk entry is still the recorded one, and probes the recorded repository's existence before trusting the record, both feeding a comparison and never an answer; (4) a projection audit — read_dir over .kin/runs listing session workspaces left materialized. That last one is a filesystem read by necessity rather than by shortcut: it detects materialized state that reconcile has not reclaimed, and a graph that believed those sessions closed would report nothing, which is the exact failure the check exists to catch, so the traversal audits the projection against graph truth instead of standing in for it. Semantic readiness itself comes from daemon-owned embedding state, not sidecar presence. A fifth class, host assessment: two absolute-path subprocess probes (pgrep for the syspolicyd pid, ps for its CPU share) sample the macOS binary-assessment daemon so a saturated assessor is named as the cause of machine-wide launch stalls instead of surfacing as random tool hangs; they read scheduler state about the host, never repository content, and no output feeds a semantic answer. A sixth class, severity discrimination: four probes that decide whether a check reports a failure or reports nothing wrong, each testing for the presence of an artifact rather than reading one. The kin-vfs driver beside the managed binaries separates a shim the installer deliberately removed on a host that cannot run projection from a shim missing where projection is installed. The repository's daemon endpoint record separates a repository no daemon has ever started for from one whose daemon left its record behind unreachable. A .kin entry the layout already refused separates a partial or corrupt repository from a directory that simply is not one, and it is a probe for the marker directory, never a read of anything inside it; the layout, not this probe, decides what a repository is, and it has already answered before the probe runs. The fourth resolves two paths to their canonical form so the managed toolchain directory can be recognized as itself rather than as a repository someone failed to initialize, which is the same comparison-only use as class (3) and returns no answer. None of the four reads repository source content, and each exists so a correct install stops being reported as broken. No pinned expression reads repository source content. Pinned rather than whole-file so this module is falsifiable at every site and any newly added filesystem primitive fails the guard",
       "owner": "kin-cli",
       "expiration": "2026-12-31",
       "allow_match": [
@@ -80,7 +81,10 @@
         "match std::fs::read_to_string(path) {",
         "path.parent()?.parent()?.canonicalize().ok()?",
         "root.canonicalize().unwrap_or(root)",
-        { "expr": "std::fs::read(path).ok()?", "count": 2 },
+        {
+          "expr": "std::fs::read(path).ok()?",
+          "count": 2
+        },
         "repo.is_dir().then_some(repo)",
         "match std::fs::read(path) {",
         ".filter(|c| c.path.exists())",
@@ -150,7 +154,7 @@
     },
     {
       "file": "crates/kin-daemon-spawn/src/lib.rs",
-      "reason": "Daemon process lifecycle boundary with zero answer-authority surface. The exact expression pins cover process construction, readiness records, port records, PID records, and Linux process-table inspection; each reaches or supervises the daemon that owns graph truth and never derives a semantic answer. The PID record is read to establish that a daemon is still running, which is a liveness question about a process rather than a question about repository content: it can only withhold a restart, never produce or repair an answer. ManagedInstallSpawnFence::acquire is separately function-pinned because it is an install-mutation boundary: it binds the configured executable and update lock, rejects replaced or retired install roots, and serializes daemon spawn against uninstall. It reads only install/process identity metadata and cannot answer locate, search, context, trace, review, xref, or rename. The rest of this single-module crate remains scanned, and exact pin counts make any added occurrence fail closed.",
+      "reason": "Daemon process lifecycle boundary with zero answer-authority surface. The exact expression pins cover process construction, readiness records, port records, PID records, and Linux process-table inspection; each reaches or supervises the daemon that owns graph truth and never derives a semantic answer. The PID record is read to establish that a daemon is still running, which is a liveness question about a process rather than a question about repository content: it can only withhold a restart, never produce or repair an answer. ManagedInstallSpawnFence::acquire is separately function-pinned because it is an install-mutation boundary: it binds the configured executable and update lock, rejects replaced or retired install roots, and serializes daemon spawn against uninstall. It reads only install/process identity metadata and cannot answer locate, search, context, trace, review, xref, or rename. The rest of this single-module crate remains scanned, and exact pin counts make any added occurrence fail closed. The death note and the daemon-log append are the same boundary read in the other direction: a daemon ended from outside cannot log its own cause, because the reaper's SIGTERM grace is shorter than the daemon's shutdown and the SIGKILL that follows lands while the arm that would print a shutdown line is still unpolled. These write that cause into the repository the daemon served and read it back, so a failed request can name a killed daemon instead of quoting a socket error. They carry process lifecycle facts only and answer no question about repository content.",
       "owner": "kin-daemon-spawn",
       "expiration": "2026-12-31",
       "allow_fn": [
@@ -159,7 +163,7 @@
       "allow_match": [
         {
           "expr": "std::process::",
-          "count": 53
+          "count": 59
         },
         {
           "expr": "tokio::process::",
@@ -192,7 +196,12 @@
         {
           "expr": ".exists()",
           "count": 2
-        }
+        },
+        "if fs::write(&tmp, body).is_ok() && fs::rename(&tmp, kin_root.join(DEATH_FILE_NAME)).is_err() {",
+        "let _ = fs::remove_file(&tmp);",
+        "let raw = fs::read_to_string(kin_root.join(DEATH_FILE_NAME)).ok()?;",
+        "let _ = fs::remove_file(kin_root.join(DEATH_FILE_NAME));",
+        ".open(kin_root.join(\"daemon.log\"))"
       ]
     },
     {
@@ -509,6 +518,19 @@
           "expr": ".metadata()",
           "count": 3
         }
+      ]
+    },
+    {
+      "file": "crates/kin-daemon/src/commit_liveness.rs",
+      "reason": "Process liveness boundary with zero answer-authority surface. This module publishes one fact about the daemon process — that it currently has a write transaction open, which phase is running, and when it last beat — into .kin/daemon.transaction, and reads that file back so the supervisor's reaper can tell a busy daemon from a wedged one. It exists because the reaper's only other liveness question is GET /health, which a daemon doing synchronous commit work on a runtime worker cannot answer, so the guard that refuses to reap a working daemon could not fire for the one state it protects; a 172-second commit was SIGKILLed as a result. Every expression here writes or reads that single marker plus this process's own pid. Nothing in it reaches repository content, and it can only withhold a kill, never produce, rank, fill, or repair an answer to locate, search, context, trace, review, xref, or rename. Pinned by exact expression so any newly added filesystem primitive in this module fails the guard until it is re-justified.",
+      "owner": "kin-daemon",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "let Ok(raw) = std::fs::read_to_string(transaction_path(repo_root)) else {",
+        "pid: std::process::id(),",
+        "if std::fs::write(&tmp, body).is_ok() && std::fs::rename(&tmp, &path).is_err() {",
+        "let _ = std::fs::remove_file(&tmp);",
+        "let _ = std::fs::remove_file(self.kin_root.join(TRANSACTION_FILE_NAME));"
       ]
     }
   ]


### PR DESCRIPTION
A one-file docstring commit on a converted psf/requests store killed the daemon
outright: the log ended mid-line with no panic and no shutdown line, `kin doctor`
read STALE with the endpoint record still on disk, six `[kin-daemon] <defunct>`
zombies had piled up, and the caller got `connection closed before message
completed`.

THE EXIT PATH. The supervisor's rogue-daemon reaper SIGTERMed then SIGKILLed it as
`OrphanedUnreachableStalled`, and every gate it checked was satisfied by a HEALTHY
commit.

- `orphaned` (supervisor.rs:2029) is `ppid == 1`, which every spawn path produces by
  calling `setsid`. It discriminates nothing.
- `Unreachable` because `command_commit` (api.rs:4613) holds the coordination gate and
  calls the synchronous `command_commit_after_admission` (api.rs:4668) on a runtime
  worker, while `/health` (api.rs:2546) reads `graph.entity_count()`, which takes the
  same kin-db `entities` RwLock the commit is writing under. The probe's budget is 2s
  (supervisor.rs:1464).
- `stall_sweeps >= 4` because `timed_commit_phase` (mcp_commit.rs:1544) logs only after
  its closure returns, and the incident's `publish_workspace_admission` ran 85,776 ms.
  One phase clears the 60s window (4 x 15s, supervisor.rs:1461/1481) with 25s to spare.

The guard written to stop exactly this cannot fire. `has_clients` (supervisor.rs:1768,
computed at 2250) is read off the `/health` body, so it only exists for a daemon that
can answer. Then SIGKILL is the normal outcome rather than the edge case, because the
reaper's grace is 5s (supervisor.rs:1467) against a documented ~18s shutdown. The
SIGTERM handler is a bare atomic store and its log line lives in a `tokio::select!` arm
a saturated runtime never polls, endpoint retirement runs only after that select
returns (daemon.rs:2717), and every reaper log line goes to the supervisor's log rather
than the repo's.

Ruled out in source: no `panic = "abort"` and no panic hook anywhere, so the absent
panic message is positive evidence no panic occurred. The idle timer is held off for an
in-flight request's full duration by an RAII guard over the whole app. No request or
server timeout tears down the server. The one runtime `process::exit` prints its reason
first. There is no self-imposed memory bound and no unregistered-to-exit path.

THE FIX. The daemon publishes `.kin/daemon.transaction` while a write transaction is
open, rewritten every 5s by a dedicated OS thread so runtime saturation cannot silence
it, and that beat also names the running phase in the log, which keeps the reaper's
stall streak from accumulating. `classify_daemon` keeps a daemon with a beating marker
across every reap criterion including the duplicate-twin path that has no stall grace.
A marker whose beat has been quiet for a minute stops shielding, and the reap that
follows names the abandoned transaction at error level. Each guard holds a token so it
retires only its own marker.

Anything that ends a daemon now says so where the operator looks: `graceful_terminate`
writes its reason into the victim's own `daemon.log` and a `daemon.death` note before
signalling, and retires the endpoint record of a daemon it proved dead, so doctor's
reading matches reality. The retirement is proof-gated in both directions and refuses a
live owner or a successor's record.

THE ZOMBIES. `setsid` does not change the parent pid, so under a launcher that outlives
the daemon a dropped `Child` waits on nothing. `kin mcp start` is such a launcher and
reaches a daemon spawn on binding, on rebinding, and on every tool call that revives
one. Both CLI spawn sites and the MCP revival path now hand the child to a reaper
thread that polls it to completion, and the revival wait is split into a helper so its
handle reaches the reaper once rather than down five returns.

THE SILENCE. `kin commit` tails `.kin/daemon.log` while the request is outstanding and
prints each phase, reading the file rather than asking the daemon, because a daemon
deep in a synchronous commit cannot answer a progress request either. On a transport
failure it reads the death note and names the daemon that died. On success it says in
one line that the change is in Kin authority and not in git.

The 820 MB full-snapshot write per publication is untouched here and stays with
FIR-2347's format-revision item.

Closes FIR-2365
