### PR TITLE
Mark a context pack's same-file fallback rows and keep the focal body in compact mode

### DIFF
--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -69,6 +69,27 @@ pub struct ContextTarget {
     pub budget_tokens: usize,
 }
 
+/// How the pack's dependency section was filled.
+///
+/// A pack whose focal has no dependency edge falls back to neighbours from the
+/// focal's own file, and the pack carries no field saying so: the tag lives in
+/// a comment inside each entry's content. `kin context` and the
+/// `get_context_pack` MCP tool report these same facts under these same names,
+/// so a reader moving between the two surfaces is not learning two
+/// vocabularies for one selection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextDependencySelection {
+    /// `dependency_edges` or `same_file_fallback`.
+    pub source: String,
+    /// Rows in `pack.dependency_signatures`.
+    pub returned: usize,
+    /// Same-file neighbours the fallback had to choose from. Zero when the
+    /// fallback did not run.
+    pub same_file_candidates: usize,
+    /// Same-file neighbours the cap or the token budget dropped.
+    pub same_file_dropped: usize,
+}
+
 /// The context response, structured half added alongside the rendered lines.
 ///
 /// `lines` stays first and required so an older client keeps decoding this, and
@@ -84,6 +105,10 @@ pub struct ContextResponse {
     /// rendering answers with guidance rather than a pack.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pack: Option<kin_model::context::ContextPack>,
+    /// Absent for the same reason as `pack`, and from a daemon that predates
+    /// the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dependency_selection: Option<ContextDependencySelection>,
 }
 
 pub async fn run(
@@ -161,6 +186,7 @@ pub fn build_context_response(
             schema_version: CONTEXT_RESPONSE_SCHEMA_VERSION.to_string(),
             target: None,
             pack: None,
+            dependency_selection: None,
         });
     };
     let opts = kin_context::ContextOptions {
@@ -172,7 +198,8 @@ pub fn build_context_response(
         assistant_hint,
     };
 
-    let pack = kin_context::build_context_pack(graph, &target.id, &opts)?;
+    let (pack, selection) =
+        kin_context::build_context_pack_with_provenance(graph, &target.id, &opts)?;
 
     let mut lines = vec![
         format!("Context pack for '{}' ({:?}):", target.name, target.kind),
@@ -183,8 +210,9 @@ pub fn build_context_response(
         ),
         format!("  Focal: {} entries", pack.focal_entities.len()),
         format!(
-            "  Dependencies: {} entries",
-            pack.dependency_signatures.len()
+            "  Dependencies: {} entries{}",
+            pack.dependency_signatures.len(),
+            dependency_selection_note(&selection, pack.dependency_signatures.len())
         ),
         format!("  Transitive: {} entries", pack.transitive_deps.len()),
         format!("  Contracts: {} entries", pack.contracts.len()),
@@ -212,8 +240,35 @@ pub fn build_context_response(
             kind: format!("{:?}", target.kind),
             budget_tokens: token_budget.max_tokens(),
         }),
+        dependency_selection: Some(ContextDependencySelection {
+            source: selection.source().as_str().to_string(),
+            returned: pack.dependency_signatures.len(),
+            same_file_candidates: selection.same_file_candidates(),
+            same_file_dropped: selection.same_file_dropped(),
+        }),
         pack: Some(pack),
     })
+}
+
+/// The parenthetical after the dependency count in the human rendering.
+///
+/// Six rows on a class with twenty-four methods and no dependency edges look
+/// exactly like six dependencies, so the rendering says which selection ran and
+/// what the cap dropped rather than leaving the reader to infer it from a
+/// comment buried in each entry.
+fn dependency_selection_note(
+    selection: &kin_context::DependencySelection,
+    returned: usize,
+) -> String {
+    match selection.source() {
+        kin_context::DependencySource::DependencyEdges if returned == 0 => String::new(),
+        kin_context::DependencySource::DependencyEdges => " (dependency edges)".to_string(),
+        kin_context::DependencySource::SameFileFallback => format!(
+            " (same-file neighbors, no dependency edges; kept {} of {})",
+            selection.same_file_kept(),
+            selection.same_file_candidates()
+        ),
+    }
 }
 
 fn resolve_context_target(
@@ -438,6 +493,100 @@ mod tests {
         );
         assert!(older.pack.is_none());
         assert_eq!(older.lines.len(), 1);
+    }
+
+    fn file_entity(name: &str, kind: EntityKind, file: &str) -> Entity {
+        let mut entity = test_entity_kind(name, kind);
+        entity.file_origin = Some(kin_model::FilePathId::new(file));
+        entity
+    }
+
+    /// `kin context` on a class with no dependency edges lists same-file
+    /// neighbours under a heading that says "Dependencies", and the only tag
+    /// saying otherwise was a comment inside each entry. The rendering and the
+    /// structured half both name the selection now, in the same words the MCP
+    /// tool uses.
+    #[test]
+    fn a_same_file_fallback_says_so_in_both_halves_of_the_response() {
+        let graph = kin_db::InMemoryGraph::new();
+        let class = file_entity("NoteStore", EntityKind::Class, "src/notes.py");
+        graph.upsert_entity(&class).unwrap();
+        for member in ["NoteStore.open", "NoteStore.close", "NoteStore.stats"] {
+            graph
+                .upsert_entity(&file_entity(member, EntityKind::Method, "src/notes.py"))
+                .unwrap();
+        }
+
+        let response = build_context_response(
+            &graph,
+            &ContextRequest {
+                entity: "NoteStore".to_string(),
+                budget: "8k".to_string(),
+                assistant: None,
+            },
+        )
+        .expect("a resolved entity builds a context response");
+
+        let rendered = response.lines.join("\n");
+        assert!(
+            rendered.contains(
+                "Dependencies: 3 entries (same-file neighbors, no dependency edges; kept 3 of 3)"
+            ),
+            "the human rendering must name the fallback: {rendered}"
+        );
+        let selection = response
+            .dependency_selection
+            .as_ref()
+            .expect("a resolved pack reports how its dependencies were selected");
+        assert_eq!(selection.source, "same_file_fallback");
+        assert_eq!(selection.returned, 3);
+        assert_eq!(selection.same_file_candidates, 3);
+        assert_eq!(selection.same_file_dropped, 0);
+    }
+
+    /// The control: a focal with a real edge must be reported as edges on this
+    /// surface too, or the fallback wording says nothing.
+    #[test]
+    fn a_pack_built_from_edges_is_not_reported_as_a_fallback() {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+
+        let graph = kin_db::InMemoryGraph::new();
+        let caller = file_entity("read_notes", EntityKind::Function, "src/reader.py");
+        let callee = file_entity("LinkRecord", EntityKind::Class, "src/records.py");
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&callee).unwrap();
+        graph
+            .upsert_relation(&Relation {
+                id: kin_model::ids::RelationId::new(),
+                kind: RelationKind::Calls,
+                src: kin_model::GraphNodeId::Entity(caller.id),
+                dst: kin_model::GraphNodeId::Entity(callee.id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let response = build_context_response(
+            &graph,
+            &ContextRequest {
+                entity: "read_notes".to_string(),
+                budget: "8k".to_string(),
+                assistant: None,
+            },
+        )
+        .expect("a resolved entity builds a context response");
+
+        let rendered = response.lines.join("\n");
+        assert!(
+            rendered.contains("Dependencies: 1 entries (dependency edges)"),
+            "an edge-built pack must say so: {rendered}"
+        );
+        let selection = response.dependency_selection.as_ref().expect("a selection");
+        assert_eq!(selection.source, "dependency_edges");
+        assert_eq!(selection.same_file_candidates, 0);
     }
 
     #[test]

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -229,6 +229,112 @@ impl Default for ContextOptions {
 /// Subgraph size at or above which the per-entity projection/token work is
 /// precomputed in parallel. Below it, rayon's fan-out overhead outweighs the
 /// gain, so the sequential path runs. Either path produces identical output.
+/// How many same-file neighbours the fallback keeps.
+///
+/// The cap is what makes a twenty-four-method class come back as six rows, so
+/// it is reported rather than applied silently: [`DependencySelection`] carries
+/// the candidate total beside the kept count.
+pub const SAME_FILE_FALLBACK_MAX: usize = 6;
+
+/// Why a row is in a pack's dependency section.
+///
+/// The two are not interchangeable. An edge row is a dependency the graph
+/// asserts; a same-file row is a neighbour the builder reached for because the
+/// focal had no dependency edge at all. A class whose only edges are `Contains`
+/// produces same-file rows, and without this distinction a caller reads them as
+/// the class's dependencies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencyRelation {
+    /// The entity reaches the focal over a real dependency edge.
+    DependencyEdge,
+    /// The focal carried no dependency edge, so this row is an entity that
+    /// shares the focal's file. Not a dependency.
+    SameFileNeighbor,
+}
+
+impl DependencyRelation {
+    /// The wire spelling shared by `kin context` and the `get_context_pack` MCP
+    /// tool, so one name means one thing on both surfaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DependencyRelation::DependencyEdge => "dependency_edge",
+            DependencyRelation::SameFileNeighbor => "same_file_neighbor",
+        }
+    }
+}
+
+/// Where a pack's dependency section came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencySource {
+    /// Every row rides a dependency edge to the focal.
+    DependencyEdges,
+    /// The focal had no dependency edge, so the section holds same-file
+    /// neighbours instead.
+    SameFileFallback,
+}
+
+impl DependencySource {
+    /// The wire spelling shared by `kin context` and the `get_context_pack` MCP
+    /// tool.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DependencySource::DependencyEdges => "dependency_edges",
+            DependencySource::SameFileFallback => "same_file_fallback",
+        }
+    }
+}
+
+/// How a pack's dependency section was filled, and what filling it left out.
+///
+/// These are selection facts only the builder holds: whether the same-file
+/// fallback ran, how many neighbours it had to choose from, and how many
+/// [`SAME_FILE_FALLBACK_MAX`] and the token budget dropped. None of it is
+/// recoverable from [`ContextPack`] alone, which is why the pack's dependency
+/// rows used to reach an agent with no way to tell an edge from a neighbour.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DependencySelection {
+    fallback: bool,
+    same_file_candidates: usize,
+    same_file_neighbors: Vec<EntityId>,
+}
+
+impl DependencySelection {
+    /// Where the rows in `dependency_signatures` came from.
+    pub fn source(&self) -> DependencySource {
+        if self.fallback {
+            DependencySource::SameFileFallback
+        } else {
+            DependencySource::DependencyEdges
+        }
+    }
+
+    /// Why one dependency row is in the pack.
+    pub fn relation_for(&self, entity_id: &EntityId) -> DependencyRelation {
+        if self.same_file_neighbors.contains(entity_id) {
+            DependencyRelation::SameFileNeighbor
+        } else {
+            DependencyRelation::DependencyEdge
+        }
+    }
+
+    /// Same-file neighbours the fallback had to choose from, before the cap and
+    /// the token budget. Zero when the fallback did not run.
+    pub fn same_file_candidates(&self) -> usize {
+        self.same_file_candidates
+    }
+
+    /// Same-file neighbours that actually reached the pack.
+    pub fn same_file_kept(&self) -> usize {
+        self.same_file_neighbors.len()
+    }
+
+    /// Same-file neighbours the cap or the budget dropped.
+    pub fn same_file_dropped(&self) -> usize {
+        self.same_file_candidates
+            .saturating_sub(self.same_file_neighbors.len())
+    }
+}
+
 const PARALLEL_ASSEMBLY_MIN_ENTITIES: usize = 64;
 
 /// Which pack section a non-focal subgraph entity projects into.
@@ -337,6 +443,25 @@ pub fn build_context_pack<G>(
 where
     G: GraphStore,
 {
+    build_context_pack_with_provenance(graph, focal_id, opts).map(|(pack, _)| pack)
+}
+
+/// Build a context pack and report how its dependency section was selected.
+///
+/// The pack itself cannot carry that: `dependency_signatures` is a flat list of
+/// entries whose provenance lived only in a `// same-file neighbor` comment
+/// inside `entry.content`, which the MCP boundary does not serialize. Callers
+/// that render dependencies for an agent take the [`DependencySelection`] with
+/// them and label every row, so a same-file neighbour is never read as an edge.
+pub fn build_context_pack_with_provenance<G>(
+    graph: &G,
+    focal_id: &EntityId,
+    opts: &ContextOptions,
+) -> Result<(ContextPack, DependencySelection)>
+where
+    G: GraphStore,
+{
+    let mut selection = DependencySelection::default();
     let budget_max = opts.budget.max_tokens();
     let mut total_tokens = 0;
 
@@ -578,7 +703,12 @@ where
     }
 
     if dep_entries.is_empty() && !same_file_fallback_entities.is_empty() {
-        for entity in same_file_fallback_entities.iter().take(6) {
+        selection.fallback = true;
+        selection.same_file_candidates = same_file_fallback_entities.len();
+        for entity in same_file_fallback_entities
+            .iter()
+            .take(SAME_FILE_FALLBACK_MAX)
+        {
             let mut content = format!("// same-file neighbor\n{}", project_signature_only(entity));
             if opts.assistant_hint == Some(AssistantHint::GeminiCli) {
                 if let Some(ref origin) = entity.file_origin {
@@ -588,6 +718,7 @@ where
             let tokens = estimate_tokens(&content);
             if total_tokens + tokens <= budget_max {
                 total_tokens += tokens;
+                selection.same_file_neighbors.push(entity.id);
                 dep_entries.push(ContextEntry {
                     entity_id: entity.id,
                     projection_level: ProjectionLevel::SignatureOnly,
@@ -656,19 +787,22 @@ where
         "built context pack"
     );
 
-    Ok(ContextPack {
-        focal_entities: vec![focal_entry],
-        dependency_signatures: dep_entries,
-        transitive_deps: transitive_entries,
-        contracts: contract_entries,
-        tests: test_entries,
-        work_items: work_entries,
-        annotations: annotation_entries,
-        traffic: vec![],
-        supporting_artifacts: vec![],
-        token_budget: opts.budget,
-        actual_tokens: total_tokens,
-    })
+    Ok((
+        ContextPack {
+            focal_entities: vec![focal_entry],
+            dependency_signatures: dep_entries,
+            transitive_deps: transitive_entries,
+            contracts: contract_entries,
+            tests: test_entries,
+            work_items: work_entries,
+            annotations: annotation_entries,
+            traffic: vec![],
+            supporting_artifacts: vec![],
+            token_budget: opts.budget,
+            actual_tokens: total_tokens,
+        },
+        selection,
+    ))
 }
 
 /// Build a context pack from an explicit retrieval plan handoff.
@@ -732,10 +866,26 @@ pub fn build_context_pack_with_traffic<G>(
 where
     G: GraphStore,
 {
-    let mut pack = build_context_pack(graph, focal_id, opts)?;
+    build_context_pack_with_traffic_and_provenance(graph, focal_id, opts, nearby_intents)
+        .map(|(pack, _)| pack)
+}
+
+/// [`build_context_pack_with_traffic`], reporting how the dependency section was
+/// selected. See [`build_context_pack_with_provenance`] for why the pack cannot
+/// carry that itself.
+pub fn build_context_pack_with_traffic_and_provenance<G>(
+    graph: &G,
+    focal_id: &EntityId,
+    opts: &ContextOptions,
+    nearby_intents: &[IntentSummary],
+) -> Result<(ContextPack, DependencySelection)>
+where
+    G: GraphStore,
+{
+    let (mut pack, selection) = build_context_pack_with_provenance(graph, focal_id, opts)?;
 
     if !opts.include_traffic || nearby_intents.is_empty() {
-        return Ok(pack);
+        return Ok((pack, selection));
     }
 
     // Classify each intent by proximity to the focal entity.
@@ -793,7 +943,7 @@ where
         "added traffic metadata to context pack"
     );
 
-    Ok(pack)
+    Ok((pack, selection))
 }
 
 fn collect_supporting_file_ids<G>(graph: &G, plan: &ContextPlan) -> Result<Vec<FilePathId>>
@@ -1623,6 +1773,104 @@ mod tests {
         assert!(
             first.contains("_safeParse"),
             "closest same-file companion should be ranked first"
+        );
+    }
+
+    /// The fallback is a different answer to a different question, and the pack
+    /// alone cannot say which one a caller got: `dependency_signatures` is the
+    /// same field either way, and the cap turns a twenty-four-member class into
+    /// six rows with nothing reporting the other eighteen.
+    #[test]
+    fn same_file_fallback_reports_its_source_and_what_the_cap_dropped() {
+        let store = kin_db::InMemoryGraph::new();
+
+        let focal = make_file_entity("NoteStore", EntityKind::Class, "src/notes.py");
+        store.upsert_entity(&focal).unwrap();
+        for index in 0..9 {
+            let neighbor = make_file_entity(
+                &format!("NoteStore.method{index}"),
+                EntityKind::Method,
+                "src/notes.py",
+            );
+            store.upsert_entity(&neighbor).unwrap();
+        }
+
+        let (pack, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &ContextOptions::default())
+                .unwrap();
+
+        assert_eq!(selection.source(), DependencySource::SameFileFallback);
+        assert_eq!(
+            pack.dependency_signatures.len(),
+            SAME_FILE_FALLBACK_MAX,
+            "the cap is what makes a nine-neighbour file answer with six rows"
+        );
+        assert_eq!(selection.same_file_candidates(), 9);
+        assert_eq!(selection.same_file_kept(), SAME_FILE_FALLBACK_MAX);
+        assert_eq!(selection.same_file_dropped(), 3);
+        for entry in &pack.dependency_signatures {
+            assert_eq!(
+                selection.relation_for(&entry.entity_id),
+                DependencyRelation::SameFileNeighbor,
+                "every fallback row must be reported as a neighbour, not an edge"
+            );
+        }
+    }
+
+    /// The other half of the same guard: a focal that really does have
+    /// dependency edges must not be reported as a fallback, or the marker means
+    /// nothing.
+    #[test]
+    fn dependency_edge_rows_are_not_reported_as_same_file_neighbors() {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+
+        let store = kin_db::InMemoryGraph::new();
+        let focal = make_file_entity("read_notes", EntityKind::Function, "src/reader.py");
+        let link_record = make_file_entity("LinkRecord", EntityKind::Class, "src/records.py");
+        let note_record = make_file_entity("NoteRecord", EntityKind::Class, "src/records.py");
+        // A neighbour in the focal's own file, which the fallback would have
+        // reached for had the edges below not existed.
+        let sibling = make_file_entity("read_note", EntityKind::Function, "src/reader.py");
+        store.upsert_entity(&focal).unwrap();
+        store.upsert_entity(&link_record).unwrap();
+        store.upsert_entity(&note_record).unwrap();
+        store.upsert_entity(&sibling).unwrap();
+
+        for callee in [&link_record, &note_record] {
+            store
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(focal.id),
+                    dst: GraphNodeId::Entity(callee.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        let (pack, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &ContextOptions::default())
+                .unwrap();
+
+        assert_eq!(selection.source(), DependencySource::DependencyEdges);
+        assert_eq!(selection.same_file_candidates(), 0);
+        assert_eq!(selection.same_file_dropped(), 0);
+        assert_eq!(pack.dependency_signatures.len(), 2);
+        for entry in &pack.dependency_signatures {
+            assert_eq!(
+                selection.relation_for(&entry.entity_id),
+                DependencyRelation::DependencyEdge
+            );
+        }
+        assert!(
+            pack.dependency_signatures
+                .iter()
+                .all(|entry| entry.entity_id != sibling.id),
+            "a same-file sibling must not join a pack that has real edges"
         );
     }
 

--- a/crates/kin-context/src/lib.rs
+++ b/crates/kin-context/src/lib.rs
@@ -8,8 +8,10 @@ pub mod error;
 pub mod tokens;
 
 pub use builder::{
-    build_context_pack, build_context_pack_from_plan, build_context_pack_with_traffic,
-    AssistantHint, ContextOptions,
+    build_context_pack, build_context_pack_from_plan, build_context_pack_with_provenance,
+    build_context_pack_with_traffic, build_context_pack_with_traffic_and_provenance, AssistantHint,
+    ContextOptions, DependencyRelation, DependencySelection, DependencySource,
+    SAME_FILE_FALLBACK_MAX,
 };
 pub use error::{ContextError, Result};
 pub use tokens::estimate_tokens;

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -2518,16 +2518,21 @@ pub fn entity_response_json<G: GraphStore>(
 /// `entry.content` is a token-accounting stub, and once it stopped being a body
 /// fallback the parameter only obliged callers to build a value this function
 /// discards.
+///
+/// Takes no `compact` flag either. Compact mode used to drop the focal body
+/// while still paying for the read that produced it, which left the one thing
+/// the pack is for out of the cheaper mode: a caller asking for a bounded pack
+/// spent a whole call learning it had to ask again. Compact now bounds the
+/// dependency rows, and the focal body it serves is already capped at
+/// [`MCP_SOURCE_MAX_LINES`]/[`MCP_SOURCE_MAX_CHARS`].
 pub fn focal_context_json<G: GraphStore>(
     store: &G,
     entity: &Entity,
-    compact: bool,
     repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<serde_json::Value> {
     focal_context_json_held(
         &HeldSourceAuthority::new(store, repository_authority),
         entity,
-        compact,
     )
 }
 
@@ -2537,7 +2542,6 @@ pub fn focal_context_json<G: GraphStore>(
 pub fn focal_context_json_held<G: GraphStore>(
     held: &HeldSourceAuthority<'_, G>,
     entity: &Entity,
-    compact: bool,
 ) -> Result<serde_json::Value> {
     let start_line = entity_presentation_start_line(entity);
     let end_line = entity_presentation_end_line(entity);
@@ -2562,13 +2566,11 @@ pub fn focal_context_json_held<G: GraphStore>(
         "source": source,
     });
 
-    if !compact {
-        match source_excerpt.as_ref() {
-            Some(source) => obj["body"] = serde_json::json!(source.body),
-            None => {
-                obj["body"] = serde_json::Value::Null;
-                obj["body_unavailable"] = serde_json::json!(entity_body_gap_reason(entity));
-            }
+    match source_excerpt.as_ref() {
+        Some(source) => obj["body"] = serde_json::json!(source.body),
+        None => {
+            obj["body"] = serde_json::Value::Null;
+            obj["body_unavailable"] = serde_json::json!(entity_body_gap_reason(entity));
         }
     }
     if let Some(source) = source_excerpt {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -604,7 +604,15 @@ selects, and it cannot bound the envelope that content travels in, so read `toke
 which measures the serialized response this call returns, as what the call costs you. \
 `focal_entity.body` in the response IS the focal entity's exact source text, so this one \
 call already answers \"show me the code\": no follow-up read is needed, and it is the body \
-to edit and stage back. If get_entity_source is available to you it is cheaper for a raw \
+to edit and stage back, in compact mode too, which drops the dependency bodies and \
+projection levels but never the focal body. Every dependency row says why it is there: \
+`relation: \"dependency_edge\"` is an edge the graph asserts, and \
+`relation: \"same_file_neighbor\"` means the focal had no dependency edge at all, so the \
+row is a neighbour sharing the focal's file rather than anything the focal depends on. \
+That is the usual shape for a class whose only edges are containment. \
+`dependency_selection` names which of the two filled the list and, for the fallback, how \
+many same-file candidates there were and how many were dropped to fit. \
+If get_entity_source is available to you it is cheaper for a raw \
 body alone; if you need to follow an actual call chain step by step, use trace_data_flow.";
 
 pub fn handle_get_context_pack<G: GraphStore>(
@@ -613,7 +621,9 @@ pub fn handle_get_context_pack<G: GraphStore>(
     sessions: &SessionRegistry,
     repository_authority: Option<&RequestRepositoryAuthority>,
 ) -> Result<ToolCallResult> {
-    use kin_context::{build_context_pack_with_traffic, ContextOptions};
+    use kin_context::{
+        build_context_pack_with_traffic_and_provenance, ContextOptions, DependencyRelation,
+    };
     use kin_model::context::TokenBudget;
 
     let id_str = get_string_param(args, "entity_id")?;
@@ -644,8 +654,9 @@ pub fn handle_get_context_pack<G: GraphStore>(
         vec![]
     };
 
-    let pack = build_context_pack_with_traffic(store, &entity_id, &opts, &nearby_intents)
-        .map_err(|e| McpError::Context(e.to_string()))?;
+    let (pack, selection) =
+        build_context_pack_with_traffic_and_provenance(store, &entity_id, &opts, &nearby_intents)
+            .map_err(|e| McpError::Context(e.to_string()))?;
 
     // Build structured response JSON. The pack still has to have projected a
     // focal entry for the focal entity to be worth serializing, but the body
@@ -659,12 +670,20 @@ pub fn handle_get_context_pack<G: GraphStore>(
     let held = HeldSourceAuthority::new(store, repository_authority);
 
     let focal_json = if let (Some(_), Some(entity)) = (focal_entry, &focal_entity) {
-        focal_context_json_held(&held, entity, compact)?
+        focal_context_json_held(&held, entity)?
     } else {
         serde_json::json!(null)
     };
 
-    let project_dep = |entry: &kin_model::context::ContextEntry| -> Result<serde_json::Value> {
+    // `relation` is what keeps a same-file neighbour from reading as a
+    // dependency. The builder tags the fallback inside `entry.content`, which
+    // this handler does not serialize, so without the selection travelling
+    // alongside the pack the two are indistinguishable on the wire. Rows in the
+    // sections that are not dependencies (transitive, tests, contracts) pass
+    // `None` and carry no relation at all.
+    let project_dep = |entry: &kin_model::context::ContextEntry,
+                       relation: Option<DependencyRelation>|
+     -> Result<serde_json::Value> {
         // Look up the entity for structured fields.
         if let Some(e) = store
             .get_entity(&entry.entity_id)
@@ -680,6 +699,9 @@ pub fn handle_get_context_pack<G: GraphStore>(
                 "start_line": entity_presentation_start_line(&e),
                 "end_line": entity_presentation_end_line(&e),
             });
+            if let Some(relation) = relation {
+                obj["relation"] = serde_json::json!(relation.as_str());
+            }
             if !compact {
                 obj["projection"] = serde_json::json!(format!("{:?}", entry.projection_level));
                 // A dependency whose file the current workspace does not contain
@@ -723,27 +745,43 @@ pub fn handle_get_context_pack<G: GraphStore>(
             }
             Ok(obj)
         } else {
-            Ok(serde_json::json!({
+            let mut obj = serde_json::json!({
                 "id": entry.entity_id.to_string(),
                 "content": entry.content,
-            }))
+            });
+            if let Some(relation) = relation {
+                obj["relation"] = serde_json::json!(relation.as_str());
+            }
+            Ok(obj)
         }
     };
 
     let dependencies: Vec<_> = pack
         .dependency_signatures
         .iter()
-        .map(&project_dep)
+        .map(|entry| project_dep(entry, Some(selection.relation_for(&entry.entity_id))))
         .collect::<Result<Vec<_>>>()?;
     let transitive: Vec<_> = pack
         .transitive_deps
         .iter()
-        .map(&project_dep)
+        .map(|entry| project_dep(entry, None))
         .collect::<Result<Vec<_>>>()?;
 
+    // The cap and the fallback are both invisible in the rows themselves: six
+    // neighbours out of twenty-four look exactly like six dependencies. This
+    // says which selection ran and what it dropped, in every mode, because a
+    // caller deciding whether to ask again needs it most when the answer is
+    // small.
+    let returned = dependencies.len();
     let mut result = serde_json::json!({
         "focal_entity": focal_json,
         "dependencies": dependencies,
+        "dependency_selection": {
+            "source": selection.source().as_str(),
+            "returned": returned,
+            "same_file_candidates": selection.same_file_candidates(),
+            "same_file_dropped": selection.same_file_dropped(),
+        },
         "token_budget": budget.max_tokens(),
         "tokens_used": pack.actual_tokens,
     });
@@ -755,7 +793,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
         let tests: Vec<_> = pack
             .tests
             .iter()
-            .map(&project_dep)
+            .map(|entry| project_dep(entry, None))
             .collect::<Result<Vec<_>>>()?;
         if !tests.is_empty() {
             result["tests"] = serde_json::json!(tests);
@@ -763,7 +801,7 @@ pub fn handle_get_context_pack<G: GraphStore>(
         let contracts: Vec<_> = pack
             .contracts
             .iter()
-            .map(&project_dep)
+            .map(|entry| project_dep(entry, None))
             .collect::<Result<Vec<_>>>()?;
         if !contracts.is_empty() {
             result["contracts"] = serde_json::json!(contracts);
@@ -836,7 +874,8 @@ value is consolidation: instead of looping get_entity_source over each step of a
 — which exhausts your context and round-trips — one call returns everything needed to \
 reason about the flow step by step. By default the focal comes back as a full body and \
 its dependencies as signatures (the shape best suited to trace reasoning); set \
-compact=true for signature-only entries everywhere when you just need the structure. \
+compact=true to drop the dependency bodies when you just need the structure, which \
+leaves the focal body in place. \
 When you specifically want the ordered call chain itself (not a flat neighborhood), \
 trace_data_flow walks the relations directionally and inlines each step.";
 

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2308,7 +2308,7 @@ mod tests {
         install_empty_store_exact_tree(&mut store, source._dir.path());
         let authority = test_repository_authority(source._dir.path());
 
-        let value = focal_context_json(&store, entity, false, Some(&authority)).unwrap();
+        let value = focal_context_json(&store, entity, Some(&authority)).unwrap();
         let object = value.as_object().unwrap();
         let body = object.get("body").and_then(|value| value.as_str()).unwrap();
 
@@ -2338,7 +2338,7 @@ mod tests {
         install_empty_store_exact_tree(&mut store, source._dir.path());
         let authority = test_repository_authority(source._dir.path());
 
-        let value = focal_context_json(&store, entity, false, Some(&authority)).unwrap();
+        let value = focal_context_json(&store, entity, Some(&authority)).unwrap();
         let object = value.as_object().unwrap();
 
         let marker = object.get("source").and_then(|v| v.as_str()).unwrap();
@@ -2394,7 +2394,7 @@ mod tests {
             "get_entity must present row 0 as line 1"
         );
 
-        let focal = focal_context_json(&store, entity, false, Some(&authority)).unwrap();
+        let focal = focal_context_json(&store, entity, Some(&authority)).unwrap();
         assert_eq!(
             focal["start_line"], 1,
             "get_context_pack focal must agree with get_entity"
@@ -2567,7 +2567,7 @@ mod tests {
             projection_level: kin_model::ProjectionLevel::FullBody,
             content: project_full_body_stub(entity),
         };
-        let focal = focal_context_json(&store, entity, false, Some(&authority)).unwrap();
+        let focal = focal_context_json(&store, entity, Some(&authority)).unwrap();
         let focal_body = focal["body"]
             .as_str()
             .expect("focal body must be a string, never null, when the graph has the source");
@@ -2617,7 +2617,7 @@ mod tests {
         install_empty_store_exact_tree(&mut store, source._dir.path());
         let authority = test_repository_authority(source._dir.path());
 
-        let focal = focal_context_json(&store, &spanless, false, Some(&authority)).unwrap();
+        let focal = focal_context_json(&store, &spanless, Some(&authority)).unwrap();
 
         assert!(
             focal["body"].is_null(),
@@ -2735,7 +2735,7 @@ mod tests {
             "the body must be the post-commit source: {excerpt}"
         );
 
-        let focal = focal_context_json(&store, &moved, false, Some(&authority)).unwrap();
+        let focal = focal_context_json(&store, &moved, Some(&authority)).unwrap();
         assert_eq!(
             focal["start_line"], 3,
             "the context pack must not serve the pre-commit position"
@@ -2967,6 +2967,301 @@ mod tests {
         );
     }
 
+    /// A pack fixture with both dependency shapes: a class whose only edges are
+    /// containment, so its dependency section can only be filled from the
+    /// neighbours in its file, and a function that really does call two
+    /// entities. One store, so the two answers are told apart by what the
+    /// payload says rather than by which fixture produced it.
+    struct PackProvenanceFixture {
+        _dir: tempfile::TempDir,
+        _env: EnvVarGuard,
+        store: EmptyStore,
+        authority: RequestRepositoryAuthority,
+        note_store: Entity,
+        reader: Entity,
+    }
+
+    const NOTES_SOURCE: &str = "export class NoteStore {\n  open(): void {}\n  close(): void {}\n  stats(): number { return 0; }\n}\n";
+
+    fn pack_provenance_fixture() -> PackProvenanceFixture {
+        let dir = tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let env = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+
+        let reader_source =
+            "export function readNotes(store: NoteStore): NoteRecord[] {\n  return [];\n}\n";
+        let records_source = "export class LinkRecord {}\nexport class NoteRecord {}\n";
+
+        let mut store = EmptyStore::default();
+        let mut file_entity =
+            |path: &str, source: &str, name: &str, kind: EntityKind, line: u32| {
+                let file_id = FilePathId::new(path);
+                let hash = blob_store.write(source.as_bytes()).unwrap();
+                store.file_hashes.insert(file_id.clone(), hash);
+                let entity = Entity {
+                    id: EntityId::new(),
+                    kind,
+                    name: name.to_string(),
+                    language: LanguageId::TypeScript,
+                    fingerprint: kin_model::entity::SemanticFingerprint {
+                        algorithm: kin_model::entity::FingerprintAlgorithm::V1TreeSitter,
+                        ast_hash: Hash256::from_bytes([5; 32]),
+                        signature_hash: Hash256::from_bytes([5; 32]),
+                        behavior_hash: Hash256::from_bytes([5; 32]),
+                        equivalence_hash: Hash256::from_bytes([0; 32]),
+                        stability_score: 1.0,
+                    },
+                    file_origin: Some(file_id.clone()),
+                    span: Some(kin_model::entity::SourceSpan {
+                        file: file_id,
+                        start_byte: 0,
+                        end_byte: source.len(),
+                        start_line: line,
+                        start_col: 0,
+                        end_line: line,
+                        end_col: 1,
+                    }),
+                    signature: format!("export {name}"),
+                    visibility: Visibility::Public,
+                    role: kin_model::entity::EntityRole::Source,
+                    doc_summary: None,
+                    metadata: kin_model::entity::EntityMetadata::default(),
+                    lineage_parent: None,
+                    created_in: None,
+                    superseded_by: None,
+                };
+                store.insert_test_entity(entity.clone());
+                entity
+            };
+
+        let note_store = file_entity("notes.ts", NOTES_SOURCE, "NoteStore", EntityKind::Class, 0);
+        let members: Vec<Entity> = ["NoteStore.open", "NoteStore.close", "NoteStore.stats"]
+            .iter()
+            .enumerate()
+            .map(|(index, name)| {
+                file_entity(
+                    "notes.ts",
+                    NOTES_SOURCE,
+                    name,
+                    EntityKind::Method,
+                    index as u32 + 1,
+                )
+            })
+            .collect();
+        let reader = file_entity(
+            "reader.ts",
+            reader_source,
+            "readNotes",
+            EntityKind::Function,
+            0,
+        );
+        let link_record = file_entity(
+            "records.ts",
+            records_source,
+            "LinkRecord",
+            EntityKind::Class,
+            0,
+        );
+        let note_record = file_entity(
+            "records.ts",
+            records_source,
+            "NoteRecord",
+            EntityKind::Class,
+            1,
+        );
+
+        // The class's only edges are containment, which is the shape that sends
+        // the builder to its same-file fallback: edges exist, none of them is a
+        // dependency.
+        for member in &members {
+            let relation = Relation {
+                id: RelationId::new(),
+                kind: RelationKind::Contains,
+                src: kin_model::GraphNodeId::Entity(note_store.id),
+                dst: kin_model::GraphNodeId::Entity(member.id),
+                confidence: 1.0,
+                origin: kin_model::relation::RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: vec![],
+            };
+            store
+                .relations_by_entity
+                .entry(note_store.id)
+                .or_default()
+                .push(relation.clone());
+            store
+                .relations_by_entity
+                .entry(member.id)
+                .or_default()
+                .push(relation);
+        }
+        store.insert_test_calls_relation(&reader, &link_record);
+        store.insert_test_calls_relation(&reader, &note_record);
+
+        install_empty_store_exact_tree(&mut store, dir.path());
+        let authority = test_repository_authority(dir.path());
+
+        PackProvenanceFixture {
+            _dir: dir,
+            _env: env,
+            store,
+            authority,
+            note_store,
+            reader,
+        }
+    }
+
+    fn context_pack_json(
+        fixture: &PackProvenanceFixture,
+        entity: &Entity,
+        compact: bool,
+    ) -> serde_json::Value {
+        let sessions = SessionRegistry::new();
+        let args = HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(entity.id.to_string()),
+            ),
+            ("compact".to_string(), serde_json::json!(compact)),
+        ]);
+        tool_result_json(
+            entities::handle_get_context_pack(
+                &args,
+                &fixture.store,
+                &sessions,
+                Some(&fixture.authority),
+            )
+            .unwrap(),
+        )
+    }
+
+    /// A class with no dependency edge came back with six `dependencies` that
+    /// were not dependencies at all: same-file neighbours the builder reached
+    /// for, tagged only inside an `entry.content` string this handler never
+    /// serializes. On the wire they were indistinguishable from edges, and the
+    /// stranger who hit this read them as the class's dependency list.
+    #[test]
+    fn a_context_pack_marks_its_same_file_fallback_rows() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        for compact in [false, true] {
+            let value = context_pack_json(&fixture, &fixture.note_store, compact);
+            let rows = value["dependencies"]
+                .as_array()
+                .unwrap_or_else(|| panic!("the pack must carry dependency rows: {value}"));
+            assert_eq!(
+                rows.len(),
+                3,
+                "the fixture's three same-file neighbours are what fills this section: {value}"
+            );
+            for row in rows {
+                assert_eq!(
+                    row["relation"],
+                    serde_json::json!("same_file_neighbor"),
+                    "a fallback row must say it is a neighbour, not an edge (compact={compact}): \
+                     {value}"
+                );
+            }
+            assert_eq!(
+                value["dependency_selection"]["source"],
+                serde_json::json!("same_file_fallback"),
+                "the pack must name the selection that filled it (compact={compact}): {value}"
+            );
+            assert_eq!(value["dependency_selection"]["returned"], 3);
+            assert_eq!(value["dependency_selection"]["same_file_candidates"], 3);
+            assert_eq!(value["dependency_selection"]["same_file_dropped"], 0);
+        }
+    }
+
+    /// The control that makes the marker mean something: a focal with real
+    /// dependency edges must report those as edges. A payload that stamped
+    /// every row `same_file_neighbor` would pass the test above and be just as
+    /// wrong.
+    #[test]
+    fn a_context_pack_marks_real_dependency_edges_as_edges() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        for compact in [false, true] {
+            let value = context_pack_json(&fixture, &fixture.reader, compact);
+            let rows = value["dependencies"]
+                .as_array()
+                .unwrap_or_else(|| panic!("the pack must carry dependency rows: {value}"));
+            assert_eq!(
+                rows.len(),
+                2,
+                "the fixture's two call edges are what fills this section: {value}"
+            );
+            for row in rows {
+                assert_eq!(
+                    row["relation"],
+                    serde_json::json!("dependency_edge"),
+                    "an edge row must say so (compact={compact}): {value}"
+                );
+            }
+            assert_eq!(
+                value["dependency_selection"]["source"],
+                serde_json::json!("dependency_edges"),
+                "a pack built from edges must not report the fallback: {value}"
+            );
+            assert_eq!(value["dependency_selection"]["same_file_candidates"], 0);
+        }
+    }
+
+    /// `compact: true` dropped the focal body while still paying for the read
+    /// that produced it, so the cheaper mode omitted the one thing the pack is
+    /// for and a caller spent a whole call learning it had to ask again.
+    /// Compact bounds the neighbour rows; the focal body stays.
+    #[test]
+    fn a_compact_context_pack_still_carries_the_focal_body() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        let compact = context_pack_json(&fixture, &fixture.note_store, true);
+        assert!(
+            compact["focal_entity"]["body"]
+                .as_str()
+                .is_some_and(|body| body.contains("export class NoteStore")),
+            "a compact pack must still serve the focal body: {compact}"
+        );
+
+        // The neighbour rows are what compact actually trims, and the control
+        // that keeps this test from passing on a compact mode that trims
+        // nothing at all.
+        let rows = compact["dependencies"].as_array().expect("rows");
+        assert!(
+            rows.iter()
+                .all(|row| row.get("body").is_none() && row.get("projection").is_none()),
+            "compact must still drop the neighbour bodies and projections: {compact}"
+        );
+        let full = context_pack_json(&fixture, &fixture.note_store, false);
+        assert!(
+            full["dependencies"]
+                .as_array()
+                .expect("rows")
+                .iter()
+                .all(|row| row.get("projection").is_some()),
+            "full mode is what carries the projection levels: {full}"
+        );
+        assert_eq!(
+            full["focal_entity"]["body"], compact["focal_entity"]["body"],
+            "the focal body must not depend on the mode"
+        );
+    }
+
     /// A path whose bytes are not valid UTF-8 keeps its byte-exact spelling.
     ///
     /// Dropping `artifact_path` as redundant is only true where a plain path can
@@ -3060,7 +3355,7 @@ mod tests {
         install_empty_store_exact_tree(&mut store, source._dir.path());
         let authority = test_repository_authority(source._dir.path());
 
-        let value = focal_context_json(&store, entity, false, Some(&authority)).unwrap();
+        let value = focal_context_json(&store, entity, Some(&authority)).unwrap();
         let object = value.as_object().unwrap();
         let body = object.get("body").and_then(|value| value.as_str()).unwrap();
 


### PR DESCRIPTION
`get_context_pack` answered a class that has no dependency edge with six rows under `dependencies`, and nothing in the payload said they were not dependencies. `crates/kin-context/src/builder.rs:428` gathers `direct_dep_ids` over dependency edges only, and when that set is empty it queries every entity sharing the focal's file, ranks them in three coarse buckets, and keeps the first six. Each of those rows was tagged by prefixing `// same-file neighbor` to `entry.content` at builder.rs:580, and `handle_get_context_pack` in `crates/kin-mcp/src/handlers/entities.rs` builds every row from the store entity and never emits `entry.content`, so the only tag distinguishing a neighbour from an edge died at the MCP boundary. The six-row cap was silent in both modes, so a twenty-four-member class came back as six rows with no count of what was dropped. Separately, `focal_context_json_held` in `crates/kin-mcp/src/handlers/common.rs` gated the focal `body` behind `if !compact` while reading the excerpt unconditionally, so compact mode paid for the read and discarded the one thing the pack is for.

`build_context_pack_with_provenance` and `build_context_pack_with_traffic_and_provenance` now return a `DependencySelection` beside the pack, and the existing `build_context_pack` and `build_context_pack_with_traffic` stay as wrappers so no other caller had to move. The selection says which selection filled the section, how many same-file candidates there were, and how many the cap or the token budget dropped; the cap is now the named constant `SAME_FILE_FALLBACK_MAX`. `get_context_pack` stamps every dependency row with `relation: "dependency_edge"` or `relation: "same_file_neighbor"` and carries a `dependency_selection` object (`source`, `returned`, `same_file_candidates`, `same_file_dropped`) in both compact and full mode. Transitive, test and contract rows carry no relation, because the field is about the dependency section. The tool description names the fallback so an agent knows what a dependency list on a class means.

`kin context` reports the same facts in the same words. Its rendered line reads `Dependencies: 3 entries (same-file neighbors, no dependency edges; kept 3 of 3)` or `Dependencies: 1 entries (dependency edges)`, and the structured response gained a `dependency_selection` field that defaults to absent, so a daemon predating it still decodes.

Compact mode keeps the focal body, still bounded by `MCP_SOURCE_MAX_LINES` (40) and `MCP_SOURCE_MAX_CHARS` (2400), and still drops the dependency bodies and projection levels. `focal_context_json` and `focal_context_json_held` lost the `compact` parameter they no longer read. Rows grew by one short string field and the selection object is four values per response, so this stays small alongside kin#902, which adds a client-sized response budget and envelope-level `compact` semantics across the retrieval tools. The two do not fight: kin#902 sheds explain keys (for this tool, `projection`) and bodies only under budget pressure, while the `compact` argument this handler reads still shapes the dependency rows, and the focal body it keeps is the answer kin#902 is written to preserve. Nothing here reads or depends on that PR's code, and the hunks do not overlap: kin#902 touches `handlers/entities.rs` at its tool descriptions near lines 123 and 903 and adds tests at the end of that file, while this change is in `handle_get_context_pack` and adds its tests in `handlers/mod.rs`.

Falsification, each break applied to the committed tree and reverted after the run:

- Removing the `relation` insertion from both row shapes: `a_context_pack_marks_its_same_file_fallback_rows` and `a_context_pack_marks_real_dependency_edges_as_edges` both FAILED, on "a fallback row must say it is a neighbour, not an edge (compact=false)" and "an edge row must say so (compact=false)".
- Removing the `dependency_selection` object: both FAILED, on "the pack must name the selection that filled it (compact=false)" and "a pack built from edges must not report the fallback".
- Making `relation_for` return `SameFileNeighbor` for every id: the fallback test PASSED and the edge test FAILED, which is why both exist; `builder::tests::dependency_edge_rows_are_not_reported_as_same_file_neighbors` FAILED too.
- Dropping the fallback bookkeeping in the builder: `same_file_fallback_reports_its_source_and_what_the_cap_dropped` FAILED with `left: DependencyEdges, right: SameFileFallback`, and the edge test stayed green.
- Restoring the compact body gate: `a_compact_context_pack_still_carries_the_focal_body` FAILED on "a compact pack must still serve the focal body".
- Making compact stop trimming rows: the same test FAILED on its control, "compact must still drop the neighbour bodies and projections".
- Dropping the selection note from the `kin context` rendering: both CLI tests FAILED, on "the human rendering must name the fallback" and "an edge-built pack must say so".

Gates: `cargo fmt --all -- --check` exits 0. The CI clippy allowlist from `.github/workflows/ci.yml` under `RUSTFLAGS=-D warnings` exits 0. The full local gate ran through `bin/kin-lane run fir2401-pack kin -- bin/kin-dev local-test kin`, which printed the tree it gated as `.kin-coord/worktrees/fir2401-pack-kin @ 06a735aa (chore/lane-fir2401-pack-kin)` and finished `Summary [321.456s] 6019 tests run: 6019 passed (3 slow, 2 leaky), 11 skipped` at exit code 0, with the doctest pass beside it and no tracked lock contamination. `git ls-tree -r HEAD --name-only` matches only `.cargo/config.toml` under `.cargo/`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

Closes FIR-2401
