### PR TITLE
Synchronise the exited-child reaper test on the exit itself

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -11073,14 +11073,47 @@ mod tests {
         let _ = child.wait();
     }
 
+    /// Block until `pid` has terminated, leaving it unreaped.
+    ///
+    /// `WNOWAIT` is what makes this a synchronization point rather than a
+    /// substitute for the code under test: it returns exactly when the child
+    /// becomes reapable and leaves it in that state, so the classifier's own
+    /// `try_wait` is still the call that observes the corpse and reaps it.
+    /// Anything that consumed the child here, including a plain `wait`, would
+    /// leave the classifier reading a cached status down a branch the daemon
+    /// path never takes.
+    #[cfg(unix)]
+    fn block_until_terminated_leaving_it_reapable(pid: u32) {
+        let pid = libc::pid_t::try_from(pid).expect("a pid we spawned fits pid_t");
+        loop {
+            let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+            let observed = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    pid as libc::id_t,
+                    &mut info,
+                    libc::WEXITED | libc::WNOWAIT,
+                )
+            };
+            if observed == 0 {
+                return;
+            }
+            let error = std::io::Error::last_os_error();
+            assert_eq!(
+                error.raw_os_error(),
+                Some(libc::EINTR),
+                "a child we spawned must stay observable until we reap it: {error}"
+            );
+        }
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn a_daemon_that_already_exited_is_reaped() {
         let mut child = std::process::Command::new("true")
             .spawn()
             .expect("spawn a child that exits immediately");
-        // Let it actually exit before classifying.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        block_until_terminated_leaving_it_reapable(child.id());
 
         let disposition = kin_daemon_spawn::startup_disposition(&mut child)
             .expect("a child we spawned is observable");


### PR DESCRIPTION
`daemon_client::tests::a_daemon_that_already_exited_is_reaped` slept 100 milliseconds and then asserted that the startup classifier had seen a corpse. Nothing in the test made the child exit inside that window. When the sleep expired while `/usr/bin/true` was still being scheduled or exec'd, `child.try_wait()` returned None, the liveness fallback reported the still-running child Alive, and the assertion fired. The classifier was right and the test was wrong.

That is not a hypothetical. It ejected pull request 871 from the merge queue at 19:27:43Z in merge-group run 32058950278, job 95475575187, panicking with `an exited child is positive evidence: Alive` after 0.111 seconds. The 0.111 is the tell: the parent's 100 millisecond timer fired exactly on schedule and the child simply had not exited yet. The same job carried two other kin-cli tests past 60 seconds and one past 120, so the contention was real rather than inferred.

The fix replaces the sleep with a blocking `waitid(P_PID, pid, WEXITED | WNOWAIT)`. It returns exactly when the child becomes reapable and, because of `WNOWAIT`, leaves it reapable, so the classifier's own `try_wait` is still the call that observes the corpse and reaps it. Anything that consumed the child first, including a plain `wait`, would have left the classifier reading a cached status down a branch the daemon path never takes, which would have weakened the test while appearing to fix it. Both assertions stay exactly as strong, and the test now carries no wall-clock budget at all.

## Evidence

The race was forced deterministically rather than waited for. Running the original body against a child that exits at 300 milliseconds reproduces the literal CI panic, `an exited child is positive evidence: Alive`, in 0.10 seconds. Running the fixed body against that same child passes in 0.31 seconds, having waited for the real event instead of a guess.

Both assertions were then falsified against a deliberately broken product. Making the classifier stop consulting `try_wait`, so an unreaped corpse falls through to `kill(pid, 0)` and reads as alive, fails with `an exited child is positive evidence: Alive`. Making no disposition authorize termination fails with `a dead child is reaped rather than left as a zombie`. Neutering the new synchronisation to a no-op fails again, which is what proves it is load-bearing rather than decoration.

Three hundred loop iterations under synthetic load pass on both the fixed and the original build. That establishes only that no new flake was introduced. It does not reproduce the original, which is a runner phenomenon an 18-core box does not exhibit, and it is reported as a negative result rather than dressed up as a statistical fix.

`waitid`, `P_PID`, `WEXITED` and `WNOWAIT` were read out of libc 0.2.189 for both the Apple and the linux_like modules rather than assumed. The signature and the constants are identical on both, which matters because the ejecting job was ubuntu-latest. The whole test is `#[cfg(unix)]`, so Windows is unaffected.

Closes FIR-2381
