### PR TITLE
Assert the daemon clock tests on their own stamps instead of adjacent clock reads

### DIFF
--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -6156,10 +6156,48 @@ mod tests {
         let repo_dir = tempfile::tempdir().unwrap();
         let init = kin_core::init(repo_dir.path()).unwrap();
         let state = test_state(init.layout, repo_dir.path());
+        let seeded = *state
+            .last_mutation
+            .lock()
+            .expect("a fresh daemon state has an unpoisoned mutation clock");
+        let epoch_before = state.mutation_epoch.load(Ordering::SeqCst);
+
         std::thread::sleep(Duration::from_millis(25));
-        assert!(state.time_since_mutation() >= Duration::from_millis(20));
+        let before = state.time_since_mutation();
+        assert!(
+            before >= Duration::from_millis(20),
+            "the mutation clock must count from construction until the first mark_dirty, got {before:?}"
+        );
+
+        let t0 = Instant::now();
         state.mark_dirty();
-        assert!(state.time_since_mutation() < Duration::from_millis(20));
+        let t1 = Instant::now();
+
+        let advanced = *state
+            .last_mutation
+            .lock()
+            .expect("a fresh daemon state has an unpoisoned mutation clock");
+        assert!(
+            advanced > seeded,
+            "mark_dirty must advance the mutation clock: seeded={seeded:?} advanced={advanced:?}"
+        );
+        assert!(
+            advanced >= t0 && advanced <= t1,
+            "mark_dirty must restart the quiescence window from the moment of the call, not from an older instant: the call spanned {:?}",
+            t1 - t0
+        );
+        assert_eq!(
+            state.mutation_epoch.load(Ordering::SeqCst),
+            epoch_before + 1,
+            "mark_dirty must record exactly one mutation"
+        );
+
+        let since = state.time_since_mutation();
+        let stamp_age = advanced.elapsed();
+        assert!(
+            since <= stamp_age,
+            "time_since_mutation must be measured from the advanced stamp, not an earlier clock: since={since:?} stamp_age={stamp_age:?}"
+        );
     }
 
     #[test]
@@ -8069,6 +8107,11 @@ mod tests {
         // `last_activity_ms` is seeded to 0, so before any activity the idle
         // clock counts from `started_at`. Let real time pass, then confirm the
         // idle duration has grown.
+        assert_eq!(
+            state.last_activity_ms.load(Ordering::SeqCst),
+            0,
+            "the activity marker must start unset so the idle clock counts from startup"
+        );
         tokio::time::sleep(Duration::from_millis(30)).await;
         let before = state.idle_duration();
         assert!(
@@ -8077,13 +8120,17 @@ mod tests {
         );
 
         // The idle monitor calls touch_activity() when it starts so the idle
-        // window begins from readiness, not process construction. Confirm the
-        // clock resets back toward zero.
+        // window begins from readiness, not process construction.
         state.touch_activity();
+        let credited_ms = state.last_activity_ms.load(Ordering::SeqCst);
+        assert!(
+            credited_ms >= 20,
+            "touch_activity must stamp the marker with the uptime it observed, got {credited_ms}ms"
+        );
         let after = state.idle_duration();
         assert!(
-            after < before,
-            "touch_activity must reset the idle clock: before={before:?} after={after:?}"
+            after + Duration::from_millis(credited_ms) <= state.started_at.elapsed(),
+            "idle_duration must count from the activity marker, not from startup: after={after:?} credited={credited_ms}ms"
         );
     }
 


### PR DESCRIPTION
Unit 2 of the FIR-2382 flake plan: the two `crates/kin-daemon/src/state.rs` tests, `touch_activity_resets_idle_clock` and `mark_dirty_advances_the_mutation_clock`, now assert ordering facts about the stamps the state owns instead of racing the wall clock. This is test-only. No production code changes.

## What changed and why

`touch_activity_resets_idle_clock` asserted `after < before` across two adjacent `idle_duration()` reads. `touch_activity` stores `floor_ms(started_at.elapsed())` and `idle_duration` returns `floor_ms(started_at.elapsed()) - credited`, so `after` was never the idle window, only the gap between the touch's clock read and the next one, and the assertion flipped whenever the test thread lost roughly 30ms between two statements. The test now asserts that the activity marker starts unset and keeps the 30ms sleep and the `before >= 20ms` floor verbatim. After the touch it asserts `credited_ms >= 20`, which is one atomic load of the value the code stored with no second clock read to race, and `after + credited <= started_at.elapsed()`, which collapses to `floor_ms(E(t2)) <= E(t3)` with `t3 >= t2` and only grows more true under preemption. The addition form is deliberate: `Duration` subtraction panics on underflow, and a panic from the assertion's own arithmetic would be indistinguishable from the failure it reports.

`mark_dirty_advances_the_mutation_clock` asserted `time_since_mutation() < 20ms` after `mark_dirty()`, an upper bound claiming a 20ms budget had not been consumed with nothing synchronising the store and the read. The rewritten test reads the seeded stamp and epoch first and keeps a `before >= 20ms` floor. It then brackets `mark_dirty()` between two `Instant::now()` samples. The four assertions that follow require the stamp to have advanced past the seeded value and to lie inside that bracket, the epoch to have moved by exactly one, and `time_since_mutation` to be measured from the advanced stamp. The bracket is required rather than cosmetic. `advanced > seeded` alone passes a `mark_dirty` written as `*last = *last + Duration::from_nanos(1)`, which never restarts the quiescence window, and `git grep time_since_mutation` shows this test is the only coverage of that reset in the workspace. The bracket also fails a `mark_dirty` that stamps 15ms in the past, which the old test passed, so this lands as a coverage gain rather than a relaxed assertion.

## Falsification

Every break was applied to the committed fix, run through the lane, and reverted. Each one turned its test red with the message the plan calls for.

For `touch_activity_resets_idle_clock`, a `touch_activity` that stores 0 fails at "touch_activity must stamp the marker with the uptime it observed, got 0ms". Dropping `.saturating_sub(last_ms)` from `idle_duration` fails at "idle_duration must count from the activity marker, not from startup: after=79ms credited=79ms". Under that break `credited_ms >= 20` stays green, so the algebraic assertion is the one doing the work, and it has a reachable false branch. Seeding `last_activity_ms` to 7 in the constructor fails at the opening `assert_eq!` (left 7, right 0).

For `mark_dirty_advances_the_mutation_clock`, deleting the store fails at "mark_dirty must advance the mutation clock" with `advanced == seeded`. Pointing `time_since_mutation` at `last_save`, and then at `started_at.elapsed()`, fails both times at "time_since_mutation must be measured from the advanced stamp, not an earlier clock" (since 68ms and 78ms against a stamp age of microseconds). Changing the store to `*last = *last + Duration::from_nanos(1)` fails at "mark_dirty must restart the quiescence window from the moment of the call, not from an older instant: the call spanned 500ns" while `advanced > seeded` passes it. That last break is the one that separates this test from the original proposal.

The plan's sleep-cut vacuity checks cannot redden on this box, because construction alone exceeds the floor: cutting either sleep to 0ms left its test green. Measured with a temporary print that was not committed, `started_at.elapsed()` at the top of `touch_activity_resets_idle_clock` read 43.1ms, 43.4ms and 42.6ms across three runs before the sleep, and `time_since_mutation()` at the top of `mark_dirty_advances_the_mutation_clock` read 43 to 48ms, since `open_with_repo_id` keeps working after `started_at` and `last_mutation` are stamped in the struct literal. Both floors are still falsifiable, shown by substitute breaks. Swapping the operands in `idle_duration` fails only the first `touch_activity` assertion ("idle clock should count from startup until first activity, got 0ns"). A `time_since_mutation` that returns its own `Duration::ZERO` fallback fails only the `mark_dirty` floor ("the mutation clock must count from construction until the first mark_dirty, got 0ns"). Both floors are lower bounds on real elapsed time that only grow more true as the machine slows. The sleeps stay verbatim, because on a runner whose construction tail is under 20ms they are what guarantees the floor.

## Two things a reader should know

Do not reach for `#[tokio::test(start_paused = true)]` on `touch_activity_resets_idle_clock`. Tokio's paused clock virtualises `tokio::time::Instant` only, while `started_at` is a `std::time::Instant` that `idle_duration` reads directly, so auto-advance would satisfy the sleep instantly while the product saw roughly zero elapsed time and `before >= Duration::from_millis(20)` would fail deterministically. The fix keeps a real-time sleep and the hazard stays.

The ticket's claim that the `mark_dirty` gap "routinely reaches tens of milliseconds on a shared 3-core runner" was an assertion rather than a measurement. The plan's verifier tried to provoke one and recorded the attempt: 116 million samples at load average 16.5 produced a worst gap of 899.875 microseconds and zero gaps over 20ms, and 434,954 samples under 96 spinner threads with an explicit `yield_now()` produced a worst gap of 1.930875ms and still zero over 20ms. The shape verdict stands, since an unsynchronised upper bound on wall clock can be broken by a single 20ms scheduling event, but no one has measured it happening.

## Scope

Gate: `cargo fmt --all -- --check` clean, clippy under `RUSTFLAGS=-D warnings` with the CI allowlist clean, and `kin-dev local-test kin` through the lane worktree green. This PR covers Unit 2 only. The other units landed as #886 and #887, and the two refuted `session_registry.rs` tests are untouched by design.

Refs FIR-2382
