### PR TITLE
Keep a server-bound MCP repository when the client's workspace roots cannot be resolved

### DIFF
--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -103,7 +103,7 @@ pub async fn start(
     // the shared handle at each invocation.
     let binder_startup = std::sync::Arc::clone(&startup);
     let repo_binder: Option<kin_mcp::RepoBinder> = Some(Box::new(
-        move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<kin_mcp::BoundRepo>> + Send>> {
+        move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = kin_mcp::WorkspaceBinding> + Send>> {
             let startup = std::sync::Arc::clone(&binder_startup);
             Box::pin(async move {
                 bind_first_kin_repo(roots, startup.pinned_by_operator()).await
@@ -519,18 +519,25 @@ async fn bind_from_registry(startup: &kin_mcp::StartupDaemonBinding) -> Option<k
 /// binding answers every later tool call from a repository the user has left.
 /// When the roots still contain the bound repository this is a no-op that keeps
 /// the running daemon; when they name a different one it repoints the process at
-/// it; when nothing there can be bound it returns `None`, which the stdio server
-/// turns into an explicit refusal.
+/// it; when the repositories they name cannot be served it reports
+/// `OtherRepository`, which the stdio server turns into an explicit refusal.
+///
+/// Roots that resolve to no Kin repository at all are reported as
+/// `Unresolvable`, which is a different fact and gets different treatment. This
+/// process may be reached through `docker exec` or over a remote boundary, where
+/// the client's roots are host paths that do not exist in this namespace: they
+/// are not evidence that the client left the repository this server serves, and
+/// a server that has one of its own keeps it.
 ///
 /// `pinned_by_operator` marks a binding that came from an explicit
 /// `--repo`/`KIN_MCP_REPO`. That pin is never repointed by the client — it is a
 /// deliberate choice about which repository this server serves — so a workspace
-/// that names a different repository returns `None` and fails loud instead of
-/// following the client or, worse, answering from the pinned repository anyway.
+/// that names a different repository fails loud instead of following the client
+/// or, worse, answering from the pinned repository anyway.
 async fn bind_first_kin_repo(
     roots: Vec<PathBuf>,
     pinned_by_operator: bool,
-) -> Option<kin_mcp::BoundRepo> {
+) -> kin_mcp::WorkspaceBinding {
     bind_first_kin_repo_against(roots, bound_repo_working_dir(), pinned_by_operator).await
 }
 
@@ -542,16 +549,26 @@ async fn bind_first_kin_repo_against(
     roots: Vec<PathBuf>,
     bound_repo: Option<PathBuf>,
     pinned_by_operator: bool,
-) -> Option<kin_mcp::BoundRepo> {
-    // Force the real upward walk. `KinLayout::discover` short-circuits to
-    // `<start>/.kin` whenever `KIN_DAEMON_URL` is set, so once a repository is
-    // bound it would accept any directory — including one with no `.kin/` at
-    // all — as the client's new repository.
+) -> kin_mcp::WorkspaceBinding {
+    // `KinLayout::discover` is filesystem-rooted: it walks up from each root and
+    // finds a `.kin/` or nothing, regardless of which daemon this process is
+    // pinned to. A root that resolves to no layout is a root this server cannot
+    // see, which is the distinction the two failure verdicts below rest on.
     let candidates: Vec<PathBuf> = roots
         .iter()
         .filter_map(|root| kin_core::KinLayout::discover(root))
         .map(|layout| canonical_path(layout.working_dir()))
         .collect();
+
+    if candidates.is_empty() {
+        // Nothing the client named resolves to a Kin repository this process can
+        // see. That is what a host path looks like from inside a container, and
+        // what a remote registration looks like from the server side, so it says
+        // nothing about which repository this server should serve. The stdio
+        // server decides whether its current binding has authority of its own.
+        return kin_mcp::WorkspaceBinding::Unresolvable;
+    }
+
     let bound_repo_still_open = bound_repo.as_deref().is_some_and(|bound| {
         candidates
             .iter()
@@ -562,9 +579,15 @@ async fn bind_first_kin_repo_against(
         // The client still has the bound repository open — anywhere in its
         // workspace, not merely first. Keep the running daemon rather than
         // churning it because another folder happens to sort ahead of it.
-        return bound_repo
-            .zip(current_daemon_url())
-            .map(|(root, daemon_url)| kin_mcp::BoundRepo { root, daemon_url });
+        return match bound_repo.zip(current_daemon_url()) {
+            Some((root, daemon_url)) => {
+                kin_mcp::WorkspaceBinding::Bound(kin_mcp::BoundRepo { root, daemon_url })
+            }
+            // The bound repository is derived from the pinned daemon URL, so
+            // losing the URL here means this process serves nothing the client
+            // named after all.
+            None => kin_mcp::WorkspaceBinding::OtherRepository(candidates),
+        };
     }
 
     if pinned_by_operator {
@@ -576,7 +599,7 @@ async fn bind_first_kin_repo_against(
             "Kin MCP: the repository pinned by --repo/KIN_MCP_REPO is not among the client's \
              workspace roots; refusing tool calls until the workspace and the pin agree."
         );
-        return None;
+        return kin_mcp::WorkspaceBinding::OtherRepository(candidates);
     }
 
     if bound_repo.is_some() {
@@ -588,8 +611,8 @@ async fn bind_first_kin_repo_against(
         std::env::remove_var("KIN_DAEMON_URL");
     }
 
-    for working_dir in candidates {
-        let Ok(url) = bind_daemon_for_repo_dir(&working_dir).await else {
+    for working_dir in candidates.iter() {
+        let Ok(url) = bind_daemon_for_repo_dir(working_dir).await else {
             continue;
         };
         // Point the process at the bound repo so the daemon delegate resolves
@@ -597,7 +620,7 @@ async fn bind_first_kin_repo_against(
         // exactly as the --repo startup path does (it set_current_dir's first).
         // Without this, tool-call forwarding sends no bearer token and the
         // daemon replies 401 even though the repo bound correctly.
-        if let Err(err) = std::env::set_current_dir(&working_dir) {
+        if let Err(err) = std::env::set_current_dir(working_dir) {
             eprintln!(
                 "Kin MCP: bound {url} but could not switch cwd to {} ({err}); \
                  tool auth will fall back to KIN_DAEMON_AUTH_TOKEN if set.",
@@ -609,12 +632,16 @@ async fn bind_first_kin_repo_against(
             "Kin MCP: bound repo daemon at {url} from workspace root {}",
             working_dir.display()
         );
-        return Some(kin_mcp::BoundRepo {
-            root: working_dir,
+        return kin_mcp::WorkspaceBinding::Bound(kin_mcp::BoundRepo {
+            root: working_dir.clone(),
             daemon_url: url,
         });
     }
-    None
+    // The client named Kin repositories this process can see and none of their
+    // daemons could be resolved. That is still a repository disagreement rather
+    // than an invisible namespace, so the server refuses instead of serving the
+    // repository the client left.
+    kin_mcp::WorkspaceBinding::OtherRepository(candidates)
 }
 
 /// The repository this process is bound to, or `None` when it is not bound.
@@ -990,6 +1017,13 @@ mod tests {
         tmp
     }
 
+    fn expect_bound(binding: kin_mcp::WorkspaceBinding, context: &str) -> kin_mcp::BoundRepo {
+        match binding {
+            kin_mcp::WorkspaceBinding::Bound(bound) => bound,
+            other => panic!("{context}, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     #[serial]
     async fn roots_naming_the_bound_repo_keep_the_running_daemon() {
@@ -999,13 +1033,15 @@ mod tests {
         let repo = kin_repo_fixture();
         let repo_dir = std::fs::canonicalize(repo.path()).unwrap();
 
-        let bound = bind_first_kin_repo_against(
-            vec![repo.path().to_path_buf()],
-            Some(repo_dir.clone()),
-            false,
-        )
-        .await
-        .expect("the bound repository still being open must stay bound");
+        let bound = expect_bound(
+            bind_first_kin_repo_against(
+                vec![repo.path().to_path_buf()],
+                Some(repo_dir.clone()),
+                false,
+            )
+            .await,
+            "the bound repository still being open must stay bound",
+        );
 
         assert_eq!(bound.root, repo_dir);
         assert_eq!(bound.daemon_url, "http://127.0.0.1:4242");
@@ -1037,8 +1073,9 @@ mod tests {
         .await;
 
         assert!(
-            bound.is_none(),
-            "an unresolvable new repository must not report a successful bind"
+            matches!(bound, kin_mcp::WorkspaceBinding::OtherRepository(_)),
+            "a real repository whose daemon will not resolve is another repository, \
+             not an unseeable root: {bound:?}"
         );
         assert_eq!(
             std::env::var("KIN_DAEMON_URL").ok().as_deref(),
@@ -1058,13 +1095,15 @@ mod tests {
         let bound = kin_repo_fixture();
         let bound_dir = std::fs::canonicalize(bound.path()).unwrap();
 
-        let result = bind_first_kin_repo_against(
-            vec![other.path().to_path_buf(), bound.path().to_path_buf()],
-            Some(bound_dir.clone()),
-            false,
-        )
-        .await
-        .expect("the bound repository being open anywhere must keep the binding");
+        let result = expect_bound(
+            bind_first_kin_repo_against(
+                vec![other.path().to_path_buf(), bound.path().to_path_buf()],
+                Some(bound_dir.clone()),
+                false,
+            )
+            .await,
+            "the bound repository being open anywhere must keep the binding",
+        );
 
         assert_eq!(result.root, bound_dir);
         assert_eq!(result.daemon_url, "http://127.0.0.1:4242");
@@ -1090,8 +1129,9 @@ mod tests {
         .await;
 
         assert!(
-            bound.is_none(),
-            "a pinned server must report failure for a workspace it does not serve"
+            matches!(bound, kin_mcp::WorkspaceBinding::OtherRepository(_)),
+            "a pinned server must report the workspace it does not serve as another \
+             repository: {bound:?}"
         );
         assert_eq!(
             std::env::var("KIN_DAEMON_URL").ok().as_deref(),
@@ -1107,13 +1147,15 @@ mod tests {
         let pinned = kin_repo_fixture();
         let pinned_dir = std::fs::canonicalize(pinned.path()).unwrap();
 
-        let bound = bind_first_kin_repo_against(
-            vec![pinned.path().to_path_buf()],
-            Some(pinned_dir.clone()),
-            true,
-        )
-        .await
-        .expect("roots naming the pinned repository must stay bound");
+        let bound = expect_bound(
+            bind_first_kin_repo_against(
+                vec![pinned.path().to_path_buf()],
+                Some(pinned_dir.clone()),
+                true,
+            )
+            .await,
+            "roots naming the pinned repository must stay bound",
+        );
 
         assert_eq!(bound.root, pinned_dir);
         assert_eq!(bound.daemon_url, "http://127.0.0.1:4242");
@@ -1126,10 +1168,52 @@ mod tests {
         // No autostart: this test must never spawn a daemon process.
         let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
         let plain = tempfile::tempdir().unwrap();
+        assert_eq!(
+            bind_first_kin_repo_against(vec![plain.path().to_path_buf()], None, false).await,
+            kin_mcp::WorkspaceBinding::Unresolvable,
+        );
+    }
+
+    /// FIR-2405. A server registered as `docker exec -i -w /work/express ... kin
+    /// mcp start` serves a container path while the client announces a host path
+    /// that never exists in this namespace. Reporting that as a repository
+    /// switch is what made every call after the first refuse: the root can never
+    /// become bindable, so the refusal was permanent for the life of a process
+    /// the client owns.
+    #[tokio::test]
+    #[serial]
+    async fn a_root_this_server_cannot_see_is_unresolvable_not_another_repository() {
+        let _daemon_guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        // No autostart: this test must never spawn a daemon process.
+        let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
+        let served = kin_repo_fixture();
+        let served_dir = std::fs::canonicalize(served.path()).unwrap();
+        // A path that exists on no filesystem this process can reach, standing
+        // in for the client's host path.
+        let host_namespace = tempfile::tempdir().unwrap();
+        let host_only = host_namespace.path().join("private/tmp/brown/work");
         assert!(
-            bind_first_kin_repo_against(vec![plain.path().to_path_buf()], None, false)
-                .await
-                .is_none()
+            !host_only.exists(),
+            "the stand-in host path must really be absent"
+        );
+
+        assert_eq!(
+            bind_first_kin_repo_against(vec![host_only], Some(served_dir.clone()), false).await,
+            kin_mcp::WorkspaceBinding::Unresolvable,
+            "a root that resolves to no Kin repository here must not be reported as a switch"
+        );
+
+        // Falsification: the same call with a root this server CAN see, holding
+        // a repository it does not serve, reports the switch it really is. The
+        // verdict tracks what the filesystem says rather than always answering
+        // `Unresolvable`.
+        let other = kin_repo_fixture();
+        let moved =
+            bind_first_kin_repo_against(vec![other.path().to_path_buf()], Some(served_dir), false)
+                .await;
+        assert!(
+            matches!(moved, kin_mcp::WorkspaceBinding::OtherRepository(_)),
+            "a visible second repository must be reported as another repository: {moved:?}"
         );
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1726,6 +1726,20 @@ enum StashAction {
 #[derive(Subcommand)]
 enum McpAction {
     /// Start the MCP stdio server
+    ///
+    /// The server binds one Kin repository: the one named by --repo or
+    /// KIN_MCP_REPO, otherwise the one containing its working directory,
+    /// otherwise whatever the MCP client's workspace roots point at.
+    ///
+    /// A server that bound a repository of its own keeps serving it and ignores
+    /// client workspace roots it cannot resolve to a Kin repository. That is
+    /// what makes a container or remote registration work: with
+    /// `docker exec -i -w /work/repo <container> kin mcp start`, the client
+    /// announces host paths that do not exist inside the container, and treating
+    /// them as a workspace change would refuse every call. Roots that do name a
+    /// Kin repository this server can see, and does not serve, are still a real
+    /// disagreement and are refused rather than answered from the wrong
+    /// repository.
     Start {
         /// Run in global mode, serving all registered repos from ~/.kin/registry.toml
         #[arg(long)]
@@ -1733,7 +1747,8 @@ enum McpAction {
         /// Bind this server to a specific Kin repository instead of relying on
         /// the launching process's working directory. Overrides KIN_MCP_REPO.
         /// Use this for a global agent-CLI MCP entry that may launch outside
-        /// any Kin repository (e.g. an umbrella workspace root).
+        /// any Kin repository (e.g. an umbrella workspace root). The pin is
+        /// never repointed by the client's workspace roots.
         #[arg(long, value_name = "PATH")]
         repo: Option<PathBuf>,
         /// Tool surface to serve: `agent-default` (the curated agent belt, and
@@ -4483,6 +4498,50 @@ mod tests {
                      an open gate"
                 );
             }
+        });
+    }
+
+    /// A server reached through `docker exec` or over a remote boundary can
+    /// never bind the host paths its client announces, so it holds the
+    /// repository it was started with instead. An operator registering that
+    /// shape has to be able to learn it from the command itself rather than from
+    /// a refusal mid-session, which is why the behavior is documented where the
+    /// registration is written.
+    #[test]
+    fn mcp_start_help_documents_that_a_bound_server_holds_unresolvable_client_roots() {
+        on_cli_test_stack(|| {
+            let command = Cli::command();
+            let start = command
+                .get_subcommands()
+                .find(|subcommand| subcommand.get_name() == "mcp")
+                .expect("kin mcp must exist")
+                .get_subcommands()
+                .find(|subcommand| subcommand.get_name() == "start")
+                .expect("kin mcp start must exist")
+                .clone();
+            let help = start
+                .get_long_about()
+                .or_else(|| start.get_about())
+                .expect("kin mcp start must carry help text")
+                .to_string();
+            let flattened = help.split_whitespace().collect::<Vec<_>>().join(" ");
+
+            assert!(
+                flattened.contains("ignores client workspace roots it cannot resolve"),
+                "help must state that a bound server ignores roots it cannot resolve: {flattened}"
+            );
+            assert!(
+                flattened.contains("docker exec"),
+                "help must name the container registration this supports: {flattened}"
+            );
+
+            // Falsification: a phrase that was never written must be absent, so
+            // a `contains` that passes on anything cannot be what made the two
+            // assertions above green.
+            assert!(
+                !flattened.contains("ignores client workspace roots entirely"),
+                "the check must be able to fail: {flattened}"
+            );
         });
     }
 

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -15,7 +15,7 @@
 //!   report, lifted from the tool payload when the daemon already included it,
 //! - graph freshness (`graph_as_of` plus honest `/health`-derived state),
 //! - degraded flags: daemon-unreachable, `embed_worker_failed` (#11),
-//!   `mass_deletion_blocked`, and offline-fallback.
+//!   `mass_deletion_blocked`, offline-fallback, and workspace-mismatch.
 //!
 //! Honesty contract (CLAUDE.md): the envelope NEVER fabricates coverage or
 //! freshness. Anything it cannot observe is `null`/absent, not a default `false`
@@ -131,6 +131,12 @@ pub struct Degraded {
     /// daemon-owned truth (graph-first: a fallback surface).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub offline_fallback: Option<bool>,
+    /// The MCP client's workspace roots name a repository this server does not
+    /// serve, so the call was refused rather than answered from the repository
+    /// the client left. The daemon is reachable; the disagreement is about which
+    /// repository the answer would be about.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_mismatch: Option<bool>,
 }
 
 impl Degraded {
@@ -141,6 +147,7 @@ impl Degraded {
             self.embed_worker_failed,
             self.mass_deletion_blocked,
             self.offline_fallback,
+            self.workspace_mismatch,
         ]
         .into_iter()
         .any(|flag| flag == Some(true))
@@ -162,6 +169,9 @@ impl Degraded {
         }
         if self.offline_fallback == Some(true) {
             labels.push("offline_fallback");
+        }
+        if self.workspace_mismatch == Some(true) {
+            labels.push("workspace_mismatch");
         }
         labels
     }
@@ -319,6 +329,28 @@ impl Envelope {
             graph_state: GraphState::default(),
             degraded: Degraded {
                 daemon_unreachable: Some(true),
+                ..Degraded::default()
+            },
+        }
+    }
+
+    /// Envelope for a call refused because the MCP client's workspace roots and
+    /// this server's repository binding disagree.
+    ///
+    /// Deliberately not [`Envelope::daemon_unreachable`]: the daemon this server
+    /// is bound to is reachable and healthy, and reporting a transport problem
+    /// sends the reader to check the daemon, restart it, or reinstall, none of
+    /// which touches the actual disagreement about which repository the answer
+    /// would be about.
+    pub fn workspace_mismatch() -> Self {
+        Self {
+            envelope_version: ENVELOPE_VERSION,
+            runtime: Runtime::RepoDaemon,
+            semantic_coverage: None,
+            graph_as_of: None,
+            graph_state: GraphState::default(),
+            degraded: Degraded {
+                workspace_mismatch: Some(true),
                 ..Degraded::default()
             },
         }
@@ -637,6 +669,29 @@ mod tests {
         assert_eq!(env.runtime, Runtime::RepoDaemon);
         assert_eq!(env.degraded.daemon_unreachable, Some(true));
         assert!(env.degraded.any());
+    }
+
+    /// A workspace disagreement is not a reachability failure, and the two must
+    /// not be spelled the same way: an agent that reads `daemon_unreachable`
+    /// goes and checks a daemon that is answering perfectly well.
+    #[test]
+    fn workspace_mismatch_envelope_is_not_a_reachability_failure() {
+        let env = Envelope::workspace_mismatch();
+        assert_eq!(env.runtime, Runtime::RepoDaemon);
+        assert_eq!(env.degraded.workspace_mismatch, Some(true));
+        assert!(env.degraded.daemon_unreachable.is_none());
+        assert!(env.degraded.any());
+        assert_eq!(env.degraded.active_labels(), vec!["workspace_mismatch"]);
+
+        // Falsification: the reachability envelope keeps its own flag and never
+        // claims a workspace mismatch, so the two verdicts stay distinguishable
+        // in both directions.
+        let unreachable = Envelope::daemon_unreachable();
+        assert!(unreachable.degraded.workspace_mismatch.is_none());
+        assert_eq!(
+            unreachable.degraded.active_labels(),
+            vec!["daemon_unreachable"]
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3535,6 +3535,7 @@ impl GraphStatusReport {
             || envelope.degraded.embed_worker_failed.is_some()
             || envelope.degraded.mass_deletion_blocked.is_some()
             || envelope.degraded.offline_fallback.is_some()
+            || envelope.degraded.workspace_mismatch.is_some()
         {
             return Err(
                 "_kin carries unscoped daemon health alongside selected-graph status".to_string(),

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -24,7 +24,7 @@ pub use handlers::LocalRepositoryAuthorityBinding;
 pub use negative::NEGATIVE_KEY;
 pub use server::{
     process_daemon_message, process_message, run_stdio, run_stdio_daemon, BoundRepo,
-    McpServerConfig, RepoBinder, SessionAuthorityMode,
+    McpServerConfig, RepoBinder, SessionAuthorityMode, WorkspaceBinding,
 };
 pub use session::{
     AssistantSession, CommitRefusal, CommitRefusalCode, CoordinationEnforcementMode,

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -149,24 +149,47 @@ pub struct BoundRepo {
     pub daemon_url: String,
 }
 
+/// What the binder made of the MCP client's advertised workspace roots.
+///
+/// The two failure shapes are kept apart because they call for opposite
+/// behavior. A root the server can see and identify as a Kin repository is
+/// evidence about which codebase the client is asking about; a root the server
+/// cannot resolve at all is evidence about nothing, because a containerised or
+/// remote server reaches its repository over a boundary the client does not
+/// share and the client's paths never exist in the server's namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceBinding {
+    /// The process is bound to this repository, either freshly or because the
+    /// roots still contain the repository it already served.
+    Bound(BoundRepo),
+    /// The roots name Kin repositories this server can see, and it is not
+    /// serving any of them: either an operator pin refuses to follow the
+    /// client, or the daemon for the repository the client moved to could not
+    /// be resolved. The client really is looking at another codebase.
+    OtherRepository(Vec<PathBuf>),
+    /// None of the roots names a Kin repository this server can see. The client
+    /// and the server describe the filesystem in different namespaces, so the
+    /// roots say nothing about which repository this server should serve.
+    Unresolvable,
+}
+
 /// Binds — or re-binds — the repo daemon from the MCP client's advertised
 /// workspace roots.
 ///
-/// Receives the filesystem paths of the client's roots, binds the daemon for the
-/// first one that is a Kin repository (setting `KIN_DAEMON_URL` as a side
-/// effect), and returns the bound repository — or `None` if none of the roots is
-/// a Kin repository whose daemon can be resolved. Supplied by the kin-cli MCP
-/// command; when `None`, roots binding is disabled (the client cannot serve
-/// roots).
+/// Receives the filesystem paths of the client's roots and binds the daemon for
+/// the first one that is a Kin repository (setting `KIN_DAEMON_URL` as a side
+/// effect), reporting what it found as a [`WorkspaceBinding`]. Supplied by the
+/// kin-cli MCP command; when the binder itself is `None`, roots binding is
+/// disabled (the client cannot serve roots).
 ///
 /// The binder is invoked for every `roots/list` response, not only the first:
 /// an editor that moves its window to another folder announces the change, and
 /// a server that keeps its original binding answers from a repository the user
-/// has left. A `None` return while a repository is already bound is therefore
-/// meaningful — it tells the server to refuse tool calls rather than serve them
-/// from the previous repository's graph.
+/// has left. A [`WorkspaceBinding::OtherRepository`] return while a repository
+/// is already bound is therefore meaningful — it tells the server to refuse tool
+/// calls rather than serve them from the previous repository's graph.
 pub type RepoBinder = Box<
-    dyn Fn(Vec<PathBuf>) -> Pin<Box<dyn Future<Output = Option<BoundRepo>> + Send>> + Send + Sync,
+    dyn Fn(Vec<PathBuf>) -> Pin<Box<dyn Future<Output = WorkspaceBinding> + Send>> + Send + Sync,
 >;
 
 /// The JSON-RPC id the server uses for its own `roots/list` request so it can
@@ -191,11 +214,20 @@ const ROOTS_REQUEST_ID: &str = "kin-mcp-roots-list";
 /// The client's workspace can move afterwards, so a `roots/list_changed`
 /// notification re-requests roots whether or not a repository is bound, and the
 /// binder decides: it re-binds the process to the repository the client is now
-/// looking at, or reports that it cannot, in which case every `tools/call` is
-/// refused with a structured repo-mismatch error until a later roots change
-/// resolves it. A bound server never keeps answering from a repository the
-/// client has left — a confident answer about the wrong codebase is worse than
-/// an error.
+/// looking at, or reports that the roots name a different Kin repository it will
+/// not follow, in which case every `tools/call` is refused with a structured
+/// repo-mismatch error until a later roots change resolves it. A bound server
+/// never keeps answering from a repository the client has left — a confident
+/// answer about the wrong codebase is worse than an error.
+///
+/// Roots this server cannot resolve at all are the other case, and it is not a
+/// workspace change. A server registered as `docker exec -w <repo> ... kin mcp
+/// start`, or reached over any other boundary, is bound to a repository by its
+/// own cwd or `--repo`/`KIN_MCP_REPO` while the client announces host paths that
+/// never exist in the server's namespace. Those roots are evidence about
+/// nothing, so a server holding its own binding keeps serving it and records the
+/// disagreement at info instead of refusing every call for the life of the
+/// process.
 pub async fn run_stdio_daemon(
     config: McpServerConfig,
     repo_binder: Option<RepoBinder>,
@@ -264,7 +296,7 @@ where
         if let Some(startup) = startup.as_ref() {
             if !binding.is_bound() {
                 if let StartupBindingState::Bound(bound) = startup.snapshot() {
-                    binding.bind(bound);
+                    binding.bind(bound, BindingOrigin::Server);
                 }
             }
         }
@@ -306,7 +338,7 @@ where
                     }
                     if !binding.is_bound() {
                         if let StartupBindingState::Bound(bound) = startup.snapshot() {
-                            binding.bind(bound);
+                            binding.bind(bound, BindingOrigin::Server);
                         }
                     }
                 }
@@ -414,7 +446,7 @@ async fn apply_workspace_roots(
 
     let previous_url = binding.daemon_url.clone();
     match binder(roots.clone()).await {
-        Some(bound) => {
+        WorkspaceBinding::Bound(bound) => {
             if previous_url.as_deref() != Some(bound.daemon_url.as_str()) {
                 // A different daemon serves this process now. Drop the revival
                 // override, which pins delegate calls at a daemon this process
@@ -426,9 +458,27 @@ async fn apply_workspace_roots(
                     "kin-mcp: bound repo daemon from the client's workspace roots"
                 );
             }
-            binding.bind(bound);
+            binding.bind(bound, BindingOrigin::ClientRoots);
         }
-        None if binding.is_bound() => {
+        WorkspaceBinding::OtherRepository(repos) if binding.is_bound() => {
+            tracing::warn!(
+                roots = ?roots,
+                repositories = ?repos,
+                "kin-mcp: the client's workspace roots name a different Kin repository this server \
+                 does not serve; refusing tool calls instead of answering from the bound repository"
+            );
+            binding.mark_mismatch(roots, repo_pinned);
+        }
+        // The client's roots resolve to nothing here. That is the shape of every
+        // containerised or remote registration: the client names host paths and
+        // the server lives in another namespace, so the roots carry no evidence
+        // that the client left the repository this server was pinned to. A
+        // server holding its own binding — its launch cwd, `--repo`, or
+        // `KIN_MCP_REPO` — keeps serving it. A server whose only authority was a
+        // previous roots answer has had that authority withdrawn, so it refuses.
+        WorkspaceBinding::Unresolvable
+            if binding.is_bound() && binding.origin == Some(BindingOrigin::ClientRoots) =>
+        {
             tracing::warn!(
                 roots = ?roots,
                 "kin-mcp: the client's workspace roots changed to a workspace with no bindable Kin \
@@ -436,7 +486,15 @@ async fn apply_workspace_roots(
             );
             binding.mark_mismatch(roots, repo_pinned);
         }
-        None => {
+        WorkspaceBinding::Unresolvable if binding.is_bound() => {
+            tracing::info!(
+                roots = ?roots,
+                repo = ?binding.repo_root,
+                "kin-mcp: none of the client's workspace roots names a Kin repository this server \
+                 can resolve; keeping the repository this server was started with"
+            );
+        }
+        WorkspaceBinding::OtherRepository(_) | WorkspaceBinding::Unresolvable => {
             tracing::info!("kin-mcp: no Kin repository among the client's workspace roots");
         }
     }
@@ -451,6 +509,21 @@ fn bound_daemon_url_from_env() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// Where a binding came from, which decides how much authority the client's
+/// workspace roots carry over it.
+///
+/// A binding this server made for itself — its launch cwd, `--repo`, or
+/// `KIN_MCP_REPO` — is an operator decision that survives roots it cannot
+/// resolve. A binding that came from a previous `roots/list` answer exists only
+/// because the client said so, so the client withdrawing it is decisive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BindingOrigin {
+    /// Bound before or beside the stdio loop from this server's own inputs.
+    Server,
+    /// Bound from a `roots/list` answer.
+    ClientRoots,
+}
+
 /// What the stdio loop knows about which repository it serves.
 #[derive(Debug, Default)]
 struct RepoBindingState {
@@ -459,6 +532,8 @@ struct RepoBindingState {
     /// Repository that daemon serves. Unknown for a binding inherited from
     /// startup, which arrives as a URL with no accompanying root.
     repo_root: Option<PathBuf>,
+    /// Where the current binding came from. `None` while nothing is bound.
+    origin: Option<BindingOrigin>,
     /// Set when the client's workspace moved somewhere this server could not
     /// follow. Cleared by the next successful bind.
     mismatch: Option<WorkspaceMismatch>,
@@ -478,6 +553,7 @@ struct WorkspaceMismatch {
 impl RepoBindingState {
     fn started_with(daemon_url: Option<String>) -> Self {
         Self {
+            origin: daemon_url.is_some().then_some(BindingOrigin::Server),
             daemon_url,
             ..Self::default()
         }
@@ -500,9 +576,10 @@ impl RepoBindingState {
         self.mismatch.is_some()
     }
 
-    fn bind(&mut self, bound: BoundRepo) {
+    fn bind(&mut self, bound: BoundRepo, origin: BindingOrigin) {
         self.daemon_url = Some(bound.daemon_url);
         self.repo_root = Some(bound.root);
+        self.origin = Some(origin);
         self.mismatch = None;
     }
 
@@ -538,7 +615,7 @@ impl RepoBindingState {
             .and_then(|name| name.as_str())
             .unwrap_or("this tool");
         let result = ToolCallResult::error(mismatch.message(tool));
-        let enveloped = envelope::finalize(result, Envelope::daemon_unreachable(), tool);
+        let enveloped = envelope::finalize(result, Envelope::workspace_mismatch(), tool);
         Some(JsonRpcResponse::success(
             Some(id),
             serde_json::to_value(&enveloped).unwrap_or_default(),
@@ -2013,7 +2090,10 @@ mod tests {
             "unbound wants a repository"
         );
 
-        binding.bind(bound_repo("/repo/a", "http://127.0.0.1:4111"));
+        binding.bind(
+            bound_repo("/repo/a", "http://127.0.0.1:4111"),
+            BindingOrigin::ClientRoots,
+        );
         assert!(
             !binding.wants_workspace_roots(),
             "a settled binding must not re-ask on every trigger"
@@ -2025,7 +2105,10 @@ mod tests {
             "bound to a repository the client left is no better than unbound"
         );
 
-        binding.bind(bound_repo("/repo/b", "http://127.0.0.1:4222"));
+        binding.bind(
+            bound_repo("/repo/b", "http://127.0.0.1:4222"),
+            BindingOrigin::ClientRoots,
+        );
         assert!(!binding.wants_workspace_roots());
         assert!(!binding.is_mismatched(), "binding again clears the refusal");
     }
@@ -2081,13 +2164,13 @@ mod tests {
     /// Records every roots list the server hands the binder and replies with a
     /// scripted outcome per call, so a test can drive a bind and then a switch.
     struct ScriptedBinder {
-        outcomes: std::sync::Mutex<std::collections::VecDeque<Option<BoundRepo>>>,
+        outcomes: std::sync::Mutex<std::collections::VecDeque<WorkspaceBinding>>,
         calls: std::sync::Arc<std::sync::Mutex<Vec<Vec<PathBuf>>>>,
     }
 
     impl ScriptedBinder {
         fn install(
-            outcomes: Vec<Option<BoundRepo>>,
+            outcomes: Vec<WorkspaceBinding>,
         ) -> (
             RepoBinder,
             std::sync::Arc<std::sync::Mutex<Vec<Vec<PathBuf>>>>,
@@ -2098,17 +2181,37 @@ mod tests {
                 calls: std::sync::Arc::clone(&calls),
             });
             let binder: RepoBinder = Box::new(
-                move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<BoundRepo>> + Send>> {
+                move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = WorkspaceBinding> + Send>> {
                     let scripted = std::sync::Arc::clone(&scripted);
                     Box::pin(async move {
                         scripted.calls.lock().unwrap().push(roots);
-                        let next = scripted.outcomes.lock().unwrap().pop_front();
-                        next.flatten()
+                        scripted
+                            .outcomes
+                            .lock()
+                            .unwrap()
+                            .pop_front()
+                            // A binder called more times than the script covers
+                            // resolves nothing rather than binding something the
+                            // test never named.
+                            .unwrap_or(WorkspaceBinding::Unresolvable)
                     })
                 },
             );
             (binder, calls)
         }
+    }
+
+    /// The binder outcome for a client that moved to a Kin repository this
+    /// server does not serve.
+    fn other_repository(root: &str) -> WorkspaceBinding {
+        WorkspaceBinding::OtherRepository(vec![PathBuf::from(root)])
+    }
+
+    /// The binder outcome for a root this server cannot resolve at all: the
+    /// container and remote shape, where the client's path does not exist in
+    /// this process's namespace.
+    fn unresolvable() -> WorkspaceBinding {
+        WorkspaceBinding::Unresolvable
     }
 
     fn bound_repo(root: &str, daemon_url: &str) -> BoundRepo {
@@ -2209,6 +2312,20 @@ mod tests {
             .collect()
     }
 
+    /// The `_kin.degraded` object an answered tool call carries. Reads it out of
+    /// the annotated content block rather than the transport frame, which is
+    /// where an agent reads it.
+    fn tool_error_degraded(response: &serde_json::Value) -> serde_json::Value {
+        let text = tool_error_text(response);
+        let payload: serde_json::Value =
+            serde_json::from_str(&text).expect("an annotated tool result is JSON");
+        payload
+            .get(ENVELOPE_KEY)
+            .and_then(|envelope| envelope.get("degraded"))
+            .cloned()
+            .unwrap_or_else(|| panic!("the response carries no _kin degraded object: {text}"))
+    }
+
     fn tool_error_text(response: &serde_json::Value) -> String {
         let result: ToolCallResult =
             serde_json::from_value(response.get("result").cloned().expect("tool result"))
@@ -2222,8 +2339,8 @@ mod tests {
     #[tokio::test]
     async fn roots_change_after_a_bind_rebinds_to_the_new_workspace() {
         let (binder, calls) = ScriptedBinder::install(vec![
-            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
-            Some(bound_repo("/repo/b", "http://127.0.0.1:4222")),
+            WorkspaceBinding::Bound(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            WorkspaceBinding::Bound(bound_repo("/repo/b", "http://127.0.0.1:4222")),
         ]);
 
         let responses = drive_daemon_loop(
@@ -2259,14 +2376,18 @@ mod tests {
 
     #[tokio::test]
     async fn tool_calls_fail_loud_when_the_new_workspace_cannot_be_bound() {
-        // Bind repo A, then switch to a workspace with no bindable Kin repo.
-        // The third outcome is the tool call's own re-check, which must find
-        // the root still unbindable and leave the refusal exactly as it was:
-        // re-checking changes when the verdict is taken, never what it is.
+        // Bind repo A from the client's own roots, then switch to a workspace
+        // with no bindable Kin repo. A binding that exists only because the
+        // client announced it does not survive the client withdrawing it, so
+        // this server refuses rather than answering from the repository it was
+        // sent to and then sent away from. The third outcome is the tool call's
+        // own re-check, which must find the root still unbindable and leave the
+        // refusal exactly as it was: re-checking changes when the verdict is
+        // taken, never what it is.
         let (binder, calls) = ScriptedBinder::install(vec![
-            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
-            None,
-            None,
+            WorkspaceBinding::Bound(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            unresolvable(),
+            unresolvable(),
         ]);
 
         let responses = drive_daemon_loop(
@@ -2311,9 +2432,9 @@ mod tests {
     #[tokio::test]
     async fn a_root_that_becomes_bindable_self_heals_on_the_next_tool_call() {
         let (binder, calls) = ScriptedBinder::install(vec![
-            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
-            None,
-            Some(bound_repo("/host/path", "http://127.0.0.1:4222")),
+            WorkspaceBinding::Bound(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            unresolvable(),
+            WorkspaceBinding::Bound(bound_repo("/host/path", "http://127.0.0.1:4222")),
         ]);
 
         let responses = drive_daemon_loop(
@@ -2355,23 +2476,27 @@ mod tests {
         );
     }
 
-    /// Drive the loop with an operator pin that bound at startup, then move the
-    /// client to a root this server cannot bind, and return the refusal text.
+    /// Drive the loop with a repository bound at startup, then move the client
+    /// to a second Kin repository this server does not serve, and return the
+    /// refusal text.
     async fn pinned_workspace_refusal(repo_pinned: bool) -> String {
         let startup = StartupDaemonBinding::new();
         startup.resolve_bound(
             bound_repo("/repo/pinned", "http://127.0.0.1:4111"),
             repo_pinned,
         );
-        // Two `None`s: the roots change that records the mismatch, and the
-        // tool call's own re-check.
-        let (binder, _calls) = ScriptedBinder::install(vec![None, None]);
+        // Twice: the roots change that records the mismatch, and the tool call's
+        // own re-check.
+        let (binder, _calls) = ScriptedBinder::install(vec![
+            other_repository("/repo/second"),
+            other_repository("/repo/second"),
+        ]);
 
         let responses = drive_daemon_loop_with_startup(
             &[
                 initialize_with_roots_capability(),
                 serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
-                roots_response(&["/host/only/path"]),
+                roots_response(&["/repo/second"]),
                 tool_call(31, "semantic_locate"),
             ],
             Some(binder),
@@ -2388,10 +2513,9 @@ mod tests {
     }
 
     /// `kin init .` is wrong advice for a repo-bound server, and wrong in the
-    /// expensive direction: the announced root is a host path a docker-exec or
-    /// remote registration may never be able to see, so following the hint
-    /// creates a second empty repository beside the real one and leaves the
-    /// refusal in place.
+    /// expensive direction: the repository the client moved to already exists,
+    /// so following the hint writes a second store into it and still leaves the
+    /// pinned server refusing.
     #[tokio::test]
     async fn a_repo_bound_refusal_does_not_suggest_kin_init() {
         let pinned = pinned_workspace_refusal(true).await;
@@ -2404,7 +2528,7 @@ mod tests {
             "the remedy that does apply must survive: {pinned}"
         );
         assert!(
-            pinned.contains("semantic_locate") && pinned.contains("/host/only/path"),
+            pinned.contains("semantic_locate") && pinned.contains("/repo/second"),
             "the refusal must still name the tool and the workspace: {pinned}"
         );
 
@@ -2419,14 +2543,133 @@ mod tests {
         );
     }
 
+    /// Drive a server that bound its own repository before the loop started —
+    /// the `docker exec -w <repo> ... kin mcp start` and plain per-repo
+    /// registration shape — through a roots answer the binder reports as
+    /// `resolution`, then two tool calls, and return their answers.
+    async fn server_bound_run(
+        resolution: WorkspaceBinding,
+        root: &str,
+    ) -> (serde_json::Value, serde_json::Value) {
+        let startup = StartupDaemonBinding::new();
+        // `pinned_by_operator: false` is the reported registration: the cwd of
+        // the `docker exec` bound the repository, with no --repo/KIN_MCP_REPO.
+        startup.resolve_bound(bound_repo("/work/express", "http://127.0.0.1:4111"), false);
+        // Three: the roots answer, and each tool call's own re-check if the
+        // first one recorded a mismatch.
+        let (binder, _calls) =
+            ScriptedBinder::install(vec![resolution.clone(), resolution.clone(), resolution]);
+
+        let responses = drive_daemon_loop_with_startup(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&[root]),
+                tool_call(41, "semantic_locate"),
+                tool_call(42, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+            Some(startup),
+        )
+        .await;
+
+        let answer_for = |id: u64| {
+            responses
+                .iter()
+                .find(|value| value.get("id").and_then(|value| value.as_u64()) == Some(id))
+                .unwrap_or_else(|| panic!("tool call {id} must be answered"))
+                .clone()
+        };
+        (answer_for(41), answer_for(42))
+    }
+
+    /// The reported shape (FIR-2405): a server reached through `docker exec`
+    /// serves `/work/express` while the client announces the host path
+    /// `/private/tmp/.../work`, which never exists inside the container. That
+    /// root is not evidence that the client left the repository this server was
+    /// started for, so the server must keep answering. Before the fix exactly
+    /// one call survived each respawn: the one that arrived before the roots
+    /// answer did, after which every call was refused.
+    #[tokio::test]
+    async fn a_server_bound_repository_survives_roots_it_cannot_resolve() {
+        let (first, second) =
+            server_bound_run(unresolvable(), "/private/tmp/kin-dogfood/brown/work").await;
+
+        for (id, answer) in [(41, &first), (42, &second)] {
+            let text = tool_error_text(answer);
+            assert!(
+                !text.contains("kin-mcp refuses"),
+                "call {id} must not be refused for a root this server cannot resolve: {text}"
+            );
+            assert!(
+                text.contains("not enabled in this MCP profile"),
+                "call {id} must reach ordinary handling: {text}"
+            );
+        }
+    }
+
+    /// Falsification of the test above, over the same helper: when the client's
+    /// roots name a Kin repository this server can see and does not serve, the
+    /// refusal is still owed. Answering would return a confident result about
+    /// the wrong codebase, which is the failure the refusal exists to prevent.
+    #[tokio::test]
+    async fn a_server_bound_repository_still_refuses_a_second_kin_repository() {
+        let (first, second) =
+            server_bound_run(other_repository("/work/requests"), "/work/requests").await;
+
+        for (id, answer) in [(41, &first), (42, &second)] {
+            let text = tool_error_text(answer);
+            assert!(
+                text.contains("kin-mcp refuses") && text.contains("semantic_locate"),
+                "call {id} must be refused and name the tool: {text}"
+            );
+            assert!(
+                text.contains("/work/requests") && text.contains("/work/express"),
+                "call {id} must name both the workspace and the bound repository: {text}"
+            );
+        }
+    }
+
+    /// The refusal reported a reachability problem it did not have: the bound
+    /// daemon answered `/health` 200 throughout, so an agent reading
+    /// `daemon_unreachable` went and checked a daemon that was fine.
+    #[tokio::test]
+    async fn a_workspace_refusal_is_not_stamped_daemon_unreachable() {
+        let (refused, _) =
+            server_bound_run(other_repository("/work/requests"), "/work/requests").await;
+        let degraded = tool_error_degraded(&refused);
+
+        assert_eq!(
+            degraded.get("workspace_mismatch"),
+            Some(&serde_json::Value::Bool(true)),
+            "the refusal must carry its own degradation: {degraded}"
+        );
+        assert!(
+            degraded.get("daemon_unreachable").is_none(),
+            "a reachable daemon must not be reported unreachable: {degraded}"
+        );
+
+        // Falsification: the same assertion run against a server that keeps
+        // serving proves the flag tracks the refusal rather than riding every
+        // response out of this loop.
+        let (served, _) = server_bound_run(unresolvable(), "/host/only/path").await;
+        assert!(
+            tool_error_degraded(&served)
+                .get("workspace_mismatch")
+                .is_none(),
+            "a served call must carry no workspace mismatch"
+        );
+    }
+
     #[tokio::test]
     async fn a_bindable_workspace_switch_clears_an_earlier_refusal() {
         // A → unbindable workspace → B: the refusal must not outlive the switch
         // that resolves it.
         let (binder, _calls) = ScriptedBinder::install(vec![
-            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
-            None,
-            Some(bound_repo("/repo/b", "http://127.0.0.1:4222")),
+            WorkspaceBinding::Bound(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            unresolvable(),
+            WorkspaceBinding::Bound(bound_repo("/repo/b", "http://127.0.0.1:4222")),
         ]);
 
         let responses = drive_daemon_loop(
@@ -2464,9 +2707,9 @@ mod tests {
         // the client to announce another change — and a bindable answer there
         // clears the refusal.
         let (binder, calls) = ScriptedBinder::install(vec![
-            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
-            None,
-            Some(bound_repo("/repo/b", "http://127.0.0.1:4222")),
+            WorkspaceBinding::Bound(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            unresolvable(),
+            WorkspaceBinding::Bound(bound_repo("/repo/b", "http://127.0.0.1:4222")),
         ]);
 
         let responses = drive_daemon_loop(
@@ -2510,8 +2753,10 @@ mod tests {
     async fn a_startup_bound_server_still_follows_a_workspace_switch() {
         // The reported shape: a repository bound before the loop starts (from
         // --repo/KIN_MCP_REPO/cwd) used to suppress roots handling entirely.
-        let (binder, calls) =
-            ScriptedBinder::install(vec![Some(bound_repo("/repo/b", "http://127.0.0.1:4222"))]);
+        let (binder, calls) = ScriptedBinder::install(vec![WorkspaceBinding::Bound(bound_repo(
+            "/repo/b",
+            "http://127.0.0.1:4222",
+        ))]);
 
         let responses = drive_daemon_loop(
             &[
@@ -2546,8 +2791,10 @@ mod tests {
         // No open folder is not a different folder: there is no other
         // repository the client's calls could be about, so a binding survives
         // and tool calls are not refused.
-        let (binder, calls) =
-            ScriptedBinder::install(vec![Some(bound_repo("/repo/a", "http://127.0.0.1:4111"))]);
+        let (binder, calls) = ScriptedBinder::install(vec![WorkspaceBinding::Bound(bound_repo(
+            "/repo/a",
+            "http://127.0.0.1:4111",
+        ))]);
 
         let responses = drive_daemon_loop(
             &[

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -29,7 +29,10 @@ The envelope's fields:
 - `semantic_coverage`: `indexed`, `total`, `pending`, and `complete` for the embedding
   signal, carried only when the daemon computed it and never fabricated here.
 - `degraded`: honest flags (`daemon_unreachable`, `embed_worker_failed`,
-  `mass_deletion_blocked`, `offline_fallback`), each present only when observed.
+  `mass_deletion_blocked`, `offline_fallback`, `workspace_mismatch`), each present only
+  when observed. `workspace_mismatch` is a refusal about which repository an answer would
+  be about, not a transport failure: the daemon is reachable and the server declined to
+  answer from a repository the client is not looking at.
 
 Empty results carry a named trust verdict, so an agent can tell "not present" apart from
 "not indexed yet". Semantic tools (`semantic_locate`, `semantic_search`) report
@@ -72,6 +75,22 @@ see the quickstart's advanced configuration for its exact JSON and repository-bo
 To wire a client up by hand, or to use the canonical npm wrapper (`@kinlab/kin`, which
 can run `kin mcp start` with the same `agent-default` profile), see
 [Advanced configuration](quickstart.md#9-advanced-configuration) in the quickstart.
+
+### Which repository the server serves
+
+A server binds one repository: the one named by `--repo` or `KIN_MCP_REPO`, otherwise the
+one containing its working directory, otherwise whatever the client's MCP workspace roots
+point at. An editor that moves its window to another Kin repository is followed, because a
+confident answer about the codebase you just left is worse than an error.
+
+A server that bound a repository of its own keeps serving it and ignores client workspace
+roots it cannot resolve to a Kin repository. That is what makes a container or remote
+registration work. Registered as `docker exec -i -w /work/repo <container> kin mcp start`,
+the server serves a container path while the client announces host paths that do not exist
+inside the container, and reading those as a workspace change would refuse every call for
+the life of the process. Roots that do name a Kin repository the server can see, and does
+not serve, are a real disagreement: those calls are refused, and the refusal carries
+`degraded.workspace_mismatch` with both paths named.
 
 ### Tool profiles
 


### PR DESCRIPTION
A Kin MCP server registered as `docker exec -i -w /work/express <container> kin mcp start` refused every tool call after the first. That registration is the shape of every containerised or remote deployment, so this is not a corner case: the client's root lives in one namespace and the server's repository in another, by construction.

## Mechanism

At `crates/kin-mcp/src/server.rs`, the stdio loop asks the client for `roots/list` on `initialized`/`tools/list` while nothing is bound, and always on `notifications/roots/list_changed`. The answer went through `apply_workspace_roots`, which called the binder and got back a bare `Option<BoundRepo>`. `crates/kin-cli/src/commands/mcp.rs` `bind_first_kin_repo_against` returned `None` both when the client had moved to another repository and when nothing the client named resolved to a Kin repository at all, and the loop read every `None` as the former: with `binding.is_bound()` already true from the launch cwd, it called `binding.mark_mismatch(roots, repo_pinned)` and refused every following `tools/call`.

In a container the client's root is a host path that never exists in the server's namespace, so the per-call re-binding kin#862 added could not help: the re-check runs, fails identically, and the refusal is permanent for the life of a process the client owns. Exactly one call survived each respawn, the one that arrived before the roots response did, which is why the stranger run measured one call per restart across five restart cycles.

The refusal also reused `Envelope::daemon_unreachable()`, so it reported a reachability problem it did not have. The bound daemon answered `/health` 200 throughout. Its three remedies all needed an `.mcp.json` edit and a client restart, neither of which an agent mid-session can do.

## The fix

The binder now reports what it saw. `WorkspaceBinding` carries three verdicts: `Bound`, `OtherRepository` (the roots name Kin repositories this process can see and does not serve), and `Unresolvable` (no root resolves to a Kin repository here). `KinLayout::discover` is filesystem-rooted, so the split is decided by what the server can actually see rather than by whether a daemon happened to resolve. The comment claiming `discover` short-circuits on `KIN_DAEMON_URL` was stale and is corrected; its own doc says discovery is always filesystem-rooted.

`RepoBindingState` now records where its binding came from. A binding the server made for itself, from its launch cwd or `--repo`/`KIN_MCP_REPO`, survives roots it cannot resolve: it keeps serving and logs the disagreement at info. A binding that came from a previous `roots/list` answer still refuses when the client withdraws it, because the client's roots were its only authority. Roots naming a different Kin repository are refused either way, since answering from the repository the client left is the failure the refusal exists to prevent.

The refusal carries a distinct `degraded.workspace_mismatch` instead of `daemon_unreachable`, and names both the bound repository and the announced workspace. `kin mcp start --help` and `docs/mcp-tools.md` now state that a bound server ignores client roots it cannot resolve, so the docker-exec registration is a documented, supported shape.

## Falsification

Every new guard was broken and confirmed to fail with its own message, then restored.

1. `a_server_bound_repository_survives_roots_it_cannot_resolve`, with the provenance branch removed so `Unresolvable` always refuses while bound: `FAILED ... call 41 must not be refused for a root this server cannot resolve`. This is the red-before, green-after test for the reported defect.
2. `a_server_bound_repository_still_refuses_a_second_kin_repository` and `a_repo_bound_refusal_does_not_suggest_kin_init`, with the `OtherRepository` arm disabled: both `FAILED`, the first on `call 41 must be refused and name the tool`.
3. `a_workspace_refusal_is_not_stamped_daemon_unreachable`, with `Envelope::daemon_unreachable()` put back into `repo_mismatch_response`: `FAILED ... the refusal must carry its own degradation: {"daemon_unreachable":true}`, which is the exact payload the ticket reports.
4. `a_root_this_server_cannot_see_is_unresolvable_not_another_repository` and `roots_with_no_kin_repository_bind_nothing`, with the empty-candidates branch returning `OtherRepository`: both `FAILED`, the first on `a root that resolves to no Kin repository here must not be reported as a switch`.
5. `mcp_start_help_documents_that_a_bound_server_holds_unresolvable_client_roots`, with the help paragraph deleted: `FAILED ... help must state that a bound server ignores roots it cannot resolve`, and the printed help proves what remained.
6. `workspace_mismatch_envelope_is_not_a_reachability_failure`, with the constructor setting both flags: `FAILED ... assertion failed: env.degraded.daemon_unreachable.is_none()`.

Each test also carries its own in-test falsification: the unresolvable case is paired with a visible second repository that must still refuse, the envelope test asserts the reachability envelope never claims a workspace mismatch, and the help test asserts a phrase that was never written is absent.

## Gate

`bin/kin-lane run fir2405-roots kin -- bin/kin-dev local-test kin` passed, resolved to `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/fir2405-roots-kin @ 29e9bd63 (chore/lane-fir2405-roots-kin)`: 6018 tests run, 6018 passed, 11 skipped, plus doctests. `cargo fmt --all -- --check` is clean and `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the ci.yml allowlist exits 0. `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty. Rebased onto `origin/main` at 320cf57a before pushing.

Composes with kin#862, whose per-call re-derivation still runs and still self-heals a root that becomes bindable, and with kin#880. The `crates/kin-mcp/src/envelope.rs` change is deliberately minimal, one `Degraded` flag plus its constructor and test, so it rebases cleanly against the concurrent lane touching that file.

Closes FIR-2405
