### PR TITLE
Pin a second dispatcher for the life of a test event capture

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -19611,7 +19611,19 @@ mod tests {
         let captured = Arc::new(std::sync::Mutex::new(Captured::default()));
         let subscriber = tracing_subscriber::registry().with(CaptureLayer(Arc::clone(&captured)));
         let response = {
-            let _default = tracing::subscriber::set_default(subscriber);
+            let _capture = crate::capture_events_on_this_thread(subscriber);
+            // The parallel test that broke this, made deliberate. A thread
+            // carrying no subscriber of its own reaches the blocking phase
+            // helper and registers its callsite. Without the second dispatcher
+            // the capture holds, `tracing` resolves that callsite against this
+            // thread's absent subscriber and caches `Interest::never()` for the
+            // whole process, so every phase below emitted through that helper is
+            // dropped while the two emitted through the async helper survive.
+            std::thread::spawn(|| {
+                crate::mcp_commit::timed_commit_phase("phase_registered_off_this_thread", || ())
+            })
+            .join()
+            .unwrap();
             app.oneshot(
                 Request::post("/commands/commit")
                     .header("content-type", "application/json")
@@ -19640,6 +19652,15 @@ mod tests {
             captured.malformed.is_empty(),
             "every commit phase line must carry both phase and elapsed_ms: {:?}",
             captured.malformed
+        );
+        assert!(
+            !captured
+                .phases
+                .iter()
+                .any(|phase| phase == "phase_registered_off_this_thread"),
+            "the capture stays scoped to the thread that installed it, so the phase \
+             registered off it must not appear; captured {:?}",
+            captured.phases
         );
         for phase in [
             "coordination_gate_wait",

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -183,3 +183,57 @@ pub(crate) fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
+
+/// Capture `tracing` events emitted on this thread, holding the process-global
+/// callsite cache open for as long as the capture lives.
+///
+/// `tracing` caches one `Interest` per `event!` callsite for the whole process,
+/// and the first thread to reach an unregistered callsite is the one that fills
+/// that cache. `tracing_core`'s registry takes a shortcut whenever exactly one
+/// dispatcher is registered: it resolves the interest against
+/// `dispatcher::get_default()` on the *calling* thread rather than against the
+/// dispatcher that is actually registered. A thread-local capture subscriber is
+/// one dispatcher, so a test running in parallel that reaches the callsite first
+/// resolves it against its own absent subscriber, `NoSubscriber` answers
+/// `Interest::never()`, and every later thread short-circuits on that cached
+/// answer, including the one doing the capturing. That is how the commit-phase
+/// capture once collected the two phases emitted through one timing helper and
+/// none of the eight emitted through the other.
+///
+/// Registering a second dispatcher for the life of the capture takes the
+/// shortcut off the table. Registration then unions the live dispatchers, the
+/// capture is always one of them, and interests that disagree settle at
+/// `Interest::sometimes()`, which asks the emitting thread's own subscriber once
+/// per event: this thread answers yes and every other thread answers no, so a
+/// test running in parallel neither gains nor loses a line. Building the capture
+/// dispatcher second also repairs a callsite an earlier test already cached as
+/// never, because registering a dispatcher rebuilds every registered callsite
+/// against the live set.
+///
+/// This is a test seam only. The daemon installs its subscriber as the global
+/// default, which `get_default()` returns on every thread, so the shortcut
+/// resolves against the real subscriber in a running daemon.
+#[cfg(test)]
+pub(crate) fn capture_events_on_this_thread<S>(subscriber: S) -> EventCapture
+where
+    S: tracing::Subscriber + Send + Sync + 'static,
+{
+    let pinned = tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default());
+    let capture = tracing::Dispatch::new(subscriber);
+    let default = tracing::dispatcher::set_default(&capture);
+    EventCapture {
+        _default: default,
+        _capture: capture,
+        _pinned: pinned,
+    }
+}
+
+/// A live capture from [`capture_events_on_this_thread`]. Dropping it restores
+/// the thread's previous subscriber and then releases the pinned dispatcher, in
+/// that order.
+#[cfg(test)]
+pub(crate) struct EventCapture {
+    _default: tracing::subscriber::DefaultGuard,
+    _capture: tracing::Dispatch,
+    _pinned: tracing::Dispatch,
+}

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -4973,7 +4973,8 @@ mod tests {
         };
         let path = PathBuf::from("/repo/Cargo.lock");
 
-        tracing::subscriber::with_default(subscriber, || {
+        {
+            let _capture = crate::capture_events_on_this_thread(subscriber);
             for attempts in 1..=4u32 {
                 report_modified_during_reconcile(
                     &path,
@@ -4984,7 +4985,7 @@ mod tests {
                     },
                 );
             }
-        });
+        }
 
         let events = std::mem::take(&mut captured.lock().unwrap().events);
         let levels = events.iter().map(|(level, _)| *level).collect::<Vec<_>>();


### PR DESCRIPTION
A merge-group run ejected a release-blocking PR when
`api::tests::the_cli_commit_path_names_every_phase_it_spends` failed with
`captured ["coordination_gate_wait", "forced_filesystem_admission"]`, two of the
ten phases it asserts. Nothing in the ejected PR touched the daemon.

The captured list splits by which helper emits, not by thread and not by time.
Those two phases are the only two the commit path emits through
`mcp_commit::timed_commit_phase_async`, whose `tracing::debug!` lives at
`mcp_commit.rs:1579`. Every phase that vanished goes through the blocking
sibling `mcp_commit::timed_commit_phase` at `mcp_commit.rs:1553`.
`scan_working_copy` runs nested inside `forced_filesystem_admission` on the same
thread and is emitted earlier in wall-clock order than the phase that survived,
so neither a thread boundary nor a truncated run explains the split. One
callsite was live and the other was dead.

`tracing` caches one `Interest` per callsite for the whole process, and the
first thread to reach an unregistered callsite fills that cache. tracing-core's
registry takes a shortcut whenever exactly one dispatcher is registered
(`callsite.rs:544`): it resolves interest against `dispatcher::get_default()` on
the calling thread rather than against the dispatcher that is registered
(`callsite.rs:565`). A thread-local capture is one dispatcher, so any test
running in parallel that reaches `timed_commit_phase` first resolves the
callsite against its own absent subscriber, `NoSubscriber` answers
`Interest::never()` (`subscriber.rs:676`), and `callsite.rs:349` short-circuits
the macro for every later thread including the capturing one.

The existing serial group cannot close this. It holds eleven tests, but
`timed_commit_phase` is reached from `api.rs`, `loop_runner.rs`,
`mcp_commit.rs` and eleven sites in `repository_commit.rs`, so the set of tests
that can register that callsite is every test in the binary that commits or
reconciles. Enumerating them is not a fix.

`capture_events_on_this_thread` registers a second dispatcher and holds it for
the life of the capture, then builds the capture dispatcher and sets it as this
thread's default. The registry can no longer take its single-dispatcher
shortcut, so a callsite registered on any thread unions the live dispatchers
instead of asking one thread's absent subscriber. Building the capture second
also repairs a callsite an earlier test already cached as never, because
registering a dispatcher rebuilds every registered callsite against the live
set. Interests that disagree settle at `Interest::sometimes()`
(`subscriber.rs:658`), which asks the emitting thread's own subscriber once per
event, so the capturing thread answers yes, every other thread answers no, and a
test running in parallel neither gains nor loses a line. `Interest::always()`
would have bypassed other tests' `EnvFilter`, and `sometimes` does not.

Production is unchanged. The daemon installs its subscriber as the global
default (`bin/kin-daemon.rs:403`), which `get_default()` returns on every
thread, so the shortcut resolves against the real subscriber in a running
daemon. The seam is `cfg(test)` and no production code path is touched.

The reproduction stays in the test permanently: one thread, spawned while the
capture is live and carrying no subscriber of its own, reaches the blocking
phase helper and registers its callsite. Run alone in a fresh process it failed
five times out of five with the ejecting message byte for byte. A new assertion
states that the phase registered off the capture thread must not appear in the
capture, which proves the capture stays thread-scoped rather than widening, and
the test already carried a fabricated phase name that can never appear, so a
capture collecting nothing fails rather than passes.

Falsification on the rebased branch: reverting the one seam line with the
reproduction in place fails three times out of three, and restoring it passes
five times out of five. Two of the three red runs also captured
`reconcile_workspace_and_commit_authority`, which had exceeded the slow-phase
threshold and so emitted through the info callsite at `mcp_commit.rs:1551`, a
different static the reproduction never poisoned. That is the per-callsite
mechanism showing itself rather than noise.

`loop_runner::tests::a_repeat_deferral_escalates_from_debug_to_warn` carries the
identical defect through `with_default`, and its callsites are reachable from
the production reconcile retry path at `loop_runner.rs:2617`. It moves to the
same seam.

Ten runs of the featureless daemon lib suite pass on this branch at 835 tests
each, and ten runs also passed on unmodified main, which is why the loop is
reported as context rather than as evidence. The exact CI step
(`cargo test -p kin-daemon --no-default-features --lib --tests --locked`), plain
`cargo test -p kin-daemon` with default features, `cargo fmt --check`, clippy
exactly as `ci.yml` runs it under `RUSTFLAGS=-D warnings`, and the full local
gate are all green.

Closes FIR-2407
