### PR TITLE
Resolve a real commit identity or refuse, instead of stamping "Author: unknown"

### DIFF
--- a/crates/kin-cli/src/commands/admit.rs
+++ b/crates/kin-cli/src/commands/admit.rs
@@ -368,7 +368,7 @@ pub async fn run() -> Result<()> {
     // rather than asking for another.
     let request = AdmitRequest {
         operation_id: OperationId::new(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
     };
     let outcome = wait_for_admission(&client, &request).await;
 

--- a/crates/kin-cli/src/commands/branch.rs
+++ b/crates/kin-cli/src/commands/branch.rs
@@ -95,15 +95,15 @@ pub async fn list(json: bool) -> Result<()> {
 }
 
 pub async fn create(name: RefName) -> Result<()> {
-    execute_and_print(mutation_request(name, BranchMutation::Create)).await
+    execute_and_print(mutation_request(name, BranchMutation::Create)?).await
 }
 
 pub async fn delete(name: RefName) -> Result<()> {
-    execute_and_print(mutation_request(name, BranchMutation::Delete)).await
+    execute_and_print(mutation_request(name, BranchMutation::Delete)?).await
 }
 
 pub async fn switch(name: RefName) -> Result<()> {
-    execute_and_print(mutation_request(name, BranchMutation::Switch)).await
+    execute_and_print(mutation_request(name, BranchMutation::Switch)?).await
 }
 
 pub fn parse_branch_ref(name: Option<&str>, ref_hex: Option<&str>) -> Result<RefName> {
@@ -135,10 +135,10 @@ enum BranchMutation {
     Switch,
 }
 
-fn mutation_request(name: RefName, mutation: BranchMutation) -> BranchRequest {
+fn mutation_request(name: RefName, mutation: BranchMutation) -> Result<BranchRequest> {
     let operation_id = OperationId::new();
-    let actor = AuthorId::new(kin_core::whoami());
-    match mutation {
+    let actor = crate::commands::require_commit_author()?;
+    Ok(match mutation {
         BranchMutation::Create => BranchRequest::Create {
             name,
             operation_id,
@@ -154,7 +154,7 @@ fn mutation_request(name: RefName, mutation: BranchMutation) -> BranchRequest {
             operation_id,
             actor,
         },
-    }
+    })
 }
 
 async fn execute(request: BranchRequest) -> Result<BranchResponse> {

--- a/crates/kin-cli/src/commands/checkout.rs
+++ b/crates/kin-cli/src/commands/checkout.rs
@@ -58,7 +58,7 @@ pub async fn run(
         path_hex,
         change_id,
         operation_id: OperationId::new(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
     };
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     let response = daemon.checkout(&request).await?;

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -39,6 +39,13 @@ async fn run_daemon_commit(
     layout: &kin_core::KinLayout,
     message: &str,
 ) -> Result<DaemonCommitResult> {
+    // Resolved here, in the caller's own environment and working directory,
+    // rather than inside the daemon. The daemon is spawned with every `GIT_*`
+    // variable scrubbed and does not share the caller's shell, so an identity it
+    // resolved for itself would answer a different question than "who is running
+    // this command". Resolution also comes before the daemon is contacted: a
+    // commit that cannot be attributed must not reach the authority path at all.
+    let author = crate::commands::require_commit_author_for(layout)?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
         .await?
         .ok_or_else(|| crate::daemon_client::daemon_required_error("commit", layout))?;
@@ -60,6 +67,7 @@ async fn run_daemon_commit(
             "operation_id": operation_id,
             "timestamp": timestamp,
             "message": message,
+            "author": author,
         }));
     if let Some(token) = crate::daemon_client::resolve_daemon_auth_token() {
         request = request.bearer_auth(token);

--- a/crates/kin-cli/src/commands/drift.rs
+++ b/crates/kin-cli/src/commands/drift.rs
@@ -12,9 +12,7 @@
 //! moves underneath it.
 
 use anyhow::{bail, Context, Result};
-use kin_model::{
-    AuthorId, OperationId, RepoPath, RepositoryId, RootBundle, WorkspaceHead, WorkspaceId,
-};
+use kin_model::{OperationId, RepoPath, RepositoryId, RootBundle, WorkspaceHead, WorkspaceId};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
@@ -143,7 +141,7 @@ pub async fn heal(json: bool) -> Result<()> {
             path_hex: Some(hex::encode(selected.as_bytes())),
             change_id: None,
             operation_id: OperationId::new(),
-            actor: AuthorId::new(kin_core::whoami()),
+            actor: crate::commands::require_commit_author()?,
         };
         daemon.checkout(&request).await.with_context(|| {
             format!("restore {selected} from repository authority while healing the projection")

--- a/crates/kin-cli/src/commands/merge.rs
+++ b/crates/kin-cli/src/commands/merge.rs
@@ -124,7 +124,7 @@ pub async fn run(source: String, json: bool) -> Result<()> {
     let response = execute(MergeRequest {
         source,
         operation_id: OperationId::new(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
     })
     .await?;
     if json {

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -114,6 +114,31 @@ pub(crate) fn require_repository_layout_at(
     kin_core::KinLayout::discover(start).ok_or_else(not_a_kin_repository)
 }
 
+/// Who this invocation is allowed to attribute new authority to, or a refusal.
+///
+/// Every command that stamps an author refuses through here so the refusal
+/// cannot drift per command, and so no command can quietly acquire a fallback of
+/// its own. There is deliberately no infallible variant: an author a caller
+/// could obtain without checking is exactly how the placeholder this replaces
+/// reached permanent history in the first place.
+pub(crate) fn require_commit_author() -> anyhow::Result<kin_model::AuthorId> {
+    let layout = require_repository_layout()?;
+    require_commit_author_for(&layout)
+}
+
+/// The same refusal for a caller that already holds the repository layout.
+pub(crate) fn require_commit_author_for(
+    layout: &kin_core::KinLayout,
+) -> anyhow::Result<kin_model::AuthorId> {
+    let identity = kin_core::resolve_commit_identity(layout)?;
+    tracing::debug!(
+        author = %identity.author,
+        source = identity.source.id(),
+        "resolved commit identity"
+    );
+    Ok(kin_model::AuthorId::new(identity.author))
+}
+
 /// The one wording every "you are not in a Kin repository" refusal is raised
 /// with, so a command whose condition is its own still states the same remedy.
 ///

--- a/crates/kin-cli/src/commands/purge_ignored.rs
+++ b/crates/kin-cli/src/commands/purge_ignored.rs
@@ -160,7 +160,7 @@ pub async fn run(confirm: bool, confirm_mass_deletion: bool) -> Result<()> {
             confirm,
             confirm_mass_deletion,
             operation_id: OperationId::new(),
-            actor: AuthorId::new(kin_core::whoami()),
+            actor: crate::commands::require_commit_author()?,
         })
         .await?;
     for line in &response.lines {

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -117,7 +117,7 @@ pub async fn run(
         column,
         json,
         operation_id: OperationId::new(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
     };
     let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
     let response = daemon.rename(&request).await?;

--- a/crates/kin-cli/src/commands/resolve.rs
+++ b/crates/kin-cli/src/commands/resolve.rs
@@ -135,7 +135,7 @@ pub async fn run(
     };
     let response = execute(ResolveRequest {
         operation_id: OperationId::new(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
         action,
         expected_record,
     })

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -341,7 +341,7 @@ pub async fn run(change_id: Option<String>, feature: Option<String>) -> Result<(
         .rollback(&RollbackRequest {
             change_id,
             operation_id: OperationId::new(),
-            actor: AuthorId::new(kin_core::whoami()),
+            actor: crate::commands::require_commit_author()?,
         })
         .await?;
     for line in response.lines {

--- a/crates/kin-cli/src/commands/stash.rs
+++ b/crates/kin-cli/src/commands/stash.rs
@@ -144,7 +144,7 @@ pub async fn push(message: Option<String>, yes: bool) -> Result<()> {
         message,
         operation_id: OperationId::new(),
         timestamp: Timestamp::now(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
     })
     .await?;
     print_lines(response);
@@ -155,7 +155,7 @@ pub async fn pop() -> Result<()> {
     super::capabilities::require_ready("stash")?;
     let response = execute(StashRequest::Pop {
         operation_id: OperationId::new(),
-        actor: AuthorId::new(kin_core::whoami()),
+        actor: crate::commands::require_commit_author()?,
     })
     .await?;
     print_lines(response);

--- a/crates/kin-cli/src/commands/tag.rs
+++ b/crates/kin-cli/src/commands/tag.rs
@@ -206,7 +206,7 @@ async fn publish(
             force,
             snapshot,
             operation_id: OperationId::new(),
-            actor: AuthorId::new(kin_core::whoami()),
+            actor: crate::commands::require_commit_author()?,
         })
         .await?;
     if snapshot {

--- a/crates/kin-cli/tests/commit_authorship.rs
+++ b/crates/kin-cli/tests/commit_authorship.rs
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Who `kin` says authored a change, through the real binaries.
+//!
+//! The defect these cover shipped in 0.5.36 and was found by a stranger running
+//! Kin in a container: every change in `kin log` read `Author: unknown`, on a
+//! host that had `git config --global user.name` and `user.email` set the whole
+//! time. Identity resolution was two environment variable reads with a string
+//! literal behind them and never consulted Git at all, and a container commonly
+//! sets neither variable.
+//!
+//! A unit test on the resolver cannot cover that, because the resolver was not
+//! the thing that was missing; the wiring was. So these drive `kin` itself and
+//! read the surface the report came from.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+fn run_git(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(repo)
+        .output()
+        .expect("run git")
+}
+
+fn require_git(repo: &Path, args: &[&str]) {
+    let output = run_git(repo, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    runtime
+        .kin_command()
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .current_dir(repo)
+        .output()
+        .expect("run kin")
+}
+
+fn require_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    let output = run_kin(runtime, repo, args);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn require_kin_json(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> Value {
+    let output = require_kin(runtime, repo, args);
+    serde_json::from_slice(&output.stdout).expect("kin should emit JSON")
+}
+
+/// A Git history with two commits by two different people, admitted into Kin.
+///
+/// Two authors rather than one on purpose: a per-commit author that is preserved
+/// and a per-commit author that is overwritten by a single repository-wide value
+/// look identical when every commit shares an author.
+fn initialize(runtime: &common::IsolatedDaemonRuntime, repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn shipped() -> u8 { 1 }\n").expect("write source");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "first commit"]);
+
+    require_git(repo, &["config", "user.name", "Grace Hopper"]);
+    require_git(repo, &["config", "user.email", "grace@example.com"]);
+    fs::write(repo.join("src/lib.rs"), b"pub fn shipped() -> u8 { 2 }\n").expect("edit source");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "second commit"]);
+
+    // Back to the first author, so the identity a native commit resolves is
+    // distinguishable from the one the most recent imported commit carries.
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+
+    let init = run_kin(runtime, repo, &["init", ".", "--json"]);
+    assert!(
+        init.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+fn log_entries(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> Vec<Value> {
+    let report = require_kin_json(runtime, repo, &["log", "--json", "--count", "20"]);
+    assert_eq!(report["schema"], "kin.log.v1");
+    report["entries"]
+        .as_array()
+        .expect("log reports its entries")
+        .clone()
+}
+
+fn authors(entries: &[Value]) -> Vec<String> {
+    entries
+        .iter()
+        .map(|entry| {
+            entry["author"]
+                .as_str()
+                .expect("every log entry names an author")
+                .to_string()
+        })
+        .collect()
+}
+
+/// The reported symptom, driven end to end: a commit made on a host with a Git
+/// identity is attributed to that identity, in the surface the report quoted.
+#[test]
+fn a_native_commit_records_the_configured_git_identity() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    fs::write(
+        repo.join("src/added.rs"),
+        b"pub fn added() -> u8 { 3 }\n",
+    )
+    .expect("add source");
+    require_kin(&runtime, &repo, &["commit", "-m", "publish added source"]);
+
+    let entries = log_entries(&runtime, &repo);
+    let newest = entries.first().expect("the native commit");
+    assert_eq!(newest["message"], "publish added source");
+    assert_eq!(
+        newest["author"].as_str().expect("author"),
+        "Ada Lovelace <ada@example.com>",
+        "a native commit must carry the identity Git resolves here"
+    );
+    assert!(
+        !authors(&entries).iter().any(|author| author == "unknown"),
+        "no change may be attributed to the placeholder: {:?}",
+        authors(&entries)
+    );
+}
+
+/// Importing a Git history must keep each commit's own author. A live-identity
+/// resolver applied to imported history would rewrite everyone who ever
+/// committed into whoever happened to run `kin init`, which is the same defect
+/// as the placeholder pointed at the past instead of the present.
+#[test]
+fn an_imported_git_history_keeps_its_original_per_commit_authors() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    let imported = authors(&log_entries(&runtime, &repo));
+
+    assert!(
+        imported.iter().any(|author| author.contains("Ada Lovelace")),
+        "the first commit's author was lost: {imported:?}"
+    );
+    assert!(
+        imported.iter().any(|author| author.contains("Grace Hopper")),
+        "the second commit's author was lost: {imported:?}"
+    );
+    assert!(
+        !imported.iter().any(|author| author == "unknown"),
+        "an imported change was attributed to the placeholder: {imported:?}"
+    );
+}
+
+/// With nothing configured, the commit is refused rather than attributed to
+/// nobody, and the refusal names the commands that fix it. The refusal happens
+/// before the daemon is contacted, because a commit that cannot be attributed
+/// must not reach the authority path at all.
+#[test]
+fn a_commit_with_no_resolvable_identity_is_refused_with_its_remedy() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    require_git(&repo, &["config", "--unset", "user.name"]);
+    require_git(&repo, &["config", "--unset", "user.email"]);
+
+    fs::write(
+        repo.join("src/orphan.rs"),
+        b"pub fn orphan() -> u8 { 4 }\n",
+    )
+    .expect("add source");
+    let refused = run_kin(&runtime, &repo, &["commit", "-m", "nobody authored this"]);
+
+    assert!(
+        !refused.status.success(),
+        "a commit with no resolvable identity must be refused: stdout={}",
+        String::from_utf8_lossy(&refused.stdout)
+    );
+    let message = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        message.contains("git config --global user.name"),
+        "the refusal must name the command that sets a name: {message}"
+    );
+    assert!(
+        message.contains("git config --global user.email"),
+        "the refusal must name the command that sets an email: {message}"
+    );
+    assert!(
+        message.contains("default_author"),
+        "the refusal must name the Kin-specific setting: {message}"
+    );
+
+    let authors = authors(&log_entries(&runtime, &repo));
+    assert!(
+        !authors.iter().any(|author| author == "unknown"),
+        "a refused commit must publish nothing: {authors:?}"
+    );
+}
+
+/// The Kin-specific setting outranks Git, so a repository can attribute its
+/// changes to something other than whatever the host developer set for
+/// themselves.
+#[test]
+fn a_kin_specific_author_outranks_the_git_identity() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    let config_path = repo.join(".kin/config.toml");
+    let config = fs::read_to_string(&config_path).expect("read kin config");
+    fs::write(
+        &config_path,
+        format!("default_author = \"Kin Author <kin@example.com>\"\n{config}"),
+    )
+    .expect("write kin config");
+
+    fs::write(
+        repo.join("src/preferred.rs"),
+        b"pub fn preferred() -> u8 { 5 }\n",
+    )
+    .expect("add source");
+    require_kin(&runtime, &repo, &["commit", "-m", "publish preferred source"]);
+
+    let entries = log_entries(&runtime, &repo);
+    let newest = entries.first().expect("the native commit");
+    assert_eq!(newest["message"], "publish preferred source");
+    assert_eq!(
+        newest["author"].as_str().expect("author"),
+        "Kin Author <kin@example.com>",
+        "the Kin-specific setting must win over the Git identity"
+    );
+}

--- a/crates/kin-cli/tests/commit_authorship.rs
+++ b/crates/kin-cli/tests/commit_authorship.rs
@@ -75,11 +75,7 @@ fn require_kin(
     output
 }
 
-fn require_kin_json(
-    runtime: &common::IsolatedDaemonRuntime,
-    repo: &Path,
-    args: &[&str],
-) -> Value {
+fn require_kin_json(runtime: &common::IsolatedDaemonRuntime, repo: &Path, args: &[&str]) -> Value {
     let output = require_kin(runtime, repo, args);
     serde_json::from_slice(&output.stdout).expect("kin should emit JSON")
 }
@@ -150,11 +146,7 @@ fn a_native_commit_records_the_configured_git_identity() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     initialize(&runtime, &repo);
 
-    fs::write(
-        repo.join("src/added.rs"),
-        b"pub fn added() -> u8 { 3 }\n",
-    )
-    .expect("add source");
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
     require_kin(&runtime, &repo, &["commit", "-m", "publish added source"]);
 
     let entries = log_entries(&runtime, &repo);
@@ -186,11 +178,15 @@ fn an_imported_git_history_keeps_its_original_per_commit_authors() {
     let imported = authors(&log_entries(&runtime, &repo));
 
     assert!(
-        imported.iter().any(|author| author.contains("Ada Lovelace")),
+        imported
+            .iter()
+            .any(|author| author.contains("Ada Lovelace")),
         "the first commit's author was lost: {imported:?}"
     );
     assert!(
-        imported.iter().any(|author| author.contains("Grace Hopper")),
+        imported
+            .iter()
+            .any(|author| author.contains("Grace Hopper")),
         "the second commit's author was lost: {imported:?}"
     );
     assert!(
@@ -213,11 +209,7 @@ fn a_commit_with_no_resolvable_identity_is_refused_with_its_remedy() {
     require_git(&repo, &["config", "--unset", "user.name"]);
     require_git(&repo, &["config", "--unset", "user.email"]);
 
-    fs::write(
-        repo.join("src/orphan.rs"),
-        b"pub fn orphan() -> u8 { 4 }\n",
-    )
-    .expect("add source");
+    fs::write(repo.join("src/orphan.rs"), b"pub fn orphan() -> u8 { 4 }\n").expect("add source");
     let refused = run_kin(&runtime, &repo, &["commit", "-m", "nobody authored this"]);
 
     assert!(
@@ -269,7 +261,11 @@ fn a_kin_specific_author_outranks_the_git_identity() {
         b"pub fn preferred() -> u8 { 5 }\n",
     )
     .expect("add source");
-    require_kin(&runtime, &repo, &["commit", "-m", "publish preferred source"]);
+    require_kin(
+        &runtime,
+        &repo,
+        &["commit", "-m", "publish preferred source"],
+    );
 
     let entries = log_entries(&runtime, &repo);
     let newest = entries.first().expect("the native commit");

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -76,6 +76,22 @@ fn initialize_kin_repo(
     kin_core::KinLayout::discover(repo).expect("discover exact layout")
 }
 
+/// Give a repository a Kin-native author, for fixtures that then hide `.git`.
+///
+/// Hiding `.git` is how these tests prove branch answers never fall back to Git,
+/// and it takes the Git identity with it, so a repository command that stamps an
+/// actor would have nobody to name. `default_author` is the setting that exists
+/// for exactly that repository shape: native, with no Git configuration to read.
+fn pin_native_identity(layout: &kin_core::KinLayout) {
+    let path = layout.config_path();
+    let existing = fs::read_to_string(&path).expect("read kin config");
+    fs::write(
+        &path,
+        format!("default_author = \"Kin Fixture <fixture@example.invalid>\"\n{existing}"),
+    )
+    .expect("write kin config");
+}
+
 fn open_authority(
     layout: &kin_core::KinLayout,
 ) -> (RepositoryId, RepositoryAuthorityManager<LocalFileBackend>) {
@@ -402,6 +418,7 @@ fn branch_list_preserves_byte_refs_and_ignores_checkout_git_state() {
     assert!(human.status.success());
     assert!(String::from_utf8_lossy(&human.stdout).contains("refs/heads/raw-\\xff"));
 
+    pin_native_identity(&layout);
     fs::rename(repo.join(".git"), repo.join("git-authority-disabled"))
         .expect("hide admitted Git metadata");
     fs::create_dir_all(repo.join(".git/refs/heads")).expect("create misleading Git refs");
@@ -713,6 +730,7 @@ fn branch_create_uses_detached_workspace_target_without_git_fallback() {
     run_git(&repo, &["checkout", "--detach"]);
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
+    pin_native_identity(&layout);
     fs::rename(repo.join(".git"), repo.join("git-authority-disabled"))
         .expect("hide admitted Git metadata");
 
@@ -809,6 +827,7 @@ fn branch_switch_projects_complete_polyglot_and_non_code_tree_from_repository_ca
             "install byte-exact switch target",
         ))
         .expect("commit byte-exact branch");
+    pin_native_identity(&layout);
     fs::rename(repo.join(".git"), repo.join("git-authority-disabled"))
         .expect("hide admitted Git metadata");
 
@@ -1390,6 +1409,7 @@ fn branch_switch_preserves_graph_only_gitlinks_without_traversing_nested_checkou
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
     let (repository_id, _) = open_authority(&layout);
+    pin_native_identity(&layout);
     fs::rename(repo.join(".git"), repo.join("git-authority-disabled"))
         .expect("hide admitted Git metadata");
 
@@ -1501,6 +1521,7 @@ fn branch_switch_retains_host_unrepresentable_byte_path_in_graph_authority() {
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
     let layout = initialize_kin_repo(&runtime, &repo);
     let (repository_id, _) = open_authority(&layout);
+    pin_native_identity(&layout);
     fs::rename(repo.join(".git"), repo.join("git-authority-disabled"))
         .expect("hide admitted Git metadata");
 

--- a/crates/kin-core/src/diff.rs
+++ b/crates/kin-core/src/diff.rs
@@ -39,15 +39,6 @@ pub fn content_identity_from_deltas(delta: &TransactionDelta) -> Result<[u8; 32]
         .map_err(|error| KinError::Other(error.to_string()))
 }
 
-/// Get a human-readable author name from environment variables.
-///
-/// Checks `USER` (Unix) then `USERNAME` (Windows), falls back to `"unknown"`.
-pub fn whoami() -> String {
-    std::env::var("USER")
-        .or_else(|_| std::env::var("USERNAME"))
-        .unwrap_or_else(|_| "unknown".to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -360,11 +351,5 @@ mod tests {
         })
         .unwrap_err();
         assert!(error.to_string().contains("invalid confidence score"));
-    }
-
-    #[test]
-    fn whoami_returns_nonempty_string() {
-        let name = whoami();
-        assert!(!name.is_empty());
     }
 }

--- a/crates/kin-core/src/identity.rs
+++ b/crates/kin-core/src/identity.rs
@@ -415,7 +415,9 @@ mod tests {
         fixture.init_git();
         fixture.set_repo_identity("unknown", "unknown");
 
-        fixture.resolve().expect_err("refuse a placeholder identity");
+        fixture
+            .resolve()
+            .expect_err("refuse a placeholder identity");
     }
 
     /// Git's own synthesized address is the same defect wearing a different

--- a/crates/kin-core/src/identity.rs
+++ b/crates/kin-core/src/identity.rs
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Who a newly minted change is attributed to.
+//!
+//! Authorship is provenance, and provenance is authority Kin publishes once and
+//! cannot correct later without rewriting history. So this module resolves an
+//! identity from configuration a person actually set, reports which surface it
+//! came from, and refuses when nothing is set rather than standing a placeholder
+//! in for a person.
+//!
+//! A placeholder is worse than a refusal precisely because it succeeds: the
+//! commit lands, the record looks complete, and the fabrication is only visible
+//! once a history exists that nobody can attribute. Git has the same failure
+//! mode wearing a different name, synthesizing `user@host.local` from the local
+//! account and hostname when no email is configured, so a value shaped like that
+//! is treated as unresolved rather than accepted.
+
+use std::fmt;
+use std::path::Path;
+
+use crate::config::KinConfig;
+use crate::error::KinError;
+use crate::layout::KinLayout;
+
+/// Which configured surface supplied the identity a change is stamped with.
+///
+/// Recorded rather than discarded so a reader can tell a repository-scoped
+/// identity from a host-wide one, and so `kin doctor` can name the surface a
+/// user would have to edit to change it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentitySource {
+    /// `default_author` in the repository's own `.kin/config.toml`.
+    KinConfig,
+    /// `user.name` / `user.email` set in this repository's or worktree's Git
+    /// configuration.
+    GitRepository,
+    /// `user.name` / `user.email` merged in from a scope wider than this
+    /// repository: the user's global file, the system file, the git
+    /// installation, or a `GIT_CONFIG_*` override.
+    GitGlobal,
+}
+
+impl IdentitySource {
+    /// A stable machine-readable name for the surface, safe to assert on.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::KinConfig => "kin-config",
+            Self::GitRepository => "git-repo",
+            Self::GitGlobal => "git-global",
+        }
+    }
+
+    /// How the surface is named to a person.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::KinConfig => "kin config default_author",
+            Self::GitRepository => "git repository config",
+            Self::GitGlobal => "git global config",
+        }
+    }
+}
+
+impl fmt::Display for IdentitySource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
+
+/// One resolved identity plus the surface it was resolved from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitIdentity {
+    /// The author string a change record carries, `Name <email>` when both
+    /// halves are configured.
+    pub author: String,
+    /// The surface `author` came from.
+    pub source: IdentitySource,
+}
+
+/// What a person has to do so a commit can be attributed to them.
+///
+/// One constant so the refusal, the `kin doctor` row, and the tests that hold
+/// them to it cannot drift apart into three different sets of instructions.
+pub const IDENTITY_REMEDIATION: &str = "Set your Git identity:\n  \
+     git config --global user.name \"Your Name\"\n  \
+     git config --global user.email \"you@example.com\"\n\
+     Or set a Kin-specific author in .kin/config.toml:\n  \
+     default_author = \"Your Name <you@example.com>\"";
+
+/// The message a mint refuses with when nobody can be named as its author.
+pub fn unresolved_identity_message() -> String {
+    format!(
+        "kin has no author identity to record for this change.\n\n\
+         Authorship is provenance. A change attributed to nobody cannot support review \
+         attribution, blame, or audit, and it cannot be corrected later without rewriting \
+         history, so kin refuses to invent one.\n\n\
+         {IDENTITY_REMEDIATION}"
+    )
+}
+
+/// Resolve who a newly minted change in this repository is authored by.
+///
+/// Order is most specific first: the repository's own Kin setting, then the Git
+/// identity Git itself would use here (repository scope before host scope), then
+/// refusal. There is no fourth step, and no synthesized value is accepted at any
+/// step.
+pub fn resolve_commit_identity(layout: &KinLayout) -> Result<CommitIdentity, KinError> {
+    if let Some(author) = kin_config_author(layout) {
+        return Ok(CommitIdentity {
+            author,
+            source: IdentitySource::KinConfig,
+        });
+    }
+    if let Some(identity) = git_identity(layout.working_dir()) {
+        return Ok(identity);
+    }
+    Err(KinError::Config(unresolved_identity_message()))
+}
+
+/// The explicit Kin-specific author for this repository, when one is set and
+/// usable.
+///
+/// A config this cannot parse is not an identity, and must not become one: an
+/// unreadable config yields no author and the caller falls through to Git
+/// rather than inheriting a half-read value.
+fn kin_config_author(layout: &KinLayout) -> Option<String> {
+    let config = KinConfig::load_or_default(&layout.config_path()).ok()?;
+    usable_author(config.default_author.as_deref()?)
+}
+
+/// The identity Git itself would attribute a commit in `working_dir` to.
+///
+/// The repository's merged configuration already layers host scope underneath
+/// repository scope, so one read answers both and the winning section reports
+/// which scope actually supplied the value. When there is no Git repository here
+/// at all, which is the ordinary shape of a native Kin repository, the host
+/// scopes are read on their own.
+fn git_identity(working_dir: &Path) -> Option<CommitIdentity> {
+    match gix::open(working_dir) {
+        Ok(repository) => {
+            let snapshot = repository.config_snapshot();
+            identity_from_config(snapshot.plumbing())
+        }
+        Err(_) => {
+            let globals = gix::config::File::from_globals().ok()?;
+            identity_from_config(&globals)
+        }
+    }
+}
+
+/// Read `user.name` and `user.email` out of one merged configuration.
+///
+/// Both halves are required. Git will happily commit with only one of them by
+/// synthesizing the other from the local account and hostname, which is the
+/// fabrication this whole module exists to keep out of history, so a half-set
+/// identity is reported as no identity and the remediation names both commands.
+fn identity_from_config(config: &gix::config::File<'_>) -> Option<CommitIdentity> {
+    let name = config_field(config, "name")?;
+    let email = config_field(config, "email")?;
+    if is_fabricated_email(&email) {
+        return None;
+    }
+    Some(CommitIdentity {
+        author: format!("{name} <{email}>"),
+        source: user_scope(config),
+    })
+}
+
+/// One `user.*` string, trimmed and checked for usability.
+fn config_field(config: &gix::config::File<'_>, value_name: &str) -> Option<String> {
+    let raw = config.string_by("user", None, value_name)?;
+    usable_field(&raw.to_string())
+}
+
+/// Which scope set the `user` section value that won.
+///
+/// Sections merge in precedence order, so the last one carrying a value is the
+/// one Git would use. Scope wider than this repository is reported as global
+/// without splitting further: a user editing it is editing something outside the
+/// repository either way, and the distinction between their file and the
+/// system's does not change what they resolve.
+fn user_scope(config: &gix::config::File<'_>) -> IdentitySource {
+    let mut winner = None;
+    if let Some(sections) = config.sections_by_name("user") {
+        for section in sections {
+            if section.contains_value_name("name") || section.contains_value_name("email") {
+                winner = Some(section.meta().source);
+            }
+        }
+    }
+    match winner {
+        Some(gix::config::Source::Local | gix::config::Source::Worktree) => {
+            IdentitySource::GitRepository
+        }
+        _ => IdentitySource::GitGlobal,
+    }
+}
+
+/// A configured field, or `None` when what is configured names nobody.
+fn usable_field(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// A configured `Name <email>` author, or `None` when it names nobody.
+fn usable_author(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let (name, email) = split_author(trimmed);
+    usable_field(name)?;
+    if let Some(email) = email {
+        usable_field(email)?;
+        if is_fabricated_email(email) {
+            return None;
+        }
+    }
+    Some(trimmed.to_string())
+}
+
+/// Split `Name <email>` into its halves, tolerating an author with no email.
+fn split_author(raw: &str) -> (&str, Option<&str>) {
+    match (raw.find('<'), raw.rfind('>')) {
+        (Some(open), Some(close)) if close > open => {
+            (raw[..open].trim(), Some(raw[open + 1..close].trim()))
+        }
+        _ => (raw, None),
+    }
+}
+
+/// Whether an address is the one Git invents when none is configured.
+///
+/// Git builds `<account>@<hostname>` and macOS hands it a `.local` hostname, so
+/// the whole class is rejected rather than the exact string. This workspace has
+/// already published a commit under such an address; it reads as a real identity
+/// right up until someone tries to reach the person it names.
+fn is_fabricated_email(email: &str) -> bool {
+    email.trim().to_ascii_lowercase().ends_with(".local")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::EnvVarGuard;
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// A repository whose `.kin` exists and whose Git configuration this test
+    /// controls outright.
+    ///
+    /// Every scope Git would read is pinned: the system file is refused, the
+    /// global file is redirected into the fixture, and the repository file is
+    /// written directly. A test that left any of those to the host would pass or
+    /// fail on whoever ran it.
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        layout: KinLayout,
+        working_dir: std::path::PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let dir = tempdir().expect("temp dir");
+            let working_dir = dir.path().join("repo");
+            fs::create_dir_all(working_dir.join(".kin")).expect("create .kin");
+            let layout = KinLayout::new(working_dir.join(".kin"));
+            fs::write(dir.path().join("global.gitconfig"), "").expect("write global config");
+            Self {
+                _dir: dir,
+                layout,
+                working_dir,
+            }
+        }
+
+        fn init_git(&self) {
+            let status = std::process::Command::new("git")
+                .args(["init", "--quiet"])
+                .current_dir(&self.working_dir)
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .env("GIT_CONFIG_GLOBAL", self.global_config())
+                .status()
+                .expect("git init");
+            assert!(status.success(), "git init failed");
+        }
+
+        fn global_config(&self) -> std::path::PathBuf {
+            self._dir.path().join("global.gitconfig")
+        }
+
+        fn set_repo_identity(&self, name: &str, email: &str) {
+            self.git_config(&self.working_dir, name, email);
+        }
+
+        fn set_global_identity(&self, name: &str, email: &str) {
+            fs::write(
+                self.global_config(),
+                format!("[user]\n\tname = {name}\n\temail = {email}\n"),
+            )
+            .expect("write global identity");
+        }
+
+        fn git_config(&self, dir: &Path, name: &str, email: &str) {
+            for (key, value) in [("user.name", name), ("user.email", email)] {
+                let status = std::process::Command::new("git")
+                    .args(["config", key, value])
+                    .current_dir(dir)
+                    .env("GIT_CONFIG_NOSYSTEM", "1")
+                    .env("GIT_CONFIG_GLOBAL", self.global_config())
+                    .status()
+                    .expect("git config");
+                assert!(status.success(), "git config {key} failed");
+            }
+        }
+
+        fn set_kin_author(&self, author: &str) {
+            fs::write(
+                self.layout.config_path(),
+                format!("default_author = \"{author}\"\ndefault_branch = \"main\"\n"),
+            )
+            .expect("write kin config");
+        }
+
+        /// Resolve with every ambient Git scope pinned to this fixture.
+        ///
+        /// The resolver reads Git configuration, and which files Git considers
+        /// is decided by the process environment, so a test that left the host's
+        /// own `~/.gitconfig` reachable would pass or fail on whoever ran it.
+        fn resolve(&self) -> Result<CommitIdentity, KinError> {
+            let _pinned = EnvVarGuard::new()
+                .with("GIT_CONFIG_NOSYSTEM", "1")
+                .with("GIT_CONFIG_GLOBAL", self.global_config())
+                .with("HOME", self._dir.path())
+                .without("XDG_CONFIG_HOME");
+            resolve_commit_identity(&self.layout)
+        }
+    }
+
+    #[test]
+    fn a_configured_git_identity_is_recorded_verbatim() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        fixture.set_repo_identity("Ada Lovelace", "ada@example.com");
+
+        let identity = fixture.resolve().expect("resolve identity");
+
+        assert_eq!(identity.author, "Ada Lovelace <ada@example.com>");
+        assert_eq!(identity.source, IdentitySource::GitRepository);
+    }
+
+    #[test]
+    fn a_global_git_identity_resolves_and_reports_its_scope() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        fixture.set_global_identity("Grace Hopper", "grace@example.com");
+
+        let identity = fixture.resolve().expect("resolve identity");
+
+        assert_eq!(identity.author, "Grace Hopper <grace@example.com>");
+        assert_eq!(identity.source, IdentitySource::GitGlobal);
+    }
+
+    #[test]
+    fn a_kin_specific_author_wins_over_the_git_identity() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        fixture.set_repo_identity("Ada Lovelace", "ada@example.com");
+        fixture.set_kin_author("Kin Author <kin@example.com>");
+
+        let identity = fixture.resolve().expect("resolve identity");
+
+        assert_eq!(identity.author, "Kin Author <kin@example.com>");
+        assert_eq!(identity.source, IdentitySource::KinConfig);
+    }
+
+    #[test]
+    fn no_resolvable_identity_refuses_with_both_remediation_commands() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+
+        let error = fixture.resolve().expect_err("refuse without an identity");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("git config --global user.name"),
+            "{message}"
+        );
+        assert!(
+            message.contains("git config --global user.email"),
+            "{message}"
+        );
+        assert!(message.contains("default_author"), "{message}");
+        assert!(!message.contains("unknown"), "{message}");
+    }
+
+    /// A repository that never had Git in it still resolves from host scope,
+    /// because a native Kin repository is the ordinary case rather than an edge
+    /// one.
+    #[test]
+    fn a_repository_with_no_git_directory_still_reads_the_global_identity() {
+        let fixture = Fixture::new();
+        fixture.set_global_identity("Grace Hopper", "grace@example.com");
+
+        let identity = fixture.resolve().expect("resolve identity");
+
+        assert_eq!(identity.author, "Grace Hopper <grace@example.com>");
+        assert_eq!(identity.source, IdentitySource::GitGlobal);
+    }
+
+    /// The exact defect this module exists for: the placeholder must not be
+    /// accepted back in through configuration either.
+    #[test]
+    fn a_configured_placeholder_is_not_an_identity() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        fixture.set_repo_identity("unknown", "unknown");
+
+        fixture.resolve().expect_err("refuse a placeholder identity");
+    }
+
+    /// Git's own synthesized address is the same defect wearing a different
+    /// name, so an explicitly configured one is refused too.
+    #[test]
+    fn a_synthesized_host_local_address_is_not_an_identity() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        fixture.set_repo_identity("troy", "troy@Troys-MacBook-Pro.local");
+
+        fixture.resolve().expect_err("refuse a synthesized address");
+    }
+
+    /// Half an identity is not an identity: Git would complete it by inventing
+    /// the other half.
+    #[test]
+    fn a_name_without_an_email_does_not_resolve() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        let status = std::process::Command::new("git")
+            .args(["config", "user.name", "Ada Lovelace"])
+            .current_dir(&fixture.working_dir)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", fixture.global_config())
+            .status()
+            .expect("git config");
+        assert!(status.success());
+
+        fixture.resolve().expect_err("refuse a half-set identity");
+    }
+
+    #[test]
+    fn a_kin_author_naming_nobody_falls_through_to_git() {
+        let fixture = Fixture::new();
+        fixture.init_git();
+        fixture.set_repo_identity("Ada Lovelace", "ada@example.com");
+        fixture.set_kin_author("   ");
+
+        let identity = fixture.resolve().expect("resolve identity");
+
+        assert_eq!(identity.source, IdentitySource::GitRepository);
+    }
+
+    #[test]
+    fn source_ids_are_stable_and_distinct() {
+        assert_eq!(IdentitySource::KinConfig.id(), "kin-config");
+        assert_eq!(IdentitySource::GitRepository.id(), "git-repo");
+        assert_eq!(IdentitySource::GitGlobal.id(), "git-global");
+    }
+}

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 pub mod exact_tree;
 pub mod git_init;
 pub mod hooks;
+pub mod identity;
 pub mod init;
 mod init_progress;
 pub use init_progress::report_admission_progress;
@@ -100,7 +101,11 @@ pub use workspace_carry::{
 };
 pub use workspace_semantics::diff_workspace_semantics;
 
-pub use diff::{compute_semantic_change_id, content_identity_from_deltas, whoami};
+pub use diff::{compute_semantic_change_id, content_identity_from_deltas};
+pub use identity::{
+    resolve_commit_identity, unresolved_identity_message, CommitIdentity, IdentitySource,
+    IDENTITY_REMEDIATION,
+};
 pub use disambiguation::{
     fallback_leaf_trace_matches, name_resolution_certainly_misses, query_trace_matches,
 };

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -102,12 +102,12 @@ pub use workspace_carry::{
 pub use workspace_semantics::diff_workspace_semantics;
 
 pub use diff::{compute_semantic_change_id, content_identity_from_deltas};
+pub use disambiguation::{
+    fallback_leaf_trace_matches, name_resolution_certainly_misses, query_trace_matches,
+};
 pub use identity::{
     resolve_commit_identity, unresolved_identity_message, CommitIdentity, IdentitySource,
     IDENTITY_REMEDIATION,
-};
-pub use disambiguation::{
-    fallback_leaf_trace_matches, name_resolution_certainly_misses, query_trace_matches,
 };
 pub use ranking::{
     normalize_symbol_hint, normalize_trace_name, qualifier_hint_from_query, select_best_match,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4612,12 +4612,20 @@ fn session_reconcile_error(error: impl std::fmt::Display) -> (StatusCode, String
 /// The daemon first admits pending filesystem input into graph state, then
 /// publishes one repository-v6 transaction containing the semantic change,
 /// exact tree, workspace base, and named-ref compare-and-swap.
+///
+/// `author` is required and carries no default. The daemon runs with every
+/// `GIT_*` variable scrubbed and does not share the caller's working directory,
+/// so it cannot resolve who is committing, and a defaulted field here is exactly
+/// how the placeholder author this endpoint used to stamp reached permanent
+/// history. A request that names nobody is refused by deserialization rather
+/// than completed by the daemon.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct CommandCommitRequest {
     operation_id: kin_model::OperationId,
     timestamp: kin_model::Timestamp,
     message: String,
+    author: kin_model::AuthorId,
     #[serde(default)]
     session_id: Option<String>,
 }
@@ -4723,7 +4731,7 @@ fn command_commit_after_admission(
             &authority_context,
             request.operation_id,
             request.timestamp,
-            kin_model::AuthorId::new(kin_core::whoami()),
+            request.author,
             request.message,
         )
     })

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17549,6 +17549,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "publish the derived entity into authority"
                         })
                         .to_string(),
@@ -17712,6 +17713,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "move authority past the sealed stash"
                         })
                         .to_string(),
@@ -19207,6 +19209,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "publish one file through one successor"
                         })
                         .to_string(),
@@ -19250,6 +19253,115 @@ mod tests {
                 .is_some(),
             "the committed file must be graph-owned after the single successor"
         );
+    }
+
+    /// The endpoint used to resolve its own author, and the resolution was two
+    /// environment reads with the word "unknown" behind them. It now takes the
+    /// author from the caller and has no fallback at all, so a request that
+    /// names nobody has to be refused rather than completed. The daemon cannot
+    /// answer this question for itself: it runs with every `GIT_*` variable
+    /// scrubbed and does not share the caller's working directory.
+    #[tokio::test]
+    async fn commit_refuses_a_request_that_names_no_author() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        std::fs::write(
+            repo.path().join("unattributable.rs"),
+            b"pub fn unattributable() -> u32 { 1 }\n",
+        )
+        .unwrap();
+
+        let before = crate::loop_runner::current_authority_admission(&state)
+            .unwrap()
+            .0
+            .generation;
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "message": "nobody authored this"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = response.status();
+        assert!(
+            status.is_client_error(),
+            "a commit naming no author must be refused, got {status}"
+        );
+        let after = crate::loop_runner::current_authority_admission(&state)
+            .unwrap()
+            .0
+            .generation;
+        assert_eq!(
+            after, before,
+            "a refused commit must publish no authority successor"
+        );
+    }
+
+    /// The author the caller named is the author the change carries, byte for
+    /// byte. A daemon that normalized, truncated, or re-derived it would be
+    /// answering with its own idea of who committed.
+    #[tokio::test]
+    async fn commit_records_the_author_the_caller_named() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        std::fs::write(
+            repo.path().join("attributed.rs"),
+            b"pub fn attributed() -> u32 { 1 }\n",
+        )
+        .unwrap();
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "author": "Ada Lovelace <ada@example.com>",
+                            "message": "attribute this change to a person"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "commit must succeed: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
+                .unwrap();
+        let authority = context.open().unwrap();
+        let lease = authority.read_authority();
+        let committed = lease
+            .snapshot()
+            .changes
+            .values()
+            .find(|change| change.message == "attribute this change to a person")
+            .expect("the published change");
+        assert_eq!(committed.author.0, "Ada Lovelace <ada@example.com>");
     }
 
     /// A commit that reaches authority clears a wedge, because its transaction
@@ -19334,6 +19446,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "must not infer emptyDir removals"
                         })
                         .to_string(),
@@ -19459,6 +19572,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "attribute the commit wall"
                         })
                         .to_string(),
@@ -19568,6 +19682,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "obsolete dry run must not commit",
                             "dry_run": true
                         })
@@ -19597,6 +19712,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "commit the complete arbitrary repository"
                         })
                         .to_string(),
@@ -19678,6 +19794,7 @@ mod tests {
                         json!({
                             "operation_id": operation_id,
                             "timestamp": Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": message
                         })
                         .to_string(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -29952,6 +29952,7 @@ mod tests {
                         json!({
                             "operation_id": kin_model::OperationId::new(),
                             "timestamp": kin_model::Timestamp::now(),
+                            "author": "Test Author <test@example.invalid>",
                             "message": "publish the raced file through one successor"
                         })
                         .to_string(),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -450,6 +450,14 @@ fn is_within_graph_only_member(state: &DaemonState, path: &RepoPath) -> Result<b
     Ok(false)
 }
 
+/// Who a workspace admission the daemon performed on its own is attributed to.
+///
+/// Not a person, and deliberately not resolved from one. This actor appears only
+/// on tree admissions the watch loop and the purge path publish without a
+/// caller, so attributing them to whoever last configured a Git identity would
+/// name someone who did not perform them.
+pub(crate) const DAEMON_ADMISSION_ACTOR: &str = "kin-daemon-admission";
+
 /// Returns the authority generation this admission published, or `None` when
 /// the desired tree already matched authority and nothing moved.
 pub(crate) fn publish_exact_workspace_tree(
@@ -464,7 +472,14 @@ pub(crate) fn publish_exact_workspace_tree(
         &authority_context,
         admitted,
         kin_model::OperationId::new(),
-        kin_model::AuthorId::new(kin_core::whoami()),
+        // The daemon's own loop is the actor here, and naming it is a statement
+        // rather than a stand-in: nobody typed a command, this publishes no
+        // history node and advances no ref, and the workspace transition it
+        // records was observed by the watcher. A person's identity would be the
+        // fabrication on this path, not the honest answer. Every path that mints
+        // a change a person authored takes that person's resolved identity from
+        // the caller instead.
+        kin_model::AuthorId::new(DAEMON_ADMISSION_ACTOR),
     )?
     else {
         return Ok(None);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -461,6 +461,10 @@ Each failing/incomplete check prints its own `fix:` line. The most common ones:
 - **`repo_init` MISSING** → run `kin init .` to initialize a repository here.
 - **`vfs_projection` MISSING** → run `kin setup` to (re)install the shim into `~/.kin/lib`.
 - **`kin_daemon_binary` MISSING** → reinstall Kin so `kin-daemon` lands beside `kin`.
+- **`commit_identity` MISCONFIGURED** → set `git config --global user.name` and
+  `git config --global user.email`, or put `default_author = "Your Name <you@example.com>"`
+  in `.kin/config.toml`. Kin refuses to commit rather than attribute a change to nobody,
+  because a change record is permanent and its author cannot be corrected afterwards.
 
 `kin doctor` (or `kin setup doctor`) runs the same checklist; add `--fix` to apply the
 safe repairs (shell hook, MCP configs, config dirs, stale-daemon cleanup) and then re-run


### PR DESCRIPTION
`kin commit` wrote the literal string "Author: unknown" into permanent authority
history instead of reading Git's identity or refusing. Found on 0.5.36 in two
isolation containers that had `git config --global user.name` and `user.email` set
the whole time, and every change either session made went into history that way.

Identity resolution was two environment variable reads with a string literal behind
them. `kin_core::whoami()` returned `USER`, then `USERNAME`, then `"unknown"`, and it
never consulted Git at all. A container commonly sets neither variable, so the
placeholder fired every time. Authorship is provenance, and a change record is
authority published once, so this cannot be corrected later without rewriting
history.

## Resolution order, with the source recorded

New `kin_core::identity` resolves an author and reports which surface it came from:

1. `default_author` in the repository's own `.kin/config.toml`. The field already
   existed in `KinConfig` and had no reader, so no config schema change was needed.
2. `user.name` and `user.email` as Git itself merges them here, read through `gix`.
   A repository's merged config already layers host scope under repository scope, so
   one read answers both and the winning section's source reports which scope
   supplied it. A native repository with no `.git` reads the host scopes alone.
3. Otherwise a refusal.

## It refuses rather than invents

Both Git halves are required, because Git completes a half-set identity by
synthesizing the other from the local account and hostname. That synthesized
`user@host.local` is the same defect wearing a different name, so an address in the
`.local` domain is refused wherever it appears, as is a literal `unknown`, from Git
config and from the Kin setting alike. The refusal names both `git config --global`
commands and the Kin setting, from one constant `kin doctor` also uses so the two
cannot drift.

## Every path that mints

All twelve CLI sites that stamped an actor now go through one
`require_commit_author` helper with no infallible variant, so no command can acquire
a fallback of its own. `kin commit` resolves in the CLI rather than the daemon,
because the daemon is spawned with every `GIT_*` variable scrubbed and does not
share the caller's working directory, so an identity it resolved for itself would
answer a different question than who is running the command. `/commands/commit` now
requires an `author` field with no serde default, which makes a request naming
nobody fail deserialization rather than get completed. `whoami` and the test
asserting it returns a non-empty string are deleted; that test passed precisely
because the placeholder existed.

The MCP transaction commit already resolved a real actor from the agent session and
is unchanged. The daemon's background workspace admission keeps a non-person actor,
now the named constant `kin-daemon-admission`, which states who acted rather than
standing in for a person. That path runs with no caller, and what it records is a
workspace tree admission rather than a history node or a ref advance.

## Importing a Git history keeps its original authors

Verified by reading the path, not inferred. `semantic_import` builds each change's
author from that commit's own author bytes and never touched `whoami`, and the one
fixed actor in `git_init` names the generation-zero bootstrap transaction that
admits the repository rather than any commit inside it. A live-identity resolver
applied to imported history would rewrite everyone who ever committed into whoever
ran `kin init`, which is this defect pointed at the past instead of the present.

## `kin doctor`

A `commit_identity` row reports the resolved author and its source, and fails when
nothing resolves, so a user learns before their first commit rather than after their
hundredth. Failing rather than warning is deliberate, because a commit in that state
really is refused. Outside a repository the row is skipped.

## Tests

Twenty covering the resolver, the doctor row, the commit route, and four end-to-end
cases driving the real `kin` and `kin-daemon` binaries and reading `kin log --json`,
the surface the report quoted. A unit test on the resolver could not have caught
this. The resolver was not what was missing. The wiring was.

Each was falsified by reverting. Returning a placeholder fails four resolver tests;
dropping the Kin-setting branch fails the precedence test; an unconditionally
healthy doctor row fails two doctor tests; defaulting the route's author back to
`unknown` fails both route tests; a placeholder from the CLI helper fails the three
live-identity end-to-end cases and leaves the import case green, which is exactly
the separation this fix depends on; pinning the import author to a constant fails
the import case alone.

Five `repository_branches` fixtures hide `.git` after admission to prove branch
answers never fall back to Git, which took the Git identity with it and left the
branch command with nobody to name. They now pin `default_author`, the setting that
exists for exactly that repository shape.

## Rebased onto a test that arrived meanwhile

`a_tick_racing_a_commit_publishes_one_authority_successor_between_them` landed on main
after this branch opened, and it builds a commit payload naming no author. It passed
there because the field was still optional, and this branch passed its own CI because
that test was not on it. Only the merged pair fails, which is the semantic conflict a
merge queue exists to catch. It now names an author like every other commit payload in
that module.

The whole workspace was swept for the same shape rather than fixing the one failure the
queue reported, since fail-fast stopped that run with 3193 tests unrun. Every POST to
the endpoint, every construction of the request type, and every payload carrying its
key shape were enumerated. One test needed the author. The refusal test is the only
payload left that omits one, which is what it exists to prove.

Closes FIR-2366

