### PR TITLE
Resolve a receiver-method call by the receiver's nameable type

### DIFF
--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -1082,18 +1082,39 @@ fn resolve_one_file(
             && !unresolvable_name_ambiguity
             && !bare_candidates.is_empty()
         {
-            let mut distinct_targets: HashSet<EntityId> = HashSet::new();
-            for &(fp, dst_id) in bare_candidates {
-                if fp != file.file_path.as_str()
-                    && blind_inference_target_allowed(src_id, dst_id, &ctx.entity_language_by_id)
-                {
-                    distinct_targets.insert(dst_id);
-                }
-            }
-            let distinct_targets =
-                prune_ids_by_arity(distinct_targets, call_arity, &ctx.entity_arity_by_id);
-            let distinct_targets =
-                narrow_candidates_by_role(src_id, distinct_targets, &ctx.entity_role_by_id);
+            let candidates: Vec<(&str, EntityId)> = bare_candidates
+                .iter()
+                .copied()
+                .filter(|&(fp, dst_id)| {
+                    fp != file.file_path.as_str()
+                        && blind_inference_target_allowed(
+                            src_id,
+                            dst_id,
+                            &ctx.entity_language_by_id,
+                        )
+                })
+                .collect();
+            let candidates = prune_pairs_by_arity(candidates, call_arity, &ctx.entity_arity_by_id);
+            let candidates = narrow_pairs_by_role(src_id, candidates, &ctx.entity_role_by_id);
+            let candidates = if receiver_is_object {
+                let owner_bound = owner_bound_targets(
+                    dst_lookup,
+                    ctx.import_map.get(file.file_path.as_str()),
+                    |key, bound| {
+                        if let Some(named) = ctx.entity_by_name.get(key) {
+                            bound.extend(named.iter().map(|&(_, id)| id));
+                        }
+                    },
+                );
+                let targets = caller_import_targets.get_or_insert_with(|| {
+                    resolve_caller_import_targets(&file.file_path, &file.imports, &ctx.known_files)
+                });
+                narrow_pairs_by_receiver_reach(candidates, targets, &owner_bound)
+            } else {
+                candidates
+            };
+            let distinct_targets: HashSet<EntityId> =
+                candidates.into_iter().map(|(_, id)| id).collect();
             if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
                 for dst_id in sorted_fanout_targets(distinct_targets) {
                     accumulate_relation(
@@ -2800,6 +2821,63 @@ fn narrow_pairs_by_role<'a>(
         .into_iter()
         .filter(|(_, id)| roles.get(id) != Some(&EntityRole::Test))
         .collect()
+}
+
+/// The receiver-method candidates whose owning type the calling file binds by
+/// name.
+///
+/// A method entity is keyed `Owner.method` or `Owner::method`, so a file's
+/// import bindings name candidate owners directly: for each local name an
+/// import introduces, the two owner-qualified spellings of the call's leaf
+/// select exactly the methods that name's type defines. `named_ids` is the
+/// caller's exact-name index, consulted once per import binding rather than
+/// once per candidate.
+fn owner_bound_targets(
+    leaf: &str,
+    file_imports: Option<&HashMap<&str, (&str, &str)>>,
+    mut named_ids: impl FnMut(&str, &mut HashSet<EntityId>),
+) -> HashSet<EntityId> {
+    let mut bound = HashSet::new();
+    let Some(file_imports) = file_imports else {
+        return bound;
+    };
+    for local_name in file_imports.keys() {
+        for key in receiver_method_keys(local_name, leaf) {
+            named_ids(&key, &mut bound);
+        }
+    }
+    bound
+}
+
+/// Narrow a receiver-method fan-out to the candidates the calling file can
+/// reach.
+///
+/// A call through an object dispatches on the receiver's static type, and a
+/// file that neither binds that type by name nor imports the module defining it
+/// cannot be holding one. Such a candidate is a same-named method of a type
+/// this file never sees, so it is not a dispatch target here however many other
+/// files do reach it.
+///
+/// Narrowing happens only when at least one candidate IS reached. A file whose
+/// imports account for none of them has no type evidence to narrow on, so it
+/// fans out exactly as before rather than losing every candidate to a rule that
+/// could not see any of them.
+fn narrow_pairs_by_receiver_reach<'a>(
+    candidates: Vec<(&'a str, EntityId)>,
+    import_target_files: &HashSet<String>,
+    owner_bound: &HashSet<EntityId>,
+) -> Vec<(&'a str, EntityId)> {
+    let reached: Vec<(&str, EntityId)> = candidates
+        .iter()
+        .copied()
+        .filter(|(file_path, id)| {
+            import_target_files.contains(*file_path) || owner_bound.contains(id)
+        })
+        .collect();
+    if reached.is_empty() {
+        return candidates;
+    }
+    reached
 }
 
 /// Confidence for a call through a receiver the file's own imports bind to a
@@ -4902,7 +4980,7 @@ fn resolve_one_file_incremental(
         if name_fallback_allowed && !unresolvable_name_ambiguity && rel.kind == RelationKind::Calls
         {
             if let Some(bare_candidates) = linker.entity_by_bare_name.get(dst_lookup) {
-                let distinct_targets: HashSet<EntityId> = bare_candidates
+                let candidates: Vec<(&str, EntityId)> = bare_candidates
                     .iter()
                     .filter(|(fp, dst_id)| {
                         fp != &file.file_path
@@ -4912,12 +4990,35 @@ fn resolve_one_file_incremental(
                                 &linker.entity_language_by_id,
                             )
                     })
-                    .map(|(_, id)| *id)
+                    .map(|(fp, id)| (fp.as_str(), *id))
                     .collect();
-                let distinct_targets =
-                    prune_ids_by_arity(distinct_targets, call_arity, &linker.entity_arity_by_id);
-                let distinct_targets =
-                    narrow_candidates_by_role(src_id, distinct_targets, &linker.entity_role_by_id);
+                let candidates =
+                    prune_pairs_by_arity(candidates, call_arity, &linker.entity_arity_by_id);
+                let candidates =
+                    narrow_pairs_by_role(src_id, candidates, &linker.entity_role_by_id);
+                let candidates = if receiver_is_object {
+                    let owner_bound = owner_bound_targets(
+                        dst_lookup,
+                        import_map.get(file.file_path.as_str()),
+                        |key, bound| {
+                            if let Some(named) = linker.entity_by_name.get(key) {
+                                bound.extend(named.iter().map(|(_, id)| *id));
+                            }
+                        },
+                    );
+                    let targets = caller_import_targets.get_or_insert_with(|| {
+                        resolve_caller_import_targets(
+                            &file.file_path,
+                            &file.imports,
+                            &linker.known_files,
+                        )
+                    });
+                    narrow_pairs_by_receiver_reach(candidates, targets, &owner_bound)
+                } else {
+                    candidates
+                };
+                let distinct_targets: HashSet<EntityId> =
+                    candidates.into_iter().map(|(_, id)| id).collect();
                 if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
                     for dst_id in sorted_fanout_targets(distinct_targets) {
                         accumulate_relation(

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -27,7 +27,8 @@ use kin_model::{
     SemanticFingerprint, SourceSpan, Visibility,
 };
 use kin_parser::{
-    CSharpAdapter, ExtractedRelation, JavaAdapter, LanguageAdapter, TypeScriptAdapter,
+    CSharpAdapter, ExtractedRelation, JavaAdapter, JavaScriptAdapter, LanguageAdapter,
+    PythonAdapter, TypeScriptAdapter,
 };
 
 // ---- helpers: direct entity construction (mirrors linker.rs unit-test idiom) ----
@@ -350,5 +351,183 @@ fn simple_name_resolves_but_dotted_receiver_name_does_not() {
         count_calls(&link_cross_file(&dotted)),
         0,
         "a dotted `obj.execute` callee must not resolve — the adapter must narrow it first"
+    );
+}
+
+// ---- (E) same-file receiver-qualified calls ----
+//
+// Every linker tier that matches a BARE method leaf considers cross-file
+// candidates only: the exact-name bucket filters out the calling file, and so
+// does the bare-name receiver tier. Only the same-file exact tier can bind
+// within one file, and it needs the qualified name. So a JavaScript adapter
+// that narrowed `helpers.normalize()` to `normalize` made a sibling call inside
+// one object literal permanently unresolvable, while the SAME call from another
+// file resolved.
+
+/// A call between two methods of the same object literal, in one file, must
+/// produce exactly one edge to the sibling.
+#[test]
+fn javascript_object_literal_sibling_call_resolves_in_one_file() {
+    let files = vec![parse_with(
+        &JavaScriptAdapter,
+        "helpers.js",
+        "const helpers = {\n  normalize(p) { return String(p).trim(); },\n  join(a, b) { return helpers.normalize(a) + '/' + helpers.normalize(b); },\n};\nmodule.exports = helpers;\n",
+    )];
+    let join = entity_id_in(&files, "helpers.js", "helpers.join");
+    let normalize = entity_id_in(&files, "helpers.js", "helpers.normalize");
+
+    let rels = link_cross_file(&files);
+    assert!(
+        has_call(&rels, join, normalize),
+        "`helpers.join` calls `helpers.normalize` in the same file and must link to it"
+    );
+    let sibling_edges = rels
+        .iter()
+        .filter(|r| {
+            r.kind == RelationKind::Calls
+                && r.src == GraphNodeId::Entity(join)
+                && r.dst == GraphNodeId::Entity(normalize)
+        })
+        .count();
+    assert_eq!(
+        sibling_edges, 1,
+        "exactly one edge to the sibling, not one per call site"
+    );
+}
+
+/// The same contract for a `this.` call inside an ES class body, which had the
+/// identical blind spot and no test.
+#[test]
+fn javascript_class_this_call_resolves_in_one_file() {
+    let files = vec![parse_with(
+        &JavaScriptAdapter,
+        "helpers.js",
+        "class Helpers {\n  normalize(p) { return String(p).trim(); }\n  join(a, b) { return this.normalize(a) + this.normalize(b); }\n}\n",
+    )];
+    let join = entity_id_in(&files, "helpers.js", "Helpers.join");
+    let normalize = entity_id_in(&files, "helpers.js", "Helpers.normalize");
+    assert!(
+        has_call(&link_cross_file(&files), join, normalize),
+        "`this.normalize()` inside `Helpers.join` must link to `Helpers.normalize`"
+    );
+}
+
+/// A receiver that is NOT the enclosing owner keeps its bare leaf, so nothing
+/// claims a resolution the syntax does not settle. `this.router.handle(...)` is
+/// a call through a property whose type is unknown; it must not bind to a
+/// same-named method of the enclosing object.
+#[test]
+fn javascript_foreign_receiver_does_not_bind_to_the_enclosing_owner() {
+    let files = vec![parse_with(
+        &JavaScriptAdapter,
+        "application.js",
+        "app.handle = function handle(req, res) {\n  this.router.handle(req, res);\n};\n",
+    )];
+    let handle = entity_id_in(&files, "application.js", "app.handle");
+    let rels = link_cross_file(&files);
+    assert!(
+        !has_call(&rels, handle, handle),
+        "`this.router.handle()` must not be read as `app.handle` calling itself"
+    );
+}
+
+// ---- (F) receiver-method fan-out narrowed by what the calling file can reach ----
+//
+// A call through an object dispatches on the receiver's static type. The
+// bare-name fan-out cannot know that type, so it once linked EVERY same-named
+// method in the repository, minting inbound callers a method provably never
+// had. Narrowing to the candidates the calling file's own imports account for
+// removes those without collapsing a genuine ambiguity to a guess.
+
+fn python_call_fixture(files: &[(&str, &str)]) -> Vec<FileParseData> {
+    files
+        .iter()
+        .map(|(path, src)| parse_with(&PythonAdapter, path, src))
+        .collect()
+}
+
+const ADAPTER_PY: &str = "class Adapter:\n    def send(self, request):\n        return request\n";
+const SESSION_PY: &str = "from .adapter import Adapter\n\n\nclass Session:\n    def __init__(self):\n        self.adapter = Adapter()\n\n    def send(self, request):\n        return self.adapter.send(request)\n";
+
+/// A call through an object must not reach a same-named method whose owning
+/// type the calling file neither binds by name nor imports the module of.
+#[test]
+fn receiver_call_does_not_reach_an_unimportable_owner() {
+    let files = python_call_fixture(&[
+        ("app/adapter.py", ADAPTER_PY),
+        ("app/session.py", SESSION_PY),
+        (
+            "app/pipeline.py",
+            "from .session import Session\n\n\ndef run_all(session):\n    return session.send({})\n",
+        ),
+    ]);
+    let run_all = entity_id_in(&files, "app/pipeline.py", "run_all");
+    let session_send = entity_id_in(&files, "app/session.py", "Session.send");
+    let adapter_send = entity_id_in(&files, "app/adapter.py", "Adapter.send");
+
+    let rels = link_cross_file(&files);
+    assert!(
+        has_call(&rels, run_all, session_send),
+        "`session.send(...)` must still reach `Session.send`, whose type this file imports"
+    );
+    assert!(
+        !has_call(&rels, run_all, adapter_send),
+        "`app/pipeline.py` never names `Adapter`, so `Adapter.send` cannot be this receiver"
+    );
+}
+
+/// A caller whose imports account for none of the candidates has no type
+/// evidence at all, and must keep the whole fan-out rather than lose every
+/// candidate to a rule that could not see any of them.
+#[test]
+fn receiver_call_with_no_import_evidence_still_fans_out() {
+    let files = python_call_fixture(&[
+        (
+            "app/a.py",
+            "class A:\n    def run(self):\n        return 1\n",
+        ),
+        (
+            "app/b.py",
+            "class B:\n    def run(self):\n        return 2\n",
+        ),
+        ("app/c.py", "def go(thing):\n    return thing.run()\n"),
+    ]);
+    let go = entity_id_in(&files, "app/c.py", "go");
+    let a_run = entity_id_in(&files, "app/a.py", "A.run");
+    let b_run = entity_id_in(&files, "app/b.py", "B.run");
+
+    let rels = link_cross_file(&files);
+    assert!(
+        has_call(&rels, go, a_run) && has_call(&rels, go, b_run),
+        "a file naming no candidate owner keeps every dispatch target"
+    );
+}
+
+/// A caller that CAN name both candidate owners is genuinely ambiguous, and the
+/// fan-out must stay ambiguous rather than pick one.
+#[test]
+fn receiver_call_naming_both_owners_keeps_both() {
+    let files = python_call_fixture(&[
+        (
+            "app/a.py",
+            "class A:\n    def run(self):\n        return 1\n",
+        ),
+        (
+            "app/b.py",
+            "class B:\n    def run(self):\n        return 2\n",
+        ),
+        (
+            "app/c.py",
+            "from .a import A\nfrom .b import B\n\n\ndef go(thing):\n    return thing.run()\n",
+        ),
+    ]);
+    let go = entity_id_in(&files, "app/c.py", "go");
+    let a_run = entity_id_in(&files, "app/a.py", "A.run");
+    let b_run = entity_id_in(&files, "app/b.py", "B.run");
+
+    let rels = link_cross_file(&files);
+    assert!(
+        has_call(&rels, go, a_run) && has_call(&rels, go, b_run),
+        "both owners are nameable here, so both stay dispatch candidates"
     );
 }

--- a/crates/kin-index/tests/python_call_resolution.rs
+++ b/crates/kin-index/tests/python_call_resolution.rs
@@ -390,3 +390,48 @@ fn incremental_hierarchy_persists_across_steps() {
         "an inheritance walk must cross incremental step boundaries via recorded hierarchy state"
     );
 }
+
+/// The receiver-reach narrowing is a property of BOTH fan-out tiers, so the
+/// incremental linker must drop the same unreachable candidate the batch linker
+/// does. Without this the live-edit path re-mints the false inbound caller the
+/// moment the calling file is relinked.
+#[test]
+fn incremental_receiver_call_does_not_reach_an_unimportable_owner() {
+    use kin_index::{link_cross_file_incremental, IncrementalLinker};
+
+    let files = vec![
+        parse_py(
+            "app/adapter.py",
+            "class Adapter:\n    def send(self, request):\n        return request\n",
+        ),
+        parse_py(
+            "app/session.py",
+            "from .adapter import Adapter\n\n\nclass Session:\n    def __init__(self):\n        self.adapter = Adapter()\n\n    def send(self, request):\n        return self.adapter.send(request)\n",
+        ),
+        parse_py(
+            "app/pipeline.py",
+            "from .session import Session\n\n\ndef run_all(session):\n    return session.send({})\n",
+        ),
+    ];
+
+    let mut linker = IncrementalLinker::new();
+    for file in &files {
+        linker.add_file(&file.file_path, ArtifactId::new(), &file.entities);
+    }
+    linker.record_class_bases(&files);
+
+    let run_all = entity_id(&files, "app/pipeline.py", "run_all");
+    let session_send = entity_id(&files, "app/session.py", "Session.send");
+    let adapter_send = entity_id(&files, "app/adapter.py", "Adapter.send");
+
+    let relations = link_cross_file_incremental(&files, &linker)
+        .expect("every fixture file has an explicitly assigned artifact identity");
+    assert!(
+        has_call(&relations, run_all, session_send),
+        "`session.send(...)` must still reach `Session.send`, whose type this file imports"
+    );
+    assert!(
+        !has_call(&relations, run_all, adapter_send),
+        "`app/pipeline.py` never names `Adapter`, so `Adapter.send` cannot be this receiver"
+    );
+}

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -204,7 +204,7 @@ fn extract_js_node(
                     span: span_from_node(node, file_id),
                 });
                 // Extract calls within function body
-                extract_calls_from_context(node, source, &name, relations);
+                extract_calls_from_context(node, source, &name, None, relations);
             }
         }
         "class_declaration" => {
@@ -296,7 +296,7 @@ fn extract_js_node(
                 });
                 if let Some(value_node) = value_node.filter(is_js_function_like_node) {
                     let context_name = name_node.utf8_text(source).unwrap_or("");
-                    extract_calls_from_context(&value_node, source, context_name, relations);
+                    extract_calls_from_context(&value_node, source, context_name, None, relations);
                 }
                 // `const utils = { parse() {}, print: () => {} }` is a namespace
                 // object whose function properties are the methods it owns.
@@ -620,7 +620,7 @@ fn extract_js_assignment_target(
                     dst_name: qualified.clone(),
                     import_source: None,
                 });
-                extract_calls_from_context(value, source, &qualified, relations);
+                extract_calls_from_context(value, source, &qualified, Some(owner), relations);
             }
             return;
         }
@@ -639,7 +639,7 @@ fn extract_js_assignment_target(
                     fingerprint: compute_fingerprint(&function_node, source),
                     span: span_from_node(&function_node, file_id),
                 });
-                extract_calls_from_context(&function_node, source, &property_name, relations);
+                extract_calls_from_context(&function_node, source, &property_name, None, relations);
             }
             return;
         }
@@ -673,7 +673,7 @@ fn extract_js_assignment_target(
         fingerprint: compute_fingerprint(stmt, source),
         span: span_from_node(stmt, file_id),
     });
-    extract_calls_from_context(value, source, &name, relations);
+    extract_calls_from_context(value, source, &name, None, relations);
 }
 
 /// The function-valued properties of an object literal, as
@@ -758,7 +758,7 @@ pub(super) fn extract_js_object_methods(
             dst_name: qualified.clone(),
             import_source: None,
         });
-        extract_calls_from_context(&function_node, source, &qualified, relations);
+        extract_calls_from_context(&function_node, source, &qualified, Some(owner), relations);
     }
 }
 
@@ -862,7 +862,7 @@ fn extract_js_class_like(
             import_source: None,
         });
         // Extract calls within method body
-        extract_calls_from_context(&member, source, &qualified, relations);
+        extract_calls_from_context(&member, source, &qualified, Some(name), relations);
     }
 }
 
@@ -920,17 +920,52 @@ fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<
     }
 }
 
+/// Whether a member call's receiver is provably the enclosing owner: `this.m()`
+/// inside one of the owner's own methods, or `Owner.m()` naming the owner's own
+/// binding from inside it.
+///
+/// Both are settled by the syntax rather than guessed, which is what lets the
+/// callee be recorded owner-qualified. Any other receiver is a value that could
+/// hold anything at run time (a parameter, an imported binding, a property chain
+/// such as `this.router.handle`), so it keeps its bare leaf.
+fn js_receiver_is_enclosing_owner(
+    function: &tree_sitter::Node,
+    source: &[u8],
+    owner: &str,
+) -> bool {
+    let Some(object) = function.child_by_field_name("object") else {
+        return false;
+    };
+    match object.kind() {
+        "this" => true,
+        "identifier" => object.utf8_text(source).is_ok_and(|text| text == owner),
+        _ => false,
+    }
+}
+
 /// Extract all function/method calls within a function/method body.
 ///
-/// For a `call_expression`, the `function` field is the callee. We unpack
-/// `member_expression` callees to the rightmost identifier (`a.b()` -> `b`),
-/// so graph edges key on the simple method name rather than the dotted
-/// source text. `new X()` is a `new_expression` (not `call_expression`) and
-/// is intentionally skipped here.
-fn extract_calls_from_context(
+/// For a `call_expression`, the `function` field is the callee. A
+/// `member_expression` callee normally unpacks to the rightmost identifier
+/// (`a.b()` -> `b`), so graph edges key on the simple method name rather than
+/// the dotted source text.
+///
+/// `owner` names the class or receiver object whose method body this is, when
+/// there is one. A call through that same owner is recorded as `Owner.method`,
+/// the same key the adapter gives the method entity itself, which is how a
+/// sibling method in one file becomes reachable: every tier that matches a bare
+/// method leaf considers cross-file candidates only, so only the exact same-file
+/// tier can bind a sibling and it needs the qualified name. Where the qualified
+/// name matches no entity the linker falls back to the bare leaf, so recall
+/// never drops below the unqualified behavior.
+///
+/// `new X()` is a `new_expression` (not `call_expression`) and is intentionally
+/// skipped here.
+pub(super) fn extract_calls_from_context(
     node: &tree_sitter::Node,
     source: &[u8],
     context_name: &str,
+    owner: Option<&str>,
     relations: &mut Vec<ExtractedRelation>,
 ) {
     let mut cursor = node.walk();
@@ -938,14 +973,22 @@ fn extract_calls_from_context(
         if child.kind() == "call_expression" {
             if let Some(function) = child.child_by_field_name("function") {
                 let callee_name = match function.kind() {
-                    "member_expression" => function
-                        .child_by_field_name("property")
-                        .map(|f| f.utf8_text(source).unwrap_or("").to_string())
-                        .unwrap_or_default(),
-                    "identifier" => {
-                        let raw = function.utf8_text(source).unwrap_or("");
-                        raw.strip_prefix("this.").unwrap_or(raw).to_string()
+                    "member_expression" => {
+                        let property = function
+                            .child_by_field_name("property")
+                            .map(|f| f.utf8_text(source).unwrap_or("").to_string())
+                            .unwrap_or_default();
+                        match owner {
+                            Some(owner)
+                                if !property.is_empty()
+                                    && js_receiver_is_enclosing_owner(&function, source, owner) =>
+                            {
+                                format!("{owner}.{property}")
+                            }
+                            _ => property,
+                        }
                     }
+                    "identifier" => function.utf8_text(source).unwrap_or("").to_string(),
                     _ => String::new(),
                 };
                 if is_valid_callee_name(&callee_name) {
@@ -960,7 +1003,7 @@ fn extract_calls_from_context(
                 }
             }
         }
-        extract_calls_from_context(&child, source, context_name, relations);
+        extract_calls_from_context(&child, source, context_name, owner, relations);
     }
 }
 

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -17,8 +17,8 @@ use crate::extract::{
 // nodes in both grammars. Sharing them keeps the two adapters from drifting into
 // different answers for the same source.
 use super::javascript::{
-    collect_js_require_imports, extract_js_assignment_function, extract_js_object_methods,
-    js_heritage_name, js_require_target, JsOwners,
+    collect_js_require_imports, extract_calls_from_context, extract_js_assignment_function,
+    extract_js_object_methods, js_heritage_name, js_require_target, JsOwners,
 };
 
 pub struct TypeScriptAdapter;
@@ -151,7 +151,7 @@ fn extract_ts_node(
                     span: span_from_node(node, file_id),
                 });
                 // Extract calls within function body
-                extract_calls_from_context(node, source, &name, relations);
+                extract_calls_from_context(node, source, &name, None, relations);
             }
         }
         "class_declaration" => {
@@ -313,6 +313,7 @@ fn extract_ts_node(
                                 &value_node,
                                 source,
                                 context_name,
+                                None,
                                 relations,
                             );
                         }
@@ -441,7 +442,7 @@ fn extract_ts_class_member(
                     import_source: None,
                 });
                 // Extract calls within method body
-                extract_calls_from_context(node, source, &qualified, relations);
+                extract_calls_from_context(node, source, &qualified, Some(class_name), relations);
             }
         }
         _ => {}
@@ -683,62 +684,6 @@ fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<
     } else {
         None
     }
-}
-
-/// Extract all function/method calls within a function/method body.
-/// The `context_name` parameter is the name of the containing function or qualified method name.
-/// This identifies cross-file references (unresolved function names from AST).
-///
-/// For a `call_expression`, the `function` field is the callee. We unpack
-/// `member_expression` callees to the rightmost identifier (`a.b()` -> `b`),
-/// so graph edges key on the simple method name rather than the dotted
-/// source text. `new X()` is a `new_expression` (not `call_expression`) and
-/// is intentionally skipped here.
-fn extract_calls_from_context(
-    node: &tree_sitter::Node,
-    source: &[u8],
-    context_name: &str,
-    relations: &mut Vec<ExtractedRelation>,
-) {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "call_expression" {
-            if let Some(function) = child.child_by_field_name("function") {
-                let callee_name = match function.kind() {
-                    "member_expression" => function
-                        .child_by_field_name("property")
-                        .map(|f| f.utf8_text(source).unwrap_or("").to_string())
-                        .unwrap_or_default(),
-                    "identifier" => {
-                        let raw = function.utf8_text(source).unwrap_or("");
-                        raw.strip_prefix("this.").unwrap_or(raw).to_string()
-                    }
-                    _ => String::new(),
-                };
-                if is_valid_callee_name(&callee_name) {
-                    relations.push(ExtractedRelation {
-                        receiver: None,
-                        call_shape: None,
-                        kind: kin_model::RelationKind::Calls,
-                        src_name: context_name.to_string(),
-                        dst_name: callee_name,
-                        import_source: None,
-                    });
-                }
-            }
-        }
-        // Recurse into child nodes
-        extract_calls_from_context(&child, source, context_name, relations);
-    }
-}
-
-/// Check if a callee name is valid (not a literal, not empty).
-fn is_valid_callee_name(name: &str) -> bool {
-    !name.is_empty()
-        && !name.starts_with('"')
-        && !name.starts_with('\'')
-        && !name.starts_with('`')
-        && !name.chars().all(|c| c.is_numeric())
 }
 
 /// Extract import-like file context from import and re-export statements.

--- a/crates/kin-parser/tests/js_ts_call_resolution.rs
+++ b/crates/kin-parser/tests/js_ts_call_resolution.rs
@@ -1,11 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Regression tests for the JS/TS dotted-callee bug.
+//! Regression tests for the JS/TS dotted-callee bug, and for the one dotted
+//! form that is deliberately kept.
 //!
 //! Prior behavior: `a.b()` emitted a `Calls` edge with `dst_name = "a.b"`,
-//! which never matched any entity in the graph. These tests assert the
-//! fixed behavior — `dst_name` is the simple method name ("b").
+//! raw source text that never matched any entity in the graph. `dst_name` is
+//! the simple method name ("b") for every receiver whose type the syntax does
+//! not settle, which is what these tests pin.
+//!
+//! The exception is a call through the method's OWN owner: `this.m()`, or
+//! `Owner.m()` written inside `Owner`. That one is recorded as `Owner.m`,
+//! matching how the Python adapter pins `self.m()` to its class. It is a
+//! resolved receiver rather than raw source text, and it is load-bearing:
+//! every linker tier that matches a bare method leaf considers cross-file
+//! candidates only, so a bare `m` can never reach a same-file `Owner.m`.
 
 use kin_model::{FilePathId, RelationKind};
 use kin_parser::{
@@ -93,32 +102,54 @@ fn js_optional_chain_resolves_to_property_name() {
 }
 
 #[test]
-fn js_this_prefix_stripped_on_identifier_callee() {
-    // `this.sayHi()` is a member_expression (object=this, property=sayHi) and
-    // resolves to `sayHi`. This test also guards the identifier-branch
-    // `strip_prefix("this.")` path in case the grammar surfaces the whole
-    // thing as an identifier.
+fn js_this_call_is_pinned_to_its_own_class() {
+    // `this.sayHi()` inside `Greeter.greet` names a method of `Greeter`, and
+    // the syntax settles that: `this` is the receiver the method was called
+    // on. Recording it as `Greeter.sayHi` is what lets the linker's same-file
+    // tier bind it, since every bare-leaf tier skips the calling file.
     let output = parse_fixture(&JavaScriptAdapter, "javascript", "calls.js");
     let names = dst_names(&output);
     assert!(
-        names.contains(&"sayHi"),
-        "`this.sayHi()` should emit call to `sayHi`, got {:?}",
+        names.contains(&"Greeter.sayHi"),
+        "`this.sayHi()` in `Greeter` should emit call to `Greeter.sayHi`, got {:?}",
+        names
+    );
+    // A receiver-less call in the same body is a free function and stays bare.
+    assert!(
+        names.contains(&"helperCall"),
+        "`helperCall()` should stay a bare name, got {:?}",
         names
     );
 }
 
 #[test]
-fn js_no_dotted_dst_names() {
+fn js_dotted_dst_names_only_ever_name_the_enclosing_owner() {
+    // The bug this file was written for: emitting raw source text like
+    // `a.b` or `console.log` as a callee, which matches no entity. That is
+    // still forbidden. A dotted callee is admissible only when its owner half
+    // is the enclosing owner, which is a resolved receiver rather than text.
     let output = parse_fixture(&JavaScriptAdapter, "javascript", "calls.js");
     let dotted: Vec<&ExtractedRelation> = calls(&output)
         .into_iter()
         .filter(|r| r.dst_name.contains('.'))
         .collect();
-    assert!(
-        dotted.is_empty(),
-        "no Calls edge should have a dotted dst_name; found {:?}",
-        dotted.iter().map(|r| &r.dst_name).collect::<Vec<_>>()
-    );
+    for rel in &dotted {
+        let owner = rel.dst_name.split('.').next().unwrap_or_default();
+        assert_eq!(
+            Some(owner),
+            rel.src_name.split('.').next(),
+            "dotted callee {:?} must be owned by the same entity as its caller {:?}",
+            rel.dst_name,
+            rel.src_name
+        );
+    }
+    let names = dst_names(&output);
+    for bare in ["log", "b", "c", "maybe"] {
+        assert!(
+            names.contains(&bare),
+            "foreign receiver call should stay bare `{bare}`, got {names:?}"
+        );
+    }
 }
 
 // ---- TypeScript ----
@@ -167,26 +198,43 @@ fn ts_optional_chain_resolves_to_property_name() {
 }
 
 #[test]
-fn ts_this_prefix_stripped_on_identifier_callee() {
+fn ts_this_call_is_pinned_to_its_own_class() {
     let output = parse_fixture(&TypeScriptAdapter, "typescript", "calls.ts");
     let names = dst_names(&output);
     assert!(
-        names.contains(&"sayHi"),
-        "`this.sayHi()` should emit call to `sayHi`, got {:?}",
+        names.contains(&"Greeter.sayHi"),
+        "`this.sayHi()` in `Greeter` should emit call to `Greeter.sayHi`, got {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"helperCall"),
+        "`helperCall()` should stay a bare name, got {:?}",
         names
     );
 }
 
 #[test]
-fn ts_no_dotted_dst_names() {
+fn ts_dotted_dst_names_only_ever_name_the_enclosing_owner() {
     let output = parse_fixture(&TypeScriptAdapter, "typescript", "calls.ts");
     let dotted: Vec<&ExtractedRelation> = calls(&output)
         .into_iter()
         .filter(|r| r.dst_name.contains('.'))
         .collect();
-    assert!(
-        dotted.is_empty(),
-        "no Calls edge should have a dotted dst_name; found {:?}",
-        dotted.iter().map(|r| &r.dst_name).collect::<Vec<_>>()
-    );
+    for rel in &dotted {
+        let owner = rel.dst_name.split('.').next().unwrap_or_default();
+        assert_eq!(
+            Some(owner),
+            rel.src_name.split('.').next(),
+            "dotted callee {:?} must be owned by the same entity as its caller {:?}",
+            rel.dst_name,
+            rel.src_name
+        );
+    }
+    let names = dst_names(&output);
+    for bare in ["log", "b", "c", "maybe"] {
+        assert!(
+            names.contains(&bare),
+            "foreign receiver call should stay bare `{bare}`, got {names:?}"
+        );
+    }
 }


### PR DESCRIPTION
A call through a receiver now resolves against the receiver's type rather than
against file identity or caller role, which closes the last two failures in the
release acceptance gate.

The JavaScript and TypeScript adapters record a call through the enclosing owner
as `Owner.method`, matching how the Python adapter already pins `self.m()` to its
class. Only a receiver the syntax settles qualifies: `this.m()` inside one of the
owner's methods, or `Owner.m()` naming the owner's own binding from inside it.
That is what makes a sibling method in one file reachable at all, because every
tier matching a bare method leaf considers cross-file candidates only. Two methods
of one object literal calling each other used to produce no edge, while the
identical call from another file resolved. Any other receiver keeps its bare leaf,
so nothing claims a resolution the source does not settle, and the TypeScript
adapter now shares the JavaScript implementation instead of carrying a copy that
could drift.

The receiver-method fan-out narrows to the candidates the calling file can reach,
in both the batch and incremental linkers. A call through an object dispatches on
the receiver's static type, and a file that neither binds that type through one of
its own imports nor imports the module defining the candidate cannot be holding
one, so a same-named method of such a type is not a dispatch target there. Before
this, a test that only ever called `Session.send` was recorded as a caller of
`Adapter.send`, and so was a production function that only ever called
`Session.send`. Role was the fan-out's only precision rule and it cannot remove a
production candidate.

Recall is protected in both directions and tested. A file whose imports account
for none of the candidates has no type evidence and keeps the whole fan-out. A
file that can name several candidate owners keeps all of them, still marked
name-only, so a genuine ambiguity stays an ambiguity rather than becoming a guess.
Narrowing runs after the arity and role rules so it can never undo them.

Every new test was falsified by breaking the behavior it guards and confirming it
fails, then reverting.

Closes FIR-2383
Closes FIR-2385
