### PR TITLE
Exclude the store at init, report 1-based lines from kin refs, and make the context pack's cost honest

### DIFF
--- a/crates/kin-cli/src/commands/declaration_neighbors.rs
+++ b/crates/kin-cli/src/commands/declaration_neighbors.rs
@@ -84,12 +84,18 @@ impl DeclarationNeighbors {
 ///
 /// Location is projection metadata for the human reading the listing; the
 /// analysis itself is keyed on graph identity, never on paths.
+///
+/// The line is 1-based, through the same seam every other presentation surface
+/// converts at. A `path:line` string is read straight into an editor, so the
+/// raw graph row this used to emit put the reader one line above the entity.
 pub fn entity_location(entity: &Entity) -> Option<String> {
     let path = entity.file_origin.as_ref().map(|f| f.0.clone())?;
-    Some(match entity.span.as_ref().map(|s| s.start_line) {
-        Some(line) => format!("{path}:{line}"),
-        None => path,
-    })
+    Some(
+        match kin_mcp::handlers::common::entity_presentation_start_line(entity) {
+            Some(line) => format!("{path}:{line}"),
+            None => path,
+        },
+    )
 }
 
 fn entity_kind_label(entity: &Entity) -> String {

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -1130,7 +1130,7 @@ mod tests {
         );
         assert!(joined.contains("--file src/nowhere.rs"), "{joined}");
         assert!(
-            joined.contains("src/a.rs:3") && joined.contains("src/b.rs:9"),
+            joined.contains("src/a.rs:4") && joined.contains("src/b.rs:10"),
             "{joined}"
         );
         assert_eq!(response.query.match_count, 0);
@@ -1141,7 +1141,7 @@ mod tests {
                 .iter()
                 .map(|candidate| candidate.location.as_str())
                 .collect::<Vec<_>>(),
-            vec!["src/a.rs:3", "src/b.rs:9"],
+            vec!["src/a.rs:4", "src/b.rs:10"],
         );
     }
 
@@ -1177,7 +1177,7 @@ mod tests {
         assert_eq!(response.resolution, "resolved");
         assert_eq!(response.query.match_count, 1);
         assert!(
-            response.lines[0].contains("src/b.rs:9"),
+            response.lines[0].contains("src/b.rs:10"),
             "{:?}",
             response.lines
         );
@@ -1249,7 +1249,7 @@ mod tests {
                 .position(|line| line.contains(needle))
                 .unwrap_or_else(|| panic!("missing '{needle}' in {lines:?}"))
         };
-        assert!(lines[0].contains("@ src/lib.rs:10"), "{lines:?}");
+        assert!(lines[0].contains("@ src/lib.rs:11"), "{lines:?}");
         assert!(
             lines
                 .iter()
@@ -1257,9 +1257,9 @@ mod tests {
             "{lines:?}"
         );
         let h1 = pos("1 hop (direct callers):");
-        let d = pos("- direct_caller (Function) @ src/direct.rs:20");
+        let d = pos("- direct_caller (Function) @ src/direct.rs:21");
         let h2 = pos("2 hops:");
-        let i = pos("- indirect_caller (Function) @ src/indirect.rs:30");
+        let i = pos("- indirect_caller (Function) @ src/indirect.rs:31");
         assert!(
             h1 < d && d < h2 && h2 < i,
             "hop groups out of order: {lines:?}"
@@ -1493,12 +1493,12 @@ mod tests {
         assert_eq!(
             response.lines,
             vec![
-                "Impact analysis for 'changed' (Function) @ src/lib.rs:10:".to_string(),
+                "Impact analysis for 'changed' (Function) @ src/lib.rs:11:".to_string(),
                 "  2 local entities impacted within 3 hops:".to_string(),
                 "  1 hop (direct callers):".to_string(),
-                "    - direct_caller (Function) @ src/direct.rs:20".to_string(),
+                "    - direct_caller (Function) @ src/direct.rs:21".to_string(),
                 "  2 hops:".to_string(),
-                "    - indirect_caller (Function) @ src/indirect.rs:30".to_string(),
+                "    - indirect_caller (Function) @ src/indirect.rs:31".to_string(),
             ]
         );
     }

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -131,6 +131,14 @@ pub async fn run(path: Option<String>, json: bool) -> Result<()> {
         }
     };
 
+    if let Err(error) = exclude_store_from_git(result.layout.working_dir()) {
+        eprintln!(
+            "warning: the Kin store at {} was not added to this repository's local Git excludes, \
+             so `git status` will list it as untracked: {error:#}",
+            result.layout.root().display()
+        );
+    }
+
     let enrichment =
         SemanticEnrichmentStatus::from_durable_summary(&result.authority.semantic_enrichment);
     if json {
@@ -207,6 +215,163 @@ fn git_prerequisite_note(git_on_path: bool) -> &'static str {
         ""
     } else {
         " Git is not installed on this host, so committing to Git needs `git` installed first."
+    }
+}
+
+/// The rule `kin init` adds so the store stays out of `git status`.
+///
+/// Anchored and directory-scoped so it names the store this command just wrote
+/// and nothing else. An unanchored `.kin/` would also hide a nested directory
+/// of that name anywhere in the tree, which is not this command's to decide.
+const STORE_EXCLUDE_RULE: &str = "/.kin/";
+
+/// Spellings of a rule that already keeps the store out of `git status`.
+///
+/// A repository converted before this command excluded anything, or one whose
+/// author added the rule by hand, is already correct. Re-stating it would leave
+/// a duplicate line behind on every re-init.
+const STORE_EXCLUDE_EQUIVALENTS: &[&str] = &[".kin", ".kin/", "/.kin", "/.kin/"];
+
+/// Keep the store out of the converted repository's `git status`.
+///
+/// Admission writes a `.kin` directory that is routinely a gigabyte, and Git
+/// has no reason to know it is Kin's. Without a rule it is reported as
+/// untracked forever, on every `git status` the author runs, which is a
+/// permanent cost paid for a one-time conversion.
+///
+/// The rule goes in `.git/info/exclude` rather than the repository's tracked
+/// `.gitignore`, because whether a peer's checkout carries a Kin store is that
+/// peer's business. Excluding it locally costs the author nothing and changing
+/// a tracked file would put Kin in their next diff.
+///
+/// Every refusal here is reported and none of them fail the command: the store
+/// is durable before this runs, and an admission that succeeded must not be
+/// turned into a failure by a convenience.
+fn exclude_store_from_git(working_dir: &Path) -> Result<Option<PathBuf>> {
+    let Some(common_dir) = git_common_dir(working_dir)? else {
+        return Ok(None);
+    };
+    if store_already_excluded(working_dir, &common_dir)? {
+        return Ok(None);
+    }
+
+    let info_dir = common_dir.join("info");
+    std::fs::create_dir_all(&info_dir)
+        .with_context(|| format!("create Git info directory {}", info_dir.display()))?;
+    let exclude = info_dir.join("exclude");
+    if let Ok(metadata) = std::fs::symlink_metadata(&exclude) {
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            anyhow::bail!(
+                "Git exclude authority must be a regular non-symlink file: {}",
+                exclude.display()
+            );
+        }
+    }
+
+    let mut body = read_optional_text(&exclude)?.unwrap_or_default();
+    if !body.is_empty() && !body.ends_with('\n') {
+        body.push('\n');
+    }
+    body.push_str(STORE_EXCLUDE_RULE);
+    body.push('\n');
+    std::fs::write(&exclude, body)
+        .with_context(|| format!("write Git exclude {}", exclude.display()))?;
+    Ok(Some(exclude))
+}
+
+/// The directory holding the shared `info/exclude` for this worktree.
+///
+/// A `.git` directory is its own common directory. A linked worktree or a
+/// submodule instead carries a `gitdir:` pointer file, and a linked worktree's
+/// excludes live with the repository it was added from, which its `commondir`
+/// names. Following the pointer is what makes this work in the worktrees Kin's
+/// own fleet runs in.
+fn git_common_dir(working_dir: &Path) -> Result<Option<PathBuf>> {
+    let dot_git = working_dir.join(".git");
+    let metadata = match std::fs::symlink_metadata(&dot_git) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("inspect {}", dot_git.display())),
+    };
+    if metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "repository Git authority must not be a symlink: {}",
+            dot_git.display()
+        );
+    }
+    if metadata.is_dir() {
+        return Ok(Some(dot_git));
+    }
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+
+    let pointer = std::fs::read_to_string(&dot_git)
+        .with_context(|| format!("read Git pointer file {}", dot_git.display()))?;
+    let Some(target) = pointer
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("gitdir:"))
+    else {
+        anyhow::bail!("Git pointer file names no gitdir: {}", dot_git.display());
+    };
+    let git_dir = resolve_against(working_dir, target.trim());
+    match read_optional_text(&git_dir.join("commondir"))? {
+        Some(common) => match common
+            .lines()
+            .next()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+        {
+            Some(common) => Ok(Some(resolve_against(&git_dir, common))),
+            None => Ok(Some(git_dir)),
+        },
+        None => Ok(Some(git_dir)),
+    }
+}
+
+fn resolve_against(base: &Path, target: &str) -> PathBuf {
+    let target = Path::new(target);
+    if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        base.join(target)
+    }
+}
+
+/// Whether some rule Git already reads keeps the store out of `git status`.
+///
+/// Checked against both places a rule can already live for this repository:
+/// the local excludes this command writes, and the tracked `.gitignore` a
+/// project may have adopted on its own. Either one makes writing a second rule
+/// pure noise.
+fn store_already_excluded(working_dir: &Path, common_dir: &Path) -> Result<bool> {
+    for candidate in [
+        common_dir.join("info").join("exclude"),
+        working_dir.join(".gitignore"),
+    ] {
+        let Some(body) = read_optional_text(&candidate)? else {
+            continue;
+        };
+        if body
+            .lines()
+            .map(str::trim)
+            .any(|line| STORE_EXCLUDE_EQUIVALENTS.contains(&line))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn read_optional_text(path: &Path) -> Result<Option<String>> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            Ok(Some(String::from_utf8(bytes).with_context(|| {
+                format!("{} is not UTF-8", path.display())
+            })?))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
     }
 }
 
@@ -722,5 +887,184 @@ mod tests {
         assert!(
             uncommitted_worktree_payload(&kin_git::GitWorkspaceDivergenceFacts::none()).is_none()
         );
+    }
+
+    fn git(repository: &Path, args: &[&str]) {
+        let output = crate::commands::test_subprocess::fixture_git(repository)
+            .args(args)
+            .output()
+            .expect("run fixture git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_status(repository: &Path) -> String {
+        let output = crate::commands::test_subprocess::fixture_git(repository)
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("run fixture git status");
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn write_store(working_dir: &Path) {
+        let store = working_dir.join(".kin");
+        std::fs::create_dir_all(store.join("objects")).unwrap();
+        std::fs::write(store.join("objects").join("pack"), b"store bytes").unwrap();
+    }
+
+    /// The whole point, asked of Git itself rather than of a string.
+    ///
+    /// A converted repository leaves a store that is routinely a gigabyte, and
+    /// before this the author saw it as untracked on every `git status` they
+    /// ever ran again. The assertion is on the porcelain, because a rule that
+    /// parses correctly and does not actually exclude the store reads exactly
+    /// like one that works.
+    #[test]
+    fn an_excluded_store_is_absent_from_git_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        git(repo, &["init", "-q"]);
+        write_store(repo);
+
+        let before = git_status(repo);
+        assert!(
+            before.contains(".kin"),
+            "the fixture must start with a visible store, or this test proves nothing: {before:?}"
+        );
+
+        exclude_store_from_git(repo).unwrap().expect("a rule");
+
+        let after = git_status(repo);
+        assert!(
+            !after.contains(".kin"),
+            "the store must be absent from git status: {after:?}"
+        );
+    }
+
+    /// Re-running init must not stack duplicate rules.
+    #[test]
+    fn excluding_the_store_twice_writes_one_rule() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        std::fs::create_dir_all(repo.join(".git").join("info")).unwrap();
+
+        let exclude = exclude_store_from_git(repo).unwrap().expect("a rule");
+        assert!(
+            exclude_store_from_git(repo).unwrap().is_none(),
+            "the second pass must find the rule already present"
+        );
+
+        let body = std::fs::read_to_string(&exclude).unwrap();
+        assert_eq!(
+            body.lines()
+                .filter(|line| line.trim() == STORE_EXCLUDE_RULE)
+                .count(),
+            1,
+            "exactly one rule survives a re-init: {body:?}"
+        );
+    }
+
+    /// A repository whose `.git` carries no `info` directory yet.
+    #[test]
+    fn a_missing_info_directory_is_created_rather_than_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        assert!(!repo.join(".git").join("info").exists());
+
+        let exclude = exclude_store_from_git(repo).unwrap().expect("a rule");
+        assert_eq!(exclude, repo.join(".git").join("info").join("exclude"));
+        assert!(std::fs::read_to_string(&exclude)
+            .unwrap()
+            .contains(STORE_EXCLUDE_RULE));
+    }
+
+    /// A rule that already excludes the store, in either place Git reads one.
+    #[test]
+    fn an_existing_rule_is_left_alone() {
+        for (name, seed) in [
+            (".git/info/exclude", ".kin\n"),
+            (".gitignore", "target\n.kin/\n"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let repo = dir.path();
+            std::fs::create_dir_all(repo.join(".git").join("info")).unwrap();
+            let seeded = repo.join(name);
+            std::fs::write(&seeded, seed).unwrap();
+
+            assert!(
+                exclude_store_from_git(repo).unwrap().is_none(),
+                "{name} already excludes the store"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&seeded).unwrap(),
+                seed,
+                "{name} must be untouched"
+            );
+        }
+    }
+
+    /// A directory Git does not own is not this command's to write into.
+    #[test]
+    fn a_directory_without_git_gets_no_rule() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(exclude_store_from_git(dir.path()).unwrap().is_none());
+        assert!(!dir.path().join(".git").exists());
+    }
+
+    /// A linked worktree's excludes live with the repository it came from.
+    ///
+    /// Kin's own fleet runs almost entirely in linked worktrees, where `.git`
+    /// is a pointer file and `info/exclude` is shared through `commondir`. A
+    /// resolver that stopped at the pointer would write a rule into the
+    /// worktree's private gitdir, where Git never reads one for excludes.
+    #[test]
+    fn a_linked_worktree_is_followed_to_its_common_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let main = dir.path().join("main");
+        let linked = dir.path().join("linked");
+        std::fs::create_dir_all(&main).unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "kin-test@example.invalid"]);
+        git(&main, &["config", "user.name", "Kin Test"]);
+        std::fs::write(main.join("seed"), b"seed").unwrap();
+        git(&main, &["add", "seed"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        git(
+            &main,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                linked.to_str().unwrap(),
+                "-b",
+                "linked",
+            ],
+        );
+        write_store(&linked);
+
+        let before = git_status(&linked);
+        assert!(
+            before.contains(".kin"),
+            "fixture must start visible: {before:?}"
+        );
+
+        let exclude = exclude_store_from_git(&linked).unwrap().expect("a rule");
+        assert_eq!(
+            exclude.canonicalize().unwrap(),
+            main.join(".git")
+                .join("info")
+                .join("exclude")
+                .canonicalize()
+                .unwrap(),
+            "a linked worktree writes to the shared exclude, not its private gitdir"
+        );
+
+        let after = git_status(&linked);
+        assert!(!after.contains(".kin"), "store must be excluded: {after:?}");
     }
 }

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -208,12 +208,14 @@ pub fn build_refs_response(
             .as_deref()
             .map(|path| display_read_path(layout, path))
             .unwrap_or_else(|| "unknown".to_string());
-        let line = entry.start_line.unwrap_or(0);
+        let location = match entry.start_line {
+            Some(line) => format!("{file_path}:{line}"),
+            None => file_path,
+        };
         lines.push(format!(
-            "  {} @ {}:{} [{}]",
+            "  {} @ {} [{}]",
             entry.name,
-            file_path,
-            line,
+            location,
             relation_kinds_label(&entry.relation_kinds)
         ));
     }
@@ -549,6 +551,9 @@ struct ReferenceEntry {
     entity_id: EntityId,
     name: String,
     file_path: Option<String>,
+    /// 1-based, as every `file:line` an agent pastes into an editor is.
+    /// `None` for an entity the graph carries no span for, because reporting a
+    /// line for one would be a fabricated position.
     start_line: Option<u32>,
     relation_kinds: Vec<RelationKind>,
 }
@@ -638,7 +643,7 @@ fn collect_graph_references(
             entity_id: source_id,
             name: entity.name.clone(),
             file_path: entity.file_origin.as_ref().map(|f| f.0.clone()),
-            start_line: entity.span.as_ref().map(|s| s.start_line),
+            start_line: kin_mcp::handlers::common::entity_presentation_start_line(&entity),
             relation_kinds: source_kinds,
         });
     }
@@ -981,7 +986,7 @@ mod tests {
             "count line must count entities: {joined}"
         );
         assert!(
-            joined.matches("shared_caller @ callers.rs:0").count() == 2,
+            joined.matches("shared_caller @ callers.rs [").count() == 2,
             "both same-metadata entity ids must be listed separately: {joined}"
         );
 
@@ -1244,6 +1249,118 @@ mod tests {
         assert!(
             error.to_string().contains("classified_count"),
             "a version-skewed response must fail instead of recovering unsafe negatives: {error}"
+        );
+    }
+
+    /// A reference must report the line a human editor shows.
+    ///
+    /// Graph spans carry tree-sitter rows, which are 0-based, and this listing
+    /// emitted them raw. An agent that read `kin refs` and jumped to the
+    /// reported `file:line` landed one line above every reference it was given,
+    /// on every reference, while `find_references` over MCP answered the same
+    /// question one line lower.
+    ///
+    /// The fixture puts the caller on graph row 41, which is line 42 of the
+    /// file, so an off-by-one cannot pass by coincidence.
+    #[test]
+    fn a_reference_reports_the_line_a_human_editor_shows() {
+        use kin_db::InMemoryGraph;
+        use kin_model::relation::{Relation, RelationOrigin};
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, SemanticFingerprint,
+            SourceSpan, Visibility,
+        };
+
+        fn entity(name: &str, rel_path: &str, graph_row: Option<u32>) -> Entity {
+            Entity {
+                id: EntityId::new(),
+                kind: EntityKind::Function,
+                name: name.to_string(),
+                language: LanguageId::Rust,
+                fingerprint: SemanticFingerprint {
+                    algorithm: FingerprintAlgorithm::V1TreeSitter,
+                    ast_hash: Hash256::from_bytes([0; 32]),
+                    signature_hash: Hash256::from_bytes([0; 32]),
+                    behavior_hash: Hash256::from_bytes([0; 32]),
+                    equivalence_hash: Hash256::from_bytes([0; 32]),
+                    stability_score: 1.0,
+                },
+                file_origin: Some(FilePathId::new(rel_path)),
+                span: graph_row.map(|row| SourceSpan {
+                    file: FilePathId::new(rel_path),
+                    start_byte: 0,
+                    end_byte: 1,
+                    start_line: row,
+                    start_col: 0,
+                    end_line: row + 3,
+                    end_col: 0,
+                }),
+                signature: name.to_string(),
+                visibility: Visibility::Public,
+                role: EntityRole::Source,
+                doc_summary: None,
+                metadata: EntityMetadata::default(),
+                lineage_parent: None,
+                created_in: None,
+                superseded_by: None,
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        std::fs::create_dir_all(repo.join(".kin")).unwrap();
+        let layout = kin_core::KinLayout::new(repo.join(".kin"));
+
+        let target = entity("probe_symbol", "target_mod.rs", Some(0));
+        let spanned_caller = entity("spanned_caller", "spanned.rs", Some(41));
+        let spanless_caller = entity("spanless_caller", "spanless.rs", None);
+
+        let graph = InMemoryGraph::new();
+        graph.upsert_entity(&target).unwrap();
+        for caller in [&spanned_caller, &spanless_caller] {
+            graph.upsert_entity(caller).unwrap();
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::References,
+                    src: GraphNodeId::Entity(caller.id),
+                    dst: GraphNodeId::Entity(target.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        let response = build_refs_response(
+            &layout,
+            &graph,
+            &RefsRequest {
+                entity: "probe_symbol".to_string(),
+                kind: "all".to_string(),
+            },
+        )
+        .unwrap();
+        let joined = response.lines.join("\n");
+
+        assert!(
+            joined.contains("spanned.rs:42"),
+            "graph row 41 is line 42 to a reader: {joined}"
+        );
+        assert!(
+            !joined.contains("spanned.rs:41"),
+            "the raw graph row must never reach the listing: {joined}"
+        );
+        assert!(
+            joined.contains("spanless_caller @ spanless.rs "),
+            "an entity with no span reports its path and no fabricated line: {joined}"
+        );
+        assert!(
+            !joined.contains("spanless.rs:0"),
+            "line 0 exists in no editor: {joined}"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1315,6 +1315,12 @@ pub struct ExactEntitySource {
 /// hex it stands for, and not the spelling any Kin surface parses back. This
 /// seam is per-dependency in a context pack, which is documented as fitted to a
 /// token budget, so the waste scaled with the pack.
+///
+/// For the same reason this carries no `artifact_path`. A `RepoPath` is bytes,
+/// and its wire form is a `{"bytes_hex": …}` object, so the path arrived as
+/// twice its own length in hex beside the plain `file_path` every caller of
+/// this seam already emits. Two spellings of one path, one of them unreadable,
+/// per entry, inside a budgeted pack.
 pub fn source_provenance_fields(
     source: &ExactEntitySource,
 ) -> serde_json::Map<String, serde_json::Value> {
@@ -1354,7 +1360,6 @@ pub fn source_provenance_fields(
         serde_json::json!(source.span_coherence.label()),
     );
     fields.insert("artifact_id".into(), serde_json::json!(source.artifact_id));
-    fields.insert("artifact_path".into(), serde_json::json!(source.path));
     fields.insert(
         "artifact_entry".into(),
         serde_json::json!(super::artifacts::TreeEntryWire::from(source.entry)),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -779,8 +779,47 @@ pub fn handle_get_context_pack<G: GraphStore>(
         result["nearby_traffic"] = serde_json::to_value(&pack.traffic).map_err(McpError::Json)?;
     }
 
-    let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
+    let json = serialize_with_measured_tokens(&mut result)?;
     Ok(ToolCallResult::text(json))
+}
+
+/// Passes allowed to settle `tokens_used` against the bytes carrying it.
+///
+/// The estimator counts a number as one token however many digits it has, so
+/// writing the measurement back changes the count only when the payload's own
+/// structure changes, which it does not. One correcting pass and one
+/// confirming pass are what this actually takes; the rest is headroom.
+const MEASURED_TOKEN_PASSES: usize = 4;
+
+/// Serialize the pack, reporting what the bytes it returns actually cost.
+///
+/// `tokens_used` is the number a caller subtracts from its own context budget
+/// before deciding what to ask for next, and it was the planner's estimate:
+/// the cost of the signature stubs admission considered, not of the bodies,
+/// provenance, and JSON structure this handler goes on to serve. A caller that
+/// trusted it spent more than it was told, on every call, and the gap grew with
+/// the pack because bodies are the part the estimate omits.
+///
+/// Measuring is self-referential, since the count is a field of the object
+/// being counted. Writing the count back and re-measuring settles that: the
+/// estimator treats a number as one token whatever its width, so the second
+/// pass confirms the first rather than chasing it.
+///
+/// What this counts is the tool's own serialized payload. The `_kin` envelope
+/// is attached after the handler returns and is not visible from here, so it
+/// remains outside the number, which is a bounded and constant understatement
+/// rather than the unbounded one this replaces.
+fn serialize_with_measured_tokens(result: &mut serde_json::Value) -> Result<String> {
+    let mut json = serde_json::to_string_pretty(result).map_err(McpError::Json)?;
+    for _ in 0..MEASURED_TOKEN_PASSES {
+        let measured = serde_json::json!(kin_context::estimate_tokens(&json));
+        if result["tokens_used"] == measured {
+            break;
+        }
+        result["tokens_used"] = measured;
+        json = serde_json::to_string_pretty(result).map_err(McpError::Json)?;
+    }
+    Ok(json)
 }
 
 pub const TRACE_COMPUTATION_DESC: &str = "\

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2898,6 +2898,95 @@ mod tests {
         );
     }
 
+    /// `tokens_used` must describe the bytes the caller received.
+    ///
+    /// It described the planner's signature stubs instead, so a caller
+    /// budgeting its next request against it had already spent more than the
+    /// number said, by the whole weight of the bodies and provenance the
+    /// handler goes on to serve. The same payload also carried `artifact_path`,
+    /// a `RepoPath` whose wire form is hex bytes, beside the plain `file_path`
+    /// that already names the same file.
+    #[test]
+    fn a_context_pack_reports_what_its_own_payload_costs() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let content = "export function budgeted_probe_9f3e(value: number): boolean {\n  return value > 0;\n}\n";
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
+
+        let mut store = EmptyStore::default();
+        store.entities_by_id.insert(entity.id, entity.clone());
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+        install_empty_store_exact_tree(&mut store, source._dir.path());
+        let authority = test_repository_authority(source._dir.path());
+        let sessions = SessionRegistry::new();
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(entity.id.to_string()),
+        )]);
+
+        let result =
+            entities::handle_get_context_pack(&args, &store, &sessions, Some(&authority)).unwrap();
+        let crate::types::ContentBlock::Text { text } = &result.content[0];
+        let served = text.clone();
+        let value: serde_json::Value = serde_json::from_str(&served).unwrap();
+
+        let reported = value["tokens_used"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("the pack must report tokens_used: {value}"))
+            as usize;
+        let actual = kin_context::estimate_tokens(&served);
+        assert!(
+            reported.abs_diff(actual) <= actual / 100,
+            "tokens_used {reported} must be within 1% of the {actual} tokens the served payload \
+             costs"
+        );
+
+        // Positive control: the payload really does carry more than the stub
+        // accounting, so a pack that lost its body could not pass the check
+        // above by measuring nothing.
+        assert!(
+            value["focal_entity"]["body"].is_string(),
+            "the pack must serve a body for this fixture: {value}"
+        );
+
+        assert_eq!(
+            value["focal_entity"]["file_path"],
+            serde_json::json!(entity.file_origin.as_ref().unwrap().to_string()),
+            "the readable path stays: {value}"
+        );
+        let mut hex_paths = Vec::new();
+        artifact_path_fields(&value, "context_pack", &mut hex_paths);
+        assert!(
+            hex_paths.is_empty(),
+            "the pack must not restate file_path as hex bytes at {hex_paths:?}: {value}"
+        );
+    }
+
+    /// Name every `artifact_path` anywhere under `value`.
+    fn artifact_path_fields(value: &serde_json::Value, at: &str, found: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    artifact_path_fields(item, &format!("{at}[{index}]"), found);
+                }
+            }
+            serde_json::Value::Object(fields) => {
+                for (key, item) in fields {
+                    if key == "artifact_path" {
+                        found.push(format!("{at}.{key}"));
+                    }
+                    artifact_path_fields(item, &format!("{at}.{key}"), found);
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Stand-in for the context builder's token-accounting projection, so the
     /// tests above assert against the exact text that used to leak into `body`.
     fn project_full_body_stub(entity: &Entity) -> String {
@@ -4803,9 +4892,13 @@ mod tests {
             renamed_source["artifact_id"],
             serde_json::to_value(source.artifact_id).unwrap()
         );
+        // The path this read resolved at is asserted on the artifact surface
+        // below, where `artifact.path` is the exact `RepoPath`. The entity
+        // surface names the same file readably and no longer restates it as
+        // hex bytes beside its own `file_path`.
         assert_eq!(
-            renamed_source["artifact_path"],
-            serde_json::to_value(&renamed_path).unwrap()
+            renamed_source["read_path"],
+            serde_json::json!(".kin/source-root/src/renamed.ts")
         );
         assert_eq!(
             renamed_source["source_excerpt"],


### PR DESCRIPTION
Follow-up to FIR-2359, which closed with #862. These are the papercuts from the
brownfield half of the same isolation experiment, one commit each so any one
reverts alone.

**`kin init` leaves the store visible in `git status`.** Admission writes a
`.kin` directory that is routinely a gigabyte, and Git has no reason to know it
is Kin's, so every `git status` after a conversion reported it as untracked,
forever. Init now adds an anchored `/.kin/` rule to the repository's local
`.git/info/exclude`. The rule is local rather than a change to the tracked
`.gitignore`, so whether a peer's checkout carries a store stays that peer's
business and Kin never appears in the author's next diff. Resolution follows a
`gitdir:` pointer file through `commondir`, so a linked worktree writes to the
shared exclude rather than its own private gitdir. A missing `info` directory is
created, a rule that already covers the store in either `.git/info/exclude` or
`.gitignore` is left alone, and every refusal is reported without failing an
admission whose store is already durable. The acceptance test asks Git itself:
a repository with a store present in `git status --porcelain` is absent from it
after the rule is written.

**`kin refs` reported 0-based line numbers.** Graph spans carry tree-sitter
rows, which are 0-based, and this listing emitted them raw, so an agent that
jumped to the reported `file:line` landed one line above every reference it was
handed while `find_references` over MCP answered the same question one line
lower. Both of the listing's emitters now convert at the presentation seam
`kin graph` and `kin trace` already use, and an entity the graph carries no span
for reports its path alone rather than line 0, which exists in no editor.

Scope note, stated rather than slipped in: the second emitter is
`declaration_neighbors::entity_location`, which `kin refs` prints through on its
empty-result path and `kin impact` shares for its header, its hop listing, its
qualifier-miss guidance, and its `--json` candidate locations. Fixing it in one
place is what makes `kin refs` self-consistent, and it corrects the same
off-by-one in `kin impact`; four impact tests asserted the old raw row and are
updated to the line a reader sees.

**`get_context_pack` under-reported what it spent.** `tokens_used` came from the
context builder's own estimate, which counts the signature stubs planning
admitted and not the bodies, provenance, and JSON structure the handler goes on
to serve, so a caller budgeting its next request against it had already spent
several times the number it was given. On a one-entity fixture the pack reported
38 tokens for 274 tokens of payload. It now measures the serialized payload the
tool returns, settling the self-reference by writing the count back and
confirming it. What stays outside the number is the `_kin` envelope, which is
attached after the handler returns and is a bounded constant rather than the
unbounded understatement it replaces.

The same payload carried `artifact_path`, a `RepoPath` whose wire form is a
`{"bytes_hex": …}` object, sitting beside the plain `file_path` every caller of
the provenance seam already emits. One path arrived spelled twice, once
unreadably, on every entry of a pack documented as fitted to a token budget. It
is dropped. The exact `RepoPath` is still served by `kin_artifact_read`, which
is the surface whose input it is.

`source_change_id` needed no change. It already renders as 64-character hex
rather than a 32-integer array, because #862 fixed it, and the accompanying test
asserts the payload carries no long integer run anywhere.

A survey of every line-number emitter in the CLI turned up more than fix 2
touches, and the rest is reported here rather than widened into. The premise
behind fix 2 is only partly true: six further surfaces are still 0-based, and
four of them live in `crates/kin-review` rather than `kin-cli`. Ordered by how
much they affect, `kin search` is worst, where one raw read feeds `--json`
`line` and `end_line`, `--show-body` `file:line`, and the artifact `line` alike.
Then `kin review run`, in both `--json` and the `L{n}` text form, rooted in
about fifteen raw reads in `kin-review/src/inline.rs`. Then `kin impact --json`
`ranked.candidates[]` in `kin-review/src/ranked_impact.rs`, `kin review shadow`
in both forms, `kin overview` in its non-compact human output, and
`kin review revert-history`. Kin's MCP surface is uniformly 1-based and has a
regression test for it (`every_read_surface_reports_the_same_one_based_start_line`);
`kin-cli` has no equivalent.

Gates: `cargo nextest run --workspace` plus `cargo test --doc` green on the lane
worktree at `b0840ff1` (5782 tests run, 5782 passed, 11 skipped), `cargo fmt --
--check` clean, the CI clippy allowlist clean under `RUSTFLAGS=-D warnings`, and
both zero-file-search scanners passing. Each new test was falsified against the
old behavior before being kept.

Closes FIR-2375
