### PR TITLE
Report 1-indexed lines from kin search and kin overview, and finish the three fixes kin#874 left short

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -340,11 +340,25 @@ fn resolve_against(base: &Path, target: &str) -> PathBuf {
 
 /// Whether some rule Git already reads keeps the store out of `git status`.
 ///
-/// Checked against both places a rule can already live for this repository:
-/// the local excludes this command writes, and the tracked `.gitignore` a
-/// project may have adopted on its own. Either one makes writing a second rule
-/// pure noise.
+/// Git is asked for the rules it actually resolves, which is the only answer
+/// that matches what the author will see. That covers a rule living in a
+/// `core.excludesFile` outside the repository, and it reads a later `!.kin`
+/// negation as Git reads it, where matching exclude-file lines against a fixed
+/// set of spellings would call the store excluded when `git status` still names
+/// it.
+///
+/// The line scan below stands in only when the question cannot be put to Git at
+/// all, which is a directory carrying a `.git` that is not an openable
+/// repository. Nothing there resolves ignore rules either, so the two files a
+/// rule can be written into are the whole of what a reader could consult.
 fn store_already_excluded(working_dir: &Path, common_dir: &Path) -> Result<bool> {
+    match kin_git::kin_store_is_git_ignored(working_dir) {
+        Ok(excluded) => return Ok(excluded),
+        Err(error) => tracing::debug!(
+            %error,
+            "Git could not resolve ignore rules here; reading the exclude files directly"
+        ),
+    }
     for candidate in [
         common_dir.join("info").join("exclude"),
         working_dir.join(".gitignore"),
@@ -1006,6 +1020,45 @@ mod tests {
                 "{name} must be untouched"
             );
         }
+    }
+
+    /// A rule Git resolves from outside the repository is honored.
+    ///
+    /// `core.excludesFile` names a file that is neither the local exclude nor
+    /// the tracked ignore file, so reading those two alone reports the store as
+    /// visible and writes a rule Git already had. The fixture proves Git itself
+    /// agrees before the decision is asked for: the store is on disk and absent
+    /// from `git status`.
+    #[test]
+    fn a_rule_resolved_from_outside_the_repository_is_honored() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-q"]);
+        let excludes = dir.path().join("global-excludes");
+        std::fs::write(&excludes, "/.kin/\n").unwrap();
+        git(
+            &repo,
+            &["config", "core.excludesFile", excludes.to_str().unwrap()],
+        );
+        write_store(&repo);
+
+        let status = git_status(&repo);
+        assert!(
+            !status.contains(".kin"),
+            "the fixture must start with the store already hidden: {status:?}"
+        );
+
+        assert!(
+            exclude_store_from_git(&repo).unwrap().is_none(),
+            "a rule Git already resolves must not be restated locally"
+        );
+        let info_exclude = std::fs::read_to_string(repo.join(".git").join("info").join("exclude"))
+            .unwrap_or_default();
+        assert!(
+            !info_exclude.contains(".kin"),
+            "no second rule may be written: {info_exclude:?}"
+        );
     }
 
     /// A directory Git does not own is not this command's to write into.

--- a/crates/kin-cli/src/commands/overview.rs
+++ b/crates/kin-cli/src/commands/overview.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{Context, Result};
+use kin_mcp::handlers::common::entity_presentation_start_line;
 use kin_model::EntityStore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -169,8 +170,15 @@ pub fn build_overview_response(
             lines.push(format!("{} ({}):", kind, ents.len()));
             for e in ents.iter().take(top_n) {
                 let file = e.file_origin.as_ref().map(|f| f.0.as_str()).unwrap_or("?");
-                let line = e.span.as_ref().map(|s| s.start_line).unwrap_or(0);
-                lines.push(format!("  {}  {}:{}", e.name, file, line));
+                // The graph stores tree-sitter rows, which are 0-based; a
+                // `file:line` a reader pastes into an editor is 1-based. An entity
+                // the graph carries no span for names its file alone rather than
+                // the `:0` that used to appear here.
+                let location = match entity_presentation_start_line(e) {
+                    Some(line) => format!("{file}:{line}"),
+                    None => file.to_string(),
+                };
+                lines.push(format!("  {}  {}", e.name, location));
             }
             if ents.len() > top_n {
                 lines.push(format!("  ... and {} more", ents.len() - top_n));
@@ -180,4 +188,106 @@ pub fn build_overview_response(
     }
 
     Ok(OverviewResponse { lines })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_overview_response, OverviewRequest};
+    use kin_db::InMemoryGraph;
+    use kin_model::{
+        Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+        FingerprintAlgorithm, Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
+    };
+
+    fn overview_entity(name: &str, path: &str, start_line: Option<u32>) -> Entity {
+        let file = FilePathId::new(path);
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Python,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([1; 32]),
+                behavior_hash: Hash256::from_bytes([2; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            span: start_line.map(|start_line| SourceSpan {
+                file: file.clone(),
+                start_byte: 0,
+                end_byte: 1,
+                start_line,
+                start_col: 0,
+                end_line: start_line + 1,
+                end_col: 1,
+            }),
+            file_origin: Some(file),
+            signature: format!("def {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    /// `kin overview`'s top-entity listing reports the line a human editor shows.
+    ///
+    /// The graph stores tree-sitter rows, which are 0-based, and every
+    /// agent-facing `file:line` is 1-based. This listing printed the raw row, so
+    /// it disagreed with `kin refs` and every MCP read surface about the same
+    /// entity, and a reader acting on it opened the line above the definition.
+    #[test]
+    fn the_top_entity_listing_reports_the_line_a_human_editor_shows() {
+        const SOURCE: &str = "# header\n\n\ndef probe_overview():\n    return 1\n";
+        // What a reader counting lines in an editor would say, derived from the
+        // fixture rather than written down.
+        let human_line = SOURCE
+            .lines()
+            .position(|line| line.contains("def probe_overview"))
+            .map(|index| index + 1)
+            .expect("the fixture declares the function") as u32;
+        let graph_row = human_line - 1;
+
+        let graph = InMemoryGraph::new();
+        graph
+            .upsert_entity(&overview_entity(
+                "probe_overview",
+                "src/probe.py",
+                Some(graph_row),
+            ))
+            .expect("upsert spanned entity");
+        // An entity the graph carries no span for has no line to report.
+        graph
+            .upsert_entity(&overview_entity("probe_spanless", "src/spanless.py", None))
+            .expect("upsert spanless entity");
+
+        let response = build_overview_response(
+            "probe-repo",
+            &graph,
+            &OverviewRequest {
+                json: false,
+                compact: false,
+            },
+        )
+        .expect("build overview");
+        let joined = response.lines.join("\n");
+
+        assert!(
+            joined.contains(&format!("src/probe.py:{human_line}")),
+            "the listing must name line {human_line}: {joined}"
+        );
+        assert!(
+            !joined.contains(&format!("src/probe.py:{graph_row}")),
+            "the raw 0-based row must not reach the reader: {joined}"
+        );
+        assert!(
+            joined.contains("src/spanless.py") && !joined.contains("src/spanless.py:0"),
+            "a spanless entity names its file without a fabricated line: {joined}"
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use kin_db::{ResolvedRetrievalItem, RetrievalKey};
+use kin_mcp::handlers::common::{entity_presentation_end_line, entity_presentation_start_line};
 use kin_model::EntityStore;
 use kin_model::{Entity, EntityFilter, EntityKind, LanguageId};
 #[cfg(feature = "vector")]
@@ -846,6 +847,21 @@ fn looks_non_production_path(path: &str) -> bool {
         || path.ends_with(".test.js")
 }
 
+/// `path:line` for a search hit, or the path alone when the record carries no
+/// line.
+///
+/// The record's `start_line` is already 1-based, converted at the one seam that
+/// builds it, so this only decides how to render it. An entity the graph carries
+/// no span for has no line to report, and the `:0` that used to appear here was a
+/// position no editor can open. Extracted from the print so the rendering is
+/// reachable from a test.
+fn search_hit_location(file: String, start_line: Option<u32>) -> String {
+    match start_line {
+        Some(line) => format!("{file}:{line}"),
+        None => file,
+    }
+}
+
 fn daemon_record_to_json(record: &DaemonSearchRecord) -> SearchJsonRecord {
     match record {
         DaemonSearchRecord::Entity(entity) => SearchJsonRecord::Entity(SearchJsonEntity {
@@ -853,6 +869,10 @@ fn daemon_record_to_json(record: &DaemonSearchRecord) -> SearchJsonRecord {
             kind: entity.kind.clone(),
             name: entity.name.clone(),
             file: entity.file.clone().unwrap_or_default(),
+            // Already 1-based: the record's lines are converted at the one seam
+            // that builds it. This field is not optional in the JSON contract, so
+            // an entity with no span keeps the "top of the file" fallback, which
+            // in a 1-based world is a line a reader can actually open.
             line: entity.start_line.unwrap_or(1),
             end_line: entity.end_line,
             score: entity.score,
@@ -903,8 +923,17 @@ fn entity_to_daemon_record(
         kind: format!("{:?}", entity.kind),
         language: entity.language.to_string(),
         file: entity.file_origin.as_ref().map(|f| f.0.clone()),
-        start_line: span.map(|span| span.start_line),
-        end_line: span.map(|span| span.end_line),
+        // The graph stores tree-sitter rows, which are 0-based; every
+        // agent-facing `file:line` is 1-based. This is the one seam a search
+        // record's lines are built at, so both emitters downstream (the JSON
+        // record and the `--body` human line) pass the converted value through
+        // rather than each converting, or each forgetting to.
+        //
+        // `start_byte`/`end_byte` are deliberately NOT shifted. They are byte
+        // offsets rather than line numbers, and the daemon slices a source blob
+        // with them to build `body`.
+        start_line: entity_presentation_start_line(entity),
+        end_line: entity_presentation_end_line(entity),
         start_byte: span.map(|span| span.start_byte),
         end_byte: span.map(|span| span.end_byte),
         signature: (!entity.signature.is_empty()).then(|| entity.signature.clone()),
@@ -943,11 +972,11 @@ fn resolved_item_to_daemon_record(
             context: format!("{:?}, {}", entity.kind, entity.language),
             file,
             artifact_kind: "entity".to_string(),
-            line: entity
-                .span
-                .as_ref()
-                .map(|span| span.start_line)
-                .unwrap_or(1),
+            // 1-based, like the three whole-file arms below that report `line: 1`.
+            // This row's `line` is not optional, so a spanless entity keeps that
+            // same "top of the file" fallback rather than gaining a `0` no editor
+            // can open.
+            line: entity_presentation_start_line(entity).unwrap_or(1),
             preview: entity
                 .doc_summary
                 .clone()
@@ -1228,10 +1257,11 @@ fn render_daemon_search_response(
                         .as_deref()
                         .map(|file| display_read_path(layout, file))
                         .unwrap_or_else(|| "unknown".to_string());
-                    let line_num = entity.start_line.unwrap_or(0);
                     println!(
-                        "{} ({}) @ {}:{}",
-                        entity.name, entity.kind, file_str, line_num
+                        "{} ({}) @ {}",
+                        entity.name,
+                        entity.kind,
+                        search_hit_location(file_str, entity.start_line)
                     );
                     if let Some(body) = entity.body.as_deref() {
                         for line in body.lines() {
@@ -1515,6 +1545,114 @@ mod tests {
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    /// Every `kin search` emitter reports the line a human editor shows.
+    ///
+    /// The graph stores tree-sitter rows, which are 0-based, and
+    /// `kin-mcp`'s `handlers::common` documents that every agent-facing
+    /// `file:line` is 1-based, converted at exactly one seam per surface. `kin
+    /// search` emitted the raw row from three places, so it disagreed with `kin
+    /// refs`, `kin trace-data-flow`, and every MCP read surface about the same
+    /// entity, and a reader acting on it edited the line above the hit.
+    ///
+    /// One test covering all three emitters on purpose: they are one contract
+    /// stated once, and the wire record they share is the seam the conversion
+    /// happens at, so asserting them apart would let the record and its renderers
+    /// drift.
+    #[test]
+    fn every_search_emitter_reports_the_line_a_human_editor_shows() {
+        use super::{
+            daemon_record_to_json, entity_to_daemon_record, resolved_item_to_daemon_record,
+            search_hit_location, SearchJsonRecord, SearchMatchKind,
+        };
+
+        const SOURCE: &str = "# header\n\ndef probe_handler():\n    return 1\n";
+        // What a reader counting lines in an editor would say.
+        let human_line = SOURCE
+            .lines()
+            .position(|line| line.contains("def probe_handler"))
+            .map(|index| index + 1)
+            .expect("the fixture declares the handler") as u32;
+        let graph_row = human_line - 1;
+        assert_eq!(
+            graph_row, 2,
+            "fixture sanity: the raw row differs from the line"
+        );
+
+        let mut entity = dedupe_test_entity("probe_handler", "src/probe.py");
+        {
+            let span = entity.span.as_mut().expect("fixture carries a span");
+            span.start_line = graph_row;
+            span.end_line = graph_row + 1;
+        }
+        let (start_byte, end_byte) = entity
+            .span
+            .as_ref()
+            .map(|span| (span.start_byte, span.end_byte))
+            .expect("fixture carries a span");
+
+        // Emitter 1: the wire record every search surface is rendered from.
+        let record = entity_to_daemon_record(&entity, SearchMatchKind::Semantic, Some(0.5));
+        assert_eq!(
+            record.start_line,
+            Some(human_line),
+            "the record must carry the 1-based line, not the raw row {graph_row}"
+        );
+        assert_eq!(record.end_line, Some(human_line + 1));
+        // Byte offsets are not line numbers and must not be shifted: the daemon
+        // slices a source blob with them to build `body`.
+        assert_eq!(record.start_byte, Some(start_byte));
+        assert_eq!(record.end_byte, Some(end_byte));
+
+        // Emitter 2: `kin search --json`.
+        let SearchJsonRecord::Entity(json_entity) =
+            daemon_record_to_json(&super::DaemonSearchRecord::Entity(record.clone()))
+        else {
+            panic!("expected an entity record");
+        };
+        let json = serde_json::to_value(&json_entity).expect("serialize");
+        assert_eq!(
+            json["line"].as_u64(),
+            Some(human_line as u64),
+            "the JSON line must be the one a reader would count: {json}"
+        );
+
+        // Emitter 3: the `--body` human `file:line`.
+        assert_eq!(
+            search_hit_location("src/probe.py".to_string(), record.start_line),
+            format!("src/probe.py:{human_line}")
+        );
+        // A hit the graph carries no span for names its file alone. `:0` was a
+        // position no editor can open.
+        assert_eq!(
+            search_hit_location("src/probe.py".to_string(), None),
+            "src/probe.py"
+        );
+
+        // Emitter 4: the artifact row, whose `line` is not optional and so keeps
+        // the same "top of the file" fallback its three whole-file siblings use.
+        let artifact = resolved_item_to_daemon_record(
+            &ResolvedRetrievalItem::Entity(entity.clone()),
+            SearchMatchKind::Semantic,
+            Some(0.5),
+        );
+        assert_eq!(
+            artifact.line, human_line,
+            "the artifact row must carry the 1-based line"
+        );
+        let mut spanless = entity;
+        spanless.span = None;
+        assert_eq!(
+            resolved_item_to_daemon_record(
+                &ResolvedRetrievalItem::Entity(spanless),
+                SearchMatchKind::Semantic,
+                Some(0.5),
+            )
+            .line,
+            1,
+            "a spanless artifact row points at the top of the file, never line 0"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -54,6 +54,66 @@ fn kin_init(repo: &Path, home: &Path, extra: &[&str]) -> std::process::Output {
         .expect("run kin init")
 }
 
+fn git_stdout(path: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("utf8 git stdout")
+}
+
+/// A converted repository's `git status` must not name the store.
+///
+/// `.kin/` runs from hundreds of megabytes to over a gigabyte, and Kin authors
+/// no ignore rules of its own, so the store stood in `git status` as untracked
+/// for the life of the checkout and one careless `git add -A` staged all of it.
+/// The exclusion belongs to this checkout, so it goes in `.git/info/exclude` and
+/// never in the tracked `.gitignore`, where it would enter the user's diff.
+///
+/// Driven through the binary, because the exclusion writer being correct and
+/// `kin init` never calling it look identical from a unit test.
+#[test]
+fn git_init_keeps_the_store_out_of_git_status() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("excluded");
+    fs::create_dir_all(&home).expect("create home");
+    seed_git_repo(&repo);
+
+    let output = kin_init(&repo, &home, &[]);
+    assert!(
+        output.status.success(),
+        "init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(repo.join(".kin").is_dir(), "init published no store");
+
+    let status = git_stdout(&repo, &["status", "--porcelain"]);
+    assert!(
+        !status.contains(".kin"),
+        "git status must not name the store after init: {status}"
+    );
+    assert!(
+        !repo.join(".gitignore").exists(),
+        "the exclusion must stay local rather than entering the tracked ignore file"
+    );
+    let exclude = fs::read_to_string(repo.join(".git/info/exclude")).expect("read local exclude");
+    assert!(
+        exclude.lines().any(|line| line.trim() == "/.kin/"),
+        "the local exclude must carry the anchored store pattern: {exclude}"
+    );
+}
+
 #[test]
 fn fresh_native_init_creates_unborn_repository_authority() {
     let root = tempdir().expect("temp root");

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -53,12 +53,13 @@ pub use lossless::{
     LosslessGitRepository,
 };
 pub use preflight::{
-    preflight_git_migration, preflight_git_migration_after_publication, reprove_git_migration,
-    reprove_git_migration_after_publication, GitBranchTrackingFact, GitIndexPreflightProof,
-    GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind, GitMigrationCompatibilityFacts,
-    GitMigrationPreflightProof, GitRemoteConfigFact, GitRemoteMappingFacts,
-    GitTrackedWorktreeProof, GitWorkspaceDivergence, GitWorkspaceDivergenceFacts,
-    GitWorkspaceDivergenceKind, IgnoredLocalEntry, IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
+    kin_store_is_git_ignored, preflight_git_migration, preflight_git_migration_after_publication,
+    reprove_git_migration, reprove_git_migration_after_publication, GitBranchTrackingFact,
+    GitIndexPreflightProof, GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind,
+    GitMigrationCompatibilityFacts, GitMigrationPreflightProof, GitRemoteConfigFact,
+    GitRemoteMappingFacts, GitTrackedWorktreeProof, GitWorkspaceDivergence,
+    GitWorkspaceDivergenceFacts, GitWorkspaceDivergenceKind, IgnoredLocalEntry,
+    IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
 };
 pub use repository_export::{
     export_repository_to_git, verify_repository_git_export, RepositoryGitCommitBinding,

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -2855,6 +2855,50 @@ pub(crate) fn local_ignore_inputs(repo: &gix::Repository) -> Result<Vec<GitLocal
     Ok(inputs)
 }
 
+/// The store directory a published Kin repository owns at its root.
+const KIN_STORE_DIR: &str = ".kin";
+
+/// Whether the ignore rules Git itself resolves already hide a Kin store at
+/// this repository's root.
+///
+/// Answered from the same authority `git status` answers from: resolved global
+/// excludes, the repository's `info/exclude`, and the committed `.gitignore`
+/// mapping this module already treats as ignore authority. A caller deciding
+/// whether to write its own rule has to ask the question this way, because
+/// comparing exclude-file lines against a fixed set of spellings agrees with
+/// Git only by coincidence. It misses a rule that lives in a `core.excludesFile`
+/// the caller never reads, and it reads a later `!.kin` negation as an exclusion
+/// when Git reads it as the opposite.
+///
+/// `Err` means the question could not be put to Git at all, which is a
+/// different answer from "no rule covers it" and is left to the caller.
+pub fn kin_store_is_git_ignored(repo_root: &Path) -> Result<bool> {
+    let repo = open_repo_with_user_ignore_config(repo_root)?;
+    let index_path = repo.index_path();
+    let index = gix::index::File::at_or_default(
+        &index_path,
+        repo.object_hash(),
+        false,
+        gix::index::decode::Options::default(),
+    )
+    .map_err(|error| {
+        preflight_error(format!(
+            "open Git index while reading the Kin store's ignore state: {error}"
+        ))
+    })?;
+    let inputs = local_ignore_inputs(&repo)?;
+    let (mut excludes, _) = frozen_ignore_stack(&repo, &index, &inputs)?;
+    Ok(excludes
+        .at_entry(
+            KIN_STORE_DIR.as_bytes().as_bstr(),
+            Some(gix::index::entry::Mode::DIR),
+        )
+        .map_err(|error| {
+            preflight_error(format!("evaluate ignore rules for the Kin store: {error}"))
+        })?
+        .is_excluded())
+}
+
 pub(crate) fn frozen_ignore_stack<'repo>(
     repo: &'repo gix::Repository,
     index: &gix::index::File,
@@ -5508,6 +5552,49 @@ mod tests {
         assert!(error
             .to_string()
             .contains("changed during migration preflight"));
+    }
+
+    /// The store's ignore state is read from every rule Git resolves, including
+    /// one that lives outside the repository.
+    ///
+    /// A `core.excludesFile` is a file no reader of `info/exclude` and
+    /// `.gitignore` ever opens, so a caller checking those two alone concludes
+    /// the store is unignored and writes a rule Git already had. The controls
+    /// below assert that neither repository-local file names the store, so the
+    /// `true` can only have come from the resolved configuration.
+    #[test]
+    fn the_store_reads_as_ignored_through_a_rule_git_resolves_outside_the_repository() {
+        let (temp, repo) = config_only_repository();
+        assert!(
+            !kin_store_is_git_ignored(&repo).expect("resolve ignore rules"),
+            "the fixture must start with nothing hiding the store, or this test proves nothing"
+        );
+
+        let excludes = temp.path().join("global-excludes");
+        fs::write(&excludes, b"/.kin/\n").expect("write the excludes file");
+        git(
+            &repo,
+            &[
+                "config",
+                "core.excludesFile",
+                excludes.to_str().expect("utf-8 fixture path"),
+            ],
+        );
+
+        assert!(
+            kin_store_is_git_ignored(&repo).expect("resolve ignore rules"),
+            "a rule Git resolves outside the repository still hides the store"
+        );
+        assert!(
+            !repo.join(".gitignore").exists(),
+            "control: the tracked ignore file must not be what answered"
+        );
+        let info_exclude =
+            fs::read_to_string(repo.join(".git").join("info").join("exclude")).unwrap_or_default();
+        assert!(
+            !info_exclude.contains(".kin"),
+            "control: the local exclude file must not be what answered: {info_exclude}"
+        );
     }
 
     fn snapshot_plan(

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1376,11 +1376,17 @@ pub struct ExactEntitySource {
 /// seam is per-dependency in a context pack, which is documented as fitted to a
 /// token budget, so the waste scaled with the pack.
 ///
-/// For the same reason this carries no `artifact_path`. A `RepoPath` is bytes,
-/// and its wire form is a `{"bytes_hex": …}` object, so the path arrived as
-/// twice its own length in hex beside the plain `file_path` every caller of
-/// this seam already emits. Two spellings of one path, one of them unreadable,
-/// per entry, inside a budgeted pack.
+/// For the same reason this carries no `artifact_path` for a path a plain
+/// string can spell. A `RepoPath` is bytes, and its wire form is a
+/// `{"bytes_hex": …}` object, so the path arrived as twice its own length in
+/// hex beside the plain `file_path` every caller of this seam already emits.
+/// Two spellings of one path, one of them unreadable, per entry, inside a
+/// budgeted pack.
+///
+/// A path whose bytes are not valid UTF-8 has no lossless plain form, so there
+/// the byte-exact spelling is the only representation those bytes have and the
+/// field is kept. `artifact_id` is emitted either way, and `kin_artifact_read`
+/// resolves the byte-exact path from it.
 pub fn source_provenance_fields(
     source: &ExactEntitySource,
 ) -> serde_json::Map<String, serde_json::Value> {
@@ -1420,6 +1426,9 @@ pub fn source_provenance_fields(
         serde_json::json!(source.span_coherence.label()),
     );
     fields.insert("artifact_id".into(), serde_json::json!(source.artifact_id));
+    if source.path.as_utf8().is_none() {
+        fields.insert("artifact_path".into(), serde_json::json!(source.path));
+    }
     fields.insert(
         "artifact_entry".into(),
         serde_json::json!(super::artifacts::TreeEntryWire::from(source.entry)),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -599,7 +599,9 @@ response with the token accounting included. Reach for it when a question is abo
 unit of code in context (\"what does X do and what does it touch?\") rather than a single \
 isolated body. Its value is that it replaces an open-ended chain of \
 get_entity_source / find_references calls — which burns round-trips and easily blows \
-your context window — with one budgeted call that stays within the limit you set. \
+your context window — with one budgeted call. `token_budget` bounds the content the pack \
+selects, and it cannot bound the envelope that content travels in, so read `tokens_used`, \
+which measures the serialized response this call returns, as what the call costs you. \
 `focal_entity.body` in the response IS the focal entity's exact source text, so this one \
 call already answers \"show me the code\": no follow-up read is needed, and it is the body \
 to edit and stage back. If get_entity_source is available to you it is cheaper for a raw \

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2967,6 +2967,52 @@ mod tests {
         );
     }
 
+    /// A path whose bytes are not valid UTF-8 keeps its byte-exact spelling.
+    ///
+    /// Dropping `artifact_path` as redundant is only true where a plain path can
+    /// say the same thing. A path Git tracks but Unicode cannot spell has no
+    /// lossless plain form, and there the `bytes_hex` object is the only truth,
+    /// so it stays. Driven through the seam directly rather than end to end,
+    /// because Darwin refuses an ill-formed UTF-8 name at the filesystem
+    /// boundary and this branch has to be covered on every host.
+    #[test]
+    fn a_path_unicode_cannot_spell_keeps_its_byte_exact_form() {
+        let byte_exact = kin_model::RepoPath::from_bytes(b"src/raw-\xff-name.ts".to_vec()).unwrap();
+        assert!(
+            byte_exact.as_utf8().is_none(),
+            "the fixture must be a path no plain string can carry"
+        );
+        let spellable = kin_model::RepoPath::from_utf8("src/plain.ts").unwrap();
+
+        let source_for = |path: kin_model::RepoPath| common::ExactEntitySource {
+            body: "export const probe = 1;".to_string(),
+            provenance: common::SourceProvenance::Committed {
+                change_id: kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes(
+                    [7; 32],
+                )),
+            },
+            span_coherence: common::SpanCoherence::Unverified,
+            artifact_id: kin_model::ArtifactId::new(),
+            path,
+            entry: kin_model::TreeEntry::blob(kin_model::Hash256::from_bytes([3; 32]), false),
+        };
+
+        let raw = common::source_provenance_fields(&source_for(byte_exact.clone()));
+        assert_eq!(
+            raw.get("artifact_path"),
+            Some(&serde_json::to_value(&byte_exact).unwrap()),
+            "a path with no plain spelling must keep the byte-exact one: {raw:?}"
+        );
+
+        // The control that makes the assertion above mean something: the field
+        // is genuinely conditional, not always present.
+        let plain = common::source_provenance_fields(&source_for(spellable));
+        assert!(
+            plain.get("artifact_path").is_none(),
+            "a UTF-8 path is already stated plainly and must not be repeated: {plain:?}"
+        );
+    }
+
     /// Name every `artifact_path` anywhere under `value`.
     fn artifact_path_fields(value: &serde_json::Value, at: &str, found: &mut Vec<String>) {
         match value {


### PR DESCRIPTION
kin#874 (`fir2359d-papercuts`) landed the FIR-2377 brownfield papercuts first, as
`49958f84`. This branch was given the same work, so it is reduced to what 874
does not cover: one command pair it never touched, and three places where its
landed behavior is incomplete or now says something untrue.

## `kin search` and `kin overview` report 1-indexed line numbers

The graph stores tree-sitter rows, which are 0-based, and every agent-facing
`file:line` is 1-based. These two commands emitted the raw row, so they
disagreed with `kin refs`, `kin trace-data-flow`, and every MCP read surface
about the same entity, and a reader acting on them opened the line above the
definition. `kin search` converts once, where the wire record its surfaces are
rendered from is built, so the JSON `line`, the artifact row's `line`, and the
`--body` human `file:line` all read the converted value rather than each
converting or each forgetting to. `start_byte`/`end_byte` on that record stay
unshifted, because they are byte offsets rather than line numbers and the daemon
slices a source blob with them to build `body`. A hit the graph carries no span
for names its file alone rather than `path:0`, a position no editor can open.
kin#874 touches neither command.

## Ask Git for the ignore rules it resolves, rather than matching four spellings

kin#874 decides "the store is already excluded" by comparing lines in two files
against `.kin`, `.kin/`, `/.kin`, and `/.kin/`. That never opens a
`core.excludesFile`, so a user who excluded the store globally still gets a
redundant local rule, and it reads a later `!.kin` as an exclusion where Git
reads it as the opposite and goes on listing the store.

`kin-git` gains `kin_store_is_git_ignored`, which puts the question to the
resolver that answers `git status`: resolved global excludes, the repository
`info/exclude`, and the committed ignore mapping that module already treats as
ignore authority. That is also what makes the write idempotent rather than
approximately idempotent, since the pattern written is one of the rules the next
call reads. The line scan stays as the answer for a directory carrying a `.git`
that is not an openable repository, where nothing resolves ignore rules at all
and those two files are the whole of what any reader could consult. Every unit
test kin#874 landed for the writer still passes unchanged.

## Keep `artifact_path` for a path whose bytes are not valid UTF-8

kin#874 drops the field unconditionally. That is right wherever a plain
`file_path` says the same thing, which is nearly always, and wrong for a path
Git tracks that Unicode cannot spell: there the `{"bytes_hex": ...}` object is
the only representation those bytes have, and `file_path` cannot carry them at
all. The field is emitted for exactly that case. `artifact_id` is present either
way, and `kin_artifact_read` resolves the byte-exact path from it. The branch is
driven through the provenance seam rather than end to end, because Darwin
refuses an ill-formed UTF-8 name at the filesystem syscall boundary, and the
test carries its own control: a spellable path in the same shape must still omit
the field. kin#874's assertion that a context pack carries no `artifact_path`
still holds, because its fixture path is spellable.

## Correct `GET_CONTEXT_PACK_DESC`

It promised "one budgeted call that stays within the limit you set". An honest
`tokens_used` can exceed `token_budget`, because the budget bounds the content
the pack selects and cannot bound the envelope that content travels in, so that
sentence became false the moment kin#874 landed. A tool description that lies is
a defect in the class of a wrong answer, since an agent plans against it. The
replacement points the reader at `tokens_used` and says what it measures.

## What was dropped, and how that was decided

The store exclusion writer with its `init.rs` result surface, 1-indexed
`kin refs` with its `declaration_neighbors` and `impact` callers, and the
context-pack token accounting all duplicated kin#874, so their commits are gone.
The comparison was made against the merged PR's own file list and diff, not by
patch id, which is squash-blind and reports long-landed commits as unlanded.

One piece of that dropped work survived, because 874 has no equivalent: an
integration test through the real binary. 874's unit tests prove the exclusion
writer is correct, and they cannot tell a correct writer that `kin init` never
calls from one it does, since both leave the same empty exclude file behind.
This runs `kin init` against a seeded Git repository and asserts on
`git status --porcelain`, so a pattern Git does not honor fails too.

Closes FIR-2378
Closes FIR-2377
