### PR TITLE
Never report a commit still in flight as failed, and refuse an empty successor

### DIFF
--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -67,10 +67,7 @@ async fn run_daemon_commit(
         .await?
         .ok_or_else(|| crate::daemon_client::daemon_required_error("commit", layout))?;
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(120))
-        .connect_timeout(std::time::Duration::from_millis(500))
-        .build()?;
+    let client = build_commit_client(commit_reply_deadline())?;
     // Create these once per CLI invocation so transport retry logic can reuse
     // the byte-identical repository transaction.
     let operation_id = kin_model::OperationId::new();
@@ -98,25 +95,216 @@ async fn run_daemon_commit(
     let response = match response {
         Ok(response) => response,
         Err(error) => {
-            // A transport error names a socket. When the daemon was killed with
-            // this request in flight, the socket is the symptom and the killer
-            // left the cause in the repository.
-            return match daemon_death_explanation(&kin_root) {
-                Some(cause) => Err(anyhow::Error::new(error).context(cause)),
-                None => Err(anyhow::Error::new(error))
-                    .context("send daemon-owned native commit request"),
-            };
+            return resolve_commit_after_lost_reply(layout, &kin_root, operation_id, error, quiet);
         }
     };
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        if let Some(refusal) = commit_refusal_message(&body) {
+            anyhow::bail!(refusal);
+        }
         anyhow::bail!("daemon native commit failed (HTTP {status}): {body}");
     }
     response
         .json()
         .await
         .context("decode daemon native commit response")
+}
+
+/// How long the CLI waits for the daemon to answer a commit.
+///
+/// `None`, and that is the fix. The client used to carry a fixed 120-second
+/// deadline, which is shorter than a one-file commit on a converted repository
+/// of any size: on a psf/requests store the phases behind one docstring edit ran
+/// for 213 seconds. Nothing about the deadline expiring cancelled the commit.
+/// The daemon kept going, published the change minutes later, and the person who
+/// had already read `operation timed out` retried, which is how a store ends up
+/// carrying an empty change stacked on the real one.
+///
+/// A deadline can only be right if the CLI knows how long the work should take,
+/// and it cannot: the cost is a property of the store. What the CLI can do is
+/// show the phases the daemon is in, which it does for the whole wait, so a
+/// commit that is working and a commit that is wedged no longer look the same.
+/// A daemon that really is wedged is ended by the supervisor's reaper, and that
+/// arrives here as a transport error carrying the reaper's own note.
+fn commit_reply_deadline() -> Option<std::time::Duration> {
+    None
+}
+
+/// The HTTP client a commit is sent with.
+///
+/// The connect timeout stays: refusing to connect is an immediate, local fact
+/// about a daemon that is not listening, and waiting on it forever would trade
+/// one bad failure mode for another. Only the reply deadline is the caller's to
+/// choose, and production chooses none.
+fn build_commit_client(deadline: Option<std::time::Duration>) -> reqwest::Result<reqwest::Client> {
+    let mut builder =
+        reqwest::Client::builder().connect_timeout(std::time::Duration::from_millis(500));
+    if let Some(deadline) = deadline {
+        builder = builder.timeout(deadline);
+    }
+    builder.build()
+}
+
+/// The one-line refusal a daemon body carries, when it carries one.
+///
+/// A refusal the daemon states in words is worth exactly those words. Wrapping
+/// it in `daemon native commit failed (HTTP 409): {"error":...}` buries the
+/// sentence a person needs inside a serialized envelope they have to read past.
+fn commit_refusal_message(body: &str) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+    if parsed.get("error")? != "nothing_to_commit" {
+        return None;
+    }
+    Some(parsed.get("message")?.as_str()?.to_string())
+}
+
+/// What the CLI can still learn about a commit whose reply never arrived.
+#[derive(Debug)]
+enum LostReply {
+    /// The operation is in repository authority. The commit landed and the
+    /// reply is the only thing that was lost.
+    Landed(Box<DaemonCommitResult>),
+    /// No receipt yet, and the daemon is still beating on an open transaction.
+    /// The commit is running; it has not failed.
+    StillRunning(String),
+    /// No receipt, and nothing proves any work is still in flight.
+    Gone,
+}
+
+/// Decide what a lost reply means from the two facts on disk.
+///
+/// Separated from the reads so the decision can be tested against every
+/// combination of them, including the one that matters: a receipt present means
+/// landed no matter what the marker says, because a daemon that finished this
+/// commit and went on to another transaction still publishes a marker.
+fn classify_lost_reply(
+    landed: Option<DaemonCommitResult>,
+    open: Option<kin_daemon_spawn::OpenTransaction>,
+    now_unix: u64,
+) -> LostReply {
+    if let Some(result) = landed {
+        return LostReply::Landed(Box::new(result));
+    }
+    match open {
+        Some(open) if open.is_beating(now_unix) => LostReply::StillRunning(open.summary()),
+        _ => LostReply::Gone,
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_secs())
+        .unwrap_or(0)
+}
+
+/// Report a commit whose reply was lost, by asking authority what happened.
+///
+/// The transport error is the last thing consulted rather than the first. A
+/// commit is recorded by the repository transaction, not by the response that
+/// describes it, so the honest question after a lost reply is whether this
+/// operation reached authority. When it did, the commit succeeded and says so;
+/// when it did not but the daemon is still beating on an open transaction, the
+/// commit is still running and says that instead of reporting a failure that has
+/// not happened.
+fn resolve_commit_after_lost_reply(
+    layout: &kin_core::KinLayout,
+    kin_root: &std::path::Path,
+    operation_id: kin_model::OperationId,
+    error: reqwest::Error,
+    quiet: bool,
+) -> Result<DaemonCommitResult> {
+    let lookup = landed_commit_for_operation(layout, operation_id);
+    let unreadable_authority = lookup.as_ref().err().map(|error| format!("{error:#}"));
+    let landed = lookup.unwrap_or(None);
+    match classify_lost_reply(
+        landed,
+        kin_daemon_spawn::read_open_transaction(kin_root),
+        unix_now(),
+    ) {
+        LostReply::Landed(result) => {
+            if !quiet {
+                eprintln!(
+                    "The daemon's reply was lost, and repository authority holds this commit \
+                     (operation {operation_id}). Reporting the change it recorded."
+                );
+            }
+            Ok(*result)
+        }
+        LostReply::StillRunning(open) => anyhow::bail!(
+            "the daemon is still committing ({open}) and this commit has not failed. \
+             Operation {operation_id} appears in `kin log` when it lands; a `kin commit` \
+             run before then waits for it and is refused rather than recorded."
+        ),
+        LostReply::Gone => {
+            // A transport error names a socket. When the daemon was killed with
+            // this request in flight, the socket is the symptom and the killer
+            // left the cause in the repository.
+            let error = match daemon_death_explanation(kin_root) {
+                Some(cause) => anyhow::Error::new(error).context(cause),
+                None => {
+                    anyhow::Error::new(error).context("send daemon-owned native commit request")
+                }
+            };
+            Err(match unreadable_authority {
+                Some(why) => error.context(format!(
+                    "repository authority could not be read to check whether operation \
+                     {operation_id} landed: {why}"
+                )),
+                None => error.context(format!(
+                    "repository authority holds no receipt for operation {operation_id}: \
+                     the change was not recorded"
+                )),
+            })
+        }
+    }
+}
+
+/// The change this operation id published, read from repository authority.
+///
+/// The same lookup the daemon performs to recover its own interrupted commits,
+/// run from the CLI over the durable store rather than over a daemon that may no
+/// longer be answering. It is deliberately not a daemon request: the state this
+/// exists to report on is exactly the state in which the daemon cannot answer.
+fn landed_commit_for_operation(
+    layout: &kin_core::KinLayout,
+    operation_id: kin_model::OperationId,
+) -> Result<Option<DaemonCommitResult>> {
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(layout)?;
+    let authority = super::repository_authority::ActiveRepositoryAuthority::open(&binding)?;
+    let lease = authority.manager().read_authority();
+    let Some(receipt) = lease
+        .metadata()
+        .receipts
+        .iter()
+        .find(|receipt| receipt.operation_id == operation_id)
+    else {
+        return Ok(None);
+    };
+    let Some((branch, change_id)) = receipt.operation.ref_mutations.iter().find_map(|mutation| {
+        match mutation.new_target.as_ref() {
+            Some(kin_model::RefTarget::Change { change_id }) => {
+                Some((mutation.name.clone(), *change_id))
+            }
+            _ => None,
+        }
+    }) else {
+        return Ok(None);
+    };
+    let change = lease.snapshot().changes.get(&change_id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "repository receipt for operation {operation_id} references missing change {change_id}"
+        )
+    })?;
+    Ok(Some(DaemonCommitResult {
+        change_id: change_id.to_string(),
+        branch: branch.to_string(),
+        entity_count: change.entity_deltas.len(),
+        relation_count: change.relation_deltas.len(),
+        file_count: change.tree_deltas.len(),
+    }))
 }
 
 /// Await `work`, printing the phases the daemon reaches while it runs.
@@ -245,6 +433,188 @@ mod tests {
                 "phase {phase} reached the caller only after the reply: {seen:?}"
             );
         }
+    }
+
+    fn commit_body() -> serde_json::Value {
+        serde_json::json!({
+            "operation_id": kin_model::OperationId::new(),
+            "timestamp": kin_model::Timestamp::now(),
+            "message": "publish one docstring edit",
+            "author": "Ada Lovelace <ada@example.com>",
+        })
+    }
+
+    fn landed_result() -> DaemonCommitResult {
+        DaemonCommitResult {
+            change_id: "5b8ca7b7".to_string(),
+            branch: "refs/heads/main".to_string(),
+            entity_count: 32,
+            relation_count: 4,
+            file_count: 1,
+        }
+    }
+
+    fn open_commit(beat_unix: u64) -> kin_daemon_spawn::OpenTransaction {
+        kin_daemon_spawn::OpenTransaction {
+            pid: std::process::id(),
+            operation: "commit".to_string(),
+            phase: Some("reconcile_workspace_and_commit_authority".to_string()),
+            elapsed_secs: 213,
+            phase_elapsed_secs: 60,
+            beat_unix,
+        }
+    }
+
+    /// A daemon stand-in that answers a commit only after `delay`.
+    ///
+    /// A real 120-second wait is not what this needs to prove. The defect is a
+    /// client deadline shorter than the daemon's work, and any two durations in
+    /// that order reproduce it.
+    async fn slow_commit_daemon(
+        delay: std::time::Duration,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let serving = tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                    let mut request = [0u8; 4096];
+                    let _ = socket.read(&mut request).await;
+                    tokio::time::sleep(delay).await;
+                    let body = serde_json::to_string(&serde_json::json!({
+                        "change_id": "5b8ca7b7",
+                        "branch": "refs/heads/main",
+                        "entity_count": 32,
+                        "relation_count": 4,
+                        "file_count": 1,
+                    }))
+                    .unwrap();
+                    let reply = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                         content-length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = socket.write_all(reply.as_bytes()).await;
+                    let _ = socket.flush().await;
+                });
+            }
+        });
+        (url, serving)
+    }
+
+    /// The reported defect, in the only two durations it needs.
+    ///
+    /// The shipped client carried a fixed 120-second deadline and a one-file
+    /// commit on a converted psf/requests store ran for 213 seconds, so the CLI
+    /// reported `operation timed out` for a commit that landed. Both arms run
+    /// against the same daemon: the deadlined client proves this daemon really
+    /// is slower than a deadline, and the production client proves the reply
+    /// still arrives. Falsify by giving `build_commit_client` back a fixed
+    /// timeout shorter than the work; the second arm then fails the same way
+    /// the first one is asserted to.
+    #[tokio::test]
+    async fn a_commit_slower_than_a_client_deadline_still_reports_its_change() {
+        let work = std::time::Duration::from_millis(600);
+        let deadline = std::time::Duration::from_millis(150);
+        let (url, serving) = slow_commit_daemon(work).await;
+        let endpoint = format!("{url}/commands/commit");
+
+        let expired = build_commit_client(Some(deadline))
+            .unwrap()
+            .post(&endpoint)
+            .json(&commit_body())
+            .send()
+            .await
+            .expect_err("a deadline shorter than the daemon's work must expire");
+        assert!(
+            expired.is_timeout(),
+            "the control must fail on the deadline, not on the transport: {expired}"
+        );
+
+        assert!(
+            commit_reply_deadline().is_none(),
+            "a commit must not carry a deadline the CLI cannot justify"
+        );
+        let response = build_commit_client(commit_reply_deadline())
+            .unwrap()
+            .post(&endpoint)
+            .json(&commit_body())
+            .send()
+            .await
+            .expect("a commit with no reply deadline waits for the daemon");
+        let result: DaemonCommitResult = response.json().await.unwrap();
+        assert_eq!(result.change_id, "5b8ca7b7");
+        assert_eq!(render_commit_summary(&result).lines().count(), 2);
+
+        serving.abort();
+    }
+
+    /// A reply that never arrived says nothing about whether the commit did.
+    ///
+    /// Authority is what records a commit, so a receipt for this operation means
+    /// the commit succeeded and only its reply was lost. That holds even while
+    /// the daemon publishes a marker, because a daemon that finished this commit
+    /// and moved on to other work is still mid-transaction.
+    #[test]
+    fn a_lost_reply_whose_operation_reached_authority_is_a_successful_commit() {
+        match classify_lost_reply(Some(landed_result()), Some(open_commit(1_000)), 1_005) {
+            LostReply::Landed(result) => {
+                assert_eq!(result.change_id, "5b8ca7b7");
+                assert_eq!(result.entity_count, 32);
+            }
+            other => panic!("a receipt is a landed commit, not {other:?}"),
+        }
+    }
+
+    /// A commit still running is reported as running, never as failed.
+    ///
+    /// The stranger read `operation timed out`, concluded the edit was
+    /// uncommitted, and retried. Both halves of that were wrong, and the retry
+    /// is what wrote the empty change.
+    #[test]
+    fn a_lost_reply_with_a_beating_daemon_is_still_running_rather_than_failed() {
+        match classify_lost_reply(None, Some(open_commit(1_000)), 1_030) {
+            LostReply::StillRunning(open) => assert!(
+                open.contains("commit in phase reconcile_workspace_and_commit_authority for 213s"),
+                "the report must name the phase and its age: {open}"
+            ),
+            other => panic!("a beating daemon is still committing, not {other:?}"),
+        }
+
+        let quiet = 1_000 + kin_daemon_spawn::TRANSACTION_BEAT_STALE_AFTER.as_secs() + 5;
+        assert!(
+            matches!(
+                classify_lost_reply(None, Some(open_commit(1_000)), quiet),
+                LostReply::Gone
+            ),
+            "a marker that stopped beating proves nothing is in flight"
+        );
+        assert!(
+            matches!(classify_lost_reply(None, None, 1_030), LostReply::Gone),
+            "no receipt and no marker is a commit that failed, and must still report failure"
+        );
+    }
+
+    /// A refusal the daemon states in words reaches the caller as those words.
+    #[test]
+    fn a_nothing_to_commit_refusal_is_reported_as_its_own_sentence() {
+        let body = serde_json::json!({
+            "error": "nothing_to_commit",
+            "change_id": "5b8ca7b7",
+            "message": "nothing to commit: this tree is already committed as 5b8ca7b7",
+        })
+        .to_string();
+        assert_eq!(
+            commit_refusal_message(&body).as_deref(),
+            Some("nothing to commit: this tree is already committed as 5b8ca7b7")
+        );
+        assert!(
+            commit_refusal_message(&serde_json::json!({"error": "lease_conflict"}).to_string())
+                .is_none(),
+            "another refusal keeps the envelope its own reader parses"
+        );
+        assert!(commit_refusal_message("daemon is starting").is_none());
     }
 
     /// `kin commit` is not a git commit and nothing said so, while `git status`

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -173,22 +173,29 @@ enum LostReply {
     Gone,
 }
 
-/// Decide what a lost reply means from the two facts on disk.
+/// Decide what a lost reply means from the facts on disk.
 ///
 /// Separated from the reads so the decision can be tested against every
-/// combination of them, including the one that matters: a receipt present means
-/// landed no matter what the marker says, because a daemon that finished this
-/// commit and went on to another transaction still publishes a marker.
+/// combination of them, including the two that are easy to get wrong. A receipt
+/// means landed no matter what the marker says, because a daemon that finished
+/// this commit and went on to other work still publishes a marker. And a marker
+/// is trusted only while the daemon that wrote it is still running: a daemon
+/// killed mid-commit never retires its marker, and the kernel's OOM killer
+/// leaves no note behind either, so a beat alone would report a dead daemon's
+/// abandoned commit as still in flight.
 fn classify_lost_reply(
     landed: Option<DaemonCommitResult>,
     open: Option<kin_daemon_spawn::OpenTransaction>,
     now_unix: u64,
+    is_alive: impl Fn(u32) -> bool,
 ) -> LostReply {
     if let Some(result) = landed {
         return LostReply::Landed(Box::new(result));
     }
     match open {
-        Some(open) if open.is_beating(now_unix) => LostReply::StillRunning(open.summary()),
+        Some(open) if open.is_beating(now_unix) && is_alive(open.pid) => {
+            LostReply::StillRunning(open.summary())
+        }
         _ => LostReply::Gone,
     }
 }
@@ -223,6 +230,7 @@ fn resolve_commit_after_lost_reply(
         landed,
         kin_daemon_spawn::read_open_transaction(kin_root),
         unix_now(),
+        kin_daemon_spawn::process_is_alive,
     ) {
         LostReply::Landed(result) => {
             if !quiet {
@@ -558,7 +566,12 @@ mod tests {
     /// and moved on to other work is still mid-transaction.
     #[test]
     fn a_lost_reply_whose_operation_reached_authority_is_a_successful_commit() {
-        match classify_lost_reply(Some(landed_result()), Some(open_commit(1_000)), 1_005) {
+        match classify_lost_reply(
+            Some(landed_result()),
+            Some(open_commit(1_000)),
+            1_005,
+            |_| true,
+        ) {
             LostReply::Landed(result) => {
                 assert_eq!(result.change_id, "5b8ca7b7");
                 assert_eq!(result.entity_count, 32);
@@ -574,7 +587,7 @@ mod tests {
     /// is what wrote the empty change.
     #[test]
     fn a_lost_reply_with_a_beating_daemon_is_still_running_rather_than_failed() {
-        match classify_lost_reply(None, Some(open_commit(1_000)), 1_030) {
+        match classify_lost_reply(None, Some(open_commit(1_000)), 1_030, |_| true) {
             LostReply::StillRunning(open) => assert!(
                 open.contains("commit in phase reconcile_workspace_and_commit_authority for 213s"),
                 "the report must name the phase and its age: {open}"
@@ -585,13 +598,26 @@ mod tests {
         let quiet = 1_000 + kin_daemon_spawn::TRANSACTION_BEAT_STALE_AFTER.as_secs() + 5;
         assert!(
             matches!(
-                classify_lost_reply(None, Some(open_commit(1_000)), quiet),
+                classify_lost_reply(None, Some(open_commit(1_000)), quiet, |_| true),
                 LostReply::Gone
             ),
             "a marker that stopped beating proves nothing is in flight"
         );
+        // The shape the reported OOM kills took: the daemon died holding the
+        // marker, and the kernel that killed it wrote no note, so the marker is
+        // the only thing left and it is still beating from seconds ago.
         assert!(
-            matches!(classify_lost_reply(None, None, 1_030), LostReply::Gone),
+            matches!(
+                classify_lost_reply(None, Some(open_commit(1_000)), 1_030, |_| false),
+                LostReply::Gone
+            ),
+            "a marker belonging to a dead daemon is a leftover, not work in flight"
+        );
+        assert!(
+            matches!(
+                classify_lost_reply(None, None, 1_030, |_| true),
+                LostReply::Gone
+            ),
             "no receipt and no marker is a commit that failed, and must still report failure"
         );
     }

--- a/crates/kin-cli/tests/commit_unchanged_tree.rs
+++ b/crates/kin-cli/tests/commit_unchanged_tree.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! What `kin commit` does when the tree it would publish is already committed,
+//! through the real binaries.
+//!
+//! A stranger running Kin in a container committed a docstring edit on a
+//! converted psf/requests store, read `operation timed out` from a client
+//! deadline the daemon outlived, concluded the edit was uncommitted, and ran the
+//! commit again. The first attempt had landed. The second was accepted and
+//! recorded as a change with no entities, no relations and no files, stacked on
+//! top of the real one, and `kin log` in the container carried that pair on both
+//! repositories it was run against.
+//!
+//! A unit test on the planner cannot cover the retry, because the retry is a
+//! whole second invocation. These drive `kin` itself and read `kin log`, which
+//! is the surface the empty changes were found in.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+fn run_git(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(repo)
+        .output()
+        .expect("run git")
+}
+
+fn require_git(repo: &Path, args: &[&str]) {
+    let output = run_git(repo, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    runtime
+        .kin_command()
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .current_dir(repo)
+        .output()
+        .expect("run kin")
+}
+
+fn require_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    let output = run_kin(runtime, repo, args);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn initialize(runtime: &common::IsolatedDaemonRuntime, repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn shipped() -> u8 { 1 }\n").expect("write source");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "first commit"]);
+
+    let init = run_kin(runtime, repo, &["init", ".", "--json"]);
+    assert!(
+        init.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+fn log_entries(runtime: &common::IsolatedDaemonRuntime, repo: &Path) -> Vec<Value> {
+    let output = require_kin(runtime, repo, &["log", "--json", "--count", "20"]);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("kin log should emit JSON");
+    assert_eq!(report["schema"], "kin.log.v1");
+    report["entries"]
+        .as_array()
+        .expect("log reports its entries")
+        .clone()
+}
+
+/// The change id a log entry names.
+///
+/// A change id serializes as its 32 raw bytes rather than as the hex a person
+/// reads, so entries are compared as values here and the human form is taken
+/// from what `kin commit` printed.
+fn change_id(entry: &Value) -> Value {
+    let id = entry["change_id"].clone();
+    assert!(!id.is_null(), "every log entry names its change: {entry}");
+    id
+}
+
+/// The change id `kin commit` printed, in the form a person reads.
+fn printed_change_id(stdout: &[u8]) -> String {
+    let printed = String::from_utf8_lossy(stdout);
+    let line = printed
+        .lines()
+        .find(|line| line.starts_with("Created semantic change "))
+        .unwrap_or_else(|| panic!("a successful commit names its change: {printed}"));
+    line.split_whitespace()
+        .nth(3)
+        .expect("the summary names the change id")
+        .to_string()
+}
+
+/// The retry that minted the empty change, run for real.
+///
+/// The refusal has to name the change that already holds the tree, because the
+/// person reading it has just been told their commit failed and needs to be able
+/// to check that claim in `kin log` without guessing which change to look at.
+///
+/// Falsify by removing the `refuse_a_successor_that_records_nothing` call from
+/// `command_commit_after_admission` in kin-daemon: the second commit then
+/// succeeds and the log grows by a change carrying nothing.
+#[test]
+fn a_second_commit_on_an_unchanged_tree_is_refused_and_adds_no_change() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    fs::write(repo.join("src/added.rs"), b"pub fn added() -> u8 { 3 }\n").expect("add source");
+    let published = require_kin(&runtime, &repo, &["commit", "-m", "publish added source"]);
+    let landed = printed_change_id(&published.stdout);
+
+    let committed = log_entries(&runtime, &repo);
+    let newest = change_id(committed.first().expect("the native commit"));
+
+    let refused = run_kin(
+        &runtime,
+        &repo,
+        &["commit", "-m", "publish added source again"],
+    );
+    assert!(
+        !refused.status.success(),
+        "a commit on a tree Kin already holds must be refused: stdout={} stderr={}",
+        String::from_utf8_lossy(&refused.stdout),
+        String::from_utf8_lossy(&refused.stderr)
+    );
+    let message = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        message.contains("nothing to commit"),
+        "the refusal must say what it refused: {message}"
+    );
+    assert!(
+        message.contains(&format!("already committed as {landed}")),
+        "the refusal must name the change that already holds this tree: {message}"
+    );
+
+    let after = log_entries(&runtime, &repo);
+    assert_eq!(
+        after.len(),
+        committed.len(),
+        "a refused commit must record nothing: {after:?}"
+    );
+    assert_eq!(
+        change_id(after.first().expect("the native commit")),
+        newest,
+        "the branch must still point at the change that did the work"
+    );
+    assert!(
+        !after.iter().any(|entry| {
+            entry["entity_delta_count"] == 0
+                && entry["relation_delta_count"] == 0
+                && entry["tree_delta_count"] == 0
+                && entry["admission_policy_changed"] == false
+        }),
+        "no change may record nothing at all: {after:?}"
+    );
+}

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -143,6 +143,91 @@ pub fn clear_daemon_death_note(kin_root: &Path) {
     let _ = fs::remove_file(kin_root.join(DEATH_FILE_NAME));
 }
 
+/// File a daemon publishes its open write transaction into.
+pub const TRANSACTION_FILE_NAME: &str = "daemon.transaction";
+
+/// How long a published beat stays trustworthy.
+///
+/// Twelve beats at the daemon's five-second interval. A daemon whose beat
+/// thread has not been scheduled for a minute is wedged rather than busy, and
+/// nothing may report it as working.
+pub const TRANSACTION_BEAT_STALE_AFTER: Duration = Duration::from_secs(60);
+
+/// What one daemon publishes about the transaction it currently has open.
+///
+/// Written by the daemon's beat thread and read by two other processes: the
+/// supervisor deciding whether a silent daemon is wedged or merely busy, and
+/// the CLI deciding whether a commit whose reply it never received is still
+/// running. One definition rather than three, because a reader carrying its own
+/// copy of these field names would report "no transaction open" for every shape
+/// change the writer made, which is the same answer a dead daemon produces.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OpenTransaction {
+    /// The daemon that owns this transaction. A marker naming a different pid
+    /// than the daemon being judged is a leftover and shields nobody.
+    pub pid: u32,
+    /// Which write path is open, e.g. `commit`.
+    pub operation: String,
+    /// Phase currently running, when one has been entered.
+    pub phase: Option<String>,
+    /// Wall seconds since the transaction opened.
+    pub elapsed_secs: u64,
+    /// Wall seconds since the running phase was entered.
+    pub phase_elapsed_secs: u64,
+    /// Unix seconds at the last beat. Freshness is decided against this.
+    pub beat_unix: u64,
+}
+
+impl OpenTransaction {
+    /// Seconds since the last published beat, at `now_unix`.
+    pub fn beat_age_secs(&self, now_unix: u64) -> u64 {
+        now_unix.saturating_sub(self.beat_unix)
+    }
+
+    /// Whether this marker is beating fresh enough to prove work in flight.
+    pub fn is_beating(&self, now_unix: u64) -> bool {
+        self.beat_age_secs(now_unix) <= TRANSACTION_BEAT_STALE_AFTER.as_secs()
+    }
+
+    /// One line naming what is open and how long it has run.
+    pub fn summary(&self) -> String {
+        match &self.phase {
+            Some(phase) => format!(
+                "{} in phase {} for {}s",
+                self.operation, phase, self.elapsed_secs
+            ),
+            None => format!("{} for {}s", self.operation, self.elapsed_secs),
+        }
+    }
+}
+
+/// Publish the open-transaction marker for `kin_root`.
+///
+/// Best effort and atomic: a reader must never see half a record, and a beat
+/// that could not be written must never end the transaction it describes.
+pub fn write_open_transaction(kin_root: &Path, record: &OpenTransaction) {
+    let Ok(body) = serde_json::to_string(record) else {
+        return;
+    };
+    let tmp = kin_root.join(format!("{TRANSACTION_FILE_NAME}.tmp"));
+    if fs::write(&tmp, body).is_ok()
+        && fs::rename(&tmp, kin_root.join(TRANSACTION_FILE_NAME)).is_err()
+    {
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+/// Read the open-transaction marker for `kin_root`, if one is there.
+pub fn read_open_transaction(kin_root: &Path) -> Option<OpenTransaction> {
+    let raw = fs::read_to_string(kin_root.join(TRANSACTION_FILE_NAME)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Retire the open-transaction marker for `kin_root`.
+pub fn clear_open_transaction(kin_root: &Path) {
+    let _ = fs::remove_file(kin_root.join(TRANSACTION_FILE_NAME));
+}
+
 /// Append a line to the repo daemon's own log.
 ///
 /// The one place a killer can put its reason where the operator will look. The

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -3277,6 +3277,17 @@ fn process_liveness(pid: u32) -> Liveness {
     }
 }
 
+/// Whether `pid` is provably still running.
+///
+/// One-directional in the same sense [`recorded_owner_is_alive`] is: `true` is
+/// positive proof of life, and every other outcome is the absence of proof
+/// rather than proof of death. It exists for readers holding a pid from a
+/// record other than the PID file, such as the open-transaction marker a daemon
+/// killed mid-commit leaves behind.
+pub fn process_is_alive(pid: u32) -> bool {
+    matches!(process_liveness(pid), Liveness::Alive)
+}
+
 /// Whether the daemon recorded for `kin_root` is provably still running.
 ///
 /// [`startup_disposition`] answers this with `Child::try_wait`, which only the

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4756,6 +4756,9 @@ fn command_commit_after_admission(
         )
     })
     .map_err(repository_commit_error)?;
+    if let Some(refusal) = refuse_a_successor_that_records_nothing(&plan) {
+        return Err(refusal);
+    }
     let change_id = plan.change.id;
     let branch_name = plan.branch.clone();
     let entity_count = plan.entity_count;
@@ -4859,6 +4862,47 @@ fn command_commit_after_admission(
         relation_count,
         file_count,
     }))
+}
+
+/// Refuse a commit whose successor would record nothing at all.
+///
+/// A `kin commit` on a tree Kin has already committed used to be accepted and
+/// published as a change with `entities=0 relations=0 tree=0`. Nothing about
+/// that change is recoverable information: it names no entity, no relation and
+/// no file, and it exists only because a caller asked twice. The way callers
+/// ask twice is the point. A commit whose reply the client never received looks
+/// exactly like a commit that never happened, so the next thing a person does
+/// is run it again, and the retry mints the empty change on top of the real
+/// one. Refusing here rather than in the CLI is what makes the guarantee hold
+/// for every caller of this endpoint, including the one that has already
+/// decided the first attempt failed.
+///
+/// A policy-only change still commits: an admission policy delta is a recorded
+/// transition even when no entity, relation or file moved.
+fn refuse_a_successor_that_records_nothing(
+    plan: &crate::repository_commit::NativeCommitPlan,
+) -> Option<(StatusCode, String)> {
+    let change = &plan.change;
+    if !change.entity_deltas.is_empty()
+        || !change.relation_deltas.is_empty()
+        || !change.tree_deltas.is_empty()
+        || change.admission_policy_delta.is_some()
+    {
+        return None;
+    }
+    let already = change.parents.first();
+    let message = match already {
+        Some(parent) => format!("nothing to commit: this tree is already committed as {parent}"),
+        None => "nothing to commit: this workspace holds no entities, relations or files to \
+                 record"
+            .to_string(),
+    };
+    let body = serde_json::json!({
+        "error": "nothing_to_commit",
+        "change_id": already.map(|parent| parent.to_string()),
+        "message": message,
+    });
+    Some((StatusCode::CONFLICT, body.to_string()))
 }
 
 fn repository_commit_error(error: crate::error::DaemonError) -> (StatusCode, String) {
@@ -19300,6 +19344,104 @@ mod tests {
                 .is_some(),
             "the committed file must be graph-owned after the single successor"
         );
+    }
+
+    /// A second commit on a tree Kin already committed is refused by the daemon.
+    ///
+    /// The retry is not hypothetical. A commit whose reply the client never
+    /// received looks exactly like a commit that never happened, so the next
+    /// thing that happens is the same commit again, and on a converted
+    /// psf/requests store that second attempt was accepted and recorded as
+    /// `entities=0 relations=0 tree=0` on top of the real change. The refusal
+    /// lives here rather than in the CLI so it holds for any caller of this
+    /// endpoint, including one that has already decided the first attempt
+    /// failed. Falsify by deleting the
+    /// `refuse_a_successor_that_records_nothing` call in
+    /// `command_commit_after_admission`: the second request then returns 200 and
+    /// the change count below goes to two.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial_test::serial(commit_phase_capture)]
+    async fn a_second_commit_on_an_unchanged_tree_is_refused_and_records_nothing() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(initialized.layout).unwrap());
+        std::fs::write(
+            repo.path().join("committed_once.rs"),
+            b"pub fn committed_once() -> u32 { 1 }\n",
+        )
+        .unwrap();
+
+        let commit = |message: &'static str| {
+            let state = Arc::clone(&state);
+            async move {
+                let response = router(state)
+                    .oneshot(
+                        Request::post("/commands/commit")
+                            .header("content-type", "application/json")
+                            .body(Body::from(
+                                json!({
+                                    "operation_id": kin_model::OperationId::new(),
+                                    "timestamp": kin_model::Timestamp::now(),
+                                    "author": "Test Author <test@example.invalid>",
+                                    "message": message
+                                })
+                                .to_string(),
+                            ))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                let status = response.status();
+                let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+                    .await
+                    .unwrap();
+                (status, String::from_utf8_lossy(&body).to_string())
+            }
+        };
+
+        let (status, body) = commit("publish the file once").await;
+        assert_eq!(status, StatusCode::OK, "the first commit must land: {body}");
+        let first: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let landed = first["change_id"].as_str().unwrap().to_string();
+
+        let changes_after_first = authority_change_count(&state);
+        let (status, body) = commit("publish the same tree again").await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "a commit that would record nothing must be refused: {body}"
+        );
+        let refusal: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(refusal["error"], "nothing_to_commit");
+        assert_eq!(
+            refusal["change_id"].as_str(),
+            Some(landed.as_str()),
+            "the refusal must name the change that already holds this tree: {body}"
+        );
+        assert!(
+            refusal["message"]
+                .as_str()
+                .unwrap()
+                .contains(&format!("already committed as {landed}")),
+            "the refusal must read as one sentence a person can act on: {body}"
+        );
+        assert_eq!(
+            authority_change_count(&state),
+            changes_after_first,
+            "a refused commit must record no change at all"
+        );
+    }
+
+    /// Changes in repository authority, read the way `kin log` reads them.
+    fn authority_change_count(state: &Arc<DaemonState>) -> usize {
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)
+                .unwrap();
+        let authority = context.open().unwrap();
+        let lease = authority.read_authority();
+        let count = lease.snapshot().changes.len();
+        count
     }
 
     /// The endpoint used to resolve its own author, and the resolution was two

--- a/crates/kin-daemon/src/commit_liveness.rs
+++ b/crates/kin-daemon/src/commit_liveness.rs
@@ -30,7 +30,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// File a daemon publishes its open transaction into, beside the endpoint
 /// record it already publishes.
-pub const TRANSACTION_FILE_NAME: &str = "daemon.transaction";
+///
+/// The record itself lives in `kin-daemon-spawn` because three processes read
+/// or write it: this daemon, the supervisor judging it, and the CLI asking
+/// whether the commit it lost a reply to is still running.
+pub use kin_daemon_spawn::{OpenTransaction, TRANSACTION_FILE_NAME};
 
 /// How often the beat thread republishes the marker and names the running phase.
 ///
@@ -44,25 +48,7 @@ const BEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// Twelve missed beats. A daemon whose OS thread has not been scheduled for a
 /// minute is wedged in a way this marker should not shield, and the reap that
 /// follows says so explicitly rather than treating the marker as absent.
-pub const BEAT_STALE_AFTER: Duration = Duration::from_secs(60);
-
-/// What one daemon publishes about the transaction it currently has open.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct OpenTransaction {
-    /// The daemon that owns this transaction. A marker naming a different pid
-    /// than the daemon being judged is a leftover and shields nobody.
-    pub pid: u32,
-    /// Which write path is open, e.g. `commit`.
-    pub operation: String,
-    /// Phase currently running, when one has been entered.
-    pub phase: Option<String>,
-    /// Wall seconds since the transaction opened.
-    pub elapsed_secs: u64,
-    /// Wall seconds since the running phase was entered.
-    pub phase_elapsed_secs: u64,
-    /// Unix seconds at the last beat. Freshness is decided against this.
-    pub beat_unix: u64,
-}
+pub const BEAT_STALE_AFTER: Duration = kin_daemon_spawn::TRANSACTION_BEAT_STALE_AFTER;
 
 /// How a reader should treat a daemon's transaction marker.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,10 +100,7 @@ pub fn transaction_path(repo_root: &Path) -> PathBuf {
 /// file, an unreadable file, a marker naming another pid — is merely the absence
 /// of proof. Callers use it to withhold a kill, never to authorize one.
 pub fn transaction_liveness(repo_root: &Path, pid: u32) -> TransactionLiveness {
-    let Ok(raw) = std::fs::read_to_string(transaction_path(repo_root)) else {
-        return TransactionLiveness::None;
-    };
-    let Ok(open) = serde_json::from_str::<OpenTransaction>(&raw) else {
+    let Some(open) = kin_daemon_spawn::read_open_transaction(&repo_root.join(".kin")) else {
         return TransactionLiveness::None;
     };
     if open.pid != pid {
@@ -199,14 +182,7 @@ fn publish_beat() {
 }
 
 fn write_marker(kin_root: &Path, record: &OpenTransaction) {
-    let Ok(body) = serde_json::to_string(record) else {
-        return;
-    };
-    let path = kin_root.join(TRANSACTION_FILE_NAME);
-    let tmp = kin_root.join(format!("{TRANSACTION_FILE_NAME}.tmp"));
-    if std::fs::write(&tmp, body).is_ok() && std::fs::rename(&tmp, &path).is_err() {
-        let _ = std::fs::remove_file(&tmp);
-    }
+    kin_daemon_spawn::write_open_transaction(kin_root, record);
 }
 
 /// Start the beat thread once per process.
@@ -277,7 +253,7 @@ impl Drop for TransactionGuard {
         // that transaction's proof of life now, and clearing it would blind the
         // reaper to a commit that is still running.
         if owned {
-            let _ = std::fs::remove_file(self.kin_root.join(TRANSACTION_FILE_NAME));
+            kin_daemon_spawn::clear_open_transaction(&self.kin_root);
         }
     }
 }


### PR DESCRIPTION
`kin commit` built its HTTP client with a fixed 120 second deadline
(`crates/kin-cli/src/commands/commit.rs:71` at fc906464), and a one-file commit
on a converted store outlives it. The reported run shows the daemon's own phases
running long past the client: `plan_transaction elapsed_ms=68378`,
`open_repository_authority elapsed_ms=53343`, and a
`reconcile_workspace_and_commit_authority` phase of 60837 ms whose last line
landed 213 seconds after the CLI started and 93 seconds after the CLI had already
printed `operation timed out`. The deadline expiring cancelled nothing, so the
change landed anyway. The person reading the error then ran the commit again, and
the daemon accepted that second commit on a tree it had already committed and
recorded it as `entities=0 relations=0 tree=0`. That is the pair `kin log`
carried on both repositories in the container.

The client now sets no reply deadline. A deadline can only be right if the CLI
knows how long the work should take, and it cannot, because the cost is a
property of the store. The connect timeout stays at 500 ms so a daemon that is
not listening still fails immediately, and the existing phase stream keeps
printing for the whole wait, so a commit that is working and a commit that is
wedged still look different.

When a reply is lost anyway, the CLI stops treating the socket as the authority
on what happened. It looks this invocation's operation id up in the repository
authority receipts, the same lookup the daemon's own `recover_native_commit`
performs, read from the durable store rather than from a daemon that may no
longer answer. A receipt means the commit landed, so the CLI reports the change
it recorded and exits 0. No receipt plus a fresh beat from a daemon that is still
alive means the commit is still running, and the CLI says exactly that, naming
the phase, the elapsed seconds and the operation id. Neither means the commit
failed, and the CLI reports the transport error with the daemon death note behind
it, as it did before.

A marker is trusted only while its daemon answers. A daemon killed mid-commit
never retires its open-transaction marker, and the kernel's OOM killer writes no
death note beside it, so reading the beat alone would have reported the two
attempts that died in an OOM-killed container as still running.

The daemon refuses a successor that would record nothing at all
(`refuse_a_successor_that_records_nothing`, called from
`command_commit_after_admission` before the lease gate). A plan whose change
carries no entity, relation or tree delta and no admission policy delta is
refused with HTTP 409 and a body naming the change that already holds the tree,
and the CLI renders that body as its own sentence instead of wrapping it in an
HTTP envelope. The refusal lives in the endpoint rather than in the client so it
holds for any caller, including one that has already decided its first attempt
failed. A policy-only change still commits.

`OpenTransaction`, its file name, its staleness bound and its read and write
helpers move to `kin-daemon-spawn`, which both `kin-daemon` and `kin-cli` already
depend on, and `commit_liveness` re-exports them so the supervisor's behavior is
unchanged. A CLI-side copy of those field names would have reported "no
transaction open" for every shape change the writer made, which is the same
answer a dead daemon produces.

Production behavior that is preserved: a real transport failure with no receipt
and no live daemon still reports failure and still exits non-zero, and a commit
the daemon genuinely refuses still exits non-zero with its own reason.

Still open, and deliberately not attempted here: the memory ceiling of a one-file
commit on a requests-sized store, where the daemon peaked at 10.9 GiB and was
OOM-killed under a 12 GiB cap. That is part (3) of the ticket's contract and it
is FIR-2347's and FIR-2291's write-path work. This change makes that failure
honest rather than smaller.

## Tests

- `a_commit_slower_than_a_client_deadline_still_reports_its_change` drives a stub
  daemon that answers after 600 ms. A 150 ms client is the control that proves
  the daemon really is slower than a deadline, and the production client then
  receives the reply. No test waits for the old 120 seconds; the defect needs two
  durations in the wrong order, not two minutes.
- `a_lost_reply_whose_operation_reached_authority_is_a_successful_commit` and
  `a_lost_reply_with_a_beating_daemon_is_still_running_rather_than_failed` cover
  the receipt, the fresh beat, the stale beat and the marker left behind by a
  daemon that is no longer alive.
- `a_second_commit_on_an_unchanged_tree_is_refused_and_records_nothing` drives the
  daemon endpoint and asserts the authority change count does not move.
- `a_second_commit_on_an_unchanged_tree_is_refused_and_adds_no_change` drives the
  real `kin` and `kin-daemon` binaries and asserts that the refusal names the
  landed change id and that `kin log` gains no entry.

## Falsification

Each guard was broken, watched to fail with its own message, and restored.

- Wrapping the `refuse_a_successor_that_records_nothing` call in `if false`:
  `a commit that would record nothing must be refused: {"change_id":"64bf6f0b...","entity_count":0,"relation_count":0,"file_count":0}` with `left: 200`,
  and end to end `a commit on a tree Kin already holds must be refused: stdout=Created semantic change a4948738... (0 entities, 0 relations, 0 artifacts)`.
  That is the ticket's empty change, reproduced through both surfaces.
- Forcing a 150 ms timeout in `build_commit_client`:
  `a commit with no reply deadline waits for the daemon: reqwest::Error { kind: Request, source: TimedOut }`.
- Making `classify_lost_reply` always answer `Gone`: `a receipt is a landed
  commit, not Gone` and `a beating daemon is still committing, not Gone`.
- Dropping the `is_alive(open.pid)` conjunct: `a marker belonging to a dead
  daemon is a leftover, not work in flight`.

## Gates

`cargo fmt --all -- --check` clean. CI clippy, `--all-targets --all-features`
with the `ci.yml` allowlist under `RUSTFLAGS=-D warnings`, exit 0 with no
warnings. The full local gate,
`bin/kin-lane run fir2403-commit kin -- bin/kin-dev local-test kin`, printed
`kin-dev: local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/fir2403-commit-kin @ c353b1ab (chore/lane-fir2403-commit-kin)`
and finished `6027 tests run: 6027 passed`, exit 0. The branch has been rebased
since onto `320cf57a`, whose only new commit is the v0.5.39 release bump and
touches none of these files. `git ls-tree -r HEAD --name-only` matches exactly
one `.cargo/` path, `.cargo/config.toml`, and `git diff origin/main --stat --
Cargo.lock .cargo/` is empty.

Closes FIR-2403
