### PR TITLE
Count entity body previews as the graph bodies of parsed source paths in locate

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1570,8 +1570,7 @@ impl SemanticCoverage {
             self.complete = false;
             let gap_note = format!(
                 "graph body gap: {} of {} graph-owned source paths carry no body, so entity \
-                 ranking over them falls back to text matching. Run `kin reconcile` (or re-run \
-                 `kin init`) to admit the missing bodies.",
+                 ranking over them falls back to text matching; graph_bodies.sample names them.",
                 bodies.gap_paths, bodies.source_paths
             );
             self.note = Some(match self.note.take() {
@@ -1785,6 +1784,44 @@ fn graph_source_path_set(graph: &kin_db::InMemoryGraph) -> HashSet<String> {
         }
     }
     source_paths
+}
+
+/// Bodies the graph holds for entity-bearing source paths without an opaque
+/// preview: the body preview the parser attaches to every entity at admission,
+/// which the text index and the embedder already read.
+fn merge_graph_entity_bodies(
+    graph: &kin_db::InMemoryGraph,
+    source_paths: &HashSet<String>,
+    previews: &mut HashMap<String, String>,
+) {
+    let Ok(entities) = graph.query_entities(&EntityFilter::default()) else {
+        return;
+    };
+    let mut bodies: HashMap<String, String> = HashMap::new();
+    for entity in entities {
+        let Some(path) = entity.file_origin.as_ref().map(|origin| origin.0.as_str()) else {
+            continue;
+        };
+        if previews.contains_key(path) || !source_paths.contains(path) || is_test_path(path) {
+            continue;
+        }
+        let Some(body) = entity
+            .metadata
+            .extra
+            .get(kin_parser::extract::EMBEDDING_BODY_PREVIEW_KEY)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|body| !body.is_empty())
+        else {
+            continue;
+        };
+        let text = bodies.entry(path.to_string()).or_default();
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str(body);
+    }
+    previews.extend(bodies);
 }
 
 // ---------------------------------------------------------------------------
@@ -2470,7 +2507,9 @@ fn run_with_graph_capture_budgeted(
                              rank on text fallback only",
                             bodies.gap_paths, bodies.source_paths
                         ),
-                        remediation: "run `kin reconcile` to admit the missing source bodies"
+                        remediation: "graph_bodies.sample names the paths; a change the daemon \
+                                      admits to one re-derives its entities with bodies, while a \
+                                      binary or empty source-like file has no text to admit"
                             .to_string(),
                     },
                 );
@@ -9658,7 +9697,7 @@ fn extract_source_text_signals(
         });
     }
 
-    let source_previews: HashMap<String, String> = graph
+    let mut source_previews: HashMap<String, String> = graph
         .list_opaque_artifacts()
         .unwrap_or_default()
         .into_iter()
@@ -9671,17 +9710,19 @@ fn extract_source_text_signals(
             Some((path, preview))
         })
         .collect();
+    let full_source_paths: HashSet<String> = source_previews
+        .iter()
+        .filter(|(_, preview)| preview.len() > 1024)
+        .map(|(path, _)| path.clone())
+        .collect();
+    merge_graph_entity_bodies(graph, &source_paths, &mut source_previews);
     let preview_source_texts: HashMap<String, String> = source_previews
         .iter()
         .map(|(path, preview)| (path.clone(), preview.to_ascii_lowercase()))
         .collect();
     let full_source_texts: HashMap<String, String> = preview_source_texts
         .iter()
-        .filter(|(path, _)| {
-            source_previews
-                .get(*path)
-                .is_some_and(|preview| preview.len() > 1024)
-        })
+        .filter(|(path, _)| full_source_paths.contains(*path))
         .map(|(path, preview)| (path.clone(), preview.clone()))
         .collect();
 
@@ -25836,6 +25877,80 @@ mod tests {
         assert_eq!(healed.gap_paths, 0);
         assert_eq!(healed.with_body, 2);
         assert!(healed.sample.is_empty());
+    }
+
+    /// The shape every admitted store has at HEAD: parsed source paths carry
+    /// entities whose bodies live in `embedding_body_preview`, and no opaque
+    /// artifact at all. Those bodies are graph-owned and must count as such and
+    /// feed the term scan; a path whose entities carry no body stays a gap.
+    #[test]
+    fn entity_body_previews_are_the_graph_bodies_of_parsed_source_paths() {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut hello = test_entity("hello", "probe.py", 1, 2);
+        hello.metadata.extra.insert(
+            "embedding_body_preview".to_string(),
+            serde_json::Value::String("def hello(): return greet_target()".to_string()),
+        );
+        graph.upsert_entity(&hello).unwrap();
+        graph
+            .upsert_entity(&test_entity("bare", "src/bare.py", 1, 2))
+            .unwrap();
+        graph.flush_text_index().unwrap();
+
+        let signals = extract_source_text_signals("where is greet_target called", &graph).unwrap();
+        let bodies = signals.graph_bodies.expect("observed");
+        assert_eq!(bodies.source_paths, 2);
+        assert_eq!(bodies.with_body, 1);
+        assert_eq!(bodies.gap_paths, 1);
+        assert_eq!(bodies.sample, vec!["src/bare.py".to_string()]);
+        assert!(
+            signals
+                .hits
+                .get("probe.py")
+                .is_some_and(|hits| hits.iter().any(|hit| hit.score >= 120.0)),
+            "a symbolic term inside an entity body must reach the source-text scan; hits: {:?}",
+            signals.hits.keys().collect::<Vec<_>>()
+        );
+
+        let mut bare = test_entity("bare", "src/bare.py", 1, 2);
+        bare.metadata.extra.insert(
+            "embedding_body_preview".to_string(),
+            serde_json::Value::String("def bare(): pass".to_string()),
+        );
+        graph.upsert_entity(&bare).unwrap();
+        graph.flush_text_index().unwrap();
+        let healed = extract_source_text_signals("where is greet_target called", &graph)
+            .unwrap()
+            .graph_bodies
+            .expect("observed");
+        assert_eq!(healed.gap_paths, 0);
+        assert_eq!(healed.with_body, 2);
+    }
+
+    /// An entity body preview is bounded and whitespace-collapsed, so it never
+    /// stands in as a full source text: a symbolic hit the text index found is
+    /// kept even when the term is absent from the composed entity bodies.
+    #[test]
+    fn entity_bodies_do_not_filter_symbolic_text_index_hits_as_full_source_would() {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut entity = test_entity("snapshot_builtin", "src/builtin.c", 1, 20);
+        entity.doc_summary = Some("writes files when JQ_ENABLE_SNAPSHOT is set".to_string());
+        entity.metadata.extra.insert(
+            "embedding_body_preview".to_string(),
+            serde_json::Value::String(format!(
+                "{} static int snapshot_builtin(void)",
+                "x ".repeat(600)
+            )),
+        );
+        graph.upsert_entity(&entity).unwrap();
+        graph.flush_text_index().unwrap();
+
+        let signals = extract_source_text_signals("JQ_ENABLE_SNAPSHOT env var", &graph).unwrap();
+        assert!(
+            signals.hits.contains_key("src/builtin.c"),
+            "the text-index hit on the doc summary must survive; hits: {:?}",
+            signals.hits.keys().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/kin-cli/tests/locate_fresh_init_body_coverage.rs
+++ b/crates/kin-cli/tests/locate_fresh_init_body_coverage.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The public install proof's capability flow, run against the real daemon: a
+//! Git repository holding one parsed source file is admitted with `kin init`,
+//! then `kin locate --json` must report every graph-owned source path as
+//! carrying a graph body. Nothing between the two commands may be required.
+
+use serial_test::serial;
+use std::fs;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+fn git(repo: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn kin_command(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
+    let mut cmd = runtime.kin_command();
+    cmd.env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
+        .env("KIN_DAEMON_AUTO_EMBED", "0");
+    cmd
+}
+
+#[test]
+#[serial]
+fn a_fresh_init_leaves_no_graph_body_gap_for_locate() {
+    let repo = tempdir().expect("temp repo");
+    let runtime = common::IsolatedDaemonRuntime::new(repo.path());
+    fs::write(
+        repo.path().join("probe.py"),
+        "def hello():\n    return 42\n",
+    )
+    .expect("write probe");
+    git(repo.path(), &["init", "-q"]);
+    git(repo.path(), &["add", "-A"]);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.name=kin-ci",
+            "-c",
+            "user.email=ci@kin.dev",
+            "commit",
+            "-q",
+            "-m",
+            "probe",
+        ],
+    );
+
+    let init = kin_command(&runtime)
+        .arg("init")
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let locate = kin_command(&runtime)
+        .args(["locate", "hello", "--json", "--explain", "--max-files", "5"])
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin locate");
+    assert!(
+        locate.status.success(),
+        "kin locate failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&locate.stdout),
+        String::from_utf8_lossy(&locate.stderr)
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&locate.stdout).expect("locate --json is one JSON document");
+
+    assert!(
+        payload["files"]
+            .as_array()
+            .is_some_and(|files| files.iter().any(|file| file["path"] == "probe.py")),
+        "locate must return the admitted probe: {payload}"
+    );
+
+    let coverage = &payload["semantic_coverage"];
+    let bodies = &coverage["graph_bodies"];
+    assert_eq!(
+        bodies,
+        &serde_json::json!({"source_paths": 1, "with_body": 1, "gap_paths": 0}),
+        "every graph-owned source path must carry a graph body straight after init: {coverage}"
+    );
+    let note = coverage["note"].as_str().unwrap_or_default();
+    assert!(
+        !note.contains("graph body gap"),
+        "no body gap may be reported after a fresh init: {note}"
+    );
+    assert!(
+        payload["degradations"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .all(|degradation| degradation["component"] != "graph_source_bodies"),
+        "no graph_source_bodies degradation may ride a fresh init: {}",
+        payload["degradations"]
+    );
+
+    let embedded = coverage["indexed"] == coverage["total"] && coverage["pending"] == 0;
+    assert_eq!(
+        coverage["complete"].as_bool(),
+        Some(embedded),
+        "complete must be decided by the embedding counters alone once bodies are whole: {coverage}"
+    );
+}


### PR DESCRIPTION
## The failing proof

Release run 32107626360 for tag v0.5.38 (sha fc906464) failed "Validate installed capability proof" on all five platforms. On the freshly initialised probe repository, `kin locate hello --json --explain --max-files 5` returned `semantic_coverage.complete = false` with `graph_bodies = {source_paths: 1, with_body: 0, gap_paths: 1, sample: ["probe.py"]}` and a note telling the user to run `kin reconcile`. The proof asserts `complete === true`, and it is right to. A fresh install must rank entities over graph-owned bodies with no hidden extra command.

Reproduced with the released macOS arm64 archive (sha256 c39e828d68375d1e99419a107d562aab1b502bf2c36eacb3eb4dfec46d7ad8cf, both binaries stamped fc906464). The proof flow (init, embed, status with wait-quiesce, locate) gives the same payload, and `kin reconcile` fails with "no exact session workspace exists" on a fresh init. An in-place edit, a new source file, `kin commit`, `kin admit`, a second `kin embed`, and a daemon restart all leave `with_body: 0`. The new file only becomes a second gap path.

## The mechanism

`GraphBodyCoverage` (kin#875) counts a graph-owned source path as bodied only when `list_opaque_artifacts()` holds an `OpaqueArtifact` carrying a `text_preview` for it (`crates/kin-cli/src/commands/locate.rs:9661-9700` on main, inside `extract_source_text_signals`). No HEAD admission path writes such a record for an entity-source file. The only production writer is `persist_non_entity_enrichment` (`crates/kin-daemon/src/loop_runner.rs:1287`), reached from the live loop only for non-entity classifications (`loop_runner.rs:2311-2313`) and from the coverage pass, which skips entity sources (`loop_runner.rs:1393-1397`). For an entity-source path the loop calls `clear_incompatible_facets(EntitySource)` (`loop_runner.rs:2353`), which deletes any opaque record on the path (`loop_runner.rs:1177-1182`), and the coverage-pass test pins that rule with "the entity source must not gain one" (`loop_runner.rs:4232`). `kin graph status` reports two facets on one path as a critical conflicting-facets issue (`crates/kin-cli/src/commands/graph_health.rs:273`, `:505`). The one producer of `text/x-source` opaque artifacts is the ref-scoped view builder, `build_historical_source_artifact` (`crates/kin-core/src/ref_view.rs:894`, pushed at `:493`), which builds a throwaway graph for `--ref` queries. locate's own reranker comment records the same fact at `locate.rs:10216` and falls back to entity payloads there.

So the counter measured a facet the HEAD design forbids. Every store holding one parsed source file reported a permanent body gap, `complete` was false everywhere, and the MCP negative envelope, which gates semantic absence on `complete`, refused to certify a semantic absence on every real store.

The graph does hold a body for every parsed source path at HEAD. The parser attaches `embedding_body_preview` to each entity at admission (`crates/kin-parser/src/extract.rs:54-64`, called with source from `crates/kin-index/src/pipeline.rs:163` and `:304`, which both `kin init` history derivation and the daemon use). kin-db indexes it in the text index, the embedder reads it, and locate already treats it as the entity's body in definition authority as well as in `query_proximity_score` and the cross-encoder candidate text. The source-text scan and the counter were the two places that ignored it.

## The fix

`extract_source_text_signals` now composes each entity-bearing source path's body from the `embedding_body_preview` its entities carry whenever the path has no opaque preview. That text feeds the symbolic and cli-flag term scans as well as the include and header promotions, and the counter reads it as the path's graph body. Entity-derived text is never treated as full source for the symbolic partial-match filter, because a body preview is whitespace-collapsed and bounded per entity. The banner note stops naming `kin reconcile` and points at `graph_bodies.sample`. The `graph_source_bodies` degradation's remediation now says what is true.

Materialising `text/x-source` opaque artifacts at HEAD was considered and rejected. It contradicts the one-facet-per-path model enforced in the daemon and in graph status. It would also push every source file into the artifact embedding queue and the artifact text index, and it would duplicate all source text into every persisted snapshot.

## Cost

Nothing changes at init. Per locate query, `extract_source_text_signals` pays one additional `query_entities` pass plus concatenation and lowercasing proportional to the total entity preview bytes, the same order the existing opaque-preview lowercasing already pays on docs-heavy stores. Ranking effect: symbolic query terms found inside entity bodies now add source-text hits at HEAD, which the ref-scoped path already did with full text.

## Tests and falsification

Unit: an entity with a body preview and no opaque artifact counts as bodied and its symbolic body term reaches the scan. A path whose entity has no preview stays a gap and heals once one is added. A text-index hit survives when the term is absent from the composed entity body. Integration (`crates/kin-cli/tests/locate_fresh_init_body_coverage.rs`): the proof flow through the real daemon (git init, probe.py, commit, `kin init`, `kin locate hello --json --explain --max-files 5`) asserts `graph_bodies == {source_paths: 1, with_body: 1, gap_paths: 0}`, that the note carries no body gap, that the degradations carry no `graph_source_bodies` entry, and that `complete` follows the embedding counters alone.

Falsified by removing the entity-body merge and rebuilding both binaries. The unit test fails on `with_body` 0 versus 1, and the integration test fails with exactly the released shape, `{"gap_paths":1,"sample":["probe.py"],"source_paths":1,"with_body":0}` plus the "graph body gap: 1 of 1" note. Restored, both are green.

## Repro before and after

Released v0.5.38 bytes: `complete: false`, `graph_bodies {source_paths: 1, with_body: 0, gap_paths: 1, sample: ["probe.py"]}`, embeddings 4 of 4. Lane release build of this branch (both binaries stamped fc906464-dirty), same flow, same isolated home: `complete: true`, `graph_bodies {source_paths: 1, with_body: 1, gap_paths: 0}`, embeddings 4 of 4, `files: ["probe.py"]`.

Gates: `cargo fmt --check` clean. clippy as ci.yml runs it under `RUSTFLAGS=-D warnings` clean. `kin-dev local-test kin` on the lane tree reads `6012 tests run: 6012 passed (2 slow, 3 leaky), 11 skipped` plus the doc-test pass, on the tree line `.kin-coord/worktrees/bodygap-kin @ fc906464 (chore/lane-bodygap-kin) DIRTY`, with the tracked lock restored clean. `bin/kin-magic-repro` against the lane release build reads 10 pass, 0 fail, 0 unreadable, every check `same` against the f4e300cb baseline.

Closes FIR-2392
