### PR TITLE
Bind the release retry timeout test to its invariant, not an attempt count

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -829,7 +829,7 @@ mod tests {
         markers: Arc<Mutex<HashSet<String>>>,
         head: Arc<Mutex<Option<String>>>,
         first_response: Arc<Mutex<Option<StatusCode>>>,
-        first_delay: Arc<Mutex<Option<Duration>>>,
+        attempt_delays: Arc<Mutex<Vec<Duration>>>,
         later_response: Arc<Mutex<Option<StatusCode>>>,
     }
 
@@ -843,11 +843,12 @@ mod tests {
         state.markers.lock().unwrap().insert(change_id.clone());
         *state.head.lock().unwrap() = Some(change_id);
 
-        if state.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-            let delay = *state.first_delay.lock().unwrap();
-            if let Some(delay) = delay {
-                tokio::time::sleep(delay).await;
-            }
+        let attempt = state.attempts.fetch_add(1, Ordering::SeqCst);
+        let delay = state.attempt_delays.lock().unwrap().get(attempt).copied();
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
+        if attempt == 0 {
             return state
                 .first_response
                 .lock()
@@ -957,7 +958,7 @@ mod tests {
             &url,
             &payload,
             "main",
-            Duration::from_secs(1),
+            Duration::from_secs(10),
             3,
             Duration::from_millis(1),
         )
@@ -974,8 +975,10 @@ mod tests {
     async fn release_timeout_retry_keeps_exactly_one_marker_and_head() {
         let repo = tempfile::tempdir().unwrap();
         let layout = kin_core::init(repo.path()).unwrap().layout;
+        let attempt_timeout = Duration::from_millis(250);
+        let max_attempts = 4;
         let state = ReleaseRetryServerState::default();
-        *state.first_delay.lock().unwrap() = Some(Duration::from_millis(80));
+        *state.attempt_delays.lock().unwrap() = vec![attempt_timeout * 120];
         let (url, server) = release_retry_server(state.clone()).await;
         let payload = serialized_release_fixture();
 
@@ -984,8 +987,8 @@ mod tests {
             &url,
             &payload,
             "main",
-            Duration::from_millis(20),
-            3,
+            attempt_timeout,
+            max_attempts,
             Duration::from_millis(1),
         )
         .await
@@ -993,13 +996,66 @@ mod tests {
         server.abort();
 
         let received = state.received.lock().unwrap();
-        assert_eq!(received.len(), 2);
-        assert!(received.iter().all(|request| request == &payload));
+        assert!(
+            (2..=max_attempts).contains(&received.len()),
+            "a timed-out attempt must be retried within the attempt bound, but the server saw {} request(s)",
+            received.len()
+        );
+        assert!(
+            received.iter().all(|request| request == &payload),
+            "a retry sent bytes the caller never persisted"
+        );
         let markers = state.markers.lock().unwrap();
         assert_eq!(
             markers.len(),
             1,
             "timeout retry manufactured a second marker"
+        );
+        assert_eq!(
+            state.head.lock().unwrap().as_deref(),
+            markers.iter().next().map(String::as_str)
+        );
+    }
+
+    #[tokio::test]
+    async fn release_timeout_retried_twice_keeps_exactly_one_marker_and_head() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let attempt_timeout = Duration::from_millis(250);
+        let max_attempts = 4;
+        let state = ReleaseRetryServerState::default();
+        *state.attempt_delays.lock().unwrap() = vec![attempt_timeout * 120, attempt_timeout * 120];
+        let (url, server) = release_retry_server(state.clone()).await;
+        let payload = serialized_release_fixture();
+
+        send_serialized_release_request(
+            &layout,
+            &url,
+            &payload,
+            "main",
+            attempt_timeout,
+            max_attempts,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+        server.abort();
+
+        let received = state.received.lock().unwrap();
+        assert!(
+            (3..=max_attempts).contains(&received.len()),
+            "each timed-out attempt must be retried within the attempt bound, but the server saw {} request(s)",
+            received.len()
+        );
+        assert!(
+            received.iter().all(|request| request == &payload),
+            "a retry sent bytes the caller never persisted"
+        );
+        let markers = state.markers.lock().unwrap();
+        assert_eq!(
+            markers.len(),
+            1,
+            "repeated timeout retries manufactured another marker"
         );
         assert_eq!(
             state.head.lock().unwrap().as_deref(),
@@ -1022,7 +1078,7 @@ mod tests {
             &url,
             &payload,
             "main",
-            Duration::from_secs(1),
+            Duration::from_secs(10),
             2,
             Duration::from_millis(1),
         )


### PR DESCRIPTION
The timeout test in `crates/kin-cli/src/backend.rs` asserted that the fixture
server received exactly two requests. That count is a wall-clock race, and it
has already reddened unrelated work: kin PR 864 touches only kin-parser files
and failed its macOS leg on this test in job 95454229542 with `left: 3,
right: 2`. The ubuntu leg was cancelled by matrix fail-fast, so one flake
reddens two legs.

The fixture delays only the first response. The test set that delay to 80ms
and gave the sender a 20ms per-attempt timeout, so attempt one timed out and
attempt two was assumed to land inside 20ms. Nothing guarantees that on a
loaded runner. A slow second attempt fires a third, and the count assertion
fails on a run where the property under test held perfectly.

The property is in the test's name and its own message: a retry must not
manufacture a second marker. That stays exactly as strong. What changes is the
scaffolding around it. The test now asserts a timed-out attempt was retried
within the attempt bound, and that every request the server saw carried
byte-identical payload, which is the real requirement. The per-attempt timeout
moves to 250ms and the injected delay is derived from it, so the first attempt
can never complete and the common case is still two attempts.

The fixture gains a per-attempt delay list in place of its first-response-only
delay, which makes a run needing more than one retry expressible at all. A new
test forces two timed-out attempts and asserts the same one-marker and matching
head invariant. That case exercises the property harder than the two-attempt
case, and the old exact count rejected it as a failure.

The 5xx and 408 siblings drive their retries with injected status codes rather
than a clock, so their attempt sequences are decided by the fixture and their
exact counts stay meaningful. Neither consumes any of its timeout budget, so
widening that budget from one second to ten costs no wall clock and removes the
same scheduling exposure without weakening an assertion.

Verification. The full lane gate is green at 5786 tests. The mechanism was
proven by forcing a third attempt and watching the old exact-count shape fail
with the identical `left: 3, right: 2` panic from CI. The fix was falsified
three ways: breaking the sender so retries regenerate the change id fails the
marker assertion with "timeout retry manufactured a second marker"; removing
the injected delay so no retry happens fails the retry-happened assertion; and
both timeout tests passed 300 loaded local iterations each.

Closes FIR-2379
