### PR TITLE
Emit and resolve a reference edge for a Python type annotation

### DIFF
--- a/crates/kin-cli/tests/python_type_annotation_references.rs
+++ b/crates/kin-cli/tests/python_type_annotation_references.rs
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Acceptance reproduction for the type-annotation edge class, on the shape a
+//! stranger's Python project produced.
+//!
+//! `parsing.py` defines `ParsedNote` and `WikiLink`. `storage.py` imports
+//! `ParsedNote` and never calls it: it appears as a parameter type, as a return
+//! type, and as a dataclass field type, and `WikiLink` appears only as the
+//! element type `ParsedNote` is built from. Because the adapter emitted no edge
+//! of any class for an annotation, `find_references("ParsedNote")` answered with
+//! the one caller in its own file and `find_references("WikiLink")` missed
+//! `ParsedNote` entirely, so a reader who renamed `ParsedNote` on that answer
+//! would have left `storage.py` holding the old name in three places.
+//!
+//! Everything here runs through the real Python adapter, the real cross-file
+//! linker, and the collector `find_references` itself calls over the relation
+//! kinds it defaults to.
+
+use std::collections::{BTreeSet, HashMap};
+
+use kin_cli::commands::refs::{build_refs_response, RefsRequest};
+use kin_cli::commands::rename::{plan_rename, RenameRequest};
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file_with_completeness, FileParseData};
+use kin_mcp::handlers::common::default_reference_kinds;
+use kin_model::{
+    ArtifactId, AuthorId, Entity, EntityId, EntityStore, FileLayout, FilePathId, GraphNodeId,
+    Hash256, ImportSection, OperationId, ParseCompleteness, RepoPath, ResolvedArtifact,
+    ResolvedTree, TreeEntry,
+};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// The defining module. Neither class is ever called.
+const PARSING_PY: &str = r#""""Note parsing."""
+
+
+class WikiLink:
+    pass
+
+
+class ParsedNote:
+    pass
+"#;
+
+/// The consuming module. `ParsedNote` is named three times and called zero
+/// times; `WikiLink` is named once, as the element type of a field.
+const STORAGE_PY: &str = r#""""Note storage."""
+
+from typing import Optional, Tuple
+
+from parsing import ParsedNote, WikiLink
+
+
+class NoteRow:
+    note: Optional[ParsedNote] = None
+    links: Tuple[WikiLink, ...] = ()
+
+
+def upsert_note(note: ParsedNote, mtime: Optional[float] = None) -> int:
+    return 1
+
+
+def latest() -> ParsedNote:
+    raise NotImplementedError
+"#;
+
+/// A third module with no consumer at all, so a fix that rescued everything
+/// would be caught as surely as one that rescued nothing.
+const ORPHAN_PY: &str = r#""""Nothing depends on this."""
+
+
+class OrphanRecord:
+    pass
+"#;
+
+fn parse_py(file_path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
+    assert!(
+        matches!(
+            ParseCompleteness::from_parse_state(&output.parse_state),
+            ParseCompleteness::Full
+        ),
+        "fixture {file_path} must parse cleanly"
+    );
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|entity| entity.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+/// Link the parsed files into a persisted graph the way ingest does, with the
+/// resolved tree, file layouts and coverage certificates a rename plan reads.
+fn link_into_graph(
+    files: Vec<FileParseData>,
+    bodies: &HashMap<String, String>,
+) -> (Vec<FileParseData>, InMemoryGraph) {
+    let completeness = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ParseCompleteness::Full))
+        .collect();
+    let artifact_ids: HashMap<String, ArtifactId> = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file_with_completeness(&files, &artifact_ids, &completeness)
+        .expect("every fixture file has an artifact identity");
+
+    let mut admitted = artifact_ids.iter().collect::<Vec<_>>();
+    admitted.sort_by(|(left, _), (right, _)| left.cmp(right));
+    // Real content digests, because repository CAS verifies the body a rename
+    // plan loads against the digest the tree names.
+    let resolved_tree =
+        ResolvedTree::from_artifacts(admitted.into_iter().map(|(path, artifact_id)| {
+            let body = bodies
+                .get(path.as_str())
+                .unwrap_or_else(|| panic!("fixture body for {path} was not supplied"));
+            ResolvedArtifact::new(
+                *artifact_id,
+                RepoPath::from_utf8(path).expect("valid fixture repository path"),
+                TreeEntry::blob(
+                    Hash256::from_bytes(kin_blobs::digest(body.as_bytes()).0),
+                    false,
+                ),
+            )
+        }))
+        .expect("unique admitted fixture artifacts");
+    let mut snapshot = kin_db::GraphSnapshot::empty();
+    snapshot.resolved_tree = resolved_tree;
+    let graph = InMemoryGraph::from_snapshot(snapshot).expect("open admitted fixture graph");
+    for file in &files {
+        graph
+            .upsert_file_layout(&FileLayout {
+                file_id: FilePathId::new(&file.file_path),
+                parse_completeness: ParseCompleteness::Full,
+                imports: ImportSection {
+                    byte_range: 0..0,
+                    items: Vec::new(),
+                },
+                regions: Vec::new(),
+            })
+            .expect("upsert file layout");
+        for entity in &file.entities {
+            graph.upsert_entity(entity).expect("upsert entity");
+        }
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    (files, graph)
+}
+
+/// Path to body, the same map the fixture parses from and a rename plan loads
+/// from, so no digest can disagree with what was indexed.
+fn bodies(files: &[(&str, &str)]) -> HashMap<String, String> {
+    files
+        .iter()
+        .map(|(path, body)| ((*path).to_string(), (*body).to_string()))
+        .collect()
+}
+
+fn notes_project() -> (Vec<FileParseData>, InMemoryGraph) {
+    let sources = [
+        ("storage.py", STORAGE_PY),
+        ("parsing.py", PARSING_PY),
+        ("orphan.py", ORPHAN_PY),
+    ];
+    let bodies = bodies(&sources);
+    let parsed = sources
+        .iter()
+        .map(|(path, body)| parse_py(path, body))
+        .collect();
+    link_into_graph(parsed, &bodies)
+}
+
+fn entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("fixture entity `{name}` in `{file}` not found"))
+        .id
+}
+
+/// The consumers `find_references` reports for one entity, as `(file, name)`.
+///
+/// Read off the graph under
+/// [`kin_mcp::handlers::common::default_reference_kinds`] itself, which is the
+/// Calls + Imports + References triple the MCP handler filters its collector
+/// on and the same triple `kin refs --kind all` and the dead-code scan use.
+/// Importing that function rather than restating the three kinds is the point:
+/// if `References` ever left the default set, this helper would stop finding
+/// the annotated consumers instead of quietly asserting a stale copy.
+///
+/// The handler adds body projection on top, which needs a live repository
+/// authority binding a parsed-in-memory fixture does not have. Which edges pass
+/// the kind filter is what decides whether a consumer is reported at all, and
+/// that is what this reads.
+fn find_references(graph: &InMemoryGraph, target: EntityId) -> BTreeSet<(String, String)> {
+    let kinds = default_reference_kinds();
+    graph
+        .get_all_relations_for_entity(&target)
+        .expect("inbound relations")
+        .into_iter()
+        .filter(|rel| rel.dst == GraphNodeId::Entity(target) && kinds.contains(&rel.kind))
+        .filter_map(|rel| rel.src.as_entity())
+        .filter_map(|source_id| {
+            graph
+                .get_entity(&source_id)
+                .expect("referencing entity")
+                .map(|entity| {
+                    (
+                        entity
+                            .file_origin
+                            .map(|file| file.0)
+                            .unwrap_or_else(|| "<graph-only>".to_string()),
+                        entity.name,
+                    )
+                })
+        })
+        .collect()
+}
+
+/// The rendered `kin refs --kind all` answer for one entity, which is the CLI
+/// half of the same reference collector.
+fn refs_lines(graph: &InMemoryGraph, entity: &str) -> String {
+    let dir = tempfile::tempdir().expect("temp repository root");
+    let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+    build_refs_response(
+        &layout,
+        graph,
+        &RefsRequest {
+            entity: entity.to_string(),
+            kind: "all".to_string(),
+        },
+    )
+    .expect("refs response")
+    .lines
+    .join("\n")
+}
+
+#[test]
+fn find_references_lists_every_consumer_that_only_annotates() {
+    // The defect, reproduced and closed. Each of these three names `ParsedNote`
+    // in an annotation and nowhere else, so before annotations carried an edge
+    // every one of them was invisible here.
+    let (files, graph) = notes_project();
+    let found = find_references(&graph, entity_id(&files, "parsing.py", "ParsedNote"));
+
+    for consumer in ["upsert_note", "latest", "NoteRow"] {
+        assert!(
+            found.contains(&("storage.py".to_string(), consumer.to_string())),
+            "`{consumer}` annotates ParsedNote and must be listed, got {found:?}"
+        );
+    }
+
+    // And the same answer through the rendered CLI surface, so the edge is
+    // proven to reach a shipped command rather than only the relation table.
+    let lines = refs_lines(&graph, "ParsedNote");
+    for consumer in ["upsert_note", "latest", "NoteRow"] {
+        assert!(
+            lines.contains(consumer),
+            "`kin refs ParsedNote` must name `{consumer}`, got:\n{lines}"
+        );
+    }
+}
+
+#[test]
+fn find_references_on_an_element_type_reaches_the_class_built_from_it() {
+    // The second half of the reported miss. `WikiLink` is named only as the
+    // element type of `NoteRow.links`, which is why the context pack for the
+    // annotated class carried no dependency on it.
+    let (files, graph) = notes_project();
+    let found = find_references(&graph, entity_id(&files, "parsing.py", "WikiLink"));
+
+    assert!(
+        found.contains(&("storage.py".to_string(), "NoteRow".to_string())),
+        "the class whose field type is WikiLink must be listed, got {found:?}"
+    );
+}
+
+#[test]
+fn a_class_nothing_annotates_still_reports_no_references() {
+    // The opposite direction. An edge class that rescued every type would be as
+    // wrong as one that rescued none.
+    let (files, graph) = notes_project();
+    let found = find_references(&graph, entity_id(&files, "orphan.py", "OrphanRecord"));
+
+    assert!(
+        found.is_empty(),
+        "an unreferenced class must keep reporting nothing, got {found:?}"
+    );
+}
+
+/// The rename fixture reaches the class through a MODULE import
+/// (`import parsing` then `parsing.ParsedNote`) rather than a named one.
+/// `plan_rename` refuses outright while a graph source imports the target by
+/// name, because artifact-level Python import edges carry no exact source span,
+/// so the named-import shape cannot reach the planner at all today. The module
+/// import puts the only `ParsedNote` token in `storage.py` inside the annotated
+/// function, which is exactly the site this fix made visible.
+const RENAME_PARSING_PY: &str = "class ParsedNote:\n    pass\n";
+const RENAME_STORAGE_PY: &str =
+    "import parsing\n\n\ndef upsert_note(note: parsing.ParsedNote) -> int:\n    return 1\n";
+
+#[test]
+fn the_rename_plan_names_the_consumer_that_only_annotates() {
+    let sources = [
+        ("storage.py", RENAME_STORAGE_PY),
+        ("parsing.py", RENAME_PARSING_PY),
+    ];
+    let bodies = bodies(&sources);
+    let parsed = sources
+        .iter()
+        .map(|(path, body)| parse_py(path, body))
+        .collect();
+    let (_files, graph) = link_into_graph(parsed, &bodies);
+
+    let plan = plan_rename(
+        &graph,
+        &RenameRequest {
+            symbol: "ParsedNote".to_string(),
+            new_name: "NoteRecord".to_string(),
+            file: Some("parsing.py".to_string()),
+            line: None,
+            column: None,
+            json: true,
+            operation_id: OperationId::new(),
+            actor: AuthorId::new("fir2399-annotation-test"),
+        },
+        |path, _hash| {
+            let path = path.as_utf8().expect("fixture paths are UTF-8");
+            bodies
+                .get(path)
+                .map(|body| body.as_bytes().to_vec())
+                .ok_or_else(|| anyhow::anyhow!("missing fixture body {path}"))
+        },
+    )
+    .expect("rename plans over the annotated consumer");
+
+    let edited: BTreeSet<&str> = plan.edits.iter().map(|edit| edit.file.0.as_str()).collect();
+    assert!(
+        edited.contains("storage.py"),
+        "the annotated consumer's file must be edited, got {edited:?}"
+    );
+
+    let annotation_edit = plan
+        .edits
+        .iter()
+        .find(|edit| edit.file.0 == "storage.py")
+        .expect("an edit inside the annotated consumer");
+    assert_eq!(
+        annotation_edit.reason, "graph-reference:references",
+        "the consumer must be reached by a graph reference edge, not by a name sweep"
+    );
+    assert_eq!(annotation_edit.old_text, "ParsedNote");
+    assert_eq!(annotation_edit.new_text, "NoteRecord");
+    assert_eq!(
+        annotation_edit.start_line, 4,
+        "the edit must land on the annotated signature"
+    );
+}

--- a/crates/kin-index/tests/python_type_annotation_linking.rs
+++ b/crates/kin-index/tests/python_type_annotation_linking.rs
@@ -179,11 +179,12 @@ fn a_field_annotation_binds_across_the_file_boundary_through_its_import() {
 
 #[test]
 fn an_annotation_does_not_bind_to_a_same_named_class_in_an_unimported_module() {
-    // The precision half, and the falsifier for the import gate. Two modules
-    // define `ParsedNote`; only one is imported. Name alone cannot choose, so
-    // the import must, and the twin must gain nothing. Drop the
-    // defined-or-imported filter in `emit_python_value_references` and this is
-    // the assertion that fails.
+    // The precision half. Two modules define `ParsedNote`; only one is
+    // imported. Name alone cannot choose, so the import must, and the twin must
+    // gain nothing. What holds this is the linker's import tier, which is
+    // reached because the name IS imported here; the extractor's
+    // defined-or-imported gate is what holds the case below, where the name is
+    // not imported at all.
     let mut files = two_file_project();
     files.push(parse_py("legacy.py", "class ParsedNote:\n    pass\n"));
     let relations = link(&files);
@@ -276,5 +277,34 @@ fn an_annotation_resolves_exactly_as_the_same_call_would() {
         annotation_edge,
         Some(IMPORT_RESOLVED_CONFIDENCE),
         "and both bind on the import tier"
+    );
+}
+
+#[test]
+fn an_annotation_naming_a_class_this_file_never_imported_emits_no_edge_at_all() {
+    // The falsifier for the extractor's defined-or-imported gate, and the
+    // ticket's negative case. `Ghost` is named in an annotation, defined in
+    // another file, and imported by nobody. A bare name that reaches the linker
+    // unfiltered lands on the blind cross-file exact-name tier and binds at 0.7
+    // to whatever entity carries that name, which is a fabricated dependency.
+    // Drop the `defined.contains(root) || symbol_bound.contains(root)` filter in
+    // `emit_python_value_references` and this assertion is the one that fails.
+    let files = vec![
+        parse_py(
+            "storage.py",
+            "def upsert_note(note: Ghost) -> int:\n    return 1\n",
+        ),
+        parse_py("legacy.py", "class Ghost:\n    pass\n"),
+    ];
+    let relations = link(&files);
+
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            entity_id_in(&files, "storage.py", "upsert_note"),
+            entity_id_in(&files, "legacy.py", "Ghost"),
+        ),
+        None,
+        "an annotation naming a class this file never imported must emit no edge"
     );
 }

--- a/crates/kin-index/tests/python_type_annotation_linking.rs
+++ b/crates/kin-index/tests/python_type_annotation_linking.rs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file resolution of Python type annotations, through the real parser
+//! and the real linker.
+//!
+//! A class named only in an annotation now carries a `References` edge out of
+//! extraction. These tests pin that such an edge crosses a file boundary
+//! through the SAME tiers a call does, so an annotated consumer binds on import
+//! evidence rather than by name alone. Confidence is asserted rather than merely
+//! the edge, because the blind cross-file name tier reaches the same entity at
+//! 0.7 in a single-definition fixture and an edge alone cannot tell the two
+//! apart.
+
+use std::collections::HashMap;
+
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityId, FilePathId, GraphNodeId, Relation, RelationKind};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// Confidence the linker records when a relation resolves through the referring
+/// file's own import declaration (tier (b) of `linker::resolve_one_file`).
+const IMPORT_RESOLVED_CONFIDENCE: f32 = 0.95;
+
+/// Confidence for a member reached through a namespace/module import
+/// (`import parsing` then `parsing.ParsedNote`, tier (b2)).
+const MODULE_MEMBER_CONFIDENCE: f32 = 0.9;
+
+fn parse_py(path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn link(files: &[FileParseData]) -> Vec<Relation> {
+    let artifact_ids: HashMap<String, ArtifactId> = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    link_cross_file(files, &artifact_ids).expect("every fixture file has an artifact identity")
+}
+
+fn entity_id_in(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+fn reference_confidence(relations: &[Relation], src: EntityId, dst: EntityId) -> Option<f32> {
+    relations
+        .iter()
+        .find(|rel| {
+            rel.kind == RelationKind::References
+                && rel.src == GraphNodeId::Entity(src)
+                && rel.dst == GraphNodeId::Entity(dst)
+        })
+        .map(|rel| rel.confidence)
+}
+
+/// The defining module. `ParsedNote` is a class; nothing here calls it.
+const PARSING_PY: &str = r#""""Note parsing."""
+
+
+class WikiLink:
+    pass
+
+
+class ParsedNote:
+    pass
+"#;
+
+/// The consuming module. It imports `ParsedNote` and names it ONLY in
+/// annotations: a parameter type, a return type, and a dataclass field type.
+const STORAGE_PY: &str = r#""""Note storage."""
+
+from typing import Optional, Tuple
+
+from parsing import ParsedNote, WikiLink
+
+
+class NoteRow:
+    note: Optional[ParsedNote] = None
+    links: Tuple[WikiLink, ...] = ()
+
+
+def upsert_note(note: ParsedNote, mtime: Optional[float] = None) -> int:
+    return 1
+
+
+def latest() -> ParsedNote:
+    raise NotImplementedError
+"#;
+
+fn two_file_project() -> Vec<FileParseData> {
+    vec![
+        parse_py("storage.py", STORAGE_PY),
+        parse_py("parsing.py", PARSING_PY),
+    ]
+}
+
+#[test]
+fn a_parameter_annotation_binds_across_the_file_boundary_through_its_import() {
+    let files = two_file_project();
+    let relations = link(&files);
+
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            entity_id_in(&files, "storage.py", "upsert_note"),
+            entity_id_in(&files, "parsing.py", "ParsedNote"),
+        ),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the parameter annotation must bind through its import, not the blind name tier"
+    );
+}
+
+#[test]
+fn a_return_annotation_binds_across_the_file_boundary_through_its_import() {
+    let files = two_file_project();
+    let relations = link(&files);
+
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            entity_id_in(&files, "storage.py", "latest"),
+            entity_id_in(&files, "parsing.py", "ParsedNote"),
+        ),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the return annotation must bind through its import"
+    );
+}
+
+#[test]
+fn a_field_annotation_binds_across_the_file_boundary_through_its_import() {
+    // Both fields, so the plain wrapper (`Optional[ParsedNote]`) and the
+    // variadic one (`Tuple[WikiLink, ...]`) are each proven rather than one
+    // standing in for the other.
+    let files = two_file_project();
+    let relations = link(&files);
+    let row = entity_id_in(&files, "storage.py", "NoteRow");
+
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            row,
+            entity_id_in(&files, "parsing.py", "ParsedNote"),
+        ),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the `Optional[ParsedNote]` field must bind through its import"
+    );
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            row,
+            entity_id_in(&files, "parsing.py", "WikiLink"),
+        ),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the `Tuple[WikiLink, ...]` field must bind through its import"
+    );
+}
+
+#[test]
+fn an_annotation_does_not_bind_to_a_same_named_class_in_an_unimported_module() {
+    // The precision half, and the falsifier for the import gate. Two modules
+    // define `ParsedNote`; only one is imported. Name alone cannot choose, so
+    // the import must, and the twin must gain nothing. Drop the
+    // defined-or-imported filter in `emit_python_value_references` and this is
+    // the assertion that fails.
+    let mut files = two_file_project();
+    files.push(parse_py("legacy.py", "class ParsedNote:\n    pass\n"));
+    let relations = link(&files);
+
+    let consumer = entity_id_in(&files, "storage.py", "upsert_note");
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            consumer,
+            entity_id_in(&files, "parsing.py", "ParsedNote"),
+        ),
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "the imported definition binds"
+    );
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            consumer,
+            entity_id_in(&files, "legacy.py", "ParsedNote"),
+        ),
+        None,
+        "the same-named class in an unimported module must gain no reference"
+    );
+}
+
+#[test]
+fn a_dotted_annotation_binds_through_the_module_import() {
+    let files = vec![
+        parse_py(
+            "storage.py",
+            "import parsing\n\n\ndef upsert_note(note: parsing.ParsedNote) -> int:\n    return 1\n",
+        ),
+        parse_py("parsing.py", PARSING_PY),
+    ];
+    let relations = link(&files);
+
+    assert_eq!(
+        reference_confidence(
+            &relations,
+            entity_id_in(&files, "storage.py", "upsert_note"),
+            entity_id_in(&files, "parsing.py", "ParsedNote"),
+        ),
+        Some(MODULE_MEMBER_CONFIDENCE),
+        "`parsing.ParsedNote` must bind through the module import"
+    );
+}
+
+#[test]
+fn an_annotation_resolves_exactly_as_the_same_call_would() {
+    // Requirement: annotations go through the SAME tiers as calls, so the same
+    // name in the same file must reach the same target at the same confidence.
+    // Parity is what proves no separate rule was invented for type positions.
+    let annotated = vec![
+        parse_py(
+            "storage.py",
+            "from parsing import ParsedNote\n\n\ndef upsert_note(note: ParsedNote) -> int:\n    return 1\n",
+        ),
+        parse_py("parsing.py", PARSING_PY),
+    ];
+    let calling = vec![
+        parse_py(
+            "storage.py",
+            "from parsing import ParsedNote\n\n\ndef upsert_note(note) -> int:\n    ParsedNote()\n    return 1\n",
+        ),
+        parse_py("parsing.py", PARSING_PY),
+    ];
+
+    let annotation_edge = reference_confidence(
+        &link(&annotated),
+        entity_id_in(&annotated, "storage.py", "upsert_note"),
+        entity_id_in(&annotated, "parsing.py", "ParsedNote"),
+    );
+    let call_relations = link(&calling);
+    let caller = entity_id_in(&calling, "storage.py", "upsert_note");
+    let callee = entity_id_in(&calling, "parsing.py", "ParsedNote");
+    let call_edge = call_relations
+        .iter()
+        .find(|rel| {
+            rel.kind == RelationKind::Calls
+                && rel.src == GraphNodeId::Entity(caller)
+                && rel.dst == GraphNodeId::Entity(callee)
+        })
+        .map(|rel| rel.confidence);
+
+    assert_eq!(
+        annotation_edge, call_edge,
+        "an annotation and the identical call must resolve alike"
+    );
+    assert_eq!(
+        annotation_edge,
+        Some(IMPORT_RESOLVED_CONFIDENCE),
+        "and both bind on the import tier"
+    );
+}

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -2062,6 +2062,9 @@ mod tests {
     fn a_parameter_name_is_still_not_a_reference() {
         // Annotations became references; parameter NAMES did not. A parameter
         // called `note` is a binding, and binding a name is not reading one.
+        // Two independent rules hold this, and it takes breaking both to make
+        // this assertion fail: only the `type` field of a parameter is walked,
+        // and a parameter name is in the shadow set anyway.
         let edges =
             references_in("def note():\n    return 1\n\n\ndef take(note: int):\n    return note\n");
         assert!(

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -420,27 +420,38 @@ fn python_module_identity(file_id: &FilePathId) -> (String, bool) {
     }
 }
 
-/// A symbol read as a VALUE rather than invoked, recorded during the walk.
+/// A symbol named without being invoked, recorded during the walk.
+///
+/// Two positions produce one of these: a VALUE read (`set_defaults(func=cmd_ingest)`)
+/// and a TYPE annotation (`def upsert(note: ParsedNote)`). Both name a symbol
+/// the enclosing entity depends on, both must be found by `find_references`,
+/// and both bind by the same rule, so they share one record and one emit path.
 ///
 /// `member` is set when the reference was written as an attribute access
-/// (`TAG_RE.pattern`), because whether that names the root or the leaf depends
-/// on how the root was bound, and the file's imports are not known until the
-/// walk finishes. Candidates are filtered rather than emitted directly because
-/// a reference may precede its definition in the file.
+/// (`TAG_RE.pattern`, `typing.Optional`), because whether that names the root or
+/// the leaf depends on how the root was bound, and the file's imports are not
+/// known until the walk finishes. Candidates are filtered rather than emitted
+/// directly because a reference may precede its definition in the file.
 struct PythonValueRef {
     src_name: String,
     root: String,
     member: Option<String>,
 }
 
-/// Collect the value references made by one `function_definition`, sourced from
-/// the entity `context_name`.
+/// Collect the references made by one `function_definition`, sourced from the
+/// entity `context_name`.
 ///
-/// Parameter defaults are walked because `def wire(handler=cmd_ingest)` reads
-/// `cmd_ingest`; parameter names and annotations are not, since a name being
-/// bound is not a name being read and a type position is a different edge
-/// class. Names the function binds locally shadow the module scope in Python,
-/// so a local called `parse` is not a read of a module-level `parse`.
+/// Three positions in a signature name a symbol. Parameter defaults read one
+/// (`def wire(handler=cmd_ingest)`), parameter annotations name a type
+/// (`def upsert(note: ParsedNote)`), and the return annotation names another
+/// (`-> ParsedNote`). Parameter NAMES are still skipped, because a name being
+/// bound is not a name being read.
+///
+/// Names the function binds locally shadow the module scope in Python, so a
+/// local called `parse` is not a read of a module-level `parse`. Annotations
+/// carry the same shadow set: it costs no recall on the CamelCase-type,
+/// snake_case-local convention Python code follows, and it keeps a local from
+/// binding to an unrelated module-level entity of the same name.
 fn extract_value_refs_from_definition(
     node: &tree_sitter::Node,
     source: &[u8],
@@ -451,6 +462,12 @@ fn extract_value_refs_from_definition(
     if let Some(params) = node.child_by_field_name("parameters") {
         let mut cursor = params.walk();
         for param in params.named_children(&mut cursor) {
+            // `typed_parameter` also carries `*args: T` and `**kw: T`, whose
+            // name sits in a splat pattern while the annotation stays on the
+            // same `type` field.
+            if let Some(annotation) = param.child_by_field_name("type") {
+                collect_python_type_refs(&annotation, source, context_name, &shadowed, out);
+            }
             if matches!(
                 param.kind(),
                 "default_parameter" | "typed_default_parameter"
@@ -460,6 +477,9 @@ fn extract_value_refs_from_definition(
                 }
             }
         }
+    }
+    if let Some(return_type) = node.child_by_field_name("return_type") {
+        collect_python_type_refs(&return_type, source, context_name, &shadowed, out);
     }
     if let Some(body) = node.child_by_field_name("body") {
         collect_python_value_refs(&body, source, context_name, &shadowed, out);
@@ -571,11 +591,17 @@ fn collect_python_binding_targets(
 /// that are not reads.
 ///
 /// Pruned: a call's callee identifier (already a `Calls` edge), an attribute's
-/// `.leaf` selector, an assignment or loop target, a keyword argument's name, a
-/// type annotation, and an import statement. Kept, because each is a genuine
-/// read of the named symbol: a call argument (`set_defaults(func=cmd_ingest)`),
-/// an assignment right-hand side, a collection literal element, a returned
-/// expression, and the receiver of an attribute access (`TAG_RE.pattern`).
+/// `.leaf` selector, an assignment or loop target, a keyword argument's name,
+/// and an import statement. Kept, because each is a genuine read of the named
+/// symbol: a call argument (`set_defaults(func=cmd_ingest)`), an assignment
+/// right-hand side, a collection literal element, a returned expression, and
+/// the receiver of an attribute access (`TAG_RE.pattern`).
+///
+/// A `type` node is not walked as a value, because the names inside an
+/// annotation are not read at this position. It is handed to
+/// [`collect_python_type_refs`] instead, which is why an annotated assignment
+/// (`links: Tuple[WikiLink, ...] = ()`) contributes both its right-hand side
+/// and the types its annotation names.
 fn collect_python_value_refs(
     node: &tree_sitter::Node,
     source: &[u8],
@@ -647,6 +673,13 @@ fn collect_python_value_refs(
             }
         }
         "assignment" | "augmented_assignment" => {
+            // `links: Tuple[WikiLink, ...] = ()` in a class body, a module-scope
+            // `TOP: ParsedNote = None`, and a body-local `note: ParsedNote = x`
+            // all wear this shape, so one arm covers every annotated binding
+            // outside a signature.
+            if let Some(annotation) = node.child_by_field_name("type") {
+                collect_python_type_refs(&annotation, source, context_name, shadowed, out);
+            }
             if let Some(right) = node.child_by_field_name("right") {
                 collect_python_value_refs(&right, source, context_name, shadowed, out);
             }
@@ -675,14 +708,119 @@ fn collect_python_value_refs(
     }
 }
 
-/// Turn collected value reads into `References` edges.
+/// Collect the symbols named inside one type annotation, sourced from the
+/// entity `context_name`.
+///
+/// A type position is a use. `def upsert(note: ParsedNote) -> int` depends on
+/// `ParsedNote` exactly as a call depends on its callee, and a rename that
+/// cannot see it leaves the old name in the signature. Before this, the Python
+/// adapter emitted no edge of any class for an annotation, so a class used only
+/// as a parameter type, a return type or a dataclass field type reported zero
+/// inbound references.
+///
+/// The walk descends through the wrappers tree-sitter builds a type expression
+/// from rather than matching each one, so `Optional[Note]`,
+/// `Tuple[WikiLink, ...]`, `dict[str, Note]`, `Note | None`,
+/// `Callable[[Note], int]` and `typing.List[Note]` each reach every name they
+/// carry. `str`, `int` and other builtins are collected here and dropped by
+/// [`emit_python_value_references`], which binds only what the file defines or
+/// imports.
+///
+/// A quoted forward reference (`x: "Note"`) is read only when the quotes hold a
+/// bare identifier. A quoted expression is left alone rather than re-parsed as
+/// a type by hand.
+fn collect_python_type_refs(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    context_name: &str,
+    shadowed: &std::collections::HashSet<String>,
+    out: &mut Vec<PythonValueRef>,
+) {
+    match node.kind() {
+        "identifier" => {
+            if let Ok(name) = node.utf8_text(source) {
+                if !name.is_empty() && !shadowed.contains(name) {
+                    out.push(PythonValueRef {
+                        src_name: context_name.to_string(),
+                        root: name.to_string(),
+                        member: None,
+                    });
+                }
+            }
+        }
+        // `typing.Optional` in a type position binds exactly as `TAG_RE.pattern`
+        // does in a value position: which half names the symbol depends on how
+        // the root was bound, so both are carried to the emit step.
+        "attribute" => {
+            let object = node.child_by_field_name("object");
+            let leaf = node
+                .child_by_field_name("attribute")
+                .and_then(|n| n.utf8_text(source).ok());
+            match (object, leaf) {
+                (Some(object), Some(leaf)) if object.kind() == "identifier" && !leaf.is_empty() => {
+                    if let Ok(root) = object.utf8_text(source) {
+                        if !root.is_empty() && !shadowed.contains(root) {
+                            out.push(PythonValueRef {
+                                src_name: context_name.to_string(),
+                                root: root.to_string(),
+                                member: Some(leaf.to_string()),
+                            });
+                        }
+                    }
+                }
+                (Some(object), _) => {
+                    collect_python_type_refs(&object, source, context_name, shadowed, out)
+                }
+                _ => {}
+            }
+        }
+        "string" => {
+            let mut cursor = node.walk();
+            let mut contents = node
+                .children(&mut cursor)
+                .filter(|child| child.kind() == "string_content");
+            if let (Some(content), None) = (contents.next(), contents.next()) {
+                if let Ok(text) = content.utf8_text(source) {
+                    if is_python_identifier(text) && !shadowed.contains(text) {
+                        out.push(PythonValueRef {
+                            src_name: context_name.to_string(),
+                            root: text.to_string(),
+                            member: None,
+                        });
+                    }
+                }
+            }
+        }
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                collect_python_type_refs(&child, source, context_name, shadowed, out);
+            }
+        }
+    }
+}
+
+/// Whether `text` is a single Python identifier, used to decide whether a
+/// quoted forward reference names one symbol or holds an expression.
+fn is_python_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_alphanumeric())
+}
+
+/// Turn collected value reads and type annotations into `References` edges.
 ///
 /// Only a name this file DEFINES or IMPORTS may bind, which in Python is the
 /// complete set: a module-level symbol is reachable from a module only when it
-/// is defined there or imported into it, and anything else in a value position
-/// is a local, a parameter, or a builtin. Filtering here rather than in the
-/// linker is what keeps a local named `config` from binding by name alone to
-/// some unrelated module-level `config` in another file.
+/// is defined there or imported into it, and anything else in a value or type
+/// position is a local, a parameter, or a builtin. Filtering here rather than
+/// in the linker is what keeps a local named `config` from binding by name
+/// alone to some unrelated module-level `config` in another file, and it is
+/// what stops an annotation naming `str` or `Optional` from reaching a
+/// same-named entity in an unimported module.
 ///
 /// `RelationKind::References` is the existing kind for a non-call reference,
 /// already emitted by the Go, C++, C# and Ruby adapters and already read by the
@@ -1766,6 +1904,169 @@ mod tests {
                 .iter()
                 .any(crate::extract::is_call_extraction_incomplete_marker),
             "reading a constant is not an unrepresented call"
+        );
+    }
+
+    /// Every `(src, dst)` the adapter emits as a `References` edge for `src`,
+    /// sorted so an assertion reads as a set rather than a walk order.
+    fn references_in(src: &str) -> Vec<(String, String)> {
+        let adapter = PythonAdapter;
+        let bytes = src.as_bytes();
+        let tree = adapter.parse(bytes).expect("fixture parses");
+        let output = adapter
+            .extract(&tree, bytes, &FilePathId::new("mod.py"))
+            .expect("fixture extracts");
+        let mut edges: Vec<(String, String)> = output
+            .relations
+            .iter()
+            .filter(|rel| rel.kind == kin_model::RelationKind::References)
+            .map(|rel| (rel.src_name.clone(), rel.dst_name.clone()))
+            .collect();
+        edges.sort();
+        edges
+    }
+
+    #[test]
+    fn a_parameter_annotation_references_the_imported_class() {
+        // The reported shape. `ParsedNote` is named only as a parameter type,
+        // so before annotations carried an edge this file reported nothing and
+        // a rename left `upsert_note` holding the old name.
+        let edges = references_in(
+            "from parsing import ParsedNote\n\n\nclass NoteStore:\n    def upsert_note(self, note: ParsedNote):\n        return 1\n",
+        );
+        assert!(
+            edges.contains(&(
+                "NoteStore.upsert_note".to_string(),
+                "ParsedNote".to_string()
+            )),
+            "a parameter annotation must reference its class, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn a_return_annotation_references_the_imported_class() {
+        let edges = references_in(
+            "from parsing import ParsedNote\n\n\ndef load(path) -> ParsedNote:\n    return parse(path)\n",
+        );
+        assert!(
+            edges.contains(&("load".to_string(), "ParsedNote".to_string())),
+            "a return annotation must reference its class, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn a_dataclass_field_annotation_references_its_element_type() {
+        // `links: Tuple[WikiLink, ...]` is the type `ParsedNote` is built from.
+        // The subscripted generic must be descended into: the edge belongs to
+        // `WikiLink`, not to `Tuple`.
+        let edges = references_in(
+            "from typing import Tuple\nfrom parsing import WikiLink\n\n\nclass ParsedNote:\n    links: Tuple[WikiLink, ...] = ()\n",
+        );
+        assert!(
+            edges.contains(&("ParsedNote".to_string(), "WikiLink".to_string())),
+            "a dataclass field type must reference its element type, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn every_annotation_wrapper_reaches_the_name_it_carries() {
+        // One fixture per wrapper tree-sitter builds a type expression from, so
+        // a grammar shape that stops the descent is a named failure rather than
+        // a quiet miss somewhere in a larger fixture.
+        let cases: [(&str, &str); 6] = [
+            ("Optional[Note]", "Optional[Note]"),
+            ("bare", "Note"),
+            ("builtin generic", "list[Note]"),
+            ("union", "Note | None"),
+            ("nested generic", "dict[str, list[Note]]"),
+            ("callable", "Callable[[Note], int]"),
+        ];
+        for (label, annotation) in cases {
+            let source = format!(
+                "from typing import Callable, Optional\nfrom parsing import Note\n\n\ndef take(value: {annotation}):\n    return value\n"
+            );
+            let edges = references_in(&source);
+            assert!(
+                edges.contains(&("take".to_string(), "Note".to_string())),
+                "`{label}` annotation `{annotation}` must reach Note, got {edges:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_dotted_annotation_keeps_the_module_qualified_form() {
+        // `import parsing` binds the module, so `parsing.Note` names a member of
+        // it. Reducing that to the bare leaf would guess which module a
+        // same-named class came from, which is the linker's namespace tier's job
+        // and only possible with the dotted form.
+        let edges =
+            references_in("import parsing\n\n\ndef take(value: parsing.Note):\n    return value\n");
+        assert!(
+            edges.contains(&("take".to_string(), "parsing.Note".to_string())),
+            "a dotted annotation must keep its module-qualified form, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn a_quoted_forward_reference_references_the_named_class() {
+        let edges = references_in(
+            "from parsing import Note\n\n\nclass Holder:\n    note: \"Note\" = None\n",
+        );
+        assert!(
+            edges.contains(&("Holder".to_string(), "Note".to_string())),
+            "a quoted forward reference must reference its class, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn a_variadic_parameter_annotation_references_its_class() {
+        let edges = references_in(
+            "from parsing import Note\n\n\ndef take(*args: Note, **kw: Note):\n    return args\n",
+        );
+        assert!(
+            edges.contains(&("take".to_string(), "Note".to_string())),
+            "`*args: Note` must reference its class, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn an_annotation_naming_a_builtin_or_an_unimported_name_emits_nothing() {
+        // The precision half, and the reason the emit filter runs on annotations
+        // rather than letting the linker sort it out: `str` and `int` are
+        // builtins, and `Ghost` is defined in no file this one can reach, so a
+        // blind exact-name tier would bind them to whatever entity elsewhere
+        // happens to carry that name.
+        let edges = references_in(
+            "def take(name: str, count: int, other: Ghost) -> bool:\n    return True\n",
+        );
+        assert!(
+            edges.is_empty(),
+            "a builtin or unimported annotation must emit no reference, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn an_annotation_naming_a_local_binding_emits_nothing() {
+        // A name the function binds itself is not a module-level symbol, so it
+        // must not reach one that happens to share its name.
+        let edges = references_in(
+            "class Note:\n    pass\n\n\ndef take(Note):\n    value: Note = 1\n    return value\n",
+        );
+        assert!(
+            !edges.contains(&("take".to_string(), "Note".to_string())),
+            "a locally bound annotation name must emit no reference, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn a_parameter_name_is_still_not_a_reference() {
+        // Annotations became references; parameter NAMES did not. A parameter
+        // called `note` is a binding, and binding a name is not reading one.
+        let edges =
+            references_in("def note():\n    return 1\n\n\ndef take(note: int):\n    return note\n");
+        assert!(
+            !edges.contains(&("take".to_string(), "note".to_string())),
+            "a parameter name must not reference a same-named function, got {edges:?}"
         );
     }
 }


### PR DESCRIPTION
A Python class named only in a type annotation produced no graph edge of any class, so a parameter type, a return type and a dataclass field type each reached the graph as nothing at all. `find_references` on such a class answered with only the callers in its own file, and it answered confidently: on the reported project it returned one reference with `total_upstream: 1` and `cross_repo.authority_complete: true` while `storage.py` took the class as a parameter type. A reader who renamed on that answer would have left the old name behind in the signature. The same miss hid `WikiLink` from `ParsedNote`, whose `links: Tuple[WikiLink, ...]` field is the type it is built from, so the context pack for the class omitted the type it depends on.

## Mechanism

`crates/kin-parser/src/languages/python.rs` pruned annotations from the value-reference walk kin#877 added. `collect_python_value_refs` (python.rs:579 at 320cf57a) listed `"type"` among the node kinds it skipped outright, `extract_value_refs_from_definition` (python.rs:444 at the same sha) walked parameter defaults but never the `type` field beside them and never the `return_type` field at all, and the annotated `assignment` arm read only its `right` child. `git grep -c UsesType` on that file was 0, so annotations produced no edge of any class rather than an edge of the wrong one.

## The fix

`collect_python_type_refs` walks one annotation subtree and pushes the same `PythonValueRef` records the value walk produces. It is called from three positions: the `type` field of each parameter, which also carries `*args: T` and `**kw: T` whose names sit in a splat pattern while the annotation stays on the same field; the `return_type` field of the function; and the `type` field of an annotated assignment, which is the single shape a class-body field, a module-scope annotation and a body-local annotation all wear.

It descends the wrappers tree-sitter builds a type expression from rather than matching each one, which is what makes `Optional[Note]`, `Tuple[WikiLink, ...]`, `dict[str, Note]`, `Note | None`, `Callable[[Note], int]` and `typing.List[Note]` each reach the names they carry. A quoted forward reference is read only when the quotes hold a bare identifier.

Nothing about binding is new. Candidates go through the existing `emit_python_value_references`, so only a name the file defines or imports may bind, and the resolved edges take the linker tiers a call takes: import-based at 0.95, namespace member at 0.9.

## Why `References` rather than `UsesType`

`UsesType` exists in `kin-model` (`kin-model/src/relation.rs:216`) and the ticket allowed either kind. `References` is the one that works, and that is checkable rather than a preference. `kin_core::reference_coverage::REFERENCE_RELATION_KINDS` (`crates/kin-core/src/reference_coverage.rs:30`) is the published Calls + Imports + References triple, and its own doc says it is the set `find_references` defaults to. `kin_mcp::handlers::common::default_reference_kinds` returns exactly those three, `parse_relation_kinds("all")` in `crates/kin-cli/src/commands/refs.rs:692` returns exactly those three, and the linker gates cross-file resolution on Calls or References at `crates/kin-index/src/linker.rs:1169`, `:3090`, `:3160` and `:5072`. Emitting `UsesType` would have meant editing all four surfaces before the edge could be counted anywhere. That is the argument kin#877 made for value reads, and it holds harder here, because the whole point of this ticket is that `find_references` must count the edge.

## Falsification

Four falsifiers, each applied to the committed tree and then reverted.

Unwiring all three annotation hook sites, which restores the pre-fix behavior exactly, turns 7 of the 10 new parser unit tests red, every one of them reporting `got []`: `a parameter annotation must reference its class, got []`, `a return annotation must reference its class, got []`, `a dataclass field type must reference its element type, got []`, and four more. All 6 linking tests present at that time go red, and 3 of the 4 acceptance tests go red. The rename one is the sharpest, because without the edge `plan_rename` does not merely omit the site, it refuses the whole rename: `exhaustive rename-reference coverage disagrees for graph entity ...: graph declarations and edges require 0 'ParsedNote' occurrence(s), but repository CAS assigns 1; refusing a partial refactor`.

Dropping the `defined.contains(root) || symbol_bound.contains(root)` filter in `emit_python_value_references` turns `an_annotation_naming_a_builtin_or_an_unimported_name_emits_nothing` red with `got [("take", "Ghost"), ("take", "bool"), ("take", "int"), ("take", "str")]`, and `an_annotation_naming_a_class_this_file_never_imported_emits_no_edge_at_all` red with `left: Some(0.7)` against `right: None`, which is the blind cross-file exact-name tier binding a dependency the file never declared.

That second linking test exists because of what the falsification found. The original twin fixture, two modules defining `ParsedNote` where only one is imported, stayed GREEN when the gate was removed, because the name it probes IS imported and the linker's import tier is what holds it, while its comment claimed the extractor's gate was the mechanism. The comment was corrected and a case the gate actually holds was added beside it, in the second commit.

Dropping the shadow set from the annotation walk turns `an_annotation_naming_a_local_binding_emits_nothing` red with `got [("take", "Note")]`. `a_parameter_name_is_still_not_a_reference` needs two rules broken at once to fail, walking the whole parameter node instead of only its `type` field AND dropping the shadow set, after which it reports `got [("take", "note")]`. Breaking either alone leaves it green, which is recorded in its comment rather than left implied.

## Gate

`bin/kin-lane run fir2399-annot kin -- bin/kin-dev local-test kin` printed `local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/fir2399-annot-kin @ 761a85c5 (chore/lane-fir2399-annot-kin)` and `Summary [225.097s] 6033 tests run: 6033 passed (2 slow, 9 leaky), 11 skipped`, exit status 0 read raw. `cargo fmt --all -- --check` exits 0. Clippy run exactly as `ci.yml` runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the workflow's 45-lint allowlist, exits 0. Both zero-file-search guards pass. Tracked `.cargo/` holds only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

`bin/kin-magic-repro` against this lane's release build reads 9 of 9 PASS plus check 0 GPU-OPTOUT PASS, exit status 0. Both binaries stamp `0.5.38 (34c4e911176d302d9478848e86eed705cd3b50d7 chore/lane-fir2399-annot-kin)`, and it ran under the daemon lock taken RC-only.

## Not claimed

Python import statements still carry no entity-level edges; they remain artifact-level, which is FIR-2354's territory. That is why the rename acceptance fixture reaches its class through `import parsing` and `parsing.ParsedNote` rather than `from parsing import ParsedNote`: `require_repository_reference_coverage` refuses outright while a graph source imports the target by name, so the named-import shape cannot reach the rename planner at all today, with or without this change. The acceptance test also does not drive the MCP handler end to end; it reads the graph under `default_reference_kinds` itself, which is the kind filter that decides whether a consumer is reported, and asserts the rendered `kin refs --kind all` answer beside it, because the handler's body projection needs a live repository authority binding an in-memory fixture does not have. Annotations on a function nested inside another function body are not covered, since such a function produces no entity of its own in this adapter.

Closes FIR-2399
