### PR TITLE
Emit and resolve a reference edge when a Python symbol is used as a value

### DIFF
--- a/crates/kin-cli/tests/python_value_reference_dead_code.rs
+++ b/crates/kin-cli/tests/python_value_reference_dead_code.rs
@@ -227,7 +227,11 @@ fn entity_id(files: &[FileParseData], name: &str) -> String {
 /// through `kin refs --bulk` over the Calls + Imports + References triple. That
 /// is the same collector, over the same kinds, that the dead-code scan consults
 /// before it puts a row on a delete list.
-fn names_with_references(graph: &InMemoryGraph, files: &[FileParseData], names: &[&str]) -> Vec<String> {
+fn names_with_references(
+    graph: &InMemoryGraph,
+    files: &[FileParseData],
+    names: &[&str],
+) -> Vec<String> {
     let request = BulkRefsRequest {
         entity_ids: names.iter().map(|name| entity_id(files, name)).collect(),
         kind: "all".to_string(),

--- a/crates/kin-cli/tests/python_value_reference_dead_code.rs
+++ b/crates/kin-cli/tests/python_value_reference_dead_code.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Acceptance reproduction for the value-reference edge class, on the fixture
+//! shape that produced seven false dead-code rows.
+//!
+//! A small multi-module Python project: an argparse CLI whose subcommands are
+//! wired by name (`ingest.set_defaults(func=cmd_ingest)`), a module constant
+//! read inside a function in its own file (`WIKI_RE`), and a second constant
+//! imported cross-file and read through an attribute (`TAG_RE.pattern`). Every
+//! one of those symbols is referenced as a VALUE and never called, which is
+//! exactly the class the Python adapter did not extract. `kin dead-code` listed
+//! all seven beside the two genuinely unused helpers, so a reader who trusted
+//! the list would have deleted a working CLI.
+//!
+//! The fixture runs through the real Python adapter and the real cross-file
+//! linker into a real `InMemoryGraph`, which is the shape `kin init` produces
+//! over an existing tree.
+
+use kin_cli::commands::dead_code::build_dead_code_response;
+use kin_cli::commands::refs::{build_bulk_refs_response, BulkRefsRequest};
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+const PARSING_PY: &str = r##""""Note parsing helpers."""
+
+import re
+
+TAG_RE = re.compile(r"#(\w+)")
+WIKI_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def extract_tags(text):
+    return sorted({m.lower() for m in TAG_RE.findall(text)})
+
+
+def extract_links(text):
+    return [m.split("|")[0] for m in WIKI_RE.findall(text)]
+
+
+def unused_helper(text):
+    return text.strip()
+"##;
+
+const STORAGE_PY: &str = r#""""Note storage."""
+
+import json
+
+from parsing import extract_links, extract_tags
+
+
+class NoteStore:
+    def __init__(self, path):
+        self.path = path
+        self.notes = {}
+
+    def ingest(self, name, text):
+        self.notes[name] = {
+            "tags": extract_tags(text),
+            "links": extract_links(text),
+        }
+        return self.notes[name]
+
+    def search(self, term):
+        return [n for n in self.notes if term in n]
+"#;
+
+const LINKGRAPH_PY: &str = r#""""Link graph queries."""
+
+
+def backlinks(notes, target):
+    return [n for n, body in notes.items() if target in body["links"]]
+
+
+def orphans(notes):
+    return [n for n, body in notes.items() if not body["links"]]
+
+
+def isolated_helper(notes):
+    return len(notes)
+"#;
+
+const CLI_PY: &str = r#""""Command line interface."""
+
+import argparse
+
+from linkgraph import backlinks, orphans
+from parsing import TAG_RE
+from storage import NoteStore
+
+
+def cmd_ingest(args):
+    store = NoteStore(args.path)
+    return store.ingest(args.name, args.text)
+
+
+def cmd_tags(args):
+    store = NoteStore(args.path)
+    return store.notes.get(args.name, {}).get("tags", [])
+
+
+def cmd_orphans(args):
+    store = NoteStore(args.path)
+    return orphans(store.notes)
+
+
+def cmd_backlinks(args):
+    store = NoteStore(args.path)
+    return backlinks(store.notes, args.name)
+
+
+def cmd_search(args):
+    store = NoteStore(args.path)
+    return store.search(args.term)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(epilog="tags: %s" % TAG_RE.pattern)
+    sub = parser.add_subparsers()
+    ingest = sub.add_parser("ingest")
+    ingest.set_defaults(func=cmd_ingest)
+    tags = sub.add_parser("tags")
+    tags.set_defaults(func=cmd_tags)
+    orph = sub.add_parser("orphans")
+    orph.set_defaults(func=cmd_orphans)
+    back = sub.add_parser("backlinks")
+    back.set_defaults(func=cmd_backlinks)
+    search = sub.add_parser("search")
+    search.set_defaults(func=cmd_search)
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+"#;
+
+/// The five subcommand handlers, wired only by `set_defaults(func=NAME)`.
+const WIRED_BY_VALUE: [&str; 5] = [
+    "cmd_backlinks",
+    "cmd_ingest",
+    "cmd_orphans",
+    "cmd_search",
+    "cmd_tags",
+];
+
+/// The two constants: one read inside its own file, one also read cross-file.
+const CONSTANTS_READ_AS_VALUES: [&str; 2] = ["TAG_RE", "WIKI_RE"];
+
+/// The only genuinely unused symbols in the fixture.
+const GENUINELY_DEAD: [&str; 2] = ["isolated_helper", "unused_helper"];
+
+fn parse_py(file_path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|entity| entity.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn notes_project() -> (InMemoryGraph, Vec<FileParseData>) {
+    let files = vec![
+        parse_py("cli.py", CLI_PY),
+        parse_py("parsing.py", PARSING_PY),
+        parse_py("storage.py", STORAGE_PY),
+        parse_py("linkgraph.py", LINKGRAPH_PY),
+    ];
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
+
+    let graph = InMemoryGraph::new();
+    for entity in files.iter().flat_map(|file| file.entities.iter()) {
+        graph.upsert_entity(entity).expect("upsert entity");
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    (graph, files)
+}
+
+fn entity_id(files: &[FileParseData], name: &str) -> String {
+    files
+        .iter()
+        .flat_map(|file| file.entities.iter())
+        .find(|entity| entity.name == name)
+        .unwrap_or_else(|| panic!("fixture entity `{name}` not found"))
+        .id
+        .0
+        .to_string()
+}
+
+/// Which of `names` the reference collector finds an inbound edge for, read
+/// through `kin refs --bulk` over the Calls + Imports + References triple. That
+/// is the same collector, over the same kinds, that the dead-code scan consults
+/// before it puts a row on a delete list.
+fn names_with_references(graph: &InMemoryGraph, files: &[FileParseData], names: &[&str]) -> Vec<String> {
+    let request = BulkRefsRequest {
+        entity_ids: names.iter().map(|name| entity_id(files, name)).collect(),
+        kind: "all".to_string(),
+        compact: true,
+    };
+    let response = build_bulk_refs_response(graph, &request).expect("bulk refs");
+    let mut found = Vec::new();
+    for (name, result) in names.iter().zip(response.results.iter()) {
+        let count = result
+            .get("reference_count")
+            .and_then(|value| value.as_u64())
+            .unwrap_or_else(|| panic!("bulk refs row for `{name}` carries no reference_count"));
+        if count > 0 {
+            found.push((*name).to_string());
+        }
+    }
+    found
+}
+
+#[test]
+fn every_symbol_wired_by_value_now_owns_an_inbound_reference() {
+    // The defect, reproduced and closed. Each of these seven is referenced as a
+    // value and never called, so before the value-reference edge class existed
+    // every one of them reported zero inbound edges of any kind.
+    let (graph, files) = notes_project();
+    let mut expected: Vec<String> = WIRED_BY_VALUE
+        .iter()
+        .chain(CONSTANTS_READ_AS_VALUES.iter())
+        .map(|name| (*name).to_string())
+        .collect();
+    expected.sort();
+
+    let mut probed: Vec<&str> = WIRED_BY_VALUE.to_vec();
+    probed.extend(CONSTANTS_READ_AS_VALUES);
+    let mut found = names_with_references(&graph, &files, &probed);
+    found.sort();
+
+    assert_eq!(
+        found, expected,
+        "every symbol used as a value must own an inbound reference edge"
+    );
+}
+
+#[test]
+fn a_symbol_with_no_reference_of_any_kind_is_still_reported() {
+    // The opposite direction. An edge class that rescued everything would be
+    // just as wrong as one that rescued nothing.
+    let (graph, files) = notes_project();
+    let found = names_with_references(&graph, &files, &GENUINELY_DEAD);
+    assert!(
+        found.is_empty(),
+        "genuinely unused helpers must keep reporting no references, got {found:?}"
+    );
+}
+
+#[test]
+fn the_cross_file_constant_leaves_the_dead_code_list() {
+    // `TAG_RE` is imported into cli.py and read there as `TAG_RE.pattern`. That
+    // is the one false row the whole-repo scan can retire on its own, because
+    // its candidate generator asks only whether an inbound edge crosses a file
+    // boundary. The same-file rows below need the scan to consult the reference
+    // collector as well, which is what kin#866 wires in.
+    let (graph, _files) = notes_project();
+    let response = build_dead_code_response(&graph).expect("dead-code scan");
+    let listed = listed_names(&response.lines);
+
+    assert!(
+        !listed.contains(&"TAG_RE".to_string()),
+        "TAG_RE is read cross-file in cli.py, got {listed:?}"
+    );
+    for name in GENUINELY_DEAD {
+        assert!(
+            listed.contains(&name.to_string()),
+            "`{name}` is genuinely unused and must stay listed, got {listed:?}"
+        );
+    }
+}
+
+#[test]
+fn the_dead_code_list_holds_only_rows_the_collector_cannot_rescue() {
+    // The acceptance statement, expressed against what this graph can prove:
+    // every row the whole-repo scan still prints either is genuinely dead, or
+    // is rescued the moment the scan reads the reference collector. Nothing
+    // else survives, and no genuinely dead symbol is hidden.
+    let (graph, files) = notes_project();
+    let response = build_dead_code_response(&graph).expect("dead-code scan");
+    let listed = listed_names(&response.lines);
+
+    let listed_refs: Vec<&str> = listed.iter().map(String::as_str).collect();
+    let rescued = names_with_references(&graph, &files, &listed_refs);
+
+    let mut unrescued: Vec<String> = listed
+        .iter()
+        .filter(|name| !rescued.contains(name))
+        .cloned()
+        .collect();
+    unrescued.sort();
+    assert_eq!(
+        unrescued,
+        GENUINELY_DEAD.map(String::from).to_vec(),
+        "only the genuinely unused helpers may survive the reference collector"
+    );
+}
+
+/// The entity names a dead-code response listed, read off its rendered rows.
+fn listed_names(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .filter_map(|line| {
+            let row = line.strip_prefix("  ")?;
+            let (name, rest) = row.split_once(" (")?;
+            rest.contains(") - ").then(|| name.to_string())
+        })
+        .collect()
+}

--- a/crates/kin-cli/tests/python_value_reference_dead_code.rs
+++ b/crates/kin-cli/tests/python_value_reference_dead_code.rs
@@ -295,7 +295,7 @@ fn the_cross_file_constant_leaves_the_dead_code_list() {
     // boundary. The same-file rows below need the scan to consult the reference
     // collector as well, which is what kin#866 wires in.
     let (graph, _files) = notes_project();
-    let response = build_dead_code_response(&graph).expect("dead-code scan");
+    let response = build_dead_code_response(None, &graph).expect("dead-code scan");
     let listed = listed_names(&response.lines);
 
     assert!(
@@ -317,7 +317,7 @@ fn the_dead_code_list_holds_only_rows_the_collector_cannot_rescue() {
     // is rescued the moment the scan reads the reference collector. Nothing
     // else survives, and no genuinely dead symbol is hidden.
     let (graph, files) = notes_project();
-    let response = build_dead_code_response(&graph).expect("dead-code scan");
+    let response = build_dead_code_response(None, &graph).expect("dead-code scan");
     let listed = listed_names(&response.lines);
 
     let listed_refs: Vec<&str> = listed.iter().map(String::as_str).collect();

--- a/crates/kin-cli/tests/python_value_reference_dead_code.rs
+++ b/crates/kin-cli/tests/python_value_reference_dead_code.rs
@@ -138,6 +138,20 @@ def main():
     return args.func(args)
 "#;
 
+/// The pytest suite. `main` is imported here and read as a value, never
+/// called, so before this edge class existed the entry point itself was on the
+/// delete list.
+const TEST_CLI_PY: &str = r#"from cli import main
+
+
+def test_ingest_then_backlinks():
+    assert main is not None
+
+
+def test_search_and_tags():
+    assert main is not None
+"#;
+
 /// The five subcommand handlers, wired only by `set_defaults(func=NAME)`.
 const WIRED_BY_VALUE: [&str; 5] = [
     "cmd_backlinks",
@@ -180,6 +194,7 @@ fn notes_project() -> (InMemoryGraph, Vec<FileParseData>) {
         parse_py("parsing.py", PARSING_PY),
         parse_py("storage.py", STORAGE_PY),
         parse_py("linkgraph.py", LINKGRAPH_PY),
+        parse_py("tests/test_cli.py", TEST_CLI_PY),
     ];
     let artifact_ids = files
         .iter()

--- a/crates/kin-index/tests/python_value_reference_linking.rs
+++ b/crates/kin-index/tests/python_value_reference_linking.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file resolution of Python value references, through the real parser
+//! and the real linker.
+//!
+//! A symbol used as a value rather than called now carries a `References` edge
+//! out of extraction. These tests pin that such an edge resolves through the
+//! SAME tiers a call does, so a value reference crossing a file boundary binds
+//! with import evidence rather than by name alone. Confidence is asserted, not
+//! merely the edge: the blind cross-file name fallback reaches the same entity
+//! at 0.7 in a single-definition fixture, so an edge alone cannot tell import
+//! resolution from a lucky name match.
+
+use std::collections::HashMap;
+
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityId, FilePathId, GraphNodeId, Relation, RelationKind};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// Confidence the linker records when a relation resolves through the
+/// referring file's own import declaration (tier (b) of
+/// `linker::resolve_one_file`).
+const IMPORT_RESOLVED_CONFIDENCE: f32 = 0.95;
+
+/// Confidence for a member reached through a namespace/module import
+/// (`import parsing` then `parsing.TAG_RE`, tier (b2)).
+const MODULE_MEMBER_CONFIDENCE: f32 = 0.9;
+
+/// Confidence for the blind cross-file exact-name fallback (tier (c)). An edge
+/// at this tier proves only that one entity of that name exists somewhere.
+const NAME_ONLY_CONFIDENCE: f32 = 0.7;
+
+fn parse_py(path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn link(files: &[FileParseData]) -> Vec<Relation> {
+    let artifact_ids: HashMap<String, ArtifactId> = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    link_cross_file(files, &artifact_ids).expect("every fixture file has an artifact identity")
+}
+
+fn entity_id_in(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+fn reference_confidence(relations: &[Relation], src: EntityId, dst: EntityId) -> Option<f32> {
+    relations
+        .iter()
+        .find(|rel| {
+            rel.kind == RelationKind::References
+                && rel.src == GraphNodeId::Entity(src)
+                && rel.dst == GraphNodeId::Entity(dst)
+        })
+        .map(|rel| rel.confidence)
+}
+
+#[test]
+fn a_value_reference_to_an_imported_constant_binds_through_the_import() {
+    let files = vec![
+        parse_py(
+            "cli.py",
+            "from parsing import TAG_RE\n\n\ndef build_parser():\n    return TAG_RE.pattern\n",
+        ),
+        parse_py(
+            "parsing.py",
+            "TAG_RE = compile(\"#\")\n\n\ndef extract_tags(text):\n    return TAG_RE.findall(text)\n",
+        ),
+    ];
+    let relations = link(&files);
+
+    let reader = entity_id_in(&files, "cli.py", "build_parser");
+    let constant = entity_id_in(&files, "parsing.py", "TAG_RE");
+    assert_eq!(
+        reference_confidence(&relations, reader, constant),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the value reference must bind through its import, not the blind name fallback"
+    );
+}
+
+#[test]
+fn a_value_reference_reached_through_a_module_import_binds_to_that_module() {
+    let files = vec![
+        parse_py(
+            "cli.py",
+            "import parsing\n\n\ndef build_parser():\n    return parsing.TAG_RE\n",
+        ),
+        parse_py("parsing.py", "TAG_RE = compile(\"#\")\n"),
+    ];
+    let relations = link(&files);
+
+    let reader = entity_id_in(&files, "cli.py", "build_parser");
+    let constant = entity_id_in(&files, "parsing.py", "TAG_RE");
+    assert_eq!(
+        reference_confidence(&relations, reader, constant),
+        Some(MODULE_MEMBER_CONFIDENCE),
+        "`parsing.TAG_RE` must bind through the module import"
+    );
+}
+
+#[test]
+fn an_imported_value_reference_does_not_bind_to_a_same_named_twin() {
+    // The precision half. Two files define TAG_RE; only one is imported. Name
+    // alone cannot choose, so the import must, and the twin must gain nothing.
+    let files = vec![
+        parse_py(
+            "cli.py",
+            "from parsing import TAG_RE\n\n\ndef build_parser():\n    return TAG_RE.pattern\n",
+        ),
+        parse_py("parsing.py", "TAG_RE = compile(\"#\")\n"),
+        parse_py("legacy.py", "TAG_RE = compile(\"@\")\n"),
+    ];
+    let relations = link(&files);
+
+    let reader = entity_id_in(&files, "cli.py", "build_parser");
+    let real = entity_id_in(&files, "parsing.py", "TAG_RE");
+    let twin = entity_id_in(&files, "legacy.py", "TAG_RE");
+    assert_eq!(
+        reference_confidence(&relations, reader, real),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the imported definition binds"
+    );
+    assert_eq!(
+        reference_confidence(&relations, reader, twin),
+        None,
+        "the same-named twin in an unimported file must gain no reference"
+    );
+}
+
+#[test]
+fn a_same_file_value_reference_resolves_without_the_linker() {
+    // The argparse shape sits entirely inside one file, so it never reaches a
+    // cross-file tier. It must still arrive fully resolved.
+    let files = vec![parse_py(
+        "cli.py",
+        "def cmd_ingest(args):\n    return 1\n\n\ndef main():\n    ingest.set_defaults(func=cmd_ingest)\n",
+    )];
+    let relations = link(&files);
+
+    let caller = entity_id_in(&files, "cli.py", "main");
+    let handler = entity_id_in(&files, "cli.py", "cmd_ingest");
+    assert_eq!(
+        reference_confidence(&relations, caller, handler),
+        Some(1.0),
+        "a same-file value reference is parsed evidence, not inference"
+    );
+}
+
+#[test]
+fn a_value_reference_resolves_exactly_as_the_same_call_would() {
+    // Requirement: value references go through the SAME tiers as calls, so they
+    // must reach the same target at the same confidence. Asserting parity
+    // rather than an absolute rule is what keeps this honest, because a bare
+    // unresolved module name (`requests`) is deliberately left to the
+    // name-global tiers rather than orphaned, for calls and references alike.
+    let referencing = vec![
+        parse_py(
+            "cli.py",
+            "from requests import Session\n\n\ndef build():\n    return Session\n",
+        ),
+        parse_py("vendor.py", "def Session():\n    return 1\n"),
+    ];
+    let calling = vec![
+        parse_py(
+            "cli.py",
+            "from requests import Session\n\n\ndef build():\n    return Session()\n",
+        ),
+        parse_py("vendor.py", "def Session():\n    return 1\n"),
+    ];
+
+    let reference_edge = reference_confidence(
+        &link(&referencing),
+        entity_id_in(&referencing, "cli.py", "build"),
+        entity_id_in(&referencing, "vendor.py", "Session"),
+    );
+    let call_relations = link(&calling);
+    let caller = entity_id_in(&calling, "cli.py", "build");
+    let callee = entity_id_in(&calling, "vendor.py", "Session");
+    let call_edge = call_relations
+        .iter()
+        .find(|rel| {
+            rel.kind == RelationKind::Calls
+                && rel.src == GraphNodeId::Entity(caller)
+                && rel.dst == GraphNodeId::Entity(callee)
+        })
+        .map(|rel| rel.confidence);
+
+    assert_eq!(
+        reference_edge, call_edge,
+        "a value reference and the identical call must resolve alike"
+    );
+    assert_eq!(
+        reference_edge,
+        Some(NAME_ONLY_CONFIDENCE),
+        "and both land on the blind name tier for an unresolved bare module name"
+    );
+}
+
+#[test]
+fn an_unimported_same_named_entity_still_reaches_the_name_fallback() {
+    // Recall control. A file-local entity referenced as a value keeps binding
+    // through the ordinary tiers; this pins that the new edge class did not
+    // acquire a stricter rule than a call has.
+    let files = vec![
+        parse_py(
+            "cli.py",
+            "def helper():\n    return 1\n\n\ndef run():\n    return helper\n",
+        ),
+        parse_py("other.py", "def unrelated():\n    return 2\n"),
+    ];
+    let relations = link(&files);
+
+    let caller = entity_id_in(&files, "cli.py", "run");
+    let helper = entity_id_in(&files, "cli.py", "helper");
+    assert_eq!(
+        reference_confidence(&relations, caller, helper),
+        Some(1.0),
+        "the same-file definition wins outright"
+    );
+    assert!(
+        NAME_ONLY_CONFIDENCE < IMPORT_RESOLVED_CONFIDENCE,
+        "the tier ladder this file asserts against must stay ordered"
+    );
+}

--- a/crates/kin-index/tests/python_value_reference_linking.rs
+++ b/crates/kin-index/tests/python_value_reference_linking.rs
@@ -242,8 +242,10 @@ fn an_unimported_same_named_entity_still_reaches_the_name_fallback() {
         Some(1.0),
         "the same-file definition wins outright"
     );
-    assert!(
-        NAME_ONLY_CONFIDENCE < IMPORT_RESOLVED_CONFIDENCE,
-        "the tier ladder this file asserts against must stay ordered"
+    let unrelated = entity_id_in(&files, "other.py", "unrelated");
+    assert_eq!(
+        reference_confidence(&relations, caller, unrelated),
+        None,
+        "and nothing else in the repository is reached"
     );
 }

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -451,7 +451,10 @@ fn extract_value_refs_from_definition(
     if let Some(params) = node.child_by_field_name("parameters") {
         let mut cursor = params.walk();
         for param in params.named_children(&mut cursor) {
-            if matches!(param.kind(), "default_parameter" | "typed_default_parameter") {
+            if matches!(
+                param.kind(),
+                "default_parameter" | "typed_default_parameter"
+            ) {
                 if let Some(value) = param.child_by_field_name("value") {
                     collect_python_value_refs(&value, source, context_name, &shadowed, out);
                 }
@@ -601,9 +604,7 @@ fn collect_python_value_refs(
                 .child_by_field_name("attribute")
                 .and_then(|n| n.utf8_text(source).ok());
             match (object, leaf) {
-                (Some(object), Some(leaf))
-                    if object.kind() == "identifier" && !leaf.is_empty() =>
-                {
+                (Some(object), Some(leaf)) if object.kind() == "identifier" && !leaf.is_empty() => {
                     if let Ok(root) = object.utf8_text(source) {
                         if !root.is_empty() && !shadowed.contains(root) {
                             out.push(PythonValueRef {
@@ -628,13 +629,7 @@ fn collect_python_value_refs(
                     "identifier" => {}
                     "attribute" => {
                         if let Some(object) = function.child_by_field_name("object") {
-                            collect_python_value_refs(
-                                &object,
-                                source,
-                                context_name,
-                                shadowed,
-                                out,
-                            );
+                            collect_python_value_refs(&object, source, context_name, shadowed, out);
                         }
                     }
                     _ => collect_python_value_refs(&function, source, context_name, shadowed, out),
@@ -664,8 +659,13 @@ fn collect_python_value_refs(
                 collect_python_value_refs(&body, source, context_name, shadowed, out);
             }
         }
-        "parameters" | "type" | "import_statement" | "import_from_statement"
-        | "future_import_statement" | "global_statement" | "nonlocal_statement" => {}
+        "parameters"
+        | "type"
+        | "import_statement"
+        | "import_from_statement"
+        | "future_import_statement"
+        | "global_statement"
+        | "nonlocal_statement" => {}
         _ => {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
@@ -1484,5 +1484,288 @@ mod tests {
             .filter(|e| e.name == "Color")
             .collect();
         assert_eq!(classes[0].kind, EntityKind::EnumDef);
+    }
+
+    /// Value references made by `path`, as `(src, dst)` pairs.
+    fn value_refs(path: &str, source: &str) -> Vec<(String, String)> {
+        let adapter = PythonAdapter;
+        let bytes = source.as_bytes();
+        let tree = adapter.parse(bytes).unwrap();
+        let output = adapter
+            .extract(&tree, bytes, &FilePathId::new(path))
+            .unwrap();
+        output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::References)
+            .map(|r| (r.src_name.clone(), r.dst_name.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn a_function_passed_as_a_keyword_argument_is_referenced() {
+        // The reported shape: an argparse subcommand wired by name. `cmd_ingest`
+        // is never called anywhere, so without this edge it owns none at all.
+        let refs = value_refs(
+            "cli.py",
+            "def cmd_ingest(args):\n    return 1\n\ndef main():\n    ingest.set_defaults(func=cmd_ingest)\n",
+        );
+        assert!(
+            refs.contains(&("main".to_string(), "cmd_ingest".to_string())),
+            "expected main -> cmd_ingest, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn every_value_position_that_names_a_local_entity_is_referenced() {
+        let refs = value_refs(
+            "wire.py",
+            concat!(
+                "def handler(args):\n    return 1\n\n",
+                "def by_argument():\n    register(handler)\n\n",
+                "def by_assignment():\n    chosen = handler\n    return chosen\n\n",
+                "def by_collection():\n    return [handler]\n\n",
+                "def by_mapping():\n    return {\"ingest\": handler}\n\n",
+                "def by_default(fn=handler):\n    return fn\n\n",
+                "def by_return():\n    return handler\n",
+            ),
+        );
+        for src in [
+            "by_argument",
+            "by_assignment",
+            "by_collection",
+            "by_mapping",
+            "by_default",
+            "by_return",
+        ] {
+            assert!(
+                refs.contains(&(src.to_string(), "handler".to_string())),
+                "expected {src} -> handler, got {refs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn attribute_access_on_a_module_constant_references_the_constant() {
+        // `TAG_RE.findall(...)` reads TAG_RE. The `.findall` leaf names a method
+        // of the compiled regex, not a symbol of this file.
+        let refs = value_refs(
+            "parsing.py",
+            "TAG_RE = compile(\"#\")\n\ndef extract_tags(text):\n    return TAG_RE.findall(text)\n",
+        );
+        assert!(
+            refs.contains(&("extract_tags".to_string(), "TAG_RE".to_string())),
+            "expected extract_tags -> TAG_RE, got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|(_, dst)| dst == "findall"),
+            "the attribute leaf is not a symbol of this file, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn an_imported_constant_read_through_an_attribute_is_referenced_by_its_bare_name() {
+        // Cross-file: the linker binds this through the file's import table, so
+        // the destination must be the imported name, not a dotted form.
+        let refs = value_refs(
+            "cli.py",
+            "from parsing import TAG_RE\n\ndef build_parser():\n    return TAG_RE.pattern\n",
+        );
+        assert!(
+            refs.contains(&("build_parser".to_string(), "TAG_RE".to_string())),
+            "expected build_parser -> TAG_RE, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_constant_reached_through_a_module_import_keeps_its_module_qualifier() {
+        // `import parsing` binds the module; `parsing.TAG_RE` names a member of
+        // it. The dotted form is what the linker's namespace-member tier
+        // resolves, and reducing it to the bare leaf would let a same-named
+        // symbol in any other file answer for it.
+        let refs = value_refs(
+            "cli.py",
+            "import parsing\n\ndef build_parser():\n    return parsing.TAG_RE\n",
+        );
+        assert!(
+            refs.contains(&("build_parser".to_string(), "parsing.TAG_RE".to_string())),
+            "expected build_parser -> parsing.TAG_RE, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn import_source_is_annotated_on_a_value_reference() {
+        let adapter = PythonAdapter;
+        let source =
+            b"from parsing import TAG_RE\n\ndef build_parser():\n    return TAG_RE.pattern\n";
+        let tree = adapter.parse(source).unwrap();
+        let output = adapter
+            .extract(&tree, source, &FilePathId::new("cli.py"))
+            .unwrap();
+        let annotated = output
+            .relations
+            .iter()
+            .find(|r| r.kind == kin_model::RelationKind::References && r.dst_name == "TAG_RE")
+            .expect("the value reference exists");
+        assert_eq!(annotated.import_source.as_deref(), Some("parsing"));
+    }
+
+    #[test]
+    fn a_module_scope_reference_is_sourced_from_the_module() {
+        let refs = value_refs(
+            "cli.py",
+            "def cmd_ingest(args):\n    return 1\n\nHANDLERS = {\"ingest\": cmd_ingest}\n",
+        );
+        assert!(
+            refs.contains(&("cli".to_string(), "cmd_ingest".to_string())),
+            "expected cli -> cmd_ingest, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_class_body_assignment_references_from_the_class() {
+        let refs = value_refs(
+            "cli.py",
+            "def handler(args):\n    return 1\n\nclass Router:\n    default = handler\n",
+        );
+        assert!(
+            refs.contains(&("Router".to_string(), "handler".to_string())),
+            "expected Router -> handler, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_local_binding_shadows_a_module_level_name_of_the_same_name() {
+        // `handler` inside `run` is a local, so reading it says nothing about
+        // the module-level function. Without the shadow rule this edge would
+        // make genuinely dead code look alive.
+        let refs = value_refs(
+            "cli.py",
+            "def handler(args):\n    return 1\n\ndef run(handler):\n    return handler\n\ndef other():\n    handler = 1\n    return handler\n",
+        );
+        assert!(
+            !refs.contains(&("run".to_string(), "handler".to_string())),
+            "a parameter shadows the module scope, got {refs:?}"
+        );
+        assert!(
+            !refs.contains(&("other".to_string(), "handler".to_string())),
+            "a local assignment shadows the module scope, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_global_declaration_lifts_the_local_shadow() {
+        let refs = value_refs(
+            "counters.py",
+            "TOTAL_SEEN = 0\n\ndef bump():\n    global TOTAL_SEEN\n    TOTAL_SEEN = TOTAL_SEEN + 1\n",
+        );
+        assert!(
+            refs.contains(&("bump".to_string(), "TOTAL_SEEN".to_string())),
+            "expected bump -> TOTAL_SEEN, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_name_this_file_neither_defines_nor_imports_emits_no_reference() {
+        // Locals, parameters and builtins are the bulk of every value position.
+        // Emitting them would let the linker bind a local called `config` to an
+        // unrelated module-level `config` in some other file, by name alone.
+        let refs = value_refs(
+            "cli.py",
+            "def run(payload):\n    total = len(payload)\n    return total\n",
+        );
+        assert!(refs.is_empty(), "expected no references, got {refs:?}");
+    }
+
+    #[test]
+    fn an_unreferenced_function_still_owns_no_edge() {
+        // The opposite direction: the rows that should stay on a dead-code list
+        // must keep reporting nothing.
+        let refs = value_refs(
+            "parsing.py",
+            "def unused_helper(text):\n    return text\n\ndef used_helper(text):\n    return text\n\ndef caller():\n    return used_helper\n",
+        );
+        assert!(
+            refs.contains(&("caller".to_string(), "used_helper".to_string())),
+            "expected caller -> used_helper, got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|(_, dst)| dst == "unused_helper"),
+            "unused_helper is named nowhere, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_self_reference_emits_no_edge() {
+        let refs = value_refs(
+            "rec.py",
+            "def wrapper(n):\n    if n:\n        return wrapper\n    return None\n",
+        );
+        assert!(
+            !refs.contains(&("wrapper".to_string(), "wrapper".to_string())),
+            "a self-reference establishes no reachability, got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn a_repeated_reference_emits_one_edge() {
+        let refs = value_refs(
+            "cli.py",
+            "def handler(args):\n    return 1\n\ndef wire():\n    a.set_defaults(func=handler)\n    b.set_defaults(func=handler)\n",
+        );
+        let hits = refs
+            .iter()
+            .filter(|(src, dst)| src == "wire" && dst == "handler")
+            .count();
+        assert_eq!(hits, 1, "expected one deduped edge, got {refs:?}");
+    }
+
+    #[test]
+    fn a_bare_decorator_stays_a_call_edge_and_gains_no_duplicate_reference() {
+        // A decorator applies its target at definition time, so it is already a
+        // Calls edge. Adding a second References edge for the same site would
+        // double-count one use.
+        let adapter = PythonAdapter;
+        let source =
+            b"def register(fn):\n    return fn\n\n@register\ndef handler():\n    return 1\n";
+        let tree = adapter.parse(source).unwrap();
+        let output = adapter
+            .extract(&tree, source, &FilePathId::new("cli.py"))
+            .unwrap();
+        assert!(
+            output.relations.iter().any(|r| {
+                r.kind == kin_model::RelationKind::Calls
+                    && r.src_name == "handler"
+                    && r.dst_name == "register"
+            }),
+            "the decorator keeps its Calls edge"
+        );
+        assert!(
+            !output
+                .relations
+                .iter()
+                .any(|r| r.kind == kin_model::RelationKind::References && r.dst_name == "register"),
+            "no duplicate reference for the same decorator site"
+        );
+    }
+
+    #[test]
+    fn a_value_reference_does_not_change_call_coverage() {
+        // The call-extraction audit records what the CALL walk could not
+        // represent. Routing value references through it would report a file as
+        // call-incomplete for reading a constant.
+        let adapter = PythonAdapter;
+        let source = b"HANDLER = 1\n\ndef run():\n    return HANDLER\n";
+        let tree = adapter.parse(source).unwrap();
+        let output = adapter
+            .extract(&tree, source, &FilePathId::new("cov.py"))
+            .unwrap();
+        assert!(
+            !output
+                .relations
+                .iter()
+                .any(crate::extract::is_call_extraction_incomplete_marker),
+            "reading a constant is not an unrepresented call"
+        );
     }
 }

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -46,8 +46,15 @@ impl LanguageAdapter for PythonAdapter {
         let mut relations = Vec::new();
         let mut imports = Vec::new();
         let mut call_audit = PythonCallExtractionAudit::default();
+        let mut value_refs = Vec::new();
         let root = tree.root_node();
         let mut cursor = root.walk();
+
+        // In Python, each `.py` file IS a module (PEP 328); `__init__.py`
+        // additionally marks its containing directory as a *package*. The name
+        // is resolved before the walk because module-scope statements are
+        // sourced to the module entity.
+        let (module_name, is_package) = python_module_identity(file_id);
 
         for child in root.children(&mut cursor) {
             extract_py_node(
@@ -58,6 +65,7 @@ impl LanguageAdapter for PythonAdapter {
                 &mut entities,
                 &mut relations,
                 &mut call_audit,
+                &mut value_refs,
             );
             // Extract imports at top level
             match child.kind() {
@@ -71,7 +79,21 @@ impl LanguageAdapter for PythonAdapter {
                         imports.push(import);
                     }
                 }
-                _ => {}
+                "function_definition" | "class_definition" | "decorated_definition" => {}
+                _ => {
+                    // Module-scope statements. `HANDLERS = {"ingest": cmd_ingest}`
+                    // at module level names its target exactly as a body statement
+                    // would, so the module entity sources those references.
+                    if !module_name.is_empty() {
+                        collect_python_value_refs(
+                            &child,
+                            source,
+                            &module_name,
+                            &std::collections::HashSet::new(),
+                            &mut value_refs,
+                        );
+                    }
+                }
             }
         }
 
@@ -95,6 +117,27 @@ impl LanguageAdapter for PythonAdapter {
             })
             .collect();
 
+        // Emit a Module entity for every Python source file. Previously only
+        // package init files produced Module entities, leaving regular modules
+        // without a node, which broke per-file graph queries on Python repos.
+        if !module_name.is_empty() {
+            entities.push(ExtractedEntity {
+                kind: EntityKind::Module,
+                name: module_name,
+                signature: if is_package {
+                    format!("package {}", file_id.0)
+                } else {
+                    format!("module {}", file_id.0)
+                },
+                visibility: Visibility::Public,
+                doc_summary: extract_module_docstring(&root, source),
+                fingerprint: compute_fingerprint(&root, source),
+                span: span_from_node(&root, file_id),
+            });
+        }
+
+        emit_python_value_references(value_refs, &entities, &imports, &mut relations);
+
         // Annotate Calls/References relations with import_source.
         //
         // A receiver-bearing call is skipped: its `dst_name` is an attribute
@@ -113,48 +156,6 @@ impl LanguageAdapter for PythonAdapter {
                     rel.import_source = Some(module.to_string());
                 }
             }
-        }
-
-        // Emit a Module entity for every Python source file.
-        //
-        // In Python, each `.py` file IS a module (PEP 328); `__init__.py` additionally
-        // marks its containing directory as a *package*. Previously only package init
-        // files produced Module entities, leaving regular modules without a node —
-        // breaking per-file graph queries on Python repos.
-        let (module_name, is_package) = if file_id.0.ends_with("__init__.py") {
-            let pkg = file_id
-                .0
-                .trim_end_matches("__init__.py")
-                .trim_end_matches('/')
-                .rsplit('/')
-                .next()
-                .unwrap_or("__init__")
-                .to_string();
-            (pkg, true)
-        } else {
-            let stem = file_id
-                .0
-                .rsplit('/')
-                .next()
-                .and_then(|leaf| leaf.strip_suffix(".py"))
-                .unwrap_or("")
-                .to_string();
-            (stem, false)
-        };
-        if !module_name.is_empty() {
-            entities.push(ExtractedEntity {
-                kind: EntityKind::Module,
-                name: module_name,
-                signature: if is_package {
-                    format!("package {}", file_id.0)
-                } else {
-                    format!("module {}", file_id.0)
-                },
-                visibility: Visibility::Public,
-                doc_summary: extract_module_docstring(&root, source),
-                fingerprint: compute_fingerprint(&root, source),
-                span: span_from_node(&root, file_id),
-            });
         }
 
         // Detect test functions (pytest: def test_*)
@@ -187,6 +188,7 @@ fn extract_py_node(
     entities: &mut Vec<ExtractedEntity>,
     relations: &mut Vec<ExtractedRelation>,
     call_audit: &mut PythonCallExtractionAudit,
+    value_refs: &mut Vec<PythonValueRef>,
 ) {
     match node.kind() {
         "function_definition" => {
@@ -213,6 +215,7 @@ fn extract_py_node(
                 });
                 // Extract calls within function/method body
                 extract_calls_from_context(node, source, &name, class_ctx, relations, call_audit);
+                extract_value_refs_from_definition(node, source, &name, value_refs);
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
                         receiver: None,
@@ -295,7 +298,24 @@ fn extract_py_node(
                             entities,
                             relations,
                             call_audit,
+                            value_refs,
                         );
+                        // Class-scope statements that define no entity of their
+                        // own still name values: `handler = cmd_ingest` in a
+                        // class body is a use of `cmd_ingest`, sourced from the
+                        // class.
+                        if !matches!(
+                            member.kind(),
+                            "function_definition" | "class_definition" | "decorated_definition"
+                        ) {
+                            collect_python_value_refs(
+                                &member,
+                                source,
+                                &name,
+                                &std::collections::HashSet::new(),
+                                value_refs,
+                            );
+                        }
                     }
                 }
             }
@@ -310,6 +330,7 @@ fn extract_py_node(
                 if child.kind() == "function_definition" || child.kind() == "class_definition" {
                     extract_py_node(
                         &child, source, file_id, class_ctx, entities, relations, call_audit,
+                        value_refs,
                     );
                     // Prepend decorator names to the last-added entity's signature
                     if !decorators.is_empty() {
@@ -346,6 +367,7 @@ fn extract_py_node(
                 if child.kind() == "assignment" || child.kind() == "assignment_statement" {
                     extract_py_node(
                         &child, source, file_id, class_ctx, entities, relations, call_audit,
+                        value_refs,
                     );
                 }
             }
@@ -368,6 +390,354 @@ fn extract_py_node(
             }
         }
         _ => {}
+    }
+}
+
+/// Resolve a Python file's module name and whether it marks a package.
+///
+/// In Python each `.py` file IS a module (PEP 328); `__init__.py` additionally
+/// marks its containing directory as a package.
+fn python_module_identity(file_id: &FilePathId) -> (String, bool) {
+    if file_id.0.ends_with("__init__.py") {
+        let pkg = file_id
+            .0
+            .trim_end_matches("__init__.py")
+            .trim_end_matches('/')
+            .rsplit('/')
+            .next()
+            .unwrap_or("__init__")
+            .to_string();
+        (pkg, true)
+    } else {
+        let stem = file_id
+            .0
+            .rsplit('/')
+            .next()
+            .and_then(|leaf| leaf.strip_suffix(".py"))
+            .unwrap_or("")
+            .to_string();
+        (stem, false)
+    }
+}
+
+/// A symbol read as a VALUE rather than invoked, recorded during the walk.
+///
+/// `member` is set when the reference was written as an attribute access
+/// (`TAG_RE.pattern`), because whether that names the root or the leaf depends
+/// on how the root was bound, and the file's imports are not known until the
+/// walk finishes. Candidates are filtered rather than emitted directly because
+/// a reference may precede its definition in the file.
+struct PythonValueRef {
+    src_name: String,
+    root: String,
+    member: Option<String>,
+}
+
+/// Collect the value references made by one `function_definition`, sourced from
+/// the entity `context_name`.
+///
+/// Parameter defaults are walked because `def wire(handler=cmd_ingest)` reads
+/// `cmd_ingest`; parameter names and annotations are not, since a name being
+/// bound is not a name being read and a type position is a different edge
+/// class. Names the function binds locally shadow the module scope in Python,
+/// so a local called `parse` is not a read of a module-level `parse`.
+fn extract_value_refs_from_definition(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    context_name: &str,
+    out: &mut Vec<PythonValueRef>,
+) {
+    let shadowed = collect_python_local_bindings(node, source);
+    if let Some(params) = node.child_by_field_name("parameters") {
+        let mut cursor = params.walk();
+        for param in params.named_children(&mut cursor) {
+            if matches!(param.kind(), "default_parameter" | "typed_default_parameter") {
+                if let Some(value) = param.child_by_field_name("value") {
+                    collect_python_value_refs(&value, source, context_name, &shadowed, out);
+                }
+            }
+        }
+    }
+    if let Some(body) = node.child_by_field_name("body") {
+        collect_python_value_refs(&body, source, context_name, &shadowed, out);
+    }
+}
+
+/// Names a Python function binds in its own scope, which therefore shadow any
+/// module-level entity of the same name.
+///
+/// A `global`/`nonlocal` declaration re-points the name at an outer scope, so
+/// those names are removed again: `global TAG_RE` followed by an assignment is
+/// a write to the module-level constant, not a local.
+fn collect_python_local_bindings(
+    node: &tree_sitter::Node,
+    source: &[u8],
+) -> std::collections::HashSet<String> {
+    let mut bound = std::collections::HashSet::new();
+    let mut rebound_outward = std::collections::HashSet::new();
+    if let Some(params) = node.child_by_field_name("parameters") {
+        collect_python_binding_targets(&params, source, &mut bound);
+    }
+    if let Some(body) = node.child_by_field_name("body") {
+        collect_python_scope_bindings(&body, source, &mut bound, &mut rebound_outward);
+    }
+    for name in rebound_outward {
+        bound.remove(&name);
+    }
+    bound
+}
+
+fn collect_python_scope_bindings(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    bound: &mut std::collections::HashSet<String>,
+    rebound_outward: &mut std::collections::HashSet<String>,
+) {
+    match node.kind() {
+        "assignment" | "augmented_assignment" | "for_statement" | "for_in_clause" => {
+            if let Some(left) = node.child_by_field_name("left") {
+                collect_python_binding_targets(&left, source, bound);
+            }
+        }
+        "named_expression" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                collect_python_binding_targets(&name, source, bound);
+            }
+        }
+        "as_pattern" => {
+            if let Some(alias) = node.child_by_field_name("alias") {
+                collect_python_binding_targets(&alias, source, bound);
+            }
+        }
+        "function_definition" | "class_definition" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                collect_python_binding_targets(&name, source, bound);
+            }
+            if let Some(params) = node.child_by_field_name("parameters") {
+                collect_python_binding_targets(&params, source, bound);
+            }
+        }
+        "global_statement" | "nonlocal_statement" => {
+            collect_python_binding_targets(node, source, rebound_outward);
+            return;
+        }
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_python_scope_bindings(&child, source, bound, rebound_outward);
+    }
+}
+
+/// Collect the identifiers a binding construct writes to, descending through
+/// tuple and list patterns. An attribute or subscript target (`self.x = 1`,
+/// `d["k"] = 1`) binds no new name, so its identifiers are not collected.
+fn collect_python_binding_targets(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    out: &mut std::collections::HashSet<String>,
+) {
+    match node.kind() {
+        "identifier" => {
+            if let Ok(name) = node.utf8_text(source) {
+                if !name.is_empty() {
+                    out.insert(name.to_string());
+                }
+            }
+        }
+        "attribute" | "subscript" | "type" => {}
+        "default_parameter" | "typed_default_parameter" | "typed_parameter" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() == "identifier" {
+                    collect_python_binding_targets(&child, source, out);
+                    break;
+                }
+            }
+        }
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                collect_python_binding_targets(&child, source, out);
+            }
+        }
+    }
+}
+
+/// Collect the value reads within an expression subtree, pruning the positions
+/// that are not reads.
+///
+/// Pruned: a call's callee identifier (already a `Calls` edge), an attribute's
+/// `.leaf` selector, an assignment or loop target, a keyword argument's name, a
+/// type annotation, and an import statement. Kept, because each is a genuine
+/// read of the named symbol: a call argument (`set_defaults(func=cmd_ingest)`),
+/// an assignment right-hand side, a collection literal element, a returned
+/// expression, and the receiver of an attribute access (`TAG_RE.pattern`).
+fn collect_python_value_refs(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    context_name: &str,
+    shadowed: &std::collections::HashSet<String>,
+    out: &mut Vec<PythonValueRef>,
+) {
+    match node.kind() {
+        "identifier" => {
+            if let Ok(name) = node.utf8_text(source) {
+                if !name.is_empty() && !shadowed.contains(name) {
+                    out.push(PythonValueRef {
+                        src_name: context_name.to_string(),
+                        root: name.to_string(),
+                        member: None,
+                    });
+                }
+            }
+        }
+        // `X.leaf` reads `X`. Whether it also names `leaf` depends on how `X`
+        // was bound, which only the import table can say, so both halves are
+        // carried and decided at emit time.
+        "attribute" => {
+            let object = node.child_by_field_name("object");
+            let leaf = node
+                .child_by_field_name("attribute")
+                .and_then(|n| n.utf8_text(source).ok());
+            match (object, leaf) {
+                (Some(object), Some(leaf))
+                    if object.kind() == "identifier" && !leaf.is_empty() =>
+                {
+                    if let Ok(root) = object.utf8_text(source) {
+                        if !root.is_empty() && !shadowed.contains(root) {
+                            out.push(PythonValueRef {
+                                src_name: context_name.to_string(),
+                                root: root.to_string(),
+                                member: Some(leaf.to_string()),
+                            });
+                        }
+                    }
+                }
+                (Some(object), _) => {
+                    collect_python_value_refs(&object, source, context_name, shadowed, out)
+                }
+                _ => {}
+            }
+        }
+        // A call contributes its arguments and, for `receiver.method()`, the
+        // receiver. The callee name is already carried by the `Calls` edge.
+        "call" => {
+            if let Some(function) = node.child_by_field_name("function") {
+                match function.kind() {
+                    "identifier" => {}
+                    "attribute" => {
+                        if let Some(object) = function.child_by_field_name("object") {
+                            collect_python_value_refs(
+                                &object,
+                                source,
+                                context_name,
+                                shadowed,
+                                out,
+                            );
+                        }
+                    }
+                    _ => collect_python_value_refs(&function, source, context_name, shadowed, out),
+                }
+            }
+            if let Some(args) = node.child_by_field_name("arguments") {
+                collect_python_value_refs(&args, source, context_name, shadowed, out);
+            }
+        }
+        // `f(name=value)`: the keyword names a parameter of the callee, not a
+        // symbol in this scope. Only the value is a read.
+        "keyword_argument" => {
+            if let Some(value) = node.child_by_field_name("value") {
+                collect_python_value_refs(&value, source, context_name, shadowed, out);
+            }
+        }
+        "assignment" | "augmented_assignment" => {
+            if let Some(right) = node.child_by_field_name("right") {
+                collect_python_value_refs(&right, source, context_name, shadowed, out);
+            }
+        }
+        "for_statement" | "for_in_clause" => {
+            if let Some(right) = node.child_by_field_name("right") {
+                collect_python_value_refs(&right, source, context_name, shadowed, out);
+            }
+            if let Some(body) = node.child_by_field_name("body") {
+                collect_python_value_refs(&body, source, context_name, shadowed, out);
+            }
+        }
+        "parameters" | "type" | "import_statement" | "import_from_statement"
+        | "future_import_statement" | "global_statement" | "nonlocal_statement" => {}
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                collect_python_value_refs(&child, source, context_name, shadowed, out);
+            }
+        }
+    }
+}
+
+/// Turn collected value reads into `References` edges.
+///
+/// Only a name this file DEFINES or IMPORTS may bind, which in Python is the
+/// complete set: a module-level symbol is reachable from a module only when it
+/// is defined there or imported into it, and anything else in a value position
+/// is a local, a parameter, or a builtin. Filtering here rather than in the
+/// linker is what keeps a local named `config` from binding by name alone to
+/// some unrelated module-level `config` in another file.
+///
+/// `RelationKind::References` is the existing kind for a non-call reference,
+/// already emitted by the Go, C++, C# and Ruby adapters and already read by the
+/// linker's import and qualified-suffix tiers, the dead-code reference triple,
+/// and `find_references`. No new kind is introduced.
+fn emit_python_value_references(
+    value_refs: Vec<PythonValueRef>,
+    entities: &[ExtractedEntity],
+    imports: &[FileImport],
+    relations: &mut Vec<ExtractedRelation>,
+) {
+    let defined: std::collections::HashSet<&str> =
+        entities.iter().map(|e| e.name.as_str()).collect();
+    let mut module_bound: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut symbol_bound: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for import in imports {
+        for spec in &import.specifiers {
+            // `import parsing` binds the module itself under its own path;
+            // `from parsing import TAG_RE` binds a symbol out of it.
+            if spec.local_name == import.module_path {
+                module_bound.insert(spec.local_name.as_str());
+            } else {
+                symbol_bound.insert(spec.local_name.as_str());
+            }
+        }
+    }
+
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    for value_ref in value_refs {
+        let root = value_ref.root.as_str();
+        let dst = match &value_ref.member {
+            // `parsing.TAG_RE` through a module binding names the member. The
+            // dotted form is what the linker's namespace-member tier resolves,
+            // and it cannot be reduced to the bare leaf without guessing which
+            // module a same-named symbol came from.
+            Some(member) if module_bound.contains(root) => format!("{root}.{member}"),
+            _ if defined.contains(root) || symbol_bound.contains(root) => root.to_string(),
+            _ => continue,
+        };
+        // A self-reference establishes no reachability from another entity, and
+        // the reference collectors drop it anyway.
+        if dst == value_ref.src_name {
+            continue;
+        }
+        if !seen.insert((value_ref.src_name.clone(), dst.clone())) {
+            continue;
+        }
+        relations.push(ExtractedRelation {
+            call_shape: None,
+            receiver: None,
+            kind: kin_model::RelationKind::References,
+            src_name: value_ref.src_name,
+            dst_name: dst,
+            import_source: None,
+        });
     }
 }
 

--- a/crates/kin-parser/tests/language_matrix_calls.rs
+++ b/crates/kin-parser/tests/language_matrix_calls.rs
@@ -282,12 +282,32 @@ fn swift_method_call_emits_rightmost_name() {
 
 #[test]
 fn go_function_value_argument_emits_reference() {
-    // Go is the only adapter that turns a bare function passed as a value into a
-    // graph edge: `register(plain)` yields a References edge to `plain`.
+    // Go and Python turn a bare function passed as a value into a graph edge:
+    // `register(plain)` yields a References edge to `plain`. TypeScript, Java
+    // and Ruby still do not, which is what the ignored cases below record.
     let out = extract(
         &GoAdapter,
         "s.go",
         "package main\nfunc plain() {}\nfunc run() { register(plain) }\n",
+    );
+    assert!(
+        has_edge(&out, RelationKind::References, "run", "plain"),
+        "expected References run -> plain, got {:?}",
+        out.relations
+            .iter()
+            .map(|r| (r.kind, r.src_name.as_str(), r.dst_name.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn python_function_value_argument_emits_reference() {
+    // The argparse shape: `set_defaults(func=cmd_ingest)` never calls
+    // `cmd_ingest`, so the References edge is the only one it can own.
+    let out = extract(
+        &PythonAdapter,
+        "s.py",
+        "def plain():\n    return 1\n\ndef run():\n    register(func=plain)\n",
     );
     assert!(
         has_edge(&out, RelationKind::References, "run", "plain"),


### PR DESCRIPTION
A Python symbol used as a value produced no graph edge at all. The adapter
emitted an edge only when a name was called, so a function passed as an
argument, assigned, returned, put in a collection, used as a parameter default,
or read through an attribute was invisible. Every reference collector then
reported zero incoming edges, and `kin dead-code` put working code on a delete
list. Seven of the nine rows it listed on the reported fixture were false. A
user who trusted that list would have deleted their whole CLI.

## The edge class added

A value read now emits `RelationKind::References`, the existing kind for a
non-call reference. It is already emitted by the Go, C++, C# and Ruby adapters,
already matched by the linker's import and qualified-suffix tiers, already in
the dead-code reference triple, and already understood by `find_references` and
`kin refs`. A new kind would have meant a `kin-model` publish, a `kin-db`
republish and a version ladder to name a thing that already had a name.

The emitting scopes are a function or method body plus its parameter defaults, a
class-body statement that defines no entity of its own, and a module-scope
statement. The walk prunes what is not a read: a call's callee identifier
(already a `Calls` edge), an attribute's `.leaf` selector, an assignment or loop
target, a keyword argument's name, a type annotation, and import statements. It
keeps a call's arguments and, for `receiver.method()`, the receiver.

What separates this from an approximation is the binding rules.

**Only a name the file defines or imports may bind.** Go emits every
value-position identifier and lets the linker drop what it cannot resolve. That
is unsafe here, because an unresolved name reaches the blind cross-file
exact-name tier and binds at 0.7 to any same-named entity anywhere. In Python
that filter costs no recall. A module-level symbol is reachable from a module
only when defined there or imported into it, so anything else in a value
position is a local, a parameter, or a builtin.

**Local bindings shadow the module scope.** Parameters, assignment and loop
targets, walrus names, `with`/`except` aliases and nested definitions are
collected and suppressed, so `def run(handler): return handler` does not mark a
module-level `handler` alive. A `global` declaration lifts the shadow again.

`X.Y` where `X` is a module import keeps the dotted form, which the linker's
namespace-member tier resolves at 0.9. Where `X` is a symbol import or a local
entity, the bare root is emitted and binds through the import table at 0.95.

## Resolution reuses the existing path

No linker code was touched. Same-file references resolve in
`pipeline::resolve_relations`, which is kind-agnostic, at confidence 1.0. Cross
file they go through the same tiers a call does: import-based (b) at 0.95,
namespace member (b2) at 0.9, blind exact name (c) at 0.7. Because they carry
the same tier constants, they classify correctly under the resolution ladder in
#868 with nothing to carry across. The Calls-only tiers stay Calls-only: a value
reference is not a dispatch, and the bare-name method fan-out is the precision
hazard #868 removed.

## Dead-code count, measured on a rebuilt fixture

The fixture rebuilds the reported project shape, with five argparse subcommands
wired by `set_defaults(func=NAME)`, `TAG_RE.pattern` read cross-file, `WIKI_RE`
read inside its own file, and a pytest module importing `main`. Real `git init`,
real `kin init`, real `kin dead-code`.

| tree | rows | false rows |
|---|---|---|
| #866 composed, extraction fix reverted | **10** | **7** |
| #866 composed, extraction fix present | **3** | **0** |

What remains is `isolated_helper`, `unused_helper` and `NoteStore.dump`, none of
which is used anywhere, and the scan's own header reports `7 as referenced by an
entity in their own file`.

On `origin/main` without #866 the same fixture goes 12 rows to 10, retiring the
cross-file reads `TAG_RE` and `main`. The same-file rows need the scan to
consult the reference collector, which #866 wires in, because
`kin_db::traverse::find_dead_code` selects candidates with
`has_cross_file_incoming` and a same-file edge cannot retire a row there.
`kin-db` is pinned at `=0.7.29`. This branch shares no file with #866 and the
composition merge was conflict-free, so either merge order works.

## Tests

16 adapter tests pin what counts as a value read and what does not, with four
negative controls beside them. One language-matrix cell is added, and the
comment on the Go cell claiming Go is the only adapter that does this is
updated rather than left to rot. 6 linker tests assert the confidence tier
rather than the edge alone, because the blind name fallback reaches the same
entity at 0.7 in a single-definition fixture. 4 acceptance tests run the fixture
through the real adapter and the real cross-file linker into a real graph and
assert by name, not by count.

Every mechanism was falsified. With emission disabled, 11 of 16 adapter tests
fail, 6 of 6 linker tests fail, 3 of 4 acceptance tests fail, and the survivors
are exactly the negative controls. With the shadow set forced empty, exactly the
shadow test fails. With the module qualifier disabled, exactly the two
module-import tests fail. With extraction reverted on the composed tree, the
seven false rows return.

## Scope not taken

JavaScript and TypeScript are unchanged. #864 is open and is rewriting
`javascript.rs` and `typescript.rs`, the exact files a JS pass would edit, so
doing it here would guarantee a conflict with a PR ahead of this one. The
follow-up needs the same walk over `assignment_expression` right-hand sides,
call arguments, array and object literal values, parameter defaults and returns,
with the callee pruned, plus a defines-or-imports filter over the file's
declarations and import specifiers. The ignored matrix cell
`typescript_callback_value_should_emit_reference` is the test to un-ignore.

Module-scope calls (`if __name__ == "__main__": main()`) still emit no edge.
That is a call-extraction gap rather than a value-reference one and needs its
own ticket.

Closes FIR-2376
