### PR TITLE
Bound every apt install in CI so a stalled mirror fails fast instead of holding the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -893,8 +893,26 @@ jobs:
           if ! command -v rg >/dev/null 2>&1; then
             case "$RUNNER_OS" in
               Linux)
-                sudo apt-get update
-                sudo apt-get install --yes ripgrep
+                # apt is bounded so a stalled mirror fails in minutes; if it
+                # still fails, the pinned release tarball is the second path,
+                # verified by checksum, so one stalled channel cannot hold
+                # the job to its timeout.
+                if ! scripts/ci-apt-install.sh ripgrep; then
+                  echo "apt failed; installing ripgrep from the pinned release tarball" >&2
+                  if [ "$(uname -m)" != "x86_64" ]; then
+                    echo "::error::no pinned ripgrep tarball for $(uname -m)"
+                    exit 1
+                  fi
+                  RG_VERSION=15.2.0
+                  RG_SHA256=33e15bcf1624b25cdd2a55813a47a2f95dbe126268203e76aa6a585d1e7b149c
+                  RG_DIR="ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
+                  tmp="$(mktemp -d)"
+                  curl -fsSL --retry 3 --max-time 120 -o "$tmp/rg.tgz" \
+                    "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_DIR}.tar.gz"
+                  echo "${RG_SHA256}  $tmp/rg.tgz" | sha256sum --check --strict
+                  tar -xzf "$tmp/rg.tgz" -C "$tmp"
+                  sudo install -m 0755 "$tmp/${RG_DIR}/rg" /usr/local/bin/rg
+                fi
                 ;;
               macOS)
                 brew install ripgrep
@@ -1207,8 +1225,7 @@ jobs:
           rustup target add x86_64-unknown-linux-musl
           # ring, oniguruma, sqlite, and tree-sitter compile C against musl, so
           # this needs the same musl-gcc the release legs install.
-          sudo apt-get update
-          sudo apt-get install --yes musl-tools
+          scripts/ci-apt-install.sh musl-tools
           cargo check --locked --target x86_64-unknown-linux-musl \
             -p kin-cli -p kin-daemon
 
@@ -1241,8 +1258,7 @@ jobs:
           # refreshed the index. This is a required context, so an implicit
           # ordering dependency between two steps is a way for a reorder to
           # turn a stale index into a red Check & Test.
-          sudo apt-get update
-          sudo apt-get install --yes gcc-aarch64-linux-gnu
+          scripts/ci-apt-install.sh gcc-aarch64-linux-gnu
           CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc \
           AR_aarch64_unknown_linux_musl=aarch64-linux-gnu-ar \
             cargo check --locked --target aarch64-unknown-linux-musl \

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Bounded apt install for CI runners.
+#
+# A stalled package mirror used to hold a job until the runner's one-hour
+# timeout, and on a merge-group run that timeout ejects the queue entry
+# without marking the pull request. Every apt call here runs under `timeout`
+# with per-fetch network bounds and is retried a fixed number of times, so a
+# mirror stall fails the step in minutes with its own error line instead of
+# consuming the whole job budget.
+set -uo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "usage: $0 <package>..." >&2
+  exit 2
+fi
+
+APT_OPTS=(
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o Acquire::Retries=3
+  -o Dpkg::Use-Pty=0
+)
+UPDATE_BOUND=${CI_APT_UPDATE_BOUND:-120}
+INSTALL_BOUND=${CI_APT_INSTALL_BOUND:-240}
+
+for attempt in 1 2 3; do
+  if timeout "$UPDATE_BOUND" sudo apt-get "${APT_OPTS[@]}" update \
+    && timeout "$INSTALL_BOUND" sudo apt-get "${APT_OPTS[@]}" install --yes "$@"; then
+    exit 0
+  fi
+  echo "apt attempt $attempt of 3 failed for: $*" >&2
+  sleep $((attempt * 10))
+done
+
+echo "::error::apt could not install after 3 bounded attempts: $*" >&2
+exit 1

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -120,6 +120,7 @@ EXPECTED_SELECTOR_INVOCATIONS = {
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 SETUP = ROOT / "crates" / "kin-cli" / "src" / "commands" / "setup.rs"
 DOCKERFILE = ROOT / "Dockerfile"
+CI_APT_INSTALL = ROOT / "scripts" / "ci-apt-install.sh"
 BASE_IMAGE_REGISTRY = "docker.io"
 BASE_IMAGE_MIRROR = 'mirrors = ["mirror.gcr.io"]'
 BASE_IMAGE_MIRROR_INPUT = "buildkitd-config-inline:"
@@ -9499,12 +9500,34 @@ def main() -> None:
 
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     # P3-4's content landed without a guard, so a deliberate deletion of the
-    # index refresh was invisible to the suite.
+    # index refresh was invisible to the suite. The refresh now lives in the
+    # bounded apt helper every apt site in the check job calls, so the guard
+    # follows it there: the aarch64 leg must call the helper for its cross
+    # toolchain, and the helper must still refresh the index before installing,
+    # under a timeout, or a stalled mirror holds the job to its one-hour bound
+    # and the merge queue ejects the entry without marking the pull request.
     require(
         ci_jobs["check"],
-        "sudo apt-get update",
-        "aarch64 release-target compile guard apt index refresh",
+        "scripts/ci-apt-install.sh gcc-aarch64-linux-gnu",
+        "aarch64 release-target compile guard apt install",
     )
+    ci_apt_install = CI_APT_INSTALL.read_text(encoding="utf-8")
+    for policy in (
+        'timeout "$UPDATE_BOUND" sudo apt-get "${APT_OPTS[@]}" update',
+        'timeout "$INSTALL_BOUND" sudo apt-get "${APT_OPTS[@]}" install --yes "$@"',
+        "-o Acquire::http::Timeout=30",
+        "-o Acquire::Retries=3",
+    ):
+        require(
+            ci_apt_install,
+            policy,
+            "bounded apt helper index refresh and install",
+        )
+    if "sudo apt-get" in ci_jobs["check"]:
+        raise AssertionError(
+            "the check job must reach apt only through scripts/ci-apt-install.sh, "
+            "so every apt call stays bounded"
+        )
 
     base_image_pins = BASE_IMAGE_PINS.read_text(encoding="utf-8")
     assert_pin_prover_cannot_refuse_a_release(base_image_pins)


### PR DESCRIPTION
A merge-group run of the ubuntu Check & Test job (run 32087672141, PR 870's group) sat for the full hour in "Install runtime guard tools" while `apt-get update` waited on a stalled Azure mirror, hit the one-hour job timeout, and the merge queue removed the entry without marking the pull request. Nothing in the PR itself was wrong; the queue slot and an hour of CI were lost to a package mirror.

The three apt sites in ci.yml (ripgrep, musl-tools, gcc-aarch64-linux-gnu) now go through `scripts/ci-apt-install.sh`, which runs update and install under `timeout` with per-fetch network bounds (`Acquire::http::Timeout=30`, `Acquire::Retries=3`) and three attempts, so a stalled mirror fails the step in minutes with its own error line instead of consuming the whole job budget. The ripgrep site also carries a second path: the pinned 15.2.0 release tarball, verified by sha256 against the checksum ripgrep publishes, installed only when apt fails, so one stalled channel cannot take the job with it. Package sets are unchanged (same packages, same recommends).

Falsified locally in both directions: with a fake `apt-get` that hangs, the helper made three bounded attempts and exited 1 in 63 seconds; with a fake `apt-get` that succeeds, it exited 0. `actionlint` and `shellcheck` are clean.

Not claiming: this does not change any test, gate, or release workflow; `release.yml` carries one apt call of its own and is out of scope here.