### PR TITLE
Gate absence authority on the cross-file edge classes a query reads

### DIFF
--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -77,21 +77,26 @@ pub async fn build_xref_response(
     let query = match spine_backend {
         Some(backend) => {
             let response = backend.cross_repo_xref_response(repo_id, &target.id);
-            // Same split the MCP surface makes: a repository the spine never
-            // registered has nothing to mismatch, and reporting it as a root
-            // mismatch describes a misconfiguration that does not exist.
-            match response.authority_roots.get(repo_id) {
-                Some(registered) if registered == graph_root => {
+            // Same split the MCP surface makes, through the same shared rule: a
+            // repository the spine never registered has nothing to mismatch, and
+            // reporting it as a root mismatch describes a misconfiguration that
+            // does not exist.
+            match response.authority_root_state(repo_id, graph_root) {
+                ::kin_spine::AuthorityRootState::Matches => {
                     ::kin_spine::SpineQuery::Found(response)
                 }
-                Some(registered) => ::kin_spine::SpineQuery::Unavailable(format!(
-                    "spine root mismatch for repository {repo_id}: live/session graph root \
-                     {graph_root} has advanced past the registered spine root {registered}"
-                )),
-                None => ::kin_spine::SpineQuery::Unavailable(format!(
-                    "repository {repo_id} has no registered spine root, so cross-repo authority \
-                     cannot answer for it"
-                )),
+                ::kin_spine::AuthorityRootState::Stale { registered } => {
+                    ::kin_spine::SpineQuery::Unavailable(format!(
+                        "spine root mismatch for repository {repo_id}: live/session graph root \
+                         {graph_root} has advanced past the registered spine root {registered}"
+                    ))
+                }
+                ::kin_spine::AuthorityRootState::Unregistered => {
+                    ::kin_spine::SpineQuery::Unavailable(format!(
+                        "repository {repo_id} has no registered spine root, so cross-repo \
+                         authority cannot answer for it"
+                    ))
+                }
             }
         }
         None => ::kin_spine::SpineQuery::NotConfigured,

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -77,12 +77,21 @@ pub async fn build_xref_response(
     let query = match spine_backend {
         Some(backend) => {
             let response = backend.cross_repo_xref_response(repo_id, &target.id);
-            if response.authority_root_matches(repo_id, graph_root) {
-                ::kin_spine::SpineQuery::Found(response)
-            } else {
-                ::kin_spine::SpineQuery::Unavailable(format!(
-                    "spine root mismatch for repository {repo_id}: live/session graph root {graph_root} is not the registered spine root"
-                ))
+            // Same split the MCP surface makes: a repository the spine never
+            // registered has nothing to mismatch, and reporting it as a root
+            // mismatch describes a misconfiguration that does not exist.
+            match response.authority_roots.get(repo_id) {
+                Some(registered) if registered == graph_root => {
+                    ::kin_spine::SpineQuery::Found(response)
+                }
+                Some(registered) => ::kin_spine::SpineQuery::Unavailable(format!(
+                    "spine root mismatch for repository {repo_id}: live/session graph root \
+                     {graph_root} has advanced past the registered spine root {registered}"
+                )),
+                None => ::kin_spine::SpineQuery::Unavailable(format!(
+                    "repository {repo_id} has no registered spine root, so cross-repo authority \
+                     cannot answer for it"
+                )),
             }
         }
         None => ::kin_spine::SpineQuery::NotConfigured,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15639,6 +15639,31 @@ mod tests {
         }
     }
 
+    /// Two entities in different files joined by a `Calls` edge: the evidence
+    /// that this graph links references across files for the language, which is
+    /// what an absence claim over reference edges depends on. Without it an empty
+    /// reference answer is a fact about the graph rather than about the target.
+    fn seed_cross_file_call_witness(state: &Arc<DaemonState>) {
+        let caller = test_entity("witness_caller", "src/witness_caller.py");
+        let callee = test_entity("witness_callee", "src/witness_callee.py");
+        state.graph.upsert_entity(&caller).unwrap();
+        state.graph.upsert_entity(&callee).unwrap();
+        state
+            .graph
+            .upsert_relation(&kin_model::relation::Relation {
+                id: kin_model::ids::RelationId::new(),
+                kind: kin_model::relation::RelationKind::Calls,
+                src: kin_model::relation::GraphNodeId::Entity(caller.id),
+                dst: kin_model::relation::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: kin_model::relation::RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+    }
+
     fn install_repository_file(
         state: &Arc<DaemonState>,
         rel_path: &str,
@@ -26722,6 +26747,7 @@ mod tests {
         let target = test_entity("target", "src/lib.rs");
         let source = test_entity("caller", "src/app.rs");
         state.graph.upsert_entity(&target).unwrap();
+        seed_cross_file_call_witness(&state);
         state
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -61,8 +61,8 @@ pub const EDGE_COVERAGE_KEY: &str = "edge_coverage";
 /// How many entities may have their relations read while looking for a witness.
 ///
 /// A healthy graph answers in single digits, so this bound is only reached on a
-/// graph that holds no cross-file edges of the requested classes at all — the
-/// case this module exists to detect. Reaching it reports `unknown` rather than
+/// graph that holds no cross-file edges of the requested classes at all, which is
+/// the case this module exists to detect. Reaching it reports `unknown` rather than
 /// `absent`, so a truncated scan is never published as a verdict.
 const WITNESS_BUDGET: usize = 4096;
 

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file edge-class coverage: the substrate fact an absence claim needs.
+//!
+//! A reference query answers from typed `Calls`/`Imports`/`References` edges
+//! that cross a file boundary. When the graph holds none of those for the
+//! focal's language, the query is structurally unable to find anything, and an
+//! empty result is a fact about the graph rather than about the code. Nothing in
+//! the freshness/degraded signals reports that: a graph can be initialized,
+//! loaded, fully embedded, undegraded, and still hold only intra-file edges.
+//! That combination is what let `find_references` certify a symbol as unused
+//! while a sibling file imported and called it.
+//!
+//! This module observes the fact directly and publishes it into the retrieval
+//! payload under [`EDGE_COVERAGE_KEY`], where [`crate::negative`] consumes it as
+//! a gate on `safe_to_conclude_absent`. The observation is a witness search, not
+//! a census: proving a class of cross-file edge EXISTS needs one example, so a
+//! healthy graph exits after a handful of lookups. A graph that holds none pays
+//! a bounded scan and the budget is reported, because a scan cut short cannot
+//! tell "absent" from "not reached" and must not be read as either.
+//!
+//! ## Published shape
+//!
+//! ```json
+//! "edge_coverage": {
+//!   "scope": "language",
+//!   "language": "Python",
+//!   "requested_classes": ["calls", "imports", "references"],
+//!   "classes": { "calls": "present", "imports": "present", "references": "absent" },
+//!   "cross_file_classes": ["calls", "imports"],
+//!   "budget_exhausted": false,
+//!   "entities_examined": 3
+//! }
+//! ```
+//!
+//! `classes` is the load-bearing field: `present` means a cross-file edge of
+//! that class was observed for the focal's language, `absent` means the scan
+//! completed and found none, `unknown` means the scan stopped on its budget
+//! before it could say. A consumer that cannot find this object must treat
+//! coverage as unknown rather than assuming either verdict.
+
+use serde_json::{json, Map, Value};
+
+use kin_model::entity::Entity;
+use kin_model::graph::{EntityFilter, EntityStore};
+use kin_model::ids::{EntityId, FilePathId};
+use kin_model::relation::RelationKind;
+
+/// Reserved, additive payload key carrying the cross-file edge-class
+/// observation. Read by [`crate::negative`]; additive to every payload it is
+/// attached to.
+pub const EDGE_COVERAGE_KEY: &str = "edge_coverage";
+
+/// How many entities may have their relations read while looking for a witness.
+///
+/// A healthy graph answers in single digits, so this bound is only reached on a
+/// graph that holds no cross-file edges of the requested classes at all — the
+/// case this module exists to detect. Reaching it reports `unknown` rather than
+/// `absent`, so a truncated scan is never published as a verdict.
+const WITNESS_BUDGET: usize = 4096;
+
+/// One class's observed cross-file state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClassState {
+    /// A cross-file edge of this class was observed for the focal's language.
+    Present,
+    /// The scan completed over the language's entities and observed none.
+    Absent,
+    /// The scan stopped on its budget before it could observe one.
+    Unknown,
+}
+
+impl ClassState {
+    fn as_str(self) -> &'static str {
+        match self {
+            ClassState::Present => "present",
+            ClassState::Absent => "absent",
+            ClassState::Unknown => "unknown",
+        }
+    }
+}
+
+/// The stable wire name for a relation kind.
+///
+/// Deliberately the same lowercase vocabulary the reference tools already
+/// publish under `relation_kinds`, so a reader matching a class against the
+/// query's own scope never has to case-fold between two spellings of one fact.
+fn class_name(kind: RelationKind) -> &'static str {
+    match kind {
+        RelationKind::Calls => "calls",
+        RelationKind::Imports => "imports",
+        RelationKind::References => "references",
+        _ => "other",
+    }
+}
+
+/// Observe whether the graph holds cross-file edges of `kinds` for `focal`'s
+/// language, as the additive object documented on this module.
+///
+/// The scan is scoped to the focal's language because extraction and enrichment
+/// gaps are per-language: a store that links Rust calls cross-file and Python
+/// calls not at all must not lend its Rust coverage to a Python absence. It is
+/// not scoped to the focal's file, because a leaf file legitimately has no
+/// cross-file edges and reading that as an extraction gap would make every
+/// genuine absence inconclusive.
+///
+/// Errors are not propagated: a store that cannot answer leaves the classes
+/// `unknown`, which is the conservative reading and the one a consumer already
+/// has to handle. Failing the whole retrieval because a trust annotation could
+/// not be computed would trade a qualified answer for no answer.
+pub fn observe_cross_file_reference_coverage<S: EntityStore>(
+    store: &S,
+    focal: &Entity,
+    kinds: &[RelationKind],
+) -> Value {
+    observe_cross_file_reference_coverage_for_languages(store, &[focal.language], kinds)
+}
+
+/// Observe cross-file coverage across every language a batch of focals spans.
+///
+/// A batch verdict covers all of them, so the weakest language governs: a class
+/// counts as present only when it is present for every language in the batch.
+/// Merging the other way would let one well-linked language certify absences for
+/// a language whose edges were never produced, which is the same borrowed
+/// authority the per-language scope exists to prevent.
+pub fn observe_cross_file_reference_coverage_for_languages<S: EntityStore>(
+    store: &S,
+    languages: &[kin_model::ids::LanguageId],
+    kinds: &[RelationKind],
+) -> Value {
+    let requested = requested_classes(kinds);
+    let mut merged: Vec<(RelationKind, ClassState)> = requested
+        .iter()
+        .copied()
+        .map(|kind| (kind, ClassState::Unknown))
+        .collect();
+    let mut examined_total = 0usize;
+    let mut any_budget_exhausted = false;
+    let mut observed_languages: Vec<kin_model::ids::LanguageId> = Vec::new();
+    for language in languages {
+        if observed_languages.contains(language) {
+            continue;
+        }
+        observed_languages.push(*language);
+    }
+
+    for (index, language) in observed_languages.iter().enumerate() {
+        let (states, examined, budget_exhausted) =
+            observe_language(store, *language, &requested);
+        examined_total += examined;
+        any_budget_exhausted |= budget_exhausted;
+        for (slot, (_, state)) in merged.iter_mut().zip(states.iter()) {
+            slot.1 = if index == 0 {
+                *state
+            } else {
+                weakest(slot.1, *state)
+            };
+        }
+    }
+
+    let mut classes = Map::new();
+    for (kind, state) in &merged {
+        classes.insert(class_name(*kind).to_string(), json!(state.as_str()));
+    }
+    let cross_file: Vec<&str> = merged
+        .iter()
+        .filter(|(_, state)| *state == ClassState::Present)
+        .map(|(kind, _)| class_name(*kind))
+        .collect();
+
+    json!({
+        "scope": "language",
+        "language": observed_languages
+            .iter()
+            .map(|language| format!("{language:?}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        "requested_classes": merged
+            .iter()
+            .map(|(kind, _)| class_name(*kind))
+            .collect::<Vec<_>>(),
+        "classes": Value::Object(classes),
+        "cross_file_classes": cross_file,
+        "budget_exhausted": any_budget_exhausted,
+        "entities_examined": examined_total,
+    })
+}
+
+/// The reference classes among `kinds`, in the order given. Other relation kinds
+/// are dropped: containment and definition edges never cross a file boundary, so
+/// including them would let an intra-file fact stand in for a cross-file one.
+fn requested_classes(kinds: &[RelationKind]) -> Vec<RelationKind> {
+    kinds
+        .iter()
+        .copied()
+        .filter(|kind| {
+            matches!(
+                kind,
+                RelationKind::Calls | RelationKind::Imports | RelationKind::References
+            )
+        })
+        .collect()
+}
+
+/// The less-authoritative of two observations. `present` only survives when both
+/// agree, and `absent` outranks `unknown` because a completed scan that found
+/// nothing is a stronger statement than one that never finished.
+fn weakest(left: ClassState, right: ClassState) -> ClassState {
+    match (left, right) {
+        (ClassState::Absent, _) | (_, ClassState::Absent) => ClassState::Absent,
+        (ClassState::Unknown, _) | (_, ClassState::Unknown) => ClassState::Unknown,
+        _ => ClassState::Present,
+    }
+}
+
+/// Witness-search one language, returning each requested class's state, how many
+/// entities were examined, and whether the search stopped on its budget.
+fn observe_language<S: EntityStore>(
+    store: &S,
+    language: kin_model::ids::LanguageId,
+    requested: &[RelationKind],
+) -> (Vec<(RelationKind, ClassState)>, usize, bool) {
+    let mut states: Vec<(RelationKind, ClassState)> = requested
+        .iter()
+        .copied()
+        .map(|kind| (kind, ClassState::Unknown))
+        .collect();
+
+    let mut examined = 0usize;
+    let mut budget_exhausted = false;
+
+    if !states.is_empty() {
+        match store.query_entities(&EntityFilter {
+            languages: Some(vec![language]),
+            ..EntityFilter::default()
+        }) {
+            Ok(candidates) => {
+                let files: std::collections::HashMap<EntityId, Option<FilePathId>> = candidates
+                    .iter()
+                    .map(|entity| (entity.id, entity.file_origin.clone()))
+                    .collect();
+                for entity in &candidates {
+                    if states
+                        .iter()
+                        .all(|(_, state)| *state == ClassState::Present)
+                    {
+                        break;
+                    }
+                    if examined >= WITNESS_BUDGET {
+                        budget_exhausted = true;
+                        break;
+                    }
+                    examined += 1;
+                    let Ok(relations) = store.get_all_relations_for_entity(&entity.id) else {
+                        continue;
+                    };
+                    for relation in relations {
+                        let Some(state) = states
+                            .iter_mut()
+                            .find(|(kind, _)| *kind == relation.kind)
+                            .map(|(_, state)| state)
+                        else {
+                            continue;
+                        };
+                        if *state == ClassState::Present {
+                            continue;
+                        }
+                        let Some(source) = relation.src.as_entity() else {
+                            continue;
+                        };
+                        let Some(destination) = relation.dst.as_entity() else {
+                            continue;
+                        };
+                        let source_file = endpoint_file(store, &files, &source);
+                        let destination_file = endpoint_file(store, &files, &destination);
+                        if let (Some(source_file), Some(destination_file)) =
+                            (source_file, destination_file)
+                        {
+                            if source_file != destination_file {
+                                *state = ClassState::Present;
+                            }
+                        }
+                    }
+                }
+                if !budget_exhausted {
+                    for (_, state) in states.iter_mut() {
+                        if *state == ClassState::Unknown {
+                            *state = ClassState::Absent;
+                        }
+                    }
+                }
+            }
+            // The store could not enumerate the language at all, so every class
+            // stays unknown rather than being reported absent from a scan that
+            // never ran.
+            Err(_) => budget_exhausted = true,
+        }
+    }
+
+    (states, examined, budget_exhausted)
+}
+
+/// The file an endpoint belongs to, preferring the language-scoped entities
+/// already in hand and falling back to a direct lookup for an endpoint outside
+/// that set (a cross-language edge still crosses a file boundary).
+fn endpoint_file<S: EntityStore>(
+    store: &S,
+    files: &std::collections::HashMap<EntityId, Option<FilePathId>>,
+    id: &EntityId,
+) -> Option<FilePathId> {
+    if let Some(file) = files.get(id) {
+        return file.clone();
+    }
+    store.get_entity(id).ok().flatten().and_then(|entity| entity.file_origin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::entity::{
+        EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
+        Visibility,
+    };
+    use kin_model::ids::{Hash256, LanguageId, RelationId};
+    use kin_model::relation::{GraphNodeId, Relation, RelationOrigin};
+
+    fn entity(name: &str, file: &str, language: LanguageId) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: None,
+            signature: format!("def {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn relation(src: EntityId, dst: EntityId, kind: RelationKind) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind,
+            src: GraphNodeId::Entity(src),
+            dst: GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    /// The FIR-2353 shape: entities and intra-file edges only. Every requested
+    /// class reads `absent`, which is what makes the absence claim unearned.
+    #[test]
+    fn an_intra_file_only_graph_reports_every_class_absent() {
+        let store = InMemoryGraph::new();
+        let caller = entity("save_note", "nk/storage.py", LanguageId::Python);
+        let target = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+        let sibling = entity("helper", "nk/storage.py", LanguageId::Python);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store.upsert_entity(&sibling).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, sibling.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[
+                RelationKind::Calls,
+                RelationKind::Imports,
+                RelationKind::References,
+            ],
+        );
+        assert_eq!(coverage["classes"]["calls"], json!("absent"));
+        assert_eq!(coverage["classes"]["imports"], json!("absent"));
+        assert_eq!(coverage["classes"]["references"], json!("absent"));
+        assert_eq!(coverage["cross_file_classes"], json!([]));
+        assert_eq!(coverage["budget_exhausted"], json!(false));
+    }
+
+    /// One cross-file witness of a class is enough to report it present, and the
+    /// classes without one stay separately reported rather than being lifted by
+    /// their sibling.
+    #[test]
+    fn a_cross_file_witness_reports_only_its_own_class_present() {
+        let store = InMemoryGraph::new();
+        let caller = entity("save_note", "nk/storage.py", LanguageId::Python);
+        let target = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage = observe_cross_file_reference_coverage(
+            &store,
+            &target,
+            &[RelationKind::Calls, RelationKind::Imports],
+        );
+        assert_eq!(coverage["classes"]["calls"], json!("present"));
+        assert_eq!(coverage["classes"]["imports"], json!("absent"));
+        assert_eq!(coverage["cross_file_classes"], json!(["calls"]));
+    }
+
+    /// Coverage is language-scoped: a store that links one language's calls
+    /// cross-file must not lend that coverage to a focal of another language,
+    /// which is exactly the per-language enrichment gap the ticket describes.
+    #[test]
+    fn coverage_does_not_cross_the_language_boundary() {
+        let store = InMemoryGraph::new();
+        let rust_caller = entity("dispatch", "src/a.rs", LanguageId::Rust);
+        let rust_callee = entity("handle", "src/b.rs", LanguageId::Rust);
+        let python_target = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+        store.upsert_entity(&rust_caller).unwrap();
+        store.upsert_entity(&rust_callee).unwrap();
+        store.upsert_entity(&python_target).unwrap();
+        store
+            .upsert_relation(&relation(
+                rust_caller.id,
+                rust_callee.id,
+                RelationKind::Calls,
+            ))
+            .unwrap();
+
+        let rust = observe_cross_file_reference_coverage(
+            &store,
+            &rust_callee,
+            &[RelationKind::Calls],
+        );
+        assert_eq!(rust["classes"]["calls"], json!("present"));
+
+        let python = observe_cross_file_reference_coverage(
+            &store,
+            &python_target,
+            &[RelationKind::Calls],
+        );
+        assert_eq!(python["classes"]["calls"], json!("absent"));
+    }
+
+    /// An intra-file edge is not a witness. Without this the FIR-2353 graph,
+    /// whose only Calls edges sat inside one file, would have reported the class
+    /// present and re-certified the absence it was meant to disqualify.
+    #[test]
+    fn an_intra_file_edge_is_not_a_cross_file_witness() {
+        let store = InMemoryGraph::new();
+        let first = entity("outer", "nk/parsing.py", LanguageId::Python);
+        let second = entity("inner", "nk/parsing.py", LanguageId::Python);
+        store.upsert_entity(&first).unwrap();
+        store.upsert_entity(&second).unwrap();
+        store
+            .upsert_relation(&relation(first.id, second.id, RelationKind::Calls))
+            .unwrap();
+
+        let coverage =
+            observe_cross_file_reference_coverage(&store, &first, &[RelationKind::Calls]);
+        assert_eq!(coverage["classes"]["calls"], json!("absent"));
+    }
+}

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -39,6 +39,12 @@
 //! completed and found none, `unknown` means the scan stopped on its budget
 //! before it could say. A consumer that cannot find this object must treat
 //! coverage as unknown rather than assuming either verdict.
+//!
+//! The single-focal tools attach it to an EMPTY answer only, since that is the
+//! only answer whose trust depends on it: one that returned rows proved the
+//! edges exist by returning them. The batch tool attaches it always, because its
+//! per-entity `has_references: false` rows are absences inside a populated
+//! response.
 
 use serde_json::{json, Map, Value};
 
@@ -169,13 +175,22 @@ pub fn observe_cross_file_reference_coverage_for_languages<S: EntityStore>(
         .map(|(kind, _)| class_name(*kind))
         .collect();
 
-    json!({
-        "scope": "language",
-        "language": observed_languages
+    // A batch that resolved no entity has no language to scope an observation to,
+    // and an empty string would read as one. Naming the absence keeps the reason
+    // it produces readable.
+    let language = if observed_languages.is_empty() {
+        "no resolved language".to_string()
+    } else {
+        observed_languages
             .iter()
             .map(|language| format!("{language:?}"))
             .collect::<Vec<_>>()
-            .join(", "),
+            .join(", ")
+    };
+
+    json!({
+        "scope": "language",
+        "language": language,
         "requested_classes": merged
             .iter()
             .map(|(kind, _)| class_name(*kind))

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -152,8 +152,7 @@ pub fn observe_cross_file_reference_coverage_for_languages<S: EntityStore>(
     }
 
     for (index, language) in observed_languages.iter().enumerate() {
-        let (states, examined, budget_exhausted) =
-            observe_language(store, *language, &requested);
+        let (states, examined, budget_exhausted) = observe_language(store, *language, &requested);
         examined_total += examined;
         any_budget_exhausted |= budget_exhausted;
         for (slot, (_, state)) in merged.iter_mut().zip(states.iter()) {
@@ -327,7 +326,11 @@ fn endpoint_file<S: EntityStore>(
     if let Some(file) = files.get(id) {
         return file.clone();
     }
-    store.get_entity(id).ok().flatten().and_then(|entity| entity.file_origin)
+    store
+        .get_entity(id)
+        .ok()
+        .flatten()
+        .and_then(|entity| entity.file_origin)
 }
 
 #[cfg(test)]
@@ -457,18 +460,12 @@ mod tests {
             ))
             .unwrap();
 
-        let rust = observe_cross_file_reference_coverage(
-            &store,
-            &rust_callee,
-            &[RelationKind::Calls],
-        );
+        let rust =
+            observe_cross_file_reference_coverage(&store, &rust_callee, &[RelationKind::Calls]);
         assert_eq!(rust["classes"]["calls"], json!("present"));
 
-        let python = observe_cross_file_reference_coverage(
-            &store,
-            &python_target,
-            &[RelationKind::Calls],
-        );
+        let python =
+            observe_cross_file_reference_coverage(&store, &python_target, &[RelationKind::Calls]);
         assert_eq!(python["classes"]["calls"], json!("absent"));
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1275,11 +1275,14 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     // reads. An empty reference list is only evidence about the code when the
     // graph demonstrably holds cross-file edges of those classes for the focal's
     // language, and nothing else in this payload reports that.
-    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage(
-        store,
-        &target,
-        &relation_kinds,
-    );
+    //
+    // Observed only for an empty answer, which is the only answer whose trust
+    // depends on it: an answer that returned rows has proved the edges exist by
+    // returning them, and paying a language scan on the populated path would be
+    // a cost with nothing to buy.
+    let edge_coverage = references.is_empty().then(|| {
+        crate::edge_coverage::observe_cross_file_reference_coverage(store, &target, &relation_kinds)
+    });
 
     let mut result = serde_json::json!({
         "focal_entity": {
@@ -1298,7 +1301,9 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         "references": references,
         "cross_repo": cross_repo,
     });
-    result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    if let Some(edge_coverage) = edge_coverage {
+        result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -2568,12 +2573,15 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     let total_steps = chain.len();
     // The walk expands exactly the reference kinds above, so an empty chain is
     // only evidence about the focal when the graph holds cross-file edges of
-    // those kinds for its language.
-    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage(
-        store,
-        &focal_entity,
-        &reference_kinds,
-    );
+    // those kinds for its language. A walk that returned steps needs no such
+    // evidence and pays no scan for it.
+    let edge_coverage = chain.is_empty().then(|| {
+        crate::edge_coverage::observe_cross_file_reference_coverage(
+            store,
+            &focal_entity,
+            &reference_kinds,
+        )
+    });
     let mut result = serde_json::json!({
         "focal_id": focal_entity.id.to_string(),
         "focal_name": focal_entity.name,
@@ -2589,7 +2597,9 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             "same_name_candidates": same_name_candidates,
         },
     });
-    result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    if let Some(edge_coverage) = edge_coverage {
+        result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -3929,6 +3939,42 @@ mod tests {
             trust_reason(&response).starts_with("cross_file_edges_absent"),
             "{}",
             trust_reason(&response)
+        );
+    }
+
+    /// An answer that returned rows proved the edges exist by returning them, so
+    /// it pays no language scan and carries no observation. Stating it as a test
+    /// keeps the populated path from silently acquiring one.
+    #[tokio::test]
+    async fn a_populated_reference_answer_carries_no_edge_observation() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&make_relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+        assert_eq!(response["total_upstream"], 1);
+        assert!(
+            response
+                .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+                .is_none(),
+            "a populated answer needs no coverage observation: {response}"
+        );
+        assert!(
+            response.get("negative").is_none(),
+            "and carries no negative to consume one"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3811,8 +3811,175 @@ mod tests {
         assert!(mismatched["cross_repo"]["reason"]
             .as_str()
             .is_some_and(|reason| reason.contains("root mismatch")));
+        // A registered root the live graph has advanced past is stale authority,
+        // and the code says which condition held rather than leaving every spine
+        // gap wearing one label.
+        assert_eq!(mismatched["cross_repo"]["code"], SPINE_ROOT_STALE);
+        assert!(mismatched["negative"]["trust_reason"]
+            .as_str()
+            .is_some_and(|reason| reason.starts_with(SPINE_ROOT_STALE)));
         assert_eq!(mismatched["negative"]["safe_to_conclude_absent"], false);
         assert!(mismatched["references"].as_array().unwrap().is_empty());
+    }
+
+    /// FIR-2353, second observation: a single-repo install whose repository the
+    /// spine never registered reported "spine root mismatch" as the reason a
+    /// local miss could not be trusted. Nothing had mismatched and nothing was
+    /// cross-repo, so the answer taught its reader to discount reason text. The
+    /// condition that actually held now names itself, and the word mismatch does
+    /// not appear.
+    #[tokio::test]
+    async fn an_unregistered_repository_reports_itself_rather_than_a_root_mismatch() {
+        let graph = InMemoryGraph::new();
+        let target = make_entity("parse_note", "nk/parsing.rs");
+        graph.upsert_entity(&target).unwrap();
+        seed_cross_file_call_witness(&graph);
+        let live_root = graph_root(&graph);
+
+        // A spine that exists and has never been told about this repository,
+        // which is the ordinary state of a fresh single-repo install.
+        let spine = kin_spine::InMemorySpineBackend::new();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = handle_find_references_with_authority(
+            &args,
+            &graph,
+            FindReferencesAuthority {
+                repo_id: "nk",
+                graph_root: &live_root,
+                spine: Some(&spine),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        let response = parsed_response(&crate::finalize_with_envelope(
+            response,
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert_eq!(response["cross_repo"]["status"], "unavailable");
+        assert_eq!(response["cross_repo"]["code"], SPINE_REPO_UNREGISTERED);
+        let reason = response["cross_repo"]["reason"].as_str().unwrap();
+        assert!(
+            !reason.contains("mismatch"),
+            "an unregistered repository has nothing to mismatch: {reason}"
+        );
+        let trust_reason = response["negative"]["trust_reason"].as_str().unwrap();
+        assert!(
+            trust_reason.starts_with(SPINE_REPO_UNREGISTERED),
+            "the reason names the condition that held: {trust_reason}"
+        );
+        assert!(
+            !trust_reason.contains("mismatch"),
+            "and never the one that did not: {trust_reason}"
+        );
+    }
+
+    /// The FIR-2353 headline, end to end through the handler: a graph holding
+    /// entities and one intra-file call edge, healthy by every freshness signal,
+    /// answering for a symbol a sibling file calls. The answer is empty because
+    /// the graph holds no cross-file edge that could have carried the reference,
+    /// and the envelope has to say so rather than certify the symbol as unused.
+    #[tokio::test]
+    async fn find_references_on_an_intra_file_only_graph_refuses_to_certify_absence() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("parse_note", "nk/parsing.rs");
+        let caller = make_entity("save_note", "nk/storage.rs");
+        let sibling = make_entity("write_bytes", "nk/storage.rs");
+        store.upsert_entity(&target).unwrap();
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&sibling).unwrap();
+        // The extractor linked what it could see inside one file and nothing
+        // across files, which is the exact shape the isolated-install repro hit.
+        store
+            .upsert_relation(&make_relation(caller.id, sibling.id, RelationKind::Calls))
+            .unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert!(response["references"].as_array().unwrap().is_empty());
+        assert_eq!(
+            response["edge_coverage"]["cross_file_classes"],
+            serde_json::json!([]),
+            "the observation is what makes the gap visible: {}",
+            response["edge_coverage"]
+        );
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "an agent acting on a true verdict here deletes live code: {}",
+            response["negative"]
+        );
+        assert_eq!(response["negative"]["trust"], "inconclusive");
+        // And the edge gap LEADS, ahead of the ambient path's own cross-repo
+        // binding gap, because it is the factor that limited this answer.
+        assert!(
+            trust_reason(&response).starts_with("cross_file_edges_absent"),
+            "{}",
+            trust_reason(&response)
+        );
+    }
+
+    /// The other half of the same claim, on the daemon authority path so nothing
+    /// but the edge coverage differs: one cross-file call edge and the identical
+    /// empty answer is certified again. A fix that made every absence
+    /// inconclusive would pass the test above and fail this one.
+    #[tokio::test]
+    async fn find_references_certifies_absence_once_the_graph_links_calls_across_files() {
+        let graph = InMemoryGraph::new();
+        let target = make_entity("parse_note", "nk/parsing.rs");
+        graph.upsert_entity(&target).unwrap();
+        seed_cross_file_call_witness(&graph);
+        let registered_root = graph_root(&graph);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo("nk", vec![spine_entry("nk", &target)], &registered_root);
+        spine.refresh_cross_repo_edges("nk", &[], &[], &["nk".to_string()]);
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references_with_authority(
+                &args,
+                &graph,
+                FindReferencesAuthority {
+                    repo_id: "nk",
+                    graph_root: &registered_root,
+                    spine: Some(&spine),
+                },
+                None,
+            )
+            .await
+            .unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert!(response["references"].as_array().unwrap().is_empty());
+        assert_eq!(
+            response["edge_coverage"]["cross_file_classes"],
+            serde_json::json!(["calls"])
+        );
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], true,
+            "a graph that links calls across files still earns absence: {}",
+            response["negative"]
+        );
+        assert_eq!(response["negative"]["trust"], "authoritative");
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1003,6 +1003,53 @@ fn reference_row_json(row: ReferenceRow) -> serde_json::Value {
     })
 }
 
+/// Machine-readable codes a spine unavailability can carry, each the name of one
+/// computed condition. A reason is prefixed with its code so a consumer reports
+/// the condition that actually held instead of collapsing every spine gap into
+/// one label.
+///
+/// [`SPINE_REPO_UNREGISTERED`] and [`SPINE_ROOT_STALE`] were one message until
+/// FIR-2353. A repository with no spine registration at all reported "spine root
+/// mismatch", which reads as a topology misconfiguration and was quoted back as
+/// the cause of a miss that had nothing to do with another repository.
+pub const SPINE_REPO_UNREGISTERED: &str = "spine_repo_unregistered";
+/// The spine holds a root for this repository, but the live graph has advanced
+/// past it: stale cross-repo authority rather than a mismatched one.
+pub const SPINE_ROOT_STALE: &str = "spine_root_stale";
+
+/// Split a spine unavailability reason into its code and human detail, or
+/// `None` for a reason that carries no recognized code (a binding failure, say,
+/// whose message is not one of the conditions computed here).
+///
+/// Only the known codes are stripped. Treating any colon-prefixed word as a code
+/// would promote the first word of an arbitrary error message into a machine
+/// label, which is the kind of guess this module exists to avoid.
+fn split_spine_unavailable_reason(reason: &str) -> (Option<&'static str>, &str) {
+    for code in [SPINE_REPO_UNREGISTERED, SPINE_ROOT_STALE] {
+        if let Some(detail) = reason
+            .strip_prefix(code)
+            .and_then(|rest| rest.strip_prefix(": "))
+        {
+            return (Some(code), detail);
+        }
+    }
+    (None, reason)
+}
+
+/// The cross-repo object for a spine that could not answer, carrying the code of
+/// the condition that held beside its human detail.
+fn cross_repo_unavailable_json(reason: &str) -> serde_json::Value {
+    let (code, detail) = split_spine_unavailable_reason(reason);
+    let mut value = serde_json::json!({
+        "status": "unavailable",
+        "reason": detail,
+    });
+    if let Some(code) = code {
+        value["code"] = serde_json::json!(code);
+    }
+    value
+}
+
 fn daemon_spine_xref(
     authority: FindReferencesAuthority<'_>,
     target_id: &kin_model::EntityId,
@@ -1011,13 +1058,29 @@ fn daemon_spine_xref(
     let query = match authority.spine {
         Some(spine) => {
             let body = spine.cross_repo_xref_response(&repo_id, target_id);
-            if body.authority_root_matches(&repo_id, authority.graph_root) {
-                kin_spine::SpineQuery::Found(body)
-            } else {
-                kin_spine::SpineQuery::Unavailable(format!(
-                    "spine root mismatch for repository {repo_id}: live/session graph root {} is not the registered spine root",
+            match body.authority_roots.get(&repo_id) {
+                Some(registered) if registered == authority.graph_root => {
+                    kin_spine::SpineQuery::Found(body)
+                }
+                // The spine registered this repository at the graph it was
+                // initialized from, and graph truth has moved since. Its
+                // topology is stale, which bears on references from OTHER
+                // repositories and says nothing about the local graph that just
+                // answered.
+                Some(registered) => kin_spine::SpineQuery::Unavailable(format!(
+                    "{SPINE_ROOT_STALE}: spine root mismatch for repository {repo_id}: \
+                     live/session graph root {} has advanced past the registered spine root \
+                     {registered}, so cross-repo authority is stale for other repositories \
+                     and says nothing about references inside this one",
                     authority.graph_root
-                ))
+                )),
+                // No registration at all, which is the ordinary state of a
+                // single-repo install rather than a mismatch of any kind.
+                None => kin_spine::SpineQuery::Unavailable(format!(
+                    "{SPINE_REPO_UNREGISTERED}: repository {repo_id} has no registered spine \
+                     root, so cross-repo authority cannot answer for it; this is the ordinary \
+                     single-repo state and says nothing about references inside this repository"
+                )),
             }
         }
         None => kin_spine::SpineQuery::NotConfigured,
@@ -1153,10 +1216,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     let cross_repo = match cross_repo_query {
         Err(reason) => {
             tracing::warn!(reason = %reason, "cross-repo repository binding unavailable for references enrichment");
-            serde_json::json!({
-                "status": "unavailable",
-                "reason": reason,
-            })
+            cross_repo_unavailable_json(&reason)
         }
         Ok((repo_id, query)) => match query {
             kin_spine::SpineQuery::Found(body) => {
@@ -1192,10 +1252,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
             // silently dropping cross-repo references (which would read as "none").
             kin_spine::SpineQuery::Unavailable(reason) => {
                 tracing::warn!(reason = %reason, "cross-repo spine unavailable for references enrichment");
-                serde_json::json!({
-                    "status": "unavailable",
-                    "reason": reason,
-                })
+                cross_repo_unavailable_json(&reason)
             }
             // Local-only (no spine configured): quiet — cross-repo refs don't apply.
             kin_spine::SpineQuery::NotConfigured => serde_json::json!({
@@ -1214,7 +1271,17 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     // repo-qualified paths and carry no local entity id.
     let references = rows.into_iter().map(reference_row_json).collect::<Vec<_>>();
 
-    let result = serde_json::json!({
+    // What the graph can structurally answer over the edge classes this query
+    // reads. An empty reference list is only evidence about the code when the
+    // graph demonstrably holds cross-file edges of those classes for the focal's
+    // language, and nothing else in this payload reports that.
+    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage(
+        store,
+        &target,
+        &relation_kinds,
+    );
+
+    let mut result = serde_json::json!({
         "focal_entity": {
             "id": target.id,
             "name": target.name,
@@ -1231,6 +1298,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         "references": references,
         "cross_repo": cross_repo,
     });
+    result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -1328,6 +1396,7 @@ fn handle_bulk_check_references_with_authority_source<G: GraphStore>(
     let mut cross_repo_unavailable = None;
     let mut federated_reference_count = 0usize;
     let mut saw_unknown_federated_subtype = false;
+    let mut batch_languages: Vec<kin_model::ids::LanguageId> = Vec::new();
 
     for raw_id in &entity_ids_raw {
         let entity_id = match parse_entity_id(raw_id) {
@@ -1371,6 +1440,10 @@ fn handle_bulk_check_references_with_authority_source<G: GraphStore>(
             results.push(row);
             continue;
         };
+
+        if !batch_languages.contains(&entity.language) {
+            batch_languages.push(entity.language);
+        }
 
         let mut reference_count = 0usize;
         let mut matched_kinds: Vec<RelationKind> = Vec::new();
@@ -1592,14 +1665,23 @@ fn handle_bulk_check_references_with_authority_source<G: GraphStore>(
         "results": results,
     });
 
+    // Every `has_references: false` row in this batch is read off the same
+    // cross-file edge classes a single reference query reads, so the batch
+    // publishes the same observation. It covers each language the resolved
+    // entities span, and the weakest of them governs.
+    result[crate::edge_coverage::EDGE_COVERAGE_KEY] =
+        crate::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+            store,
+            &batch_languages,
+            &relation_kinds,
+        );
+
     if authority.is_some() {
         result["cross_repo"] = if let Some(reason) = cross_repo_unavailable {
-            serde_json::json!({
-                "status": "unavailable",
-                "reason": reason,
-                "checked_entities": cross_repo_checked,
-                "relation_subtype_complete": false,
-            })
+            let mut unavailable = cross_repo_unavailable_json(&reason);
+            unavailable["checked_entities"] = serde_json::json!(cross_repo_checked);
+            unavailable["relation_subtype_complete"] = serde_json::json!(false);
+            unavailable
         } else {
             serde_json::json!({
                 "status": "available",
@@ -2484,7 +2566,15 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     }
 
     let total_steps = chain.len();
-    let result = serde_json::json!({
+    // The walk expands exactly the reference kinds above, so an empty chain is
+    // only evidence about the focal when the graph holds cross-file edges of
+    // those kinds for its language.
+    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage(
+        store,
+        &focal_entity,
+        &reference_kinds,
+    );
+    let mut result = serde_json::json!({
         "focal_id": focal_entity.id.to_string(),
         "focal_name": focal_entity.name,
         "focal_kind": format!("{:?}", focal_entity.kind),
@@ -2499,6 +2589,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             "same_name_candidates": same_name_candidates,
         },
     });
+    result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -3655,6 +3746,9 @@ mod tests {
         let graph = InMemoryGraph::new();
         let target = make_entity("target", "src/lib.rs");
         graph.upsert_entity(&target).unwrap();
+        // The graph has to be able to hold a cross-file reference before an empty
+        // one is evidence about the target rather than about the graph.
+        seed_cross_file_call_witness(&graph);
         let registered_root = graph_root(&graph);
 
         let spine = kin_spine::InMemorySpineBackend::new();
@@ -3810,6 +3904,7 @@ mod tests {
         let graph = InMemoryGraph::new();
         let target = make_entity("target", "src/lib.rs");
         graph.upsert_entity(&target).unwrap();
+        seed_cross_file_call_witness(&graph);
         let provider_root = graph_root(&graph);
 
         let spine = kin_spine::InMemorySpineBackend::new();
@@ -3858,6 +3953,7 @@ mod tests {
         let target = make_entity("target", "src/lib.rs");
         let source = make_entity("caller", "src/app.rs");
         graph.upsert_entity(&target).unwrap();
+        seed_cross_file_call_witness(&graph);
         let provider_root = graph_root(&graph);
 
         let spine = kin_spine::InMemorySpineBackend::new();
@@ -4342,16 +4438,32 @@ mod tests {
             .to_string()
     }
 
+    /// A pair of entities in different files joined by a `Calls` edge: the
+    /// witness that this graph does link references across files for the
+    /// language, without which an empty walk is a fact about the graph rather
+    /// than about the focal.
+    fn seed_cross_file_call_witness(store: &InMemoryGraph) {
+        let caller = make_entity("witness_caller", "src/witness_caller.rs");
+        let callee = make_entity("witness_callee", "src/witness_callee.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&callee).unwrap();
+        store
+            .upsert_relation(&make_relation(caller.id, callee.id, RelationKind::Calls))
+            .unwrap();
+    }
+
     /// The authoritative side of the trace absence: a focal that is in the
     /// graph, carries a name nothing else shares, is not a method, and has no
-    /// edges at all. That is a real absence, and the qualifier must still be
-    /// willing to say so. A gate that never certifies anything is as useless
-    /// as one that certifies everything.
+    /// edges at all, on a graph that demonstrably links calls across files.
+    /// That is a real absence, and the qualifier must still be willing to say
+    /// so. A gate that never certifies anything is as useless as one that
+    /// certifies everything.
     #[test]
     fn trace_data_flow_isolated_focal_is_authoritative_on_a_ready_graph() {
         let store = InMemoryGraph::new();
         let lonely = make_entity("lonely", "src/lonely.rs");
         store.upsert_entity(&lonely).unwrap();
+        seed_cross_file_call_witness(&store);
 
         let response = traced_response(
             &store,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1058,29 +1058,31 @@ fn daemon_spine_xref(
     let query = match authority.spine {
         Some(spine) => {
             let body = spine.cross_repo_xref_response(&repo_id, target_id);
-            match body.authority_roots.get(&repo_id) {
-                Some(registered) if registered == authority.graph_root => {
-                    kin_spine::SpineQuery::Found(body)
-                }
+            match body.authority_root_state(&repo_id, authority.graph_root) {
+                kin_spine::AuthorityRootState::Matches => kin_spine::SpineQuery::Found(body),
                 // The spine registered this repository at the graph it was
                 // initialized from, and graph truth has moved since. Its
                 // topology is stale, which bears on references from OTHER
                 // repositories and says nothing about the local graph that just
                 // answered.
-                Some(registered) => kin_spine::SpineQuery::Unavailable(format!(
-                    "{SPINE_ROOT_STALE}: spine root mismatch for repository {repo_id}: \
-                     live/session graph root {} has advanced past the registered spine root \
-                     {registered}, so cross-repo authority is stale for other repositories \
-                     and says nothing about references inside this one",
-                    authority.graph_root
-                )),
+                kin_spine::AuthorityRootState::Stale { registered } => {
+                    kin_spine::SpineQuery::Unavailable(format!(
+                        "{SPINE_ROOT_STALE}: spine root mismatch for repository {repo_id}: \
+                         live/session graph root {} has advanced past the registered spine root \
+                         {registered}, so cross-repo authority is stale for other repositories \
+                         and says nothing about references inside this one",
+                        authority.graph_root
+                    ))
+                }
                 // No registration at all, which is the ordinary state of a
                 // single-repo install rather than a mismatch of any kind.
-                None => kin_spine::SpineQuery::Unavailable(format!(
-                    "{SPINE_REPO_UNREGISTERED}: repository {repo_id} has no registered spine \
-                     root, so cross-repo authority cannot answer for it; this is the ordinary \
-                     single-repo state and says nothing about references inside this repository"
-                )),
+                kin_spine::AuthorityRootState::Unregistered => {
+                    kin_spine::SpineQuery::Unavailable(format!(
+                        "{SPINE_REPO_UNREGISTERED}: repository {repo_id} has no registered spine \
+                         root, so cross-repo authority cannot answer for it; this is the ordinary \
+                         single-repo state and says nothing about references inside this repository"
+                    ))
+                }
             }
         }
         None => kin_spine::SpineQuery::NotConfigured,

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 pub mod daemon_delegate;
+pub mod edge_coverage;
 pub mod envelope;
 pub mod error;
 pub mod handlers;
@@ -17,6 +18,7 @@ pub use envelope::{
     annotate as annotate_with_envelope, finalize as finalize_with_envelope, Envelope, ENVELOPE_KEY,
     ENVELOPE_VERSION,
 };
+pub use edge_coverage::EDGE_COVERAGE_KEY;
 pub use error::{McpError, Result};
 pub use handlers::LocalRepositoryAuthorityBinding;
 pub use negative::NEGATIVE_KEY;

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -14,11 +14,11 @@ pub mod tools;
 pub mod types;
 
 pub use daemon_delegate::note_startup_repository;
+pub use edge_coverage::EDGE_COVERAGE_KEY;
 pub use envelope::{
     annotate as annotate_with_envelope, finalize as finalize_with_envelope, Envelope, ENVELOPE_KEY,
     ENVELOPE_VERSION,
 };
-pub use edge_coverage::EDGE_COVERAGE_KEY;
 pub use error::{McpError, Result};
 pub use handlers::LocalRepositoryAuthorityBinding;
 pub use negative::NEGATIVE_KEY;

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -174,7 +174,7 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
     Some(spec)
 }
 
-/// The cross-file edge classes each tool's ABSENCE claim depends on — the
+/// The cross-file edge classes each tool's ABSENCE claim depends on: the
 /// per-tool dependency map, in code, so authority can only be granted for a
 /// substrate the tool actually reads.
 ///
@@ -249,6 +249,17 @@ fn reference_classes() -> Vec<String> {
 /// unknown coverage, and it is the reading that makes a tool declare its
 /// dependency in [`absence_cross_file_classes`] and publish the observation
 /// before it can certify anything.
+///
+/// The extraction side grew a richer statement of the same fact under FIR-2354:
+/// `kin_core::cross_file_coverage::CrossFileCoverage`, whole-graph counts plus a
+/// per-language entry carrying `reference_enrichment`, which knows something this
+/// gate cannot observe from the graph alone (a language whose server is not
+/// installed). It reaches the CLI surfaces rather than any retrieval payload
+/// today. When a payload carries it, this gate should prefer it, mapping zero
+/// cross-file entity relations to `absent` for every class, a language's zero to
+/// `absent` for that language, and an unavailable `reference_enrichment` to
+/// `unknown`; [`crate::edge_coverage`] can then be retired, since it is called
+/// from exactly three payload builders.
 fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
     let requested = absence_cross_file_classes(tool, payload);
     if requested.is_empty() {

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -29,6 +29,25 @@
 //! observed. Unknown freshness/coverage is `null` and forces
 //! `safe_to_conclude_absent = false` — absence is never certified on data the
 //! envelope did not see.
+//!
+//! ## What an absence claim depends on
+//!
+//! Freshness and degraded signals describe the daemon, not the substrate a
+//! particular query reads. A graph can be initialized, loaded, fully embedded and
+//! undegraded while holding no cross-file `calls`/`imports`/`references` edges at
+//! all, and every reference query against it returns an empty array for reasons
+//! that have nothing to do with the code. [`absence_cross_file_classes`] is the
+//! per-tool map of which edge classes each tool's absence claim depends on, and
+//! [`edge_coverage_gap`] is the gate that reads the observation
+//! [`crate::edge_coverage`] publishes into the payload. A tool that declares a
+//! dependency and publishes no observation is inconclusive by construction, so
+//! authority cannot be inherited by a tool that has not earned it.
+//!
+//! Gaps accumulate through [`push_gap`] in limiting-factor-first order rather
+//! than overwriting one another. Order matters as much as the verdict: a correct
+//! `inconclusive` beside an unrelated reason teaches readers to skip the reason,
+//! which is how a missing-cross-file-edge absence came back explained as a
+//! cross-repo spine mismatch.
 
 use serde_json::{json, Map, Value};
 
@@ -153,6 +172,153 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
         _ => return None,
     };
     Some(spec)
+}
+
+/// The cross-file edge classes each tool's ABSENCE claim depends on — the
+/// per-tool dependency map, in code, so authority can only be granted for a
+/// substrate the tool actually reads.
+///
+/// A tool's absence is a claim about edges, and the only edges that can carry a
+/// reference from one file to another are cross-file `calls`/`imports`/
+/// `references`. A graph that holds none of them for the focal's language
+/// answers every reference query with an empty array no matter how healthy it
+/// is, which is why membership in this map, and not the freshness signals,
+/// decides whether an absence can be certified.
+///
+/// | tool | classes an absence depends on | why |
+/// |---|---|---|
+/// | `find_references` | the query's own `relation_kinds` (default calls, imports, references) | its rows ARE those edges |
+/// | `bulk_check_references` | the query's own `relation_kinds` | one `has_references: false` row per entity, read off the same edges |
+/// | `trace_data_flow` | calls, imports, references | the walk expands exactly those kinds |
+/// | `impact_analysis` | calls, imports, references | downstream impact is those edges transitively; it has no absence spec today, and this entry is what stops one inheriting authority if it gains one |
+/// | `graph_neighborhood` | none | the merged walk includes containment edges, which are intra-file by construction, so an empty neighborhood is not evidence about cross-file coverage; its absence is gated instead by focal-not-in-graph and depth-zero |
+/// | `semantic_locate` | none | ranks entities from embeddings and never traverses an edge |
+/// | `semantic_search` | none | filters declarations by name/kind/language and never traverses an edge |
+/// | `dead_code`, `find_dead_code_seeded` | none | their empty result is the INVERSE claim ("nothing unreachable"), and missing edges produce more candidates rather than fewer, so absence there is not endangered by a coverage gap |
+/// | `entity_history` | none | reads change history, not relations |
+///
+/// A tool absent from the map contributes no classes, so a new retrieval tool
+/// starts with no edge-derived authority to inherit and has to declare what it
+/// reads to earn one.
+fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<String> {
+    match tool {
+        "find_references" | "bulk_check_references" => payload
+            .get("relation_kinds")
+            .and_then(Value::as_array)
+            .map(|kinds| {
+                kinds
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_ascii_lowercase)
+                    .filter(|kind| {
+                        matches!(kind.as_str(), "calls" | "imports" | "references")
+                    })
+                    .collect()
+            })
+            .unwrap_or_else(reference_classes),
+        "trace_data_flow" | "impact_analysis" => reference_classes(),
+        _ => Vec::new(),
+    }
+}
+
+/// The default reference edge classes, matching `default_reference_kinds` on the
+/// handler side. Kept as the fallback for a payload that does not report the
+/// scope it ran with, because assuming a narrower scope than the query used
+/// would let an unreported union query pass a gate only its narrowest arm earned.
+fn reference_classes() -> Vec<String> {
+    vec![
+        "calls".to_string(),
+        "imports".to_string(),
+        "references".to_string(),
+    ]
+}
+
+/// Why the graph cannot certify this absence over the edge classes the query
+/// reads, or `None` when at least one requested class is demonstrably present.
+///
+/// One observed cross-file edge of a requested class is the bar. It is
+/// deliberately not "every requested class is present": `references` edges are
+/// legitimately rare, so demanding all of them would report every absence on
+/// every real graph as inconclusive, which is the failure mode opposite to
+/// FIR-2353 and just as useless. One witness proves the extractor and linker do
+/// produce cross-file edges of that class for this language, which is the fact
+/// an absence claim was silently assuming.
+///
+/// A payload carrying no observation at all is the unknown case, not the healthy
+/// one. That is the reading the module's honesty contract already takes for
+/// unknown coverage, and it is the reading that makes a tool declare its
+/// dependency in [`absence_cross_file_classes`] and publish the observation
+/// before it can certify anything.
+fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
+    let requested = absence_cross_file_classes(tool, payload);
+    if requested.is_empty() {
+        return None;
+    }
+    let named = requested.join(", ");
+
+    let Some(coverage) = payload
+        .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+        .and_then(Value::as_object)
+    else {
+        return Some(format!(
+            "edge_coverage_unreported: this answer did not report whether the graph holds \
+             cross-file {named} edges, so an empty result cannot be distinguished from a graph \
+             that could not have found a reference in the first place"
+        ));
+    };
+    let language = coverage
+        .get("language")
+        .and_then(Value::as_str)
+        .unwrap_or("an unreported language");
+    let states = coverage.get("classes").and_then(Value::as_object);
+    let state_for = |class: &str| -> &str {
+        states
+            .and_then(|states| states.get(class))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    };
+
+    if requested
+        .iter()
+        .any(|class| state_for(class) == "present")
+    {
+        return None;
+    }
+    if requested
+        .iter()
+        .any(|class| state_for(class) == "unknown")
+        || coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true)
+    {
+        return Some(format!(
+            "edge_coverage_unknown: whether the graph holds cross-file {named} edges for \
+             {language} could not be established, so an empty result may mean the query had no \
+             edges to answer from rather than that the target is unused"
+        ));
+    }
+    Some(format!(
+        "cross_file_edges_absent: the graph holds no cross-file {named} edges for {language}, so \
+         no reference from another file could have been found and an empty result says nothing \
+         about whether the target is used; the gap is in extraction/enrichment for that language, \
+         not in the code"
+    ))
+}
+
+/// Add one gap to the running verdict: the reason a gap names replaces a
+/// substrate reason that certified authority, and follows one that already
+/// reported a gap, so the composed reason reads limiting-factor-first and never
+/// drops a fact that was already true.
+///
+/// Every gate in [`negative_for`] goes through this rather than assigning
+/// `trust_reason` directly. Direct assignment is how a cross-repo topology note
+/// came to overwrite the reason an absence was actually limited by, leaving a
+/// correct verdict beside an unrelated explanation.
+fn push_gap(trustworthy: &mut bool, trust_reason: &mut String, gap: String) {
+    *trust_reason = if *trustworthy {
+        gap
+    } else {
+        format!("{trust_reason}; {gap}")
+    };
+    *trustworthy = false;
 }
 
 /// Number of items in the tool's result collection within `payload`, or `None`
@@ -554,6 +720,24 @@ fn focal_is_method(payload: &Value) -> bool {
     focal_kind(payload).is_some_and(|kind| kind.eq_ignore_ascii_case("method"))
 }
 
+/// The label an unavailable cross-repo answer reports, and its detail.
+///
+/// The producer names the condition that held under `code`, so the label is that
+/// name rather than one catch-all. `cross_repo_unavailable` remains the label for
+/// an answer carrying no code, because a reason with no computed condition behind
+/// it must not be dressed up as one.
+fn cross_repo_unavailable_gap(cross_repo: &Value) -> String {
+    let code = cross_repo
+        .get("code")
+        .and_then(Value::as_str)
+        .unwrap_or("cross_repo_unavailable");
+    let reason = cross_repo
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or("the cross-repo spine could not answer");
+    format!("{code}: {reason}")
+}
+
 fn cross_repo_references_gap(payload: &Value) -> Option<String> {
     let Some(cross_repo) = payload.get("cross_repo") else {
         return Some(
@@ -562,13 +746,7 @@ fn cross_repo_references_gap(payload: &Value) -> Option<String> {
         );
     };
     match cross_repo.get("status").and_then(Value::as_str) {
-        Some("unavailable") => {
-            let reason = cross_repo
-                .get("reason")
-                .and_then(Value::as_str)
-                .unwrap_or("the cross-repo spine could not answer");
-            Some(format!("cross_repo_unavailable: {reason}"))
-        }
+        Some("unavailable") => Some(cross_repo_unavailable_gap(cross_repo)),
         Some("available") => {
             let authority_complete = cross_repo
                 .get("authority_complete")
@@ -634,13 +812,7 @@ fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
         );
     };
     match cross_repo.get("status").and_then(Value::as_str) {
-        Some("unavailable") => Some(format!(
-            "cross_repo_unavailable: {}",
-            cross_repo
-                .get("reason")
-                .and_then(Value::as_str)
-                .unwrap_or("the cross-repo spine could not answer")
-        )),
+        Some("unavailable") => Some(cross_repo_unavailable_gap(cross_repo)),
         Some("available") => {
             let authority_complete = cross_repo
                 .get("authority_complete")
@@ -712,6 +884,16 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     let (mut trustworthy, trust_reason) = envelope.negative_trust(spec.class);
     let mut trust_reason = trust_reason.to_string();
 
+    // The edge-class gate leads every other gap because it is the one that can
+    // make the query structurally unable to answer. A graph holding no
+    // cross-file edges of the class a reference query reads returns an empty
+    // array for every symbol in it, healthy or not, so no later gap is the
+    // limiting factor when this one applies and none of them may be reported as
+    // if it were.
+    if let Some(gap) = edge_coverage_gap(tool, payload) {
+        push_gap(&mut trustworthy, &mut trust_reason, gap);
+    }
+
     // Receiver-method calls (`x.method()`) are resolved by bare name in
     // the linker while method entities are keyed by their qualified name, so a
     // method's incoming `Calls` edges are frequently dropped. An empty
@@ -720,28 +902,35 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // read "safe to delete" off an incomplete call graph: downgrade to
     // inconclusive so the absence is flagged as possibly-unresolved, not certain.
     if tool == "find_references" && focal_is_method(payload) {
-        trustworthy = false;
-        trust_reason = "method_call_resolution_incomplete: receiver-method calls are \
+        push_gap(
+            &mut trustworthy,
+            &mut trust_reason,
+            "method_call_resolution_incomplete: receiver-method calls are \
              linked by bare name and may be unresolved, so an empty result is not an \
              authoritative absence for a method"
-            .to_string();
+                .to_string(),
+        );
     }
 
     // A healthy local graph is not enough to certify "no references" when the
     // configured cross-repo authority failed or returned an invalid payload.
     // Keep the local rows, but make the negative verdict explicitly
     // inconclusive so agents cannot read the gap as safe-to-delete proof.
+    //
+    // It follows the gates above rather than replacing them. A spine that cannot
+    // answer for a repository is a real gap, but it is a gap about OTHER
+    // repositories, so it is never the reason a local absence could not be
+    // certified. Reporting it as that reason is how a miss inside one file came
+    // back explained as a cross-repo root mismatch.
     if tool == "find_references" {
         if let Some(reason) = cross_repo_references_gap(payload) {
-            trustworthy = false;
-            trust_reason = reason;
+            push_gap(&mut trustworthy, &mut trust_reason, reason);
         }
     }
 
     if tool == "bulk_check_references" {
         if let Some(reason) = cross_repo_bulk_gap(payload) {
-            trustworthy = false;
-            trust_reason = reason;
+            push_gap(&mut trustworthy, &mut trust_reason, reason);
         }
     }
 
@@ -830,12 +1019,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         // absent, so it leads and the specific gap follows rather than being
         // overwritten by it.
         if let Some(gap) = neighborhood_gap {
-            trust_reason = if trustworthy {
-                gap.to_string()
-            } else {
-                format!("{trust_reason}; {gap}")
-            };
-            trustworthy = false;
+            push_gap(&mut trustworthy, &mut trust_reason, gap.to_string());
         }
     }
 
@@ -848,13 +1032,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         }
         let gaps = trace_flow_gaps(payload);
         if !gaps.is_empty() {
-            let gaps = gaps.join("; ");
-            trust_reason = if trustworthy {
-                gaps
-            } else {
-                format!("{trust_reason}; {gaps}")
-            };
-            trustworthy = false;
+            push_gap(&mut trustworthy, &mut trust_reason, gaps.join("; "));
         }
     }
 
@@ -866,17 +1044,15 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // is not saying it better.
     let degradations = payload_degradation_labels(payload);
     if !degradations.is_empty() && tool != "trace_data_flow" {
-        let gap = format!(
-            "retrieval_degraded: this query reported degradations [{}], so it did not run at \
-             full capability",
-            degradations.join(", ")
+        push_gap(
+            &mut trustworthy,
+            &mut trust_reason,
+            format!(
+                "retrieval_degraded: this query reported degradations [{}], so it did not run at \
+                 full capability",
+                degradations.join(", ")
+            ),
         );
-        trust_reason = if trustworthy {
-            gap
-        } else {
-            format!("{trust_reason}; {gap}")
-        };
-        trustworthy = false;
     }
 
     // A graph holding no entities answers every query identically, so an empty
@@ -885,14 +1061,13 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // ways of reporting "nothing" have to agree about an empty graph, or an
     // agent learns which phrasing to trust rather than which answer.
     if envelope.graph_state.entity_count == Some(0) {
-        let gap = "graph_empty: the graph holds no entities at all, so an empty result says \
-                   nothing about whether the target exists";
-        trust_reason = if trustworthy {
-            gap.to_string()
-        } else {
-            format!("{trust_reason}; {gap}")
-        };
-        trustworthy = false;
+        push_gap(
+            &mut trustworthy,
+            &mut trust_reason,
+            "graph_empty: the graph holds no entities at all, so an empty result says \
+             nothing about whether the target exists"
+                .to_string(),
+        );
     }
 
     let interpretation = if ranking_names_nothing {
@@ -1019,14 +1194,13 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
     // bare "not found" dangerous: an agent reads it as proof the symbol does not
     // exist and acts on it.
     if envelope.graph_state.entity_count == Some(0) {
-        let gap = "graph_empty: the graph holds no entities at all, so a name that resolves to \
-                   nothing says nothing about whether the symbol exists";
-        trust_reason = if trustworthy {
-            gap.to_string()
-        } else {
-            format!("{trust_reason}; {gap}")
-        };
-        trustworthy = false;
+        push_gap(
+            &mut trustworthy,
+            &mut trust_reason,
+            "graph_empty: the graph holds no entities at all, so a name that resolves to \
+             nothing says nothing about whether the symbol exists"
+                .to_string(),
+        );
     }
 
     let consequence = if trustworthy {
@@ -1110,6 +1284,24 @@ mod tests {
         }))
     }
 
+    /// A graph that demonstrably links references across files for the focal's
+    /// language: one observed cross-file `calls` witness, the rest scanned and
+    /// reported absent. Without this object in the payload an absence claim has
+    /// no evidence that the query could have found anything, which is the whole
+    /// FIR-2353 failure, so every fixture asserting authoritative absence carries
+    /// it.
+    fn cross_file_edges_observed() -> Value {
+        json!({
+            "scope": "language",
+            "language": "Rust",
+            "requested_classes": ["calls", "imports", "references"],
+            "classes": { "calls": "present", "imports": "absent", "references": "absent" },
+            "cross_file_classes": ["calls"],
+            "budget_exhausted": false,
+            "entities_examined": 2,
+        })
+    }
+
     fn authoritative_empty_references(kind: &str) -> Value {
         json!({
             "focal_entity": {
@@ -1129,6 +1321,7 @@ mod tests {
                 "authority_revision": "sha256:complete",
                 "authority_roots": { "provider": "provider-root" },
             },
+            "edge_coverage": cross_file_edges_observed(),
         })
     }
 
@@ -1383,6 +1576,207 @@ mod tests {
             .contains("authoritative"));
     }
 
+    /// FIR-2353, the reproduction: a graph the daemon reports as initialized,
+    /// loaded and undegraded, holding entities and intra-file edges only. Every
+    /// freshness signal is green and the answer is still worthless, because no
+    /// cross-file reference edge exists for the language to be found. The verdict
+    /// must be inconclusive and the reason must name the edge gap.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_no_cross_file_edges_exist() {
+        let mut payload = authoritative_empty_references("function");
+        payload["edge_coverage"] = json!({
+            "scope": "language",
+            "language": "Python",
+            "requested_classes": ["calls", "imports", "references"],
+            "classes": { "calls": "absent", "imports": "absent", "references": "absent" },
+            "cross_file_classes": [],
+            "budget_exhausted": false,
+            "entities_examined": 26,
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("cross_file_edges_absent"),
+            "the limiting factor must lead the reason: {reason}"
+        );
+        assert!(
+            reason.contains("Python"),
+            "the reason names the language whose edges are missing: {reason}"
+        );
+        // The advice an agent acts on has to agree with the verdict, or the
+        // envelope contradicts itself one field apart.
+        assert!(negative["advice"]
+            .as_str()
+            .unwrap()
+            .contains("NOT authoritative"));
+    }
+
+    /// A payload that reports no observation at all is the unknown case. This is
+    /// the shape every retrieval tool had before FIR-2353, and reading it as
+    /// healthy is precisely how absence was certified on a graph that could not
+    /// answer.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_coverage_is_unreported() {
+        let mut payload = authoritative_empty_references("function");
+        payload
+            .as_object_mut()
+            .unwrap()
+            .remove("edge_coverage")
+            .expect("the fixture carries an observation to remove");
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("edge_coverage_unreported"));
+    }
+
+    /// A scan that stopped on its budget knows nothing, and "nothing" is not
+    /// "absent". Reporting the truncated scan as a completed one would hand back
+    /// the same false authority through a different door.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_the_scan_was_truncated() {
+        let mut payload = authoritative_empty_references("function");
+        payload["edge_coverage"] = json!({
+            "scope": "language",
+            "language": "Rust",
+            "requested_classes": ["calls"],
+            "classes": { "calls": "unknown" },
+            "cross_file_classes": [],
+            "budget_exhausted": true,
+            "entities_examined": 4096,
+        });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("edge_coverage_unknown"));
+    }
+
+    /// The gate is scoped to the classes the QUERY asked for. A calls-only query
+    /// against a graph whose only cross-file edges are imports has no coverage
+    /// for what it read, and borrowing the sibling class's witness would certify
+    /// an absence over edges that were never produced.
+    #[test]
+    fn the_edge_gate_reads_the_classes_the_query_asked_for() {
+        let mut payload = authoritative_empty_references("function");
+        payload["relation_kinds"] = json!(["calls"]);
+        payload["edge_coverage"] = json!({
+            "scope": "language",
+            "language": "Python",
+            "requested_classes": ["calls", "imports"],
+            "classes": { "calls": "absent", "imports": "present" },
+            "cross_file_classes": ["imports"],
+            "budget_exhausted": false,
+            "entities_examined": 12,
+        });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.starts_with("cross_file_edges_absent"), "{reason}");
+        assert!(
+            reason.contains("calls") && !reason.contains("imports"),
+            "the reason names the class the query read, not the one it did not: {reason}"
+        );
+
+        // The same graph answering the imports arm keeps its authority, so the
+        // gate narrows the claim rather than blanket-denying it.
+        payload["relation_kinds"] = json!(["imports"]);
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+    }
+
+    /// The regression the fix must not become: making every absence inconclusive
+    /// would satisfy FIR-2353 and destroy the tool. A graph that demonstrably
+    /// links references across files still certifies a genuinely unused symbol.
+    #[test]
+    fn a_graph_with_cross_file_edges_still_certifies_a_genuinely_unused_symbol() {
+        let payload = authoritative_empty_references("function");
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "one observed cross-file witness is enough to earn authority"
+        );
+        assert_eq!(negative["trust"], json!("authoritative"));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("structural_authoritative"));
+    }
+
+    /// Tools that read no edges must not be gated by an edge observation they
+    /// have no way to publish. `semantic_locate` ranks embeddings and
+    /// `semantic_search` filters declarations, so their absences answer to their
+    /// own substrates and stay reachable.
+    #[test]
+    fn tools_that_traverse_no_edges_are_not_gated_by_edge_coverage() {
+        assert!(edge_coverage_gap("semantic_locate", &json!({ "results": [] })).is_none());
+        assert!(edge_coverage_gap("semantic_search", &json!({ "results": [] })).is_none());
+        assert!(edge_coverage_gap("graph_neighborhood", &json!({ "relations": [] })).is_none());
+        assert!(edge_coverage_gap("entity_history", &json!([])).is_none());
+        assert!(edge_coverage_gap("dead_code", &json!([])).is_none());
+        // And an unknown tool inherits nothing: it declares no dependency, so it
+        // is neither gated nor granted authority by this map.
+        assert!(edge_coverage_gap("some_future_tool", &json!({})).is_none());
+    }
+
+    /// The map is the contract, so it is asserted directly rather than only
+    /// through the tools that happen to consume it today. `impact_analysis` has
+    /// no absence spec yet; its entry is what stops one inheriting authority.
+    #[test]
+    fn the_per_tool_dependency_map_names_what_each_absence_reads() {
+        let all = vec![
+            "calls".to_string(),
+            "imports".to_string(),
+            "references".to_string(),
+        ];
+        assert_eq!(
+            absence_cross_file_classes("find_references", &json!({})),
+            all
+        );
+        assert_eq!(
+            absence_cross_file_classes("bulk_check_references", &json!({})),
+            all
+        );
+        assert_eq!(absence_cross_file_classes("trace_data_flow", &json!({})), all);
+        assert_eq!(
+            absence_cross_file_classes("impact_analysis", &json!({})),
+            all,
+            "an absence spec added to impact_analysis must arrive already gated"
+        );
+        assert_eq!(
+            absence_cross_file_classes(
+                "find_references",
+                &json!({ "relation_kinds": ["Calls", "other"] })
+            ),
+            vec!["calls".to_string()],
+            "the query's own scope narrows the dependency, case-insensitively"
+        );
+        for tool in [
+            "semantic_locate",
+            "semantic_search",
+            "graph_neighborhood",
+            "dead_code",
+            "find_dead_code_seeded",
+            "entity_history",
+        ] {
+            assert!(
+                absence_cross_file_classes(tool, &json!({})).is_empty(),
+                "{tool} traverses no cross-file reference edge for its absence claim"
+            );
+        }
+    }
+
     #[test]
     fn find_references_on_method_is_inconclusive_despite_loaded_graph() {
         // Receiver-method call edges are under-resolved by the linker
@@ -1527,6 +1921,105 @@ mod tests {
             .expect("empty references yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
         assert_eq!(negative["trust"], json!("authoritative"));
+    }
+
+    /// FIR-2353, generation 7: the same miss came back inconclusive with
+    /// "cross_repo_unavailable: spine root mismatch" as the reason. The verdict
+    /// was right and the explanation belonged to another repository, which trains
+    /// a reader to ignore the reason text. The edge gap is the limiting factor and
+    /// has to lead; the spine note may follow but must never stand in for it.
+    #[test]
+    fn a_spine_gap_never_stands_in_for_the_edge_gap_that_actually_limited_the_answer() {
+        let mut payload = authoritative_empty_references("function");
+        payload["edge_coverage"] = json!({
+            "scope": "language",
+            "language": "Python",
+            "requested_classes": ["calls", "imports", "references"],
+            "classes": { "calls": "absent", "imports": "absent", "references": "absent" },
+            "cross_file_classes": [],
+            "budget_exhausted": false,
+            "entities_examined": 26,
+        });
+        payload["cross_repo"] = json!({
+            "status": "unavailable",
+            "code": "spine_root_stale",
+            "reason": "spine root mismatch for repository nk: live/session graph root b2 has \
+                       advanced past the registered spine root a1",
+        });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("cross_file_edges_absent"),
+            "the edge gap is the limiting factor and leads: {reason}"
+        );
+        let edge_position = reason.find("cross_file_edges_absent").unwrap();
+        let spine_position = reason.find("spine_root_stale").unwrap();
+        assert!(
+            edge_position < spine_position,
+            "a cross-repo note must follow the local limiting factor, not precede it: {reason}"
+        );
+    }
+
+    /// The spine reason survives where it IS the limiting factor: cross-file
+    /// coverage present, local graph healthy, and only the cross-repo watermark
+    /// stale. A fix that simply suppressed the spine gap would lose a real one.
+    #[test]
+    fn the_spine_reason_leads_when_the_spine_is_the_only_gap() {
+        let mut payload = authoritative_empty_references("function");
+        payload["cross_repo"] = json!({
+            "status": "unavailable",
+            "code": "spine_root_stale",
+            "reason": "spine root mismatch for repository nk: live/session graph root b2 has \
+                       advanced past the registered spine root a1",
+        });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("spine_root_stale"));
+    }
+
+    /// An unregistered repository is the ordinary single-repo state, and it must
+    /// not be reported as a mismatch of anything. The old wording made a healthy
+    /// local install look misconfigured.
+    #[test]
+    fn an_unregistered_repository_is_not_reported_as_a_root_mismatch() {
+        let mut payload = authoritative_empty_references("function");
+        payload["cross_repo"] = json!({
+            "status": "unavailable",
+            "code": "spine_repo_unregistered",
+            "reason": "repository nk has no registered spine root, so cross-repo authority \
+                       cannot answer for it",
+        });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.starts_with("spine_repo_unregistered"), "{reason}");
+        assert!(
+            !reason.contains("mismatch"),
+            "nothing mismatched: {reason}"
+        );
+    }
+
+    /// A reason with no computed code behind it keeps the catch-all label rather
+    /// than being promoted into a condition the producer never named.
+    #[test]
+    fn an_uncoded_cross_repo_reason_keeps_the_generic_label() {
+        let mut payload = authoritative_empty_references("function");
+        payload["cross_repo"] = json!({
+            "status": "unavailable",
+            "reason": "KIN_REPO_ID is empty",
+        });
+        let negative =
+            negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("cross_repo_unavailable: KIN_REPO_ID is empty"));
     }
 
     #[test]
@@ -1797,6 +2290,7 @@ mod tests {
                 "addressed_by": "name",
                 "same_name_candidates": 1,
             },
+            "edge_coverage": cross_file_edges_observed(),
         })
     }
 

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -210,9 +210,7 @@ fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<String> {
                     .iter()
                     .filter_map(Value::as_str)
                     .map(str::to_ascii_lowercase)
-                    .filter(|kind| {
-                        matches!(kind.as_str(), "calls" | "imports" | "references")
-                    })
+                    .filter(|kind| matches!(kind.as_str(), "calls" | "imports" | "references"))
                     .collect()
             })
             .unwrap_or_else(reference_classes),
@@ -290,15 +288,10 @@ fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
             .unwrap_or("unknown")
     };
 
-    if requested
-        .iter()
-        .any(|class| state_for(class) == "present")
-    {
+    if requested.iter().any(|class| state_for(class) == "present") {
         return None;
     }
-    if requested
-        .iter()
-        .any(|class| state_for(class) == "unknown")
+    if requested.iter().any(|class| state_for(class) == "unknown")
         || coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true)
     {
         return Some(format!(
@@ -1796,7 +1789,10 @@ mod tests {
             absence_cross_file_classes("bulk_check_references", &json!({})),
             all
         );
-        assert_eq!(absence_cross_file_classes("trace_data_flow", &json!({})), all);
+        assert_eq!(
+            absence_cross_file_classes("trace_data_flow", &json!({})),
+            all
+        );
         assert_eq!(
             absence_cross_file_classes("impact_analysis", &json!({})),
             all,
@@ -2066,10 +2062,7 @@ mod tests {
             negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
         let reason = negative["trust_reason"].as_str().unwrap();
         assert!(reason.starts_with("spine_repo_unregistered"), "{reason}");
-        assert!(
-            !reason.contains("mismatch"),
-            "nothing mismatched: {reason}"
-        );
+        assert!(!reason.contains("mismatch"), "nothing mismatched: {reason}");
     }
 
     /// A reason with no computed code behind it keeps the catch-all label rather

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -269,6 +269,7 @@ fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
     let language = coverage
         .get("language")
         .and_then(Value::as_str)
+        .filter(|language| !language.trim().is_empty())
         .unwrap_or("an unreported language");
     let states = coverage.get("classes").and_then(Value::as_object);
     let state_for = |class: &str| -> &str {
@@ -675,18 +676,42 @@ fn build_advice(
 }
 
 /// The consequence sentence for a retrieval tool that ran and came back empty.
+///
+/// The untrustworthy arms prescribe nothing specific, because the advice is
+/// finished by naming the gap that actually held (see
+/// [`absence_advice_consequence`]). They
+/// used to end with "re-check after embedding is complete", which is the wrong
+/// instruction for every structural gap: a missing cross-file call edge is not
+/// waiting on an embedding, and a reader who follows that advice re-runs the
+/// query unchanged and gets the identical unusable answer.
 fn absence_consequence(always: bool, trustworthy: bool) -> &'static str {
     match (always, trustworthy) {
         (true, true) => {
             "A `has_references: false` row here is an authoritative negative — safe to treat that entity as unreferenced."
         }
         (true, false) => {
-            "Do NOT treat a `has_references: false` row as proof of disuse: the index is not authoritative yet, so a false verdict may simply mean 'not indexed'. Re-check once trust is authoritative."
+            "Do NOT treat a `has_references: false` row as proof of disuse: a false verdict here may mean the batch could not observe what it was asked about."
         }
         (false, true) => "Absence is authoritative: safe to treat the target as genuinely absent/unused.",
         (false, false) => {
-            "Absence is NOT authoritative: do not conclude the target is unused or deletable — an empty result may mean 'not indexed'. Re-check after embedding is complete and the daemon is healthy."
+            "Absence is NOT authoritative: do not conclude the target is unused or deletable, because an empty result here may mean the query could not observe what it was asked about."
         }
+    }
+}
+
+/// The consequence an absence carries, with the limiting factor named when there
+/// is one.
+///
+/// A verdict and its cause belong in the same sentence a reader acts on. The
+/// isolated-install report quoted the advice line verbatim as the thing it
+/// believed, so an advice line that states the consequence and leaves the cause
+/// in a neighbouring field is one field away from being acted on blind.
+fn absence_advice_consequence(always: bool, trustworthy: bool, trust_reason: &str) -> String {
+    let consequence = absence_consequence(always, trustworthy);
+    if trustworthy {
+        consequence.to_string()
+    } else {
+        format!("{consequence} Limiting factor: {trust_reason}")
     }
 }
 
@@ -1078,9 +1103,9 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         "absent_as_indexed"
     };
     let consequence = if ranking_names_nothing {
-        unnamed_ranking_consequence()
+        unnamed_ranking_consequence().to_string()
     } else {
-        absence_consequence(spec.always, trustworthy)
+        absence_advice_consequence(spec.always, trustworthy, &trust_reason)
     };
 
     let degraded_signals = degraded_signals(payload, envelope);
@@ -1109,7 +1134,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         "advice".to_string(),
         json!(build_advice(
             subject,
-            consequence,
+            &consequence,
             envelope,
             &degraded_signals
         )),
@@ -1204,9 +1229,12 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
     }
 
     let consequence = if trustworthy {
-        "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name and not about the symbol's usage, because nothing was looked up."
+        "The name is authoritatively absent from this graph: no entity carries it. That is a fact about the name and not about the symbol's usage, because nothing was looked up.".to_string()
     } else {
-        "Absence is NOT authoritative: the name may simply not be indexed yet, so do not conclude the symbol does not exist. Re-check once the graph is complete and the daemon is healthy."
+        format!(
+            "Absence is NOT authoritative: the name may simply not be indexed yet, so do not \
+             conclude the symbol does not exist. Limiting factor: {trust_reason}"
+        )
     };
 
     // A miss carries no payload, so the daemon's own flags are the whole
@@ -1242,7 +1270,7 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
         "advice".to_string(),
         json!(build_advice(
             subject,
-            consequence,
+            &consequence,
             envelope,
             &degraded_signals
         )),
@@ -1608,10 +1636,19 @@ mod tests {
         );
         // The advice an agent acts on has to agree with the verdict, or the
         // envelope contradicts itself one field apart.
-        assert!(negative["advice"]
-            .as_str()
-            .unwrap()
-            .contains("NOT authoritative"));
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(advice.contains("NOT authoritative"));
+        // And it has to name the gap rather than prescribe an unrelated remedy.
+        // The old wording told the reader to re-check after embedding was
+        // complete, which no amount of embedding would ever satisfy here.
+        assert!(
+            advice.contains("Limiting factor: cross_file_edges_absent"),
+            "the advice names the gap it is about: {advice}"
+        );
+        assert!(
+            !advice.contains("after embedding is complete"),
+            "embedding completeness is not the remedy for a missing edge class: {advice}"
+        );
     }
 
     /// A payload that reports no observation at all is the unknown case. This is
@@ -1803,6 +1840,25 @@ mod tests {
             negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
         assert_eq!(negative["trust"], json!("authoritative"));
+    }
+
+    /// The one substrate reason the suite could not produce before: a daemon
+    /// that finished first reconciliation and reports no graph loaded. An
+    /// unreachable reason is indistinguishable from a wrong one, since nothing
+    /// shows it follows from the condition it names.
+    #[test]
+    fn find_references_on_an_unloaded_graph_names_the_load_gate() {
+        let env = Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": false,
+        }));
+        let payload = authoritative_empty_references("function");
+        let negative = negative_for("find_references", &payload, &env).unwrap();
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("graph_not_loaded"));
     }
 
     #[test]

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -100,6 +100,22 @@ pub struct SpineXrefResponse {
     pub authority_roots: BTreeMap<RepoId, String>,
 }
 
+/// How a spine response's watermark for one repository relates to the caller's
+/// live graph root.
+///
+/// The three cases are separate because they are separate facts about the
+/// deployment, and only one of them is a mismatch of anything: an unregistered
+/// repository is the ordinary state of a single-repo install.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorityRootState<'a> {
+    /// The registered root is exactly the caller's live graph root.
+    Matches,
+    /// The repository is registered at a root the live graph has advanced past.
+    Stale { registered: &'a str },
+    /// The spine holds no root for the repository at all.
+    Unregistered,
+}
+
 impl SpineXrefResponse {
     /// Construct an unwatermarked response.
     ///
@@ -197,10 +213,37 @@ impl SpineXrefResponse {
     /// Whether the response's primary-repo watermark is the exact graph root
     /// held by the caller. A complete spine rooted at an older live/session
     /// graph is stale authority, including for positive rows.
+    ///
+    /// True only for [`AuthorityRootState::Matches`]. A caller that reports WHY
+    /// the spine cannot answer must use [`Self::authority_root_state`] instead:
+    /// this boolean collapses "registered at an older root" and "never
+    /// registered" into one false, and a caller that then invents a message for
+    /// it describes a root mismatch on a repository that has no root to
+    /// mismatch.
     pub fn authority_root_matches(&self, repo_id: &str, expected_root: &str) -> bool {
-        self.authority_roots
-            .get(repo_id)
-            .is_some_and(|root| root == expected_root)
+        matches!(
+            self.authority_root_state(repo_id, expected_root),
+            AuthorityRootState::Matches
+        )
+    }
+
+    /// How the response's watermark for `repo_id` relates to the caller's live
+    /// graph root: the same root, an older one, or no registration at all.
+    ///
+    /// One implementation of the rule, because two callers (`find_references` on
+    /// the MCP surface and `kin xref` on the CLI) each report it to a user, and
+    /// two hand-rolled copies of a three-way distinction drift into disagreeing
+    /// about what a single-repo install is.
+    pub fn authority_root_state<'a>(
+        &'a self,
+        repo_id: &str,
+        expected_root: &str,
+    ) -> AuthorityRootState<'a> {
+        match self.authority_roots.get(repo_id) {
+            Some(root) if root == expected_root => AuthorityRootState::Matches,
+            Some(registered) => AuthorityRootState::Stale { registered },
+            None => AuthorityRootState::Unregistered,
+        }
     }
 
     /// Decode and version-check an xref response as one shared contract.
@@ -1072,6 +1115,47 @@ mod tests {
     use std::sync::{mpsc, Arc};
     use std::thread;
     use std::time::Duration;
+
+    /// The watermark rule separates three deployments that a boolean collapsed
+    /// into two: same root, older root, and no registration. The third is the
+    /// ordinary state of a single-repo install, and reporting it as a mismatch
+    /// described a misconfiguration that did not exist.
+    #[test]
+    fn the_watermark_rule_separates_a_stale_root_from_no_registration() {
+        let mut response = SpineXrefResponse::new(Vec::new(), Vec::new());
+        assert_eq!(
+            response.authority_root_state("nk", "live"),
+            AuthorityRootState::Unregistered
+        );
+        assert!(!response.authority_root_matches("nk", "live"));
+
+        response
+            .authority_roots
+            .insert("nk".to_string(), "older".to_string());
+        assert_eq!(
+            response.authority_root_state("nk", "live"),
+            AuthorityRootState::Stale {
+                registered: "older"
+            }
+        );
+        assert!(!response.authority_root_matches("nk", "live"));
+
+        response
+            .authority_roots
+            .insert("nk".to_string(), "live".to_string());
+        assert_eq!(
+            response.authority_root_state("nk", "live"),
+            AuthorityRootState::Matches
+        );
+        assert!(response.authority_root_matches("nk", "live"));
+
+        // And the state is per repository: another repo's registration answers
+        // nothing about this one.
+        assert_eq!(
+            response.authority_root_state("other", "live"),
+            AuthorityRootState::Unregistered
+        );
+    }
 
     fn test_fp() -> SemanticFingerprint {
         SemanticFingerprint {

--- a/crates/kin-spine/src/lib.rs
+++ b/crates/kin-spine/src/lib.rs
@@ -31,8 +31,8 @@ pub use firestore::FirestoreSpineBackend;
 #[cfg(feature = "firestore")]
 pub use firestore::FirestoreStore;
 pub use index::{
-    CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex, SpineXrefAuthorityAnchor,
-    SpineXrefDecodeError, SpineXrefResponse,
+    AuthorityRootState, CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex,
+    SpineXrefAuthorityAnchor, SpineXrefDecodeError, SpineXrefResponse,
 };
 pub use query::{classify_spine_probe, SpineProbe, SpineQuery};
 pub use routing::{RepoEndpoint, RoutingTable};


### PR DESCRIPTION
`find_references` returned zero references for a symbol a sibling file imported and called,
and stamped the answer `safe_to_conclude_absent: true`, `trust: authoritative`, reason
"daemon graph initialized and loaded with no degraded signals". An agent acting on that
answer deletes live code. The graph was healthy by every signal the envelope had. What it
did not hold was one cross-file `Calls` or `Imports` edge for the language, so no reference
from another file could ever have been found, and the authority computation had no way to
know that because it never asked.

Absence authority now depends on the edge classes a query actually reads.

`crates/kin-mcp/src/edge_coverage.rs` observes one fact per language: does the graph hold at
least one cross-file edge of each requested reference class? It is a witness search rather
than a census, because proving a class exists needs one example, so a healthy graph exits
after a handful of relation lookups. A graph that holds none pays a bounded scan and reports
`budget_exhausted`, so a scan cut short is published as `unknown` rather than as either
verdict. Scope is the focal's language, since extraction gaps are per-language and a store
that links Rust calls must not lend that coverage to a Python absence. The observation rides
the payload under `edge_coverage`, on an empty answer for the single-focal tools and always
for the batch tool, whose false rows are absences inside a populated response.

`negative::edge_coverage_gap` reads it and emits `cross_file_edges_absent`,
`edge_coverage_unknown`, or `edge_coverage_unreported`. Authority requires at least one
requested class observed present. Deliberately not every requested class: `references` edges
are legitimately rare, and demanding all three would report every absence on every real
graph as inconclusive, which is the opposite failure and just as useless. A test excludes
that lazy shape, and reverting the gate's escape hatch fails sixteen tests, nine of them
pre-existing ones that assert an absence can be trusted.

`negative::absence_cross_file_classes` is the per-tool dependency map, in code, with a
doc-comment table: `find_references` and `bulk_check_references` take the query's own
`relation_kinds`, `trace_data_flow` and `impact_analysis` take all three reference classes,
and `graph_neighborhood`, `semantic_locate`, `semantic_search`, `dead_code`,
`find_dead_code_seeded` and `entity_history` declare none, each with its reason.
`impact_analysis` has no absence spec today, and its entry is what stops one inheriting
authority if it gains one. A tool absent from the map contributes no classes, so a new
retrieval tool starts with nothing to inherit.

The second half of the ticket was the reason text. Every gap now goes through
`negative::push_gap`, which composes limiting-factor first instead of overwriting, so a
cross-repo note can follow the local factor but never stand in for it. The spine gap itself
was two conditions wearing one message: `daemon_spine_xref` reported `spine root mismatch`
both when the spine held a stale root for the repository and when it held no registration at
all. On a single-repo install the second is the ordinary state and nothing had mismatched.
The conditions are now `spine_repo_unregistered` and `spine_root_stale`, published as a
`code` beside the human reason and reported by that code, with the same split applied to the
`kin xref` CLI surface. Underneath, the staleness is real and worth naming:
`begin_graph_authority_mutation` invalidates the spine's cross-repo edges on every graph
mutation but never re-registers the new root, and the root is registered once behind a
`OnceLock`, so after the first commit the live root has moved past the registered one for
good.

The advice line got the same treatment. It used to end "Re-check after embedding is complete
and the daemon is healthy". No amount of embedding produces a missing cross-file call edge,
so a reader who followed that instruction got the identical unusable answer back. It now ends
by naming the gap that held, because the isolated-install report quoted that line verbatim as
the thing it believed.

Fixtures across kin-mcp and kin-daemon asserted authoritative absence on graphs holding no
cross-file edges whatsoever, most of them a single entity with no relations at all. The
graph-backed ones now seed a cross-file `Calls` witness and the shared payload helpers carry
an observation, which is what makes those assertions true rather than accidental.

`SpineXrefResponse::authority_root_state` is where the watermark rule now lives, so the MCP
and CLI surfaces share one copy of a three-way distinction instead of hand-rolling two.
`authority_root_matches` stays as a wrapper with a doc comment saying what it cannot tell you.

That staleness is filed as FIR-2374 rather than fixed here, since making the spine's
watermark follow graph truth is a decision about what a re-registration should cost.

FIR-2357, the partial-answer half, is NOT in this PR. Its plan is written against code in
`.kin-coord/reports/fir2353-envelope-20260817.md`: `negative_for` returns early on any
populated answer, `envelope::finalize` is where a `completeness` key belongs, and the two
`.then()` guards this PR added for cost come off when every answer needs the observation.

Closes FIR-2353
