### PR TITLE
Update h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
cargo-deny in the SAST job started refusing every merge-group run at 08:34Z today on RUSTSEC-2026-0258: h2 0.4.15 accepts and queues empty DATA frames without limit, patched in 0.4.16, low severity. The advisory published between kin#893's PR-level SAST run (green) and its merge-group run (red), which ejected #893 from the queue with nothing wrong in it. Every entry behind it would fail the same way, so this lands first.

The lockfile moves h2 alone from 0.4.15 to 0.4.16 with the checksum cargo resolved for it. No other lock entry changes (`cargo update -p h2 --precise 0.4.16` also wanted to re-pin several windows-sys entries, which is unrelated churn, so the h2 entry was set directly). `cargo metadata --locked` and `cargo check --locked -p kin-cli -p kin-daemon` accept the lock, and `cargo deny --locked check advisories` reads clean locally.

Not claiming anything about behavior: h2 is transitive through hyper and the change is the patched point release.