### PR TITLE
Scope the admission progress ladder to the thread that installs it

### DIFF
--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -3270,6 +3270,32 @@ mod tests {
         assert!(!staging_root.exists());
     }
 
+    /// The bootstrap commit reports each of its steps into the admission
+    /// phase open on the committing thread, and an exact retry reports none.
+    #[test]
+    fn a_bootstrap_commit_reports_each_step_into_the_open_admission_phase() {
+        let directory = tempfile::tempdir().unwrap();
+        let (mut prepared, transaction) = prepare_unborn(directory.path(), "progress");
+        let mut progress = crate::init_progress::PhaseProgress::new(1);
+        progress.begin("commit bootstrap transaction");
+
+        prepared
+            .commit_repository_bootstrap(transaction.clone())
+            .unwrap();
+        assert_eq!(
+            progress.detail_updates(),
+            4,
+            "validating, committing, binding and summarizing must each advance the phase line"
+        );
+
+        prepared.commit_repository_bootstrap(transaction).unwrap();
+        assert_eq!(
+            progress.detail_updates(),
+            4,
+            "an exact retry returns the existing bootstrap without reporting new work"
+        );
+    }
+
     #[test]
     fn bootstrap_allows_only_exact_operation_retry() {
         let directory = tempfile::tempdir().unwrap();

--- a/crates/kin-core/src/init_progress.rs
+++ b/crates/kin-core/src/init_progress.rs
@@ -14,6 +14,7 @@
 //! its elapsed time; off a terminal each phase prints a start line and an end
 //! line, and in-phase detail is throttled so a pipe is not flooded.
 
+use std::cell::RefCell;
 use std::fmt::Arguments;
 use std::io::{IsTerminal, Write};
 use std::sync::{Arc, Mutex};
@@ -28,40 +29,53 @@ pub(crate) const GIT_ADMISSION_PHASES: usize = 17;
 /// terminal, so a redirected log never receives escape bytes.
 const ERASE_LINE: &str = "\x1b[2K\r";
 
-/// The ladder a long phase's own instrumentation should report into.
-///
-/// A phase that spends minutes inside one call into another crate cannot tick
-/// this ladder itself, because the call takes no progress handle and the crate
-/// below has no way to reach one. What it does have is `tracing`, and the
-/// admission commands already raise the emitting targets to `info` so the work
-/// says something while it runs. Before this, that something was a raw log
-/// record written straight over the redrawn phase line, complete with ANSI and
-/// the internal span path it was emitted under.
-///
-/// So the ladder registers itself here for its lifetime and a subscriber layer
-/// hands those events to [`report_admission_progress`] instead of formatting
-/// them. The phase line advances, and nothing internal reaches the user.
-static ACTIVE_LADDER: Mutex<Option<Arc<Mutex<Ladder>>>> = Mutex::new(None);
+thread_local! {
+    /// The ladder a long phase's own instrumentation should report into.
+    ///
+    /// A phase that spends minutes inside one call into another crate cannot tick
+    /// this ladder itself, because the call takes no progress handle and the crate
+    /// below has no way to reach one. What it does have is `tracing`, and the
+    /// admission commands already raise the emitting targets to `info` so the work
+    /// says something while it runs. Before this, that something was a raw log
+    /// record written straight over the redrawn phase line, complete with ANSI and
+    /// the internal span path it was emitted under.
+    ///
+    /// So the ladder registers itself here for its lifetime and a subscriber layer
+    /// hands those events to [`report_admission_progress`] instead of formatting
+    /// them. The phase line advances, and nothing internal reaches the user.
+    ///
+    /// The slot belongs to the thread that installs the ladder. An admission is
+    /// created, driven and dropped on one thread, and every report into it,
+    /// whether a direct call from the commit or a `tracing` event a subscriber
+    /// layer forwards, is made from that thread's own call stack.
+    static ACTIVE_LADDER: RefCell<Option<Arc<Mutex<Ladder>>>> = const { RefCell::new(None) };
+}
 
-/// Report progress within whatever admission phase is currently open.
+/// Report progress within whatever admission phase is currently open on the
+/// calling thread.
 ///
 /// Returns whether a ladder was live to take it, so a caller with no ladder to
-/// report into can print the line itself rather than dropping it.
+/// report into can print the line itself rather than dropping it. A thread
+/// that has installed no ladder is declined, whatever other threads hold.
 ///
 /// Never blocks on the ladder's own writes: the lock is held only for the
-/// redraw, and the emitting thread is by construction not the one inside a
-/// [`PhaseProgress`] method, because none of them log.
+/// redraw, and none of the [`PhaseProgress`] methods log.
 pub fn report_admission_progress(detail: &str) -> bool {
-    let Ok(active) = ACTIVE_LADDER.lock() else {
-        return false;
-    };
-    let Some(ladder) = active.as_ref() else {
+    let Some(ladder) = installed_ladder() else {
         return false;
     };
     let Ok(mut ladder) = ladder.lock() else {
         return false;
     };
     ladder.detail(format_args!("{detail}"))
+}
+
+/// The ladder the calling thread has installed, if any.
+fn installed_ladder() -> Option<Arc<Mutex<Ladder>>> {
+    ACTIVE_LADDER
+        .try_with(|active| active.try_borrow().ok().and_then(|active| active.clone()))
+        .ok()
+        .flatten()
 }
 
 /// Stderr phase reporter for a fixed-length phase ladder.
@@ -85,10 +99,10 @@ struct Ladder {
 impl PhaseProgress {
     /// Start a reporter for a ladder of `total` phases.
     ///
-    /// Installs it as the process's live admission ladder. Nested admissions do
-    /// not happen, and if one ever did the inner ladder would take the slot and
-    /// hand it back on drop, which is the same discipline a single ladder
-    /// already keeps.
+    /// Installs it as the calling thread's live admission ladder. Nested
+    /// admissions do not happen, and if one ever did the inner ladder would
+    /// take the slot and hand it back on drop, which is the same discipline a
+    /// single ladder already keeps.
     pub(crate) fn new(total: usize) -> Self {
         let ladder = Arc::new(Mutex::new(Ladder {
             total,
@@ -100,9 +114,11 @@ impl PhaseProgress {
             started: Instant::now(),
             in_phase: false,
         }));
-        if let Ok(mut active) = ACTIVE_LADDER.lock() {
-            *active = Some(Arc::clone(&ladder));
-        }
+        let _ = ACTIVE_LADDER.try_with(|active| {
+            if let Ok(mut active) = active.try_borrow_mut() {
+                *active = Some(Arc::clone(&ladder));
+            }
+        });
         Self { ladder }
     }
 
@@ -148,24 +164,26 @@ impl PhaseProgress {
     }
 
     #[cfg(test)]
-    fn detail_updates(&self) -> usize {
+    pub(crate) fn detail_updates(&self) -> usize {
         self.ladder.lock().expect("ladder lock").detail_updates
     }
 }
 
 impl Drop for PhaseProgress {
-    /// Release the process ladder slot, and terminate a line a phase abandoned
+    /// Release the thread's ladder slot, and terminate a line a phase abandoned
     /// by an early return left half-drawn, so an error message is never
     /// appended to it.
     fn drop(&mut self) {
-        if let Ok(mut active) = ACTIVE_LADDER.lock() {
-            let ours = active
-                .as_ref()
-                .is_some_and(|installed| Arc::ptr_eq(installed, &self.ladder));
-            if ours {
-                *active = None;
+        let _ = ACTIVE_LADDER.try_with(|active| {
+            if let Ok(mut active) = active.try_borrow_mut() {
+                let ours = active
+                    .as_ref()
+                    .is_some_and(|installed| Arc::ptr_eq(installed, &self.ladder));
+                if ours {
+                    *active = None;
+                }
             }
-        }
+        });
         self.with(|ladder| {
             if ladder.in_phase {
                 ladder.in_phase = false;
@@ -279,7 +297,6 @@ mod tests {
 
     #[test]
     fn a_phase_ladder_numbers_every_phase_it_enters() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         assert_eq!(progress.index(), 0);
         progress.begin("first");
@@ -293,7 +310,6 @@ mod tests {
 
     #[test]
     fn beginning_a_phase_closes_the_previous_one() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.begin("first");
         progress.begin("second");
@@ -303,7 +319,6 @@ mod tests {
 
     #[test]
     fn detail_outside_a_phase_is_ignored() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.detail(format_args!("1/2"));
         assert_eq!(progress.detail_updates(), 0);
@@ -315,7 +330,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "phase ladder completed 1 of 3 declared phases")]
     fn finishing_short_of_the_declared_total_is_a_drift_bug() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.begin("first");
         progress.finish("done");
@@ -323,7 +337,6 @@ mod tests {
 
     #[test]
     fn finishing_on_the_declared_total_is_accepted() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(2);
         progress.begin("first");
         progress.begin("second");
@@ -333,14 +346,8 @@ mod tests {
 
     /// The sink advances the open phase, declines when none is open, and stops
     /// reaching a ladder that has been dropped.
-    ///
-    /// Serialized with the other ladder-installing tests through one mutex,
-    /// because the sink is process-global by construction: the events it
-    /// carries are emitted from inside a call that has no handle to pass.
     #[test]
     fn the_progress_sink_reaches_the_open_phase_and_nothing_else() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
-
         assert!(
             !crate::report_admission_progress("before any ladder"),
             "with no ladder installed there is no phase to advance"
@@ -370,16 +377,32 @@ mod tests {
         );
     }
 
-    /// One mutex for every test that installs a ladder, since they share the
-    /// process slot.
-    fn ladder_slot() -> &'static Mutex<()> {
-        static SLOT: Mutex<()> = Mutex::new(());
-        &SLOT
+    /// A report made on a thread that installed no ladder is declined and
+    /// leaves the ladder open on another thread untouched.
+    #[test]
+    fn a_report_from_another_thread_does_not_reach_this_threads_ladder() {
+        let mut progress = PhaseProgress::new(2);
+        progress.begin("commit bootstrap transaction");
+        let foreign = std::thread::spawn(|| crate::report_admission_progress("foreign init step"))
+            .join()
+            .expect("the foreign reporter must not panic");
+        assert!(
+            !foreign,
+            "a thread with no ladder of its own must be declined, not routed into another thread's ladder"
+        );
+        assert!(
+            crate::report_admission_progress("own init step"),
+            "the installing thread's own report still takes the line"
+        );
+        assert_eq!(
+            progress.detail_updates(),
+            1,
+            "only the installing thread's report may advance the phase line"
+        );
     }
 
     #[test]
     fn each_phase_restarts_its_detail_throttle() {
-        let _serial = ladder_slot().lock().unwrap_or_else(|e| e.into_inner());
         let mut progress = PhaseProgress::new(3);
         progress.begin("first");
         progress.detail(format_args!("1/2"));


### PR DESCRIPTION
Plain `cargo test -p kin-core --lib` on `origin/main` at 46635f8a failed 15 of 20 runs on this machine. Fourteen of those runs failed `init_progress::tests::the_progress_sink_reaches_the_open_phase_and_nothing_else` at `init_progress.rs:360` with `left: 2`, `3` or `4` against `right: 1`, and two failed `init_progress::tests::each_phase_restarts_its_detail_throttle` at lines 387 and 389 (`left: 4, right: 2` and `left: 1, right: 0`). Both are one mechanism.

## Mechanism

`report_admission_progress` wrote into a process-wide slot. The tests that install a ladder serialized themselves through one mutex, but nothing serialized the writers. `crates/kin-core/src/init.rs` reaches the sink from `commit_repository_bootstrap` and `commit_bootstrap_transaction` (the validating, committing, binding and summarizing steps at `:335`, `:1449`, `:1464` and `:1484`), and dozens of kin-core tests run those paths concurrently, so whichever ladder another test had installed took their reports and a test read four details where it had written one. nextest gives every test its own process, so CI and `bin/kin-dev local-test` never shared a slot and never saw it.

## Fix

The slot is now a thread local (`thread_local!` holding `RefCell<Option<Arc<Mutex<Ladder>>>>`), which is the scope an admission actually has: `PhaseProgress::new` installs on the calling thread, the phases are driven on that thread, and every report into it, whether a direct call from the bootstrap commit or a `tracing` event the CLI's `AdmissionProgressLayer` forwards, is made from that thread's own call stack. A report from a thread that has installed no ladder is declined, which is the answer a report with no ladder open already got, and the CLI prints such a line plainly. The ladder tests no longer need a serializing mutex, and it is removed. Under a test binary, where unrelated tests share one process, this is what makes the ladder not process-global.

## How I know a real `kin init` behaves the same

I read the callers rather than assuming. `commands::init::run` and `commands::clone::run` call `kin_core::init_from_git` synchronously inside the tokio `block_on` on the main thread. `init_from_git_with_hooks` (`git_init.rs:197`) creates the ladder on that thread and drives every phase there. The four `report_admission_progress` sites in `init.rs` run on that same call stack. The only `tracing` target the CLI routes onto the phase line, `kin_db::storage::history_replay`, is emitted by `ReplayProgress::new` and `ReplayProgress::record` inside kin-db 0.7.31's synchronous replay on the calling thread (`history_replay.rs:301` and `:339`, `repository.rs:2575` and `:2648`), so `AdmissionProgressLayer::on_event` calls `report_admission_progress` on the ladder's thread. Nothing in kin-core, kin-cli or kin-db 0.7.31 reports from a thread other than the one the admission created the ladder on, and no sibling repository calls the sink at all.

The new test `init::tests::a_bootstrap_commit_reports_each_step_into_the_open_admission_phase` pins the four `init.rs` sites: a real bootstrap commit advances a ladder open on the committing thread exactly four times, and an exact retry adds none. Under the process-wide slot that same test failed 5 of 5 runs (`left: 9`, `9`, `9`, `10` and `14` against `right: 4`) because other tests' commits landed in its ladder, which is the defect seen from the writer's side.

## Reproduction and falsification

Reproduction on `origin/main` 46635f8a: 20 runs of `cargo test -p kin-core --lib` through `bin/kin-lane run`, one log per run, exit statuses read raw. 15 failed (runs 1 to 4, 6, 8 to 12, 14 and 17 to 20) and 5 passed. The literal failure is `thread 'init_progress::tests::the_progress_sink_reaches_the_open_phase_and_nothing_else' panicked at crates/kin-core/src/init_progress.rs:360:13: assertion left == right failed: the sink must advance the same counter the phase's own detail does, left: 4, right: 1`.

The committed deterministic reproduction is `init_progress::tests::a_report_from_another_thread_does_not_reach_this_threads_ladder`: install a ladder, begin a phase, report from a spawned thread, then assert the report was declined and the phase counter reads one. With the fix reverted (main's mechanism plus the new tests) it failed 5 of 5 runs by exact name with `a thread with no ladder of its own must be declined, not routed into another thread's ladder`, and five full-lib runs of that variant failed 5 of 5 (the init.rs test 5 of 5, the sink test 2 of 5). With the fix reapplied it passed 5 of 5 by exact name.

With the fix, 20 runs of `cargo test -p kin-core --lib` had no ladder or init test fail. One run (15 of 20) failed an unrelated test, `git_init::tests::exact_remote_configuration_is_sealed_in_local_kin_config` at `git_init.rs:1061`, with `RepositoryPublishedButUncertain ... Git source proof changed across repository publication`, which is the post-publication source reproof seeing the source change under it inside `init_from_git`. That path touches nothing this change touches, it did not appear in the 20 runs on main, and it is filed as FIR-2388 rather than folded in here.

## Gates

`cargo nextest run -p kin-core` through the lane: 577 tests run, 577 passed. `cargo fmt -- --check`: clean. `cargo clippy --all-targets --all-features` with `RUSTFLAGS=-D warnings` and the ci.yml allow list: clean. `bin/kin-dev local-test kin` through the lane on the worktree at 46635f8a: 5950 tests run, 5950 passed, 11 skipped, doctests passed, no tracked lock contamination. A further plain `cargo test -p kin-core` after the gate: 576 lib tests passed and the integration test passed. `Cargo.lock` and `.cargo/` are unchanged against `origin/main`.

Closes FIR-2386
