### PR TITLE
Report graph-body coverage, and make each status counter name the view it shows

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1828,9 +1828,13 @@ mod tests {
             .upsert_entity(&external_target_entity("urllib3.poolmanager", 2))
             .unwrap();
 
-        let response =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         let entity_line = response
             .lines
@@ -1884,9 +1888,13 @@ mod tests {
         graph.upsert_entity(&documented).unwrap();
         graph.upsert_entity(&test_entity("undocumented")).unwrap();
 
-        let response =
-            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
-                .unwrap();
+        let response = build_graph_status_response(
+            &pinned(&binding),
+            &graph,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
 
         let line = response
             .lines

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -600,8 +600,22 @@ fn build_graph_status_response(
         }
     }
     lines.push(embeddings_line);
+    // A census, not a queue, and the label has to say so.
+    //
+    // This counter sat directly beneath the embeddings line above, which IS a
+    // fill counter with a real pending count, and read as the same kind of
+    // thing. On the 0.5.36 evidence store it showed 305/777 at the start of a
+    // session and the identical 305/777 at the end, which a reader took for a
+    // stalled worker. Nothing stalled and nothing was scheduled: `doc_summary`
+    // is set by the language extractors from the comment preceding a
+    // declaration (`extract_preceding_comment`, every adapter in kin-parser)
+    // and by nothing else on any live path. So the fraction is a property of
+    // the source code, and it moves only when the source gains or loses doc
+    // comments. Stating that inline is the fix; there is no queue depth to
+    // publish and no stalled flag to raise.
     lines.push(format!(
-        "Doc summaries: {}/{} ({:.0}%)",
+        "Documented entities: {}/{} ({:.0}%) carry a doc comment extracted from the source at \
+         parse time (a census of the code as written, not a job filling in the background)",
         with_docs,
         entity_count,
         if entity_count == 0 {
@@ -1786,6 +1800,114 @@ mod tests {
                 .iter()
                 .any(|line| line.starts_with("Relations: ") || line.contains("  |  Relations: ")),
             "{:?}",
+            response.lines
+        );
+    }
+
+    /// Two surfaces counting one store must each name the view they show, and
+    /// the surface holding the excluded set must publish the arithmetic that
+    /// reconciles them.
+    ///
+    /// `kin graph status` and `kin status` disagreed by 45 entities on one store
+    /// at one instant with neither acknowledging a second view existed, so a
+    /// reader judging coverage had two denominators and no way to choose. The
+    /// gap is not an error: external reference targets are dropped from this
+    /// surface's entity total on purpose and counted by durable authority
+    /// enrichment. Reverting either half of the disclosure fails this test.
+    #[test]
+    fn graph_status_names_its_entity_view_and_reconciles_it_with_durable_status() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        graph.upsert_entity(&test_entity("run_task")).unwrap();
+        // Two nodes this repository references without defining. They are real
+        // entities in the graph and are excluded from the entity total below,
+        // which is exactly the shape that made the two surfaces disagree.
+        graph
+            .upsert_entity(&external_target_entity("requests.adapters", 1))
+            .unwrap();
+        graph
+            .upsert_entity(&external_target_entity("urllib3.poolmanager", 2))
+            .unwrap();
+
+        let response =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
+
+        let entity_line = response
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Entities: "))
+            .unwrap_or_else(|| panic!("no entity line: {:?}", response.lines));
+        assert!(
+            entity_line.contains("Entities: 1"),
+            "the entity total must still exclude external reference targets: {entity_line}"
+        );
+        assert!(
+            entity_line.contains("live query graph"),
+            "the entity total must name the view it counts: {entity_line}"
+        );
+
+        let external_line = response
+            .lines
+            .iter()
+            .find(|line| line.starts_with("External reference targets: "))
+            .unwrap_or_else(|| panic!("no external line: {:?}", response.lines));
+        assert!(
+            external_line.contains("External reference targets: 2"),
+            "the excluded count must be stated: {external_line}"
+        );
+        assert!(
+            external_line.contains("excluded from the entity total"),
+            "the excluded set must say it is excluded, or the two totals do not add up for a \
+             reader: {external_line}"
+        );
+        assert!(
+            external_line.contains("kin status"),
+            "the reconciliation must name the other surface, or a reader still has to guess \
+             which denominator is real: {external_line}"
+        );
+    }
+
+    /// A census must not wear a queue's clothes.
+    ///
+    /// `doc_summary` is set by the language extractors from the comment
+    /// preceding a declaration and by nothing else on any live path: there is no
+    /// worker, no queue, and nothing that can stall. The old label read
+    /// "Doc summaries: 305/777 (39%)" one line under a genuine embedding fill
+    /// counter, and an unchanging fraction across a session was reported as a
+    /// silently stalled job. This holds the line that the counter states what it
+    /// measures.
+    #[test]
+    fn documented_entity_census_does_not_read_as_a_pending_queue() {
+        let (_temp, binding, graph) = graph_validation_fixture();
+        let mut documented = test_entity("send");
+        documented.doc_summary = Some("Send the prepared request.".to_string());
+        graph.upsert_entity(&documented).unwrap();
+        graph.upsert_entity(&test_entity("undocumented")).unwrap();
+
+        let response =
+            build_graph_status_response(&binding, &graph, &Default::default(), &Default::default())
+                .unwrap();
+
+        let line = response
+            .lines
+            .iter()
+            .find(|line| line.starts_with("Documented entities: "))
+            .unwrap_or_else(|| panic!("no documented-entity line: {:?}", response.lines));
+        assert!(
+            line.contains("1/2"),
+            "the census must still count accurately: {line}"
+        );
+        assert!(
+            line.contains("parse time") && line.contains("not a job filling in the background"),
+            "the line must say the fraction is extraction-time source truth, or an unchanging \
+             value reads as a stalled worker: {line}"
+        );
+        assert!(
+            !response
+                .lines
+                .iter()
+                .any(|line| line.starts_with("Doc summaries: ")),
+            "the queue-shaped label must be gone: {:?}",
             response.lines
         );
     }

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -453,8 +453,14 @@ fn build_graph_status_response(
     let mut lines = Vec::new();
     lines.push("=== Graph Health ===".to_string());
     lines.push(String::new());
+    // Name the view before the number. This counter and the one `kin status`
+    // prints are two different measurements of one store, and a reader given
+    // both bare totals has no way to tell which denominator applies to the
+    // coverage question they are actually asking. Each surface states what it
+    // counts, and the reconciliation below states why they differ.
     lines.push(format!(
-        "Entities: {}  |  Entity-to-entity relations: {}  |  Files: {}",
+        "Entities: {} (live query graph, definitions this repository owns)  |  Entity-to-entity \
+         relations: {}  |  Files: {} (files those entities originate in)",
         entity_count,
         total_relations,
         unique_files.len()
@@ -467,8 +473,22 @@ fn build_graph_status_response(
             total_relations as f64 / entity_count as f64
         }
     ));
+    // The reconciliation between this surface and `kin status`, stated as
+    // arithmetic rather than left to the reader.
+    //
+    // These two totals counted the same store and disagreed by 45 on the
+    // 0.5.36 evidence store, with nothing on either surface acknowledging a
+    // second view existed. The excluded set is not a rounding difference: the
+    // partition above drops external reference targets from `entity_count` on
+    // purpose (counting a node this repository merely references would report
+    // documentation coverage falling with no change to documentation), while
+    // durable authority enrichment replays every semantic identity it admitted
+    // and so counts them. Naming the excluded count beside the total is what
+    // makes the two surfaces add up.
     lines.push(format!(
-        "External reference targets: {}",
+        "External reference targets: {} (referenced elsewhere, not defined here, and excluded \
+         from the entity total above; `kin status` reports durable authority enrichment, a \
+         different view that counts them, so its entity total is the larger of the two)",
         external_targets.len()
     ));
     lines.push(String::new());

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -25781,6 +25781,63 @@ mod tests {
         assert!(hits.contains_key("src/main.c"));
     }
 
+    /// The observation is wired to the real path, not only to its helper.
+    ///
+    /// A path the graph owns as source but holds no body for is exactly the
+    /// state behind the 111 `kin.locate.graph_gap` warnings: the term loops skip
+    /// it, so entities in it can rank on nothing but a name match. This asserts
+    /// the source-text phase reports that as a number, and that a store with
+    /// every body present reports a clean scan rather than silence.
+    #[test]
+    fn source_text_signals_report_the_body_gap_they_ranked_around() {
+        let graph = kin_db::InMemoryGraph::new();
+        graph
+            .upsert_entity(&test_entity("Session", "src/requests/sessions.py", 1, 20))
+            .unwrap();
+        graph
+            .upsert_entity(&test_entity("request", "src/requests/api.py", 1, 20))
+            .unwrap();
+        // Only one of the two source paths carries a graph-owned body.
+        graph
+            .put_opaque(&OpaqueArtifact {
+                file_id: FilePathId::new("src/requests/api.py"),
+                content_hash: Hash256::from_bytes([9; 32]),
+                mime_type: Some("text/x-source".into()),
+                text_preview: Some("def request(method, url): return Session().request()".into()),
+            })
+            .unwrap();
+        graph.flush_text_index().unwrap();
+
+        let bodies = extract_source_text_signals("where is the Session request path", &graph)
+            .unwrap()
+            .graph_bodies
+            .expect("the source-text phase observed the store and owes a number");
+        assert_eq!(bodies.source_paths, 2);
+        assert_eq!(bodies.with_body, 1);
+        assert_eq!(bodies.gap_paths, 1);
+        assert_eq!(bodies.sample, vec!["src/requests/sessions.py".to_string()]);
+
+        // Same store, gap closed: the scan must now report clean, or the number
+        // says nothing a caller can act on.
+        graph
+            .put_opaque(&OpaqueArtifact {
+                file_id: FilePathId::new("src/requests/sessions.py"),
+                content_hash: Hash256::from_bytes([10; 32]),
+                mime_type: Some("text/x-source".into()),
+                text_preview: Some("class Session: def request(self, method, url): pass".into()),
+            })
+            .unwrap();
+        graph.flush_text_index().unwrap();
+
+        let healed = extract_source_text_signals("where is the Session request path", &graph)
+            .unwrap()
+            .graph_bodies
+            .expect("observed");
+        assert_eq!(healed.gap_paths, 0);
+        assert_eq!(healed.with_body, 2);
+        assert!(healed.sample.is_empty());
+    }
+
     #[test]
     fn extract_source_text_signals_filters_symbolic_partial_matches_when_full_source_is_available()
     {
@@ -27135,6 +27192,153 @@ mod tests {
         assert!(
             synth.contains("6 pending"),
             "synthesized banner cites pending"
+        );
+    }
+
+    fn fully_embedded_coverage() -> SemanticCoverage {
+        SemanticCoverage {
+            supported: true,
+            indexed: 1644,
+            total: 1644,
+            pending: 0,
+            complete: true,
+            note: None,
+            graph_bodies: None,
+        }
+    }
+
+    /// The graph gap becomes a number a caller can read.
+    ///
+    /// It was a `kin.locate.graph_gap` tracing warning and a process-global
+    /// counter behind a `#[cfg(test)]` accessor, so the only way to learn that
+    /// 111 authority paths carried no graph body was to have daemon logs open.
+    #[test]
+    fn graph_body_coverage_counts_and_samples_the_paths_with_no_body() {
+        let paths: Vec<String> = [
+            "src/requests/sessions.py",
+            "src/requests/utils.py",
+            "src/requests/cookies.py",
+            "src/requests/api.py",
+        ]
+        .iter()
+        .map(|path| (*path).to_string())
+        .collect();
+        let bodies = GraphBodyCoverage::observe(paths.iter(), |path| path.ends_with("api.py"));
+
+        assert_eq!(bodies.source_paths, 4);
+        assert_eq!(bodies.with_body, 1);
+        assert_eq!(bodies.gap_paths, 3);
+        assert!(bodies.has_gap());
+        // Sorted, so two reads of an unchanged store name the same paths.
+        assert_eq!(
+            bodies.sample,
+            vec![
+                "src/requests/cookies.py".to_string(),
+                "src/requests/sessions.py".to_string(),
+                "src/requests/utils.py".to_string(),
+            ]
+        );
+    }
+
+    /// The sample is bounded; the count never is.
+    #[test]
+    fn graph_body_coverage_bounds_its_sample_without_capping_the_count() {
+        let paths: Vec<String> = (0..40).map(|index| format!("src/mod{index:02}.py")).collect();
+        let bodies = GraphBodyCoverage::observe(paths.iter(), |_| false);
+
+        assert_eq!(bodies.gap_paths, 40, "the count must be the whole truth");
+        assert_eq!(
+            bodies.sample.len(),
+            GRAPH_BODY_GAP_SAMPLE,
+            "the sample must stay bounded"
+        );
+    }
+
+    /// A completeness signal must not read `complete` while ranking is degraded.
+    ///
+    /// This is the ticket's acceptance line. With embeddings at 1644/1644 the
+    /// payload said `semantic_coverage: complete` while every entity hit came
+    /// back `match_kind: "text_fallback"`, because `complete` was computed from
+    /// the embedding counter and ranking needs a graph-owned body. Reverting the
+    /// conjunction in `with_graph_bodies` fails here.
+    #[test]
+    fn a_body_gap_clears_complete_on_a_fully_embedded_store() {
+        let coverage = fully_embedded_coverage().with_graph_bodies(GraphBodyCoverage::observe(
+            [
+                "src/requests/sessions.py".to_string(),
+                "src/requests/utils.py".to_string(),
+            ]
+            .iter(),
+            |_| false,
+        ));
+
+        assert!(
+            !coverage.complete,
+            "every embedding indexed is not a complete signal while ranking runs on text fallback"
+        );
+        assert_eq!(coverage.indexed, 1644, "the embedding counts stay exact");
+        assert_eq!(coverage.pending, 0);
+        let note = coverage.note.as_deref().expect("a cleared flag owes a reason");
+        assert!(
+            note.contains("graph body gap") && note.contains("2 of 2"),
+            "the note must name the cause and its size: {note}"
+        );
+        assert_eq!(
+            coverage.graph_bodies.expect("the number rides along").gap_paths,
+            2
+        );
+    }
+
+    /// Absence of evidence is not evidence of a gap.
+    ///
+    /// A surface that ran no retrieval observed no bodies, and reporting that
+    /// silence as a gap would mark every such payload degraded. The caller tells
+    /// the two apart by reading `graph_bodies`, which stays absent.
+    #[test]
+    fn full_body_coverage_and_an_unobserved_one_both_leave_complete_alone() {
+        let observed = fully_embedded_coverage()
+            .with_graph_bodies(GraphBodyCoverage::observe(
+                ["src/requests/api.py".to_string()].iter(),
+                |_| true,
+            ));
+        assert!(observed.complete, "no gap, so nothing to clear");
+        assert!(observed.note.is_none(), "no gap, so no note");
+        assert_eq!(observed.graph_bodies.expect("observed").gap_paths, 0);
+
+        let unobserved = fully_embedded_coverage();
+        assert!(unobserved.complete);
+        assert!(
+            unobserved.graph_bodies.is_none(),
+            "absent means not observed, and a caller must be able to tell that from a clean scan"
+        );
+    }
+
+    /// An embedding shortfall and a body gap are different remediations, so a
+    /// payload carrying both must state both.
+    #[test]
+    fn a_body_gap_note_is_appended_to_an_embedding_note_rather_than_replacing_it() {
+        let partial = SemanticCoverage {
+            supported: true,
+            indexed: 4,
+            total: 10,
+            pending: 6,
+            complete: false,
+            note: Some("semantic signal partial: 4/10 embedded.".to_string()),
+            graph_bodies: None,
+        };
+        let coverage = partial.with_graph_bodies(GraphBodyCoverage::observe(
+            ["src/requests/sessions.py".to_string()].iter(),
+            |_| false,
+        ));
+
+        let note = coverage.note.as_deref().expect("both causes owe a reason");
+        assert!(
+            note.contains("4/10 embedded"),
+            "the embedding cause must survive: {note}"
+        );
+        assert!(
+            note.contains("graph body gap"),
+            "the body cause must be stated too: {note}"
         );
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -143,13 +143,107 @@ pub struct SemanticCoverage {
     pub total: usize,
     /// Entities still queued for embedding.
     pub pending: usize,
-    /// True when the semantic signal was complete (`total == 0`, or every
-    /// entity indexed with nothing pending).
+    /// True when the retrieval signals this report covers were all complete.
+    ///
+    /// This is a CONJUNCTION, not the embedding fraction. Every embedding can be
+    /// indexed while ranking still runs on text fallback alone, because scoring an
+    /// entity needs a graph-owned body for its source path and the embedding
+    /// counter says nothing about whether one exists. Reporting `complete` off the
+    /// embedding count alone is how a store with 1644/1644 indexed and 111
+    /// body-less authority paths told callers retrieval was healthy while every
+    /// hit came back `match_kind: "text_fallback"`. So a known body gap clears
+    /// this flag and [`Self::graph_bodies`] carries the number behind it.
+    ///
+    /// An UNOBSERVED body coverage does not clear the flag. Absence of evidence is
+    /// not evidence of a gap, and treating it as one would report every surface
+    /// that cannot observe bodies as degraded. Read `graph_bodies.observed` to
+    /// tell "no gap" from "not looked at"; they are different answers.
     pub complete: bool,
     /// Human-readable note describing the degraded state, present only when the
     /// semantic signal was partial. Lexical + graph signals still ran.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// Graph-owned source-body coverage behind this query's ranking.
+    ///
+    /// Absent on payloads from surfaces that ran no retrieval, and on payloads
+    /// minted before this field existed. Absent therefore means "not observed",
+    /// never "no gap".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph_bodies: Option<GraphBodyCoverage>,
+}
+
+/// How much of the graph's own source-path authority carries a graph-owned body.
+///
+/// This is the `kin.locate.graph_gap` warning promoted to a number a caller can
+/// read. That warning went only to the daemon log, and its running total lived in
+/// a process-global counter whose accessor was `#[cfg(test)]`, so no caller could
+/// reach it at all. A path the graph admits as source but holds no body for is a
+/// path locate can neither scan for terms nor rank on anything but a name match,
+/// which is precisely the state that produces `all_fallback: true` on a fully
+/// embedded store.
+///
+/// Deliberately NOT a new coverage type alongside `kin_core::cross_file_coverage`
+/// and `kin_mcp::edge_coverage`. Those answer questions about relation topology:
+/// whether edges leave their file, and whether the graph holds the edge class an
+/// absence claim depends on. Body presence is a different axis, and it belongs on
+/// the coverage object whose `complete` flag it falsifies rather than in a fourth
+/// place a caller would have to know to check.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct GraphBodyCoverage {
+    /// Source paths the graph owns as retrieval authority for this query.
+    pub source_paths: usize,
+    /// Of those, the ones carrying a non-empty graph-owned body.
+    pub with_body: usize,
+    /// Of those, the ones the graph holds no body for. `source_paths -
+    /// with_body`, stated rather than left to the caller's arithmetic.
+    pub gap_paths: usize,
+    /// A bounded sample of gap paths, so an operator can act without turning on
+    /// daemon logging. Capped at [`GRAPH_BODY_GAP_SAMPLE`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sample: Vec<String>,
+}
+
+/// Gap paths named in [`GraphBodyCoverage::sample`]. Enough to recognize a
+/// pattern (one directory, one language, one adapter) without pasting a repo
+/// listing into every payload.
+const GRAPH_BODY_GAP_SAMPLE: usize = 8;
+
+impl GraphBodyCoverage {
+    /// Assemble from the two sets locate already holds: the graph's source-path
+    /// authority, and the subset it resolved a body for.
+    fn observe<'a>(
+        source_paths: impl IntoIterator<Item = &'a String>,
+        has_body: impl Fn(&str) -> bool,
+    ) -> Self {
+        let mut total = 0usize;
+        let mut with_body = 0usize;
+        let mut gaps: Vec<String> = Vec::new();
+        for path in source_paths {
+            total += 1;
+            if has_body(path) {
+                with_body += 1;
+            } else {
+                gaps.push(path.clone());
+            }
+        }
+        // Sorted before truncation so the sample is a stable fact about the
+        // store rather than a hash-order accident that changes between two
+        // reads of an unchanged graph.
+        gaps.sort();
+        let gap_paths = gaps.len();
+        gaps.truncate(GRAPH_BODY_GAP_SAMPLE);
+        Self {
+            source_paths: total,
+            with_body,
+            gap_paths,
+            sample: gaps,
+        }
+    }
+
+    /// Whether ranking ran against an incomplete body set.
+    fn has_gap(&self) -> bool {
+        self.gap_paths > 0
+    }
 }
 
 fn semantic_signal_supported_default() -> bool {
@@ -1434,6 +1528,7 @@ fn coverage_from_status(status: &kin_db::EmbeddingStatus) -> SemanticCoverage {
                 "semantic vector ranking is unsupported in this build; lexical and graph signals remain available"
                     .to_string(),
             ),
+            graph_bodies: None,
         };
     }
 
@@ -1455,7 +1550,37 @@ fn coverage_from_status(status: &kin_db::EmbeddingStatus) -> SemanticCoverage {
             pending: status.pending,
             complete,
             note,
+            graph_bodies: None,
         }
+    }
+}
+
+impl SemanticCoverage {
+    /// Fold an observed graph-body coverage into this report.
+    ///
+    /// `complete` becomes the conjunction it always claimed to be: a body gap
+    /// clears it even on a fully embedded store, because ranking an entity needs
+    /// a graph-owned body and an embedding count cannot see that. The note names
+    /// the gap so a human reading the CLI banner learns the same fact the JSON
+    /// carries, and an already-present embedding note is kept rather than
+    /// overwritten, since both causes can hold at once and the caller needs to
+    /// know which remediation applies.
+    pub fn with_graph_bodies(mut self, bodies: GraphBodyCoverage) -> Self {
+        if bodies.has_gap() {
+            self.complete = false;
+            let gap_note = format!(
+                "graph body gap: {} of {} graph-owned source paths carry no body, so entity \
+                 ranking over them falls back to text matching. Run `kin reconcile` (or re-run \
+                 `kin init`) to admit the missing bodies.",
+                bodies.gap_paths, bodies.source_paths
+            );
+            self.note = Some(match self.note.take() {
+                Some(existing) => format!("{existing} {gap_note}"),
+                None => gap_note,
+            });
+        }
+        self.graph_bodies = Some(bodies);
+        self
     }
 }
 
@@ -2296,11 +2421,16 @@ fn run_with_graph_capture_budgeted(
     // It's cheap (budget 10s) and provides result diversity that entity
     // resolution alone cannot. Without it, files only reachable via text
     // search are invisible in EntityDominant scoring.
+    // Body coverage is observed by the source-text phase and stays `None` when
+    // that phase was budget-skipped. A skipped phase measured nothing, and
+    // reporting its silence as full coverage is the exact substitution this
+    // ticket exists to remove.
+    let mut graph_body_coverage: Option<GraphBodyCoverage> = None;
     let source_text = if budget.phase_should_skip("source_text") {
         HashMap::new()
     } else {
         let phase_start = std::time::Instant::now();
-        let source_text = extract_source_text_signals(text, graph)?;
+        let signals = extract_source_text_signals(text, graph)?;
         if phase_start.elapsed().as_secs_f64()
             > budget
                 .phase_budgets
@@ -2310,6 +2440,8 @@ fn run_with_graph_capture_budgeted(
         {
             budget.warn_phase_timeout("source_text", phase_start.elapsed());
         }
+        graph_body_coverage = signals.graph_bodies;
+        let source_text = signals.hits;
         if source_text_priority_query {
             merge_priority_files_from_hits_with_trace(
                 &mut priority_files,
@@ -2319,6 +2451,33 @@ fn run_with_graph_capture_budgeted(
             );
         }
         source_text
+    };
+    // Fold the observation into the coverage report the caller reads, and record
+    // the gap on the degradation ledger beside it. Two channels because they
+    // answer different questions: the coverage object says how much of the store
+    // ranking could see, the degradation says this query ran degraded and names
+    // the remediation.
+    let semantic_coverage = match graph_body_coverage {
+        Some(bodies) => {
+            if bodies.has_gap() {
+                record_degradation(
+                    &mut degradations,
+                    RetrievalDegradation {
+                        component: "graph_source_bodies".to_string(),
+                        reason: "partial".to_string(),
+                        detail: format!(
+                            "{} of {} graph-owned source paths carry no body; entities in them \
+                             rank on text fallback only",
+                            bodies.gap_paths, bodies.source_paths
+                        ),
+                        remediation: "run `kin reconcile` to admit the missing source bodies"
+                            .to_string(),
+                    },
+                );
+            }
+            semantic_coverage.with_graph_bodies(bodies)
+        }
+        None => semantic_coverage,
     };
     let priority_hits: HashMap<String, Vec<FileHit>> = priority_files
         .iter()
@@ -9461,10 +9620,24 @@ fn extract_snippet_signals(
     Ok(hits)
 }
 
+/// Source-text signals for a query, plus the graph-body coverage observing them
+/// cost nothing to produce.
+///
+/// The two are returned together because this function is the only place that
+/// holds both halves of the answer: the graph's source-path authority and the
+/// subset it resolved a body for. Recomputing the observation anywhere else
+/// would mean a second `list_opaque_artifacts`, which deep-clones every source
+/// preview in the store, so the cheap place to measure is the place that already
+/// paid.
+struct SourceTextSignals {
+    hits: HashMap<String, Vec<FileHit>>,
+    graph_bodies: Option<GraphBodyCoverage>,
+}
+
 fn extract_source_text_signals(
     text: &str,
     graph: &kin_db::InMemoryGraph,
-) -> Result<HashMap<String, Vec<FileHit>>> {
+) -> Result<SourceTextSignals> {
     let _span =
         tracing::info_span!("locate.extract_source_text_signals", text_len = text.len()).entered();
     let mut hits: HashMap<String, Vec<FileHit>> = HashMap::new();
@@ -9476,7 +9649,13 @@ fn extract_source_text_signals(
     let body_text = text.lines().skip(1).collect::<Vec<_>>().join("\n");
     let source_paths = graph_source_path_set(graph);
     if source_paths.is_empty() {
-        return Ok(hits);
+        // No source-path authority means nothing to have a body for. That is a
+        // different state from "paths exist and bodies are missing", so it is
+        // reported as unobserved rather than as perfect coverage over zero paths.
+        return Ok(SourceTextSignals {
+            hits,
+            graph_bodies: None,
+        });
     }
 
     let source_previews: HashMap<String, String> = graph
@@ -9505,6 +9684,20 @@ fn extract_source_text_signals(
         })
         .map(|(path, preview)| (path.clone(), preview.clone()))
         .collect();
+
+    // Measure body coverage here, against exactly the two sets the term loops
+    // below consult. Scope is `source_paths` minus test paths, because
+    // `source_previews` excludes test paths by construction and counting them as
+    // gaps would report a hole the ranking path never had.
+    //
+    // Every miss the loops take also emits a `kin.locate.graph_gap` warning, one
+    // per path per term, which is why a session logs far more warnings than it
+    // has body-less paths. This is the same fact stated once, as a number, on
+    // the payload.
+    let graph_bodies = GraphBodyCoverage::observe(
+        source_paths.iter().filter(|path| !is_test_path(path)),
+        |path| preview_source_texts.contains_key(path),
+    );
     let mut path_term_support: HashMap<String, HashSet<String>> = HashMap::new();
 
     let mut terms = extract_search_terms(text);
@@ -9669,7 +9862,10 @@ fn extract_source_text_signals(
         &source_paths,
     );
 
-    Ok(hits)
+    Ok(SourceTextSignals {
+        hits,
+        graph_bodies: Some(graph_bodies),
+    })
 }
 
 fn promote_cli_surface_companion_headers_in_source_text(
@@ -23110,7 +23306,8 @@ mod tests {
             "Add `JSON_PRIVATE_UNLESS_TESTED` for private members used by tests",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(
             hits.contains_key("include/nlohmann/detail/iterators/iter_impl.hpp"),
@@ -25578,7 +25775,8 @@ mod tests {
             "Fix exit code on JSON parse error\n\nThe `--exit-status` option should distinguish invalid JSON parse errors.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(hits.contains_key("src/main.c"));
     }
@@ -25630,7 +25828,8 @@ mod tests {
             "Implement `_experimental_snapshot/2`\n\nEnable writes with `JQ_ENABLE_SNAPSHOT=1`.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(hits.contains_key("src/builtin.c"));
         assert!(!hits.contains_key("src/decNumber/example4.c"));
@@ -25667,7 +25866,8 @@ mod tests {
             "Implement `_experimental_snapshot/2`\n\nThis builtin performs a dry run by default before writing any data to disk.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(hits.contains_key("src/builtin.c"));
         assert!(hits.contains_key("src/main.c"));
@@ -25704,7 +25904,8 @@ mod tests {
             "fix cli issue when providing --help=false.\n\nThe help option parser should accept bool flags.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         let options_score: f32 = hits["src/options.c"].iter().map(|hit| hit.score).sum();
         let runtime_score: f32 = hits["src/runtime.c"].iter().map(|hit| hit.score).sum();
@@ -25734,7 +25935,8 @@ mod tests {
             "Fix #3719 : mixing -c, -o and --rm\n\n`-c` disables `--rm`, but only if it's selected.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(hits.contains_key("programs/zstdcli.c"));
     }
@@ -25759,7 +25961,8 @@ mod tests {
             "Fix #3719 : mixing -c, -o and --rm\n\n`-c` disables `--rm`, but only if it's selected.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(hits.contains_key("programs/zstdcli.c"));
     }
@@ -25811,7 +26014,8 @@ mod tests {
             "Fix #3719 : mixing -c, -o and --rm\n\n`-c` disables `--rm`, but only if it's selected.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         let cli_score: f32 = hits["programs/zstdcli.c"].iter().map(|hit| hit.score).sum();
         let fileio_score: f32 = hits["programs/fileio.h"].iter().map(|hit| hit.score).sum();
@@ -25867,7 +26071,8 @@ mod tests {
             "Fix #3719 : mixing -c, -o and --rm\n\n`-c` disables `--rm`, but only if it's selected.",
             &graph,
         )
-        .unwrap();
+        .unwrap()
+        .hits;
 
         assert!(hits.contains_key("programs/fileio.h"));
         assert!(hits.contains_key("programs/fileio_types.h"));
@@ -26891,6 +27096,7 @@ mod tests {
             pending: 0,
             complete: true,
             note: None,
+            graph_bodies: None,
         };
         assert!(
             coverage_banner(&complete).is_none(),
@@ -26904,6 +27110,7 @@ mod tests {
             pending: 6,
             complete: false,
             note: Some("custom degradation note".to_string()),
+            graph_bodies: None,
         };
         assert_eq!(
             coverage_banner(&partial_with_note).as_deref(),
@@ -26918,6 +27125,7 @@ mod tests {
             pending: 6,
             complete: false,
             note: None,
+            graph_bodies: None,
         };
         let synth = coverage_banner(&partial_no_note).expect("degraded coverage emits a banner");
         assert!(

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -27243,7 +27243,9 @@ mod tests {
     /// The sample is bounded; the count never is.
     #[test]
     fn graph_body_coverage_bounds_its_sample_without_capping_the_count() {
-        let paths: Vec<String> = (0..40).map(|index| format!("src/mod{index:02}.py")).collect();
+        let paths: Vec<String> = (0..40)
+            .map(|index| format!("src/mod{index:02}.py"))
+            .collect();
         let bodies = GraphBodyCoverage::observe(paths.iter(), |_| false);
 
         assert_eq!(bodies.gap_paths, 40, "the count must be the whole truth");
@@ -27278,13 +27280,19 @@ mod tests {
         );
         assert_eq!(coverage.indexed, 1644, "the embedding counts stay exact");
         assert_eq!(coverage.pending, 0);
-        let note = coverage.note.as_deref().expect("a cleared flag owes a reason");
+        let note = coverage
+            .note
+            .as_deref()
+            .expect("a cleared flag owes a reason");
         assert!(
             note.contains("graph body gap") && note.contains("2 of 2"),
             "the note must name the cause and its size: {note}"
         );
         assert_eq!(
-            coverage.graph_bodies.expect("the number rides along").gap_paths,
+            coverage
+                .graph_bodies
+                .expect("the number rides along")
+                .gap_paths,
             2
         );
     }
@@ -27296,11 +27304,10 @@ mod tests {
     /// the two apart by reading `graph_bodies`, which stays absent.
     #[test]
     fn full_body_coverage_and_an_unobserved_one_both_leave_complete_alone() {
-        let observed = fully_embedded_coverage()
-            .with_graph_bodies(GraphBodyCoverage::observe(
-                ["src/requests/api.py".to_string()].iter(),
-                |_| true,
-            ));
+        let observed = fully_embedded_coverage().with_graph_bodies(GraphBodyCoverage::observe(
+            ["src/requests/api.py".to_string()].iter(),
+            |_| true,
+        ));
         assert!(observed.complete, "no gap, so nothing to clear");
         assert!(observed.note.is_none(), "no gap, so no note");
         assert_eq!(observed.graph_bodies.expect("observed").gap_paths, 0);

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -117,6 +117,9 @@ fn evaluate_semantic_coverage(
         pending: status.pending,
         complete,
         note,
+        // Search does not run locate's source-text phase, so it observes no
+        // bodies. Absent means unobserved, never "no gap".
+        graph_bodies: None,
     })
 }
 

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -1056,7 +1056,15 @@ fn render_text(
             report.semantic_enrichment.authority_generation,
             report.semantic_enrichment.workspace_generation
         ),
-        "Live graph enrichment: see `kin graph status`".to_string(),
+        // The counter above is durable authority truth; `kin graph status`
+        // measures the daemon's live query graph and excludes external
+        // reference targets from its entity total. Both are correct and they do
+        // not match, so this line names the second view rather than leaving a
+        // reader to discover the disagreement by running both commands.
+        "Live graph enrichment: see `kin graph status`, which counts the daemon's live query \
+         graph and excludes external reference targets, so its entity total is lower than the \
+         durable one above"
+            .to_string(),
         format!(
             "Live embedding coverage: {}",
             render_embedding_coverage(&report.embedding_coverage)

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12622,6 +12622,7 @@ mod tests {
             pending: 0,
             complete: true,
             note: None,
+            graph_bodies: None,
         };
         let tool = semantic_locate_payload(
             "where does the daemon start",

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -76,6 +76,14 @@ pub struct SemanticCoverage {
     /// semantic signal was partial.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// Graph-owned source paths carrying no body, when the payload reported it.
+    ///
+    /// `complete` above is a conjunction of the embedding count and this number,
+    /// so the flag alone cannot say which of the two limited the answer. A
+    /// caller reading `complete: false` beside `indexed == total` is looking at
+    /// a body gap, and the remediation is a reconcile rather than an embed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph_body_gap_paths: Option<u64>,
 }
 
 impl SemanticCoverage {
@@ -90,6 +98,14 @@ impl SemanticCoverage {
             pending: obj.get("pending").and_then(Value::as_u64)?,
             complete: obj.get("complete").and_then(Value::as_bool)?,
             note: obj.get("note").and_then(Value::as_str).map(str::to_string),
+            // Optional: payloads from surfaces that ran no retrieval, and every
+            // payload minted before graph-body coverage existed, carry no such
+            // object. Absent stays absent rather than becoming a fabricated zero.
+            graph_body_gap_paths: obj
+                .get("graph_bodies")
+                .and_then(Value::as_object)
+                .and_then(|bodies| bodies.get("gap_paths"))
+                .and_then(Value::as_u64),
         })
     }
 }
@@ -279,6 +295,9 @@ impl Envelope {
                 "Selected-graph embedding coverage is incomplete at this point-in-time observation."
                     .to_string()
             }),
+            // Graph status observes embeddings, not the source-text phase's body
+            // resolution, so it has no reading to report here.
+            graph_body_gap_paths: None,
         });
         self.graph_as_of = None;
         self.graph_state = GraphState {
@@ -413,6 +432,20 @@ impl Envelope {
                     false,
                     "coverage_unknown: embedding coverage was not reported, so an empty result may mean 'not indexed' rather than 'not present'",
                 ),
+                // A body gap and an embedding shortfall both clear `complete`,
+                // and they are different problems with different remediations.
+                // Reporting a body gap as "the semantic index is incomplete"
+                // sends a caller to `kin embed` on a store whose embeddings are
+                // already whole, so the limiting factor is named.
+                Some(coverage)
+                    if !coverage.complete
+                        && coverage.graph_body_gap_paths.is_some_and(|gaps| gaps > 0) =>
+                {
+                    (
+                        false,
+                        "coverage_graph_body_gap: graph-owned source bodies are missing for some paths, so entities in them rank on text fallback and an empty result may mean 'no body to rank' rather than 'not present'",
+                    )
+                }
                 Some(coverage) if !coverage.complete => (
                     false,
                     "coverage_partial: the semantic index is incomplete, so an empty result may mean 'not indexed' rather than 'not present'",

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -1299,6 +1299,7 @@ mod tests {
             pending: 0,
             complete: true,
             note: None,
+            graph_body_gap_paths: None,
         });
         env.graph_as_of = Some(json!("change:deadbeef"));
         env
@@ -1423,6 +1424,7 @@ mod tests {
             pending: 60,
             complete: false,
             note: Some("indexing".to_string()),
+            graph_body_gap_paths: None,
         });
         let payload = json!({ "query": "auth", "results": [], "total_ranked": 0 });
         let negative = negative_for("semantic_locate", &payload, &env).unwrap();
@@ -1432,6 +1434,41 @@ mod tests {
             .unwrap()
             .contains("coverage_partial"));
         assert_eq!(negative["semantic_coverage"]["percent"], json!(40.0));
+    }
+
+    /// A body gap is not an embedding shortfall, and the reason must say so.
+    ///
+    /// This is the state the ticket reported: 1644/1644 embedded, so every
+    /// embedding-derived number reads healthy, while the paths retrieval needs
+    /// carry no graph-owned body. Sending that caller to `kin embed` would be
+    /// advice against a counter that is already whole, so the limiting factor is
+    /// named separately from the embedding one.
+    #[test]
+    fn a_fully_embedded_store_with_a_body_gap_names_the_body_gap_not_the_index() {
+        let mut env = Envelope::daemon();
+        env.semantic_coverage = Some(SemanticCoverage {
+            indexed: 1644,
+            total: 1644,
+            pending: 0,
+            complete: false,
+            note: Some("graph body gap: 111 of 777 …".to_string()),
+            graph_body_gap_paths: Some(111),
+        });
+        env.graph_as_of = Some(json!("change:deadbeef"));
+
+        let payload = json!({ "query": "Session", "results": [], "total_ranked": 0 });
+        let negative = negative_for("semantic_locate", &payload, &env).unwrap();
+
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("coverage_graph_body_gap"),
+            "the limiting factor must be the body gap: {reason}"
+        );
+        assert!(
+            !reason.contains("coverage_partial"),
+            "a whole embedding index must not be reported as incomplete: {reason}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Four status-honesty defects from the isolated stranger session on 0.5.36, all
one theme: the surfaces a user consults to judge whether an answer can be trusted
disagreed with each other and with what retrieval actually needs.

## `semantic_coverage: complete` described the embedding count, not ranking

With embeddings at 1644/1644 the payload reported a complete semantic signal
while every entity hit came back `match_kind: "text_fallback"` with
`all_fallback: true`. `complete` was `embedding_status_complete(status)` and
nothing else. What actually gates entity ranking is a graph-owned body for the
authority source path, and that was reported nowhere a caller could reach:
`record_graph_source_gap` emitted a `kin.locate.graph_gap` warning and bumped a
process-global atomic whose only accessor was `#[cfg(test)]`. That is not
log-only. It is unreadable by construction.

`GraphBodyCoverage` now rides on `SemanticCoverage` as `graph_bodies`, carrying
how many graph-owned source paths were consulted, how many carry a body, how many
do not, and a sorted bounded sample so an operator can act without turning on
daemon logging. `complete` becomes the conjunction it always claimed to be: a
body gap clears it even at 1644/1644. An unobserved coverage does not clear it,
because absence of evidence is not evidence of a gap, and callers read
`graph_bodies` presence to tell a clean scan from one that never ran.

This deliberately extends the coverage object whose flag it falsifies rather than
minting a fourth type beside `kin_core::cross_file_coverage` (#861) and
`kin_mcp::edge_coverage` (#872). Those answer relation-topology questions:
whether edges leave their file, and whether the graph holds the edge class an
absence depends on. Body presence is a different axis, and a caller should not
have to know about a fourth place to check.

The observation costs nothing extra. It is computed inside
`extract_source_text_signals`, the one place already holding both the source-path
authority set and the resolved preview map. `list_opaque_artifacts` deep-clones
every source preview in the store and locate already pays it twice per query, so
measuring anywhere else would have been a real regression.

A `graph_source_bodies` degradation rides beside the coverage object. The two
answer different questions: coverage says how much of the store ranking could
see, the degradation says this query ran degraded and names the remediation.

The envelope gets the same correction for free. `negative_trust` gates
`NegativeClass::Semantic` on `complete`, so a body-gapped store now refuses to
certify a semantic absence. That is right, because an empty result there cannot
be trusted. But its reason said "the semantic index is incomplete", which sends a
caller to `kin embed` on a store whose embeddings are whole. `gap_paths` now
rides the envelope and `coverage_graph_body_gap` names the real limiting factor.

## 777 entities on one surface, 822 on another, one store, one instant

Both counters were correct and neither said which view it showed. `kin graph
status` counts the daemon's live query graph and partitions out external
reference targets on purpose; durable authority enrichment replays every semantic
identity it admitted and counts them. The gap is the excluded set.

Serving both from one authority would have been the wrong trade:
`durable_semantic_enrichment_summary` is O(commits), so routing graph status
through it merges this defect into the status-cost one. Each surface now names
its view instead, and the surface holding the excluded set publishes the
arithmetic that reconciles them, so a reader adds two printed numbers rather than
guessing which denominator is real.

## Doc summaries did not stall; there is no worker to stall

The counter read the same 305/777 at both ends of a session and was taken for a
dead job. Nothing was scheduled. `doc_summary` receives a value on exactly one
non-test path, `ExtractedEntity::into_entity_with_source`, from the synchronous
tree-sitter helpers in every kin-parser adapter. The daemon's four background
passes are embed, reconcile, lsp enrichment and projection, none of which touch
it, and `mcp_commit` refuses a caller-supplied summary precisely because the
value is derived from committed source.

So the fraction is a property of the code as written, and an unchanging reading
is what a census does. The defect was the label: it sat one line under a genuine
embedding fill counter with a real pending count and read as the same kind of
thing. Publishing a queue depth or a stalled flag would have been fiction. The
line now states it is an extraction-time census, and a test holds the
queue-shaped label gone.

## Status cost growth: reported, not touched

#873 does not cover the curve, and nothing here duplicates it. It routes graph
status onto the existing `ProjectionAuthorityCache`, whose key is the publication
identity, and every commit advances the publication. So each commit invalidates
the slot and the next read is cold at the new larger history size, which is what
the 7.1s to 49.1s reading was. The O(history) cost lives inside that open, in
kin-db's `validate_all_authority_bodies` (unconditional, unions the blob digests
of every commit's tree deltas), `validate_history_replay` (skipped only when a
history-validation proof binds), and the full snapshot decode. kin-db already
logs the per-phase breakdown at debug with a public
`opened_by_history_validation()` accessor; that reading should be taken before
attributing the time, because which phase dominates changes the fix. Findings are
in `.kin-coord/reports/fir2368-statushonesty-20260817.md`.

## Tests

Each fails when the change it covers is reverted: a store whose counters
legitimately differ reports the difference with its reason; the doc census does
not read as a pending queue; a store with graph-gap paths reports a number and a
stable sample rather than a log line; the observation is wired to the real
retrieval path and reports clean once the gap is closed; a fully embedded store
with a body gap is not `complete`; a clean scan and an unobserved one both leave
the flag alone; two causes produce two notes; and the envelope names the body gap
rather than the index.

Closes FIR-2368
