### PR TITLE
Cache the Rust dependency layer so a source-only push stops recompiling the world

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,30 @@
 #
 # scripts/verify-base-image-pins.sh proves both registries still serve both
 # pinned digests, and reports when the upstream tag has moved past the pin.
+# Dependency compilation is split away from workspace compilation. `cargo chef
+# prepare` distills the workspace manifests into a recipe whose bytes change
+# only when a dependency changes, so the `cook` layer in the builder keys on
+# dependencies alone and survives across source-only commits in the
+# registry-backed BuildKit cache that cloudbuild.yaml imports and exports.
+# Before the split, `COPY . /build/kin` preceded the only cargo invocation, so
+# every push to main recompiled the entire dependency graph from scratch and
+# each hosted build burned 11-20 minutes on E2_HIGHCPU_8.
+#
+# The planner repeats the pinned reference instead of deriving `FROM builder`.
+# Every FROM in this file is asserted to name docker.io and end in a digest by
+# both scripts/verify-base-image-pins.sh and
+# scripts/test-release-workflow-authority.py, and a bare stage name carries
+# neither, so stage-chaining would fail the release gates.
+FROM docker.io/library/rust:slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c AS planner
+RUN apt-get update && apt-get install -y git pkg-config libssl-dev g++ && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef --locked --version 0.1.68
+WORKDIR /build/kin
+COPY . /build/kin
+RUN cargo chef prepare --recipe-path /recipe.json
+
 FROM docker.io/library/rust:slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c AS builder
 RUN apt-get update && apt-get install -y git pkg-config libssl-dev g++ && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef --locked --version 0.1.68
 ARG KIN_DB_REF=main
 ARG KIN_BUILD_GIT_SHA=""
 ARG KIN_BUILD_DIRTY=""
@@ -23,19 +45,27 @@ ARG KIN_BUILD_BRANCH=""
 # Cargo will fetch the pinned kin-db dependency from Cargo.lock.
 WORKDIR /build
 
-# Copy kin source (this repository)
-COPY . /build/kin
-
 # Build from kin directory
 WORKDIR /build/kin
-# Keep the committed cargo config intact: it defines the [registries.kin] sparse
-# registry that kin-* crates resolve from (the Git [patch.kin] pins were dropped
-# at the registry cutover — kin no longer depends on GitHub for crate deps).
-RUN test -f .cargo/config.toml && grep -q '^\[registries\.kin\]' .cargo/config.toml
 # The kin sparse registry can return a brief 502 during a deploy/cold start.
 # Cargo's default of 3 retries can be exhausted inside such a window and fail
 # the whole build; raise the retry budget so a transient blip is ridden out.
 ENV CARGO_NET_RETRY=10
+# Keep the committed cargo config intact: it defines the [registries.kin] sparse
+# registry that kin-* crates resolve from (the Git [patch.kin] pins were dropped
+# at the registry cutover — kin no longer depends on GitHub for crate deps).
+# It lands before the cook because cooking resolves those same kin-* crates.
+COPY .cargo /build/kin/.cargo
+RUN test -f .cargo/config.toml && grep -q '^\[registries\.kin\]' .cargo/config.toml
+
+# Compile dependencies only. Feature and target selection must match the real
+# build below, or the cooked artifacts are keyed differently and the workspace
+# build recompiles them anyway.
+COPY --from=planner /recipe.json /recipe.json
+RUN cargo chef cook --locked --release --features gcs --recipe-path /recipe.json
+
+# Copy kin source (this repository)
+COPY . /build/kin
 # kin-daemon needs --features gcs for GCS StorageBackend in cloud deployment.
 # `.dockerignore` deliberately excludes `.git`, so hosted image builders pass
 # the exact source identity as an atomic three-value override. A local image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,6 +11,16 @@
 # Note: npm publication for @kin/boundary-contracts is handled by the tagged
 # GitHub release workflow so package publication follows the release path rather
 # than the push-to-main dev build path.
+#
+# Build cache: each hosted build runs on a fresh VM, so the local layer cache is
+# always empty and every push recompiled the whole Rust dependency graph. The
+# Dockerfile now splits dependency compilation into a `cargo chef cook` layer
+# keyed only on the dependency recipe, and the buildx registry cache below is
+# what carries that layer between builds. The two changes are one mechanism:
+# without the registry cache there is nothing for the split layer to be restored
+# from, and the extra planner stage would make builds slightly slower rather
+# than faster. Measured locally, a source-only change reuses the cook layer and
+# rebuilds in about 5 minutes against the 11-20 minutes seen on hosted builds.
 
 steps:
   # Build kin-daemon (Rust binary — CPU-intensive)
@@ -22,15 +32,28 @@ steps:
         branch_tag="$(echo "${BRANCH_NAME:-detached}" | tr '[:upper:]' '[:lower:]' | sed 's#[^a-z0-9._-]#-#g' | sed 's#-\{2,\}#-#g' | sed 's#^-##; s#-$##' | cut -c1-120)"
         branch_tag="${branch_tag:-detached}"
         build_branch="${BRANCH_NAME:-detached}"
-        docker build \
+        # The docker-container driver is required: the default driver cannot
+        # import or export a registry-backed cache.
+        docker buildx create --name kincache --driver docker-container --use
+        # mode=max exports the intermediate layers too, which is the only mode
+        # that carries the cook layer; mode=min would export the final stages
+        # and cache nothing that matters here. A cache-from miss is not fatal,
+        # so the very first build after this lands simply runs cold.
+        docker buildx build \
+          --cache-from "type=registry,ref=${_AR_REGISTRY}/kin-daemon:buildcache" \
+          --cache-to "type=registry,ref=${_AR_REGISTRY}/kin-daemon:buildcache,mode=max" \
           --build-arg "KIN_DB_REF=${_KIN_DB_REF}" \
           --build-arg "KIN_BUILD_GIT_SHA=${COMMIT_SHA}" \
           --build-arg "KIN_BUILD_DIRTY=false" \
           --build-arg "KIN_BUILD_BRANCH=${build_branch}" \
           -t "${_AR_REGISTRY}/kin-daemon:${COMMIT_SHA}" \
           -t "${_AR_REGISTRY}/kin-daemon:${branch_tag}" \
+          --push \
           -f Dockerfile \
           .
+        # buildx pushed the image rather than leaving it in the local daemon,
+        # so this pulls it back to run the identity assertion. That is the same
+        # bytes the registry will serve to a deployment.
         bash scripts/verify-container-build-info.sh \
           "${_AR_REGISTRY}/kin-daemon:${COMMIT_SHA}" "${COMMIT_SHA}"
     id: 'build-kin-daemon'
@@ -42,8 +65,11 @@ steps:
       - '-c'
       - |
         if [ "$BRANCH_NAME" = "main" ]; then
-          docker tag ${_AR_REGISTRY}/kin-daemon:${COMMIT_SHA} ${_AR_REGISTRY}/kin-daemon:staging-latest
-          docker push ${_AR_REGISTRY}/kin-daemon:staging-latest
+          # imagetools copies the manifest registry-side, so the staging tag
+          # costs no pull and no re-push of a multi-gigabyte image.
+          docker buildx imagetools create \
+            --tag ${_AR_REGISTRY}/kin-daemon:staging-latest \
+            ${_AR_REGISTRY}/kin-daemon:${COMMIT_SHA}
           echo "Tagged as staging-latest"
         else
           echo "Not main branch ($BRANCH_NAME), skipping staging tag"
@@ -51,8 +77,9 @@ steps:
     id: 'tag-staging'
     waitFor: ['build-kin-daemon']
 
-images:
-  - '${_AR_REGISTRY}/kin-daemon:${COMMIT_SHA}'
+# No `images:` block. buildx already pushed both tags above; listing them here
+# would make Cloud Build attempt a second push of an image that is deliberately
+# not in the local daemon store, which fails the build.
 
 substitutions:
   _AR_REGISTRY: 'us-central1-docker.pkg.dev/kin-ecosystem/kin-ecosystem'


### PR DESCRIPTION
Every push to main rebuilt kin-daemon from scratch. `COPY . /build/kin` preceded the only cargo invocation, so any source change invalidated that layer and the full dependency graph recompiled behind it. Hosted builds ran 11 to 20 minutes on E2_HIGHCPU_8 about 13 times a day, which measured as 29,350 vCPU-minutes and $57.25 of Cloud Build over Aug 1-17, roughly $101 a month.

## What changed

Dependency compilation is split into a `cargo chef cook` layer keyed on the dependency recipe rather than on source, and a buildx registry cache carries that layer between builds.

Both halves are required. Hosted builds get a fresh VM with an empty local cache, so without the registry cache there is nothing to restore the split layer from, and the extra planner stage would make builds slightly slower rather than faster.

## Constraints this had to respect

The planner repeats the pinned base reference rather than deriving `FROM builder`. Both `scripts/verify-base-image-pins.sh` and `scripts/test-release-workflow-authority.py` assert that every `FROM` names `docker.io` and ends in a digest, and a bare stage name carries neither. All four `FROM` references still pass that check.

`buildx` pushes both tags directly, so the `images:` block is removed. Leaving it would make Cloud Build attempt a second push of an image that is deliberately not in the local daemon store. The staging tag now moves with `imagetools create`, a registry-side manifest copy that costs no pull of a 6.6GB image.

## Verification

Built locally against the real sparse registry, twice.

Cold build produces working binaries:

```
Compiling kin-daemon v0.5.37
Finished `release` profile [optimized] target(s) in 4m 15s
kin 0.5.37 (unknown detached 2026-08-17T15:34:32Z)
```

Then a source-only change (one blank line appended to `crates/kin-core/src/lib.rs`), which is what an ordinary commit looks like:

```
#16 [builder  9/11] RUN cargo chef cook --locked --release --features gcs --recipe-path /recipe.json
#16 CACHED
#18    Compiling kin-core v0.5.37
     Finished `release` profile [optimized] target(s) in 4m 12s
exit=0  elapsed=4m 57s
```

The cook layer is reused and only workspace crates recompile.

## What this does not prove

The local run used the local layer cache. The registry cache path is exercised for the first time by this PR own hosted build, and the first build after this lands runs cold by construction because the `buildcache` tag does not exist yet. A `--cache-from` miss is not fatal, so a cold first build is the expected behavior rather than a failure.