### PR TITLE
Pin the Linux kin-vfs glibc floor and refuse a release above it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           python3 ./scripts/test-npm-automatic-release.py
           python3 ./scripts/test-verify-npm-release.py
           node --test \
+            ./scripts/check-glibc-floor.test.mjs \
             ./scripts/check-release-version.test.mjs \
             ./scripts/extract-release-notes.test.mjs \
             ./scripts/prepare-release.test.mjs \
@@ -112,6 +113,7 @@ jobs:
             ./scripts/release-hold-alarm.test.mjs \
             ./scripts/verify-capability-proof.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs
+          node --check ./scripts/check-glibc-floor.mjs
           node --check ./scripts/read-update-build-identity.cjs
           node --check ./scripts/check-release-version.mjs
           node --check ./scripts/prepare-release.mjs
@@ -948,6 +950,7 @@ jobs:
         run: |
           python3 scripts/test-release-workflow-authority.py
           node --test \
+            scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/extract-release-notes.test.mjs \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -593,17 +593,80 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
 
+      # kin and kin-daemon are static musl and carry no glibc floor at all. The
+      # VFS pair is the only glibc-linked thing Kin publishes for Linux, and
+      # until now its floor was a property of the runner image: Rust std
+      # references pidfd_spawnp and pidfd_getpid as weak undefined symbols, the
+      # linker binds them to whatever libc the build host exports, and the
+      # ubuntu-24.04 images export them at GLIBC_2.39. v0.5.38 shipped a
+      # linux-aarch64 kin-vfs the Debian 12 loader refused outright for exactly
+      # that reason. Zig ships glibc headers for every version, so building
+      # through it pins the floor to a number under review here rather than to
+      # whichever image the runner label resolves to this month.
+      - name: Install the pinned glibc floor toolchain (Linux)
+        if: ${{ runner.os == 'Linux' && !matrix.cross && !matrix.skip_vfs }}
+        shell: bash
+        env:
+          ZIG_VERSION: "0.13.0"
+          CARGO_ZIGBUILD_VERSION: "0.19.8"
+          # Published by ziglang.org/download/index.json for these exact
+          # tarballs. A release input must be immutable, so the download is
+          # checked rather than trusted.
+          ZIG_SHA256_X86_64: d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea
+          ZIG_SHA256_AARCH64: 041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64) zig_arch=x86_64; zig_sha="$ZIG_SHA256_X86_64" ;;
+            aarch64) zig_arch=aarch64; zig_sha="$ZIG_SHA256_AARCH64" ;;
+            *)
+              echo "::error::no pinned zig tarball for Linux $(uname -m); the release cannot pin its glibc floor on this host"
+              exit 1
+              ;;
+          esac
+          tarball="$RUNNER_TEMP/zig-${ZIG_VERSION}.tar.xz"
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
+            --location --silent --show-error --fail \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${zig_arch}-${ZIG_VERSION}.tar.xz" \
+            --output "$tarball"
+          echo "${zig_sha}  ${tarball}" | sha256sum --check --strict -
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$tarball" -C "$RUNNER_TEMP/zig" --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --locked --version "$CARGO_ZIGBUILD_VERSION"
+
       - name: Build kin-vfs (native)
         if: ${{ !matrix.cross && !matrix.skip_vfs }}
         working-directory: kin-vfs
         shell: bash
         run: |
+          set -euo pipefail
           # The VFS shim is an LD_PRELOAD libc interceptor and is therefore
           # libc-specific: on Linux it builds against gnu (VFS_TARGET) so it can
           # preload into the host distro's glibc programs. macOS/Windows have no
           # vfs_target, so VFS_TARGET falls back to the core target there.
-          cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-cli
-          cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-shim
+          if [ "$RUNNER_OS" != "Linux" ]; then
+            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-cli
+            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-shim
+            exit 0
+          fi
+          # The floor is read out of the guard rather than written here as
+          # well. A build targeting one floor while the guard enforces another
+          # is worse than no guard, and the two drifting apart is exactly the
+          # shape that survives review.
+          floor="$(node "$GITHUB_WORKSPACE/scripts/check-glibc-floor.mjs" --print-floor)"
+          # zig cc does not search Debian/Ubuntu multiarch directories, and the
+          # OpenSSL that kin-vfs-daemon links through reqwest lives in them:
+          # the headers under /usr/include/<multiarch> and the link libraries
+          # under /usr/lib/<multiarch>. Both Linux legs build natively, so the
+          # multiarch triple is the VFS target's architecture.
+          multiarch="${VFS_TARGET%%-*}-linux-gnu"
+          scoped="$(printf '%s' "$VFS_TARGET" | tr - _)"
+          upper="$(printf '%s' "$scoped" | tr '[:lower:]' '[:upper:]')"
+          export "CFLAGS_${scoped}=-I/usr/include/${multiarch}"
+          export "CARGO_TARGET_${upper}_RUSTFLAGS=-L native=/usr/lib/${multiarch}"
+          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-cli
+          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-shim
         env:
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
 
@@ -913,6 +976,21 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
+          ARTIFACT: ${{ matrix.artifact }}
+          SHIM_NAME: ${{ matrix.shim_name }}
+
+      # Read the floor back off the bytes that were just packaged. The build
+      # above pins it, and a pin goes quiet the day it stops taking effect,
+      # which is how v0.5.38 published a kin-vfs that no Debian 12 could start
+      # while every check in this workflow stayed green. This step is the half
+      # that cannot pass by accident: it names the highest GLIBC requirement in
+      # each shipped dynamic binary and the symbols that set it, and refuses the
+      # release above the floor.
+      - name: Verify the packaged Linux binaries meet the published glibc floor
+        if: ${{ runner.os == 'Linux' && !matrix.skip_vfs }}
+        shell: bash
+        run: node scripts/check-glibc-floor.mjs "$ARTIFACT/kin-vfs" "$ARTIFACT/$SHIM_NAME"
+        env:
           ARTIFACT: ${{ matrix.artifact }}
           SHIM_NAME: ${{ matrix.shim_name }}
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ boundaries:
 | Platform | Core Kin runtime | `kin-vfs` projection |
 | --- | --- | --- |
 | macOS, Apple Silicon and Intel | Native graph, vector, daemon, setup, MCP, and review surfaces ship in the release archive. | Shipped and exercised on both architectures. It uses `DYLD_INSERT_LIBRARIES`; SIP-protected or hardened programs may reject injection. |
-| Linux x86_64 and arm64 | `kin` and `kin-daemon` are static musl builds intended to run on glibc and musl distributions. | The public VFS executable and shim are GNU/glibc builds, not musl builds. Current artifacts require glibc 2.39; Alpine/musl and older-glibc distributions are not supported projection hosts. The arm64 release proof runs on Ubuntu 24.04. |
+| Linux x86_64 and arm64 | `kin` and `kin-daemon` are static musl builds intended to run on glibc and musl distributions. | The public VFS executable and shim are GNU/glibc builds, not musl builds. They are built against a pinned glibc floor of 2.31 and link OpenSSL 3, so a projection host needs both; Debian 12 loads them, and Alpine and other musl distributions are not supported projection hosts. The release refuses to publish a Linux archive whose binaries ask for more glibc than that floor. The arm64 release proof runs on Ubuntu 24.04. |
 | Native Windows x86_64 | Early support: repositories admit and graph and lexical queries answer natively, but MCP and review workflows are not yet covered end to end by the install proof. WSL2 remains the recommended path for full Kin. | Not shipped. Use WSL2 with a Linux distribution that meets the glibc boundary for projection. |
 
 First indexing reads the entire reachable Git history, so `kin init` on a

--- a/scripts/check-glibc-floor.mjs
+++ b/scripts/check-glibc-floor.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Refuse a Linux release archive whose dynamic binaries demand a newer glibc
+// than the oldest distribution Kin claims to run on.
+//
+// The v0.5.38 linux-aarch64 archive shipped a kin-vfs that the Debian 12
+// loader refused outright:
+//
+//   kin-vfs: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
+//
+// Nothing in the build was wrong about kin-vfs. Rust std references
+// pidfd_spawnp and pidfd_getpid as weak undefined symbols, and the linker
+// binds a weak undefined symbol to whatever the BUILD HOST's libc exports. On
+// a runner image carrying glibc 2.39 those two references acquire a
+// GLIBC_2.39 version requirement; on an older host they stay unresolved and
+// cost nothing. So the floor of every shipped binary was a property of the
+// runner image rather than of anything under review, and a routine image bump
+// moved it past a distribution Kin's own install docs name.
+//
+// The build now pins that floor explicitly (release.yml builds the Linux
+// kin-vfs and shim through zig's bundled glibc headers at FLOOR), and this
+// guard is the half that cannot be skipped: it reads the produced bytes and
+// refuses anything above the floor, naming the symbols that pushed it there.
+// Pinning alone would go quiet the day the pin stops working; a check on the
+// artifact fails loudly instead.
+
+import childProcess from 'node:child_process';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+// The oldest glibc a published Linux binary must load against. Debian 11 is
+// 2.31, Debian 12 is 2.36, Ubuntu 22.04 is 2.35, Ubuntu 24.04 is 2.39. The
+// floor sits BELOW Debian 12 on purpose: a floor set at the distribution we
+// care about most leaves no margin, so the next symbol pulled in from a newer
+// libc lands directly on a supported user. At 2.31 both current Debian
+// stables load the archive, and the release build has room to acquire a
+// symbol without shipping a binary nobody can start.
+//
+// This value is the one source of truth for the floor. release.yml reads it
+// from here (`--print-floor`) to build against it rather than recording it a
+// second time, because a guard checking a different floor than the build
+// targets is worse than no guard.
+export const GLIBC_FLOOR = '2.31';
+
+// readelf prints `symbol@GLIBC_2.39` or `symbol@@GLIBC_2.39`.
+const READELF_REQUIREMENT = /([A-Za-z_][A-Za-z0-9_.]*)@@?GLIBC_(\d+(?:\.\d+)*)/g;
+// objdump -T puts the version before the name, parenthesized when the symbol
+// is undefined: `(GLIBC_2.39) pidfd_spawnp`.
+const OBJDUMP_REQUIREMENT = /\bGLIBC_(\d+(?:\.\d+)*)\)?\s+([A-Za-z_][A-Za-z0-9_.]*)\s*$/gm;
+
+export function compareVersions(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const a = leftParts[index] ?? 0;
+    const b = rightParts[index] ?? 0;
+    if (a !== b) {
+      return a < b ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+// Parses either tool's dynamic symbol listing. readelf is tried first and
+// objdump only when readelf's shape matched nothing, because objdump's
+// "version then name" pattern would otherwise read readelf's trailing
+// `(12)` version index as a symbol name.
+export function parseGlibcRequirements(text) {
+  const requirements = [];
+  for (const match of text.matchAll(READELF_REQUIREMENT)) {
+    requirements.push({ symbol: match[1], version: match[2] });
+  }
+  if (requirements.length > 0) {
+    return requirements;
+  }
+  for (const match of text.matchAll(OBJDUMP_REQUIREMENT)) {
+    requirements.push({ symbol: match[2], version: match[1] });
+  }
+  return requirements;
+}
+
+// Fails closed on an empty parse. Every binary this guard is pointed at links
+// glibc dynamically, so "no requirements found" means the listing was
+// unreadable, not that the binary is clean, and reading one as the other is
+// exactly how a guard stops being able to fail.
+export function summarizeGlibcRequirements(text, { label } = {}) {
+  const requirements = parseGlibcRequirements(text);
+  if (requirements.length === 0) {
+    throw new Error(
+      `${label ?? 'binary'} reported no GLIBC version requirements at all; ` +
+      'a dynamically linked release binary always has some, so this listing ' +
+      'is unreadable rather than clean',
+    );
+  }
+  const max = requirements
+    .map((requirement) => requirement.version)
+    .reduce((highest, version) => (compareVersions(version, highest) > 0 ? version : highest));
+  const symbols = [
+    ...new Set(
+      requirements
+        .filter((requirement) => requirement.version === max)
+        .map((requirement) => requirement.symbol),
+    ),
+  ].sort();
+  return { max, symbols, count: requirements.length };
+}
+
+const runTool = (command, args, file) => {
+  const result = childProcess.spawnSync(command, [...args, file], { encoding: 'utf8' });
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  return result.stdout;
+};
+
+export function readDynamicSymbols(file, { run = runTool } = {}) {
+  const listing =
+    run('readelf', ['--dyn-syms', '-W'], file) ?? run('objdump', ['-T'], file);
+  if (listing === null) {
+    throw new Error(
+      `could not read the dynamic symbols of ${file} with readelf or objdump; ` +
+      'refusing to publish a binary whose glibc floor was never read',
+    );
+  }
+  return listing;
+}
+
+export function checkFiles(files, { floor = GLIBC_FLOOR, run = runTool, log = console.log } = {}) {
+  if (files.length === 0) {
+    throw new Error(
+      'no binaries were named; a floor check that runs on nothing reports the ' +
+      'same success as a floor check that passed',
+    );
+  }
+  const violations = [];
+  for (const file of files) {
+    const summary = summarizeGlibcRequirements(readDynamicSymbols(file, { run }), {
+      label: file,
+    });
+    log(
+      `${file}: highest requirement GLIBC_${summary.max} ` +
+      `(${summary.symbols.join(', ')}) across ${summary.count} versioned references`,
+    );
+    if (compareVersions(summary.max, floor) > 0) {
+      violations.push({ file, ...summary });
+    }
+  }
+  if (violations.length > 0) {
+    const detail = violations
+      .map(
+        (violation) =>
+          `${violation.file} requires GLIBC_${violation.max} ` +
+          `(${violation.symbols.join(', ')})`,
+      )
+      .join('; ');
+    throw new Error(
+      `${detail}; the published floor is GLIBC_${floor}, so this archive cannot ` +
+      'start on a distribution below that glibc. Build the Linux kin-vfs ' +
+      'binaries against the pinned floor instead of against the runner image.',
+    );
+  }
+  return floor;
+}
+
+export function main({ argv = process.argv.slice(2), log = console.log } = {}) {
+  if (argv.includes('--print-floor')) {
+    log(GLIBC_FLOOR);
+    return GLIBC_FLOOR;
+  }
+  return checkFiles(argv, { log });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/check-glibc-floor.test.mjs
+++ b/scripts/check-glibc-floor.test.mjs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  GLIBC_FLOOR,
+  checkFiles,
+  compareVersions,
+  parseGlibcRequirements,
+  readDynamicSymbols,
+  summarizeGlibcRequirements,
+} from './check-glibc-floor.mjs';
+
+// Real `readelf --dyn-syms -W` bytes from the v0.5.38 linux-aarch64 archive.
+// The last two lines are the defect: Rust std's pidfd spawn path, versioned by
+// the runner image's glibc, which the Debian 12 loader refuses.
+const READELF_2_39 = `
+Symbol table '.dynsym' contains 199 entries:
+   Num:    Value          Size Type    Bind   Vis      Ndx Name
+     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
+    26: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND dlsym@GLIBC_2.34 (6)
+    40: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND pthread_detach@GLIBC_2.34 (6)
+    93: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND pidfd_spawnp@GLIBC_2.39 (12)
+   182: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND pidfd_getpid@GLIBC_2.39 (12)
+`;
+
+// Real bytes from the same archive's libkin_vfs_shim.so. It loads on Debian 12
+// and was never the reported defect, but 2.34 is still above the floor: it is
+// where the runner image happened to leave it, and only a build pinned to the
+// floor keeps it there on the next image.
+const READELF_2_34 = `
+Symbol table '.dynsym' contains 121 entries:
+   Num:    Value          Size Type    Bind   Vis      Ndx Name
+     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memcpy@GLIBC_2.17 (2)
+     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memmove@GLIBC_2.17 (2)
+    72: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND dlsym@GLIBC_2.34 (8)
+    63: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND pthread_create@GLIBC_2.34 (8)
+`;
+
+// Real bytes from the same shim rebuilt through the pinned floor. This is what
+// the guard has to pass, and the whole point of the pin: the highest reference
+// left is gettid, which glibc has carried since 2.30.
+const READELF_2_30 = `
+Symbol table '.dynsym' contains 96 entries:
+   Num:    Value          Size Type    Bind   Vis      Ndx Name
+     2: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memcpy@GLIBC_2.17 (2)
+     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND getcwd@GLIBC_2.17 (2)
+    28: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND gettid@GLIBC_2.30 (5)
+`;
+
+// Real `objdump -T` bytes from the same binary. The version comes before the
+// name here, and is parenthesized on an undefined symbol.
+const OBJDUMP_2_39 = `
+DYNAMIC SYMBOL TABLE:
+0000000000000000      DF *UND*\t0000000000000000 (GLIBC_2.34) dlsym
+0000000000000000      DF *UND*\t0000000000000000 (GLIBC_2.34) pthread_detach
+0000000000000000      DF *UND*\t0000000000000000 (GLIBC_2.39) pidfd_spawnp
+`;
+
+test('the published floor stays below Debian 12 glibc', () => {
+  assert.equal(compareVersions(GLIBC_FLOOR, '2.36') < 0, true);
+});
+
+test('compares versions numerically rather than lexically', () => {
+  assert.equal(compareVersions('2.9', '2.31'), -1);
+  assert.equal(compareVersions('2.31', '2.9'), 1);
+  assert.equal(compareVersions('2.34', '2.34'), 0);
+  assert.equal(compareVersions('2.34', '2.34.1'), -1);
+});
+
+test('reads every requirement out of a readelf listing', () => {
+  const requirements = parseGlibcRequirements(READELF_2_39);
+  assert.deepEqual(
+    requirements.map((requirement) => `${requirement.symbol}@${requirement.version}`),
+    [
+      'dlsym@2.34',
+      'pthread_detach@2.34',
+      'pidfd_spawnp@2.39',
+      'pidfd_getpid@2.39',
+    ],
+  );
+});
+
+test('reads an objdump listing, whose columns are the other way round', () => {
+  const summary = summarizeGlibcRequirements(OBJDUMP_2_39);
+  assert.equal(summary.max, '2.39');
+  assert.deepEqual(summary.symbols, ['pidfd_spawnp']);
+});
+
+test('names the symbols that set the highest requirement', () => {
+  const summary = summarizeGlibcRequirements(READELF_2_39);
+  assert.equal(summary.max, '2.39');
+  assert.deepEqual(summary.symbols, ['pidfd_getpid', 'pidfd_spawnp']);
+  assert.equal(summary.count, 4);
+});
+
+test('the floor-pinned shim passes', () => {
+  const floor = checkFiles(['libkin_vfs_shim.so'], {
+    run: () => READELF_2_30,
+    log: () => {},
+  });
+  assert.equal(floor, GLIBC_FLOOR);
+});
+
+test('the runner-image shim at 2.34 is refused too, not just kin-vfs', () => {
+  assert.throws(
+    () => checkFiles(['libkin_vfs_shim.so'], { run: () => READELF_2_34, log: () => {} }),
+    /libkin_vfs_shim\.so requires GLIBC_2\.34 \(dlsym, pthread_create\)/,
+  );
+});
+
+test('the shipped 2.39 kin-vfs is refused, with the pidfd symbols named', () => {
+  assert.throws(
+    () => checkFiles(['kin-vfs'], { run: () => READELF_2_39, log: () => {} }),
+    (error) => {
+      assert.match(error.message, /kin-vfs requires GLIBC_2\.39/);
+      assert.match(error.message, /pidfd_getpid/);
+      assert.match(error.message, /pidfd_spawnp/);
+      return true;
+    },
+  );
+});
+
+test('a binary exactly at the floor passes', () => {
+  const atFloor = `    1: 0 0 FUNC GLOBAL DEFAULT UND memfd_create@GLIBC_${GLIBC_FLOOR} (3)\n`;
+  assert.equal(
+    checkFiles(['kin-vfs'], { run: () => atFloor, log: () => {} }),
+    GLIBC_FLOOR,
+  );
+});
+
+test('one requirement above the floor refuses the whole set', () => {
+  const files = ['libkin_vfs_shim.so', 'kin-vfs'];
+  assert.throws(
+    () =>
+      checkFiles(files, {
+        run: (_command, _args, file) =>
+          file === 'kin-vfs' ? READELF_2_39 : READELF_2_30,
+        log: () => {},
+      }),
+    /kin-vfs requires GLIBC_2\.39/,
+  );
+});
+
+test('an unreadable listing is refused rather than read as clean', () => {
+  assert.throws(
+    () => checkFiles(['kin-vfs'], { run: () => '', log: () => {} }),
+    /unreadable rather than clean/,
+  );
+});
+
+test('both symbol readers failing refuses rather than passing', () => {
+  assert.throws(
+    () => readDynamicSymbols('kin-vfs', { run: () => null }),
+    /whose glibc floor was never read/,
+  );
+});
+
+test('a check pointed at no binaries at all refuses', () => {
+  assert.throws(
+    () => checkFiles([], { run: () => READELF_2_34, log: () => {} }),
+    /runs on nothing/,
+  );
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -65,6 +65,16 @@ ABANDONED_TAGS_POLICY = "scripts/abandoned-release-tags.json"
 TAG_SELECTOR_POLICY = "scripts/select-admissible-release-tag.py"
 ASSERTION_REACHABILITY = ROOT / "scripts" / "test-assertion-reachability.py"
 ASSERTION_REACHABILITY_POLICY = "scripts/test-assertion-reachability.py"
+GLIBC_FLOOR_GUARD = ROOT / "scripts" / "check-glibc-floor.mjs"
+GLIBC_FLOOR_GUARD_POLICY = "scripts/check-glibc-floor.mjs"
+GLIBC_FLOOR_TEST = ROOT / "scripts" / "check-glibc-floor.test.mjs"
+GLIBC_FLOOR_TEST_POLICY = "scripts/check-glibc-floor.test.mjs"
+GLIBC_FLOOR_RELEASE_CHECK = (
+    'run: node scripts/check-glibc-floor.mjs "$ARTIFACT/kin-vfs" "$ARTIFACT/$SHIM_NAME"'
+)
+GLIBC_FLOOR_BUILD_READ = (
+    'floor="$(node "$GITHUB_WORKSPACE/scripts/check-glibc-floor.mjs" --print-floor)"'
+)
 KIN_VFS_COMPAT_GUARD = ROOT / "scripts" / "check-kin-vfs-compat.mjs"
 KIN_VFS_COMPAT_GUARD_POLICY = "scripts/check-kin-vfs-compat.mjs"
 KIN_VFS_COMPAT_TEST = ROOT / "scripts" / "check-kin-vfs-compat.test.mjs"
@@ -3487,6 +3497,76 @@ def assert_assertion_reachability_gate_wired(workflow: str) -> None:
         raise AssertionError(
             f"{ASSERTION_REACHABILITY_POLICY} is missing; the release gates "
             "would no longer prove their own checks run"
+        )
+
+
+def assert_glibc_floor_guard_wired(ci: str, release: str) -> None:
+    """Keep the floor that decides which Linux distributions can start Kin.
+
+    kin and kin-daemon are static musl and carry no glibc floor. The kin-vfs
+    pair is the only glibc-linked thing Kin publishes for Linux, and its floor
+    used to be a property of the runner image rather than of anything under
+    review: Rust std references pidfd_spawnp and pidfd_getpid as weak undefined
+    symbols, the linker binds them to whatever libc the build host exports, and
+    the ubuntu-24.04 images export them at GLIBC_2.39. v0.5.38 shipped a
+    linux-aarch64 kin-vfs that the Debian 12 loader refused outright, while
+    every check in the release stayed green, because nothing read the floor.
+
+    Two halves are required here and neither is sufficient alone. The build
+    must go through the pinned floor, reading it from the guard rather than
+    recording it a second time, or the number the guard enforces and the number
+    the build targets can drift apart. And the release must read the floor back
+    off the packaged bytes, because a pin that quietly stops taking effect
+    looks exactly like a pin that worked.
+    """
+
+    for path, policy in (
+        (GLIBC_FLOOR_GUARD, GLIBC_FLOOR_GUARD_POLICY),
+        (GLIBC_FLOOR_TEST, GLIBC_FLOOR_TEST_POLICY),
+    ):
+        if not path.is_file():
+            raise AssertionError(
+                f"{policy} is missing; the Linux archives could ship a kin-vfs "
+                "no supported distribution can start and nothing would notice"
+            )
+
+    # Match whole invocations rather than searching for the path, which a
+    # commented-out line would still satisfy.
+    release_lines = {line.strip() for line in release.splitlines()}
+    if GLIBC_FLOOR_RELEASE_CHECK not in release_lines:
+        raise AssertionError(
+            "release.yml must run "
+            f"{GLIBC_FLOOR_GUARD_POLICY} against the packaged Linux binaries; "
+            "the build's intent to pin a floor is not the same evidence as the "
+            "floor of the bytes about to be published"
+        )
+    if GLIBC_FLOOR_BUILD_READ not in release_lines:
+        raise AssertionError(
+            "release.yml must read the glibc floor from "
+            f"{GLIBC_FLOOR_GUARD_POLICY}; a build targeting one floor while the "
+            "guard enforces another is worse than no guard"
+        )
+    if 'cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}"' not in release:
+        raise AssertionError(
+            "release.yml must build the Linux kin-vfs binaries against the "
+            "pinned floor; a plain cargo build takes its floor from the runner "
+            "image, which is what shipped an unloadable v0.5.38 kin-vfs"
+        )
+
+    # The tests are load-bearing rather than decorative: the guard's whole
+    # answer is a parse of readelf output, and a parse that silently found
+    # nothing would be a guard that cannot fail.
+    ci_lines = {line.strip() for line in ci.splitlines()}
+    if not ci_lines & {
+        GLIBC_FLOOR_TEST_POLICY,
+        f"{GLIBC_FLOOR_TEST_POLICY} \\",
+        f"./{GLIBC_FLOOR_TEST_POLICY}",
+        f"./{GLIBC_FLOOR_TEST_POLICY} \\",
+    }:
+        raise AssertionError(
+            "ci.yml must run "
+            f"{GLIBC_FLOOR_TEST_POLICY}; the guard reads a floor out of readelf "
+            "output, and an unproven parse is a gate that cannot fail"
         )
 
 
@@ -10263,6 +10343,53 @@ def main() -> None:
     assert_docs_only_classifier_guard(ci_workflow)
     assert_assertion_reachability_gate_wired(ci_workflow)
     assert_kin_vfs_compat_gate_wired(ci_workflow)
+    assert_glibc_floor_guard_wired(ci_workflow, release)
+    expect_assertion(
+        "release.yml stops reading the glibc floor off the packaged binaries",
+        "release.yml must run",
+        lambda: assert_glibc_floor_guard_wired(
+            ci_workflow,
+            release.replace(GLIBC_FLOOR_RELEASE_CHECK, "run: true"),
+        ),
+    )
+    expect_assertion(
+        "the floor check survives only as a commented-out release.yml step",
+        "release.yml must run",
+        lambda: assert_glibc_floor_guard_wired(
+            ci_workflow,
+            release.replace(
+                GLIBC_FLOOR_RELEASE_CHECK,
+                GLIBC_FLOOR_RELEASE_CHECK.replace("run: ", "run: # "),
+            ),
+        ),
+    )
+    expect_assertion(
+        "the release build stops reading the floor from the guard that enforces it",
+        "must read the glibc floor",
+        lambda: assert_glibc_floor_guard_wired(
+            ci_workflow,
+            release.replace(GLIBC_FLOOR_BUILD_READ, 'floor="2.31"'),
+        ),
+    )
+    expect_assertion(
+        "the Linux kin-vfs build reverts to taking its floor from the runner image",
+        "must build the Linux kin-vfs binaries against the pinned floor",
+        lambda: assert_glibc_floor_guard_wired(
+            ci_workflow,
+            release.replace(
+                'cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}"',
+                'cargo build --locked --release --target "$VFS_TARGET"',
+            ),
+        ),
+    )
+    expect_assertion(
+        "ci.yml keeps the floor guard but drops the tests proving its parse",
+        "ci.yml must run",
+        lambda: assert_glibc_floor_guard_wired(
+            ci_workflow.replace(GLIBC_FLOOR_TEST_POLICY, "scripts/absent.test.mjs"),
+            release,
+        ),
+    )
     expect_assertion(
         "ci.yml drops the pull-request Kin/kin-vfs compatibility gate",
         "ci.yml must run",


### PR DESCRIPTION
The v0.5.38 `kin-linux-aarch64` archive shipped a `kin-vfs` that Debian 12 cannot start:

```
kin-vfs: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by kin-vfs)
```

`kin` and `kin-daemon` are static musl and carry no glibc floor at all. The kin-vfs pair is the only glibc-linked thing the Linux archives ship, and its floor was a property of the runner image rather than of anything under review. Rust std references `pidfd_spawnp` and `pidfd_getpid` as weak undefined symbols; the linker binds them to whatever libc the build host exports, and the ubuntu-24.04 images export them at GLIBC_2.39. On an older host those references stay unresolved and cost nothing. So a routine runner image bump moved the floor past a distribution the install docs name, and every check in the release stayed green.

## What changed

`release.yml` builds the Linux kin-vfs binary and its shim through `cargo-zigbuild` against an explicit glibc target, so the floor is a reviewed number instead of an image property. Zig does not search the Debian multiarch directories, and the OpenSSL that `kin-vfs-daemon` links through reqwest lives in them, so the step points its target CFLAGS and link search there. The zig tarball is pinned by version and sha256.

`scripts/check-glibc-floor.mjs` reads the highest GLIBC requirement out of each packaged dynamic binary and refuses the release above the floor, naming the symbols that set it. The build reads its target floor from the same script, so the number the guard enforces and the number the build targets cannot drift apart. The guard runs on the packaged bytes, because a pin that stops taking effect looks exactly like a pin that worked.

The floor is `2.31`, below Debian 12's 2.36 on purpose: a floor set at the distribution we care about most leaves no margin, so the next symbol pulled in from a newer libc lands directly on a supported user.

## Proof

Run inside an ubuntu-24.04 arm64 replica of the release runner, against the pinned kin-vfs release input.

A plain `cargo build` there reproduces the shipped v0.5.38 symbol profile exactly, both GLIBC_2.39 references included. The floor-pinned build tops out at GLIBC_2.30 for both binaries, on aarch64 and on x86_64.

The guard, run verbatim on real bytes:

```
### the shipped v0.5.38 binaries (refuses)
kin-vfs: highest requirement GLIBC_2.39 (pidfd_getpid, pidfd_spawnp) across 130 versioned references
libkin_vfs_shim.so: highest requirement GLIBC_2.34 (dlsym, pthread_create, ...) across 75 versioned references
::error::kin-vfs requires GLIBC_2.39 (pidfd_getpid, pidfd_spawnp); ... the published floor is GLIBC_2.31
rc=1

### the floor-pinned rebuild (passes)
kin-vfs: highest requirement GLIBC_2.30 (gettid) across 135 versioned references
libkin_vfs_shim.so: highest requirement GLIBC_2.30 (gettid) across 83 versioned references
rc=0
```

It also refuses a run naming no binaries at all, and refuses an unreadable listing rather than reading it as clean (pointed at the static `kin`, it says so instead of passing).

On Debian 12 arm64 the rebuilt `kin-vfs` runs and answers as a CLI where the shipped one died in the loader. The rebuilt shim preloads into `/bin/ls` and, with a workspace configured and no daemon, reports the same interception behavior and the same exit codes as the shipped shim, so the `dlsym(RTLD_NEXT)` machinery still works under the zig link.

Both new release steps were rehearsed verbatim: the toolchain install (which refuses a tampered tarball on the sha256 check) and the build step.

## Gates

`test-release-workflow-authority.py`, `test-assertion-reachability.py`, `test-homebrew-release-gate.py`, the installer asset and archive-binary guards with their falsifiers, the npm release policy suites, the full `node --test` set (116 tests), and `actionlint` on both changed workflows all pass. The authority suite now requires both halves of this guard and falsifies each: a deleted guard, a deleted unit test, a commented-out release step, a build that stops reading the floor, and a build reverted to plain cargo all go red.

## Remaining risk

`release.yml` takes no `workflow_dispatch`, and a tag run resolves its workflows from the tag, so the first real exercise of these steps is the next release tag. The replica proof covers the compile, the link, the floor, and the guard, but not the GitHub runner itself.

Closes FIR-2393
