### PR TITLE
Report one find_references row per caller and say what the count counted

### DIFF
--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -879,6 +879,165 @@ mod tests {
         );
     }
 
+    /// `kin refs` and MCP `find_references` must return the same number for the
+    /// same entity on the same graph.
+    ///
+    /// They did not. The CLI counts distinct referencing entities; the MCP tool
+    /// keyed its rows on the caller's FILE path and so counted distinct files,
+    /// which is FIR-2398. Two surfaces answering one question with two numbers
+    /// is worse than either being wrong alone, because whichever an agent read
+    /// looked internally consistent.
+    ///
+    /// The fixture is built so the two counts cannot coincide by luck: three
+    /// callers share one file, a fourth sits in another, and the target also
+    /// calls itself. Under the old rule the MCP tool saw three keys
+    /// (two caller files plus the target's own, from the self edge) against the
+    /// CLI's four entities, so a regression separates them again.
+    #[tokio::test]
+    async fn cli_refs_and_mcp_find_references_agree_on_the_caller_count() {
+        use kin_db::InMemoryGraph;
+        use kin_model::relation::{Relation, RelationOrigin};
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, SemanticFingerprint,
+            Visibility,
+        };
+
+        fn entity(name: &str, rel_path: &str) -> Entity {
+            Entity {
+                id: EntityId::new(),
+                kind: EntityKind::Function,
+                name: name.to_string(),
+                language: LanguageId::Rust,
+                fingerprint: SemanticFingerprint {
+                    algorithm: FingerprintAlgorithm::V1TreeSitter,
+                    ast_hash: Hash256::from_bytes([0; 32]),
+                    signature_hash: Hash256::from_bytes([0; 32]),
+                    behavior_hash: Hash256::from_bytes([0; 32]),
+                    equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
+                    stability_score: 1.0,
+                },
+                file_origin: Some(FilePathId::new(rel_path)),
+                span: None,
+                signature: name.to_string(),
+                visibility: Visibility::Public,
+                role: EntityRole::Source,
+                doc_summary: None,
+                metadata: EntityMetadata::default(),
+                lineage_parent: None,
+                created_in: None,
+                superseded_by: None,
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let graph = InMemoryGraph::new();
+
+        let target = entity("to_dot", "linkgraph.rs");
+        let callers = [
+            entity("draws_nodes", "test_linkgraph.rs"),
+            entity("draws_edges", "test_linkgraph.rs"),
+            entity("draws_dashed", "test_linkgraph.rs"),
+            entity("cmd_graph", "cli.rs"),
+        ];
+        graph.upsert_entity(&target).unwrap();
+
+        let edge = |src: EntityId, dst: EntityId| {
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(src),
+                    dst: GraphNodeId::Entity(dst),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        };
+        for caller in &callers {
+            graph.upsert_entity(caller).unwrap();
+            edge(caller.id, target.id);
+        }
+        // Recursive: an upstream caller on neither surface.
+        edge(target.id, target.id);
+
+        let cli = build_refs_response(
+            &layout,
+            &graph,
+            &RefsRequest {
+                entity: target.id.to_string(),
+                kind: "calls".to_string(),
+            },
+        )
+        .unwrap();
+        let cli_text = cli.lines.join("\n");
+
+        let args = std::collections::HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(target.id.to_string()),
+            ),
+            ("relation_kinds".to_string(), serde_json::json!(["calls"])),
+        ]);
+        let mcp = kin_mcp::handlers::entities::handle_find_references(&args, &graph, None)
+            .await
+            .unwrap();
+        let kin_mcp::types::ContentBlock::Text { text } = mcp.content.first().unwrap();
+        let mcp_body: serde_json::Value = serde_json::from_str(text).unwrap();
+        let mcp_count = mcp_body["total_upstream"].as_u64().unwrap();
+
+        // Absolute value first: two surfaces agreeing on a wrong number is not
+        // agreement, and this is the assertion that catches both regressing the
+        // same way.
+        assert_eq!(
+            mcp_count, 4,
+            "four callers, whichever files they share: {mcp_body:#}"
+        );
+        assert!(
+            cli_text.contains("referenced by 4 entities:"),
+            "the CLI must count the same four: {cli_text}"
+        );
+        assert_eq!(
+            mcp_body["counts"]["counted"], "referencing_entities",
+            "the agreed count must name its unit: {mcp_body:#}"
+        );
+        // Non-vacuity: the file count is genuinely different, so the assertions
+        // above are not passing because every number in the fixture is 4.
+        assert_eq!(
+            mcp_body["counts"]["files"], 2,
+            "the fixture must span fewer files than callers: {mcp_body:#}"
+        );
+
+        // Row for row, not just in total: every caller the CLI names is a row
+        // the MCP tool returned, by entity id.
+        let mcp_ids = mcp_body["references"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["entity_id"].as_str().unwrap().to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+        for caller in &callers {
+            assert!(
+                mcp_ids.contains(&caller.id.to_string()),
+                "MCP dropped caller {}: {mcp_body:#}",
+                caller.name
+            );
+            assert!(
+                cli_text.contains(&caller.name),
+                "the CLI dropped caller {}: {cli_text}",
+                caller.name
+            );
+        }
+        assert!(
+            !mcp_ids.contains(&target.id.to_string()),
+            "the recursive edge must not be reported as a caller: {mcp_body:#}"
+        );
+    }
+
     #[test]
     fn parse_relation_kinds_accepts_import_alias() {
         let kinds = parse_relation_kinds("import").unwrap();

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1048,8 +1048,19 @@ pub struct ReferenceRow {
     /// and it compounds any staleness in the definition's own span. The reference
     /// site is a graph fact, so it is served as one. Empty when the parser
     /// recorded no span for any contributing edge, which is honest absence rather
-    /// than a derived guess.
+    /// than a derived guess -- and `reference_lines_absent` then names which
+    /// absence it is.
     pub reference_lines: Vec<u32>,
+    /// Why this row carries no `reference_lines`, and `None` when it carries
+    /// some.
+    ///
+    /// An empty list on a returned reference is the quiet-partial failure in
+    /// miniature (FIR-2357 item 3): the row proves a caller exists while saying
+    /// nothing about why its site could not be located, so a reader cannot tell
+    /// a parser gap from a bug. The row is still reported, because dropping a
+    /// caller whose site was never recorded would understate blast radius, but
+    /// the reason is stated rather than left to inference.
+    pub reference_lines_absent: Option<ReferenceLinesAbsent>,
     pub signature: Option<String>,
     /// Bounded inline body excerpt of the referencing entity, projected from the
     /// same content-addressed, hash-verified graph body that backs
@@ -1067,6 +1078,47 @@ pub struct ReferenceRow {
     pub resolution: Option<RelationResolution>,
 }
 
+/// Why a reference row carries no site lines.
+///
+/// Each variant is one measured condition, not a label chosen for how it reads.
+/// A consumer that wants to edit every call site needs to know whether the sites
+/// are unknown because the parser recorded none, because the ones recorded
+/// belong to another file, or because the edge lives in a graph this response
+/// has no authority over -- those are three different follow-ups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferenceLinesAbsent {
+    /// No edge behind this row carried a `RelationEvidence::source_span`: the
+    /// relation was recorded without the syntax position that produced it.
+    NoEvidenceSpan,
+    /// Edges carried spans, but every one named a file other than the caller's.
+    /// Reporting them under this row's `file_path` would print lines of one file
+    /// as lines of another, so they are dropped and the drop is declared.
+    SpanOutsideCallerFile,
+    /// A federated cross-repository xref: the resolving edge and its span live in
+    /// the other repository's graph.
+    FederatedXref,
+}
+
+impl ReferenceLinesAbsent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoEvidenceSpan => "no_evidence_span",
+            Self::SpanOutsideCallerFile => "span_outside_caller_file",
+            Self::FederatedXref => "federated_xref",
+        }
+    }
+}
+
+/// One row per REFERENCING ENTITY that reaches `entity_id` over an allowed
+/// relation kind.
+///
+/// Rows are keyed on the caller's entity id. They were keyed on the caller's
+/// FILE path, which collapsed every caller in one file into a single row that
+/// kept the first caller's id, name and signature, and left `total_upstream`
+/// reporting the number of distinct files: a function with eleven callers across
+/// two files answered "2" with both completeness flags true (FIR-2398). Keying
+/// on the entity also makes this agree with the shared CLI collector
+/// (`kin refs`), which has always counted distinct referencing entities.
 pub fn collect_graph_reference_rows<G: GraphStore>(
     store: &G,
     entity_id: &EntityId,
@@ -1074,7 +1126,12 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<Vec<ReferenceRow>> {
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
-    let mut grouped: HashMap<String, ReferenceRow> = HashMap::new();
+    let mut grouped: HashMap<EntityId, ReferenceRow> = HashMap::new();
+    // Spans a row's edges carried that named some other file, counted so an
+    // empty `reference_lines` can say which absence it is instead of collapsing
+    // "the parser recorded nothing" and "what it recorded was unusable here"
+    // into one silent empty list.
+    let mut spans_outside_caller_file: HashMap<EntityId, usize> = HashMap::new();
 
     // One held authority for the whole reference set. This projects a body per
     // REFERENCING entity, so it is the same multi-entity shape the retrieval
@@ -1092,6 +1149,13 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         if rel.dst != GraphNodeId::Entity(*entity_id) || !allowed.contains(&rel.kind) {
             continue;
         }
+        // A self/recursive edge does not make an entity its own upstream caller.
+        // The shared CLI collector has always excluded it, so counting it here
+        // would leave `kin refs` and `find_references` one apart on every
+        // recursive function.
+        if source_entity_id == *entity_id {
+            continue;
+        }
         let Some(entity) = store
             .get_entity(&source_entity_id)
             .map_err(McpError::graph)?
@@ -1100,7 +1164,6 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         };
 
         let file_path = entity.file_origin.as_ref().map(|path| path.0.clone());
-        let key = reference_row_key(file_path.as_deref(), &entity.name);
         // A referencing entity the current workspace does not contain is a
         // reference from history, not a caller of this code today, so it is not
         // reported as one. Failing the whole reference set over it -- the shape
@@ -1115,21 +1178,24 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
             Err(error) if is_absent_at_generation(&error) => continue,
             Err(error) => return Err(error),
         };
-        let entry = grouped.entry(key).or_insert_with(|| ReferenceRow {
-            entity_id: Some(source_entity_id.to_string()),
-            name: entity.name.clone(),
-            kind: Some(format!("{:?}", entity.kind)),
-            file_path: file_path.clone(),
-            start_line: entity_presentation_start_line(&entity),
-            reference_lines: Vec::new(),
-            signature: Some(entity.signature.clone()),
-            // Project the caller's bounded body once, where the entity is in
-            // hand, so `find_references` hands back act-on-able code per caller
-            // without a follow-up id→body round-trip.
-            snippet,
-            relation_kinds: Vec::new(),
-            resolution: None,
-        });
+        let entry = grouped
+            .entry(source_entity_id)
+            .or_insert_with(|| ReferenceRow {
+                entity_id: Some(source_entity_id.to_string()),
+                name: entity.name.clone(),
+                kind: Some(format!("{:?}", entity.kind)),
+                file_path: file_path.clone(),
+                start_line: entity_presentation_start_line(&entity),
+                reference_lines: Vec::new(),
+                reference_lines_absent: None,
+                signature: Some(entity.signature.clone()),
+                // Project the caller's bounded body once, where the entity is in
+                // hand, so `find_references` hands back act-on-able code per caller
+                // without a follow-up id→body round-trip.
+                snippet,
+                relation_kinds: Vec::new(),
+                resolution: None,
+            });
         if entry.file_path.is_none() {
             entry.file_path = file_path;
         }
@@ -1139,14 +1205,16 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         if entry.signature.is_none() {
             entry.signature = Some(entity.signature.clone());
         }
-        // Every edge contributing to this row carries its own site span, so a row
-        // that collapses several call sites reports all of them rather than the
-        // first. Only spans inside the referencing entity's own file are taken: a
-        // cross-file evidence span would be a line number the row's `file_path`
-        // does not explain.
-        entry
-            .reference_lines
-            .extend(relation_reference_lines(&rel, entity.file_origin.as_ref()));
+        // Every edge contributing to this row carries its own site span, so a
+        // caller that references the target several times reports all of its
+        // sites rather than the first. Only spans inside the referencing
+        // entity's own file are taken: a cross-file evidence span would be a
+        // line number the row's `file_path` does not explain.
+        let tally = relation_reference_lines(&rel, entity.file_origin.as_ref());
+        entry.reference_lines.extend(tally.lines);
+        *spans_outside_caller_file
+            .entry(source_entity_id)
+            .or_default() += tally.outside_caller_file;
         push_reference_kind(&mut entry.relation_kinds, rel.kind);
         let resolution = RelationResolution::of(&rel);
         entry.resolution = Some(match entry.resolution {
@@ -1155,13 +1223,34 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         });
     }
 
-    let mut rows = grouped.into_values().collect::<Vec<_>>();
-    for row in &mut rows {
+    let mut rows = Vec::with_capacity(grouped.len());
+    for (source_entity_id, mut row) in grouped {
         row.relation_kinds.sort_by_key(relation_kind_rank);
         row.reference_lines.sort_unstable();
         row.reference_lines.dedup();
+        row.reference_lines_absent = if !row.reference_lines.is_empty() {
+            None
+        } else if spans_outside_caller_file
+            .get(&source_entity_id)
+            .is_some_and(|dropped| *dropped > 0)
+        {
+            Some(ReferenceLinesAbsent::SpanOutsideCallerFile)
+        } else {
+            Some(ReferenceLinesAbsent::NoEvidenceSpan)
+        };
+        rows.push(row);
     }
     Ok(rows)
+}
+
+/// What one relation's evidence says about where its reference sites are.
+struct RelationSpanTally {
+    /// 1-based site lines inside the referencing entity's own file.
+    lines: Vec<u32>,
+    /// Spans that named a different file and were therefore not reportable under
+    /// this row. Counted rather than discarded so an empty `lines` can be
+    /// explained.
+    outside_caller_file: usize,
 }
 
 /// 1-based reference-site lines a single relation records, restricted to the
@@ -1172,23 +1261,28 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
 /// rather than something a consumer has to reconstruct. Evidence carrying no span
 /// contributes nothing; a span in some other file is dropped because the row
 /// reports one `file_path` and a line from a different file would read as a line
-/// in that one.
+/// in that one. Both kinds of miss are counted, because an empty result that
+/// cannot say why is the defect this reports around.
 fn relation_reference_lines(
     rel: &kin_model::relation::Relation,
     caller_file: Option<&kin_model::ids::FilePathId>,
-) -> Vec<u32> {
-    rel.evidence
+) -> RelationSpanTally {
+    let mut tally = RelationSpanTally {
+        lines: Vec::new(),
+        outside_caller_file: 0,
+    };
+    for span in rel
+        .evidence
         .iter()
         .filter_map(|evidence| evidence.source_span.as_ref())
-        .filter(|span| caller_file.is_none_or(|file| &span.file == file))
-        .map(|span| presentation_line(span.start_line))
-        .collect()
-}
-
-pub fn reference_row_key(file_path: Option<&str>, name: &str) -> String {
-    file_path
-        .map(|path| path.to_string())
-        .unwrap_or_else(|| format!("name:{name}"))
+    {
+        if caller_file.is_none_or(|file| &span.file == file) {
+            tally.lines.push(presentation_line(span.start_line));
+        } else {
+            tally.outside_caller_file += 1;
+        }
+    }
+    tally
 }
 
 pub const MCP_SOURCE_MAX_LINES: usize = 40;

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -884,15 +884,24 @@ pub fn handle_trace_computation<G: GraphStore>(
 }
 
 pub const FIND_REFERENCES_DESC: &str = "\
-Find who depends on an entity — its direct upstream callers, importers, and references. \
+Find who depends on an entity: its direct upstream callers, importers, and references. \
 Give it an entity_id or an exact symbol name (it resolves the best-matching canonical \
-definition) and it returns one row per upstream site with the relation kind, file path, \
-line, and signature. Use it to answer \"who calls / imports / uses this?\" before you \
+definition) and it returns ONE ROW PER REFERENCING ENTITY, with that caller's entity id, \
+name, kind, file path, its own definition line (start_line), and every line inside it \
+that references the focal (reference_lines). Two callers in one file are two rows, and \
+`total_upstream` is the number of referencing entities, the same unit `kin refs` prints. \
+The `counts` object states the unit outright and adds `files` and `reference_sites`, so \
+a count is never read against the wrong unit. `reference_sites` is null when some row's \
+sites could not be located, with `known_reference_sites` the lower bound and each such \
+row naming why under `reference_lines_absent_reason`. Rows omit the caller's body by \
+default to keep the response small; pass include_snippets=true for the signature and a \
+bounded body excerpt, or drill to any row's entity_id with get_entity_source. \
+Use it to answer \"who calls / imports / uses this?\" before you \
 change or remove something, to gauge blast radius, or to navigate from a definition out \
 to its usages. Filter with relation_kinds (calls, imports, references) when you only \
 care about one kind of edge; it defaults to all three. When you need this answer for \
 many entities at once (e.g. classifying a whole set as used vs. unused), don't loop \
-this call per entity — bulk_check_references does the batch in one shot. \
+this call per entity, because bulk_check_references does the batch in one shot. \
 When no references come back, the additive `negative` object's `safe_to_conclude_absent` \
 flag says whether \"nothing depends on this\" is authoritative (daemon-owned graph, \
 complete coverage, no degraded signals) or merely \"not indexed yet\" — consult it \
@@ -1011,8 +1020,10 @@ fn spine_reference_rows(
             kind: source.map(|entity| format!("{:?}", entity.kind)),
             file_path: Some(file_path),
             start_line: None,
-            // A federated xref carries no site span from the other repo's graph.
+            // A federated xref carries no site span from the other repo's graph,
+            // and says so rather than leaving an unexplained empty list.
             reference_lines: Vec::new(),
+            reference_lines_absent: Some(ReferenceLinesAbsent::FederatedXref),
             signature: source.map(|entity| entity.signature.clone()),
             snippet: None,
             // CrossRepoEdge proves a dependency but does not retain whether
@@ -1033,8 +1044,53 @@ fn reference_filter_covers_unknown_subtypes(relation_kinds: &[RelationKind]) -> 
         && defaults.iter().all(|kind| relation_kinds.contains(kind))
 }
 
-fn reference_row_json(row: ReferenceRow) -> serde_json::Value {
+/// What a reference answer counted, stated rather than left to be inferred.
+///
+/// `total_upstream` is a bare number, and a reader who does not know its unit
+/// cannot tell an under-count from a small repository. It counted distinct FILES
+/// until FIR-2398, which is how eleven callers across two files were served as
+/// "2" beside two flags that read complete.
+///
+/// The site total follows the rule `bulk_check_references` already uses: a
+/// number is emitted only when it is complete, and the lower bound is named as a
+/// bound otherwise. A row whose site lines the graph does not carry makes the
+/// site total a floor, never a fact.
+///
+/// `reference_sites_complete` is about the rows that came back: it says every
+/// returned reference could be located at a line. Whether the row SET itself is
+/// complete is the `negative` object's question for an empty answer and
+/// `edge_coverage`'s for the classes the query read; this field does not restate
+/// either, and on an empty answer it describes an empty set.
+fn reference_counts(rows: &[ReferenceRow]) -> serde_json::Value {
+    let known_reference_sites: usize = rows.iter().map(|row| row.reference_lines.len()).sum();
+    let reference_sites_complete = rows.iter().all(|row| !row.reference_lines.is_empty());
+    let files = rows
+        .iter()
+        .filter_map(|row| row.file_path.as_deref())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
     serde_json::json!({
+        "counted": "referencing_entities",
+        "referencing_entities": rows.len(),
+        "files": files,
+        "reference_sites": reference_sites_complete.then_some(known_reference_sites),
+        "known_reference_sites": known_reference_sites,
+        "reference_sites_complete": reference_sites_complete,
+    })
+}
+
+/// Project one reference row.
+///
+/// `include_snippets` adds the caller's bounded body and signature. They are off
+/// by default because the row count is now the caller count rather than the file
+/// count, and each body runs to [`RETRIEVAL_SNIPPET_MAX_CHARS`]: the case that
+/// motivated the row change went from two rows to eleven, so bodies scale with
+/// callers where they used to scale with files. The identifying fields an agent
+/// navigates by (entity id, name, kind, file, caller line, site lines, relation
+/// kinds, resolution) are always present, and `entity_id` still drills straight
+/// to the body on demand.
+fn reference_row_json(row: ReferenceRow, include_snippets: bool) -> serde_json::Value {
+    let mut value = serde_json::json!({
         "entity_id": row.entity_id,
         "name": row.name,
         "kind": row.kind,
@@ -1044,8 +1100,15 @@ fn reference_row_json(row: ReferenceRow) -> serde_json::Value {
         // agent never has to count forward from a definition to find a call site.
         "start_line": row.start_line,
         "reference_lines": row.reference_lines,
-        "signature": row.signature,
-        "snippet": row.snippet,
+        "reference_line_count": row.reference_lines.len(),
+        // Why `reference_lines` is empty, when it is: `no_evidence_span` (the
+        // parser recorded the edge without a position), `span_outside_caller_file`
+        // (the spans it recorded name another file), or `federated_xref` (the
+        // edge lives in another repository's graph). Null when site lines came
+        // back, so an empty list is never an unexplained silence.
+        "reference_lines_absent_reason": row
+            .reference_lines_absent
+            .map(ReferenceLinesAbsent::as_str),
         "relation_kinds": row
             .relation_kinds
             .into_iter()
@@ -1057,7 +1120,12 @@ fn reference_row_json(row: ReferenceRow) -> serde_json::Value {
         // candidate rather than a fact. Absent only for a federated row, whose
         // edge lives in another repository's graph.
         "resolution": row.resolution.map(RelationResolution::as_str),
-    })
+    });
+    if include_snippets {
+        value["signature"] = serde_json::json!(row.signature);
+        value["snippet"] = serde_json::json!(row.snippet);
+    }
+    value
 }
 
 /// Machine-readable codes a spine unavailability can carry, each the name of one
@@ -1218,6 +1286,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     authority_source: FindReferencesAuthoritySource<'_>,
     repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
+    let include_snippets = get_optional_bool(args, "include_snippets", false);
     let relation_kinds = if let Some(raw_kinds) = get_optional_string_array(args, "relation_kinds")
     {
         if raw_kinds.is_empty() {
@@ -1291,7 +1360,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
                 };
                 let federated_references = federated_rows
                     .into_iter()
-                    .map(reference_row_json)
+                    .map(|row| reference_row_json(row, include_snippets))
                     .collect::<Vec<_>>();
                 let authority_complete = body.authority_complete_for(&repo_id, &target.id);
                 serde_json::json!({
@@ -1320,15 +1389,27 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         },
     };
 
+    // Same order as the shared CLI collector, entity id included: rows come off
+    // a hash map, and several callers can share a file and a name, so without
+    // the last key the order of two such rows is whatever the map iterated.
     rows.sort_by(|left, right| {
         left.file_path
             .cmp(&right.file_path)
             .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.entity_id.cmp(&right.entity_id))
     });
+
+    // What this answer counted, computed before the rows are projected. One row
+    // is one referencing entity, so `referencing_entities` is the row count and
+    // `files` is what the pre-FIR-2398 `total_upstream` was reporting.
+    let counts = reference_counts(&rows);
 
     // `entity_id` remains the local drill-through keystone. Federated rows use
     // repo-qualified paths and carry no local entity id.
-    let references = rows.into_iter().map(reference_row_json).collect::<Vec<_>>();
+    let references = rows
+        .into_iter()
+        .map(|row| reference_row_json(row, include_snippets))
+        .collect::<Vec<_>>();
 
     // What the graph can structurally answer over the edge classes this query
     // reads. An empty reference list is only evidence about the code when the
@@ -1356,7 +1437,13 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
             .copied()
             .map(relation_kind_name)
             .collect::<Vec<_>>(),
+        // One referencing entity per unit, which is what `kin refs` prints as
+        // "referenced by N entities". It counted distinct FILES until FIR-2398.
+        // `counts.counted` names the unit in the payload so no reader has to
+        // infer it, and `counts.reference_sites` carries the finer number when
+        // every row could be located.
         "total_upstream": references.len(),
+        "counts": counts,
         "references": references,
         "cross_repo": cross_repo,
     });
@@ -3660,7 +3747,9 @@ mod tests {
     };
     use kin_model::graph::EntityStore as _;
     use kin_model::ids::{EntityId, FilePathId, Hash256, LanguageId, RelationId};
-    use kin_model::relation::{GraphNodeId, Relation, RelationKind, RelationOrigin};
+    use kin_model::relation::{
+        GraphNodeId, Relation, RelationEvidence, RelationKind, RelationOrigin,
+    };
     use kin_spine::SpineBackend as _;
 
     fn make_entity(name: &str, file: &str) -> Entity {
@@ -4210,9 +4299,280 @@ mod tests {
         // The keystone: each reference carries the caller's graph entity_id so an
         // agent can drill straight to its body with no name re-resolution.
         assert_eq!(refs[0]["entity_id"], caller_id.to_string());
-        // `snippet` is always present in the shape (null here: the fixture has no
+        // Bodies are opt-in, so the default row carries neither the excerpt nor
+        // the signature. `entity_id` above is what reaches the body.
+        assert!(!refs[0].as_object().unwrap().contains_key("snippet"));
+        assert!(!refs[0].as_object().unwrap().contains_key("signature"));
+
+        args.insert("include_snippets".to_string(), serde_json::json!(true));
+        let verbose = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let verbose_refs = verbose["references"].as_array().unwrap();
+        // Present in the shape when asked for (null here: the fixture has no
         // blob-backed body to project).
-        assert!(refs[0].as_object().unwrap().contains_key("snippet"));
+        assert!(verbose_refs[0].as_object().unwrap().contains_key("snippet"));
+        assert_eq!(verbose_refs[0]["signature"], "fn caller()");
+    }
+
+    /// One row per REFERENCING ENTITY, and `total_upstream` counting those
+    /// entities rather than the files they sit in.
+    ///
+    /// Rows were keyed on the caller's file path, so every caller in one file
+    /// collapsed into a single row keeping the first caller's id and name, and
+    /// `total_upstream` reported the number of distinct files. That is how
+    /// FIR-2398's `to_dot`, with eleven callers across two files, was answered
+    /// with "2" beside `authority_complete` and `relation_subtype_complete` both
+    /// true. The tool's stated job is blast radius, so an agent renaming or
+    /// deleting on that answer saw a fifth of the work.
+    ///
+    /// The fixture is deliberately lopsided: three callers in one file and one
+    /// in another. A balanced fixture would let the file count and the caller
+    /// count coincide, and the assertion could not fail.
+    #[tokio::test]
+    async fn find_references_reports_every_caller_not_one_row_per_file() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("to_dot", "src/linkgraph.rs");
+        store.upsert_entity(&target).unwrap();
+
+        let shared_file_callers = ["draws_nodes", "draws_edges", "draws_dashed"]
+            .map(|name| make_entity(name, "tests/test_linkgraph.rs"));
+        let other_file_caller = make_entity("cmd_graph", "src/cli.rs");
+        for caller in shared_file_callers.iter().chain([&other_file_caller]) {
+            store.upsert_entity(caller).unwrap();
+            store
+                .upsert_relation(&make_relation(caller.id, target.id, RelationKind::Calls))
+                .unwrap();
+        }
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+
+        let refs = body["references"].as_array().unwrap();
+        assert_eq!(
+            refs.len(),
+            4,
+            "four callers are four rows, whatever files they share: {body:#}"
+        );
+        assert_eq!(
+            body["total_upstream"], 4,
+            "total_upstream counts referencing entities, not the 2 files: {body:#}"
+        );
+
+        // Every caller present by identity, so a row cannot stand in for the
+        // callers it collapsed. Names are distinct here only to make a failure
+        // readable; the ids are the assertion that matters.
+        let returned_ids = refs
+            .iter()
+            .map(|row| row["entity_id"].as_str().unwrap().to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+        for caller in shared_file_callers.iter().chain([&other_file_caller]) {
+            assert!(
+                returned_ids.contains(&caller.id.to_string()),
+                "caller {} is missing from the answer: {body:#}",
+                caller.name
+            );
+        }
+
+        // The unit is named in the payload, and the file count is still
+        // available beside it rather than being what `total_upstream` means.
+        assert_eq!(body["counts"]["counted"], "referencing_entities");
+        assert_eq!(body["counts"]["referencing_entities"], 4);
+        assert_eq!(body["counts"]["files"], 2);
+    }
+
+    /// A returned reference with no site lines says why, and the answer says
+    /// whether any site could be located at all.
+    ///
+    /// FIR-2357 item 3: an empty `reference_lines` on a row that DID come back
+    /// is the quiet-partial failure in miniature. No production ingest path
+    /// populates `RelationEvidence::source_span` today (measured and asserted at
+    /// zero by `kin-index`'s `relation_evidence_span_coverage`), so this is what
+    /// every real answer looks like, and saying so is the difference between a
+    /// caller that knows the sites are unavailable and one that reads `[]` as
+    /// "no sites".
+    #[tokio::test]
+    async fn find_references_says_why_a_row_carries_no_site_lines() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&make_relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        assert_eq!(row["reference_lines"], serde_json::json!([]));
+        assert_eq!(row["reference_line_count"], 0);
+        assert_eq!(
+            row["reference_lines_absent_reason"], "no_evidence_span",
+            "an empty site list must name its cause, not stay silent: {body:#}"
+        );
+        // The row is still reported. Dropping a caller whose site the graph does
+        // not carry would understate blast radius, which is the defect this
+        // whole surface is being fixed for.
+        assert_eq!(body["total_upstream"], 1);
+
+        assert_eq!(
+            body["counts"]["reference_sites"],
+            serde_json::Value::Null,
+            "a site total that cannot be completed is not emitted as a number: {body:#}"
+        );
+        assert_eq!(body["counts"]["known_reference_sites"], 0);
+        assert_eq!(body["counts"]["reference_sites_complete"], false);
+    }
+
+    /// The completeness signal must be able to say "complete".
+    ///
+    /// FIR-2357 item 4 names the lazy regression directly: a fix that marks
+    /// every answer uncertain is not a fix. This is the same surface as the test
+    /// above with the one input changed that should flip the verdict, so a
+    /// hardcoded `false` fails here and a hardcoded `true` fails there.
+    #[tokio::test]
+    async fn find_references_reports_complete_sites_when_the_graph_carries_spans() {
+        let store = InMemoryGraph::new();
+        let caller_file = FilePathId::new("src/a.rs");
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+
+        // Two call sites inside one caller, graph rows 11 and 41, which the
+        // agent-facing surface reports 1-based as 12 and 42.
+        let site_span = |row: u32| kin_model::entity::SourceSpan {
+            file: caller_file.clone(),
+            start_byte: 0,
+            end_byte: 1,
+            start_line: row,
+            start_col: 0,
+            end_line: row,
+            end_col: 1,
+        };
+        let mut relation = make_relation(caller.id, target.id, RelationKind::Calls);
+        relation.evidence = vec![11, 41]
+            .into_iter()
+            .map(|row| RelationEvidence {
+                source_span: Some(site_span(row)),
+                ..RelationEvidence::default()
+            })
+            .collect();
+        store.upsert_relation(&relation).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        assert_eq!(
+            row["reference_lines"],
+            serde_json::json!([12, 42]),
+            "both sites, 1-based, ascending: {body:#}"
+        );
+        assert_eq!(row["reference_line_count"], 2);
+        assert_eq!(
+            row["reference_lines_absent_reason"],
+            serde_json::Value::Null,
+            "a row with sites has no absence to explain: {body:#}"
+        );
+        // One caller, two sites: the counts object distinguishes them, which is
+        // the whole point of naming the unit.
+        assert_eq!(body["total_upstream"], 1);
+        assert_eq!(body["counts"]["referencing_entities"], 1);
+        assert_eq!(body["counts"]["reference_sites"], 2);
+        assert_eq!(body["counts"]["known_reference_sites"], 2);
+        assert_eq!(body["counts"]["reference_sites_complete"], true);
+    }
+
+    /// A span the parser recorded against some other file is dropped, and the
+    /// drop is declared rather than looking like a parser that recorded nothing.
+    ///
+    /// The two absences call for different follow-ups, so collapsing them into
+    /// one empty list would hide which one held.
+    #[tokio::test]
+    async fn find_references_distinguishes_a_dropped_span_from_a_missing_one() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+
+        let mut relation = make_relation(caller.id, target.id, RelationKind::Calls);
+        relation.evidence = vec![RelationEvidence {
+            source_span: Some(kin_model::entity::SourceSpan {
+                file: FilePathId::new("src/somewhere_else.rs"),
+                start_byte: 0,
+                end_byte: 1,
+                start_line: 7,
+                start_col: 0,
+                end_line: 7,
+                end_col: 1,
+            }),
+            ..RelationEvidence::default()
+        }];
+        store.upsert_relation(&relation).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+        let row = &body["references"].as_array().unwrap()[0];
+
+        assert_eq!(
+            row["reference_lines"],
+            serde_json::json!([]),
+            "line 8 of another file is not a line of src/a.rs: {body:#}"
+        );
+        assert_eq!(
+            row["reference_lines_absent_reason"], "span_outside_caller_file",
+            "the reason must name the condition that held: {body:#}"
+        );
+    }
+
+    /// A recursive edge is not an upstream caller, on either surface.
+    ///
+    /// The shared CLI collector has always excluded self edges, so counting them
+    /// here would put `kin refs` and `find_references` one apart on every
+    /// recursive function while both looked internally consistent.
+    #[tokio::test]
+    async fn find_references_excludes_a_self_edge() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("recurse", "src/b.rs");
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&make_relation(target.id, target.id, RelationKind::Calls))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+
+        assert_eq!(
+            body["total_upstream"], 1,
+            "the recursive edge is not a second caller: {body:#}"
+        );
+        assert_eq!(
+            body["references"][0]["entity_id"],
+            caller.id.to_string(),
+            "the one row must be the external caller: {body:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -399,6 +399,11 @@ fn registered_tools() -> ToolsListResult {
                             "type": "array",
                             "description": "Filter relation kinds. Supported values: calls, imports, references. Defaults to all three.",
                             "items": { "type": "string" }
+                        },
+                        "include_snippets": {
+                            "type": "boolean",
+                            "description": "If true, each row also carries the referencing entity's signature and a bounded body excerpt. Off by default, because one row is one caller and bodies would then scale with the number of callers. Every row still carries entity_id, which drills to the full body via get_entity_source.",
+                            "default": false
                         }
                     }
                 }),

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -120,7 +120,7 @@ boundary you can rely on.
 
 - **`trace_computation`**: Get a focal entity together with its control-/data-flow neighborhood in one structured response (a flat snapshot, not an ordered walk). The response carries its body plus callers, callees, and imports.
 - **`trace_data_flow`**: Walk the directional call/data-flow chain rooted at a focal entity and return it as an ordered list of steps (the path-walk counterpart to `trace_computation`'s flat neighborhood).
-- **`find_references`**: Find all entities that import, call, or reference a target symbol.
+- **`find_references`**: Find all entities that import, call, or reference a target symbol. One row is one referencing entity, so two callers in one file are two rows, and `total_upstream` counts those entities, the same unit `kin refs` prints. The `counts` object names the unit and adds the file and reference-site totals beside it. A row's `reference_lines` gives the lines inside that caller which reference the target, and names why under `reference_lines_absent_reason` when the graph does not carry them. Rows omit the caller's body by default; pass `include_snippets=true` for it.
 - **`bulk_check_references`**: Classify many entities by reachability in one call.
 - **`entity_history`**: Retrieve version changes scoped to a specific entity.
 


### PR DESCRIPTION
MCP `find_references` reported the number of FILES a symbol is referenced from and called it `total_upstream`. On the v0.5.38 release-candidate bytes, `to_dot` has eleven callers across two files and the tool answered `2`, with `authority_complete` and `relation_subtype_complete` both reading true and `reference_lines` empty on every row. The tool's own description tells an agent to use it to gauge blast radius before a rename or a delete, so that answer sized the work at a fifth of what it was, and nothing in the payload let the reader notice.

## Mechanism

`collect_graph_reference_rows` in `crates/kin-mcp/src/handlers/common.rs:1103` grouped rows under `reference_row_key(file_path, name)`, and that key was the bare file path whenever the referencing entity had one. Every caller sharing a file collapsed into one `ReferenceRow`, which kept the first caller's id, name and signature and dropped the rest. `handle_find_references_with_authority_source` in `crates/kin-mcp/src/handlers/entities.rs:1383` then emitted `total_upstream: references.len()`, which is the count of distinct files rather than of callers.

## The fix

Rows are keyed on the referencing entity's `EntityId`, so one caller is one row. That is the unit the shared CLI collector `collect_graph_references` in `crates/kin-cli/src/commands/refs.rs` has always counted, which is both why the two surfaces disagreed and why keying on the entity is what makes them agree. Self edges are now excluded on the MCP side as well, because the CLI collector has always excluded them and a recursive call is not an upstream caller; without that the two surfaces would have stayed one apart on every recursive function.

A `counts` object states the unit in `counted` and carries `files` and the reference-site totals beside it, so a bare number is never read against the wrong unit. `reference_sites` is emitted as a number only when every returned row could be located at a line, and otherwise it is null with `known_reference_sites` as the explicit lower bound. That is the discipline `bulk_check_references` already applies to its own totals.

Each row carries `reference_line_count` and, when `reference_lines` is empty, `reference_lines_absent_reason`: `no_evidence_span`, `span_outside_caller_file`, or `federated_xref`. A row is never dropped for a missing line, because dropping one would understate the blast radius this tool exists to size. That is FIR-2357 item 3 on this surface.

## Why reference_lines is empty, which is larger than this ticket

The empty `reference_lines` is not a Python problem and not a cross-file problem. No production ingest path in the workspace ever sets `RelationEvidence::source_span`, in any language. Every construction site in `crates/kin-index/src/pipeline.rs` and `crates/kin-index/src/linker.rs` builds evidence through `..RelationEvidence::default()`, whose `source_span` is `None`, and the root cause is that `kin_parser::ExtractedRelation` at `crates/kin-parser/src/extract.rs:176` has no span field, so the call site's position is discarded inside the language adapter before the linker sees it. The Python adapter knows the byte range and throws it away at `crates/kin-parser/src/languages/python.rs:971`.

This is already measured in the repo: `crates/kin-index/tests/relation_evidence_span_coverage.rs:658` pins `MEASURED_RELATIONS_WITH_SPAN` at 0 and asserts it, with a message telling whoever lands span emission to update the constant. So `no_evidence_span` is what every real answer reports today, and filling the lines for real means adding a span to `ExtractedRelation`, threading it through the language adapters and both resolver arms, then flipping that constant. That is a separate multi-crate change in `kin-parser` and `kin-index` and needs its own ticket.

## Response size

Rows omit the caller's body and signature unless `include_snippets=true`. One row is now one caller rather than one file, so bodies scale with callers, and each body runs to `RETRIEVAL_SNIPPET_MAX_CHARS`, which is 800 at `crates/kin-mcp/src/handlers/common.rs:2252`. This is how this lane kept its rows small alongside the response-budget work, by construction rather than by depending on that lane's code. `entity_id` still drills any row to its full body through `get_entity_source`.

## Scope note

The row unit is the caller, not the individual reference site, with every site line carried on the caller's row and the site total reported separately in `counts`. The ticket's fix contract item 1 asks for exactly that, and its ground truth of eleven is eleven distinct calling functions. It is also the only unit on which the CLI and the MCP tool can agree, because `kin refs` prints "referenced by N entities" and `refs_and_bulk_count_distinct_external_entities_not_relation_edges_or_self_edges` pins that unit. No information is lost, since a caller row lists every site line it contains.

## Falsification

Every new test was broken at the behavior it guards and failed with the message it names.

Re-collapsing the rows by file after collection, which reproduces the exact defect, failed `find_references_reports_every_caller_not_one_row_per_file` ("four callers are four rows", left 2, right 4) and the cross-surface test `cli_refs_and_mcp_find_references_agree_on_the_caller_count` (left 2, right 4).

Forcing `reference_lines_absent` to `None` failed `find_references_says_why_a_row_carries_no_site_lines` ("an empty site list must name its cause, not stay silent", left Null, right "no_evidence_span").

Forcing `reference_sites_complete` to false, which is the lazy regression FIR-2357 item 4 names, failed `find_references_reports_complete_sites_when_the_graph_carries_spans` (left Null, right 2).

Dropping the outside-file span counter failed `find_references_distinguishes_a_dropped_span_from_a_missing_one` (left "no_evidence_span", right "span_outside_caller_file").

Removing the self-edge skip failed `find_references_excludes_a_self_edge` (left 2, right 1).

The tree restored clean after each, verified with `git status --porcelain` returning nothing. The agreement test asserts the absolute number 4 before asserting the surfaces match, so both regressing the same way cannot pass it, and it asserts `counts.files` is 2 so the fixture cannot pass by having every number in it be the same.

## Gate

`bin/kin-dev local-test kin`, run through `bin/kin-lane run fir2398-refs kin --` from the lane worktree with output to a file and the status read raw. The pass printed its own resolution line, `local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/fir2398-refs-kin @ 4bd6a17c (chore/lane-fir2398-refs-kin)`, which is this lane's tree and commit. Result: `6006 tests run: 6006 passed (10 slow), 11 skipped`, exit 0, and "no tracked lock contamination".

`cargo fmt --all -- --check` returned 0. Clippy ran exactly as `ci.yml` invokes it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 45-lint allowlist copied out of the workflow, and returned 0.

After rebasing onto `origin/main` at 320cf57a, which moved to the v0.5.39 release and touched neither `crates/kin-mcp` nor `crates/kin-cli/src/commands/refs.rs`, the two changed crates were re-run: kin-mcp 454 passed, kin-cli 1470 passed, 0 failed.

`git ls-tree -r HEAD --name-only` matches only `.cargo/config.toml` under `.cargo/`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

Closes FIR-2398
Part of FIR-2357
