### PR TITLE
Drop the Azure apt mirror on retry so a stalled package download cannot exhaust every attempt

### DIFF
--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -23,7 +23,28 @@ APT_OPTS=(
 UPDATE_BOUND=${CI_APT_UPDATE_BOUND:-120}
 INSTALL_BOUND=${CI_APT_INSTALL_BOUND:-240}
 
+# On the second attempt onward, stop asking the runner's Azure mirror. The
+# hosted mirrorlist puts azure.archive.ubuntu.com first, and a stall there
+# trickles bytes slowly enough that no per-fetch timeout fires; the primary
+# archive answers the same packages. The rewrite is idempotent and only
+# touches the mirror lines the runner image ships.
+drop_azure_mirror() {
+  local f
+  for f in /etc/apt/apt-mirrors.txt /etc/apt/sources.list; do
+    [ -f "$f" ] || continue
+    sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
+  done
+  if [ -d /etc/apt/sources.list.d ]; then
+    sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) \
+      -exec sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' {} +
+  fi
+}
+
 for attempt in 1 2 3; do
+  if [ "$attempt" -ge 2 ]; then
+    echo "apt attempt $attempt: dropping the azure mirror in favour of archive.ubuntu.com" >&2
+    drop_azure_mirror
+  fi
   if timeout "$UPDATE_BOUND" sudo apt-get "${APT_OPTS[@]}" update \
     && timeout "$INSTALL_BOUND" sudo apt-get "${APT_OPTS[@]}" install --yes "$@"; then
     exit 0


### PR DESCRIPTION
kin#889 bounded every apt call so a stalled mirror fails in minutes instead of holding a job to its hour. Today it did exactly that, and it was still not enough: kin#893's merge-group run 32121270434 failed "Check the aarch64 Linux release target (musl)" because all three bounded attempts to install gcc-aarch64-linux-gnu stalled downloading cpp-13-aarch64-linux-gnu from azure.archive.ubuntu.com (09:40 to 09:53Z), and #893 was ejected from the queue a second time. A trickling download does not trip `Acquire::http::Timeout`, and every attempt asked the same mirror.

From the second attempt onward the helper now rewrites the runner's mirror list (`/etc/apt/apt-mirrors.txt`), `/etc/apt/sources.list`, and every `.list` or `.sources` file under `/etc/apt/sources.list.d` to point at `archive.ubuntu.com` instead of `azure.archive.ubuntu.com`, then runs update and install again. The rewrite is idempotent and only touches the mirror lines the runner image ships.

Falsified locally in both directions with GNU sed on a fixture mirror file: a fake apt that fails while the file names azure and succeeds once it does not makes attempt 2 pass (exit 0, mirror file rewritten to archive.ubuntu.com); an apt that always fails still exits 1 after three attempts. shellcheck clean; the release-workflow authority test still passes.

Not claiming: this does not add a second path for gcc-aarch64-linux-gnu or musl-tools beyond apt; if archive.ubuntu.com itself stalls the step still fails in bounded time.