### PR TITLE
Refuse a bare Python call that only a receiver could reach

### DIFF
--- a/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
+++ b/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Acceptance reproduction for the fabricated cross-module call edge a bare
+//! Python builtin used to mint (FIR-2400).
+//!
+//! The fixture is the shape the isolated stranger run hit: a parsing module
+//! that reads a file with the builtin `open`, and a storage module it never
+//! imports whose `NoteStore` exposes an `open` classmethod. The bare name
+//! reached the linker's bare-name index, matched the one entity in the graph
+//! carrying it, and `trace_data_flow` from `ingest_directory` walked a whole
+//! subtree of a module `parsing.py` cannot see, `default_db_path` included.
+//!
+//! Everything here runs through the real Python adapter, the real cross-file
+//! linker, and a real `InMemoryGraph`, which is what `kin init` builds over an
+//! existing tree. The positive controls sit in the same fixture on purpose: the
+//! receiver call `NoteStore.open(path)` in `cli.py` must still resolve, so a
+//! gate that simply deleted the entity from the graph would fail this file.
+
+use std::sync::Arc;
+
+use kin_cli::commands::refs::{build_refs_response, RefsRequest};
+use kin_cli::commands::repository_authority::RequestRepositoryAuthority;
+use kin_cli::commands::trace_data_flow::{
+    build_trace_data_flow_response, TraceDataFlowRequest, TraceDirection,
+};
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+/// `parse_file` reads with the builtin `open` and imports nothing from storage.
+/// This is the call site the ticket names, verbatim in shape.
+const PARSING_PY: &str = r##""""Note parsing."""
+
+import os
+import re
+
+TAG_RE = re.compile(r"#(\w+)")
+
+
+def parse_file(path):
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        text = handle.read()
+    return {"name": os.path.basename(path), "tags": TAG_RE.findall(text)}
+"##;
+
+/// `NoteStore.open` is a classmethod, which no bare-name call can invoke, and
+/// `default_db_path` is reachable from it. In the measured response those were
+/// steps 8 and 16.
+const STORAGE_PY: &str = r#""""Note storage."""
+
+import os
+
+
+def default_db_path(root):
+    return os.path.join(root, "notes.json")
+
+
+class NoteStore:
+    def __init__(self, path):
+        self.path = path
+        self.notes = {}
+
+    @classmethod
+    def open(cls, path):
+        return cls(default_db_path(path))
+
+    def upsert_note(self, note):
+        self.notes[note["name"]] = note
+        return note
+
+    def prune_except(self, keep):
+        self.notes = {k: v for k, v in self.notes.items() if k in keep}
+        return self.notes
+"#;
+
+/// The focal. It never calls `NoteStore.open`, so the only route from here to
+/// the storage module's classmethod is through `parse_file`'s builtin call.
+const INGEST_PY: &str = r#""""Directory ingest."""
+
+import os
+
+from parsing import parse_file
+
+
+def ingest_directory(path, store):
+    for name in os.listdir(path):
+        note = parse_file(os.path.join(path, name))
+        store.upsert_note(note)
+    return store
+"#;
+
+/// The positive control for the receiver path: this file imports the class and
+/// calls the classmethod through it, which must still resolve.
+const CLI_PY: &str = r#""""Command line interface."""
+
+from ingest import ingest_directory
+from storage import NoteStore
+
+
+def open_store(path):
+    return NoteStore.open(path)
+
+
+def main(path):
+    store = open_store(path)
+    return ingest_directory(path, store)
+"#;
+
+fn parse_py(file_path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|entity| entity.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn notekeeper_project() -> (InMemoryGraph, Vec<FileParseData>) {
+    let files = vec![
+        parse_py("cli.py", CLI_PY),
+        parse_py("ingest.py", INGEST_PY),
+        parse_py("parsing.py", PARSING_PY),
+        parse_py("storage.py", STORAGE_PY),
+    ];
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
+
+    let graph = InMemoryGraph::new();
+    for entity in files.iter().flat_map(|file| file.entities.iter()) {
+        graph.upsert_entity(entity).expect("upsert entity");
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    (graph, files)
+}
+
+fn entity_id(files: &[FileParseData], name: &str) -> String {
+    files
+        .iter()
+        .flat_map(|file| file.entities.iter())
+        .find(|entity| entity.name == name)
+        .unwrap_or_else(|| panic!("fixture entity `{name}` not found"))
+        .id
+        .0
+        .to_string()
+}
+
+fn absent_binding() -> kin_core::LocalRepositoryAuthorityBinding {
+    let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
+    kin_core::LocalRepositoryAuthorityBinding::from_parts(
+        kin_model::RepositoryId::new("absent-python-bare-builtin").unwrap(),
+        kin_model::WorkspaceId::new(),
+        Arc::new(kin_db::LocalFileBackend::new(layout.kindb_dir())),
+    )
+}
+
+/// Every entity name `trace_data_flow` reports when it walks callees from
+/// `focal`, at the ticket's own depth and direction.
+fn callee_chain(graph: &InMemoryGraph, files: &[FileParseData], focal: &str) -> Vec<String> {
+    let response = build_trace_data_flow_response(
+        &RequestRepositoryAuthority::pinned(absent_binding()),
+        graph,
+        &TraceDataFlowRequest {
+            focal: entity_id(files, focal),
+            depth: Some(3),
+            direction: Some(TraceDirection::Calls),
+            limit_per_step: Some(25),
+            include_body: Some(false),
+            max_response_chars: None,
+        },
+    )
+    .expect("trace fixture");
+    response
+        .chain
+        .iter()
+        .map(|step| step.entity.entity_name.clone())
+        .collect()
+}
+
+/// The defect, reproduced and closed. `ingest_directory` reaches `parse_file`,
+/// and `parse_file` opens a file. Before the fix that builtin call carried the
+/// trace into `NoteStore.open` and on to `default_db_path`, in a module
+/// `parsing.py` neither imports nor names.
+#[test]
+fn tracing_calls_never_crosses_a_builtin_open_into_the_storage_module() {
+    let (graph, files) = notekeeper_project();
+    let chain = callee_chain(&graph, &files, "ingest_directory");
+
+    assert!(
+        chain.iter().any(|name| name == "parse_file"),
+        "the real cross-module call must still be walked, got {chain:?}"
+    );
+    assert!(
+        !chain.iter().any(|name| name == "NoteStore.open"),
+        "a builtin `open` must not carry the trace into NoteStore.open, got {chain:?}"
+    );
+    assert!(
+        !chain.iter().any(|name| name == "default_db_path"),
+        "nothing under the fabricated edge may be reached, got {chain:?}"
+    );
+}
+
+/// The receiver path this fix must leave working. `cli.py` imports the class
+/// and calls the classmethod through it, so the same two entities the previous
+/// test refuses are exactly what this trace must reach.
+#[test]
+fn tracing_calls_from_an_importing_caller_still_reaches_the_classmethod() {
+    let (graph, files) = notekeeper_project();
+    let chain = callee_chain(&graph, &files, "open_store");
+
+    assert!(
+        chain.iter().any(|name| name == "NoteStore.open"),
+        "`NoteStore.open(path)` in a file importing NoteStore must resolve, got {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|name| name == "default_db_path"),
+        "the classmethod's own callee must still be reached, got {chain:?}"
+    );
+}
+
+/// `find_references` and `trace_data_flow` read the same edges, so the two must
+/// agree about who calls `NoteStore.open`: `open_store` does, `parse_file` never
+/// did.
+#[test]
+fn find_references_on_the_classmethod_lists_the_importing_caller_and_not_the_parser() {
+    let (graph, files) = notekeeper_project();
+    let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
+    let response = build_refs_response(
+        &layout,
+        &graph,
+        &RefsRequest {
+            entity: entity_id(&files, "NoteStore.open"),
+            kind: "all".to_string(),
+        },
+    )
+    .expect("refs fixture");
+    let listing = response.lines.join("\n");
+
+    assert!(
+        listing.contains("open_store"),
+        "the importing caller must be listed, got:\n{listing}"
+    );
+    assert!(
+        !listing.contains("parse_file"),
+        "a bare builtin `open` must not appear as a caller, got:\n{listing}"
+    );
+}

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -19,7 +19,8 @@ use kin_model::{
     Visibility,
 };
 use kin_parser::{
-    is_call_extraction_incomplete_marker, CallArgShape, ExtractedRelation, FileImport,
+    is_call_extraction_incomplete_marker, is_python_builtin_name, CallArgShape, ExtractedRelation,
+    FileImport,
 };
 
 use crate::error::{IndexError, Result as IndexResult};
@@ -853,6 +854,29 @@ fn resolve_one_file(
             continue;
         }
 
+        // (a1) Python builtin gate. `open(path)`, `len(items)` and the rest of
+        // the builtins table are bound by the interpreter, not by this
+        // repository, and the same-file tier above has already given a local
+        // definition its win. Every tier below answers by matching the name
+        // somewhere else in the repo, so without this the one entity in the
+        // graph carrying that name captures the call.
+        if is_unbound_python_builtin_call(
+            rel,
+            src_id,
+            file,
+            dst_same_file.is_some(),
+            ctx.import_map.get(file.file_path.as_str()),
+            &ctx.entity_language_by_id,
+        ) {
+            debug!(
+                src = %rel.src_name,
+                dst = %rel.dst_name,
+                file = %file.file_path,
+                "linker: bare Python builtin call the file neither defines nor imports, leaving unlinked"
+            );
+            continue;
+        }
+
         // (a2) Inheritance-aware receiver-method resolution. The Python adapter
         // emits `self.m()` / `cls.m()` class-qualified (`EnclosingClass.m`), so
         // when the owner half names a class in this file — i.e. the parser
@@ -1112,6 +1136,11 @@ fn resolve_one_file(
                     resolve_caller_import_targets(&file.file_path, &file.imports, &ctx.known_files)
                 });
                 narrow_pairs_by_receiver_reach(candidates, targets, &owner_bound)
+            } else if is_python_bare_identifier_call(rel, src_id, &ctx.entity_language_by_id) {
+                // This tier exists for calls made through a receiver. A bare
+                // Python identifier has none, so no method here is a dispatch
+                // target for it.
+                drop_method_candidates(candidates, &ctx.entity_kind_by_id)
             } else {
                 candidates
             };
@@ -2775,6 +2804,84 @@ where
     }
 }
 
+/// Whether this relation is a Python call written as a bare identifier.
+///
+/// Python is the only adapter that separates the two call shapes at extraction
+/// time: an attribute call carries its receiver as written, a `self`/`cls` call
+/// folds its owner into the callee name, and only a bare `name(...)` arrives
+/// with neither. Adapters that record no receiver at all cannot tell the shapes
+/// apart, so the gates keyed on this predicate stay off their calls rather than
+/// reading a missing receiver as proof of a bare call.
+fn is_python_bare_identifier_call(
+    rel: &ExtractedRelation,
+    src_id: EntityId,
+    languages: &HashMap<EntityId, LanguageId>,
+) -> bool {
+    rel.kind == RelationKind::Calls
+        && rel.receiver.is_none()
+        && !rel.dst_name.contains('.')
+        && !rel.dst_name.contains("::")
+        && languages.get(&src_id) == Some(&LanguageId::Python)
+}
+
+/// Whether a wildcard import could be binding names this file never spells.
+///
+/// `from constants import *` is recorded as an import with no specifiers,
+/// because there is no name to record. Every name that import binds is
+/// therefore invisible here, so a file carrying one has no answer to "does this
+/// file import that name" and the builtin gate stands down instead of guessing.
+fn imports_are_name_complete(imports: &[FileImport]) -> bool {
+    imports.iter().all(|import| !import.specifiers.is_empty())
+}
+
+/// Whether a bare Python call names a builtin this file cannot have rebound.
+///
+/// A module-level name is reachable inside a Python module only when that
+/// module defines it or imports it. So a bare call to a name in the builtins
+/// table, from a file that does neither, is a call into the interpreter, and
+/// every remaining linker tier would answer it by matching the name somewhere
+/// else in the repository. That is how `open(path)` in a parsing module that
+/// imports `os` and `re` acquired a `Calls` edge to `NoteStore.open` in a
+/// storage module it never imports, and a `trace_data_flow` subtree underneath
+/// it.
+///
+/// A local definition or an import of the same name is the shadow Python allows,
+/// and it wins: this returns false there, leaving the same-file and import tiers
+/// to resolve the call exactly as before.
+fn is_unbound_python_builtin_call(
+    rel: &ExtractedRelation,
+    src_id: EntityId,
+    file: &FileParseData,
+    defined_in_file: bool,
+    file_imports: Option<&HashMap<&str, (&str, &str)>>,
+    languages: &HashMap<EntityId, LanguageId>,
+) -> bool {
+    is_python_bare_identifier_call(rel, src_id, languages)
+        && is_python_builtin_name(rel.dst_name.as_str())
+        && !defined_in_file
+        && !file_imports.is_some_and(|imports| imports.contains_key(rel.dst_name.as_str()))
+        && imports_are_name_complete(&file.imports)
+}
+
+/// Drop the method candidates a bare Python call can never dispatch to.
+///
+/// A method needs a receiver to be reached, and a bare `name(...)` has none, so
+/// a same-named method is a decoy however few of them the repository holds. The
+/// bare-name index holds only owner-qualified entities, which is exactly where
+/// `open` found `NoteStore.open`: a `@classmethod` no bare-name call can invoke.
+///
+/// Non-method candidates are left to the builtin and import tiers above; this
+/// filter only answers the receiver question.
+fn drop_method_candidates<'a>(
+    candidates: Vec<(&'a str, EntityId)>,
+    kinds: &HashMap<EntityId, EntityKind>,
+) -> Vec<(&'a str, EntityId)> {
+    candidates
+        .into_iter()
+        .filter(|(_, id)| kinds.get(id) != Some(&EntityKind::Method))
+        .collect()
+}
+
 /// Keep a production call site from resolving to a test entity while a
 /// production entity of the same name is available.
 ///
@@ -4028,7 +4135,7 @@ pub struct IncrementalLinkerCheckpointV1 {
 }
 
 /// Bump whenever [`IncrementalLinkerCheckpointV1`] or linker semantics change.
-pub const INCREMENTAL_LINKER_CHECKPOINT_VERSION: u32 = 4;
+pub const INCREMENTAL_LINKER_CHECKPOINT_VERSION: u32 = 5;
 
 /// Build-time kin-index identity included in the composite hydration
 /// checkpoint version key.
@@ -4758,6 +4865,27 @@ fn resolve_one_file_incremental(
             continue;
         }
 
+        // (a1) Python builtin gate, mirroring the batch linker. A bare call to
+        // a name the interpreter binds, from a file that neither defines nor
+        // imports it, has no destination in this repository and must not be
+        // answered by the name tiers below.
+        if is_unbound_python_builtin_call(
+            rel,
+            src_id,
+            file,
+            dst_same_file.is_some(),
+            import_map.get(file.file_path.as_str()),
+            &linker.entity_language_by_id,
+        ) {
+            debug!(
+                src = %rel.src_name,
+                dst = %rel.dst_name,
+                file = %file.file_path,
+                "linker(incremental): bare Python builtin call the file neither defines nor imports, leaving unlinked"
+            );
+            continue;
+        }
+
         // (a2) Inheritance-aware receiver-method resolution — mirrors the
         // batch linker: a class-qualified `self.m()`/`cls.m()` callee whose
         // owner is a class in this file resolves through the recorded
@@ -5017,6 +5145,11 @@ fn resolve_one_file_incremental(
                         )
                     });
                     narrow_pairs_by_receiver_reach(candidates, targets, &owner_bound)
+                } else if is_python_bare_identifier_call(rel, src_id, &linker.entity_language_by_id)
+                {
+                    // A bare Python identifier carries no receiver, and this
+                    // tier resolves calls that have one.
+                    drop_method_candidates(candidates, &linker.entity_kind_by_id)
                 } else {
                     candidates
                 };
@@ -5280,6 +5413,7 @@ mod tests {
         ArtifactId, EntityKind, EntityMetadata, EntityRole, FilePathId, FingerprintAlgorithm,
         GraphNodeId, Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
     };
+    use kin_parser::ImportedName;
     use std::sync::{Mutex, OnceLock};
 
     #[test]
@@ -7153,6 +7287,429 @@ void f();
             .expect("incremental unambiguous receiver-method call should resolve to Type::method");
         assert_eq!(calls.src, GraphNodeId::Entity(caller.id));
         assert_eq!(calls.dst, GraphNodeId::Entity(callee.id));
+    }
+
+    fn make_python_entity(name: &str, file_path: &str, kind: EntityKind) -> Entity {
+        let mut entity = make_entity(name, file_path);
+        entity.language = LanguageId::Python;
+        entity.kind = kind;
+        entity
+    }
+
+    fn python_import(module_path: &str, names: &[&str]) -> FileImport {
+        FileImport {
+            module_path: module_path.to_string(),
+            specifiers: names
+                .iter()
+                .map(|name| ImportedName {
+                    local_name: (*name).to_string(),
+                    original_name: None,
+                    is_default: false,
+                })
+                .collect(),
+        }
+    }
+
+    fn bare_call(src_name: &str, dst_name: &str) -> ExtractedRelation {
+        ExtractedRelation {
+            receiver: None,
+            call_shape: None,
+            kind: RelationKind::Calls,
+            src_name: src_name.to_string(),
+            dst_name: dst_name.to_string(),
+            import_source: None,
+        }
+    }
+
+    /// The FIR-2400 shape exactly: `parse_file` opens a path with the builtin
+    /// `open`, and a storage module the parsing module never imports defines a
+    /// `NoteStore.open` classmethod. The bare-name index held one entry, so it
+    /// captured the call and `trace_data_flow` walked a subtree of a module the
+    /// file cannot see.
+    #[test]
+    fn a_bare_python_builtin_call_reaches_no_cross_module_method() {
+        let caller =
+            make_python_entity("parse_file", "notekeeper/parsing.py", EntityKind::Function);
+        let method = make_python_entity(
+            "NoteStore.open",
+            "notekeeper/storage.py",
+            EntityKind::Method,
+        );
+
+        let files = vec![
+            FileParseData {
+                file_path: "notekeeper/parsing.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![bare_call("parse_file", "open")],
+                imports: vec![python_import("os", &["os"]), python_import("re", &["re"])],
+            },
+            FileParseData {
+                file_path: "notekeeper/storage.py".to_string(),
+                entities: vec![method.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let calls: Vec<&Relation> = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .collect();
+        assert!(
+            calls.is_empty(),
+            "a bare builtin call must not reach a method of an unimported module, got {calls:?}"
+        );
+    }
+
+    /// The same gate with a module-level function as the decoy. A method needs a
+    /// receiver, but a same-named free function does not, so only the builtin
+    /// table can refuse this one.
+    #[test]
+    fn a_bare_python_builtin_call_reaches_no_cross_module_function() {
+        let caller =
+            make_python_entity("parse_file", "notekeeper/parsing.py", EntityKind::Function);
+        let decoy = make_python_entity("open", "notekeeper/storage.py", EntityKind::Function);
+        let counted = make_python_entity("len", "notekeeper/metrics.py", EntityKind::Function);
+
+        let files = vec![
+            FileParseData {
+                file_path: "notekeeper/parsing.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![
+                    bare_call("parse_file", "open"),
+                    bare_call("parse_file", "len"),
+                ],
+                imports: vec![python_import("os", &["os"])],
+            },
+            FileParseData {
+                file_path: "notekeeper/storage.py".to_string(),
+                entities: vec![decoy.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "notekeeper/metrics.py".to_string(),
+                entities: vec![counted.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let calls: Vec<&Relation> = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .collect();
+        assert!(
+            calls.is_empty(),
+            "bare `open`/`len` calls must not reach same-named module functions, got {calls:?}"
+        );
+    }
+
+    /// The receiver half of the fix, on a name no builtins table contains: a
+    /// bare `prune_except(...)` cannot dispatch to `NoteStore.prune_except`,
+    /// because a method call needs a receiver and this call site has none.
+    #[test]
+    fn a_bare_python_call_reaches_no_method_it_has_no_receiver_for() {
+        let caller = make_python_entity("run_gc", "notekeeper/cleanup.py", EntityKind::Function);
+        let method = make_python_entity(
+            "NoteStore.prune_except",
+            "notekeeper/storage.py",
+            EntityKind::Method,
+        );
+
+        let files = vec![
+            FileParseData {
+                file_path: "notekeeper/cleanup.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![bare_call("run_gc", "prune_except")],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "notekeeper/storage.py".to_string(),
+                entities: vec![method.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let calls: Vec<&Relation> = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .collect();
+        assert!(
+            calls.is_empty(),
+            "a bare call must not dispatch to a method, got {calls:?}"
+        );
+    }
+
+    /// Recall control for the builtin gate: a module that defines its own
+    /// `open` shadows the interpreter's, and the same-file tier must still bind
+    /// the call at full confidence.
+    #[test]
+    fn a_python_module_that_defines_open_still_resolves_its_own_call() {
+        let caller =
+            make_python_entity("parse_file", "notekeeper/parsing.py", EntityKind::Function);
+        let local_open = make_python_entity("open", "notekeeper/parsing.py", EntityKind::Function);
+
+        let files = vec![FileParseData {
+            file_path: "notekeeper/parsing.py".to_string(),
+            entities: vec![caller.clone(), local_open.clone()],
+            relations: vec![bare_call("parse_file", "open")],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file(&files);
+        let call = result
+            .iter()
+            .find(|r| r.kind == RelationKind::Calls)
+            .expect("a same-file `open` must still resolve");
+        assert_eq!(call.src, GraphNodeId::Entity(caller.id));
+        assert_eq!(call.dst, GraphNodeId::Entity(local_open.id));
+        assert_eq!(call.confidence, 1.0);
+    }
+
+    /// Recall control for the import half: `from storage import open_store` and
+    /// a bare `open_store(...)` is the shape the ticket asks to keep, and an
+    /// imported builtin name must keep resolving too.
+    #[test]
+    fn an_imported_python_name_still_resolves_including_a_builtin_one() {
+        let caller =
+            make_python_entity("parse_file", "notekeeper/parsing.py", EntityKind::Function);
+        let imported =
+            make_python_entity("open_store", "notekeeper/storage.py", EntityKind::Function);
+        let shadow = make_python_entity("open", "notekeeper/storage.py", EntityKind::Function);
+
+        let files = vec![
+            FileParseData {
+                file_path: "notekeeper/parsing.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![
+                    bare_call("parse_file", "open_store"),
+                    bare_call("parse_file", "open"),
+                ],
+                imports: vec![python_import("notekeeper.storage", &["open_store", "open"])],
+            },
+            FileParseData {
+                file_path: "notekeeper/storage.py".to_string(),
+                entities: vec![imported.clone(), shadow.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let targets: HashSet<GraphNodeId> = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls && r.src == GraphNodeId::Entity(caller.id))
+            .map(|r| r.dst)
+            .collect();
+        assert!(
+            targets.contains(&GraphNodeId::Entity(imported.id)),
+            "an imported name must still resolve, got {targets:?}"
+        );
+        assert!(
+            targets.contains(&GraphNodeId::Entity(shadow.id)),
+            "an imported symbol that shadows a builtin must still resolve, got {targets:?}"
+        );
+    }
+
+    /// The receiver path this fix must leave alone: a file that imports the
+    /// class and calls `store.open()` reaches `NoteStore.open` through the
+    /// receiver-reach narrowing kin#888 added.
+    #[test]
+    fn a_receiver_call_on_an_imported_class_still_resolves() {
+        let caller = make_python_entity("ingest", "notekeeper/ingest.py", EntityKind::Function);
+        let method = make_python_entity(
+            "NoteStore.open",
+            "notekeeper/storage.py",
+            EntityKind::Method,
+        );
+
+        let files = vec![
+            FileParseData {
+                file_path: "notekeeper/ingest.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![ExtractedRelation {
+                    receiver: Some("store".to_string()),
+                    call_shape: None,
+                    kind: RelationKind::Calls,
+                    src_name: "ingest".to_string(),
+                    dst_name: "open".to_string(),
+                    import_source: None,
+                }],
+                imports: vec![python_import("notekeeper.storage", &["NoteStore"])],
+            },
+            FileParseData {
+                file_path: "notekeeper/storage.py".to_string(),
+                entities: vec![method.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let call = result
+            .iter()
+            .find(|r| r.kind == RelationKind::Calls)
+            .expect("`store.open()` in a file importing NoteStore must still resolve");
+        assert_eq!(call.src, GraphNodeId::Entity(caller.id));
+        assert_eq!(call.dst, GraphNodeId::Entity(method.id));
+    }
+
+    /// A wildcard import records no names, so the file has no answer to "do you
+    /// import `open`". The gate stands down rather than dropping an edge it
+    /// cannot see the binding for.
+    #[test]
+    fn a_wildcard_import_stands_the_python_builtin_gate_down() {
+        let caller =
+            make_python_entity("parse_file", "notekeeper/parsing.py", EntityKind::Function);
+        let shadow = make_python_entity("open", "notekeeper/compat.py", EntityKind::Function);
+
+        let files = vec![
+            FileParseData {
+                file_path: "notekeeper/parsing.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![bare_call("parse_file", "open")],
+                imports: vec![FileImport {
+                    module_path: "notekeeper.compat".to_string(),
+                    specifiers: Vec::new(),
+                }],
+            },
+            FileParseData {
+                file_path: "notekeeper/compat.py".to_string(),
+                entities: vec![shadow.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let call = result
+            .iter()
+            .find(|r| r.kind == RelationKind::Calls)
+            .expect("a star import may bind `open`, so the gate must not fire");
+        assert_eq!(call.dst, GraphNodeId::Entity(shadow.id));
+    }
+
+    /// The gates are Python-scoped because Python is the only adapter that
+    /// records a receiver for attribute calls. An adapter that records none
+    /// cannot distinguish `x.open()` from `open()`, so reading its missing
+    /// receiver as proof of a bare call would drop every receiver-method edge
+    /// it resolves.
+    #[test]
+    fn a_non_python_bare_call_still_reaches_its_method() {
+        let mut caller = make_entity("build", "src/wiring.ts");
+        caller.language = LanguageId::TypeScript;
+        let mut method = make_entity("Store.open", "src/store.ts");
+        method.language = LanguageId::TypeScript;
+        method.kind = EntityKind::Method;
+
+        let files = vec![
+            FileParseData {
+                file_path: "src/wiring.ts".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![bare_call("build", "open")],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/store.ts".to_string(),
+                entities: vec![method.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let call = result
+            .iter()
+            .find(|r| r.kind == RelationKind::Calls)
+            .expect("a TypeScript receiver-method call must still resolve");
+        assert_eq!(call.dst, GraphNodeId::Entity(method.id));
+    }
+
+    /// Incremental parity: a relink of the caller alone must not re-mint the
+    /// edge the batch linker refuses.
+    #[test]
+    fn incremental_bare_python_builtin_call_reaches_no_cross_module_method() {
+        let caller =
+            make_python_entity("parse_file", "notekeeper/parsing.py", EntityKind::Function);
+        let method = make_python_entity(
+            "NoteStore.open",
+            "notekeeper/storage.py",
+            EntityKind::Method,
+        );
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file(
+            "notekeeper/parsing.py",
+            admitted_artifact_id("notekeeper/parsing.py"),
+            std::slice::from_ref(&caller),
+        );
+        linker.add_file(
+            "notekeeper/storage.py",
+            admitted_artifact_id("notekeeper/storage.py"),
+            std::slice::from_ref(&method),
+        );
+
+        let files = vec![FileParseData {
+            file_path: "notekeeper/parsing.py".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![bare_call("parse_file", "open")],
+            imports: vec![python_import("os", &["os"])],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let calls: Vec<&Relation> = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .collect();
+        assert!(
+            calls.is_empty(),
+            "incremental relink must not re-mint the builtin edge, got {calls:?}"
+        );
+    }
+
+    /// Incremental parity for the receiver half.
+    #[test]
+    fn incremental_bare_python_call_reaches_no_method_it_has_no_receiver_for() {
+        let caller = make_python_entity("run_gc", "notekeeper/cleanup.py", EntityKind::Function);
+        let method = make_python_entity(
+            "NoteStore.prune_except",
+            "notekeeper/storage.py",
+            EntityKind::Method,
+        );
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file(
+            "notekeeper/cleanup.py",
+            admitted_artifact_id("notekeeper/cleanup.py"),
+            std::slice::from_ref(&caller),
+        );
+        linker.add_file(
+            "notekeeper/storage.py",
+            admitted_artifact_id("notekeeper/storage.py"),
+            std::slice::from_ref(&method),
+        );
+
+        let files = vec![FileParseData {
+            file_path: "notekeeper/cleanup.py".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![bare_call("run_gc", "prune_except")],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let calls: Vec<&Relation> = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .collect();
+        assert!(
+            calls.is_empty(),
+            "incremental relink must not dispatch a bare call to a method, got {calls:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/mod.rs
+++ b/crates/kin-parser/src/languages/mod.rs
@@ -23,7 +23,7 @@ pub use java::JavaAdapter;
 pub use javascript::JavaScriptAdapter;
 pub use kotlin::KotlinAdapter;
 pub use php::PhpAdapter;
-pub use python::PythonAdapter;
+pub use python::{is_python_builtin_name, PythonAdapter, PYTHON_BUILTIN_NAMES};
 pub use rust_lang::RustAdapter;
 pub use shallow_backed::{CSharpAdapter, RubyAdapter};
 pub use swift::SwiftAdapter;

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -13,6 +13,180 @@ use crate::extract::{
     ExtractedTest, ExtractedTestKind, FileImport, ImportedName, ParseOutput,
 };
 
+/// Every public name CPython's `builtins` module binds, sorted so
+/// [`is_python_builtin_name`] can binary-search it.
+///
+/// Read off `sorted(n for n in dir(builtins) if not n.startswith("_"))` on
+/// CPython 3.13, plus `WindowsError`, which the language reference documents as
+/// a built-in exception that only a Windows interpreter binds. Transcribing a
+/// remembered dozen would leave the rest of the table resolving by name, and the
+/// names left out are not the obvious ones: `format`, `id`, `filter`, `next` and
+/// `exit` all read like ordinary repository functions.
+///
+/// This is a complete list rather than a heuristic because Python makes it one.
+/// A module-level name is reachable inside a module only when that module
+/// defines it or imports it, so a bare call this file does neither for is a call
+/// into the interpreter, whatever a same-named symbol elsewhere in the
+/// repository looks like.
+pub const PYTHON_BUILTIN_NAMES: &[&str] = &[
+    "ArithmeticError",
+    "AssertionError",
+    "AttributeError",
+    "BaseException",
+    "BaseExceptionGroup",
+    "BlockingIOError",
+    "BrokenPipeError",
+    "BufferError",
+    "BytesWarning",
+    "ChildProcessError",
+    "ConnectionAbortedError",
+    "ConnectionError",
+    "ConnectionRefusedError",
+    "ConnectionResetError",
+    "DeprecationWarning",
+    "EOFError",
+    "Ellipsis",
+    "EncodingWarning",
+    "EnvironmentError",
+    "Exception",
+    "ExceptionGroup",
+    "False",
+    "FileExistsError",
+    "FileNotFoundError",
+    "FloatingPointError",
+    "FutureWarning",
+    "GeneratorExit",
+    "IOError",
+    "ImportError",
+    "ImportWarning",
+    "IndentationError",
+    "IndexError",
+    "InterruptedError",
+    "IsADirectoryError",
+    "KeyError",
+    "KeyboardInterrupt",
+    "LookupError",
+    "MemoryError",
+    "ModuleNotFoundError",
+    "NameError",
+    "None",
+    "NotADirectoryError",
+    "NotImplemented",
+    "NotImplementedError",
+    "OSError",
+    "OverflowError",
+    "PendingDeprecationWarning",
+    "PermissionError",
+    "ProcessLookupError",
+    "PythonFinalizationError",
+    "RecursionError",
+    "ReferenceError",
+    "ResourceWarning",
+    "RuntimeError",
+    "RuntimeWarning",
+    "StopAsyncIteration",
+    "StopIteration",
+    "SyntaxError",
+    "SyntaxWarning",
+    "SystemError",
+    "SystemExit",
+    "TabError",
+    "TimeoutError",
+    "True",
+    "TypeError",
+    "UnboundLocalError",
+    "UnicodeDecodeError",
+    "UnicodeEncodeError",
+    "UnicodeError",
+    "UnicodeTranslateError",
+    "UnicodeWarning",
+    "UserWarning",
+    "ValueError",
+    "Warning",
+    "WindowsError",
+    "ZeroDivisionError",
+    "abs",
+    "aiter",
+    "all",
+    "anext",
+    "any",
+    "ascii",
+    "bin",
+    "bool",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "complex",
+    "copyright",
+    "credits",
+    "delattr",
+    "dict",
+    "dir",
+    "divmod",
+    "enumerate",
+    "eval",
+    "exec",
+    "exit",
+    "filter",
+    "float",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "hex",
+    "id",
+    "input",
+    "int",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "len",
+    "license",
+    "list",
+    "locals",
+    "map",
+    "max",
+    "memoryview",
+    "min",
+    "next",
+    "object",
+    "oct",
+    "open",
+    "ord",
+    "pow",
+    "print",
+    "property",
+    "quit",
+    "range",
+    "repr",
+    "reversed",
+    "round",
+    "set",
+    "setattr",
+    "slice",
+    "sorted",
+    "staticmethod",
+    "str",
+    "sum",
+    "super",
+    "tuple",
+    "type",
+    "vars",
+    "zip",
+];
+
+/// Whether a bare Python name is bound by the interpreter itself.
+pub fn is_python_builtin_name(name: &str) -> bool {
+    PYTHON_BUILTIN_NAMES.binary_search(&name).is_ok()
+}
+
 pub struct PythonAdapter;
 
 impl LanguageAdapter for PythonAdapter {
@@ -1135,6 +1309,68 @@ fn extract_py_from_import(node: &tree_sitter::Node, source: &[u8]) -> Option<Fil
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [`is_python_builtin_name`] binary-searches the table, which is only
+    /// correct while the table is sorted and holds no duplicate. A hand edit
+    /// that breaks either would make the lookup miss names silently, which
+    /// reads exactly like a name the interpreter does not bind.
+    #[test]
+    fn the_builtin_table_is_sorted_deduped_and_searchable() {
+        let mut sorted = PYTHON_BUILTIN_NAMES.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.as_slice(),
+            PYTHON_BUILTIN_NAMES,
+            "the builtins table must stay sorted and deduped for binary search"
+        );
+        for name in PYTHON_BUILTIN_NAMES {
+            assert!(
+                is_python_builtin_name(name),
+                "every table entry must be findable, missed {name}"
+            );
+        }
+    }
+
+    /// The table is the full `dir(builtins)` surface, not the handful of names
+    /// a reader remembers. The ones checked here are the ones a call-resolution
+    /// gate needs and a hand-typed list omits.
+    #[test]
+    fn the_builtin_table_covers_the_names_a_hand_typed_list_would_miss() {
+        for name in [
+            "open",
+            "print",
+            "len",
+            "range",
+            "str",
+            "list",
+            "format",
+            "id",
+            "filter",
+            "next",
+            "exit",
+            "vars",
+            "aiter",
+            "ValueError",
+            "StopIteration",
+            "NotImplemented",
+        ] {
+            assert!(is_python_builtin_name(name), "{name} must be a builtin");
+        }
+        for name in [
+            "NoteStore",
+            "parse_file",
+            "open_store",
+            "ingest_directory",
+            "os",
+            "",
+        ] {
+            assert!(
+                !is_python_builtin_name(name),
+                "{name} must not be read as a builtin"
+            );
+        }
+    }
 
     /// Depth-first search for the first `call` node in a parsed tree.
     fn first_call_node<'a>(node: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -57,9 +57,10 @@ pub use extract::{
     FILE_SURFACE_CONTEXT_KEY,
 };
 pub use languages::{
-    attach_go_command_effect_contract_metadata, AdapterRegistry, CAdapter, CSharpAdapter,
-    CppAdapter, GoAdapter, HclAdapter, JavaAdapter, JavaScriptAdapter, KotlinAdapter, PhpAdapter,
-    PythonAdapter, RubyAdapter, RustAdapter, SwiftAdapter, TypeScriptAdapter,
+    attach_go_command_effect_contract_metadata, is_python_builtin_name, AdapterRegistry, CAdapter,
+    CSharpAdapter, CppAdapter, GoAdapter, HclAdapter, JavaAdapter, JavaScriptAdapter,
+    KotlinAdapter, PhpAdapter, PythonAdapter, RubyAdapter, RustAdapter, SwiftAdapter,
+    TypeScriptAdapter, PYTHON_BUILTIN_NAMES,
 };
 pub use shallow::{
     extract_shallow, get_shallow_grammar, parse_shallow_file, ShallowDecl, ShallowDeclKind,


### PR DESCRIPTION
A bare call to a Python builtin resolved by name alone to whatever single entity in the repository carried that name. On the six-module fixture the isolated stranger run used, `parse_file` in `parsing.py` reads a file with `open(path, "r", encoding="utf-8", errors="replace")`, and the linker's bare-name index held exactly one `open`: the `NoteStore.open` classmethod in a storage module `parsing.py` never imports. That single candidate captured the call, so `trace_data_flow` from `ingest_directory` walked into the storage module and reached `default_db_path` underneath it, and `find_references` on the classmethod listed `parse_file` as a caller.

## Mechanism

A bare `open(...)` reaches the linker as `ExtractedRelation { receiver: None, dst_name: "open" }` (`crates/kin-parser/src/languages/python.rs`, `extract_named_callee`, the `identifier` arm). It then falls past every tier that could prove a destination: same-file finds nothing, the `self`/`cls` walk needs a dotted callee, the import tiers find no `open` in the file's import map, and the exact-name bucket holds none because a method is indexed under `NoteStore.open`. It lands at the receiver-method fan-out, `crates/kin-index/src/linker.rs` tier (c2), which reads `entity_by_bare_name["open"]`, finds the one method there, and emits it at confidence 0.3, which `RelationResolution::of` classifies `name_only`.

The value-reference path already applied the right rule and the Calls path did not: `emit_python_value_references` binds only a name the file defines or imports, and its test `a_name_this_file_neither_defines_nor_imports_emits_no_reference` covers `len`. Nothing equivalent guarded a call.

## The fix

Two gates, in `resolve_one_file` and its incremental twin `resolve_one_file_incremental`.

Tier (a1), the builtin gate: a bare identifier naming a Python builtin, from a file that neither defines nor imports it, emits no edge and logs the gap. This is not a heuristic. A module-level name is reachable inside a Python module only through a definition or an import, so there is no third possibility to preserve. The table is the full public surface of CPython's `builtins` module, read off `sorted(n for n in dir(builtins) if not n.startswith("_"))` on CPython 3.13 plus `WindowsError`, 151 names, and lives in `crates/kin-parser/src/languages/python.rs` as `PYTHON_BUILTIN_NAMES` with `is_python_builtin_name` binary-searching it. A remembered dozen would have omitted `format`, `id`, `filter`, `next` and `exit`, which all read like ordinary repository functions.

Inside tier (c2), the method gate: a bare identifier never binds to a method-kind entity, because a method needs a receiver and this call shape has none. That tier exists for calls made through a receiver.

Both gates are scoped to Python. Python is the only adapter that separates the shapes at extraction time: an attribute call carries its receiver as written, a `self`/`cls` call folds its owner into the callee name, so a relation with neither is a bare identifier. Ten of the thirteen adapters record no receiver at all, so reading a missing receiver as proof of a bare call there would drop every receiver-method edge they resolve. `a_non_python_bare_call_still_reaches_its_method` pins that scoping.

A wildcard import records no specifiers, because there is no name to record, so a file carrying one cannot answer whether it binds the name and the builtin gate stands down rather than guessing. `INCREMENTAL_LINKER_CHECKPOINT_VERSION` is bumped 4 to 5, which its own doc comment requires on a linker semantics change.

## Falsification

Each gate was removed in turn and the named test went red. Both were restored; the tree carries neither edit.

Builtin gate off, method gate on: `a_bare_python_builtin_call_reaches_no_cross_module_function` FAILED, "bare `open`/`len` calls must not reach same-named module functions", two `confidence: 0.7` edges. 113 passed, 1 failed.

Method gate off, builtin gate on: `a_bare_python_call_reaches_no_method_it_has_no_receiver_for` and its incremental twin FAILED, "a bare call must not dispatch to a method", `confidence: 0.3`. 112 passed, 2 failed.

Both off: the ticket's own shape FAILED, `a_bare_python_builtin_call_reaches_no_cross_module_method`, "a bare builtin `open` must not reach a method of an unimported module", `confidence: 0.3`. 109 passed, 5 failed.

Both off, end to end: `tracing_calls_never_crosses_a_builtin_open_into_the_storage_module` FAILED with the chain `["parse_file", "NoteStore.upsert_note", "NoteStore.open", "TAG_RE", "default_db_path"]`, and the refs test FAILED with:

```
References to 'NoteStore.open' (Method) @ storage.py
referenced by 2 entities:
  open_store @ cli.py:7 [Calls] (import_scoped)
  parse_file @ parsing.py:9 [Calls] (name_only)
```

The positive control `tracing_calls_from_an_importing_caller_still_reaches_the_classmethod` stayed green in that same run, which is what says the gates refuse an edge rather than delete an entity.

## Tests

Ten unit tests in `crates/kin-index/src/linker.rs`, three acceptance tests in a new `crates/kin-cli/tests/python_bare_builtin_call_resolution.rs` that run the real Python adapter, the real cross-file linker, and a real `InMemoryGraph`, and two tests in `crates/kin-parser/src/languages/python.rs` for the table's sortedness and its coverage of the names a short list omits.

Recall controls, all green: a module defining its own `open` still binds at confidence 1.0; an imported symbol shadowing a builtin still resolves; `from storage import open_store` plus a bare `open_store(...)` still resolves; `store.open()` in a file importing `NoteStore` still resolves through the receiver scoping kin#888 added; a star import stands the builtin gate down; a TypeScript bare call still reaches its method.

## Gate

`bin/kin-lane run fir2400-builtin kin -- bin/kin-dev local-test kin` printed `local-test: kin /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/fir2400-builtin-kin @ d21dc8b2 (chore/lane-fir2400-builtin-kin)`, then `Summary [852.889s] 6027 tests run: 6027 passed (3 slow, 2 leaky), 11 skipped`, exit status 0 read raw. `cargo fmt --all -- --check` exit 0. Clippy exactly as `.github/workflows/ci.yml` runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the workflow's 45-lint allowlist, exit 0.

Main moved two commits after that gate, a v0.5.39 release bump and the glibc floor scripts, neither touching linker or parser code. The branch was rebased onto `320cf57a` and the three affected suites re-run at the new tip: kin-index linker 114 passed, the new acceptance file 3 passed, the parser table tests 2 passed. `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

## Magic repro

`bin/kin-magic-repro` ran against this lane's own release build, both binaries, under the `daemon` lock taken RC-only and released in a trap. The GPU lock was never taken and the suite exports `KIN_DAEMON_AUTO_EMBED=0`, which its own check 0 asserts the daemon honored. Both binaries stamp `0.5.39 (fde606a83e71d7de7bcca0fc4dad682d047357ad chore/lane-fir2400-builtin-kin)`. Result: `10 pass, 0 fail, 0 unreadable`, exit status 0, checks 0 through 9. CHECK 5, the FIR-2360 call-edge-precision check that shares this territory, reads `PASS the ambiguous receiver in Session.drain produced 1 edge(s)`.

Closes FIR-2400
