### PR TITLE
Reuse the first Git source proof, draw admission progress on the phase line, and serve graph status from the daemon's cached authority

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1496,9 +1496,13 @@ mod tests {
         // separates the two halves here and asserting on it would pass whatever
         // the reconcile term did. What must differ is the reconcile warning
         // itself: absent on a healthy daemon, present on this one.
-        let healthy =
-            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let healthy = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
         assert!(
             !healthy
                 .lines
@@ -1681,9 +1685,13 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
-        let response =
-            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         // The entity-rooted total and the whole-table total count different
         // scopes, so neither line may carry a bare "Relations" label.
@@ -1879,9 +1887,13 @@ mod tests {
 
         // A store that has never finished a fill is in the same structural
         // state and says so, minus the marker clause it has not earned.
-        let first_fill =
-            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let first_fill = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
         let first_fill_line = first_fill
             .lines
             .iter()
@@ -2049,9 +2061,13 @@ mod tests {
             ))
             .unwrap();
 
-        let response =
-            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         assert!(response
             .lines
@@ -2981,9 +2997,13 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
 
         let validate = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
-        let status =
-            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let status = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         let validate_notes = note_lines(&validate);
         assert!(

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1743,9 +1743,13 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
-        let response =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         assert!(
             response
@@ -1780,9 +1784,13 @@ mod tests {
             .upsert_relation(&test_relation(RelationKind::Calls, caller.id, callee.id))
             .unwrap();
 
-        let response =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         assert!(
             response

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -10,7 +10,7 @@ use kin_model::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::graph_health::{inspect_graph, inspect_graph_with_pending_embeddings};
+use super::graph_health::{inspect_graph, inspect_graph_with_entities};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -216,8 +216,16 @@ fn print_graph_response(response: GraphCommandResponse) -> Result<()> {
 /// internally perfect and simply out of date, and every content check here
 /// passes on it. That is how `kin graph status` came to report no issues on a
 /// store the daemon had been failing to admit since Aug 6.
+///
+/// `authority` is how this command reaches durable repository state. It is a
+/// [`RequestRepositoryAuthority`](super::repository_authority::RequestRepositoryAuthority)
+/// rather than a binding because opening durable authority re-verifies every
+/// persisted body against its content address, and a long-lived server that has
+/// already opened at the publication this request reads should not pay for it
+/// again per request. `status` used to take a bare binding and so opened the
+/// whole store on every call, which is where most of its wall time went.
 pub fn execute_graph_command(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    authority: &super::repository_authority::RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     request: &GraphCommandRequest,
     reconcile: &crate::commands::resources::ReconcileHealth,
@@ -225,15 +233,13 @@ pub fn execute_graph_command(
 ) -> Result<GraphCommandResponse> {
     match request {
         GraphCommandRequest::Status => {
-            build_graph_status_response(binding, graph, reconcile, embedding_runtime)
+            build_graph_status_response(authority, graph, reconcile, embedding_runtime)
         }
-        GraphCommandRequest::Validate => build_graph_validate_response(binding, graph),
+        GraphCommandRequest::Validate => build_graph_validate_response(authority, graph),
         GraphCommandRequest::Inspect { name } => build_graph_inspect_response(graph, name),
-        GraphCommandRequest::Source { entity } => build_graph_source_response(
-            &super::repository_authority::RequestRepositoryAuthority::pinned(binding.clone()),
-            graph,
-            entity,
-        ),
+        GraphCommandRequest::Source { entity } => {
+            build_graph_source_response(authority, graph, entity)
+        }
     }
 }
 
@@ -333,7 +339,7 @@ fn cross_file_coverage(
 }
 
 fn build_graph_status_response(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    authority: &super::repository_authority::RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     reconcile: &crate::commands::resources::ReconcileHealth,
     embedding_runtime: &crate::commands::resources::EmbedRuntimeState,
@@ -345,9 +351,12 @@ fn build_graph_status_response(
     // (the v0.5.21 battery caught 1 of 12 paired readings disagreeing by 512).
     let embed_status = graph.embedding_status();
     let coverage_is_measured = embedding_coverage_is_measured(graph) || embed_status.total == 0;
-    let health = inspect_graph_with_pending_embeddings(binding, graph, Some(embed_status.pending))?;
-
+    // One listing for this whole response. It feeds both the counters below and
+    // the health report, which used to take its own and clone every entity in
+    // the graph a second time.
     let entities = graph.list_all_entities()?;
+    let health =
+        inspect_graph_with_entities(authority, graph, &entities, Some(embed_status.pending))?;
 
     // An external reference target is a node this repository references without
     // owning: no file, no span, no signature, and a uniform kind. Counting it
@@ -671,10 +680,10 @@ fn append_health_notes(lines: &mut Vec<String>, notes: &[String]) {
 }
 
 fn build_graph_validate_response(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    authority: &super::repository_authority::RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
 ) -> Result<GraphCommandResponse> {
-    let health = inspect_graph(binding, graph)?;
+    let health = inspect_graph(authority, graph)?;
 
     // Validation needs the complete relation table, including corrupt edges
     // whose source and destination are both absent. Entity-rooted traversal
@@ -1284,6 +1293,14 @@ mod tests {
     };
     use std::fs;
 
+    /// The one-shot authority arm, which is what a test with no server around
+    /// it has. The shared arm is exercised where a daemon supplies it.
+    fn pinned(
+        binding: &kin_core::LocalRepositoryAuthorityBinding,
+    ) -> super::super::repository_authority::RequestRepositoryAuthority {
+        super::super::repository_authority::RequestRepositoryAuthority::pinned(binding.clone())
+    }
+
     mod freshness {
         use super::super::append_freshness_line;
         use chrono::TimeZone;
@@ -1480,7 +1497,7 @@ mod tests {
         // the reconcile term did. What must differ is the reconcile warning
         // itself: absent on a healthy daemon, present on this one.
         let healthy =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
                 .unwrap();
         assert!(
             !healthy
@@ -1492,7 +1509,7 @@ mod tests {
         );
 
         let degraded = build_graph_status_response(
-            &binding,
+            &pinned(&binding),
             &graph,
             &crate::commands::resources::ReconcileHealth {
                 admission_failure_streak: 412,
@@ -1542,7 +1559,7 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
 
         let response = build_graph_status_response(
-            &binding,
+            &pinned(&binding),
             &graph,
             &crate::commands::resources::ReconcileHealth {
                 untracked_path_count: 1,
@@ -1583,7 +1600,7 @@ mod tests {
         graph.upsert_entity(&entity).unwrap();
 
         let response = build_graph_status_response(
-            &binding,
+            &pinned(&binding),
             &graph,
             &crate::commands::resources::ReconcileHealth {
                 skipped_events: 7,
@@ -1665,7 +1682,7 @@ mod tests {
             .unwrap();
 
         let response =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
                 .unwrap();
 
         // The entity-rooted total and the whole-table total count different
@@ -1809,7 +1826,7 @@ mod tests {
         // no sidecar was on disk at open, while the persisted marker says this
         // store finished a fill once.
         let no_sidecar = build_graph_status_response(
-            &binding,
+            &pinned(&binding),
             &graph,
             &Default::default(),
             &crate::commands::resources::EmbedRuntimeState {
@@ -1863,7 +1880,7 @@ mod tests {
         // A store that has never finished a fill is in the same structural
         // state and says so, minus the marker clause it has not earned.
         let first_fill =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
                 .unwrap();
         let first_fill_line = first_fill
             .lines
@@ -1895,7 +1912,7 @@ mod tests {
             .unwrap();
 
         let remote = build_graph_status_response(
-            &binding,
+            &pinned(&binding),
             &graph,
             &Default::default(),
             &crate::commands::resources::EmbedRuntimeState {
@@ -1943,7 +1960,7 @@ mod tests {
         let status = graph.embedding_status();
 
         let discarded = build_graph_status_response(
-            &binding,
+            &pinned(&binding),
             &graph,
             &Default::default(),
             &crate::commands::resources::EmbedRuntimeState {
@@ -1989,7 +2006,7 @@ mod tests {
         // with nothing pending renders the plain measured line.
         let (_temp2, binding2, empty_graph) = graph_validation_fixture();
         let recovered = build_graph_status_response(
-            &binding2,
+            &pinned(&binding2),
             &empty_graph,
             &Default::default(),
             &crate::commands::resources::EmbedRuntimeState {
@@ -2033,7 +2050,7 @@ mod tests {
             .unwrap();
 
         let response =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
                 .unwrap();
 
         assert!(response
@@ -2061,7 +2078,7 @@ mod tests {
         graph.upsert_entity(&caller).unwrap();
         graph.upsert_relation(&relation).unwrap();
 
-        let response = build_graph_validate_response(&binding, &graph).unwrap();
+        let response = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
 
         assert!(response.error.is_none(), "{:?}", response.lines);
         assert!(response
@@ -2083,7 +2100,7 @@ mod tests {
             ))
             .unwrap();
 
-        let response = build_graph_validate_response(&binding, &graph).unwrap();
+        let response = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
 
         assert!(response.error.is_some(), "{:?}", response.lines);
         assert!(response
@@ -2103,7 +2120,7 @@ mod tests {
             ))
             .unwrap();
 
-        let response = build_graph_validate_response(&binding, &graph).unwrap();
+        let response = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
 
         assert!(response.error.is_some(), "{:?}", response.lines);
         assert!(response
@@ -2122,7 +2139,7 @@ mod tests {
         let (_caller, relation) = external_placeholder_relation(RelationKind::References);
         graph.upsert_relation(&relation).unwrap();
 
-        let response = build_graph_validate_response(&binding, &graph).unwrap();
+        let response = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
 
         assert!(response.error.is_some(), "{:?}", response.lines);
         assert!(response
@@ -2881,7 +2898,7 @@ mod tests {
         entity.file_origin = Some(FilePathId::new("src/present.rs"));
         graph.upsert_entity(&entity).unwrap();
 
-        let response = build_graph_validate_response(&binding, &graph).unwrap();
+        let response = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
 
         let line = orphan_line(&response).expect("graph tree lacks the file, so it is orphaned");
         assert!(line.contains('1'), "{line}");
@@ -2931,7 +2948,7 @@ mod tests {
             .upsert_entity(&external_target_entity("info", 0x22))
             .unwrap();
 
-        let distinct = build_graph_validate_response(&binding, &graph).unwrap();
+        let distinct = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
         assert!(
             duplicate_line(&distinct).is_none(),
             "distinct import sources are distinct entities: {}",
@@ -2944,7 +2961,7 @@ mod tests {
             .upsert_entity(&external_target_entity("info", 0x22))
             .unwrap();
 
-        let duplicated = build_graph_validate_response(&binding, &graph).unwrap();
+        let duplicated = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
         let line = duplicate_line(&duplicated)
             .expect("two entities claiming one external target is a duplicate");
         assert!(line.contains('1'), "{line}");
@@ -2963,9 +2980,9 @@ mod tests {
         entity.file_origin = Some(FilePathId::new("src/tracked.rs"));
         graph.upsert_entity(&entity).unwrap();
 
-        let validate = build_graph_validate_response(&binding, &graph).unwrap();
+        let validate = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
         let status =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+            build_graph_status_response(&pinned(&binding), &graph, &Default::default(), &Default::default())
                 .unwrap();
 
         let validate_notes = note_lines(&validate);
@@ -3002,7 +3019,7 @@ mod tests {
         entity.file_origin = Some(FilePathId::new("src/tracked.rs"));
         graph.upsert_entity(&entity).unwrap();
 
-        let response = build_graph_validate_response(&binding, &graph).unwrap();
+        let response = build_graph_validate_response(&pinned(&binding), &graph).unwrap();
 
         assert!(
             orphan_line(&response).is_none(),

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use super::repository_authority::ActiveRepositoryAuthority;
+use super::repository_authority::RequestRepositoryAuthority;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RepositoryArtifactCoverage {
@@ -98,10 +98,10 @@ struct ContaminationSummary {
 }
 
 pub(crate) fn inspect_graph(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    authority: &RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
 ) -> Result<GraphHealthReport> {
-    inspect_graph_with_pending_embeddings(binding, graph, None)
+    inspect_graph_with_pending_embeddings(authority, graph, None)
 }
 
 /// Build the report against a pending count the caller already sampled.
@@ -116,14 +116,33 @@ pub(crate) fn inspect_graph(
 /// both takes one sample and hands it here so the two cannot disagree. Callers
 /// that render no counter pass `None` and keep the report's own sample.
 pub(crate) fn inspect_graph_with_pending_embeddings(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    authority: &RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
     pending_embeddings: Option<usize>,
 ) -> Result<GraphHealthReport> {
+    let entities = graph.list_all_entities()?;
+    inspect_graph_with_entities(authority, graph, &entities, pending_embeddings)
+}
+
+/// Build the report against an entity listing the caller already took.
+///
+/// `list_all_entities` clones every entity in the graph out from under a lock,
+/// and a `graph status` response needs the same listing the report does. Taking
+/// it once and passing it here is what keeps one response from cloning the
+/// whole entity table three times: once for the renderer's counters, once for
+/// this report, and once more inside contamination collection.
+pub(crate) fn inspect_graph_with_entities(
+    authority: &RequestRepositoryAuthority,
+    graph: &kin_db::InMemoryGraph,
+    entities: &[kin_model::Entity],
+    pending_embeddings: Option<usize>,
+) -> Result<GraphHealthReport> {
     let stats = graph.graph_stats();
-    let supported_inputs = collect_supported_inputs(graph);
-    let contamination = collect_contamination(graph)?;
-    let artifact_coverage = collect_repository_artifact_coverage(binding, graph)?;
+    // One resolved-tree clone for the whole report, for the same reason.
+    let resolved_tree = graph.resolved_tree();
+    let supported_inputs = collect_supported_inputs(&resolved_tree);
+    let contamination = collect_contamination(graph, entities)?;
+    let artifact_coverage = collect_repository_artifact_coverage(authority, graph, &resolved_tree)?;
     Ok(build_graph_health_report(
         &stats,
         &supported_inputs,
@@ -147,14 +166,22 @@ struct EnrichmentFacets {
     structured: Vec<(ArtifactKind, Hash256)>,
 }
 
+/// Coverage against the authority this request reads at.
+///
+/// Takes the request's authority rather than its binding because
+/// [`ActiveRepositoryAuthority::open`] re-verifies every persisted body against
+/// its content address, so it costs whatever the whole store is worth. A server
+/// that has already paid for one open at the publication this request reads
+/// hands it over here; a one-shot caller still opens for itself.
 fn collect_repository_artifact_coverage(
-    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    authority: &RequestRepositoryAuthority,
     graph: &kin_db::InMemoryGraph,
+    graph_tree: &ResolvedTree,
 ) -> Result<RepositoryArtifactCoverage> {
-    let authority = ActiveRepositoryAuthority::open(binding)?;
+    let authority = authority.open()?;
     let workspace = authority.workspace()?;
     workspace.validate()?;
-    collect_repository_artifact_coverage_for_tree(&workspace.tree, graph, &|hash| {
+    collect_repository_artifact_coverage_for_tree(&workspace.tree, graph, graph_tree, &|hash| {
         authority.load_source_blob(hash)
     })
 }
@@ -181,14 +208,14 @@ fn structured_facet_disagrees(
 fn collect_repository_artifact_coverage_for_tree(
     authority_tree: &ResolvedTree,
     graph: &kin_db::InMemoryGraph,
+    graph_tree: &ResolvedTree,
     read_body: &dyn Fn(Hash256) -> Result<Vec<u8>>,
 ) -> Result<RepositoryArtifactCoverage> {
-    let graph_tree = graph.resolved_tree();
-    let repository_tree_in_sync = graph_tree == *authority_tree;
+    let repository_tree_in_sync = *graph_tree == *authority_tree;
 
     let mut issue_paths = BTreeSet::new();
     if !repository_tree_in_sync {
-        collect_tree_divergence_paths(authority_tree, &graph_tree, &mut issue_paths);
+        collect_tree_divergence_paths(authority_tree, graph_tree, &mut issue_paths);
     }
 
     let mut facets = BTreeMap::<String, EnrichmentFacets>::new();
@@ -327,11 +354,11 @@ fn collect_tree_divergence_paths(
     }
 }
 
-fn collect_supported_inputs(graph: &kin_db::InMemoryGraph) -> SupportedInputCounts {
+fn collect_supported_inputs(resolved_tree: &ResolvedTree) -> SupportedInputCounts {
     let mut entity_source = 0usize;
     let mut shallow_source = 0usize;
 
-    for artifact in graph.resolved_tree().artifacts_by_path() {
+    for artifact in resolved_tree.artifacts_by_path() {
         if !matches!(artifact.entry, TreeEntry::Blob { .. }) {
             continue;
         }
@@ -356,16 +383,19 @@ fn collect_supported_inputs(graph: &kin_db::InMemoryGraph) -> SupportedInputCoun
     }
 }
 
-fn collect_contamination(graph: &kin_db::InMemoryGraph) -> Result<ContaminationSummary> {
+fn collect_contamination(
+    graph: &kin_db::InMemoryGraph,
+    entities: &[kin_model::Entity],
+) -> Result<ContaminationSummary> {
     let mut path_set = BTreeSet::new();
     let mut contaminated_entity_count = 0usize;
     let mut contaminated_non_entity_count = 0usize;
 
-    for entity in graph.list_all_entities()? {
-        if let Some(file_origin) = entity.file_origin {
+    for entity in entities {
+        if let Some(file_origin) = &entity.file_origin {
             if !kin_index::should_index_repo_relative_path(Path::new(&file_origin.0)) {
                 contaminated_entity_count += 1;
-                path_set.insert(file_origin.0);
+                path_set.insert(file_origin.0.clone());
             }
         }
     }
@@ -1002,9 +1032,11 @@ mod tests {
             })
             .unwrap();
 
+        let graph_tree = graph.resolved_tree();
         let coverage = collect_repository_artifact_coverage_for_tree(
             &tree,
             &graph,
+            &graph_tree,
             &staged_bodies([(compose_hash, compose_body)]),
         )
         .unwrap();
@@ -1082,7 +1114,13 @@ mod tests {
             .unwrap();
 
         let coverage =
-            collect_repository_artifact_coverage_for_tree(&tree, &graph, &no_bodies()).unwrap();
+            collect_repository_artifact_coverage_for_tree(
+                &tree,
+                &graph,
+                &graph.resolved_tree(),
+                &no_bodies(),
+            )
+            .unwrap();
 
         assert!(!coverage.complete);
         assert_eq!(coverage.conflicting_enrichment_path_count, 1);
@@ -1160,7 +1198,12 @@ mod tests {
         )])
         .unwrap();
         let coverage =
-            collect_repository_artifact_coverage_for_tree(&authority_tree, &graph, &no_bodies())
+            collect_repository_artifact_coverage_for_tree(
+                &authority_tree,
+                &graph,
+                &graph.resolved_tree(),
+                &no_bodies(),
+            )
                 .unwrap();
         assert_eq!(coverage.missing_enrichment_path_count, 1);
         assert_eq!(coverage.content_mismatch_path_count, 0);
@@ -1202,7 +1245,12 @@ mod tests {
                 text_preview: None,
             })
             .unwrap();
-        collect_repository_artifact_coverage_for_tree(&tree, &graph, &staged_bodies([(hash, body)]))
+        collect_repository_artifact_coverage_for_tree(
+            &tree,
+            &graph,
+            &graph.resolved_tree(),
+            &staged_bodies([(hash, body)]),
+        )
             .unwrap()
     }
 

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -1113,14 +1113,13 @@ mod tests {
             })
             .unwrap();
 
-        let coverage =
-            collect_repository_artifact_coverage_for_tree(
-                &tree,
-                &graph,
-                &graph.resolved_tree(),
-                &no_bodies(),
-            )
-            .unwrap();
+        let coverage = collect_repository_artifact_coverage_for_tree(
+            &tree,
+            &graph,
+            &graph.resolved_tree(),
+            &no_bodies(),
+        )
+        .unwrap();
 
         assert!(!coverage.complete);
         assert_eq!(coverage.conflicting_enrichment_path_count, 1);
@@ -1197,14 +1196,13 @@ mod tests {
             TreeEntry::blob(new_hash, false),
         )])
         .unwrap();
-        let coverage =
-            collect_repository_artifact_coverage_for_tree(
-                &authority_tree,
-                &graph,
-                &graph.resolved_tree(),
-                &no_bodies(),
-            )
-                .unwrap();
+        let coverage = collect_repository_artifact_coverage_for_tree(
+            &authority_tree,
+            &graph,
+            &graph.resolved_tree(),
+            &no_bodies(),
+        )
+        .unwrap();
         assert_eq!(coverage.missing_enrichment_path_count, 1);
         assert_eq!(coverage.content_mismatch_path_count, 0);
         assert_eq!(coverage.stale_enrichment_path_count, 0);
@@ -1251,7 +1249,7 @@ mod tests {
             &graph.resolved_tree(),
             &staged_bodies([(hash, body)]),
         )
-            .unwrap()
+        .unwrap()
     }
 
     /// An admitted workflow file whose facet is exactly what its extractor

--- a/crates/kin-cli/src/commands/support.rs
+++ b/crates/kin-cli/src/commands/support.rs
@@ -81,7 +81,10 @@ pub fn inspect_support_graph(
     binding: &kin_core::LocalRepositoryAuthorityBinding,
     graph: &kin_db::InMemoryGraph,
 ) -> Result<SupportJson> {
-    let health = super::graph_health::inspect_graph(binding, graph)?;
+    let health = super::graph_health::inspect_graph(
+        &super::repository_authority::RequestRepositoryAuthority::pinned(binding.clone()),
+        graph,
+    )?;
     let stats = graph.graph_stats();
     Ok(SupportJson::from_parts(&stats, health))
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -8,9 +8,9 @@ use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{self, Shell};
 use kin_cli::commands;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use tracing::Instrument;
-use std::io::IsTerminal;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
@@ -3580,7 +3580,11 @@ impl tracing::field::Visit for AdmissionProgressFields {
 }
 
 impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for AdmissionProgressLayer {
-    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
         if !is_periodic_admission_progress(event.metadata().target()) {
             return;
         }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -10,6 +10,7 @@ use clap_complete::{self, Shell};
 use kin_cli::commands;
 use std::path::PathBuf;
 use tracing::Instrument;
+use std::io::IsTerminal;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
@@ -2328,7 +2329,18 @@ fn main() -> Result<()> {
     } else {
         tracing_subscriber::registry()
             .with(default_env_filter(&command_name))
-            .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+            .with(AdmissionProgressLayer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::io::stderr)
+                    // The fmt layer does not sniff for a terminal, so without
+                    // this it writes colour escapes into a redirected log or a
+                    // captured transcript.
+                    .with_ansi(std::io::stderr().is_terminal())
+                    .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
+                        !is_periodic_admission_progress(metadata.target())
+                    })),
+            )
             .init();
     }
 
@@ -3513,6 +3525,81 @@ fn env_flag(name: &str) -> bool {
 /// killed after 11h43m of silence that turned out to be ordinary progress.
 const PROGRESS_REPORTING_COMMANDS: [&str; 2] = ["init", "clone"];
 
+/// Targets whose events are progress within an admission phase, not outcomes.
+///
+/// These report the same work the phase ladder is already drawing a line for,
+/// repeatedly, while that line is on screen. Formatting them as log records put
+/// ANSI escapes and the internal span path they were emitted under straight
+/// through a redrawn progress display, so [`AdmissionProgressLayer`] takes them
+/// and the fmt layer is filtered to leave them alone.
+fn is_periodic_admission_progress(target: &str) -> bool {
+    target == "kin_db::storage::history_replay"
+}
+
+/// Render an admission progress event onto the live phase line.
+///
+/// The event's own message is not reused. `history_replay` reports elapsed
+/// whole seconds, so its terminal line reads "validated 6,413 changes in 0s"
+/// for any replay under a second and says nothing useful about a replay that
+/// took two minutes. The phase line already carries its own elapsed time, so
+/// what is wanted from the event is how far along it is, which is what its
+/// `validated` and `total` fields carry.
+///
+/// With no ladder open the line is printed plainly instead of dropped, so
+/// running an admission phase's instrumentation outside the ladder still says
+/// something, just without escapes or span paths.
+struct AdmissionProgressLayer;
+
+#[derive(Default)]
+struct AdmissionProgressFields {
+    message: Option<String>,
+    validated: Option<u64>,
+    total: Option<u64>,
+}
+
+impl tracing::field::Visit for AdmissionProgressFields {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        match field.name() {
+            "validated" => self.validated = Some(value),
+            "total" => self.total = Some(value),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for AdmissionProgressLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        if !is_periodic_admission_progress(event.metadata().target()) {
+            return;
+        }
+        let mut fields = AdmissionProgressFields::default();
+        event.record(&mut fields);
+        let detail = match (fields.validated, fields.total) {
+            (Some(validated), Some(total)) => format!("{validated}/{total} changes validated"),
+            (Some(validated), None) => format!("{validated} changes validated"),
+            _ => match fields.message {
+                Some(message) => message,
+                None => return,
+            },
+        };
+        if !kin_core::report_admission_progress(&detail) {
+            eprintln!("  {detail}");
+        }
+    }
+}
+
 /// Admission targets raised to `info` for [`PROGRESS_REPORTING_COMMANDS`].
 ///
 /// Deliberately target-scoped rather than crate-wide. `kin_core=info` would also
@@ -3529,15 +3616,17 @@ const PROGRESS_REPORTING_COMMANDS: [&str; 2] = ["init", "clone"];
 ///   admission surfaces its own outcome and so no further `kin-cli` change is
 ///   needed later.
 /// - `kin_db::storage::history_replay` is the only periodic emitter, throttled
-///   at its source. It does not exist in the KinDB this workspace currently
-///   pins, and a directive naming an absent target simply never matches, so it
-///   is pre-wired and inert.
+///   at its source. It is **live**, and has been since this workspace's KinDB
+///   pin moved: the module ships in the pinned version, so the directive that
+///   was written as pre-wired and inert now matches. That is how raw log
+///   records first appeared inside the phase ladder's display, and it is why
+///   [`AdmissionProgressLayer`] exists rather than the fmt layer rendering
+///   them. Anything added to this list that emits mid-flight rather than
+///   terminally needs the same treatment, or it will scribble over the ladder
+///   the same way.
 ///
-/// So a long admission does **not** report mid-flight progress at this version.
-/// It begins the moment this workspace consumes a KinDB shipping
-/// `storage::history_replay`, with no change here. Anyone diagnosing an
-/// apparently stalled `kin init` before then should not read silence as
-/// evidence that the instrumentation ran.
+/// So a long admission does report mid-flight progress, on the phase line
+/// itself rather than as separate records.
 ///
 /// `kin_db::storage::snapshot` is deliberately not here, despite carrying three
 /// live conditional `info!` sites. All three sit on `SnapshotManager` reopen and
@@ -3800,18 +3889,62 @@ mod tests {
                 )),
                 "kin {command} must admit Git admission output"
             );
-            // Pre-wired rather than live: no module of this name exists in the
-            // KinDB this workspace pins, so nothing emits on it yet. Probing it
-            // proves the directive carries such events the moment one does,
-            // which is the only thing pre-wiring can be held to.
+            // Live, not pre-wired: the module ships in the pinned KinDB and
+            // emits during the commit phase. It has to survive the filter to
+            // reach `AdmissionProgressLayer`, which is what draws it onto the
+            // phase line instead of letting the fmt layer print it.
             assert!(
                 survives(installed_filter(command), || tracing::info!(
                     target: "kin_db::storage::history_replay",
                     "probe"
                 )),
-                "kin {command} must already admit the pre-wired replay target"
+                "kin {command} must admit the replay progress target"
             );
         }
+    }
+
+    /// The periodic replay target reaches the progress layer and not the fmt
+    /// layer, and every other admission target keeps printing as a record.
+    ///
+    /// Both halves matter and they fail differently. If the replay target were
+    /// not excluded from fmt it would print raw, with ANSI and the internal
+    /// span path, over the redrawn phase line, which is the defect. If the
+    /// exclusion were written broadly enough to catch `kin_core::git_init` it
+    /// would swallow the admission receipt, and the command would finish
+    /// saying nothing about what it admitted.
+    #[test]
+    fn only_the_periodic_replay_target_is_taken_off_the_record_layer() {
+        assert!(is_periodic_admission_progress(
+            "kin_db::storage::history_replay"
+        ));
+        for printed in [
+            "kin_core::init",
+            "kin_core::git_init",
+            "kin_db::storage::snapshot",
+            "kin_db::storage::repository",
+            "kin_cli",
+        ] {
+            assert!(
+                !is_periodic_admission_progress(printed),
+                "{printed} must keep printing as a record"
+            );
+        }
+    }
+
+    /// With no admission ladder open, a progress event is printed rather than
+    /// dropped.
+    ///
+    /// The sink reports whether a live phase took the line, and that return is
+    /// the only thing standing between "routed onto the phase line" and
+    /// "silently discarded". A sink that always answered true would make an
+    /// admission's instrumentation vanish outside the ladder, and nothing about
+    /// the display would look wrong while it did.
+    #[test]
+    fn a_progress_report_with_no_ladder_open_is_not_swallowed() {
+        assert!(
+            !kin_core::report_admission_progress("4096/6413 changes validated"),
+            "no ladder is open in a unit test, so the sink must decline the line"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -204,7 +204,9 @@ fn graph_status(
     graph: &kin_db::InMemoryGraph,
 ) -> kin_cli::commands::graph::GraphCommandResponse {
     execute_graph_command(
-        binding,
+        &kin_cli::commands::repository_authority::RequestRepositoryAuthority::pinned(
+            binding.clone(),
+        ),
         graph,
         &GraphCommandRequest::Status,
         &Default::default(),
@@ -266,7 +268,9 @@ fn graph_validate(
     graph: &kin_db::InMemoryGraph,
 ) -> kin_cli::commands::graph::GraphCommandResponse {
     execute_graph_command(
-        binding,
+        &kin_cli::commands::repository_authority::RequestRepositoryAuthority::pinned(
+            binding.clone(),
+        ),
         graph,
         &GraphCommandRequest::Validate,
         &Default::default(),

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -16,9 +16,10 @@ use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
     check_git_admission_blockers, plan_semantic_git_import, preflight_git_migration,
-    preflight_git_migration_after_publication, seal_all_content_observation_observed,
-    AdmittedContentClosure, GitLocalIgnoreSourceKind, GitMigrationPreflightProof,
-    LosslessGitRepository, SealedContentObservation, SealedContentSource,
+    reprove_git_migration, reprove_git_migration_after_publication,
+    seal_all_content_observation_observed, AdmittedContentClosure, GitLocalIgnoreSourceKind,
+    GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
+    SealedContentSource,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
@@ -275,6 +276,17 @@ fn init_from_git_with_hooks(
         })?
     };
 
+    // PROOF 1 of 3. Guards: the mutable Git boundary this admission is about to
+    // build a repository from is exactly the committed state the capture was
+    // taken from, and the import plan is a deterministic function of those raw
+    // objects rather than something enriched beyond them.
+    //
+    // It is first because everything after it consumes it: the remote mapping
+    // becomes the repository's Git config, the ignored-local inputs are copied
+    // as authority, the workspace binding is sealed from it, and the divergence
+    // it observed is what init reports to the operator. It is also the only one
+    // of the three that revalidates the plan structurally, which is what the
+    // other two reuse rather than repeat.
     progress.begin("prove Git source");
     let source_proof = {
         let _span = info_span!("kin.init.source_proof_staged").entered();
@@ -364,43 +376,60 @@ fn init_from_git_with_hooks(
 
     let mut result = publish_repository_layout_linearized(prepared, |publication| {
         before_final_source_proof();
+        // PROOF 2 of 3. Guards: nothing moved the source during the minutes
+        // between proof 1 and this instant. Everything expensive in the ladder
+        // sits in that window, so it is the window a source can actually drift
+        // in, and this is the last point at which drift can still be prevented
+        // rather than merely reported: the rename below is the linearization
+        // point, and a refusal here leaves `.kin` absent.
+        //
+        // Distinct from proof 1 by WHEN it runs, not by what it looks at, which
+        // is why it observes once against proof 1 rather than twice against
+        // itself.
         progress.begin("re-prove Git source");
-        let final_proof = {
+        {
             let _span = info_span!("kin.init.source_proof_final").entered();
-            preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
-                .map_err(|error| git_boundary_error("repeat final Git source proof", error))?
+            reprove_git_migration(
+                &source,
+                &source_proof,
+                &snapshot,
+                &semantic_plan,
+                &capture_store,
+            )
+            .map_err(|error| git_boundary_error("repeat final Git source proof", error))?
         };
-        if final_proof != source_proof {
-            return Err(KinError::Other(
-                "Git source proof changed before repository publication; retry from a fresh capture"
-                    .to_string(),
-            ));
-        }
         progress.begin("publish repository");
         let published = {
             let _span = info_span!("kin.init.publish_repository").entered();
             publication.publish()?
         };
         after_repository_publication();
+        // PROOF 3 of 3. Guards: publication put `.kin` in the worktree and did
+        // nothing else to it. Proof 2 cannot cover this, because it necessarily
+        // ran before the rename; this is the only proof taken on a source that
+        // Kin has written into, and the only one that has to be told which
+        // directory is legitimately new.
+        //
+        // Its power is different from proof 2's rather than additional. Past
+        // the linearization point a refusal cannot unpublish, so this detects
+        // and reports as `RepositoryPublishedButUncertain` where proof 2
+        // prevents. That is what makes it worth keeping and what bounds it:
+        // publication is one no-replace rename, so an honest re-proof here
+        // needs one observation measured against proof 1, not a fresh
+        // self-contained double proof.
         progress.begin("prove Git source after publication");
-        let published_proof = {
+        {
             let _span = info_span!("kin.init.source_proof_published").entered();
-            preflight_git_migration_after_publication(
+            reprove_git_migration_after_publication(
                 &source,
                 published.path(),
+                &source_proof,
                 &snapshot,
                 &semantic_plan,
                 &capture_store,
             )
             .map_err(|error| git_boundary_error("prove Git source after publication", error))?
         };
-        if published_proof != source_proof {
-            return Err(KinError::Other(
-                "Git source proof changed across repository publication; published authority is \
-                 not safe to use without recovery"
-                    .to_string(),
-            ));
-        }
         // Re-seal the published repository, deriving the closure from the exact
         // import plan rather than its admitted form. Requiring both derivations
         // to fingerprint identically proves publication preserved graph-owned

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -332,6 +332,7 @@ impl PreparedRepositoryInit {
             }
             slot @ None => {
                 {
+                    crate::report_admission_progress("validating transaction");
                     let _span = info_span!("kin.init.commit.validate_bootstrap").entered();
                     validate_bootstrap_transaction(
                         &transaction,
@@ -1438,7 +1439,17 @@ where
             Some(RefTarget::Change { change_id }) => Some(change_id),
             _ => None,
         });
+    // Coarse ticks across the four sub-steps of the commit, because this is
+    // the longest phase in the ladder and none of it is reachable from the
+    // phase reporter: `commit_repository_transaction` takes no progress
+    // callback, so between entering this phase and leaving it the line would
+    // otherwise sit unchanged for minutes, which reads as a hang. What kin-db
+    // reports from inside its own replay arrives through the same sink.
     let receipt = {
+        crate::report_admission_progress(&format!(
+            "committing {} changes to authority",
+            transaction.changes.len()
+        ));
         let _span = info_span!(
             "kin.init.commit.authority_commit",
             external_objects = transaction.external_objects.len(),
@@ -1450,6 +1461,7 @@ where
             .map_err(graph_error)?
     };
     let workspace = {
+        crate::report_admission_progress("binding workspace to committed roots");
         let _span = info_span!("kin.init.commit.workspace_binding").entered();
         authority
             .workspace_snapshot_binding(repository_id, &workspace_id)
@@ -1469,6 +1481,7 @@ where
         .validate()
         .map_err(|error| KinError::Other(error.to_string()))?;
     let semantic_enrichment = {
+        crate::report_admission_progress("summarizing semantic enrichment");
         let _span = info_span!("kin.init.commit.enrichment_summary").entered();
         let lease = authority.read_authority();
         if lease.roots() != &receipt.roots_after {

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -16,6 +16,7 @@
 
 use std::fmt::Arguments;
 use std::io::{IsTerminal, Write};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 /// Number of phases in the exact Git admission ladder. A ladder that completes
@@ -27,8 +28,50 @@ pub(crate) const GIT_ADMISSION_PHASES: usize = 17;
 /// terminal, so a redirected log never receives escape bytes.
 const ERASE_LINE: &str = "\x1b[2K\r";
 
+/// The ladder a long phase's own instrumentation should report into.
+///
+/// A phase that spends minutes inside one call into another crate cannot tick
+/// this ladder itself, because the call takes no progress handle and the crate
+/// below has no way to reach one. What it does have is `tracing`, and the
+/// admission commands already raise the emitting targets to `info` so the work
+/// says something while it runs. Before this, that something was a raw log
+/// record written straight over the redrawn phase line, complete with ANSI and
+/// the internal span path it was emitted under.
+///
+/// So the ladder registers itself here for its lifetime and a subscriber layer
+/// hands those events to [`report_admission_progress`] instead of formatting
+/// them. The phase line advances, and nothing internal reaches the user.
+static ACTIVE_LADDER: Mutex<Option<Arc<Mutex<Ladder>>>> = Mutex::new(None);
+
+/// Report progress within whatever admission phase is currently open.
+///
+/// Returns whether a ladder was live to take it, so a caller with no ladder to
+/// report into can print the line itself rather than dropping it.
+///
+/// Never blocks on the ladder's own writes: the lock is held only for the
+/// redraw, and the emitting thread is by construction not the one inside a
+/// [`PhaseProgress`] method, because none of them log.
+pub fn report_admission_progress(detail: &str) -> bool {
+    let Ok(active) = ACTIVE_LADDER.lock() else {
+        return false;
+    };
+    let Some(ladder) = active.as_ref() else {
+        return false;
+    };
+    let Ok(mut ladder) = ladder.lock() else {
+        return false;
+    };
+    ladder.detail(format_args!("{detail}"))
+}
+
 /// Stderr phase reporter for a fixed-length phase ladder.
 pub(crate) struct PhaseProgress {
+    ladder: Arc<Mutex<Ladder>>,
+}
+
+/// The ladder's own state, behind the lock the reporter and the subscriber
+/// layer share.
+struct Ladder {
     total: usize,
     is_tty: bool,
     index: usize,
@@ -41,8 +84,13 @@ pub(crate) struct PhaseProgress {
 
 impl PhaseProgress {
     /// Start a reporter for a ladder of `total` phases.
+    ///
+    /// Installs it as the process's live admission ladder. Nested admissions do
+    /// not happen, and if one ever did the inner ladder would take the slot and
+    /// hand it back on drop, which is the same discipline a single ladder
+    /// already keeps.
     pub(crate) fn new(total: usize) -> Self {
-        Self {
+        let ladder = Arc::new(Mutex::new(Ladder {
             total,
             is_tty: std::io::stderr().is_terminal(),
             index: 0,
@@ -51,12 +99,84 @@ impl PhaseProgress {
             phase_started: Instant::now(),
             started: Instant::now(),
             in_phase: false,
+        }));
+        if let Ok(mut active) = ACTIVE_LADDER.lock() {
+            *active = Some(Arc::clone(&ladder));
         }
+        Self { ladder }
+    }
+
+    fn with<R>(&mut self, act: impl FnOnce(&mut Ladder) -> R) -> Option<R> {
+        self.ladder.lock().ok().map(|mut ladder| act(&mut ladder))
     }
 
     /// Enter the next phase. Closes any open phase first, so a caller cannot
     /// leave a half-drawn line behind by forgetting to end one.
     pub(crate) fn begin(&mut self, label: &'static str) {
+        self.with(|ladder| ladder.begin(label));
+    }
+
+    /// Report progress within the current phase. Callers throttle their own
+    /// call rate; this throttles again off a terminal so a pipe stays readable.
+    pub(crate) fn detail(&mut self, detail: Arguments<'_>) {
+        self.with(|ladder| ladder.detail(detail));
+    }
+
+    /// Close the current phase, leaving one line carrying its elapsed time.
+    ///
+    /// Admission never ends a phase without entering the next one or finishing,
+    /// and both of those close the open phase themselves, so nothing outside
+    /// the tests that pin that behaviour needs to reach this directly.
+    #[cfg(test)]
+    fn end(&mut self) {
+        self.with(|ladder| ladder.end());
+    }
+
+    /// Close the ladder with one total-elapsed line.
+    pub(crate) fn finish(&mut self, label: &str) {
+        self.with(|ladder| ladder.finish(label));
+    }
+
+    #[cfg(test)]
+    fn index(&self) -> usize {
+        self.ladder.lock().expect("ladder lock").index
+    }
+
+    #[cfg(test)]
+    fn in_phase(&self) -> bool {
+        self.ladder.lock().expect("ladder lock").in_phase
+    }
+
+    #[cfg(test)]
+    fn detail_updates(&self) -> usize {
+        self.ladder.lock().expect("ladder lock").detail_updates
+    }
+}
+
+impl Drop for PhaseProgress {
+    /// Release the process ladder slot, and terminate a line a phase abandoned
+    /// by an early return left half-drawn, so an error message is never
+    /// appended to it.
+    fn drop(&mut self) {
+        if let Ok(mut active) = ACTIVE_LADDER.lock() {
+            let ours = active
+                .as_ref()
+                .is_some_and(|installed| Arc::ptr_eq(installed, &self.ladder));
+            if ours {
+                *active = None;
+            }
+        }
+        self.with(|ladder| {
+            if ladder.in_phase {
+                ladder.in_phase = false;
+                ladder.writeln(format_args!(""));
+            }
+        });
+    }
+}
+
+impl Ladder {
+    fn begin(&mut self, label: &'static str) {
         if self.in_phase {
             self.end();
         }
@@ -78,11 +198,12 @@ impl PhaseProgress {
         }
     }
 
-    /// Report progress within the current phase. Callers throttle their own
-    /// call rate; this throttles again off a terminal so a pipe stays readable.
-    pub(crate) fn detail(&mut self, detail: Arguments<'_>) {
+    /// Reports whether an open phase took it. A ladder between phases has no
+    /// line to advance, and telling the caller so is what lets an event that
+    /// arrives then be printed rather than silently dropped.
+    fn detail(&mut self, detail: Arguments<'_>) -> bool {
         if !self.in_phase {
-            return;
+            return false;
         }
         self.detail_updates += 1;
         if self.is_tty {
@@ -104,10 +225,10 @@ impl PhaseProgress {
                 self.phase_started.elapsed().as_secs_f64()
             ));
         }
+        true
     }
 
-    /// Close the current phase, leaving one line carrying its elapsed time.
-    pub(crate) fn end(&mut self) {
+    fn end(&mut self) {
         if !self.in_phase {
             return;
         }
@@ -120,12 +241,10 @@ impl PhaseProgress {
         ));
     }
 
-    /// Close the ladder with one total-elapsed line.
-    ///
     /// Only the success path finishes a ladder, so every declared phase must
     /// have run. Asserting that here is what keeps the declared total and the
     /// call sites from drifting apart unnoticed.
-    pub(crate) fn finish(&mut self, label: &str) {
+    fn finish(&mut self, label: &str) {
         debug_assert_eq!(
             self.index, self.total,
             "phase ladder completed {} of {} declared phases",
@@ -154,56 +273,49 @@ impl PhaseProgress {
     }
 }
 
-impl Drop for PhaseProgress {
-    /// A phase abandoned by an early return still terminates its line, so an
-    /// error message is never appended to a half-drawn progress line.
-    fn drop(&mut self) {
-        if self.in_phase {
-            self.in_phase = false;
-            self.writeln(format_args!(""));
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn a_phase_ladder_numbers_every_phase_it_enters() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
-        assert_eq!(progress.index, 0);
+        assert_eq!(progress.index(), 0);
         progress.begin("first");
-        assert_eq!(progress.index, 1);
-        assert!(progress.in_phase);
+        assert_eq!(progress.index(), 1);
+        assert!(progress.in_phase());
         progress.end();
-        assert!(!progress.in_phase);
+        assert!(!progress.in_phase());
         progress.begin("second");
-        assert_eq!(progress.index, 2);
+        assert_eq!(progress.index(), 2);
     }
 
     #[test]
     fn beginning_a_phase_closes_the_previous_one() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.begin("first");
         progress.begin("second");
-        assert_eq!(progress.index, 2);
-        assert!(progress.in_phase);
+        assert_eq!(progress.index(), 2);
+        assert!(progress.in_phase());
     }
 
     #[test]
     fn detail_outside_a_phase_is_ignored() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.detail(format_args!("1/2"));
-        assert_eq!(progress.detail_updates, 0);
+        assert_eq!(progress.detail_updates(), 0);
         progress.begin("first");
         progress.detail(format_args!("1/2"));
-        assert_eq!(progress.detail_updates, 1);
+        assert_eq!(progress.detail_updates(), 1);
     }
 
     #[test]
     #[should_panic(expected = "phase ladder completed 1 of 3 declared phases")]
     fn finishing_short_of_the_declared_total_is_a_drift_bug() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.begin("first");
         progress.finish("done");
@@ -211,21 +323,69 @@ mod tests {
 
     #[test]
     fn finishing_on_the_declared_total_is_accepted() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(2);
         progress.begin("first");
         progress.begin("second");
         progress.finish("done");
-        assert_eq!(progress.index, 2);
+        assert_eq!(progress.index(), 2);
+    }
+
+    /// The sink advances the open phase, declines when none is open, and stops
+    /// reaching a ladder that has been dropped.
+    ///
+    /// Serialized with the other ladder-installing tests through one mutex,
+    /// because the sink is process-global by construction: the events it
+    /// carries are emitted from inside a call that has no handle to pass.
+    #[test]
+    fn the_progress_sink_reaches_the_open_phase_and_nothing_else() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
+
+        assert!(
+            !crate::report_admission_progress("before any ladder"),
+            "with no ladder installed there is no phase to advance"
+        );
+
+        {
+            let mut progress = PhaseProgress::new(2);
+            assert!(
+                !crate::report_admission_progress("between phases"),
+                "an installed ladder that has entered no phase has no line yet"
+            );
+            progress.begin("commit bootstrap transaction");
+            assert!(
+                crate::report_admission_progress("4096/6413 changes validated"),
+                "an open phase takes the line"
+            );
+            assert_eq!(
+                progress.detail_updates(),
+                1,
+                "the sink must advance the same counter the phase's own detail does"
+            );
+        }
+
+        assert!(
+            !crate::report_admission_progress("after the ladder dropped"),
+            "a dropped ladder must release the slot rather than be written into"
+        );
+    }
+
+    /// One mutex for every test that installs a ladder, since they share the
+    /// process slot.
+    fn ladder_slot() -> &'static Mutex<()> {
+        static SLOT: Mutex<()> = Mutex::new(());
+        &SLOT
     }
 
     #[test]
     fn each_phase_restarts_its_detail_throttle() {
+        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.begin("first");
         progress.detail(format_args!("1/2"));
         progress.detail(format_args!("2/2"));
-        assert_eq!(progress.detail_updates, 2);
+        assert_eq!(progress.detail_updates(), 2);
         progress.begin("second");
-        assert_eq!(progress.detail_updates, 0);
+        assert_eq!(progress.detail_updates(), 0);
     }
 }

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod git_init;
 pub mod hooks;
 pub mod init;
 mod init_progress;
+pub use init_progress::report_admission_progress;
 mod init_staging;
 pub mod last_admission;
 pub mod layout;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3449,9 +3449,17 @@ async fn command_graph(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let repository_authority = state
+    // Through the cache rather than the bare binding. Every graph command here
+    // reads durable repository state, and an open re-verifies every persisted
+    // body against its content address, so opening per request made `kin graph
+    // status` cost the whole store each time it printed counters. The cache is
+    // keyed on the durable publication identity read before the load it labels,
+    // so a reused authority is one this daemon confirmed is still current.
+    let binding = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
+    let repository_authority =
+        shared_command_authority(binding, command_repository_authority(&state)?);
     let embedding_runtime = graph_status_embedding_runtime(&state, &graph);
     let response = kin_cli::commands::graph::execute_graph_command(
         &repository_authority,
@@ -13402,7 +13410,9 @@ mod tests {
 
         let runtime = graph_status_embedding_runtime(&state, &state.graph);
         let response = kin_cli::commands::graph::execute_graph_command(
-            &state.local_repository_authority_binding().unwrap(),
+            &kin_cli::commands::repository_authority::RequestRepositoryAuthority::pinned(
+                state.local_repository_authority_binding().unwrap(),
+            ),
             state.graph.as_ref(),
             &kin_cli::commands::graph::GraphCommandRequest::Status,
             &Default::default(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3449,17 +3449,29 @@ async fn command_graph(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    // Through the cache rather than the bare binding. Every graph command here
-    // reads durable repository state, and an open re-verifies every persisted
-    // body against its content address, so opening per request made `kin graph
-    // status` cost the whole store each time it printed counters. The cache is
-    // keyed on the durable publication identity read before the load it labels,
-    // so a reused authority is one this daemon confirmed is still current.
+    // Through the cache rather than the bare binding. `graph status` reads
+    // durable repository state, and an open re-verifies every persisted body
+    // against its content address, so opening per request made it cost the
+    // whole store every time it printed counters. The cache is keyed on the
+    // durable publication identity read before the load it labels, so a reused
+    // authority is one this daemon confirmed is still current.
+    //
+    // Resolved lazily rather than eagerly, because `graph inspect` answers from
+    // the live graph alone. Eager resolution would make it start requiring a
+    // storage capability it has never needed and pay for an open it never
+    // reads.
     let binding = state
         .local_repository_authority_binding()
         .map_err(repository_authority_error)?;
+    let resolver_state = Arc::clone(&state);
     let repository_authority =
-        shared_command_authority(binding, command_repository_authority(&state)?);
+        kin_cli::commands::repository_authority::RequestRepositoryAuthority::shared(
+            binding,
+            Arc::new(move || {
+                command_repository_authority(&resolver_state)
+                    .map_err(|(_, message)| anyhow::anyhow!(message))
+            }),
+        );
     let embedding_runtime = graph_status_embedding_runtime(&state, &graph);
     let response = kin_cli::commands::graph::execute_graph_command(
         &repository_authority,

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -53,7 +53,8 @@ pub use lossless::{
     LosslessGitRepository,
 };
 pub use preflight::{
-    preflight_git_migration, preflight_git_migration_after_publication, GitBranchTrackingFact,
+    preflight_git_migration, preflight_git_migration_after_publication, reprove_git_migration,
+    reprove_git_migration_after_publication, GitBranchTrackingFact,
     GitIndexPreflightProof, GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind,
     GitMigrationCompatibilityFacts, GitMigrationPreflightProof, GitRemoteConfigFact,
     GitRemoteMappingFacts, GitTrackedWorktreeProof, GitWorkspaceDivergence,

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -54,12 +54,11 @@ pub use lossless::{
 };
 pub use preflight::{
     preflight_git_migration, preflight_git_migration_after_publication, reprove_git_migration,
-    reprove_git_migration_after_publication, GitBranchTrackingFact,
-    GitIndexPreflightProof, GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind,
-    GitMigrationCompatibilityFacts, GitMigrationPreflightProof, GitRemoteConfigFact,
-    GitRemoteMappingFacts, GitTrackedWorktreeProof, GitWorkspaceDivergence,
-    GitWorkspaceDivergenceFacts, GitWorkspaceDivergenceKind, IgnoredLocalEntry,
-    IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
+    reprove_git_migration_after_publication, GitBranchTrackingFact, GitIndexPreflightProof,
+    GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind, GitMigrationCompatibilityFacts,
+    GitMigrationPreflightProof, GitRemoteConfigFact, GitRemoteMappingFacts,
+    GitTrackedWorktreeProof, GitWorkspaceDivergence, GitWorkspaceDivergenceFacts,
+    GitWorkspaceDivergenceKind, IgnoredLocalEntry, IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
 };
 pub use repository_export::{
     export_repository_to_git, verify_repository_git_export, RepositoryGitCommitBinding,

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -448,6 +448,12 @@ struct ExpectedIndexEntry {
 /// observation is repeated before returning to close the practical TOCTOU
 /// window; any change fails closed.
 ///
+/// This is the standalone form, for the first proof of an admission, where
+/// there is nothing earlier to compare against. It is also the only form that
+/// structurally revalidates the import plan, which is what makes it the
+/// expensive one: see [`reprove_git_migration`] for what a later proof in the
+/// same admission may reuse from it and why.
+///
 /// A later history-enrichment/admission step must still attach and validate
 /// shared admission policy deltas before repository authority can be published.
 pub fn preflight_git_migration(
@@ -456,7 +462,61 @@ pub fn preflight_git_migration(
     plan: &SemanticGitImportPlan,
     blob_store: &BlobStore,
 ) -> Result<GitMigrationPreflightProof> {
-    preflight_git_migration_with_hook(repo_path, snapshot, plan, blob_store, None, || {})
+    preflight_git_migration_with_hook(repo_path, snapshot, plan, blob_store, None, None, || {})
+}
+
+/// Repeat a source proof this admission already took, against that proof.
+///
+/// The invariant is the same one [`preflight_git_migration`] establishes: the
+/// mutable Git boundary this admission is reading still holds exactly the
+/// committed state the capture was taken from. What differs is only how much
+/// work it takes to establish it a second time, and the whole of that
+/// difference rests on `baseline` being a proof of the SAME source, snapshot,
+/// and plan, taken earlier in this admission.
+///
+/// Two reuses follow from that, and neither weakens the proof:
+///
+/// The single observation. A standalone proof observes twice and requires the
+/// two to agree, because on its own it has no earlier reading to be measured
+/// against and a lone observation could be a torn read. A re-proof does have
+/// one: `baseline`. Requiring one fresh observation to equal `baseline` is
+/// strictly stronger than requiring two adjacent observations to equal each
+/// other, because the baseline was taken minutes rather than seconds earlier,
+/// so its window contains the doubled window entirely. A torn read still fails,
+/// because a torn read does not equal the clean baseline either. Neither form
+/// can see a source that changes and changes back between samples; adding a
+/// third sample would not close that, and pretending it does is the reason the
+/// doubling looked load-bearing.
+///
+/// The skipped plan revalidation. [`SemanticGitImportPlan::validate`] rebuilds
+/// the entire plan from the captured objects and requires the rebuild to be
+/// identical, which is the guard against a plan enriched with anything not
+/// derivable from the source. It is a pure function of an immutable in-memory
+/// plan and an append-only content-addressed store, so re-running it over the
+/// same plan value cannot reach a different verdict. What it would catch, a
+/// plan that is not the one the baseline proved, is caught instead by
+/// `semantic_plan_fingerprint`, which is still derived fresh on every
+/// observation and compared through the whole-proof comparison below.
+pub fn reprove_git_migration(
+    repo_path: &Path,
+    baseline: &GitMigrationPreflightProof,
+    snapshot: &LosslessGitRepository,
+    plan: &SemanticGitImportPlan,
+    blob_store: &BlobStore,
+) -> Result<GitMigrationPreflightProof> {
+    preflight_git_migration_with_hook(
+        repo_path,
+        snapshot,
+        plan,
+        blob_store,
+        None,
+        Some(ProofBaseline {
+            proof: baseline,
+            changed: "Git source proof changed before repository publication; retry from a fresh \
+                      capture",
+        }),
+        || {},
+    )
 }
 
 /// Repeat an exact Git source proof after Kin has atomically installed `.kin`.
@@ -464,7 +524,53 @@ pub fn preflight_git_migration(
 /// Only the supplied real `.kin` directory at the canonical worktree root is
 /// excluded from the worktree walk. Every Git object, ref, index byte, tracked
 /// leaf, ignored-local fact, and any other untracked path remains subject to
-/// the same two-observation proof as pre-publication migration.
+/// the same proof as pre-publication migration, and the result must equal
+/// `baseline` exactly.
+///
+/// This is the one proof publication itself can move, and it is why the
+/// exclusion is spelled out rather than inferred: publication is a single
+/// no-replace rename of a staged directory into the worktree root, so the only
+/// difference from `baseline` it can legitimately produce is that `.kin` now
+/// exists. Anything else this observes, a second path that appeared, a tracked
+/// leaf whose bytes moved, an object or ref that is no longer the captured one,
+/// is either publication writing somewhere it must not or a non-cooperating
+/// writer racing the rename. Both are refusals, and because the rename has
+/// already happened they are detections rather than preventions: the caller
+/// reports them as a published repository that is not safe to use without
+/// recovery.
+///
+/// It observes once for the reasons given at [`reprove_git_migration`].
+pub fn reprove_git_migration_after_publication(
+    repo_path: &Path,
+    published_kin_dir: &Path,
+    baseline: &GitMigrationPreflightProof,
+    snapshot: &LosslessGitRepository,
+    plan: &SemanticGitImportPlan,
+    blob_store: &BlobStore,
+) -> Result<GitMigrationPreflightProof> {
+    let source_worktree =
+        fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
+    let published_kin_dir = canonical_published_kin_dir(&source_worktree, published_kin_dir)?;
+    preflight_git_migration_with_hook(
+        &source_worktree,
+        snapshot,
+        plan,
+        blob_store,
+        Some(&published_kin_dir),
+        Some(ProofBaseline {
+            proof: baseline,
+            changed: "Git source proof changed across repository publication; published \
+                      authority is not safe to use without recovery",
+        }),
+        || {},
+    )
+}
+
+/// Repeat an exact Git source proof after publication, without a baseline.
+///
+/// The standalone post-publication form, kept for callers that have no earlier
+/// proof of this source to measure against. An admission always does, and uses
+/// [`reprove_git_migration_after_publication`].
 pub fn preflight_git_migration_after_publication(
     repo_path: &Path,
     published_kin_dir: &Path,
@@ -474,6 +580,27 @@ pub fn preflight_git_migration_after_publication(
 ) -> Result<GitMigrationPreflightProof> {
     let source_worktree =
         fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
+    let published_kin_dir = canonical_published_kin_dir(&source_worktree, published_kin_dir)?;
+    preflight_git_migration_with_hook(
+        &source_worktree,
+        snapshot,
+        plan,
+        blob_store,
+        Some(&published_kin_dir),
+        None,
+        || {},
+    )
+}
+
+/// The exact `.kin` a post-publication proof is allowed to exclude.
+///
+/// Only a real directory at the canonical worktree root qualifies. Resolving
+/// through a symlink, or accepting a path elsewhere, would let the exclusion
+/// hide a part of the worktree the proof is supposed to cover.
+fn canonical_published_kin_dir(
+    source_worktree: &Path,
+    published_kin_dir: &Path,
+) -> Result<PathBuf> {
     let expected_kin_dir = source_worktree.join(".kin");
     let metadata = fs::symlink_metadata(published_kin_dir)
         .map_err(|error| GitError::io(published_kin_dir, error))?;
@@ -491,14 +618,20 @@ pub fn preflight_git_migration_after_publication(
             expected_kin_dir.display()
         )));
     }
-    preflight_git_migration_with_hook(
-        &source_worktree,
-        snapshot,
-        plan,
-        blob_store,
-        Some(&published_kin_dir),
-        || {},
-    )
+    Ok(published_kin_dir)
+}
+
+/// An earlier proof of this same admission, and what to say when the source no
+/// longer matches it.
+///
+/// Carrying the sentence here rather than leaving the comparison to the caller
+/// is what keeps the cheaper single-observation path from being reachable
+/// without one: the baseline is the argument that makes one observation
+/// sufficient, so the type that authorizes it also performs the comparison.
+#[derive(Clone, Copy)]
+struct ProofBaseline<'a> {
+    proof: &'a GitMigrationPreflightProof,
+    changed: &'static str,
 }
 
 fn preflight_git_migration_with_hook(
@@ -507,41 +640,57 @@ fn preflight_git_migration_with_hook(
     plan: &SemanticGitImportPlan,
     blob_store: &BlobStore,
     published_kin_dir: Option<&Path>,
+    baseline: Option<ProofBaseline<'_>>,
     after_first_observation: impl FnOnce(),
 ) -> Result<GitMigrationPreflightProof> {
-    validate_plan_binding(snapshot, plan, blob_store)?;
-    let expected = expected_index_entries(snapshot, plan)?;
-    let first = observe(
-        repo_path,
-        snapshot,
-        plan,
-        blob_store,
-        &expected,
-        published_kin_dir,
-    )?;
-    after_first_observation();
-    let second = observe(
-        repo_path,
-        snapshot,
-        plan,
-        blob_store,
-        &expected,
-        published_kin_dir,
-    )?;
-    if first != second {
-        return Err(preflight_error(
-            "Git source changed during migration preflight; retry from a fresh snapshot",
-        ));
+    // Structurally rebuilding the plan is what a baselined re-proof reuses
+    // rather than repeats; the binding comparison below is cheap and runs
+    // either way. Both halves of the reasoning are at `reprove_git_migration`.
+    if baseline.is_none() {
+        plan.validate(blob_store)?;
     }
-    Ok(second.proof)
+    bind_plan_to_snapshot(snapshot, plan)?;
+    // A pure function of the plan, which no observation mutates. Derived once
+    // per proof rather than once per observation, and still derived rather than
+    // carried over from a baseline, so a plan that is not the proved one moves
+    // the proof and fails the comparison.
+    let semantic_plan_fingerprint = fingerprint_plan(plan)?;
+    let expected = expected_index_entries(snapshot, plan)?;
+    let observation = || {
+        observe(
+            repo_path,
+            snapshot,
+            plan,
+            blob_store,
+            &expected,
+            published_kin_dir,
+            semantic_plan_fingerprint,
+        )
+    };
+
+    let Some(baseline) = baseline else {
+        let first = observation()?;
+        after_first_observation();
+        let second = observation()?;
+        if first != second {
+            return Err(preflight_error(
+                "Git source changed during migration preflight; retry from a fresh snapshot",
+            ));
+        }
+        return Ok(second.proof);
+    };
+
+    let observed = observation()?;
+    if observed.proof != *baseline.proof {
+        return Err(preflight_error(baseline.changed));
+    }
+    Ok(observed.proof)
 }
 
-fn validate_plan_binding(
+fn bind_plan_to_snapshot(
     snapshot: &LosslessGitRepository,
     plan: &SemanticGitImportPlan,
-    blob_store: &BlobStore,
 ) -> Result<()> {
-    plan.validate(blob_store)?;
     if plan.repository_id != snapshot.repository_id
         || plan.object_format != snapshot.object_format
         || plan.external_objects != snapshot.objects
@@ -562,6 +711,7 @@ fn observe(
     blob_store: &BlobStore,
     expected_entries: &BTreeMap<RepoPath, ExpectedIndexEntry>,
     published_kin_dir: Option<&Path>,
+    semantic_plan_fingerprint: Hash256,
 ) -> Result<PreflightObservation> {
     let source_worktree =
         fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
@@ -656,7 +806,6 @@ fn observe(
     )?;
     let workspace_divergence = divergence.finish();
     let snapshot_fingerprint = fingerprint_snapshot(&snapshot);
-    let semantic_plan_fingerprint = fingerprint_plan(plan)?;
     let compatibility = GitMigrationCompatibilityFacts {
         // Tolerated siblings are recorded rather than dropped. Both
         // observations carry them, so one appearing or vanishing mid-proof
@@ -3975,6 +4124,134 @@ mod tests {
         assert_eq!(proof.tracked_worktree.gitlink_count, 0);
     }
 
+    /// A baselined re-proof of an unchanged source agrees with its baseline,
+    /// and both re-proof forms refuse the moment it does not.
+    ///
+    /// This is what pays for observing once instead of twice, so it is asserted
+    /// on both entry points rather than assumed from one. The post-publication
+    /// arm additionally has to accept the `.kin` publication installed, which is
+    /// the only difference it is allowed to tolerate.
+    #[test]
+    fn a_baselined_reproof_agrees_with_its_baseline_and_refuses_any_drift() {
+        let fixture = Fixture::clean();
+        let baseline = fixture.preflight().expect("baseline proof");
+
+        let agreed = reprove_git_migration(
+            &fixture.repo,
+            &baseline,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect("an unchanged source re-proves against its baseline");
+        assert_eq!(agreed, baseline);
+
+        let published_kin = fixture.repo.join(".kin");
+        fs::create_dir(&published_kin).expect("published Kin directory");
+        fs::write(published_kin.join("version"), b"6\n").expect("published Kin metadata");
+        let after_publication = reprove_git_migration_after_publication(
+            &fixture.repo,
+            &published_kin,
+            &baseline,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect("publication alone does not move the proof");
+        assert_eq!(after_publication, baseline);
+
+        // One tracked byte is enough, and it must refuse on both arms rather
+        // than report the drift, because a single observation has no second
+        // reading of its own to disagree with.
+        fs::write(fixture.repo.join("compose.yaml"), b"services: {}\n")
+            .expect("tracked source drift");
+        let before_publication = reprove_git_migration(
+            &fixture.repo,
+            &baseline,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect_err("drift before publication is refused");
+        assert!(
+            before_publication
+                .to_string()
+                .contains("source proof changed"),
+            "{before_publication}"
+        );
+        let across_publication = reprove_git_migration_after_publication(
+            &fixture.repo,
+            &published_kin,
+            &baseline,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect_err("drift across publication is refused");
+        assert!(
+            across_publication
+                .to_string()
+                .contains("changed across repository publication"),
+            "{across_publication}"
+        );
+    }
+
+    /// A path that appears outside `.kin` after publication is still caught.
+    ///
+    /// The exclusion is the one thing the post-publication re-proof tolerates,
+    /// so the test that matters is that it tolerates nothing beside it.
+    #[test]
+    fn a_baselined_post_publication_reproof_excludes_only_the_published_kin_directory() {
+        let fixture = Fixture::clean();
+        let baseline = fixture.preflight().expect("baseline proof");
+        let published_kin = fixture.repo.join(".kin");
+        fs::create_dir(&published_kin).expect("published Kin directory");
+        fs::write(published_kin.join("version"), b"6\n").expect("published Kin metadata");
+        fs::write(fixture.repo.join("outside-kin.txt"), b"untracked\n").expect("untracked sibling");
+
+        let error = reprove_git_migration_after_publication(
+            &fixture.repo,
+            &published_kin,
+            &baseline,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect_err("a path that appeared beside .kin is not excluded");
+        assert!(
+            error
+                .to_string()
+                .contains("changed across repository publication"),
+            "{error}"
+        );
+    }
+
+    /// A re-proof will not accept a baseline taken from a different plan.
+    ///
+    /// Skipping the structural plan rebuild rests on the plan being the one the
+    /// baseline proved, and `semantic_plan_fingerprint` is what carries that.
+    /// It is still derived on every observation, so a mismatched plan moves the
+    /// proof and fails the comparison rather than passing unvalidated.
+    #[test]
+    fn a_baselined_reproof_refuses_a_baseline_from_another_plan() {
+        let fixture = Fixture::clean();
+        let mut baseline = fixture.preflight().expect("baseline proof");
+        baseline.semantic_plan_fingerprint = digest(b"a plan this admission never proved");
+
+        let error = reprove_git_migration(
+            &fixture.repo,
+            &baseline,
+            &fixture.snapshot,
+            &fixture.plan,
+            &fixture.store,
+        )
+        .expect_err("a baseline bound to another plan is refused");
+        assert!(
+            error.to_string().contains("source proof changed"),
+            "{error}"
+        );
+    }
+
     #[test]
     fn post_publication_proof_excludes_only_the_exact_published_kin_directory() {
         let fixture = Fixture::clean();
@@ -4885,6 +5162,7 @@ mod tests {
             &fixture.plan,
             &fixture.store,
             None,
+            None,
             move || {
                 git(&repo, &["config", "--unset-all", "remote.origin.url"]);
                 git(
@@ -5199,6 +5477,7 @@ mod tests {
             &source_change.plan,
             &source_change.store,
             None,
+            None,
             move || {
                 fs::write(repo.join("ignored/new-cache"), b"new\n").expect("TOCTOU file");
             },
@@ -5215,6 +5494,7 @@ mod tests {
             &ignore_change.snapshot,
             &ignore_change.plan,
             &ignore_change.store,
+            None,
             None,
             move || {
                 let mut file = fs::OpenOptions::new()


### PR DESCRIPTION
`kin init` on expressjs/express spent 92 seconds of a 435 second admission phase proving
the same Git repository three times, printed raw tracing records with ANSI escapes and
internal span paths into an otherwise clean progress display during the stage that
dominates the wait, and `kin graph status` took 7 to 11 seconds to print counters that
`kin doctor` beats with richer information in 32ms.

All three are fixed. No proof was weakened and no counter changed.

## 1. The three source proofs keep their invariants and stop repeating each other's work

They are not three copies of one check. They differ by **when** they run, and each site now
says so in a doc comment because the next reader will ask:

- `[ 7/17] prove Git source` — the boundary matches the capture, and the import plan is
  derivable from the raw objects. Everything downstream consumes its result: the remote
  mapping becomes the repository's Git config, the ignored-local inputs are copied as
  authority, the workspace binding is sealed from it.
- `[14/17] re-prove Git source` — nothing moved during the minutes of staging in between.
  This is the last point at which drift can be **prevented** rather than reported: it runs
  immediately before the no-replace rename, and a refusal leaves `.kin` absent.
- `[16/17] prove Git source after publication` — publication installed `.kin` and did
  nothing else to the worktree. The only proof taken on a source Kin has written into, and
  the only one that must be told which directory is legitimately new. Past the
  linearization point it **detects** where the previous one prevents, reporting
  `RepositoryPublishedButUncertain`.

All three are load-bearing, so none is dropped. What is dropped is the work the later two
repeated.

`reprove_git_migration` and `reprove_git_migration_after_publication` take the first proof
as a baseline and observe once against it.

**The single observation.** A standalone proof observes twice because it has no earlier
reading to be measured against and a lone observation could be torn. A re-proof does have
one. Requiring one fresh observation to equal a baseline taken minutes earlier is strictly
stronger than requiring two adjacent observations to equal each other: the baseline's
window contains the doubled window entirely. A torn read still fails, because a torn read
does not equal the clean baseline either. Neither form can see a source that changes and
changes back between samples, and a third sample would not close that; believing it does is
what made the doubling look load-bearing.

**The skipped plan revalidation.** `SemanticGitImportPlan::validate` rebuilds the whole plan
from the captured objects and compares, which is the guard against a plan enriched with
anything the source does not derive. It is a pure function of an immutable in-memory plan
and an append-only content-addressed store, so a second run over the same value cannot
reach a different verdict. A plan that is not the one the baseline proved is caught instead
by `semantic_plan_fingerprint`, still derived fresh on every observation and compared
through the whole-proof comparison. That fingerprint also moves out of the observation,
since no observation mutates the plan.

**Crash and corruption argument.** Nothing moves across the publication rename. It is still
the linearization point and still bracketed by a proof on each side. A refusal before it
still leaves `.kin` absent; a refusal after it still reports the repository as published but
uncertain, with the same recovery advice. The removed work is a second sample of a source
and a second derivation of a value that cannot have changed between the two, so no crash,
corruption, or concurrent writer the previous code refused is admitted by this one.

The cheaper path is unreachable without a baseline: the type that authorizes it also carries
the sentence to print and performs the comparison, so a caller cannot take the shortcut and
forget the check. Both existing error sentences are preserved verbatim.

## 2. Admission progress is drawn on the phase line instead of over it

The four records came from `kin_db::storage::history_replay` in the pinned KinDB, which this
repo does not build. They reached the console because kin's own `ADMISSION_PROGRESS_TARGETS`
raises that target to `info` for `init` and `clone`, on a doc block explaining the directive
was safe because no such module existed in the pinned KinDB. It exists now; the pin moved.
A test asserted the same stale claim. The comment kept reading as current after it stopped
being true.

`AdmissionProgressLayer` now takes that target, reads its `validated` and `total` fields,
and reports through `kin_core::report_admission_progress`, which advances whatever admission
phase is open. The fmt layer is filtered to leave that one target alone. Every other
admission target still prints as a record, including the receipt naming what was admitted,
and the test pins both directions.

The message text is deliberately not reused. `history_replay` reports elapsed whole seconds,
so a sub-second replay reads "in 0s" and a two-minute one would read no better; the phase
line already carries its own elapsed time, and what the event uniquely knows is how far
along it is. With no ladder open the line prints plainly rather than being dropped.

Measured on express, all eight records land in the first 65s of a 421.7s phase, so routing
them alone still leaves the line frozen for the rest. The commit phase therefore also
reports its own four sub-steps, which is every seam kin-core can see;
`commit_repository_transaction` takes no progress callback, so the remainder is only
reachable from kin-db and is filed as FIR-2372.

The fmt layer also stops emitting colour into a redirected stream. It never sniffed for a
terminal, which is why the evidence for this ticket carries escape bytes verbatim.

## 3. Graph status serves from the authority the daemon already opened

`command_graph` handed `execute_graph_command` a bare binding, so every request reached
`ActiveRepositoryAuthority::open`, which re-verifies every persisted body against its content
address and recomputes the store roots. Its own doc comment says it "costs whatever the whole
store is worth rather than whatever the caller asked for". `kin doctor` never opens an
authority at all.

The daemon already caches exactly that object. `ProjectionAuthorityCache` is keyed on the
durable publication identity read before the load it labels, and was built because
`get_entity_sources` was paying N whole-store verifications for a batch of N entities.
`command_graph` simply never used it.

Graph commands now take a `RequestRepositoryAuthority`, resolved lazily through that cache,
so `graph inspect` (which answers from the live graph alone) does not start requiring a
storage capability it never needed. Two duplicated walks go with it: `list_all_entities`,
which clones every entity out from under a lock, ran three times per response, and
`resolved_tree` was cloned twice.

No `--full` flag was added. The expensive path was not a counter that needs one; it was a
per-request whole-store reopen with an unused cache beside it, and a flag would have
preserved the waste behind an opt-out.

## Measurements

NON-CITABLE local numbers, founder dev host under fleet build load, expressjs/express at
`a3714473` (6,413 commits, 33,522 objects, 213 tracked files) — the exact commit the ticket
measured, reproducing its graph exactly (613 entities, 211 relations, 137 files, 1,226
pending embeddings).

**Read the untouched stages first.** `[2]`, `[5]`, `[9]`, `[10]`, `[13]`, and `[17]` are not
touched by this change and moved between the two runs by factors of 1.71, 1.23, 0.84, 1.63,
1.22 and 0.72, because the after run began at load average 72 against the baseline's 26 to
61. Absolute walls between these two runs are not comparable, and the phase total rising
from 933.9s to 1205.8s is that noise. What follows leads with counted work instead.

Counted work across the three proofs of one init, exact rather than measured:

| | before | after |
|---|---:|---:|
| full `SemanticGitImportPlan` rebuilds | 3 | 1 |
| full Git object-closure captures | 6 | 4 |
| `fingerprint_plan` derivations | 6 | 3 |

Share of the admission phase, the timing claim least sensitive to host noise: the three
proofs were **65.0s of 933.9s (6.96%)** before and **34.9s of 1205.8s (2.89%)** after.

| stage | before | after |
|---|---:|---:|
| `[ 7/17] prove Git source` | 21.4s | 14.0s |
| `[14/17] re-prove Git source` | 29.5s | 17.1s |
| `[16/17] prove Git source after publication` | 14.1s | 3.8s |
| raw tracing records printed into the progress display | 8 | 0 |
| `kin graph status`, warm | 18.825s / 17.498s | 0.150s / 0.147s |
| `kin doctor` | 2.897s | 1.377s |

`[16/17]` is the cleanest single reading and is conservative: its neighbour `[17/17]` ran
0.72x, i.e. faster, in the after run, so the environment there was not slower. `[7/17]`
improved too despite still running the full double observation and the plan rebuild, because
`fingerprint_plan` moved out of the observation; that also means it is not a clean control
for the other two.

Warm `graph status` is 119x faster and now roughly 9x faster than `kin doctor`. Its cold
first call still pays exactly one open, which is what populates the cache. **The rendered
output is byte-identical between the two runs** — diffing the full bodies yields only the
harness's own run label, so every counter, warning and note is unchanged.

## Verification

- Full lane gate green against the lane worktree at `a437bf66`: 5714 tests run, 5714 passed,
  11 skipped.
- `cargo fmt --check`, the ci.yml clippy allowlist under `RUSTFLAGS=-D warnings`, and both
  zero-file-search scanners all clean, the scanners re-run capturing their true exit codes
  rather than a pipeline's.
- Guards falsified: deleting the baseline comparison fails all three new preflight tests;
  restoring it passes them. The progress-sink test caught a real defect on first run (sibling
  tests sharing the process ladder slot), which is the evidence its assertion is live.

## Not claiming

The largest single cost of `kin init` is untouched and is not in this repo: the bootstrap
commit transaction remains the dominant stage, and `validate_git_authority_shape_and_projection`
appears to run twice per `prepare_successor`, each materializing all 6,413 commit trees. That
attribution is a source read of the pinned crate rather than a profile, and is filed with the
command that would confirm it. Store size is unchanged at 403 MiB for an 11 MiB Git object
store. The empty-vector-index degradation gap is filed separately.

Follow-ups: FIR-2372 (kin-db bootstrap commit cost and missing progress callback), FIR-2373
(fresh conversion reports no vector-index degradation).

Closes FIR-2363
