### PR TITLE
Install Rust toolchains from the runner's rustup instead of a downloaded action

### DIFF
--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -1,0 +1,151 @@
+name: rustup toolchain install
+description: >
+  Install a Rust toolchain using the rustup that every GitHub-hosted runner
+  image already ships, so starting a Rust job needs no action tarball from
+  codeload. Toolchain artifacts come from static.rust-lang.org instead, which
+  carries no per-repository download limit.
+
+inputs:
+  toolchain:
+    description: >
+      Toolchain to install. Defaults to the channel in rust-toolchain.toml so
+      the version has one source of truth rather than one per workflow.
+    required: false
+    default: ""
+  targets:
+    description: Target triples to add, separated by commas or spaces.
+    required: false
+    default: ""
+  components:
+    description: Components to add, separated by commas or spaces.
+    required: false
+    default: ""
+
+outputs:
+  toolchain:
+    description: The resolved toolchain name, suitable for `cargo +<name>`.
+    value: ${{ steps.resolve.outputs.toolchain }}
+
+runs:
+  using: composite
+  steps:
+    # Inputs reach the shell through the environment rather than through
+    # `${{ }}` interpolation, so a value can never close the quoting and run as
+    # script text.
+    - name: Resolve the toolchain
+      id: resolve
+      shell: bash
+      env:
+        INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
+      run: |
+        set -euo pipefail
+        toolchain="$INPUT_TOOLCHAIN"
+        if [ -z "$toolchain" ]; then
+          pin="$GITHUB_WORKSPACE/rust-toolchain.toml"
+          if [ -f "$pin" ]; then
+            toolchain=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p;' "$pin" | sed -n '1p')
+          fi
+        fi
+        # Refuse rather than default. A wrong toolchain installed quietly is a
+        # compile error attributed to the code under test.
+        if [ -z "$toolchain" ]; then
+          echo "no toolchain resolved: pass the 'toolchain' input, or keep a [toolchain] channel in rust-toolchain.toml" >&2
+          exit 1
+        fi
+        echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+        echo "resolved toolchain: $toolchain"
+
+    - name: Pin CARGO_HOME for later steps
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${CARGO_HOME:-}" ]; then
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            echo "CARGO_HOME=$USERPROFILE\\.cargo" >> "$GITHUB_ENV"
+          else
+            echo "CARGO_HOME=$HOME/.cargo" >> "$GITHUB_ENV"
+          fi
+        fi
+
+    # Every current GitHub-hosted image ships rustup, so this is a no-op there.
+    # It stays because a self-hosted or future image that drops rustup would
+    # otherwise fail at the install step with a bare "command not found".
+    - name: Install rustup if the runner image lacks it
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v rustup >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
+            --location --silent --show-error --fail https://sh.rustup.rs \
+            | sh -s -- --default-toolchain none -y
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+        fi
+
+    - name: Install rustup if the runner image lacks it
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v rustup >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
+            --location --silent --show-error --fail \
+            "https://win.rustup.rs/${{ runner.arch == 'ARM64' && 'aarch64' || 'x86_64' }}" \
+            --output "$RUNNER_TEMP/rustup-init.exe"
+          "$RUNNER_TEMP/rustup-init.exe" --default-toolchain none --no-modify-path -y
+          echo "${CARGO_HOME:-$USERPROFILE\\.cargo}\\bin" >> "$GITHUB_PATH"
+        fi
+
+    # The flag lists are built as strings and expanded unquoted on purpose:
+    # that is the word split that turns "clippy, rustfmt" into two --component
+    # flags. An empty string expands to no argument at all, which is why this
+    # does not use an array; `"${arr[@]}"` on an empty array is an unbound
+    # variable error under `set -u` in the bash 3.2 that macOS runners ship.
+    - name: Install the toolchain
+      shell: bash
+      env:
+        TOOLCHAIN: ${{ steps.resolve.outputs.toolchain }}
+        TARGETS: ${{ inputs.targets }}
+        COMPONENTS: ${{ inputs.components }}
+        RUSTUP_PERMIT_COPY_RENAME: 1
+      run: |
+        set -euo pipefail
+        target_flags=""
+        for t in ${TARGETS//,/ }; do target_flags="$target_flags --target $t"; done
+        component_flags=""
+        for c in ${COMPONENTS//,/ }; do component_flags="$component_flags --component $c"; done
+        downgrade=""
+        if [ "$TOOLCHAIN" = "nightly" ] && [ -n "$COMPONENTS" ]; then
+          downgrade=" --allow-downgrade"
+        fi
+        rustup toolchain install "$TOOLCHAIN" $target_flags $component_flags \
+          --profile minimal$downgrade --no-self-update
+
+    # Non-fatal for the same reason it is upstream: on a runner whose rustup
+    # already has a default, re-defaulting can fail while the toolchain is
+    # installed and usable, and rust-toolchain.toml selects it regardless.
+    - name: Make it the default toolchain
+      shell: bash
+      continue-on-error: true
+      env:
+        TOOLCHAIN: ${{ steps.resolve.outputs.toolchain }}
+      run: rustup default "$TOOLCHAIN"
+
+    - name: Set the Cargo defaults CI expects
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${CARGO_INCREMENTAL+set}" ]; then
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+        fi
+        if [ -z "${CARGO_TERM_COLOR+set}" ]; then
+          echo "CARGO_TERM_COLOR=always" >> "$GITHUB_ENV"
+        fi
+
+    - name: Report the installed toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        rustup show active-toolchain || true
+        rustc --version --verbose
+        cargo --version

--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -41,7 +41,15 @@ runs:
         set -euo pipefail
         toolchain="$INPUT_TOOLCHAIN"
         if [ -z "$toolchain" ]; then
-          pin="$GITHUB_WORKSPACE/rust-toolchain.toml"
+          # This action lives at <repo>/.github/actions/rust-toolchain, so the
+          # repository root is three levels above it. Deriving the root from the
+          # action's own location keeps this correct when a job checks the
+          # repository out under a `path:` instead of at the workspace root,
+          # where $GITHUB_WORKSPACE would point at the wrong tree.
+          pin="$GITHUB_ACTION_PATH/../../../rust-toolchain.toml"
+          if [ ! -f "$pin" ]; then
+            pin="$GITHUB_WORKSPACE/rust-toolchain.toml"
+          fi
           if [ -f "$pin" ]; then
             toolchain=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p;' "$pin" | sed -n '1p')
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
           node --check ./scripts/prove-windows-npm-first-run.mjs
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -368,7 +368,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -434,7 +434,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -537,7 +537,7 @@ jobs:
         run: ./scripts/test-install-checksum.ps1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           targets: x86_64-pc-windows-msvc
 
@@ -953,7 +953,7 @@ jobs:
         run: node scripts/check-kin-vfs-compat.mjs
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           components: clippy, rustfmt
 
@@ -1117,7 +1117,7 @@ jobs:
       # TEMPORARY debt allow-list; burn entries down and delete each allow once its
       # lint is clean. No additions without lead sign-off.
       # Enumerated from `cargo clippy --all-targets --all-features` on main against
-      # the CI toolchain (rustc/clippy 1.96.0, dtolnay rust-toolchain@stable):
+      # the CI toolchain (rustc/clippy 1.96.0, the channel in rust-toolchain.toml):
       # 45 distinct clippy lints (the 1.96 bump from 1.94 added collapsible_match,
       # manual_checked_ops, useless_conversion). The `--` keeps these allows AFTER the
       # RUSTFLAGS=-Dwarnings group so each specific lint overrides it. (The ArtifactId
@@ -1324,7 +1324,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
 
       - name: Verify kin cargo registry config
         # Same tracked config the check job verifies.

--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
 
       - name: Verify kin cargo registry config
         # Preserve the tracked config because it carries public Git [patch.kin]

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -111,7 +111,7 @@ jobs:
       # pins a per-toolchain sha deliberately: it wants stable and passes only
       # `targets`.
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # default branch
+        uses: ./.github/actions/rust-toolchain
         with:
           toolchain: nightly-2026-06-17
 

--- a/.github/workflows/install-proof-canary.yml
+++ b/.github/workflows/install-proof-canary.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
 
       - name: Verify kin cargo registry config
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           # On the Linux legs the core (kin, kin-daemon) targets musl and the VFS
           # leg targets gnu (vfs_target), so both targets must be installed.

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
 
       - name: Verify kin cargo registry config
         # cargo-deny resolves the full dependency graph via `cargo metadata`.

--- a/.github/workflows/windows-vector-proof.yml
+++ b/.github/workflows/windows-vector-proof.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # branch 1.96.0, 2026-07-16
+        uses: ./.github/actions/rust-toolchain
         with:
           targets: x86_64-pc-windows-msvc
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -98,10 +98,11 @@ STEP_ENV_TOKEN_BINDING = re.compile(r"(?m)^\s+GH_TOKEN:\s*(?P<token>\S.*?)\s*$")
 # contexts. A required context is release evidence, so whatever can write into it
 # is release supply chain and has to be pinned to an immutable object rather than
 # a tag anyone upstream can move. `actions/*` are first-party and governed
-# separately; these are the ones outside that trust boundary.
+# separately, and `./`-prefixed actions are this repository's own tree, which
+# moves only through a reviewed pull request here; these are the ones outside
+# that trust boundary.
 EXPECTED_REQUIRED_CONTEXT_ACTION_PINS = {
     ".github/workflows/sast.yml": {
-        "dtolnay/rust-toolchain": "191af2e1955bbe165f9bbacff2d2438002dff4d4",
         "taiki-e/install-action": "6a1bd70eaac3c8bdf093356838d7ee09fda951cf",
     },
 }
@@ -5205,6 +5206,12 @@ def assert_required_context_action_pins(workflows: dict[Path, str]) -> None:
         observed: dict[str, set[str]] = {}
         for reference in re.findall(r"uses:\s*(\S+)", content):
             if reference.startswith("actions/"):
+                continue
+            # A `./` reference resolves inside the checkout this workflow already
+            # made, so it carries no upstream that could move under the pin and
+            # has no immutable object to name. It changes only by a reviewed pull
+            # request to this repository, which is the same control the pin buys.
+            if reference.startswith("./"):
                 continue
             action, _, version = reference.partition("@")
             observed.setdefault(action, set()).add(version)


### PR DESCRIPTION
Every Rust job started by downloading dtolnay/rust-toolchain as a tarball from
codeload.github.com during "Set up job". That download is now returning 429 and
503, three attempts then a hard failure, so jobs die before any code runs. The
first-party actions in the same job download cleanly seconds earlier, and all
three third-party tarballs the fleet uses return 200 when fetched from outside
the runner pool, so the limit tracks request volume against that one repository
rather than a GitHub-wide outage. The fleet supplies that volume itself: many
repos, many Rust jobs per workflow, many pull requests, each pulling the same
tarball.

Replace the twelve call sites with a local composite action at
.github/actions/rust-toolchain. It resolves from the checkout the job has
already made, so nothing is fetched from codeload to start a Rust job. The
toolchain itself comes from static.rust-lang.org through the rustup that every
GitHub-hosted runner image ships, and that CDN carries no per-repository
download limit.

The action reproduces what the pinned upstream did for these inputs: install
with --profile minimal and --no-self-update, add each target and component,
rustup default with failure tolerated, CARGO_HOME pinned for later steps, and
CARGO_INCREMENTAL=0 plus CARGO_TERM_COLOR=always when unset. The two upstream
branches that only fire for toolchains 1.66 through 1.71 are dropped as dead
code at 1.96.0. Inputs reach the shell through the environment rather than
through expression interpolation, and the flag lists are built as strings
because "${arr[@]}" on an empty array is an unbound variable error under set -u
in the bash 3.2 that macOS runners ship.

The version now has one source of truth. With no toolchain input the action
reads the channel from rust-toolchain.toml, which already pinned 1.96.0 for
local builds, so the workflow pins can no longer drift from it. When neither an
input nor a parsable channel is present the action fails loudly rather than
defaulting, because a quietly wrong toolchain surfaces as a compile error
attributed to the code under test. fuzz.yml keeps passing its explicit
nightly-2026-06-17.

Every existing `with:` block is carried over unchanged, so no leg loses a
target or a component. The four Windows legs and windows-vector-proof keep
targets: x86_64-pc-windows-msvc, the check job keeps components: clippy,
rustfmt, and the release build matrix keeps its computed target pair.

sast.yml produces a presence-required release context, so its third-party
action set is asserted exactly. A ./ reference has no upstream that could move
under a pin and no immutable object to name, and it changes only by a reviewed
pull request to this repository, so the guard now skips those the way it
already skips actions/*. The same exemption already exists in the release.yml
pin guard in this file.

Swatinem/rust-cache is deliberately untouched. Its save-if and cache-on-failure
semantics are covered by an adversarial authority suite here, and a cache that
misses is a slow build rather than a dead job.
