### PR TITLE
Derace the session-registry idle-window and default-TTL tests

### DIFF
--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -2532,13 +2532,16 @@ mod tests {
     /// hard-lock scopes against every other session for the life of the daemon,
     /// because the sweeper is the only collector for those scopes. That trades
     /// a mid-write reap for a permanent leak, which is the worse of the two.
+    /// Each half owns its own coordinator because `session_idle_ttl` is fixed
+    /// at construction: one TTL cannot be both far larger than the work between
+    /// two adjacent statements and small enough to elapse during a sleep.
     #[test]
     fn a_call_in_flight_past_the_idle_window_stops_protecting_its_session() {
-        let coord = SessionCoordinator::with_session_idle_ttl(
+        let protected = SessionCoordinator::with_session_idle_ttl(
             Arc::new(kin_db::InMemoryGraph::new()),
-            Duration::from_millis(5),
+            Duration::from_secs(3600),
         );
-        let sid = coord
+        let protected_sid = protected
             .register_session(
                 "claude-code",
                 "stuck-agent",
@@ -2549,21 +2552,38 @@ mod tests {
             )
             .unwrap();
 
-        let _stuck = coord.begin_call(&sid);
+        let _stuck = protected.begin_call(&protected_sid);
         assert_eq!(
-            coord.sweep_stale_sessions().unwrap(),
+            protected.sweep_stale_sessions().unwrap(),
             0,
             "a call inside the window still protects its session"
         );
+        assert!(protected.get_session(&protected_sid).unwrap().is_some());
 
-        std::thread::sleep(Duration::from_millis(20));
+        let outrun = SessionCoordinator::with_session_idle_ttl(
+            Arc::new(kin_db::InMemoryGraph::new()),
+            Duration::from_millis(5),
+        );
+        let outrun_sid = outrun
+            .register_session(
+                "claude-code",
+                "stuck-agent",
+                SessionTransport::Mcp,
+                Some(999_999_999),
+                PathBuf::from("/"),
+                write_capabilities(),
+            )
+            .unwrap();
+
+        let _outrunning = outrun.begin_call(&outrun_sid);
+        std::thread::sleep(Duration::from_millis(100));
 
         assert_eq!(
-            coord.sweep_stale_sessions().unwrap(),
+            outrun.sweep_stale_sessions().unwrap(),
             1,
             "a call outrunning the idle window must not defer the sweep forever"
         );
-        assert!(coord.get_session(&sid).unwrap().is_none());
+        assert!(outrun.get_session(&outrun_sid).unwrap().is_none());
     }
 
     /// The reported age is the oldest call STILL RUNNING, not the start of the
@@ -2640,8 +2660,16 @@ mod tests {
     /// The default was two 30-second heartbeat intervals, so a read phase
     /// longer than a minute stranded the agent and its transaction. The
     /// default idle window is now the same one the MCP transport uses.
+    ///
+    /// `SessionCoordinator::new` resolves the window from the process
+    /// environment, which a sibling test in this binary drives through every
+    /// accepted and rejected value, so the default is only observable here with
+    /// the override cleared and the mutation domain held.
     #[test]
+    #[serial_test::serial]
     fn pid_less_sessions_survive_a_thinking_pause_by_default() {
+        let _no_override = kin_core::test_env::EnvVarGuard::unset(SESSION_IDLE_TTL_ENV);
+
         assert_eq!(DEFAULT_SESSION_IDLE_TTL, Duration::from_secs(1800));
 
         let coord = SessionCoordinator::new(Arc::new(kin_db::InMemoryGraph::new()));


### PR DESCRIPTION
The macOS leg of kin#870 was ejected from the merge queue at 00:23Z by
`a_call_in_flight_past_the_idle_window_stops_protecting_its_session`, with
`assertion left == right failed: a call inside the window still protects its
session`. That test and one env race beside it are fixed here, ahead of the rest
of the flake pass, so the release path is not held behind the riskier units.

## a_call_in_flight_past_the_idle_window_stops_protecting_its_session

One 5ms `session_idle_ttl` served two opposing halves. The protected half raced
`begin_call`'s `Instant::now()` against the sweeper's `active_call_age`, and the
window between them holds the arbitration mutex, a `graph.list_sessions()` clone
of every `AgentSession` with its `String` fields, a `sort_by_key` allocating a
`session_id.to_string()` per key, `Timestamp::now()`, and a `BTreeMap` lookup.
Once that work exceeded 5ms the in-flight branch fell through, the pid
`999_999_999` failed `is_process_alive` on every platform, and the session was
reaped, so the assertion accused the product of failing to protect a call it had
in fact protected.

`session_idle_ttl` is immutable after construction, so each half now gets its own
coordinator rather than a mutation. The protected half runs at 3600s, where
`in_flight <= TTL` fails only if two adjacent statements are separated by an
hour, which is a hang the harness times out on rather than a scheduling event.
The outrun half keeps a 5ms TTL and sleeps 100ms. Both original assertion
messages are unchanged, and the protected half additionally reads the session
back, so a zero sweep count can no longer pass as protection on its own.

This is not a widening. "A call inside the window protects its session" is
scale-free and never referenced the TTL's magnitude.

## pid_less_sessions_survive_a_thinking_pause_by_default

Not a timing race, and it carried no wall-clock budget at all, so it could fire
on a fast machine. `SessionCoordinator::new()` resolves the window from
`KIN_SESSION_IDLE_TTL_SECS` through `configured_session_idle_ttl()`, while
`session_idle_ttl_is_configurable_and_rejects_nonsense` drives that same variable
through `"60"`, `"0"`, `""`, `"  "`, `"later"`, `"-5"` and a past-ceiling value.
`serial_test` orders a test only against other serial tests, so it gave this
plain reader no protection against running beside that one on another libtest
thread in the same process.

Both halves of the fix are required and neither is sufficient alone: the test
takes `#[serial_test::serial]`, and clears the variable for its own duration with
`kin_core::test_env::EnvVarGuard`. Clearing rather than merely ordering is what
makes the assertion state its real requirement, which is that with no operator
override the default applies. `EnvVarGuard` mutates process-global state, so it
is unsound without the serial attribute.

**Standing rule for this file.** Every test that reads
`configured_session_idle_ttl()`, meaning every `SessionCoordinator::new()` caller
whose TTL value matters, must be serial or env-pinned. The other two `new()`
callers are safe by accident rather than by construction:
`a_call_that_panics_still_releases_its_session` reaps on a dead pid whatever the
TTL, and `the_reported_call_age_tracks_the_oldest_call_still_running` never
sweeps.

## Evidence

Loop runs cannot prove either fix. Neither flake reproduces on an 18-core box, so
a green run shows only that no new flake was introduced. What follows is the
deterministic mechanism proof and the falsification.

**Deleting the in-flight `continue` in `sweep_stale_sessions_with_reservation`**
fails phase 1 alone:

```
assertion `left == right` failed: a call inside the window still protects its session
  left: 1
 right: 0
```

**Removing the `in_flight <= stale_threshold` ceiling** fails phase 2 alone:

```
assertion `left == right` failed: a call outrunning the idle window must not defer the sweep forever
  left: 0
 right: 1
```

Each break flips exactly one phase, which is what the split was for.

**Vacuity, phase 1.** The dead pid is load-bearing. With the protection deleted
*and* the phase-1 pid changed to `std::process::id()`, the test passes again, so
phase 1's zero really is a claim about in-flight protection and not about a live
pid. The added `is_some()` read-back is what stops it proving only that a counter
read zero.

**Mechanism, the env race.** The race is exactly reproducible by putting the
variable in the process environment, which is behaviourally identical to the
sibling test having just set it. With the fix, `KIN_SESSION_IDLE_TTL_SECS=60
cargo test -p kin-daemon --lib pid_less_sessions_survive_a_thinking_pause` passes,
because the guard clears it. With the guard line deleted and nothing else
changed, the same command fails with the panic the interleaving produces:

```
assertion `left == right` failed
  left: 60s
 right: 1800s
```

**Falsification against production.** Shortening `DEFAULT_SESSION_IDLE_TTL` from
1800s to 60s fails the test with the same message, so the assertion still guards
the constant it names.

Full gate green on the lane worktree at `9cee972c`: `cargo nextest run
--workspace` 5920 tests run, 5920 passed, 11 skipped, plus `cargo test --doc`;
`cargo fmt --all -- --check` clean; `cargo clippy --all-targets --all-features`
with CI's exact 45-entry allowlist under `RUSTFLAGS=-Dwarnings` exit 0.

Refs FIR-2382
