### PR TITLE
Bound every retrieval tool's MCP response on one client-sized budget

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8040,11 +8040,81 @@ fn resolved_entity_source_from_outcome<E: std::fmt::Display>(
     }
 }
 
+/// POST /mcp/tools/call.
+///
+/// The route bounds every retrieval response it serves, on the same budget and
+/// through the same ladder the stdio MCP path applies. This arm carries no
+/// `_kin` envelope, which was already a gap, and serving an unbounded payload
+/// here would have widened it into a second one: a client calling the daemon
+/// directly would have been handed exactly the response the stdio client is
+/// protected from, and the tool would have been bounded or not depending on
+/// which door the caller came through.
+///
+/// It cuts against the budget less the envelope reserve, because the stdio path
+/// wraps this payload in `_kin` and `negative` before a client counts it. Both
+/// arms measuring the full budget would put every enveloped response slightly
+/// over it and make the stdio pass re-cut a payload that had already been cut to
+/// fit.
 async fn mcp_tools_call(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<McpToolCallRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let budget =
+        kin_mcp::budget::ResponseBudget::from_arguments(&request.arguments).less_envelope_reserve();
+    let tool = request.name.clone();
+    let Json(result) = mcp_tools_call_inner(headers, State(state), Json(request)).await?;
+    Ok(Json(bound_mcp_tool_result(result, &tool, &budget)))
+}
+
+/// Apply the response budget to one tool result's payload text.
+///
+/// Measured and rewritten on the serialized payload rather than inside each
+/// handler because the tools this route serves build their JSON in six different
+/// places, and a bound implemented once per handler is a bound six code paths
+/// can each forget. A payload that is not JSON, or a tool the budget does not
+/// govern, is returned exactly as built.
+fn bound_mcp_tool_result(
+    result: kin_mcp::ToolCallResult,
+    tool: &str,
+    budget: &kin_mcp::budget::ResponseBudget,
+) -> kin_mcp::ToolCallResult {
+    if !kin_mcp::budget::is_budgeted(tool) {
+        return result;
+    }
+    let content = result
+        .content
+        .into_iter()
+        .map(|block| {
+            let kin_mcp::ContentBlock::Text { text } = block;
+            let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(&text) else {
+                return kin_mcp::ContentBlock::Text { text };
+            };
+            if !payload.is_object() {
+                return kin_mcp::ContentBlock::Text { text };
+            }
+            kin_mcp::budget::enforce(&mut payload, tool, budget);
+            match serde_json::to_string_pretty(&payload) {
+                Ok(rendered) => kin_mcp::ContentBlock::Text { text: rendered },
+                Err(_) => kin_mcp::ContentBlock::Text { text },
+            }
+        })
+        .collect();
+    kin_mcp::ToolCallResult {
+        content,
+        is_error: result.is_error,
+    }
+}
+
+async fn mcp_tools_call_inner(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<McpToolCallRequest>,
+) -> Result<Json<kin_mcp::ToolCallResult>, (StatusCode, String)> {
+    // The same budget the wrapper will enforce, so an arm that bounds its own
+    // walk bounds it to the number this call is actually served under.
+    let response_budget =
+        kin_mcp::budget::ResponseBudget::from_arguments(&request.arguments).less_envelope_reserve();
     if !state
         .is_initialized
         .load(std::sync::atomic::Ordering::Relaxed)
@@ -8203,11 +8273,17 @@ async fn mcp_tools_call(
                     .and_then(serde_json::Value::as_bool)
                     .map(|compact| !compact)
             });
+        // Defaulted to the budget THIS ROUTE will enforce rather than to the
+        // tool's own default, so one call is bounded once. The walk and the
+        // route pass would otherwise hold two different numbers for the same
+        // response, the walk would cut to the larger, and the route would cut
+        // again to a smaller one that the walk's own disclosure does not name.
         let max_response_chars = request
             .arguments
             .get("max_response_chars")
             .and_then(serde_json::Value::as_u64)
-            .map(|v| v as usize);
+            .map(|v| v as usize)
+            .or(Some(response_budget.max_chars));
         let Some(focal) = focal else {
             return Ok(Json(kin_mcp::ToolCallResult::error(
                 "missing required parameter: focal".to_string(),
@@ -30292,5 +30368,239 @@ mod tests {
                 .is_some(),
             "the committed file must be graph-owned after the single successor"
         );
+    }
+
+    /// FIR-2396: the call from the ticket, at the scale it was measured at.
+    ///
+    /// A `semantic_locate` with three query variants at `limit: 10` returned
+    /// 80,571 characters on the v0.5.38 release-candidate bytes and Claude Code
+    /// refused it, spilling the answer to a file the agent then had to read. The
+    /// fixture reproduces that scale through the REAL fused serializer, so the
+    /// number under test is the one the tool actually emits rather than a
+    /// hand-built object that resembles it.
+    #[test]
+    fn semantic_locate_at_the_measured_scale_fits_the_response_budget() {
+        use kin_cli::commands::locate::{
+            LocateEntity, LocateFileEntry, LocateProvenance, LocateResult, LocateSymbol,
+        };
+        let variants = vec![
+            "resolve_redirects".to_string(),
+            "follow redirect chain build next request".to_string(),
+            "Location header handling 301 302 303 307 308".to_string(),
+        ];
+        let body = |name: &str, lines: usize| {
+            format!(
+                "def {name}(self, resp, req, stream=False, timeout=None, verify=True, cert=None, \
+                 proxies=None, yield_requests=False, **adapter_kwargs):\n{}",
+                "    hist = []  # keep track of history of redirects for this request\n"
+                    .repeat(lines)
+            )
+        };
+        let make_entities = || -> Vec<LocateEntity> {
+            (0..10)
+                .map(|index| LocateEntity {
+                    entity_id: format!("0000{index:04}-0000-4000-8000-000000000000"),
+                    id_space: kin_cli::commands::locate::LocateIdSpace::Entity,
+                    artifact_path: None,
+                    kind: "method".into(),
+                    name: format!("resolve_redirects_variant_{index}"),
+                    signature: "def resolve_redirects(self, resp, req, stream=False)".into(),
+                    score: 0.9 - (index as f32 / 100.0),
+                    definition: true,
+                    span: Some([100 + index as u32, 220 + index as u32]),
+                    body: Some(body(&format!("resolve_redirects_variant_{index}"), 22)),
+                    match_kind: None,
+                    provenance: LocateProvenance {
+                        file: Some(format!("requests/sessions_{index}.py")),
+                        origin: "vector".into(),
+                        cosine: Some(0.71),
+                    },
+                    matched_queries: variants.clone(),
+                })
+                .collect()
+        };
+        let make_files = || -> Vec<LocateFileEntry> {
+            (0..10)
+                .map(|index| LocateFileEntry {
+                    path: format!("requests/sessions_{index}.py"),
+                    score: 0.9 - (index as f32 / 100.0),
+                    signals: vec![
+                        "vector".into(),
+                        "lexical".into(),
+                        "graph".into(),
+                        "name_exact".into(),
+                    ],
+                    spans: vec![[100, 220], [240, 300]],
+                    symbols: (0..6)
+                        .map(|symbol| LocateSymbol {
+                            name: format!("symbol_{index}_{symbol}_rebuild_auth"),
+                            span: Some([10 * symbol as u32, 40 * symbol as u32]),
+                            score: 0.5,
+                            kind: "function".into(),
+                            definition: true,
+                            origin: "vector".into(),
+                            cosine: Some(0.6),
+                            snippet: Some(body(&format!("symbol_{index}_{symbol}"), 9)),
+                        })
+                        .collect(),
+                    explain: vec![
+                        "vector similarity 0.81 on the primary variant".to_string(),
+                        "lexical hit on token `redirect`".to_string(),
+                        "graph: called by Session.send".to_string(),
+                    ],
+                    provenance: None,
+                    signal_scores: None,
+                    score_breakdown: None,
+                    matched_queries: variants.clone(),
+                })
+                .collect()
+        };
+        let make_result = || LocateResult {
+            entities: make_entities(),
+            next_cursor: Some("deadbeefdeadbeef.1".to_string()),
+            page: 0,
+            total_ranked: 47,
+            files: make_files(),
+            queries: variants.clone(),
+            ..Default::default()
+        };
+
+        let unbounded = mcp_result_text(&fused_semantic_locate_payload(
+            make_result(),
+            "where HTTP redirects are actually resolved and followed",
+            false,
+        ));
+        assert!(
+            unbounded.len() > kin_mcp::budget::RESPONSE_DEFAULT_MAX_CHARS,
+            "the fixture must reproduce the overflow, or the bound is untested: {} chars",
+            unbounded.len()
+        );
+
+        // The budget the route actually applies: the default less the room the
+        // stdio path's envelope and negative need.
+        let budget = kin_mcp::budget::ResponseBudget::default().less_envelope_reserve();
+        let bounded = mcp_result_text(&bound_mcp_tool_result(
+            fused_semantic_locate_payload(
+                make_result(),
+                "where HTTP redirects are actually resolved and followed",
+                false,
+            ),
+            "semantic_locate",
+            &budget,
+        ));
+        eprintln!(
+            "FIR-2396 semantic_locate: {} chars unbounded, {} chars bounded",
+            unbounded.len(),
+            bounded.len()
+        );
+        assert!(
+            bounded.len() <= budget.max_chars,
+            "the response a client receives must fit its budget: {} chars against {}",
+            bounded.len(),
+            budget.max_chars
+        );
+        let payload: serde_json::Value =
+            serde_json::from_str(&bounded).expect("a bounded locate response is still JSON");
+        // The ranking itself is what a caller came for, so the hits survive and
+        // the cut lands on the diagnostics and the duplicated roll-up first.
+        assert_eq!(
+            payload["entities"].as_array().map(Vec::len),
+            Some(10),
+            "every hit the caller asked for is still reported: {payload}"
+        );
+        for hit in payload["entities"].as_array().unwrap() {
+            assert!(
+                hit.get("match_evidence").is_none(),
+                "compact is the default: the per-signal breakdown is not shipped unasked"
+            );
+            assert!(hit["entity_id"].is_string(), "a hit keeps its handle");
+        }
+        assert_eq!(
+            payload["total_ranked"],
+            json!(47),
+            "the full ranking size is still reported so the page is not mistaken for the whole"
+        );
+        assert_eq!(
+            payload["next_cursor"],
+            json!("deadbeefdeadbeef.1"),
+            "the rest of the ranking stays reachable through the cursor"
+        );
+        let cut = payload["degradations"]
+            .as_array()
+            .expect("a cut must be disclosed")
+            .iter()
+            .find(|entry| entry["component"] == json!("response_budget"))
+            .expect("the budget discloses its own cut");
+        assert_eq!(
+            cut["max_chars"],
+            json!(budget.max_chars),
+            "the applied budget is named"
+        );
+        assert!(
+            cut["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("symbol roll-up"),
+            "the disclosure names what it took: {cut}"
+        );
+    }
+
+    /// The raw daemon route carries no `_kin` envelope, which is a known gap.
+    /// Serving an unbounded payload here would have made it two gaps: a client
+    /// calling the daemon directly would get exactly the response the stdio
+    /// client is protected from.
+    #[test]
+    fn the_raw_route_bounds_a_tool_the_stdio_path_would_have_bounded() {
+        let oversized = json!({
+            "focal_entity": { "name": "resolve_redirects" },
+            "total_upstream": 400,
+            "references": (0..400).map(|index| json!({
+                "name": format!("caller_{index}"),
+                "file_path": format!("requests/module_{index}/handler.py"),
+                "line": index,
+                "relation_kind": "calls",
+                "snippet": "def send(self, request, **kwargs):\n    return self.adapter.send(request)\n".repeat(6),
+            })).collect::<Vec<_>>(),
+        });
+        let built = kin_mcp::ToolCallResult::text(
+            serde_json::to_string_pretty(&oversized).expect("fixture serializes"),
+        );
+        let before = mcp_result_text(&built).len();
+        assert!(
+            before > kin_mcp::budget::RESPONSE_DEFAULT_MAX_CHARS,
+            "the fixture must overflow: {before} chars"
+        );
+        let budget = kin_mcp::budget::ResponseBudget::default().less_envelope_reserve();
+        let bounded = mcp_result_text(&bound_mcp_tool_result(built, "find_references", &budget));
+        assert!(
+            bounded.len() <= budget.max_chars,
+            "the raw route must hold the same bound: {} chars against {}",
+            bounded.len(),
+            budget.max_chars
+        );
+        // Reserved room, so the stdio path's envelope and negative still fit
+        // inside the budget a client counts rather than pushing it back over.
+        assert!(
+            bounded.len()
+                <= kin_mcp::budget::RESPONSE_DEFAULT_MAX_CHARS
+                    - kin_mcp::budget::RESPONSE_ENVELOPE_RESERVE_CHARS
+        );
+        let payload: serde_json::Value = serde_json::from_str(&bounded).unwrap();
+        assert_eq!(payload["total_upstream"], json!(400));
+    }
+
+    /// A tool the budget does not govern is returned exactly as built. A source
+    /// read that silently returned less code than was asked for would be
+    /// answering a different question.
+    #[test]
+    fn the_raw_route_leaves_an_unbudgeted_tool_byte_identical() {
+        let text = "x".repeat(200_000);
+        let built = kin_mcp::ToolCallResult::text(text.clone());
+        let after = bound_mcp_tool_result(
+            built,
+            "get_entity_source",
+            &kin_mcp::budget::ResponseBudget::default(),
+        );
+        assert_eq!(mcp_result_text(&after), text);
     }
 }

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -1,0 +1,816 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! One response-size budget for every retrieval tool.
+//!
+//! A tool result the client refuses is worse than a short one: the caller gets
+//! neither the answer nor a way to ask for less. Claude Code, the agent client
+//! this server is most often driven by, refuses an over-size result and spills
+//! it to a temp file the agent then has to `Read` with an offset, which is the
+//! file-read fallback the product exists to remove, plus a round trip. The MCP
+//! protocol carries no field for the client's ceiling, so the server has to pick
+//! a default that fits the clients that matter and make size a first-class,
+//! reportable property of the response.
+//!
+//! Two measured payloads are what this module is sized against. On the v0.5.38
+//! release-candidate bytes a `semantic_locate` with three query variants at
+//! `limit: 10` returned 80,571 characters and a `trace_data_flow` at depth 4
+//! with `include_body: false` returned 79,278; both were refused. Neither was
+//! bodies: they were per-signal breakdowns, per-file explanation, duplicated hit
+//! shapes, and envelopes.
+//!
+//! The ladder cuts in priority order, and every cut is disclosed through the
+//! `degradations` channel the retrieval tools already use, so a caller can tell
+//! a whole answer from a bounded one and knows which parameter recovers the
+//! rest.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Map, Value};
+
+/// Serialized characters one retrieval response may occupy by default.
+///
+/// Sized against **Claude Code**, the primary agent client for this server: it
+/// rejects a tool result above roughly 25,000 tokens and writes it to a file
+/// instead. JSON-wrapped source runs around 3.5 characters per token, so the
+/// refusal threshold sits near 87,000 characters, which is why the two measured
+/// payloads above (80,571 and 79,278) both tripped it while sitting inside the
+/// 80,000-character trace budget that was supposed to prevent exactly this.
+///
+/// 30,000 characters is roughly 8,500 tokens: about a third of that ceiling. The
+/// margin is deliberate and is not a guess about tokenization. A response is
+/// counted by the client after its own JSON-RPC framing, an agent typically
+/// holds several tool results in one context window, and a budget chosen to
+/// *just* fit one client's limit becomes the next overflow the moment any client
+/// counts slightly differently. A caller with a larger window raises it per call
+/// with `max_chars`.
+pub const RESPONSE_DEFAULT_MAX_CHARS: usize = 30_000;
+
+/// Floor for a caller-supplied budget. Below this the envelope and the
+/// disclosure alone do not fit, so a smaller number could only be honoured by
+/// returning nothing.
+pub const RESPONSE_MIN_MAX_CHARS: usize = 2_000;
+
+/// Ceiling for a caller-supplied budget. A caller with a larger window may raise
+/// the bound, but not to unbounded: the daemon serving this has other callers,
+/// and a response nothing can read is not worth building.
+pub const RESPONSE_MAX_MAX_CHARS: usize = 400_000;
+
+/// Characters held back from the budget for the disclosure a cut adds.
+///
+/// A response cut to exactly its ceiling and then told to explain the cut is
+/// over its ceiling again, by the length of the explanation. Reserving the room
+/// first is what makes the bound hold for the payload that actually ships.
+pub const RESPONSE_DISCLOSURE_RESERVE_CHARS: usize = 1_500;
+
+/// Characters the daemon's raw `/mcp/tools/call` route holds back so the MCP
+/// path's wrapper still fits.
+///
+/// The raw route returns the tool payload alone; the stdio MCP path then adds
+/// the `_kin` envelope and, on an empty or all-fallback result, the `negative`
+/// object. Both ride inside the same JSON the client counts. Bounding the raw
+/// payload to the full budget would put every enveloped response a few hundred
+/// characters over it, and the stdio pass would then trim a response that had
+/// already been cut to fit. The bound has to hold for the bytes the client
+/// actually receives, so the room is reserved once, up front, by the arm that
+/// cuts first.
+pub const RESPONSE_ENVELOPE_RESERVE_CHARS: usize = 2_000;
+
+/// The size contract one tool call is served under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponseBudget {
+    /// Serialized characters the response may occupy, already clamped.
+    pub max_chars: usize,
+    /// Whether ranking explanation and per-signal breakdowns are shed before
+    /// anything else. On by default: the breakdowns are diagnostics, and a
+    /// caller that wants them asks with `explain` or `compact: false`.
+    pub compact: bool,
+    /// True when the caller named a budget rather than taking the default.
+    pub explicit_max_chars: bool,
+}
+
+impl Default for ResponseBudget {
+    fn default() -> Self {
+        Self {
+            max_chars: RESPONSE_DEFAULT_MAX_CHARS,
+            compact: true,
+            explicit_max_chars: false,
+        }
+    }
+}
+
+impl ResponseBudget {
+    /// Read the budget a call asks for.
+    ///
+    /// `max_chars` is the documented spelling; `max_response_chars` is the
+    /// spelling `trace_data_flow` shipped first and keeps working, because an
+    /// agent that learned it from that tool must not be handed an unbounded
+    /// response for using it. Either is clamped to what this server will serve.
+    ///
+    /// `compact` defaults on. An explicit `compact` wins; failing that,
+    /// `explain: true` turns it off, because a caller asking for the ranking
+    /// explanation is asking for the very fields compaction sheds.
+    pub fn from_arguments(args: &HashMap<String, Value>) -> Self {
+        let requested = ["max_chars", "max_response_chars"]
+            .into_iter()
+            .find_map(|key| args.get(key).and_then(Value::as_u64));
+        let explain = args
+            .get("explain")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        Self {
+            max_chars: requested
+                .map(|value| value as usize)
+                .unwrap_or(RESPONSE_DEFAULT_MAX_CHARS)
+                .clamp(RESPONSE_MIN_MAX_CHARS, RESPONSE_MAX_MAX_CHARS),
+            compact: args
+                .get("compact")
+                .and_then(Value::as_bool)
+                .unwrap_or(!explain),
+            explicit_max_chars: requested.is_some(),
+        }
+    }
+
+    /// The same budget, reduced by the room the MCP path's envelope and negative
+    /// need. Used by the arm that cuts first so the later one has nothing left
+    /// to cut.
+    ///
+    /// A budget the CALLER named is returned unchanged. The reserve is this
+    /// server's own arithmetic about its own default, and quietly enforcing
+    /// something smaller than the number a caller passed would make two arms
+    /// answer one call under two ceilings: the tool would report the cut it made
+    /// at the requested budget, and a later pass would cut again to a number the
+    /// caller never asked for and the response never names.
+    pub fn less_envelope_reserve(self) -> Self {
+        if self.explicit_max_chars {
+            return self;
+        }
+        Self {
+            max_chars: self
+                .max_chars
+                .saturating_sub(RESPONSE_ENVELOPE_RESERVE_CHARS)
+                .max(RESPONSE_MIN_MAX_CHARS),
+            ..self
+        }
+    }
+}
+
+/// What the budget did to one response. Carried on the `_kin` envelope under
+/// `response`, so a caller can see that an answer was bounded and by how much
+/// without having to compare it against an unbounded run it cannot make.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BudgetAccounting {
+    /// The budget that was applied, after clamping.
+    pub max_chars: usize,
+    /// What the payload measured BEFORE the budget touched it.
+    #[serde(rename = "chars_before_budget")]
+    pub chars_before: usize,
+    /// True when something was actually removed.
+    pub bounded: bool,
+    /// True when explanation and per-signal breakdowns were shed.
+    pub compact: bool,
+}
+
+impl BudgetAccounting {
+    pub fn to_value(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+}
+
+/// Serialized size of a payload, measured the way every emitter on both
+/// surfaces renders it. Measuring a compact form nobody sends would charge the
+/// budget for a payload no caller receives.
+pub fn measure(value: &Value) -> usize {
+    serde_json::to_string_pretty(value).map_or(usize::MAX, |json| json.len())
+}
+
+/// One tool's payload shape, in the terms the budget acts on.
+struct ResponseShape {
+    /// Arrays holding one entry per hit, most important FIRST. The ladder trims
+    /// from the last, because the last is the one whose content another array in
+    /// the same response already carries.
+    collections: &'static [&'static str],
+    /// Per-hit keys holding source text.
+    body_keys: &'static [&'static str],
+    /// Per-hit keys holding ranking explanation or per-signal breakdowns.
+    explain_keys: &'static [&'static str],
+    /// Top-level keys holding explanation blocks.
+    top_explain_keys: &'static [&'static str],
+    /// Per-hit keys holding a nested repeat of hits another collection already
+    /// reports in full.
+    duplicate_keys: &'static [&'static str],
+    /// The parameter a caller narrows to avoid a trim.
+    narrow_param: &'static str,
+}
+
+/// The retrieval tools this budget governs, and the shape of what each returns.
+///
+/// Membership is deliberately not "every tool". A tool whose whole purpose is to
+/// hand back requested source (`get_entity_source`, `get_entity_sources`,
+/// `kin_artifact_read`) would be answering a different question if it silently
+/// returned less code than was asked for; those carry their own explicit line
+/// and byte caps instead. What is listed here is the retrieval family, where the
+/// answer is a ranking or a walk and the caller can always ask for the rest.
+fn shape_for(tool: &str) -> Option<ResponseShape> {
+    let shape = match tool {
+        "semantic_locate" => ResponseShape {
+            collections: &["entities", "files"],
+            body_keys: &["body", "snippet"],
+            explain_keys: &[
+                "match_evidence",
+                "explain",
+                "signal_scores",
+                "score_breakdown",
+            ],
+            top_explain_keys: &["debug"],
+            // Every symbol in `files[].symbols[]` is a hit `entities[]` already
+            // reports with more fields, so the roll-up is the redundant copy.
+            duplicate_keys: &["symbols"],
+            narrow_param: "limit",
+        },
+        "semantic_search" => ResponseShape {
+            collections: &["results"],
+            body_keys: &["doc_summary"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "limit",
+        },
+        "trace_data_flow" => ResponseShape {
+            collections: &["chain"],
+            body_keys: &["body"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "depth",
+        },
+        "get_context_pack" | "trace_computation" => ResponseShape {
+            collections: &["dependencies", "transitive_deps", "tests", "contracts"],
+            body_keys: &["body"],
+            explain_keys: &["projection"],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "depth",
+        },
+        "find_references" => ResponseShape {
+            collections: &["references"],
+            body_keys: &["body", "snippet"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "relation_kinds",
+        },
+        "graph_neighborhood" => ResponseShape {
+            collections: &["entities", "relations"],
+            body_keys: &["body", "signature"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "depth",
+        },
+        "impact_analysis" => ResponseShape {
+            collections: &["impacted_entities", "affected_tests"],
+            body_keys: &["body"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "depth",
+        },
+        "find_dead_code_seeded" => ResponseShape {
+            collections: &["candidates"],
+            body_keys: &["body"],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "limit",
+        },
+        "bulk_check_references" => ResponseShape {
+            collections: &["results"],
+            body_keys: &[],
+            explain_keys: &[],
+            top_explain_keys: &[],
+            duplicate_keys: &[],
+            narrow_param: "entity_ids",
+        },
+        _ => return None,
+    };
+    Some(shape)
+}
+
+/// Whether this tool's response is governed by the budget.
+pub fn is_budgeted(tool: &str) -> bool {
+    shape_for(tool).is_some()
+}
+
+/// Compact and bound one retrieval payload in place, disclosing every cut.
+///
+/// Returns `None` for a tool the budget does not govern, so a caller can tell
+/// "not budgeted" from "budgeted and untouched" rather than reading an absent
+/// accounting as either.
+///
+/// The ladder is ordered by what a caller loses. Explanation and per-signal
+/// breakdowns go first: they are diagnostics about a hit, not the hit. A nested
+/// repeat of hits another array already carries goes next, because dropping it
+/// costs nothing at all. Source bodies go next, recoverable one call at a time
+/// through `get_entity_source`. Only then are hits themselves withheld, from the
+/// tail of the least important array first, which is the only cut that removes
+/// an answer rather than a description of one.
+pub fn enforce(
+    payload: &mut Value,
+    tool: &str,
+    budget: &ResponseBudget,
+) -> Option<BudgetAccounting> {
+    let shape = shape_for(tool)?;
+    let chars_before = measure(payload);
+    let mut accounting = BudgetAccounting {
+        max_chars: budget.max_chars,
+        chars_before,
+        bounded: false,
+        compact: budget.compact,
+    };
+    let mut cuts: Vec<String> = Vec::new();
+    let mut remediations: Vec<String> = Vec::new();
+
+    // Compact by default, whether or not the payload is over budget: the
+    // breakdowns are diagnostics a caller did not ask for, and shipping them
+    // unasked is what made a ten-result ranking an 80,000-character response.
+    // This one is not disclosed as a cut, because it is the documented default
+    // shape rather than something the budget took away under pressure.
+    if budget.compact {
+        strip_keys(payload, &shape, shape.explain_keys, shape.top_explain_keys);
+    }
+
+    if measure(payload) <= budget.max_chars {
+        return Some(accounting);
+    }
+
+    // The reserve holds room for the disclosure the cut adds, but it can never
+    // be a fixed number: at the floor of the clamp a flat 1,500 characters would
+    // leave a few hundred for the answer, and the ladder would strip a response
+    // down to nothing to make room for the note explaining that it had. It
+    // scales with the budget instead.
+    let reserve = RESPONSE_DISCLOSURE_RESERVE_CHARS.min(budget.max_chars / 4);
+    let target = budget.max_chars.saturating_sub(reserve);
+
+    // A caller that explicitly turned compaction off still cannot be served a
+    // response its client refuses, so the diagnostics go under pressure anyway.
+    // The disclosure names what happened; silence would leave the caller reading
+    // an explain-less response it had explicitly asked to explain.
+    if !budget.compact {
+        let stripped = strip_keys(payload, &shape, shape.explain_keys, shape.top_explain_keys);
+        if stripped > 0 {
+            accounting.bounded = true;
+            cuts.push(format!(
+                "ranking explanation and per-signal breakdowns dropped from {stripped} entries"
+            ));
+        }
+        if measure(payload) <= target {
+            disclose(payload, budget.max_chars, &cuts, &remediations);
+            return Some(accounting);
+        }
+    }
+
+    if !shape.duplicate_keys.is_empty() {
+        let stripped = strip_keys(payload, &shape, shape.duplicate_keys, &[]);
+        if stripped > 0 {
+            accounting.bounded = true;
+            cuts.push(format!(
+                "the per-file symbol roll-up dropped from {stripped} entries, every symbol of \
+                 which is still reported in full under `{}`",
+                shape.collections.first().copied().unwrap_or("entities")
+            ));
+        }
+        if measure(payload) <= target {
+            disclose(payload, budget.max_chars, &cuts, &remediations);
+            return Some(accounting);
+        }
+    }
+
+    if !shape.body_keys.is_empty() {
+        let stripped = strip_keys(payload, &shape, shape.body_keys, &[]);
+        if stripped > 0 {
+            accounting.bounded = true;
+            cuts.push(format!(
+                "inline source dropped from {stripped} hits, each of which still carries its \
+                 identity, location, and span"
+            ));
+            remediations.push("read one body with get_entity_source".to_string());
+        }
+        if measure(payload) <= target {
+            disclose(payload, budget.max_chars, &cuts, &remediations);
+            return Some(accounting);
+        }
+    }
+
+    // Last resort: withhold hits, from the tail of the least important array
+    // first. This is the only stage that removes an answer, so it reports the
+    // count withheld and the parameter that recovers them.
+    //
+    // The first collection is the primary one and always keeps at least one
+    // entry. A bound is not a refusal: a caller handed an empty ranking cannot
+    // tell it from "nothing matched", which is the one reading a size cut must
+    // never produce.
+    let primary = shape.collections.first().copied();
+    let mut withheld_any = false;
+    for key in shape.collections.iter().rev() {
+        let floor = usize::from(Some(*key) == primary);
+        let withheld = trim_collection(payload, key, target, floor);
+        if withheld > 0 {
+            accounting.bounded = true;
+            withheld_any = true;
+            cuts.push(format!(
+                "{withheld} entries withheld from the end of `{key}`"
+            ));
+            payload["truncated"] = Value::Bool(true);
+        }
+        if measure(payload) <= target {
+            break;
+        }
+    }
+    if withheld_any {
+        let kept = primary
+            .and_then(|key| payload.get(key))
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        if payload.get("next_cursor").is_some() && kept > 0 {
+            remediations.push(format!(
+                "re-issue with `page_size: {kept}` and follow `next_cursor`"
+            ));
+        } else {
+            remediations.push(format!("narrow the request with `{}`", shape.narrow_param));
+        }
+    }
+
+    disclose(payload, budget.max_chars, &cuts, &remediations);
+    Some(accounting)
+}
+
+/// Remove `keys` from every hit in every collection, and `top_keys` from the
+/// payload itself. Returns how many entries lost at least one key, which is the
+/// number the disclosure reports.
+fn strip_keys(
+    payload: &mut Value,
+    shape: &ResponseShape,
+    keys: &[&str],
+    top_keys: &[&str],
+) -> usize {
+    let mut stripped = 0usize;
+    for key in top_keys {
+        if let Some(map) = payload.as_object_mut() {
+            if map.remove(*key).is_some() {
+                stripped += 1;
+            }
+        }
+    }
+    if keys.is_empty() {
+        return stripped;
+    }
+    for collection in shape.collections {
+        let Some(entries) = payload.get_mut(*collection).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for entry in entries.iter_mut() {
+            let Some(map) = entry.as_object_mut() else {
+                continue;
+            };
+            let mut touched = false;
+            for key in keys {
+                if remove_present(map, key) {
+                    touched = true;
+                }
+            }
+            if touched {
+                stripped += 1;
+            }
+        }
+    }
+    // A focal record is reported in the same shape as a hit and carries the same
+    // keys, so it is charged the same cuts. Leaving it whole would keep the
+    // largest single body in a response that just dropped every other one.
+    for focal in ["focal_entity", "focal"] {
+        if let Some(map) = payload.get_mut(focal).and_then(Value::as_object_mut) {
+            let mut touched = false;
+            for key in keys {
+                if remove_present(map, key) {
+                    touched = true;
+                }
+            }
+            if touched {
+                stripped += 1;
+            }
+        }
+    }
+    stripped
+}
+
+/// Remove one key when it carries something. A key already absent, or already
+/// explicitly null, is not a cut and must not be counted as one: a disclosure
+/// naming entries nothing was taken from is a false report of loss.
+fn remove_present(map: &mut Map<String, Value>, key: &str) -> bool {
+    match map.get(key) {
+        None | Some(Value::Null) => false,
+        Some(_) => {
+            map.remove(key);
+            true
+        }
+    }
+}
+
+/// Withhold entries from the tail of one collection until the payload fits,
+/// returning how many were withheld.
+///
+/// Bisected rather than popped one at a time: the same answer, in a handful of
+/// serializations instead of one per withheld entry. A suffix is what makes the
+/// cut safe for a walk whose entries reference earlier ones by index, because
+/// removing the end never orphans a surviving entry's parent.
+fn trim_collection(payload: &mut Value, key: &str, target: usize, min_keep: usize) -> usize {
+    let Some(full) = payload.get(key).and_then(Value::as_array).cloned() else {
+        return 0;
+    };
+    if full.len() <= min_keep || measure(payload) <= target {
+        return 0;
+    }
+    let mut kept = min_keep;
+    let mut low = min_keep;
+    let mut high = full.len();
+    while low <= high {
+        let mid = (low + high) / 2;
+        payload[key] = Value::Array(full[..mid].to_vec());
+        if measure(payload) <= target {
+            kept = mid;
+            low = mid + 1;
+        } else if mid == min_keep {
+            break;
+        } else {
+            high = mid - 1;
+        }
+    }
+    payload[key] = Value::Array(full[..kept].to_vec());
+    let withheld = full.len() - kept;
+    if withheld > 0 {
+        payload[format!("{key}_withheld")] = Value::from(withheld);
+    }
+    withheld
+}
+
+/// Append the cuts to the `degradations` channel the retrieval tools already
+/// use, so a bounded response is attributable rather than merely short.
+///
+/// One entry for the whole ladder rather than one per stage. Four separate
+/// notes, each restating the budget and its own remediation, ran to more
+/// characters than a small budget has to spend, so the disclosure competed with
+/// the answer it was describing and the ladder emptied the ranking to make room
+/// for it.
+///
+/// Appended rather than assigned: the pipeline may already have disclosed
+/// something about this same answer, and overwriting that would trade one silent
+/// degradation for another.
+fn disclose(payload: &mut Value, max_chars: usize, cuts: &[String], remediations: &[String]) {
+    if cuts.is_empty() {
+        return;
+    }
+    let mut remediation = remediations.join("; ");
+    if !remediation.is_empty() {
+        remediation.push_str("; ");
+    }
+    remediation
+        .push_str("or raise max_chars if the caller's own result limit accepts a larger payload");
+    let entry = json!({
+        "component": "response_budget",
+        "reason": "response_bounded",
+        "detail": format!(
+            "the response exceeded its {max_chars}-character budget, so {}",
+            cuts.join("; ")
+        ),
+        "remediation": remediation,
+        "max_chars": max_chars,
+    });
+    match payload
+        .get_mut("degradations")
+        .and_then(Value::as_array_mut)
+    {
+        Some(existing) => existing.push(entry),
+        None => payload["degradations"] = Value::Array(vec![entry]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn locate_payload(hits: usize, body_chars: usize) -> Value {
+        let entities: Vec<Value> = (0..hits)
+            .map(|index| {
+                json!({
+                    "entity_id": format!("00000000-0000-0000-0000-{index:012}"),
+                    "name": format!("handler_{index}"),
+                    "kind": "function",
+                    "score": 0.5,
+                    "definition": true,
+                    "body": "x".repeat(body_chars),
+                    "match_evidence": {
+                        "ranker": "fused-v1",
+                        "signals": ["vector", "lexical", "graph"],
+                        "matched_variants": ["a", "b", "c"],
+                    },
+                    "provenance": { "file": format!("src/f{index}.rs") },
+                })
+            })
+            .collect();
+        let files: Vec<Value> = (0..hits)
+            .map(|index| {
+                json!({
+                    "path": format!("src/f{index}.rs"),
+                    "score": 0.5,
+                    "signals": ["vector", "lexical"],
+                    "symbols": (0..8).map(|s| json!({
+                        "name": format!("sym_{index}_{s}"),
+                        "kind": "function",
+                        "score": 0.4,
+                        "span": [1, 40],
+                    })).collect::<Vec<_>>(),
+                    "explain": ["ranked by vector similarity 0.81", "lexical hit on token"],
+                })
+            })
+            .collect();
+        json!({
+            "query": "where redirects are resolved",
+            "entities": entities,
+            "files": files,
+            "total_ranked": hits,
+            "next_cursor": "deadbeefdeadbeef.1",
+        })
+    }
+
+    #[test]
+    fn unbudgeted_tool_is_left_alone() {
+        let mut payload = json!({ "anything": "at all" });
+        assert!(enforce(&mut payload, "kin_work_create", &ResponseBudget::default()).is_none());
+        assert_eq!(payload, json!({ "anything": "at all" }));
+    }
+
+    #[test]
+    fn compact_sheds_breakdowns_without_touching_the_hits() {
+        let mut payload = locate_payload(4, 20);
+        let before = measure(&payload);
+        let accounting = enforce(&mut payload, "semantic_locate", &ResponseBudget::default())
+            .expect("semantic_locate is budgeted");
+        assert_eq!(accounting.chars_before, before);
+        assert_eq!(payload["entities"].as_array().unwrap().len(), 4);
+        for hit in payload["entities"].as_array().unwrap() {
+            assert!(
+                hit.get("match_evidence").is_none(),
+                "breakdown survived: {hit}"
+            );
+            assert!(
+                hit.get("body").is_some(),
+                "a compact pass must keep the answer"
+            );
+        }
+        for file in payload["files"].as_array().unwrap() {
+            assert!(file.get("explain").is_none());
+        }
+    }
+
+    #[test]
+    fn an_oversized_response_is_cut_to_its_budget_and_says_so() {
+        const BUDGET: usize = 6_000;
+        let mut payload = locate_payload(30, 400);
+        let before = measure(&payload);
+        assert!(before > BUDGET, "the fixture must overflow: {before}");
+        let budget = ResponseBudget {
+            max_chars: BUDGET,
+            ..ResponseBudget::default()
+        };
+        let accounting =
+            enforce(&mut payload, "semantic_locate", &budget).expect("semantic_locate is budgeted");
+        let after = measure(&payload);
+        assert!(
+            after <= BUDGET,
+            "the tool must return what it promised: {after}"
+        );
+        assert!(accounting.bounded);
+        assert_eq!(accounting.chars_before, before);
+        assert_eq!(accounting.max_chars, BUDGET);
+        let cuts = payload["degradations"]
+            .as_array()
+            .expect("a cut is disclosed");
+        assert!(cuts
+            .iter()
+            .all(|cut| cut["component"] == json!("response_budget")));
+    }
+
+    /// At the floor of the clamp the disclosure is a large fraction of the whole
+    /// budget, which is exactly where a ladder that cuts to make room for its own
+    /// explanation returns an empty ranking. An empty ranking is indistinguishable
+    /// from "nothing matched", so the primary collection always keeps one hit.
+    #[test]
+    fn a_bound_is_not_a_refusal() {
+        let mut payload = locate_payload(60, 2_000);
+        let budget = ResponseBudget {
+            max_chars: RESPONSE_MIN_MAX_CHARS,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
+        assert!(
+            !payload["entities"].as_array().unwrap().is_empty(),
+            "a budget must still answer: {payload}"
+        );
+        assert_eq!(payload["truncated"], json!(true));
+        assert_eq!(payload["total_ranked"], json!(60));
+    }
+
+    #[test]
+    fn withheld_hits_are_counted_and_flagged() {
+        let mut payload = locate_payload(40, 300);
+        let budget = ResponseBudget {
+            max_chars: 4_000,
+            ..ResponseBudget::default()
+        };
+        enforce(&mut payload, "semantic_locate", &budget).expect("budgeted");
+        let kept = payload["entities"].as_array().unwrap().len();
+        if kept < 40 {
+            assert_eq!(
+                payload["entities_withheld"].as_u64().unwrap() as usize + kept,
+                40
+            );
+            assert_eq!(payload["truncated"], json!(true));
+        }
+        assert_eq!(
+            payload["total_ranked"],
+            json!(40),
+            "the full ranking size is still reported"
+        );
+    }
+
+    #[test]
+    fn a_response_inside_its_budget_keeps_every_hit() {
+        let mut payload = locate_payload(3, 50);
+        let accounting =
+            enforce(&mut payload, "semantic_locate", &ResponseBudget::default()).expect("budgeted");
+        assert_eq!(payload["entities"].as_array().unwrap().len(), 3);
+        assert!(payload.get("entities_withheld").is_none());
+        assert!(payload.get("truncated").is_none());
+        assert!(accounting.chars_before > 0);
+    }
+
+    #[test]
+    fn caller_budget_is_clamped_and_both_spellings_are_read() {
+        let mut args = HashMap::new();
+        args.insert("max_chars".to_string(), json!(10));
+        assert_eq!(
+            ResponseBudget::from_arguments(&args).max_chars,
+            RESPONSE_MIN_MAX_CHARS
+        );
+        args.insert("max_chars".to_string(), json!(9_000_000u64));
+        assert_eq!(
+            ResponseBudget::from_arguments(&args).max_chars,
+            RESPONSE_MAX_MAX_CHARS
+        );
+        let mut legacy = HashMap::new();
+        legacy.insert("max_response_chars".to_string(), json!(50_000));
+        assert_eq!(ResponseBudget::from_arguments(&legacy).max_chars, 50_000);
+        assert!(ResponseBudget::from_arguments(&legacy).explicit_max_chars);
+        assert!(!ResponseBudget::from_arguments(&HashMap::new()).explicit_max_chars);
+    }
+
+    #[test]
+    fn explain_turns_compaction_off_and_an_explicit_compact_wins() {
+        let mut explaining = HashMap::new();
+        explaining.insert("explain".to_string(), json!(true));
+        assert!(!ResponseBudget::from_arguments(&explaining).compact);
+        explaining.insert("compact".to_string(), json!(true));
+        assert!(ResponseBudget::from_arguments(&explaining).compact);
+        assert!(ResponseBudget::from_arguments(&HashMap::new()).compact);
+    }
+
+    /// The reserve is this server's arithmetic about its own default. A caller
+    /// that names a ceiling gets that ceiling on every arm, so one call is
+    /// bounded once, at a number the response names.
+    #[test]
+    fn an_explicit_budget_is_enforced_exactly_and_the_default_reserves_room() {
+        let mut named = HashMap::new();
+        named.insert("max_chars".to_string(), json!(6_000));
+        let named = ResponseBudget::from_arguments(&named);
+        assert_eq!(named.less_envelope_reserve().max_chars, 6_000);
+
+        let defaulted = ResponseBudget::from_arguments(&HashMap::new());
+        assert_eq!(
+            defaulted.less_envelope_reserve().max_chars,
+            RESPONSE_DEFAULT_MAX_CHARS - RESPONSE_ENVELOPE_RESERVE_CHARS
+        );
+    }
+
+    #[test]
+    fn an_absent_key_is_never_reported_as_a_cut() {
+        let mut payload = json!({
+            "references": [ { "name": "a", "body": null }, { "name": "b" } ],
+        });
+        let accounting =
+            enforce(&mut payload, "find_references", &ResponseBudget::default()).expect("budgeted");
+        assert!(
+            !accounting.bounded,
+            "nothing was carried, so nothing was cut: {payload}"
+        );
+    }
+}

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -34,6 +34,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
+use crate::budget::ResponseBudget;
 use crate::types::{ContentBlock, ToolCallResult};
 
 /// Current envelope schema version. Bump on any breaking field change so
@@ -236,6 +237,13 @@ pub struct Envelope {
     /// Degraded-state flags (always present; individual flags omitted when not
     /// observed).
     pub degraded: Degraded,
+    /// What the response budget did to this payload: the budget applied and what
+    /// the response measured before it. Present only on the retrieval tools the
+    /// budget governs, and written by [`finalize_bounded`] AFTER this struct is
+    /// serialized, because the number it reports is a property of the bytes the
+    /// envelope itself rides in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response: Option<crate::budget::BudgetAccounting>,
 }
 
 impl Envelope {
@@ -252,6 +260,7 @@ impl Envelope {
                 offline_fallback: Some(true),
                 ..Degraded::default()
             },
+            response: None,
         }
     }
 
@@ -266,6 +275,7 @@ impl Envelope {
             graph_as_of: None,
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
+            response: None,
         }
     }
 
@@ -321,6 +331,7 @@ impl Envelope {
                 daemon_unreachable: Some(true),
                 ..Degraded::default()
             },
+            response: None,
         }
     }
 
@@ -495,7 +506,7 @@ impl Envelope {
 ///
 /// `is_error` and any non-text content blocks are preserved unchanged.
 pub fn annotate(result: ToolCallResult, envelope: &Envelope) -> ToolCallResult {
-    annotate_inner(result, envelope, None)
+    annotate_inner(result, envelope, None, "", &ResponseBudget::default())
 }
 
 /// Like [`annotate`], but also attaches a confidence-qualified `negative` object
@@ -506,12 +517,14 @@ fn annotate_inner(
     result: ToolCallResult,
     envelope: &Envelope,
     negative: Option<&Value>,
+    tool_name: &str,
+    budget: &ResponseBudget,
 ) -> ToolCallResult {
     let envelope_value = envelope.to_value();
     let content = result
         .content
         .into_iter()
-        .map(|block| annotate_block(block, &envelope_value, negative))
+        .map(|block| annotate_block(block, &envelope_value, negative, tool_name, budget))
         .collect();
     ToolCallResult {
         content,
@@ -552,6 +565,26 @@ fn first_message_text(result: &ToolCallResult) -> Option<&str> {
 /// resolved answer from the same tool carried a full negative. That asymmetry
 /// is the one an agent cannot see, so the miss is qualified here too.
 pub fn finalize(result: ToolCallResult, base: Envelope, tool_name: &str) -> ToolCallResult {
+    finalize_bounded(result, base, tool_name, &ResponseBudget::default())
+}
+
+/// [`finalize`] under the size contract the CALL asked for.
+///
+/// This is the last point at which the bytes a client receives are known, so it
+/// is where the budget has to hold. The envelope and the `negative` object are
+/// part of those bytes and are attached here, which is why the payload cannot
+/// bound itself alone: a handler that cut to exactly its ceiling would go back
+/// over it the moment this function wrapped the result.
+///
+/// The budget never touches `_kin` or `negative`. Those are the fields that say
+/// how far the answer can be trusted, and an answer that was shortened is
+/// exactly when a caller needs them most.
+pub fn finalize_bounded(
+    result: ToolCallResult,
+    base: Envelope,
+    tool_name: &str,
+    budget: &ResponseBudget,
+) -> ToolCallResult {
     let payload = first_payload_value(&result);
     let envelope = match &payload {
         Some(payload) => base.with_payload_metadata(payload),
@@ -564,13 +597,15 @@ pub fn finalize(result: ToolCallResult, base: Envelope, tool_name: &str) -> Tool
         }),
         None => None,
     };
-    annotate_inner(result, &envelope, negative.as_ref())
+    annotate_inner(result, &envelope, negative.as_ref(), tool_name, budget)
 }
 
 fn annotate_block(
     block: ContentBlock,
     envelope_value: &Value,
     negative: Option<&Value>,
+    tool_name: &str,
+    budget: &ResponseBudget,
 ) -> ContentBlock {
     let ContentBlock::Text { text } = block;
     let annotated = match serde_json::from_str::<Value>(&text) {
@@ -602,9 +637,48 @@ fn annotate_block(
             Value::Object(map)
         }
     };
+    let mut annotated = annotated;
+    apply_response_budget(&mut annotated, tool_name, budget);
     let rendered =
         serde_json::to_string_pretty(&annotated).unwrap_or_else(|_| annotated.to_string());
     ContentBlock::Text { text: rendered }
+}
+
+/// Bound the fully annotated payload and record what that cost under
+/// `_kin.response`.
+///
+/// The accounting stanza is written BEFORE the cut as well as after it. The
+/// number it carries is a property of the object it sits inside, so a stanza
+/// added afterwards would push a response that had just been cut to fit back
+/// over its ceiling by its own length. Writing it first means the ladder
+/// measures the bytes that actually ship. `chars_before` is then restored to the
+/// first measurement, which is the one taken before anything was removed.
+fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &ResponseBudget) {
+    if !crate::budget::is_budgeted(tool_name) {
+        return;
+    }
+    let chars_before = crate::budget::measure(annotated);
+    let mut accounting = crate::budget::BudgetAccounting {
+        max_chars: budget.max_chars,
+        chars_before,
+        bounded: false,
+        compact: budget.compact,
+    };
+    write_response_accounting(annotated, &accounting);
+    if let Some(applied) = crate::budget::enforce(annotated, tool_name, budget) {
+        accounting = applied;
+        accounting.chars_before = chars_before;
+    }
+    write_response_accounting(annotated, &accounting);
+}
+
+fn write_response_accounting(annotated: &mut Value, accounting: &crate::budget::BudgetAccounting) {
+    if let Some(envelope) = annotated
+        .get_mut(ENVELOPE_KEY)
+        .and_then(Value::as_object_mut)
+    {
+        envelope.insert("response".to_string(), accounting.to_value());
+    }
 }
 
 #[cfg(test)]

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -409,33 +409,37 @@ pub use kin_ranking::entity_ranking::{
 /// lines from a 777-entity repository and the client refused the whole result,
 /// so the caller got neither the chain nor a way to ask for less.
 ///
-/// Sized against the tool-result ceilings agent clients actually apply, which
-/// are counted in tokens; at roughly 3.5 characters per token of JSON-wrapped
-/// source this leaves headroom under a 25k-token cap for the envelope the MCP
-/// path wraps around this payload.
+/// This is now an alias for [`crate::budget::RESPONSE_DEFAULT_MAX_CHARS`], the
+/// one default every retrieval tool is served under, rather than a number of its
+/// own. It had one, 80,000, chosen against the same client ceiling this is
+/// chosen against, and a `trace_data_flow` that came in at 79,278 characters,
+/// inside that budget, was refused by the client anyway. A per-tool budget that
+/// the tool alone believes in is how a bound reports success while the caller
+/// gets a file to read, so there is one number and every retrieval tool answers
+/// under it.
 ///
-/// Defined here rather than beside either walk because BOTH walks serve this one
-/// tool — the generic-store arm in `handlers::entities` and the body-inlining
-/// arm in `kin_cli::commands::trace_data_flow`, which reads these through this
-/// module. Two definitions would let one arm promise a bound the other does not
-/// keep.
-pub const TRACE_DEFAULT_MAX_RESPONSE_CHARS: usize = 80_000;
+/// Defined through this module rather than beside either walk because BOTH walks
+/// serve this one tool - the generic-store arm in `handlers::entities` and the
+/// body-inlining arm in `kin_cli::commands::trace_data_flow`, which reads these
+/// through here. Two definitions would let one arm promise a bound the other
+/// does not keep.
+pub const TRACE_DEFAULT_MAX_RESPONSE_CHARS: usize = crate::budget::RESPONSE_DEFAULT_MAX_CHARS;
 
 /// Floor for a caller-supplied budget. Below this the envelope alone does not
 /// fit, so a smaller number could only be honoured by returning nothing.
-pub const TRACE_MIN_MAX_RESPONSE_CHARS: usize = 2_000;
+pub const TRACE_MIN_MAX_RESPONSE_CHARS: usize = crate::budget::RESPONSE_MIN_MAX_CHARS;
 
 /// Ceiling for a caller-supplied budget. A caller with a larger window may raise
 /// the bound, but not to unbounded: the daemon serving this has other callers,
 /// and a response nothing can read is not worth building.
-pub const TRACE_MAX_MAX_RESPONSE_CHARS: usize = 400_000;
+pub const TRACE_MAX_MAX_RESPONSE_CHARS: usize = crate::budget::RESPONSE_MAX_MAX_CHARS;
 
 /// Characters held back from the budget for the disclosure a cut adds.
 ///
 /// A response cut to exactly its ceiling and then told to explain the cut is
 /// over its ceiling again, by the length of the explanation. Reserving the room
 /// first is what makes the bound hold for the payload that actually ships.
-pub const TRACE_DISCLOSURE_RESERVE_CHARS: usize = 1_500;
+pub const TRACE_DISCLOSURE_RESERVE_CHARS: usize = crate::budget::RESPONSE_DISCLOSURE_RESERVE_CHARS;
 
 /// The budget a trace request asks for, clamped to what this tool will serve.
 pub fn trace_response_budget(requested: Option<usize>) -> usize {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -123,7 +123,13 @@ the graph, so get_entity_source, get_context_pack, graph_neighborhood, and find_
 all take it. `id_space: \"artifact\"` means the hit is an artifact-level embedding — a \
 tracked file the parsers produced no entities for — so it carries `artifact_path` and NO \
 `entity_id`, and those tools will refuse it; read it with kin_artifact_read instead. Do \
-not synthesize an entity id from an artifact hit's path.";
+not synthesize an entity id from an artifact hit's path. The response bounds its own size \
+(max_chars, default 30000 serialized characters) so it is never refused by a client for being \
+too large: it is compact by default, meaning no per-signal `match_evidence` breakdown unless you \
+ask with explain=true or compact=false, and under pressure it sheds the per-file symbol roll-up, \
+then inline snippets, and only then withholds hits from the end of the page. Any cut is reported \
+in `degradations` and in `_kin.response`, which carries the budget applied and what the response \
+measured before it, and the rest of the ranking stays reachable through `next_cursor`.";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///
@@ -903,7 +909,11 @@ binding, a declared import, or a resolved dispatch class), `import_scoped` (the 
 module was known and the symbol selected inside it), or `name_only` (a bare same-name \
 match across the repo, with nothing at the reference site proving it). A `name_only` row \
 is a candidate, not a fact; do not count it as use, and do not conclude something is \
-unused from the absence of anything but `name_only` rows without confirming.";
+unused from the absence of anything but `name_only` rows without confirming. \
+The response bounds its own size (max_chars, default 30000 serialized characters): a symbol \
+with hundreds of call sites sheds its inline snippets before it withholds any row, and any cut \
+is reported in `degradations` and in `_kin.response` with the size the response had before the \
+budget, so a short answer is never mistaken for a complete one.";
 
 fn normalize_cross_repo_repo_id(raw: Option<&str>) -> std::result::Result<String, String> {
     raw.map(str::trim)
@@ -5888,5 +5898,336 @@ mod tests {
         assert_eq!(result.is_error, Some(true));
         let crate::types::ContentBlock::Text { text } = &result.content[0];
         assert!(text.contains("requires the Kin daemon"), "{text}");
+    }
+
+    // ---------------------------------------------------------------------
+    // FIR-2396: the response budget, one test per retrieval tool.
+    //
+    // Each builds a fixture large enough to overflow the shared default, then
+    // asserts the FINAL annotated text -- the bytes a client actually counts,
+    // envelope and negative included -- stays under it. The control in every
+    // case is the same call served at the clamp ceiling, which proves the
+    // fixture overflows and that the bound, rather than the fixture, is what
+    // shrank it.
+    // ---------------------------------------------------------------------
+
+    use crate::budget::{ResponseBudget, RESPONSE_DEFAULT_MAX_CHARS, RESPONSE_MAX_MAX_CHARS};
+
+    /// The text a client receives for one tool result: the payload with `_kin`
+    /// and `negative` attached, rendered exactly as the stdio path renders it.
+    fn client_text(result: ToolCallResult, tool: &str, budget: &ResponseBudget) -> String {
+        let enveloped =
+            crate::envelope::finalize_bounded(result, crate::Envelope::offline(), tool, budget);
+        let crate::types::ContentBlock::Text { text } = enveloped
+            .content
+            .into_iter()
+            .next()
+            .expect("one content block");
+        text
+    }
+
+    /// A budget that cannot bind, for the control arm.
+    fn unbounded() -> ResponseBudget {
+        ResponseBudget {
+            max_chars: RESPONSE_MAX_MAX_CHARS,
+            compact: false,
+            explicit_max_chars: true,
+        }
+    }
+
+    /// Assert one tool's overflow and its bound in the one unit the refusal was
+    /// ever reported in, and hand back both numbers and the bounded payload.
+    fn assert_bounded(
+        tool: &str,
+        unbounded_text: String,
+        bounded_text: String,
+    ) -> (usize, usize, serde_json::Value) {
+        let before = unbounded_text.len();
+        let after = bounded_text.len();
+        assert!(
+            before > RESPONSE_DEFAULT_MAX_CHARS,
+            "{tool}: the fixture must overflow the default budget, or the bound is untested: \
+             {before} chars"
+        );
+        assert!(
+            after <= RESPONSE_DEFAULT_MAX_CHARS,
+            "{tool}: the response a client receives must fit its budget: {after} chars against \
+             {RESPONSE_DEFAULT_MAX_CHARS}"
+        );
+        let bounded: serde_json::Value = serde_json::from_str(&bounded_text)
+            .unwrap_or_else(|error| panic!("{tool}: a bounded response is still JSON: {error}"));
+        assert_eq!(
+            bounded["_kin"]["response"]["max_chars"],
+            serde_json::json!(RESPONSE_DEFAULT_MAX_CHARS),
+            "{tool}: the applied budget is recorded on the envelope"
+        );
+        let chars_before = bounded["_kin"]["response"]["chars_before_budget"]
+            .as_u64()
+            .expect("the pre-truncation size is recorded") as usize;
+        assert!(
+            chars_before > 0,
+            "{tool}: the envelope reports the size the response had before the budget"
+        );
+        // Bounded SOMEWHERE, and the response says where. The envelope stage
+        // reports its own cut on `_kin`; a tool that enforces the same budget
+        // inside its own walk has already fit by the time the envelope sees it,
+        // and discloses that cut through `degradations` instead. Accepting only
+        // the first reading would make this assertion fail on exactly the tool
+        // that bounds itself best.
+        let envelope_cut = bounded["_kin"]["response"]["bounded"] == serde_json::json!(true);
+        let handler_cut = bounded["degradations"].as_array().is_some_and(|cuts| {
+            cuts.iter()
+                .any(|cut| cut["component"] == serde_json::json!("response_budget"))
+        });
+        assert!(
+            envelope_cut || handler_cut,
+            "{tool}: a response that was cut has to say so: {bounded}"
+        );
+        assert!(
+            !envelope_cut || chars_before > RESPONSE_DEFAULT_MAX_CHARS,
+            "{tool}: the envelope stage cuts only what was over its budget, and reports the size \
+             it was over by: {chars_before} chars"
+        );
+        eprintln!("FIR-2396 {tool}: {before} chars unbounded, {after} chars bounded");
+        (before, after, bounded)
+    }
+
+    fn wide_store(callers: usize) -> (InMemoryGraph, EntityId) {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("resolve_redirects", "src/sessions.rs");
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+        for index in 0..callers {
+            let mut caller = make_entity(
+                &format!("caller_number_{index}_with_a_realistic_symbol_name"),
+                &format!("src/module_{index}/handler.rs"),
+            );
+            caller.doc_summary = Some(
+                "Resolves the redirect chain for one request and replays the body when the \
+                 method survives the hop."
+                    .to_string(),
+            );
+            store.upsert_entity(&caller).unwrap();
+            store
+                .upsert_relation(&make_relation(caller.id, focal_id, RelationKind::Calls))
+                .unwrap();
+        }
+        (store, focal_id)
+    }
+
+    #[test]
+    fn semantic_search_response_fits_the_budget() {
+        let (store, _) = wide_store(400);
+        let args = |compact: bool| -> HashMap<String, serde_json::Value> {
+            HashMap::from([
+                ("query".to_string(), serde_json::json!("caller")),
+                ("limit".to_string(), serde_json::json!(200)),
+                ("compact".to_string(), serde_json::json!(compact)),
+            ])
+        };
+        let before = client_text(
+            handle_semantic_search(&args(false), &store).unwrap(),
+            "semantic_search",
+            &unbounded(),
+        );
+        let after = client_text(
+            handle_semantic_search(&args(true), &store).unwrap(),
+            "semantic_search",
+            &ResponseBudget::default(),
+        );
+        assert_bounded("semantic_search", before, after);
+    }
+
+    #[tokio::test]
+    async fn find_references_response_fits_the_budget() {
+        let (store, focal_id) = wide_store(400);
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        )]);
+        let before = client_text(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            "find_references",
+            &unbounded(),
+        );
+        let after = client_text(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            "find_references",
+            &ResponseBudget::default(),
+        );
+        let (_, _, bounded) = assert_bounded("find_references", before, after);
+        // The full count is still reported, so a caller reading a shortened list
+        // can tell it from a complete one without comparing runs.
+        assert_eq!(bounded["total_upstream"], serde_json::json!(400));
+    }
+
+    #[test]
+    fn graph_neighborhood_response_fits_the_budget() {
+        let (store, focal_id) = wide_store(400);
+        let args = HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(focal_id.to_string()),
+            ),
+            ("limit".to_string(), serde_json::json!(400)),
+            ("depth".to_string(), serde_json::json!(2)),
+        ]);
+        let before = client_text(
+            handle_graph_neighborhood(&args, &store).unwrap(),
+            "graph_neighborhood",
+            &unbounded(),
+        );
+        let after = client_text(
+            handle_graph_neighborhood(&args, &store).unwrap(),
+            "graph_neighborhood",
+            &ResponseBudget::default(),
+        );
+        assert_bounded("graph_neighborhood", before, after);
+    }
+
+    #[test]
+    fn trace_data_flow_response_fits_the_budget() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("Session_request", "src/sessions.rs");
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+        let mut previous = vec![focal_id];
+        for depth in 0..4 {
+            let mut next = Vec::new();
+            for (parent_index, parent) in previous.iter().enumerate() {
+                for index in 0..5 {
+                    let callee = make_entity(
+                        &format!("step_{depth}_{parent_index}_{index}_resolve_redirect_target"),
+                        &format!("src/adapters/level_{depth}/module_{index}.rs"),
+                    );
+                    store.upsert_entity(&callee).unwrap();
+                    store
+                        .upsert_relation(&make_relation(*parent, callee.id, RelationKind::Calls))
+                        .unwrap();
+                    next.push(callee.id);
+                }
+            }
+            previous = next;
+        }
+        let args = HashMap::from([
+            ("focal".to_string(), serde_json::json!(focal_id.to_string())),
+            ("direction".to_string(), serde_json::json!("calls")),
+            ("depth".to_string(), serde_json::json!(4)),
+            ("limit_per_step".to_string(), serde_json::json!(15)),
+            ("include_body".to_string(), serde_json::json!(false)),
+        ]);
+        let mut wide = args.clone();
+        wide.insert(
+            "max_response_chars".to_string(),
+            serde_json::json!(RESPONSE_MAX_MAX_CHARS),
+        );
+        let before = client_text(
+            handle_trace_data_flow(&wide, &store).unwrap(),
+            "trace_data_flow",
+            &unbounded(),
+        );
+        let after = client_text(
+            handle_trace_data_flow(&args, &store).unwrap(),
+            "trace_data_flow",
+            &ResponseBudget::default(),
+        );
+        let (_, _, bounded) = assert_bounded("trace_data_flow", before, after);
+        // This tool bounds itself inside its own walk, so the number it enforces
+        // has to BE the shared default rather than merely sit under it. A
+        // per-tool budget of its own is what let a 79,278-character response
+        // report success while the client refused it.
+        assert_eq!(
+            bounded["max_response_chars"],
+            serde_json::json!(RESPONSE_DEFAULT_MAX_CHARS),
+            "trace_data_flow answers under the one shared default, not a budget of its own"
+        );
+    }
+
+    #[test]
+    fn get_context_pack_response_fits_the_budget() {
+        let (store, focal_id) = wide_store(0);
+        for index in 0..300 {
+            let dep = make_entity(
+                &format!("dependency_{index}_rebuild_auth_and_replay_body"),
+                &format!("src/deps/module_{index}/inner.rs"),
+            );
+            store.upsert_entity(&dep).unwrap();
+            store
+                .upsert_relation(&make_relation(focal_id, dep.id, RelationKind::Calls))
+                .unwrap();
+        }
+        let sessions = SessionRegistry::new();
+        let args = HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(focal_id.to_string()),
+            ),
+            ("token_budget".to_string(), serde_json::json!(2_000_000u64)),
+            ("depth".to_string(), serde_json::json!(2)),
+        ]);
+        let before = client_text(
+            handle_get_context_pack(&args, &store, &sessions, None).unwrap(),
+            "get_context_pack",
+            &unbounded(),
+        );
+        let after = client_text(
+            handle_get_context_pack(&args, &store, &sessions, None).unwrap(),
+            "get_context_pack",
+            &ResponseBudget::default(),
+        );
+        assert_bounded("get_context_pack", before, after);
+    }
+
+    #[test]
+    fn bulk_check_references_response_fits_the_budget() {
+        let (store, focal_id) = wide_store(200);
+        let ids: Vec<serde_json::Value> = store
+            .list_all_entities()
+            .unwrap()
+            .iter()
+            .take(200)
+            .map(|entity| serde_json::json!(entity.id.to_string()))
+            .collect();
+        let _ = focal_id;
+        let args = |compact: bool| -> HashMap<String, serde_json::Value> {
+            HashMap::from([
+                ("entity_ids".to_string(), serde_json::json!(ids)),
+                ("compact".to_string(), serde_json::json!(compact)),
+            ])
+        };
+        let before = client_text(
+            handle_bulk_check_references(&args(false), &store).unwrap(),
+            "bulk_check_references",
+            &unbounded(),
+        );
+        let after = client_text(
+            handle_bulk_check_references(&args(true), &store).unwrap(),
+            "bulk_check_references",
+            &ResponseBudget::default(),
+        );
+        assert_bounded("bulk_check_references", before, after);
+    }
+
+    /// The envelope and the confidence-qualified negative are what a caller
+    /// reads to know how far a shortened answer can be trusted, so they are the
+    /// two things the budget may never take.
+    #[test]
+    fn the_budget_never_cuts_the_envelope_or_the_negative() {
+        let (store, _) = wide_store(400);
+        let args = HashMap::from([
+            ("query".to_string(), serde_json::json!("caller")),
+            ("limit".to_string(), serde_json::json!(200)),
+        ]);
+        let text = client_text(
+            handle_semantic_search(&args, &store).unwrap(),
+            "semantic_search",
+            &ResponseBudget::default(),
+        );
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(value["_kin"]["envelope_version"], serde_json::json!(1));
+        assert_eq!(
+            value["_kin"]["degraded"]["offline_fallback"],
+            serde_json::json!(true)
+        );
     }
 }

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+pub mod budget;
 pub mod daemon_delegate;
 pub mod edge_coverage;
 pub mod envelope;
@@ -13,11 +14,14 @@ pub mod startup_binding;
 pub mod tools;
 pub mod types;
 
+pub use budget::{
+    is_budgeted as is_budgeted_tool, BudgetAccounting, ResponseBudget, RESPONSE_DEFAULT_MAX_CHARS,
+};
 pub use daemon_delegate::note_startup_repository;
 pub use edge_coverage::EDGE_COVERAGE_KEY;
 pub use envelope::{
-    annotate as annotate_with_envelope, finalize as finalize_with_envelope, Envelope, ENVELOPE_KEY,
-    ENVELOPE_VERSION,
+    annotate as annotate_with_envelope, finalize as finalize_with_envelope,
+    finalize_bounded as finalize_with_envelope_bounded, Envelope, ENVELOPE_KEY, ENVELOPE_VERSION,
 };
 pub use error::{McpError, Result};
 pub use handlers::LocalRepositoryAuthorityBinding;

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
+use crate::budget::ResponseBudget;
 use crate::daemon_delegate;
 use crate::envelope::{self, Envelope};
 use crate::error::{McpError, Result};
@@ -1049,6 +1050,7 @@ async fn handle_tools_call<G: PersistableMcpStore>(
             return JsonRpcResponse::error(id, -32602, format!("Invalid params: {}", e));
         }
     };
+    let budget = ResponseBudget::from_arguments(&call_params.arguments);
 
     if let Some(allowed) = &config.allowed_tools {
         if !allowed.contains(&call_params.name) {
@@ -1056,7 +1058,7 @@ async fn handle_tools_call<G: PersistableMcpStore>(
                 "tool '{}' is not enabled in this MCP profile",
                 call_params.name
             ));
-            return offline_envelope_success(id, error_result, &call_params.name);
+            return offline_envelope_success(id, error_result, &call_params.name, &budget);
         }
     }
 
@@ -1105,14 +1107,17 @@ async fn handle_tools_call<G: PersistableMcpStore>(
                     let error_result = ToolCallResult::error(format!(
                         "tool succeeded but snapshot persistence failed: {error}"
                     ));
-                    return offline_envelope_success(id, error_result, &call_params.name);
+                    return offline_envelope_success(id, error_result, &call_params.name, &budget);
                 }
             }
-            offline_envelope_success(id, result, &call_params.name)
+            offline_envelope_success(id, result, &call_params.name, &budget)
         }
-        Err(e) => {
-            offline_envelope_success(id, ToolCallResult::error(e.to_string()), &call_params.name)
-        }
+        Err(e) => offline_envelope_success(
+            id,
+            ToolCallResult::error(e.to_string()),
+            &call_params.name,
+            &budget,
+        ),
     }
 }
 
@@ -1125,8 +1130,9 @@ fn offline_envelope_success(
     id: Option<serde_json::Value>,
     result: ToolCallResult,
     tool_name: &str,
+    budget: &ResponseBudget,
 ) -> JsonRpcResponse {
-    let enveloped = envelope::finalize(result, Envelope::offline(), tool_name);
+    let enveloped = envelope::finalize_bounded(result, Envelope::offline(), tool_name, budget);
     JsonRpcResponse::success(id, serde_json::to_value(&enveloped).unwrap_or_default())
 }
 
@@ -1141,6 +1147,7 @@ async fn handle_tools_call_daemon(
             return JsonRpcResponse::error(id, -32602, format!("Invalid params: {}", e));
         }
     };
+    let budget = ResponseBudget::from_arguments(&call_params.arguments);
 
     if let Some(allowed) = &config.allowed_tools {
         if !allowed.contains(&call_params.name) {
@@ -1148,7 +1155,12 @@ async fn handle_tools_call_daemon(
                 "tool '{}' is not enabled in this MCP profile",
                 call_params.name
             ));
-            let enveloped = envelope::finalize(error_result, Envelope::daemon(), &call_params.name);
+            let enveloped = envelope::finalize_bounded(
+                error_result,
+                Envelope::daemon(),
+                &call_params.name,
+                &budget,
+            );
             return JsonRpcResponse::success(
                 id,
                 serde_json::to_value(&enveloped).unwrap_or_default(),
@@ -1185,7 +1197,7 @@ async fn handle_tools_call_daemon(
         }
     }
 
-    let enveloped = envelope::finalize(result, base_env, &call_params.name);
+    let enveloped = envelope::finalize_bounded(result, base_env, &call_params.name, &budget);
     JsonRpcResponse::success(id, serde_json::to_value(&enveloped).unwrap_or_default())
 }
 

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -197,6 +197,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
                         "query": { "type": "string", "description": "Name pattern to search for" },
                         "kind": { "type": "string", "description": "Entity kind filter (function, class, etc.)" },
                         "language": { "type": "string", "description": "Language filter (rust, typescript, etc.)" },
@@ -213,6 +214,8 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "query": { "type": "string", "description": "Natural-language description of the code to find. Optional when paging with `cursor`." },
                         "queries": {
                             "type": "array",
@@ -325,6 +328,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
                         "entity_id": { "type": "string", "description": "Focal entity UUID" },
                         "token_budget": { "type": "integer", "description": "Token budget (8000, 16000, or 32000)", "default": 16000 },
                         "depth": { "type": "integer", "description": "Dependency traversal depth", "default": 2 },
@@ -341,6 +345,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
                         "entity_id": { "type": "string", "description": "Focal entity UUID. Required if `query` is not given." },
                         "query": { "type": "string", "description": "Exact entity name to resolve to a focal entity. Required if `entity_id` is not given." },
                         "depth": { "type": "integer", "description": "Dependency traversal depth across the trace neighborhood", "default": 3 },
@@ -377,8 +382,15 @@ fn registered_tools() -> ToolsListResult {
                         },
                         "max_response_chars": {
                             "type": "integer",
-                            "description": "Serialized characters this response may occupy (default 80000). The tool enforces it itself, dropping bodies before edges and reporting the cut in degradations, so a result is never refused for size.",
-                            "default": 80000,
+                            "description": "Serialized characters this response may occupy (default 30000, the same default every retrieval tool answers under). The tool enforces it itself, dropping bodies before edges and reporting the cut in degradations, so a result is never refused for size. `max_chars` is the same parameter under the name the other retrieval tools use.",
+                            "default": 30000,
+                            "minimum": 2000,
+                            "maximum": 400000
+                        },
+                        "max_chars": {
+                            "type": "integer",
+                            "description": "Alias for max_response_chars, the spelling shared with the other retrieval tools.",
+                            "default": 30000,
                             "minimum": 2000,
                             "maximum": 400000
                         }
@@ -393,6 +405,8 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "entity_id": { "type": "string", "description": "Exact entity UUID. Optional if query is provided." },
                         "query": { "type": "string", "description": "Exact symbol name to resolve. Optional if entity_id is provided." },
                         "relation_kinds": {
@@ -410,6 +424,7 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
                         "entity_ids": {
                             "type": "array",
                             "description": "Entity UUIDs to classify. Minimum 1, maximum 200.",
@@ -439,6 +454,8 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to analyze impact for" },
@@ -520,6 +537,8 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "query": {
                             "type": "string",
                             "description": "Search query — concept or partial name to seed candidates"
@@ -554,6 +573,8 @@ fn registered_tools() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
+                        "max_chars": { "type": "integer", "description": "Serialized characters this response may occupy (default 30000, clamped 2000..400000). The tool enforces it itself: it sheds ranking explanation, then duplicated hit shapes, then inline source, and only then withholds hits, so a result is never refused for being too large. Any cut is reported in `degradations` and in `_kin.response`, which also carries the size the response had before the budget. Raise it only if your client accepts a larger tool result.", "default": 30000, "minimum": 2000, "maximum": 400000 },
+                        "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "entity_id": { "type": "string", "description": "Entity UUID" },
                         "depth": { "type": "integer", "description": "Traversal depth", "default": 2 },
                         "limit": { "type": "integer", "description": "Max entities to return (default 30)", "default": 30 },


### PR DESCRIPTION
Kin's own answers were arriving as files the agent had to read. On the v0.5.38 release-candidate bytes, a `semantic_locate` with three query variants at `limit: 10` came back at 80,571 characters and a `trace_data_flow` at depth 4 with `include_body: false` came back at 79,278. Claude Code refused both, spilled them to temp files, and told the model to `Read` them with an offset. That is the file-read fallback this product exists to remove, plus a round trip, on the two most common retrieval calls an agent makes.

kin#867 had already bounded `trace_data_flow`, at 80,000 characters. The measured 79,278 sat inside that budget and was refused anyway. That is the real defect. A per-tool budget the tool alone believes in reports success while the caller gets a file to read. `semantic_locate` had no character bound at all, only a row-count `limit`.

**One constant, for every retrieval tool.** `crates/kin-mcp/src/budget.rs` defines `RESPONSE_DEFAULT_MAX_CHARS = 30_000`, and the comment says why that number and which client it is sized against. Claude Code refuses a tool result above roughly 25,000 tokens. JSON-wrapped source runs near 3.5 characters per token, so the refusal threshold sits around 87,000 characters, which is exactly why two payloads at 80,571 and 79,278 both tripped it. 30,000 is about a third of that. The margin is deliberate rather than a guess about tokenization, because the client counts a result after its own framing, an agent holds several results in one window, and a budget chosen to just fit one client becomes the next overflow the moment another one counts slightly differently. `TRACE_DEFAULT_MAX_RESPONSE_CHARS` in `handlers/common.rs:426` is now an alias for it, so the two arms of `trace_data_flow` and every other retrieval tool cannot promise different bounds. `max_chars` overrides it per call, clamped to 2,000..400,000, and `max_response_chars` keeps working, because an agent that learned that spelling from `trace_data_flow` must not be handed an unbounded response for using it.

**The envelope now reports size.** `_kin.response` carries `max_chars`, `chars_before_budget`, `bounded`, and `compact`, so a caller can see that an answer was shortened and by how much without running an unbounded call it cannot make. The accounting stanza is written before the cut as well as after it, because a note added afterwards would push a response that had just been cut to fit back over its ceiling by its own length.

**Compact by default.** Ranking explanation and per-signal breakdowns are diagnostics about a hit rather than the hit, and serving them unasked is a large part of how a ten-result ranking became 80,571 characters. `compact` defaults on and sheds `match_evidence`, `explain`, `signal_scores`, and `score_breakdown`. Setting `explain: true` or `compact: false` gets them back. Under budget pressure the ladder then sheds the per-file symbol roll-up, which repeats hits `entities[]` already carries in full, then inline source, recoverable one body at a time through `get_entity_source`, and only after both of those does it withhold hits from the tail. The primary collection always keeps at least one entry, because an empty ranking cannot be told apart from "nothing matched", and that is the one reading a size cut must never produce. Every cut is disclosed in one `degradations` entry naming what went and the parameter that recovers it. `total_ranked` and `next_cursor` are left exactly as built, so the rest of a locate ranking stays reachable through the paging the tool already had.

**Both surfaces are bound, on one ladder.** `envelope::finalize_bounded` is the last point at which the bytes a client receives are known, and the bound holds there. The `_kin` envelope and the `negative` object are part of those bytes, so a handler that cut to exactly its ceiling would go back over it the moment the result was wrapped. The daemon's raw `/mcp/tools/call` route bounds too, on the same budget less a reserve for that wrapper. That route already lacked the envelope, and serving an unbounded payload there would have made it two gaps, with the same tool bounded or not depending on which door the caller came through. The budget never touches `_kin` or `negative`, which say how far a shortened answer can be trusted and matter most on exactly the answers that were shortened.

**One call is bounded once.** The reserve is this server's arithmetic about its own default, so a budget the caller names is enforced exactly, on every arm, and the daemon's trace walk now defaults to the number the route will hold rather than to its own. kin#867's `a_trace_over_its_budget_drops_bodies_and_keeps_every_edge` caught the first version of this change doing the opposite: a caller asking for 6,000 characters had the walk cut bodies at 6,000 and the route cut steps again at 4,000, so a chain that lost only bodies came back marked truncated. When the walk and the route hold different ceilings for one call, the response gets cut to a number it never names.

**Ranking is unchanged.** Every scorer, fusion step, and ordering rule is the same, and an unbounded request returns the same result set it returned before. `max_chars: 400000` returns the same hits in the same order. What changed is the shape and the size of what gets serialized.

**Measured, before and after, on fixtures that overflow.** Each number is the final annotated text a client would count, printed by the test that asserts it:

| tool | unbounded | bounded |
|---|---|---|
| `semantic_locate` (three variants, limit 10, through the real fused serializer) | 117,183 | 12,446 |
| `graph_neighborhood` | 238,077 | 29,069 |
| `get_context_pack` | 215,465 | 28,504 |
| `find_references` | 180,034 | 28,572 |
| `trace_data_flow` (depth 4, include_body false) | 131,665 | 28,877 |
| `bulk_check_references` | 102,106 | 28,723 |
| `semantic_search` | 90,406 | 28,863 |

**Falsification.** Disabling the `enforce` call in `envelope::apply_response_budget` fails five of the six kin-mcp tests, one of them with `find_references: the response a client receives must fit its budget: 180032 chars against 30000`. The sixth, `trace_data_flow`, survives that edit because it bounds itself inside its own walk, so it also asserts the number it enforces IS the shared default. Restoring `TRACE_DEFAULT_MAX_RESPONSE_CHARS` to 80,000 fails it with `left: Number(80000), right: Number(30000)`. Disabling the `enforce` call in the daemon's `bound_mcp_tool_result` fails `the_raw_route_bounds_a_tool_the_stdio_path_would_have_bounded` at `245776 chars against 28000` and the locate test at `117183 chars against 28000`. Disabling the compact stage fails `compact_sheds_breakdowns_without_touching_the_hits` on a surviving `match_evidence`, and fails the locate test on the same key. `the_raw_route_leaves_an_unbudgeted_tool_byte_identical` stays green under every one of those edits. The budget is scoped, and a tool whose job is handing back requested source stays untouched.

Closes FIR-2396
