### PR TITLE
Derace eight process-lifecycle, lock and runtime tests on their own events

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -9927,12 +9927,22 @@ mod tests {
         // the preceding no-endpoint and PID-only slices.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
+        // Nothing here asserts patience expiry; that invariant belongs to
+        // `unpublished_daemon_singleton_owner_forbids_spawn` and to
+        // `a_health_probe_that_never_answers_is_not_evidence_against_the_daemon`,
+        // which set deliberately tiny patiences. Putting it out of reach is what
+        // keeps a slow machine from turning a followed owner into `LiveNotReady`.
+        const FOLLOW_PATIENCE: Duration = Duration::from_secs(600);
+        // Strictly smaller than the patience it wraps, so a hang is reported as
+        // this test hanging rather than as the waiter giving up.
+        const HANG_GUARD: Duration = Duration::from_secs(60);
+
         let waiter_root = root.clone();
         let waiter = tokio::spawn(async move {
             wait_for_existing_daemon_within(
                 &waiter_root,
                 Duration::from_millis(20),
-                Duration::from_secs(3),
+                FOLLOW_PATIENCE,
             )
             .await
         });
@@ -9949,14 +9959,23 @@ mod tests {
             "PID-only publication must be followed, not rejected"
         );
         std::fs::write(root.join("daemon.port"), port.to_string()).unwrap();
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Synchronise on a value the code owns rather than on a sleep: the
+        // waiter's own probe connection is the proof it read the published
+        // endpoint. Dropping the accepted socket is safe by the probe's
+        // documented contract, which records an unanswered health connection as
+        // no evidence either way, so it retries into the real server below.
+        let probe = tokio::time::timeout(HANG_GUARD, listener.accept())
+            .await
+            .expect("the waiter must probe the endpoint it was told about")
+            .expect("accept the waiter's probe connection");
         assert!(
             !waiter.is_finished(),
             "a complete endpoint that has not served yet must remain owned"
         );
+        drop(probe);
 
         let server = serve_repo_daemon_health(listener, repo.path());
-        let outcome = tokio::time::timeout(Duration::from_secs(2), waiter)
+        let outcome = tokio::time::timeout(HANG_GUARD, waiter)
             .await
             .expect("waiter must follow endpoint publication")
             .expect("waiter task");

--- a/crates/kin-cli/src/daemon_client/probe_process.rs
+++ b/crates/kin-cli/src/daemon_client/probe_process.rs
@@ -1576,6 +1576,18 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn hard_parent_death_terminates_the_guarded_probe() {
+        // Readiness here is a three-hop spawn chain, and its middle hop already
+        // waits out a full REAP_GRACE of its own, so a test budget no larger
+        // than one nested product budget can expire while every component is
+        // still inside its permitted window. Parent-death cleanup is contracted
+        // as "eventually", with no published latency bound anywhere, so the
+        // assertions below carry the whole requirement and these two numbers
+        // only stop a hang from running forever. They are deliberately local:
+        // REAP_GRACE carries production reap semantics at many other call
+        // sites and must not move for a test's benefit.
+        const PARENT_DEATH_READY_GUARD: Duration = Duration::from_secs(60);
+        const PARENT_DEATH_CLEANUP_GUARD: Duration = Duration::from_secs(60);
+
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("parent-death-probe.pid");
         let mut owner_command = Command::new(std::env::current_exe().unwrap());
@@ -1591,31 +1603,46 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         let mut owner = KillAndReapOnDrop(Some(owner_command.spawn().unwrap()));
-        let ready_deadline = Instant::now() + Duration::from_secs(5);
-        let mut guarded_pid = read_pid_marker(&marker);
-        while guarded_pid.is_none() && Instant::now() < ready_deadline {
+        let owner_pid = owner.child_mut().id();
+        let ready_deadline = Instant::now() + PARENT_DEATH_READY_GUARD;
+        let guarded_pid = loop {
+            if let Some(pid) = read_pid_marker(&marker) {
+                break pid;
+            }
             assert!(
                 owner.child_mut().try_wait().unwrap().is_none(),
                 "parent fixture exited before its guarded probe became ready"
             );
+            assert!(
+                Instant::now() < ready_deadline,
+                "guarded probe published no parseable PID {}s after the owner was spawned; \
+                 the readiness chain never reached the nested probe",
+                PARENT_DEATH_READY_GUARD.as_secs()
+            );
             std::thread::sleep(POLL_INTERVAL);
-            guarded_pid = read_pid_marker(&marker);
-        }
-        let guarded_pid = guarded_pid
-            .expect("guarded probe did not publish a parseable PID for parent-death test");
+        };
+        assert_ne!(
+            guarded_pid, owner_pid,
+            "the marker must name the nested guarded probe, not the owner the test spawned"
+        );
 
         // This bypasses Rust Drop inside the owner process. Only the
         // guardian's parent-death ownership pipe can clean the nested probe.
         owner.kill_and_reap();
 
-        let cleanup_deadline = Instant::now() + REAP_GRACE;
-        while process_is_live(guarded_pid) && Instant::now() < cleanup_deadline {
+        let cleanup_deadline = Instant::now() + PARENT_DEATH_CLEANUP_GUARD;
+        loop {
+            if !process_is_live(guarded_pid) {
+                break;
+            }
+            assert!(
+                Instant::now() < cleanup_deadline,
+                "guarded probe {guarded_pid} was still live {}s after hard parent death; \
+                 the guardian's parent-death ownership pipe did not clean it",
+                PARENT_DEATH_CLEANUP_GUARD.as_secs()
+            );
             std::thread::sleep(POLL_INTERVAL);
         }
-        assert!(
-            !process_is_live(guarded_pid),
-            "guarded probe {guarded_pid} survived hard parent death"
-        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-cli/src/daemon_client/probe_process.rs
+++ b/crates/kin-cli/src/daemon_client/probe_process.rs
@@ -1576,17 +1576,22 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn hard_parent_death_terminates_the_guarded_probe() {
-        // Readiness here is a three-hop spawn chain, and its middle hop already
-        // waits out a full REAP_GRACE of its own, so a test budget no larger
-        // than one nested product budget can expire while every component is
-        // still inside its permitted window. Parent-death cleanup is contracted
-        // as "eventually", with no published latency bound anywhere, so the
-        // assertions below carry the whole requirement and these two numbers
-        // only stop a hang from running forever. They are deliberately local:
-        // REAP_GRACE carries production reap semantics at many other call
-        // sites and must not move for a test's benefit.
-        const PARENT_DEATH_READY_GUARD: Duration = Duration::from_secs(60);
-        const PARENT_DEATH_CLEANUP_GUARD: Duration = Duration::from_secs(60);
+        // Readiness here is a three-hop spawn chain whose middle hop already
+        // waits out a full REAP_GRACE of its own, so a budget no larger than one
+        // nested product budget can expire while every component is still inside
+        // its permitted window. Both guards are deliberately local: REAP_GRACE
+        // carries production reap semantics at many other call sites and must
+        // not move for a test's benefit.
+        //
+        // Both must also stay strictly BELOW the descendant fixture's own 30s
+        // lifetime. A cleanup guard above it cannot fail: a probe that survives
+        // cleanup completely would return of old age inside the window, every
+        // liveness check would find it gone, and the test would pass green while
+        // proving nothing. That ceiling, not the cleanup latency, is what bounds
+        // these numbers; observed cleanup is under 100ms, so 20s already leaves
+        // two orders of magnitude of margin.
+        const PARENT_DEATH_READY_GUARD: Duration = Duration::from_secs(20);
+        const PARENT_DEATH_CLEANUP_GUARD: Duration = Duration::from_secs(20);
 
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("parent-death-probe.pid");

--- a/crates/kin-cli/tests/daemon_runtime_containment.rs
+++ b/crates/kin-cli/tests/daemon_runtime_containment.rs
@@ -15,6 +15,21 @@ const TREE_PARENT: &str = "KIN_TEST_RUNTIME_TREE_PARENT";
 const TREE_DESCENDANT: &str = "KIN_TEST_RUNTIME_TREE_DESCENDANT";
 const TREE_STOP: &str = "KIN_TEST_RUNTIME_TREE_STOP";
 
+/// Ceiling on the descendant fixture's own lifetime.
+///
+/// It must strictly exceed readiness plus the entire `Drop` budget, or the
+/// descendant expires while the test is still measuring and every liveness
+/// check reads as containment on a process that died of old age. The expiry
+/// marker makes that outcome loud rather than silent, and this number is what
+/// keeps it from happening in the first place.
+const DESCENDANT_LIFETIME_CAP: Duration = Duration::from_secs(300);
+
+/// How long the test waits for the descendant to publish its pid. The
+/// descendant publishes as its first action, so this stays near its original
+/// value; whatever it becomes must satisfy readiness plus `Drop` under
+/// [`DESCENDANT_LIFETIME_CAP`].
+const DESCENDANT_READY_BUDGET: Duration = Duration::from_secs(10);
+
 #[test]
 fn bounded_capture_deadline_cannot_be_bypassed_by_continuous_output() {
     common::bounded_capture_deadline_cannot_be_bypassed_by_continuous_output();
@@ -96,11 +111,20 @@ impl Drop for KillAndReapChild {
 #[test]
 fn isolated_runtime_tree_worker() {
     if let Some(marker) = std::env::var_os(TREE_DESCENDANT) {
-        publish_marker_atomically(&PathBuf::from(marker), std::process::id().to_string());
+        let marker = PathBuf::from(marker);
+        publish_marker_atomically(&marker, std::process::id().to_string());
         let stop = PathBuf::from(std::env::var_os(TREE_STOP).expect("tree stop marker"));
-        let deadline = Instant::now() + Duration::from_secs(60);
+        let deadline = Instant::now() + DESCENDANT_LIFETIME_CAP;
         while !stop.is_file() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(20));
+        }
+        // Returning of old age and being terminated by containment are the same
+        // observation from outside: the pid stops being live either way. Only a
+        // descendant that outlived its own cap can publish this, so its absence
+        // is what makes the assertions below statements about containment
+        // rather than about how long the machine took.
+        if !stop.is_file() {
+            publish_marker_atomically(&marker.with_extension("expired"), "expired");
         }
         return;
     }
@@ -137,6 +161,7 @@ fn dropping_isolated_runtime_terminates_a_late_descendant() {
     let repository = root.path().join("repository");
     std::fs::create_dir_all(&repository).expect("create repository");
     let descendant_marker = root.path().join("descendant.pid");
+    let expiry_marker = root.path().join("descendant.expired");
     let stop_marker = root.path().join("stop");
     let runtime = common::IsolatedDaemonRuntime::with_cleanup_command_for_test(
         &repository,
@@ -147,7 +172,7 @@ fn dropping_isolated_runtime_terminates_a_late_descendant() {
             "--nocapture".into(),
         ],
         Vec::new(),
-        Duration::from_secs(5),
+        Duration::from_secs(15),
     );
     let mut command =
         runtime.process_command_for_test(std::env::current_exe().expect("current test executable"));
@@ -163,7 +188,7 @@ fn dropping_isolated_runtime_terminates_a_late_descendant() {
             .expect("spawn runtime-owned process tree"),
     );
     let parent_pid = parent.id();
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + DESCENDANT_READY_BUDGET;
     let descendant_pid = loop {
         if let Some(pid) = read_pid_marker(&descendant_marker) {
             break pid;
@@ -219,6 +244,11 @@ fn dropping_isolated_runtime_terminates_a_late_descendant() {
         }
     }
 
+    assert!(
+        !expiry_marker.exists(),
+        "the descendant returned at its own lifetime cap rather than being terminated, so \
+         every liveness check below would read as containment on a process that died of old age"
+    );
     assert!(
         runtime_drop.is_ok(),
         "IsolatedDaemonRuntime Drop reported containment failure"

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -14058,27 +14058,32 @@ mod tests {
         let first = ProjectionRoot::open(root.path()).unwrap();
 
         let contender_root = root.path().to_path_buf();
+        // Unbounded, so the send never blocks the contender and cannot inflate
+        // the wait it is about to measure. The stamp precedes the send, which is
+        // what puts the contender's clock ahead of the hold rather than after
+        // however long the OS took to schedule the thread.
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
         let contender = std::thread::spawn(move || {
             let started = std::time::Instant::now();
+            ready_tx.send(()).unwrap();
             let opened = ProjectionRoot::open_with_projection_lock_deadline(
                 &contender_root,
-                std::time::Duration::from_secs(10),
+                std::time::Duration::from_secs(60),
             );
             (opened.map(|_| ()), started.elapsed())
         });
 
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        ready_rx.recv().unwrap();
+        let hold_began = std::time::Instant::now();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let held_for = hold_began.elapsed();
         drop(first);
 
         let (opened, waited) = contender.join().unwrap();
         opened.expect("the contender must acquire once the holder releases");
         assert!(
-            waited >= std::time::Duration::from_millis(250),
-            "the contender should have genuinely waited, waited {waited:?}"
-        );
-        assert!(
-            waited < std::time::Duration::from_secs(10),
-            "the contender must not burn the full deadline once the lock frees"
+            waited >= held_for,
+            "the contender must wait out the whole hold, held {held_for:?} but waited {waited:?}"
         );
     }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -4741,13 +4741,10 @@ mod tests {
         .parse::<libc::pid_t>()
         .unwrap();
         assert!(relay.wait().unwrap().success());
-        let escaped_group = wait_for_test_report_fields(
-            &escape_report_path,
-            1,
-            Duration::from_secs(10),
-        )[0]
-            .parse::<libc::pid_t>()
-            .unwrap();
+        let escaped_group =
+            wait_for_test_report_fields(&escape_report_path, 1, Duration::from_secs(10))[0]
+                .parse::<libc::pid_t>()
+                .unwrap();
         assert_ne!(
             escaped_group, target_group,
             "late inherited member did not escape the target group"
@@ -5038,13 +5035,10 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         let mut escaped = guardian.spawn(escaped_command).unwrap();
-        let escaped_group = wait_for_test_report_fields(
-            &escape_report_path,
-            1,
-            Duration::from_secs(10),
-        )[0]
-            .parse::<libc::pid_t>()
-            .unwrap();
+        let escaped_group =
+            wait_for_test_report_fields(&escape_report_path, 1, Duration::from_secs(10))[0]
+                .parse::<libc::pid_t>()
+                .unwrap();
         assert_ne!(
             escaped_group, target_group,
             "escaped worker did not leave the target group"

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3787,6 +3787,9 @@ mod tests {
     const ESCAPE_GROUP_ENV: &str = "KIN_INTERNAL_TEST_ESCAPE_GROUP";
 
     #[cfg(unix)]
+    const ESCAPE_GROUP_REPORT_ENV: &str = "KIN_INTERNAL_TEST_ESCAPE_GROUP_REPORT";
+
+    #[cfg(unix)]
     const OWNER_DEATH_DRIVER_ENV: &str = "KIN_INTERNAL_TEST_GUARDIAN_OWNER_DEATH_DRIVER";
 
     #[cfg(unix)]
@@ -3843,6 +3846,18 @@ mod tests {
         if std::env::var_os(ESCAPE_GROUP_ENV).is_some() {
             assert_ne!(unsafe { libc::setsid() }, -1, "escape target process group");
         }
+        // Read outside the branch above, never inside it. A successful setsid
+        // makes the caller its own group leader, so a value sampled inside that
+        // branch is this process's own pid by construction and can never equal
+        // the guardian's group, which would make the reader's assertion hold in
+        // every reachable path. Sampling here is what lets that assertion fail
+        // when the escape did not happen.
+        if let Some(report) = std::env::var_os(ESCAPE_GROUP_REPORT_ENV) {
+            publish_test_report(
+                &PathBuf::from(report),
+                format!("{}\n", unsafe { libc::getpgid(0) }),
+            );
+        }
         loop {
             unsafe {
                 libc::pause();
@@ -3876,6 +3891,9 @@ mod tests {
             .stderr(Stdio::null());
         if std::env::var_os(LATE_RELAY_ESCAPE_CHILD_ENV).is_some() {
             child.env(ESCAPE_GROUP_ENV, "1");
+            if let Some(escape_report) = std::env::var_os(ESCAPE_GROUP_REPORT_ENV) {
+                child.env(ESCAPE_GROUP_REPORT_ENV, escape_report);
+            }
         }
         let child = child.spawn().expect("spawn late inherited member");
         let child_id = child.id();
@@ -4676,7 +4694,8 @@ mod tests {
         wait_for_test_pid_gone(late_member_pid, Duration::from_secs(5));
     }
 
-    #[cfg(unix)]
+    // Same platform reasoning as the direct twin below.
+    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
     #[test]
     fn deliberate_late_setsid_escape_is_outside_the_guardian_contract() {
         use std::process::Stdio;
@@ -4685,12 +4704,14 @@ mod tests {
         let readiness_path = root.path().join("guardian.ready");
         let trigger_path = root.path().join("late-escape.trigger");
         let report_path = root.path().join("late-escape.report");
+        // A stem distinct from `late-escape.report`, because
+        // `publish_test_report` stages through `with_extension`.
+        let escape_report_path = root.path().join("late-escape-group.report");
         let executable = std::env::current_exe().unwrap();
         let launcher = ProcessGroupGuardianLauncher::exact_test(
             &executable,
             "tests::process_group_guardian_worker",
-        )
-        .with_cleanup_timeout(Duration::from_millis(150));
+        );
         let mut guardian = launcher
             .spawn_with(
                 &readiness_path,
@@ -4706,6 +4727,7 @@ mod tests {
             .env(LATE_RELAY_TRIGGER_ENV, &trigger_path)
             .env(LATE_RELAY_REPORT_ENV, &report_path)
             .env(LATE_RELAY_ESCAPE_CHILD_ENV, "1")
+            .env(ESCAPE_GROUP_REPORT_ENV, &escape_report_path)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
@@ -4719,20 +4741,30 @@ mod tests {
         .parse::<libc::pid_t>()
         .unwrap();
         assert!(relay.wait().unwrap().success());
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while unsafe { libc::getpgid(late_member_pid) } == target_group {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "late inherited member did not escape the target group"
-            );
-            std::thread::sleep(PROCESS_GROUP_GUARDIAN_POLL_INTERVAL);
-        }
+        let escaped_group = wait_for_test_report_fields(
+            &escape_report_path,
+            1,
+            Duration::from_secs(10),
+        )[0]
+            .parse::<libc::pid_t>()
+            .unwrap();
+        assert_ne!(
+            escaped_group, target_group,
+            "late inherited member did not escape the target group"
+        );
 
         guardian.request_cleanup();
         guardian
-            .reap_until(std::time::Instant::now() + Duration::from_secs(2))
+            .reap_until(std::time::Instant::now() + Duration::from_secs(5))
             .expect("detached child is explicitly outside the cooperative group contract");
-        assert_eq!(unsafe { libc::kill(late_member_pid, 0) }, 0);
+        // This escapee is a reparented grandchild that init reaps, so a cleared
+        // slot makes `kill(pid, 0)` fail for a reason unrelated to the claim,
+        // and a zombie makes it succeed for one. Ask the product's own liveness
+        // primitive instead.
+        assert!(
+            !process_has_exited(late_member_pid).expect("poll the escaped late member"),
+            "watcher falsely claimed success by killing an out-of-group member"
+        );
 
         assert_eq!(unsafe { libc::kill(late_member_pid, libc::SIGKILL) }, 0);
         wait_for_test_pid_gone(late_member_pid, Duration::from_secs(5));
@@ -4965,19 +4997,25 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    // `process_has_exited` answers `Unsupported` outside macOS and Linux, and
+    // `process_group_containment` is `Indeterminate` there, so this test cannot
+    // pass on a third unix regardless of the product's behavior.
+    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
     #[test]
     fn deliberate_direct_setsid_escape_is_outside_the_guardian_contract() {
         use std::process::Stdio;
 
         let root = tempfile::tempdir().unwrap();
         let readiness_path = root.path().join("guardian.ready");
+        // A stem of its own: `publish_test_report` derives its staging name with
+        // `with_extension`, so two reports sharing a stem stage to names that
+        // differ only by pid.
+        let escape_report_path = root.path().join("direct-escape-group.report");
         let executable = std::env::current_exe().unwrap();
         let launcher = ProcessGroupGuardianLauncher::exact_test(
             &executable,
             "tests::process_group_guardian_worker",
-        )
-        .with_cleanup_timeout(Duration::from_millis(150));
+        );
         let mut guardian = launcher
             .spawn_with(
                 &readiness_path,
@@ -4995,27 +5033,32 @@ mod tests {
             ])
             .env(INERT_GROUP_MEMBER_ENV, "1")
             .env(ESCAPE_GROUP_ENV, "1")
+            .env(ESCAPE_GROUP_REPORT_ENV, &escape_report_path)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         let mut escaped = guardian.spawn(escaped_command).unwrap();
-        let escaped_pid = libc::pid_t::try_from(escaped.id()).unwrap();
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while unsafe { libc::getpgid(escaped_pid) } == target_group {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "escaped worker did not leave the target group"
-            );
-            std::thread::sleep(PROCESS_GROUP_GUARDIAN_POLL_INTERVAL);
-        }
+        let escaped_group = wait_for_test_report_fields(
+            &escape_report_path,
+            1,
+            Duration::from_secs(10),
+        )[0]
+            .parse::<libc::pid_t>()
+            .unwrap();
+        assert_ne!(
+            escaped_group, target_group,
+            "escaped worker did not leave the target group"
+        );
 
         guardian.request_cleanup();
         guardian
-            .reap_until(std::time::Instant::now() + Duration::from_secs(2))
+            .reap_until(std::time::Instant::now() + Duration::from_secs(5))
             .expect("detached child is explicitly outside the cooperative group contract");
-        assert_eq!(
-            unsafe { libc::kill(escaped_pid, 0) },
-            0,
+        assert!(
+            escaped
+                .try_wait()
+                .expect("poll the escaped member")
+                .is_none(),
             "watcher falsely claimed success by killing an out-of-group member"
         );
 

--- a/crates/kin-daemon/tests/common/mod.rs
+++ b/crates/kin-daemon/tests/common/mod.rs
@@ -12,6 +12,16 @@ use tokio::io::AsyncReadExt as _;
 use tokio::process::{Child, Command};
 
 const DAEMON_REAP_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long a containment spawn waits for its guardian to publish readiness.
+///
+/// This is the tightest budget on the cold-start path of every containment
+/// spawn in this suite, and it runs before any test's own readiness clock
+/// starts, so it expires as a spawn failure rather than as the readiness
+/// message a reader would expect. Reaching it costs two re-execs of the test
+/// binary, and nothing asserts how long that may take, so the number is a hang
+/// guard only.
+#[cfg(unix)]
+const GUARDIAN_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(180);
 const DAEMON_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const DAEMON_TEST_CAPTURE_LIMIT: usize = 4 * 1024 * 1024;
 /// Maximum rendered UTF-8 bytes, including any truncation marker.
@@ -261,7 +271,7 @@ impl DaemonContainment {
         let guardian = launcher
             .spawn_with(
                 &ready,
-                Instant::now() + Duration::from_secs(5),
+                Instant::now() + GUARDIAN_HANDSHAKE_TIMEOUT,
                 scrub_daemon_test_guardian_environment,
             )
             .map_err(|error| {

--- a/crates/kin-daemon/tests/port_handshake.rs
+++ b/crates/kin-daemon/tests/port_handshake.rs
@@ -228,7 +228,7 @@ async fn dropping_a_direct_daemon_child_terminates_its_containment() {
         let child = spawn_daemon_test_command(command, "direct contained child")
             .expect("spawn direct contained child");
         let pid = child.id().expect("spawned contained child pid");
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + READINESS_TIMEOUT;
         while !marker.is_file() && Instant::now() < deadline {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
@@ -290,11 +290,18 @@ async fn dropping_containment_terminates_a_late_descendant() {
         .env(CONTAINMENT_TREE_PARENT, &descendant_marker)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    let child = spawn_daemon_test_command(command, "direct-containment tree")
+    let mut child = spawn_daemon_test_command(command, "direct-containment tree")
         .expect("spawn direct-containment tree");
     let parent_pid = child.id().expect("contained parent pid");
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + READINESS_TIMEOUT;
     while !descendant_marker.is_file() && Instant::now() < deadline {
+        assert!(
+            child
+                .try_wait()
+                .expect("poll direct-containment tree")
+                .is_none(),
+            "direct-containment tree exited before descendant readiness"
+        );
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     assert!(
@@ -345,7 +352,7 @@ async fn explicit_cleanup_proves_quiescence_before_releasing_containment() {
     let mut child = spawn_daemon_test_command(command, "explicit-cleanup tree")
         .expect("spawn explicit-cleanup tree");
     let parent_pid = child.id().expect("contained parent pid");
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + READINESS_TIMEOUT;
     while !descendant_marker.is_file() && Instant::now() < deadline {
         assert!(
             child

--- a/crates/kin-daemon/tests/shutdown_escalation.rs
+++ b/crates/kin-daemon/tests/shutdown_escalation.rs
@@ -34,17 +34,21 @@ const SATURATED_WORKER_ROOT: &str = "KIN_TEST_SATURATED_SHUTDOWN_ROOT";
 /// wins the race on a daemon that is not starved.
 const GRACEFUL_WORKER_ROOT: &str = "KIN_TEST_GRACEFUL_SHUTDOWN_ROOT";
 
-/// Grace the graceful worker is given: long enough that a force-exit could
-/// never be mistaken for the graceful path finishing. The whole point of that
-/// test is to distinguish the two, so this must stay far above
-/// [`GRACEFUL_EXIT_BUDGET`].
+/// Grace the graceful worker is given before its force-exit backstop fires.
 const GRACEFUL_WORKER_GRACE_SECS: u64 = 30;
 
 /// How long the parent waits for the healthy worker to exit after SIGTERM.
-/// Must stay well below [`GRACEFUL_WORKER_GRACE_SECS`]: exceeding it means the
-/// tokio signal path never observed the signal and only the backstop could
-/// still end the process.
-const GRACEFUL_EXIT_BUDGET: Duration = Duration::from_secs(8);
+///
+/// This must stay ABOVE [`GRACEFUL_WORKER_GRACE_SECS`], which is the opposite
+/// of the ordering an exit-code test would want. Both paths exit 0, so the exit
+/// code discriminates nothing and the marker the worker writes on the tokio
+/// signal path is what separates them. A displaced signal path leaves only the
+/// backstop, which exits inside this window, and the marker assertion is what
+/// then fails, with its own message, rather than a timeout blaming a slow
+/// machine. Restoring the old ordering would make the marker unreachable and
+/// silently retire the discrimination. It also stays below
+/// [`WORKER_WALL_CLOCK_CAP`], so a cap firing can never be mistaken for a pass.
+const GRACEFUL_EXIT_BUDGET: Duration = Duration::from_secs(45);
 
 /// Grace the worker grants before force-exiting, fed through the same
 /// `KIN_DAEMON_SHUTDOWN_GRACE_SECS` knob production reads. Short so the test is
@@ -164,10 +168,12 @@ fn stop_terminates_a_daemon_whose_runtime_is_saturated() {
 /// saturated test above cannot catch that, because a force-exit also satisfies
 /// "the process exited".
 ///
-/// This one distinguishes them by clock: the worker gets a 30s grace and is
-/// required to exit within 8s. Only the tokio signal path can do that, so a
-/// pass here means the graceful path observed the signal rather than the
-/// backstop rescuing a broken one.
+/// This one distinguishes them by evidence rather than by clock: the worker
+/// writes a marker from inside the tokio SIGTERM arm, which only that path can
+/// reach, so a pass means the graceful path observed the signal rather than the
+/// backstop rescuing a broken one. The budget deliberately exceeds the grace so
+/// that a displaced signal path still exits inside the window and is caught by
+/// the missing marker.
 ///
 /// Nothing about the daemon's own SIGKILL-based test helpers covers this: they
 /// reap daemons with `start_kill`, so no existing test sends SIGTERM at all.
@@ -175,6 +181,7 @@ fn stop_terminates_a_daemon_whose_runtime_is_saturated() {
 fn a_healthy_daemon_still_stops_through_the_graceful_path() {
     let root = tempfile::tempdir().expect("scratch root for the graceful worker");
     let ready = root.path().join("graceful.ready");
+    let observed = root.path().join("graceful.observed");
 
     let mut command = Command::new(std::env::current_exe().expect("current test executable"));
     command
@@ -214,15 +221,20 @@ fn a_healthy_daemon_still_stops_through_the_graceful_path() {
                 Some(0),
                 "the graceful path exits 0 of its own accord"
             );
+            assert!(
+                observed.is_file(),
+                "the worker exited 0 without ever reaching tokio's SIGTERM arm, so the \
+                 force-exit backstop ended it. Chaining the runtime-independent handler \
+                 onto SIGTERM must not displace tokio's own registration, or every stop \
+                 silently degrades to a force-exit that skips the final flush, the \
+                 derived-CAS barrier and endpoint retirement."
+            );
             return;
         }
         assert!(
             Instant::now() < deadline,
-            "a healthy daemon did not stop through the graceful path within {}s, \
-             despite a {}s force-exit grace. Chaining the runtime-independent \
-             handler onto SIGTERM must not displace tokio's own registration, \
-             or every stop silently degrades to a force-exit that skips the \
-             final flush and endpoint retirement.",
+            "a healthy daemon did not stop at all within {}s, which is past its own {}s \
+             force-exit grace, so neither the graceful path nor the backstop ended it",
             GRACEFUL_EXIT_BUDGET.as_secs(),
             GRACEFUL_WORKER_GRACE_SECS
         );
@@ -237,7 +249,9 @@ fn graceful_daemon_shutdown_worker() {
     let Some(root) = std::env::var_os(GRACEFUL_WORKER_ROOT) else {
         return;
     };
-    let ready = PathBuf::from(root).join("graceful.ready");
+    let root = PathBuf::from(root);
+    let ready = root.join("graceful.ready");
+    let observed = root.join("graceful.observed");
 
     spawn_parent_death_watchdog();
     spawn_wall_clock_cap();
@@ -261,6 +275,10 @@ fn graceful_daemon_shutdown_worker() {
         // is still latched by tokio and delivered to `recv`.
         std::fs::write(&ready, b"listening").expect("publish readiness");
         sigterm.recv().await;
+        // Only tokio's own SIGTERM registration can reach this line. The
+        // backstop ends the process from an OS thread and never runs it, which
+        // is what lets the parent tell the two exit-0 paths apart.
+        std::fs::write(&observed, b"sigterm").expect("publish the observed marker");
         let _ = cancel_tx.send(true);
     });
 }

--- a/crates/kin-migrate/src/bounded_process.rs
+++ b/crates/kin-migrate/src/bounded_process.rs
@@ -1473,6 +1473,18 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn hard_parent_death_terminates_the_guarded_probe() {
+        // Readiness here is a three-hop spawn chain, and its middle hop already
+        // waits out a full REAP_GRACE of its own, so a test budget no larger
+        // than one nested product budget can expire while every component is
+        // still inside its permitted window. Parent-death cleanup is contracted
+        // as "eventually", with no published latency bound anywhere, so the
+        // assertions below carry the whole requirement and these two numbers
+        // only stop a hang from running forever. They are deliberately local:
+        // REAP_GRACE carries production reap semantics at many other call
+        // sites and must not move for a test's benefit.
+        const PARENT_DEATH_READY_GUARD: Duration = Duration::from_secs(60);
+        const PARENT_DEATH_CLEANUP_GUARD: Duration = Duration::from_secs(60);
+
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("parent-death-probe.pid");
         let mut owner_command = Command::new(std::env::current_exe().unwrap());
@@ -1488,31 +1500,46 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         let mut owner = KillAndReapOnDrop(Some(owner_command.spawn().unwrap()));
-        let ready_deadline = Instant::now() + Duration::from_secs(5);
-        let mut guarded_pid = read_pid_marker(&marker);
-        while guarded_pid.is_none() && Instant::now() < ready_deadline {
+        let owner_pid = owner.child_mut().id();
+        let ready_deadline = Instant::now() + PARENT_DEATH_READY_GUARD;
+        let guarded_pid = loop {
+            if let Some(pid) = read_pid_marker(&marker) {
+                break pid;
+            }
             assert!(
                 owner.child_mut().try_wait().unwrap().is_none(),
                 "parent fixture exited before its guarded probe became ready"
             );
+            assert!(
+                Instant::now() < ready_deadline,
+                "guarded probe published no parseable PID {}s after the owner was spawned; \
+                 the readiness chain never reached the nested probe",
+                PARENT_DEATH_READY_GUARD.as_secs()
+            );
             std::thread::sleep(POLL_INTERVAL);
-            guarded_pid = read_pid_marker(&marker);
-        }
-        let guarded_pid = guarded_pid
-            .expect("guarded probe did not publish a parseable PID for parent-death test");
+        };
+        assert_ne!(
+            guarded_pid, owner_pid,
+            "the marker must name the nested guarded probe, not the owner the test spawned"
+        );
 
         // This bypasses Rust Drop inside the owner process. Only the
         // guardian's parent-death ownership pipe can clean the nested probe.
         owner.kill_and_reap();
 
-        let cleanup_deadline = Instant::now() + REAP_GRACE;
-        while process_is_live(guarded_pid) && Instant::now() < cleanup_deadline {
+        let cleanup_deadline = Instant::now() + PARENT_DEATH_CLEANUP_GUARD;
+        loop {
+            if !process_is_live(guarded_pid) {
+                break;
+            }
+            assert!(
+                Instant::now() < cleanup_deadline,
+                "guarded probe {guarded_pid} was still live {}s after hard parent death; \
+                 the guardian's parent-death ownership pipe did not clean it",
+                PARENT_DEATH_CLEANUP_GUARD.as_secs()
+            );
             std::thread::sleep(POLL_INTERVAL);
         }
-        assert!(
-            !process_is_live(guarded_pid),
-            "guarded probe {guarded_pid} survived hard parent death"
-        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-migrate/src/bounded_process.rs
+++ b/crates/kin-migrate/src/bounded_process.rs
@@ -1473,17 +1473,22 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn hard_parent_death_terminates_the_guarded_probe() {
-        // Readiness here is a three-hop spawn chain, and its middle hop already
-        // waits out a full REAP_GRACE of its own, so a test budget no larger
-        // than one nested product budget can expire while every component is
-        // still inside its permitted window. Parent-death cleanup is contracted
-        // as "eventually", with no published latency bound anywhere, so the
-        // assertions below carry the whole requirement and these two numbers
-        // only stop a hang from running forever. They are deliberately local:
-        // REAP_GRACE carries production reap semantics at many other call
-        // sites and must not move for a test's benefit.
-        const PARENT_DEATH_READY_GUARD: Duration = Duration::from_secs(60);
-        const PARENT_DEATH_CLEANUP_GUARD: Duration = Duration::from_secs(60);
+        // Readiness here is a three-hop spawn chain whose middle hop already
+        // waits out a full REAP_GRACE of its own, so a budget no larger than one
+        // nested product budget can expire while every component is still inside
+        // its permitted window. Both guards are deliberately local: REAP_GRACE
+        // carries production reap semantics at many other call sites and must
+        // not move for a test's benefit.
+        //
+        // Both must also stay strictly BELOW the descendant fixture's own 30s
+        // lifetime. A cleanup guard above it cannot fail: a probe that survives
+        // cleanup completely would return of old age inside the window, every
+        // liveness check would find it gone, and the test would pass green while
+        // proving nothing. That ceiling, not the cleanup latency, is what bounds
+        // these numbers; observed cleanup is under 100ms, so 20s already leaves
+        // two orders of magnitude of margin.
+        const PARENT_DEATH_READY_GUARD: Duration = Duration::from_secs(20);
+        const PARENT_DEATH_CLEANUP_GUARD: Duration = Duration::from_secs(20);
 
         let temp = tempfile::tempdir().unwrap();
         let marker = temp.path().join("parent-death-probe.pid");

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -54,9 +54,22 @@ pub struct CargoRegistryState {
     #[cfg(test)]
     fail_next_blob_commit: std::sync::atomic::AtomicBool,
     #[cfg(test)]
-    delay_next_blob_commit_ms: std::sync::atomic::AtomicU64,
+    blob_commit_gate: std::sync::Mutex<Option<BlobCommitGate>>,
     #[cfg(test)]
     fail_next_manifest_repair: std::sync::atomic::AtomicBool,
+}
+
+/// Parks a durable blob commit inside its blocking region until a test releases
+/// it, and reports having got there.
+///
+/// The invariant under test is that the commit runs off the async runtime's
+/// worker thread. A rendezvous proves that by having the worker answer while
+/// the commit is parked; a sleep only proves a clock did not expire, which a
+/// loaded machine can falsify on a correct product.
+#[cfg(test)]
+struct BlobCommitGate {
+    entered: tokio::sync::oneshot::Sender<()>,
+    release: std::sync::mpsc::Receiver<()>,
 }
 
 impl CargoRegistryState {
@@ -80,7 +93,7 @@ impl CargoRegistryState {
             #[cfg(test)]
             fail_next_blob_commit: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
-            delay_next_blob_commit_ms: std::sync::atomic::AtomicU64::new(0),
+            blob_commit_gate: std::sync::Mutex::new(None),
             #[cfg(test)]
             fail_next_manifest_repair: std::sync::atomic::AtomicBool::new(false),
         }
@@ -782,11 +795,20 @@ fn write_crate_blob(
 
     #[cfg(test)]
     {
-        let delay = state
-            .delay_next_blob_commit_ms
-            .swap(0, std::sync::atomic::Ordering::SeqCst);
-        if delay > 0 {
-            std::thread::sleep(std::time::Duration::from_millis(delay));
+        let gate = state
+            .blob_commit_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(gate) = gate {
+            let _ = gate.entered.send(());
+            gate.release
+                .recv_timeout(std::time::Duration::from_secs(30))
+                .map_err(|_| {
+                    std::io::Error::other(
+                        "durable commit was never released: the async worker never resumed",
+                    )
+                })?;
         }
     }
 
@@ -1451,7 +1473,6 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use std::time::Duration;
     use tower::ServiceExt;
 
     fn registry_state() -> (tempfile::TempDir, Arc<CargoRegistryState>) {
@@ -2022,24 +2043,30 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
     #[tokio::test(flavor = "current_thread")]
     async fn delayed_durable_commit_does_not_block_the_async_worker() {
         let (_root, state) = registry_state_with_token(Some("s3cret"));
-        state
-            .delay_next_blob_commit_ms
-            .store(200, std::sync::atomic::Ordering::SeqCst);
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        *state
+            .blob_commit_gate
+            .lock()
+            .expect("a fresh registry state has an unpoisoned commit gate") = Some(BlobCommitGate {
+            entered: entered_tx,
+            release: release_rx,
+        });
+
         let publisher = tokio::spawn(publish(
-            state,
+            Arc::clone(&state),
             "demo",
             "1.0.0",
             Some("s3cret"),
             valid_crate("demo", "1.0.0"),
         ));
 
-        tokio::time::timeout(Duration::from_millis(75), async {
-            for _ in 0..3 {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("Tokio heartbeat stalled behind the durable registry commit");
+        entered_rx
+            .await
+            .expect("the durable commit must report entering its blocking region");
+        release_tx
+            .send(())
+            .expect("the parked commit must still be waiting for the async worker");
         assert_eq!(publisher.await.unwrap(), StatusCode::OK);
     }
 

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -2048,10 +2048,11 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
         *state
             .blob_commit_gate
             .lock()
-            .expect("a fresh registry state has an unpoisoned commit gate") = Some(BlobCommitGate {
-            entered: entered_tx,
-            release: release_rx,
-        });
+            .expect("a fresh registry state has an unpoisoned commit gate") =
+            Some(BlobCommitGate {
+                entered: entered_tx,
+                release: release_rx,
+            });
 
         let publisher = tokio::spawn(publish(
             Arc::clone(&state),


### PR DESCRIPTION
Eight more racy tests, following the verified plan's rulings rather than its
original proposals. Unit 1 shipped separately as kin#886 because it holds the
test that ejected kin#870 from the merge queue.

None of these flakes reproduce on an 18-core box, so a green loop run shows only
that no new flake was introduced and can never show an old one is fixed. Every
item below therefore carries a deterministic mechanism proof and a falsification,
and every quoted panic was observed.

## What changed, and the evidence for each

**`projection_lock_waits_out_a_short_lived_holder`** stamped the contender's
clock inside the spawned closure, so the contender's timer started only when the
OS scheduled that thread while the holder's 300ms began when `thread::spawn`
returned. The waiter is a poll loop whose backoff doubles to a 250ms cap, so the
measured wait could only land on a rung at 0, 25, 75, 175 or 375ms, and any
scheduling latency above roughly 125ms dropped it to 175 and failed a 250ms
floor. It now stamps before a readiness send, measures the hold it actually
performed, and asserts `waited >= held_for`.

Falsified twice, one break per half. Failing fast on contention:
`the contender must acquire once the holder releases: ... "another exact-source
projection is active after waiting 60.0s ..."`. Taking no kernel lock at all:
`the contender must wait out the whole hold, held 500.499375ms but waited
816.584µs`.

**`daemon_waiter_follows_no_endpoint_pid_only_and_unready_publication`** coupled
three budgets: 300ms of test sleeps against the waiter's own 3s patience, an
outer 2s timeout expiring 700ms *inside* the patience it wrapped, and a probe
retrying on a fixed 200ms sleep against a listener the test never accepted on.
Patience moves out of reach, the third slice synchronises on the waiter's own
probe connection instead of a sleep, and the outer bound becomes a hang guard
strictly smaller than the patience it wraps.

Falsified by rejecting a held singleton with no endpoint: `a held singleton with
no endpoint must be followed, not rejected`. The accept step is not vacuous:
publishing a port nothing is bound to fails with `the waiter must probe the
endpoint it was told about: Elapsed(())`, so only the waiter's own connection to
the listener the test bound can satisfy it.

**`hard_parent_death_terminates_the_guarded_probe`, both copies.** A 5s
readiness budget had to contain a three-hop spawn chain whose middle hop already
waits out a 5s `REAP_GRACE` of its own, and the cleanup assertion was the exact
negation of its loop's condition, so it could not tell "will never happen" from
"has not happened yet". Both assertions move inside their loops against
test-local guards. `REAP_GRACE` and `POLL_INTERVAL` are untouched.

**One departure from the plan, with evidence.** The plan specified 60s guards. I
measured that 60s makes the cleanup assertion unable to fail: the descendant
fixture sleeps 30s and returns on its own, so a probe that escaped cleanup
entirely dies of old age inside a 60s window. With the probe escaping its process
group so nothing could reach it, the test passed in 30.07s. That is precisely the
defect the plan's own section 4.7 refuses to land elsewhere. The guards are 20s:
still four times the nested `REAP_GRACE` the original 5s could not contain, two
orders of magnitude above the observed sub-100ms cleanup, and strictly below the
fixture's 30s ceiling so the assertion stays falsifiable. Re-falsified at 20s in
both copies: `guarded probe 10768 was still live 20s after hard parent death; the
guardian's parent-death ownership pipe did not clean it`. Both test names were
confirmed present with `--list`, since the whole test is `#[cfg(unix)]` and its
fixture self-disables on a missing env var, which makes exclusion and success
indistinguishable in a workspace total.

**`a_healthy_daemon_still_stops_through_the_graceful_path`** discriminated
nothing. Both the graceful path and the force-exit backstop end in exit 0, so an
8s deadline stood in for the discrimination. The worker now writes a marker from
inside tokio's SIGTERM arm, which only that path reaches, and the budget is
raised to 45s so it sits **above** the 30s grace rather than below it. That
inversion is what makes the marker reachable, and the header prose that demanded
the old ordering is rewritten so the next reader does not restore it and silently
retire the check. 45s stays below the 60s `WORKER_WALL_CLOCK_CAP`, which is not
raised.

Falsified by making tokio's SIGTERM arm never resolve, standing in for a
displaced registration. The backstop force-exited 0 at 30.30s, inside the new
window, and the test failed with `the worker exited 0 without ever reaching
tokio's SIGTERM arm, so the force-exit backstop ended it. ...`. Under the old 8s
budget the same regression produced a timeout blaming the machine. The exit-code
assertion passed throughout, which is the direct demonstration that it
discriminated nothing.

**`dropping_containment_terminates_a_late_descendant`** takes the file's named
readiness constant together with the eager child-liveness check its sibling
already has, never the constant alone: detecting a dying tree through its own
handle is what licenses the number. `DAEMON_REAP_TIMEOUT` is deliberately **not**
raised. It is not a hang guard,
`explicit_cleanup_proves_quiescence_before_releasing_containment` consumes
exactly that budget as its assertion, and raising it to 60s would pass a
containment path that needed 45 seconds to prove a group empty. It is also shared
by three test binaries and used as a capture-drain deadline, which is not a reap
at all. Nothing shows it has ever fired.

Falsified by making the contained tree exit before readiness: `direct-containment
tree exited before descendant readiness` in 0.07s rather than sitting out the
readiness budget.

**The guardian handshake, which is worth more than the test that surfaced it.**
`spawn_daemon_test_command` reaches `start_guardian`, which re-execs the test
binary twice and waited for the watcher under a hardcoded 5s. It is the tightest
budget on the cold-start path of every containment spawn in `port_handshake.rs`,
`chaos_recovery.rs` and `compat_json_stdout.rs`, it expires before any test's own
readiness clock starts, and it surfaces as a spawn failure rather than as the
readiness message a reader would expect. It now has a name and a hang-guard-sized
value.

**`dropping_isolated_runtime_terminates_a_late_descendant`** could not tell
containment from old age: the descendant returned at its own 60s deadline whether
or not it was stopped, and its parent then exited on its own, so on a slow
machine every check would find an empty group and all four assertions would pass
with `Drop` having contained nothing. The order here was mandatory and was
followed: discrimination first, falsify, only then touch a number. The descendant
now publishes an expiry marker when it returns of its own accord and the test
refuses that outcome before reading any liveness.

Falsified before widening, with the descendant escaping containment via `setsid`
so it could only die of old age: `the descendant returned at its own lifetime cap
rather than being terminated, so every liveness check below would read as
containment on a process that died of old age`. Re-confirmed against the final
budgets. `PROCESS_REAP_TIMEOUT` is untouched: 35 integration binaries share it,
and two sibling tests in `hermeticity.rs` assert against 30s workers that would
die of old age if it moved.

**`delayed_durable_commit_does_not_block_the_async_worker`** named a contest
between a heartbeat and a commit but decided it on three tokio timer sleeps
totalling 30ms against a 75ms deadline, on a single starved worker whose timer
wheel only advances when its thread is scheduled. The budget could not be widened
honestly, because any timeout at or above the 200ms injected delay stops catching
a blocked worker. The injected delay is replaced by a two-way rendezvous, so the
evidence is the worker answering rather than a clock not expiring. On a correct
product the handshake closes in microseconds at any machine speed, and the test
stops paying 200ms of real sleep.

Falsified by running the commit inline on the async worker instead of through
`spawn_blocking`: `the parked commit must still be waiting for the async worker:
SendError { .. }`, after the full 30s guard, which is the deadlock converted into
a loud failure. Not vacuous: leaving the gate unarmed fails with `the durable
commit must report entering its blocking region: RecvError(())`, proving the
production hook is executed rather than skipped.

**Both guardian setsid escape tests.** Three defects, one of which made the test
unable to fail. The survival assertion was structurally vacuous: `escaped` is a
`Child` the test still owns and has not waited, so a killed escapee sits as an
unreaped zombie and `kill(zombie_pid, 0)` returns 0. The test passed both in the
world where the barrier respects the escape and in the world where it kills the
escapee, which is the exact regression its own message claims to catch.

The plan's cross-cutting correction is applied: the worker publishes its process
group **outside** the setsid success branch. Publishing inside it, as originally
proposed, would have been a check that cannot fail, because after a successful
setsid the caller is its own group leader, so the sampled value is the caller's
own pid, the target is the sentinel's pid, and two live processes cannot share a
pid. Sampling outside the branch is what makes deleting the setsid turn the test
red, and it does: both tests fail with `late inherited member did not escape the
target group / left: 87638 / right: 87638` and `escaped worker did not leave the
target group / left: 87639 / right: 87639`.

The vacuity proof for the survival half is direct. SIGKILLing the escapee before
cleanup, then asserting the old form alongside the new one, shows `kill(pid, 0)`
still returning 0 on the zombie while the new assertion fails with `watcher
falsely claimed success by killing an out-of-group member`. The old assertion
passed on a killed escapee; the new one does not.

`reap_until` goes from 2s to the 5s this file already uses for the same call on
the preceding test, measured at 12.2ms p50 and 27.4ms max at 72-way concurrency.
The 150ms cleanup override is dropped so both tests use the 3s default their
untuned neighbours use; nothing in either test asserts anything about the
escalation deadline. Both tests narrow to macOS and Linux, matching the file's
other containment tests, because `process_has_exited` answers `Unsupported` on a
third unix and `process_group_containment` is `Indeterminate` there.

The worker publish is gated on a new env var, so the ten other call sites that
spawn `inert_process_group_member_worker` as a plain group member are unaffected;
only the two escape tests set it. Confirmed by the full `kin-daemon-spawn` suite.

## Not in this change

**`crates/kin-daemon/src/state.rs` is skipped.** Open PR kin#870 owns that file,
so `touch_activity_resets_idle_clock` and
`mark_dirty_advances_the_mutation_clock` are untouched here. They must land as
one PR from one lane once 870 is in.

**Two tests were refuted as racy and are deliberately unchanged.**
`a_heartbeat_extends_a_session_past_its_idle_window` and
`the_reported_call_age_tracks_the_oldest_call_still_running`, both in
`session_registry.rs`, were claimed racy on estimated margins and then measured:
the second at 102,000 samples under saturation with a worst case of 146.7
microseconds against a 20ms ceiling. Both carry a real hygiene improvement that
belongs in its own change, not in a flake PR.

**`a_daemon_that_served_a_branch_command_keeps_answering_its_recorded_endpoint`
is excluded.** It was not analysed to the standard the rest were. Its absence
here is not a clean bill of health.

**One product defect is filed rather than fixed.** The guardian's watcher
fallback opens with `signal_process_group_strict`, which treats EPERM as a hard
error, while its sibling `signal_process_group_after_delivered_kill` accepts
EPERM as `Absent`. On Darwin an already-killed zombie-only group answers EPERM,
so a single parent-barrier overrun yields `parent fallback barrier failed:
Operation not permitted (os error 1)`, reproduced 25 of 25. This is reachable in
production at the 3s default. Dropping the 150ms override makes these tests enter
that path less often; it does not fix it.

**A named trap worth keeping.** Do not reach for `start_paused = true` on either
the shutdown or the registry test. Tokio's paused clock virtualises only
`tokio::time::Instant`, so a real `std::thread::sleep` does not advance it, and
both fixes keep a real-time component. In the registry case a paused clock makes
the old 75ms timeout unable to elapse at all, so that variant passes even with
the commit running inline on the worker.

## Gate

Full gate green on the lane worktree, which the pass's own line names as
`.kin-coord/worktrees/flakeapply-kin @ 4573a9c2 (chore/lane-flakeapply2-kin)`:
`cargo nextest run --workspace` 5920 tests run, 5920 passed, 11 skipped, plus
`cargo test --doc`, tracked `Cargo.lock` snapshot restored. `cargo fmt --all --
--check` exit 0. `cargo clippy --all-targets --all-features` under
`RUSTFLAGS=-Dwarnings` with CI's exact 45-entry allowlist, exit 0.

The pass reported four leaky tests. None is a test changed here: all four are
pre-existing never-EOF and sleeping-subprocess fixtures, and they report no leak
when run in isolation, so the marks are load-dependent rather than introduced.

Closes FIR-2382
