### PR TITLE
Probe the kin-vfs driver, and stop doctor and setup overclaiming

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -14,8 +14,9 @@ use serde_json::Value;
 
 use crate::commands::auth::default_base_url_for_health;
 use crate::commands::setup::{
-    check_binary_in_path, configured_mcp_launcher, detect_shell, home_dir, hook_filename, kin_dir,
-    shell_rc, shim_filename, CANONICAL_NPM_MCP_COMMAND, CANONICAL_NPM_MCP_PACKAGE,
+    check_binary_in_path, configured_mcp_launcher, detect_shell, detected_ai_client_names,
+    home_dir, hook_filename, kin_dir, shell_rc, shim_filename, CANONICAL_NPM_MCP_COMMAND,
+    CANONICAL_NPM_MCP_PACKAGE,
 };
 use crate::daemon_client::{InstalledStartupProtocol, SupervisorStartupSentinel};
 
@@ -637,8 +638,12 @@ fn check_vfs_projection() -> HealthCheck {
         }
     };
     let lib_path = kin_home.join("lib").join(shim_filename());
+    let driver = resolve_vfs_driver(&vfs_driver_candidates(
+        &kin_home,
+        env::current_exe().ok().as_deref(),
+    ));
 
-    vfs_projection_check_for(&lib_path, projection_installed_under(&kin_home))
+    vfs_projection_check_for(&lib_path, &driver)
 }
 
 /// Name of the projection driver binary the installer places beside `kin`.
@@ -650,20 +655,121 @@ fn vfs_binary_filename() -> &'static str {
     }
 }
 
-/// Whether filesystem projection was actually installed under `kin_home`.
+/// Every place the projection driver can be, in resolution order.
 ///
-/// The installer ships projection only where it can run. When the archive
-/// carries no projection, or the host loader cannot execute the one it carries,
-/// the installer deletes `kin-vfs` and the shim together and says so out loud:
-/// "Filesystem projection is unavailable on this platform; core CLI and daemon
-/// are fully functional without it." So a shim absent beside an absent
-/// `kin-vfs` is that sanctioned outcome, not a broken install — and telling
-/// such a user to reinstall contradicts what the installer just told them and
-/// sends them somewhere that cannot help. A shim absent while `kin-vfs` is
-/// installed is the opposite case: projection is on this machine and the half
-/// that gets injected into processes is gone.
-fn projection_installed_under(kin_home: &Path) -> bool {
-    kin_home.join("bin").join(vfs_binary_filename()).exists()
+/// The installer ships `kin-vfs` beside the `kin` binary it installs, and that
+/// is `~/.kin/bin` only for the managed layout. An archive or Homebrew install
+/// puts both somewhere else, so looking in `~/.kin/bin` alone read a driver
+/// sitting next to the running binary as absent, and the check then phrased
+/// that guess as a confident "neither is present here".
+fn vfs_driver_candidates(kin_home: &Path, exe: Option<&Path>) -> Vec<PathBuf> {
+    fn push_unique(into: &mut Vec<PathBuf>, path: PathBuf) {
+        if !into.contains(&path) {
+            into.push(path);
+        }
+    }
+
+    let name = vfs_binary_filename();
+    let mut candidates = Vec::new();
+    if let Some(dir) = exe.and_then(Path::parent) {
+        push_unique(&mut candidates, dir.join(name));
+    }
+    push_unique(&mut candidates, kin_home.join("bin").join(name));
+    if let Some(found) = check_binary_in_path("kin-vfs") {
+        push_unique(&mut candidates, found);
+    }
+    candidates
+}
+
+/// What a projection driver on disk actually does when it is run.
+///
+/// The installer removes `kin-vfs` and its shim together where projection
+/// cannot run, so an absent driver is a sanctioned outcome rather than a broken
+/// install. A driver that is present and refuses to load is neither: it is a
+/// real defect, and reporting it as absence tells a user nothing is missing on
+/// a machine where projection is installed and dead.
+#[derive(Debug, PartialEq, Eq)]
+enum VfsDriverState {
+    /// No `kin-vfs` beside the running binary, in `~/.kin/bin`, or on PATH.
+    Absent,
+    /// A driver that runs: probing it reached the driver's own code.
+    Loadable(PathBuf),
+    /// A driver on disk the loader refuses, carrying its literal complaint.
+    Unloadable { path: PathBuf, message: String },
+}
+
+/// Probe one driver path by running it.
+///
+/// Existence is not loadability. The linux-aarch64 archive has shipped a
+/// `kin-vfs` needing a newer glibc than the host carries, and on disk that
+/// driver is an ordinary file: only executing it produces the loader's refusal.
+/// Stdin is closed so a candidate that is not Kin's driver cannot stall the
+/// check by reading from the terminal.
+fn probe_vfs_driver(path: &Path) -> VfsDriverState {
+    use std::process::{Command, Stdio};
+
+    match Command::new(path).arg("--help").stdin(Stdio::null()).output() {
+        Ok(output) if driver_ran(&output.status) => VfsDriverState::Loadable(path.to_path_buf()),
+        Ok(output) => VfsDriverState::Unloadable {
+            path: path.to_path_buf(),
+            message: loader_failure_message(&output.stderr, &output.status),
+        },
+        Err(error) => VfsDriverState::Unloadable {
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        },
+    }
+}
+
+/// Whether the probed process actually reached its own code.
+///
+/// Loading is not the same as exiting zero. `kin-vfs` takes a subcommand and
+/// carries no `--version`, so `kin-vfs --version` exits 2 with a clap usage
+/// error on a perfectly healthy install; judging on `success()` would have
+/// reported every installed driver as broken, which is the same shape of wrong
+/// answer this check exists to remove. What a refusal to load looks like is a
+/// process that never reaches main: `ld.so` prints its complaint and exits 127,
+/// dyld kills the process outright, and a wrong-architecture or unreadable file
+/// fails at spawn.
+fn driver_ran(status: &std::process::ExitStatus) -> bool {
+    match status.code() {
+        Some(127) => false,
+        Some(_) => true,
+        None => false,
+    }
+}
+
+/// The loader's own words, or the exit status when it said nothing.
+fn loader_failure_message(stderr: &[u8], status: &std::process::ExitStatus) -> String {
+    String::from_utf8_lossy(stderr)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("it exited with {status} and printed nothing"))
+}
+
+/// Resolve the projection driver by running the candidates in order.
+///
+/// A driver that runs wins over one that does not, so a stale copy in one
+/// location cannot hide a working install in another. A candidate that exists
+/// and refuses to run is reported only when nothing else runs.
+fn resolve_vfs_driver(candidates: &[PathBuf]) -> VfsDriverState {
+    let mut refused: Option<VfsDriverState> = None;
+    for candidate in candidates {
+        if !candidate.is_file() {
+            continue;
+        }
+        match probe_vfs_driver(candidate) {
+            VfsDriverState::Loadable(path) => return VfsDriverState::Loadable(path),
+            state => {
+                if refused.is_none() {
+                    refused = Some(state);
+                }
+            }
+        }
+    }
+    refused.unwrap_or(VfsDriverState::Absent)
 }
 
 /// The durable step that repairs a missing or corrupt shim when `kin doctor
@@ -672,6 +778,15 @@ fn projection_installed_under(kin_home: &Path) -> bool {
 /// list, where pointing back at the command that just ran is a dead loop.
 const SHIM_REINSTALL_HINT: &str =
     "reinstall kin to restore the shim: curl -fsSL https://get.kinlab.dev/install | sh";
+
+/// The durable step for a projection driver the loader refuses. It must not
+/// promise that a reinstall clears it: the loader's message can name a system
+/// library this host is too old to carry, and no build of the driver runs on
+/// such a host. Saying so is the difference between a remediation and a loop.
+const BROKEN_DRIVER_HINT: &str =
+    "reinstall kin for this platform: curl -fsSL https://get.kinlab.dev/install | sh. If the \
+     message names a system library version this host does not have, projection cannot run \
+     here, and the CLI and daemon are fully functional without it.";
 
 /// On-disk state of the VFS shim. Existence alone is not health: a 0-byte file
 /// crashes every process the shim is injected into, and a non-object blob is a
@@ -759,12 +874,36 @@ fn shim_object_kind() -> &'static str {
     }
 }
 
-/// Build the `vfs_projection` check from a resolved shim path and whether
-/// projection is installed on this machine at all. Split out from
-/// [`check_vfs_projection`] so the size/magic classification is testable.
-fn vfs_projection_check_for(lib_path: &Path, projection_installed: bool) -> HealthCheck {
+/// Build the `vfs_projection` check from a resolved shim path and the probed
+/// state of the projection driver. Split out from [`check_vfs_projection`] so
+/// the size/magic classification and the three driver states are testable.
+///
+/// The driver decides the headline. A driver that will not load is a defect
+/// whatever the shim looks like, and it is the one state the old check could
+/// not express: it inferred absence from `~/.kin/bin` alone and reported it as
+/// "neither is present here", which is a confident negative built from a place
+/// it never looked.
+fn vfs_projection_check_for(lib_path: &Path, driver: &VfsDriverState) -> HealthCheck {
+    if let VfsDriverState::Unloadable { path, message } = driver {
+        return HealthCheck::new(
+            "vfs_projection",
+            "VFS projection",
+            HealthStatus::Misconfigured,
+            format!(
+                "the kin-vfs driver at {} is installed but will not run: {message}",
+                path.display()
+            ),
+        )
+        .with_manual_fix(BROKEN_DRIVER_HINT);
+    }
+
+    let driver_note = match driver {
+        VfsDriverState::Loadable(path) => format!("; kin-vfs driver at {} runs", path.display()),
+        _ => String::new(),
+    };
+
     match classify_shim(lib_path) {
-        ShimState::Missing if !projection_installed => HealthCheck::new(
+        ShimState::Missing if matches!(driver, VfsDriverState::Absent) => HealthCheck::new(
             "vfs_projection",
             "VFS projection",
             HealthStatus::Unsupported,
@@ -773,14 +912,17 @@ fn vfs_projection_check_for(lib_path: &Path, projection_installed: bool) -> Heal
         )
         .with_platform_note(
             "The installer ships projection only where it can run, and removes the kin-vfs \
-             driver and its shim together when it cannot. Neither is present here, so nothing \
-             is missing.",
+             driver and its shim together when it cannot. No kin-vfs was found beside the kin \
+             binary, in ~/.kin/bin, or on PATH, and no shim is installed, so nothing is missing.",
         ),
         ShimState::Valid(size) => HealthCheck::new(
             "vfs_projection",
             "VFS projection",
             HealthStatus::Healthy,
-            format!("shim installed ({size} bytes, {})", lib_path.display()),
+            format!(
+                "shim installed ({size} bytes, {}){driver_note}",
+                lib_path.display()
+            ),
         ),
         ShimState::Empty => HealthCheck::new(
             "vfs_projection",
@@ -809,7 +951,7 @@ fn vfs_projection_check_for(lib_path: &Path, projection_installed: bool) -> Heal
             "vfs_projection",
             "VFS projection",
             HealthStatus::Missing,
-            format!("shim not installed at {}", lib_path.display()),
+            format!("shim not installed at {}{driver_note}", lib_path.display()),
         )
         .fixable()
         .with_manual_fix(SHIM_REINSTALL_HINT),
@@ -983,6 +1125,7 @@ fn check_shell_path() -> HealthCheck {
         hook_path: &hook_path,
         rc_display: &rc_display,
         bin_dir: &bin_dir,
+        bin_dir_present: bin_dir.is_dir(),
         hook_installed,
         rc_sources,
         on_path,
@@ -1025,6 +1168,10 @@ struct ShellIntegrationState<'a> {
     hook_path: &'a Path,
     rc_display: &'a str,
     bin_dir: &'a Path,
+    /// Whether `~/.kin/bin` exists at all. Only the launcher-provisioned layout
+    /// populates it, so an archive or Homebrew install has no such directory and
+    /// nothing that belongs on PATH through it.
+    bin_dir_present: bool,
     hook_installed: bool,
     rc_sources: bool,
     on_path: bool,
@@ -1053,6 +1200,7 @@ fn shell_path_check_from(state: ShellIntegrationState<'_>) -> HealthCheck {
         hook_path,
         rc_display,
         bin_dir,
+        bin_dir_present,
         hook_installed,
         rc_sources,
         on_path,
@@ -1060,21 +1208,33 @@ fn shell_path_check_from(state: ShellIntegrationState<'_>) -> HealthCheck {
         recorded_by_setup,
     } = state;
 
-    if hook_installed && rc_sources && (on_path || rc_sets_path) {
-        let detail = match (on_path, rc_sets_path) {
-            (true, _) => {
+    if hook_installed && rc_sources && (on_path || rc_sets_path || !bin_dir_present) {
+        let detail = match (bin_dir_present, on_path, rc_sets_path) {
+            (true, true, _) => {
                 format!(
                     "{shell} hook installed and sourced from {rc_display}; {} on PATH",
                     bin_dir.display()
                 )
             }
-            (false, true) => {
+            (true, false, true) => {
                 format!(
                     "{shell} hook installed and sourced from {rc_display}; {} will be on PATH after shell restart",
                     bin_dir.display()
                 )
             }
-            (false, false) => unreachable!(),
+            (false, _, true) => {
+                format!(
+                    "{shell} hook installed and sourced from {rc_display}; that rc adds {} to PATH, a directory this install did not create",
+                    bin_dir.display()
+                )
+            }
+            (false, _, false) => {
+                format!(
+                    "{shell} hook installed and sourced from {rc_display}; no PATH line was added because {} does not exist on this host",
+                    bin_dir.display()
+                )
+            }
+            (true, false, false) => unreachable!(),
         };
         HealthCheck::new(
             "shell_path",
@@ -1100,7 +1260,7 @@ fn shell_path_check_from(state: ShellIntegrationState<'_>) -> HealthCheck {
         if !rc_sources {
             missing.push(format!("{rc_display} does not source the kin-vfs hook"));
         }
-        if !on_path && !rc_sets_path {
+        if bin_dir_present && !on_path && !rc_sets_path {
             missing.push(format!(
                 "{rc_display} does not add {} to PATH",
                 bin_dir.display()
@@ -1597,6 +1757,37 @@ fn mcp_client_check_from(
     }
 }
 
+/// Build the row for a machine carrying no AI client config file at all.
+///
+/// A config file is evidence a client was configured, not evidence one is
+/// installed. Reading only config files, this row told the user there was
+/// nothing to configure in the same minute `kin setup` detected Claude Code and
+/// wrote both its MCP config and a global instruction file. Both surfaces now
+/// read setup's detection, so they cannot disagree about what is on the machine.
+fn no_mcp_client_config_check(detected: &[&str]) -> HealthCheck {
+    if detected.is_empty() {
+        return HealthCheck::new(
+            "mcp_clients",
+            "AI client MCP config",
+            HealthStatus::Healthy,
+            "no AI client detected and no client config files present, so there is nothing \
+             to configure",
+        );
+    }
+
+    HealthCheck::new(
+        "mcp_clients",
+        "AI client MCP config",
+        HealthStatus::Unsupported,
+        format!(
+            "{} detected with no client config file yet; `kin setup` writes the kin MCP server \
+             entry for it",
+            detected.join(", ")
+        ),
+    )
+    .with_manual_fix("run `kin setup` to register the kin MCP server with the detected client(s)")
+}
+
 fn check_mcp_clients() -> Vec<HealthCheck> {
     let clients: Vec<McpClient> = mcp_client_config_paths()
         .into_iter()
@@ -1605,12 +1796,7 @@ fn check_mcp_clients() -> Vec<HealthCheck> {
         .collect();
 
     if clients.is_empty() {
-        return vec![HealthCheck::new(
-            "mcp_clients",
-            "AI client MCP config",
-            HealthStatus::Healthy,
-            "no AI client config files detected — nothing to configure",
-        )];
+        return vec![no_mcp_client_config_check(&detected_ai_client_names())];
     }
 
     let recorded = mcp_paths_recorded_by_setup();
@@ -2683,8 +2869,9 @@ mod tests {
         let corrupt = dir.path().join("corrupt");
         write_file(&corrupt, b"not an object file");
 
+        let driver = VfsDriverState::Loadable(dir.path().join(vfs_binary_filename()));
         for path in [&missing, &empty, &corrupt] {
-            let check = vfs_projection_check_for(path, true);
+            let check = vfs_projection_check_for(path, &driver);
             assert!(check.fixable, "{}: should be fixable", path.display());
             let fix = check.manual_fix.clone().unwrap_or_default();
             assert!(!fix.is_empty(), "{}: missing manual fix", path.display());
@@ -2706,7 +2893,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("libkin_vfs_shim");
 
-        let uninstalled = vfs_projection_check_for(&missing, false);
+        let uninstalled = vfs_projection_check_for(&missing, &VfsDriverState::Absent);
         assert!(
             matches!(uninstalled.status, HealthStatus::Unsupported),
             "no projection on this machine must be skipped, got {:?}",
@@ -2723,8 +2910,11 @@ mod tests {
         );
         assert!(uninstalled.platform_note.is_some());
 
-        // Falsification: flip only the installed flag, keep the same path.
-        let installed = vfs_projection_check_for(&missing, true);
+        // Falsification: flip only the driver state, keep the same path.
+        let installed = vfs_projection_check_for(
+            &missing,
+            &VfsDriverState::Loadable(dir.path().join(vfs_binary_filename())),
+        );
         assert!(
             matches!(installed.status, HealthStatus::Missing),
             "a shim missing where projection is installed must stay a failure, got {:?}",
@@ -2747,7 +2937,7 @@ mod tests {
         write_file(&corrupt, b"not an object file");
 
         for path in [&empty, &corrupt] {
-            let check = vfs_projection_check_for(path, false);
+            let check = vfs_projection_check_for(path, &VfsDriverState::Absent);
             if cfg!(any(target_os = "macos", target_os = "linux")) || path == &empty {
                 assert!(
                     is_failing(&check.status),
@@ -2759,15 +2949,166 @@ mod tests {
         }
     }
 
+    /// The driver the user just ran `kin` from is the one to judge. An archive
+    /// or Homebrew install puts `kin-vfs` beside the `kin` binary rather than in
+    /// `~/.kin/bin`, and looking only in `~/.kin/bin` reported that driver as
+    /// absent.
     #[test]
-    fn projection_is_detected_from_the_driver_beside_the_managed_binaries() {
+    fn the_driver_beside_the_running_binary_is_a_candidate() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(!projection_installed_under(dir.path()));
+        let install = dir.path().join("opt/kin");
+        std::fs::create_dir_all(&install).unwrap();
+        let exe = install.join("kin");
+        write_file(&exe, b"kin");
 
-        let bin = dir.path().join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        write_file(&bin.join(vfs_binary_filename()), b"driver");
-        assert!(projection_installed_under(dir.path()));
+        let candidates = vfs_driver_candidates(&dir.path().join("kin-home"), Some(&exe));
+        assert!(
+            candidates.contains(&install.join(vfs_binary_filename())),
+            "a driver beside the running binary must be probed: {candidates:?}"
+        );
+        assert!(
+            candidates.contains(
+                &dir.path()
+                    .join("kin-home")
+                    .join("bin")
+                    .join(vfs_binary_filename())
+            ),
+            "the managed location must still be probed: {candidates:?}"
+        );
+    }
+
+    /// Write an executable stand-in for the projection driver.
+    #[cfg(unix)]
+    fn write_driver(path: &Path, script: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        write_file(path, script.as_bytes());
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    /// A driver the loader refuses is not an absent driver. The linux-aarch64
+    /// archive shipped a `kin-vfs` requiring a newer glibc than the host had,
+    /// and the check reported "neither is present here" with both files sitting
+    /// beside the `kin` binary it had just resolved by full path.
+    #[test]
+    #[cfg(unix)]
+    fn a_driver_that_will_not_load_is_reported_as_broken_rather_than_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let driver = dir.path().join(vfs_binary_filename());
+        write_driver(
+            &driver,
+            "#!/bin/sh\necho \"kin-vfs: /lib/libc.so.6: version GLIBC_2.39 not found\" >&2\nexit 127\n",
+        );
+
+        let state = resolve_vfs_driver(std::slice::from_ref(&driver));
+        let VfsDriverState::Unloadable { path, message } = &state else {
+            panic!("a driver that refuses to run must be Unloadable, got {state:?}");
+        };
+        assert_eq!(path, &driver);
+        assert!(
+            message.contains("GLIBC_2.39"),
+            "the loader's own words must reach the report: {message}"
+        );
+
+        let check = vfs_projection_check_for(&dir.path().join("no-shim"), &state);
+        assert!(
+            is_failing(&check.status),
+            "a driver that cannot run must need attention, got {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("GLIBC_2.39")
+                && check.detail.contains(&driver.display().to_string()),
+            "the row must name the driver and quote the loader: {}",
+            check.detail
+        );
+        let fix = check.manual_fix.clone().unwrap_or_default();
+        assert!(!fix.is_empty(), "a broken driver must carry a remediation");
+        assert!(!fix.contains("doctor --fix"), "circular fix text: {fix}");
+
+        // Falsification: the same missing shim with no driver anywhere is the
+        // installer's sanctioned outcome and stays a green n/a.
+        let absent = vfs_projection_check_for(&dir.path().join("no-shim"), &VfsDriverState::Absent);
+        assert!(
+            matches!(absent.status, HealthStatus::Unsupported),
+            "an absent driver must stay skipped, got {:?}",
+            absent.status
+        );
+        assert!(!is_failing(&absent.status));
+    }
+
+    /// The probe may not require a successful exit. The shipped `kin-vfs` takes
+    /// a subcommand and carries no `--version`, so it answers an unknown flag
+    /// with a clap usage error and exit 2 on a healthy install. Scoring that as
+    /// a driver that will not load fails every install that works.
+    #[test]
+    #[cfg(unix)]
+    fn a_driver_answering_with_a_usage_error_still_counts_as_loaded() {
+        let dir = tempfile::tempdir().unwrap();
+        let driver = dir.path().join(vfs_binary_filename());
+        write_driver(
+            &driver,
+            "#!/bin/sh\necho \"error: unexpected argument found\" >&2\nexit 2\n",
+        );
+
+        assert_eq!(
+            resolve_vfs_driver(std::slice::from_ref(&driver)),
+            VfsDriverState::Loadable(driver.clone()),
+            "a driver that ran and complained about arguments is installed and loadable"
+        );
+
+        // Falsification: the loader's own refusal exits 127 and stays broken.
+        let refused = dir.path().join("refused").join(vfs_binary_filename());
+        std::fs::create_dir_all(refused.parent().unwrap()).unwrap();
+        write_driver(&refused, "#!/bin/sh\necho 'libc.so.6: version not found' >&2\nexit 127\n");
+        assert!(
+            matches!(
+                resolve_vfs_driver(std::slice::from_ref(&refused)),
+                VfsDriverState::Unloadable { .. }
+            ),
+            "a loader refusal must still be caught"
+        );
+    }
+
+    /// Absent, present and loadable, present and unloadable must be three
+    /// different rows. They were two: the first two were the same green n/a,
+    /// and the third had no way to be said at all.
+    #[test]
+    #[cfg(unix)]
+    fn the_three_driver_states_are_three_different_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_shim = dir.path().join("no-shim");
+
+        let working = dir.path().join("works").join(vfs_binary_filename());
+        std::fs::create_dir_all(working.parent().unwrap()).unwrap();
+        write_driver(&working, "#!/bin/sh\necho 'kin-vfs 0.0.0-test'\n");
+        let loadable = resolve_vfs_driver(std::slice::from_ref(&working));
+        assert_eq!(loadable, VfsDriverState::Loadable(working.clone()));
+
+        let broken = dir.path().join("broken").join(vfs_binary_filename());
+        std::fs::create_dir_all(broken.parent().unwrap()).unwrap();
+        write_driver(&broken, "#!/bin/sh\nexit 127\n");
+
+        let absent = vfs_projection_check_for(&missing_shim, &VfsDriverState::Absent);
+        let installed = vfs_projection_check_for(&missing_shim, &loadable);
+        let unloadable = vfs_projection_check_for(
+            &missing_shim,
+            &resolve_vfs_driver(std::slice::from_ref(&broken)),
+        );
+
+        assert!(matches!(absent.status, HealthStatus::Unsupported));
+        assert!(matches!(installed.status, HealthStatus::Missing));
+        assert!(matches!(unloadable.status, HealthStatus::Misconfigured));
+        assert!(
+            installed.detail.contains(&working.display().to_string()),
+            "a driver that runs must be named as running: {}",
+            installed.detail
+        );
+        let details = [&absent.detail, &installed.detail, &unloadable.detail];
+        for (i, left) in details.iter().enumerate() {
+            for right in details.iter().skip(i + 1) {
+                assert_ne!(left, right, "two states must never print the same row");
+            }
+        }
     }
 
     /// A repository that has never started a daemon is the resting state every
@@ -2918,6 +3259,7 @@ mod tests {
             hook_path: Path::new("/home/u/.kin/shell/kin-vfs.zsh"),
             rc_display: "/home/u/.zshrc",
             bin_dir: Path::new("/home/u/.kin/bin"),
+            bin_dir_present: true,
             hook_installed,
             rc_sources: hook_installed,
             on_path: hook_installed,
@@ -3138,7 +3480,7 @@ mod tests {
         let checks = vec![
             check_with("kin_binary", HealthStatus::Healthy),
             check_with("kin_daemon_binary", HealthStatus::Healthy),
-            vfs_projection_check_for(&dir.path().join("no-shim"), false),
+            vfs_projection_check_for(&dir.path().join("no-shim"), &VfsDriverState::Absent),
             repo_init_check_for(&repo, None, None),
             daemon_not_running_check_for("/repo", &dir.path().join("daemon.pid")),
             mcp_client_check_from(
@@ -3232,6 +3574,46 @@ mod tests {
         assert!(matches!(check.status, HealthStatus::Healthy));
     }
 
+    /// The row that reported `~/.kin/bin will be on PATH after shell restart`
+    /// on a host where that directory did not exist. Which of the two cases the
+    /// install is in has to be in the row, since the PATH line is written only
+    /// in one of them.
+    #[test]
+    fn the_shell_row_says_whether_a_path_line_was_wanted() {
+        let mut archive = shell_state(true, true);
+        archive.bin_dir_present = false;
+        archive.on_path = false;
+        archive.rc_sets_path = false;
+        let check = shell_path_check_from(archive);
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "a hook installed by an archive install is not broken: {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("does not exist"),
+            "the row must say why no PATH line was written: {}",
+            check.detail
+        );
+
+        // Falsification: the same rc on the layout that does provision the
+        // directory is a real missing PATH line and stays a failure.
+        let mut managed = shell_state(true, true);
+        managed.on_path = false;
+        managed.rc_sets_path = false;
+        let check = shell_path_check_from(managed);
+        assert!(
+            matches!(check.status, HealthStatus::Misconfigured),
+            "a provisioned bin directory missing from PATH stays a failure: {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("does not add"),
+            "the failing row still names the missing PATH line: {}",
+            check.detail
+        );
+    }
+
     #[test]
     #[serial]
     fn shell_path_is_healthy_when_rc_declares_path_for_next_shell() {
@@ -3241,6 +3623,8 @@ mod tests {
         let hook_dir = kin_home.join("shell");
         std::fs::create_dir_all(&home).unwrap();
         std::fs::create_dir_all(&hook_dir).unwrap();
+
+        std::fs::create_dir_all(kin_home.join("bin")).unwrap();
 
         let hook = hook_dir.join(hook_filename("zsh"));
         std::fs::write(&hook, "# kin-vfs test hook\n").unwrap();
@@ -3334,6 +3718,93 @@ mod tests {
 
     fn check_with(id: &str, status: HealthStatus) -> HealthCheck {
         HealthCheck::new(id, id, status, "")
+    }
+
+    /// Doctor said "no AI client config files detected, nothing to configure"
+    /// and `kin setup` configured Claude Code seconds later on the same host.
+    /// The row now reports what setup's own detection sees, so the two surfaces
+    /// cannot contradict each other.
+    #[test]
+    fn the_no_client_row_reports_detection_rather_than_config_files() {
+        let nothing = no_mcp_client_config_check(&[]);
+        assert!(matches!(nothing.status, HealthStatus::Healthy));
+        assert!(
+            nothing.detail.contains("nothing to configure"),
+            "a host with no client keeps the settled answer: {}",
+            nothing.detail
+        );
+
+        // Falsification: one detected client and the same absent config files.
+        let detected = no_mcp_client_config_check(&["Claude Code"]);
+        assert!(
+            detected.detail.contains("Claude Code"),
+            "a detected client must be named: {}",
+            detected.detail
+        );
+        assert!(
+            !detected.detail.contains("nothing to configure"),
+            "setup has work to do here, so the row may not say otherwise: {}",
+            detected.detail
+        );
+        assert!(
+            detected.manual_fix.is_some(),
+            "the row must point at the command that does the work"
+        );
+        assert!(
+            !is_failing(&detected.status),
+            "an unconfigured client is first-run work, not a broken install: {:?}",
+            detected.status
+        );
+    }
+
+    /// The same question asked of the real check, with a real home that has no
+    /// client config and a PATH that does or does not carry a client binary.
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn a_detected_client_reaches_the_row_that_used_to_say_nothing_to_configure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let empty_bin = tmp.path().join("empty-bin");
+        let client_bin = tmp.path().join("client-bin");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&empty_bin).unwrap();
+        std::fs::create_dir_all(&client_bin).unwrap();
+
+        let _home = EnvVarGuard::set("HOME", &home);
+
+        let without = {
+            let _path = EnvVarGuard::set("PATH", &empty_bin);
+            check_mcp_clients()
+        };
+        assert_eq!(without.len(), 1, "no config files means one rollup row");
+        assert!(
+            !without[0].detail.contains("Claude Code"),
+            "no client on PATH and none in this home: {}",
+            without[0].detail
+        );
+
+        let claude = client_bin.join("claude");
+        write_file(&claude, b"#!/bin/sh\nexit 0\n");
+        std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let with = {
+            let _path = EnvVarGuard::set("PATH", &client_bin);
+            check_mcp_clients()
+        };
+        assert_eq!(with.len(), 1, "still no config files, still one rollup row");
+        assert!(
+            with[0].detail.contains("Claude Code"),
+            "an installed client must reach the row: {}",
+            with[0].detail
+        );
+        assert!(
+            !with[0].detail.contains("nothing to configure"),
+            "setup will configure it, so the row may not say there is nothing to do: {}",
+            with[0].detail
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1583,6 +1583,38 @@ fn detect_ai_assistants() -> Vec<AiAssistant> {
     ]
 }
 
+/// What setup may claim after writing one client's MCP config.
+///
+/// "Configured" is a statement about a client that is on this machine. Setup
+/// writes for a client it did not detect only when an operator picked one in the
+/// advanced picker, and saying "configured" there reports an install that does
+/// not exist: the only new thing on disk is the config file Kin just created.
+fn client_write_summary(name: &str, detected: bool, path: &Path) -> String {
+    if detected {
+        format!("{name} configured ({})", path.display())
+    } else {
+        format!(
+            "{name} pre-configured for a client that is not installed ({})",
+            path.display()
+        )
+    }
+}
+
+/// Names of the AI clients setup detects on this machine.
+///
+/// `kin doctor` reads this rather than keeping its own rule, because the two
+/// answered differently in the same minute: doctor said "no AI client config
+/// files detected, nothing to configure" from the absence of config files, and
+/// `kin setup` then found a client and configured it. A config file is evidence
+/// a client was configured, not evidence one is installed.
+pub(crate) fn detected_ai_client_names() -> Vec<&'static str> {
+    detect_ai_assistants()
+        .into_iter()
+        .filter(|assistant| assistant.detected)
+        .map(|assistant| assistant.name)
+        .collect()
+}
+
 /// Merge the "kin" MCP server entry into an existing JSON config file.
 /// Creates the file if it doesn't exist.
 fn merge_mcp_config(path: &PathBuf, target_id: &str) -> Result<()> {
@@ -1991,20 +2023,29 @@ These tools operate on the graph-native substrate and return richer, more
 accurate results than filesystem heuristics. Use them first.
 "#;
 
+/// Heading the reminder is recognized by, and the line setup names before it
+/// appends anything to a user's global instruction file.
+const KIN_DISCOVERY_MARKER: &str = "## Kin-first discovery (added by `kin setup`)";
+
+/// Whether an instruction file already carries Kin's reminder heading.
+fn discovery_reminder_marker_present(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .map(|content| content.contains(KIN_DISCOVERY_MARKER))
+        .unwrap_or(false)
+}
+
 /// Append the Kin-first discovery reminder to an agent instruction file
 /// (e.g. `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`).
 ///
 /// Idempotent: skips if the marker is already present.
 fn inject_discovery_reminder(path: &PathBuf) -> Result<()> {
-    const MARKER: &str = "## Kin-first discovery (added by `kin setup`)";
-
     let existing = if path.exists() {
         fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?
     } else {
         String::new()
     };
 
-    if existing.contains(MARKER) {
+    if existing.contains(KIN_DISCOVERY_MARKER) {
         return Ok(());
     }
 
@@ -2102,6 +2143,14 @@ fn apply_discovery_reminders(
                 );
             }
             continue;
+        }
+        if !discovery_reminder_marker_present(&path) {
+            println!(
+                "  {} {label}: appending the \"{KIN_DISCOVERY_MARKER}\" block to {}, a global \
+                 instruction file every {label} session on this host reads",
+                style("→").cyan(),
+                path.display()
+            );
         }
         match inject_discovery_reminder(&path) {
             Ok(()) => {
@@ -2274,8 +2323,15 @@ fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
         String::new()
     };
 
-    let update = plan_rc_update(&rc_content, shell_name, &source_line, &rc_path, &bin_dir);
-    for line in &update.already_present {
+    let update = plan_rc_update(
+        &rc_content,
+        shell_name,
+        &source_line,
+        &rc_path,
+        &bin_dir,
+        bin_dir.is_dir(),
+    );
+    for line in update.already_present.iter().chain(&update.skipped) {
         println!("{line}");
     }
     if !update.applied.is_empty() {
@@ -2304,6 +2360,9 @@ struct RcUpdate {
     content: String,
     applied: Vec<String>,
     already_present: Vec<String>,
+    /// Lines this run chose not to write, and why. A repair that silently
+    /// declines to act reads exactly like one that acted.
+    skipped: Vec<String>,
 }
 
 fn plan_rc_update(
@@ -2312,10 +2371,12 @@ fn plan_rc_update(
     source_line: &str,
     rc_path: &Path,
     bin_dir: &Path,
+    bin_dir_present: bool,
 ) -> RcUpdate {
     let mut content = existing.to_string();
     let mut applied = Vec::new();
     let mut already_present = Vec::new();
+    let mut skipped = Vec::new();
 
     let append = |content: &mut String, block: &str| {
         if !content.ends_with('\n') && !content.is_empty() {
@@ -2339,6 +2400,16 @@ fn plan_rc_update(
             "  Shell rc already adds {} to PATH",
             bin_dir.display()
         ));
+    } else if !bin_dir_present {
+        // Only the launcher-provisioned layout populates ~/.kin/bin. An archive
+        // or Homebrew install puts the binaries elsewhere, and writing the
+        // export anyway left the user's rc pointing at a directory this install
+        // never created, which nobody reading that rc later can tell from an
+        // install that went missing.
+        skipped.push(format!(
+            "  Skipped the PATH line: {} does not exist, and this install put nothing there",
+            bin_dir.display()
+        ));
     } else {
         append(&mut content, &rc_path_block(shell_name, bin_dir));
         applied.push(format!(
@@ -2351,6 +2422,7 @@ fn plan_rc_update(
         content,
         applied,
         already_present,
+        skipped,
     }
 }
 
@@ -12001,10 +12073,9 @@ async fn apply_plan(
             match result {
                 Some(Ok(path)) => {
                     println!(
-                        "  {} {} configured ({})",
+                        "  {} {}",
                         style("✓").green(),
-                        a.name,
-                        path.display()
+                        client_write_summary(a.name, a.detected, &path)
                     );
                     // Which repository a client ends up bound to is decided by
                     // the directory this ran in, and nothing said so. A later
@@ -14574,6 +14645,104 @@ wait
         assert_eq!(find_shim().as_deref(), Some(shim.as_path()));
     }
 
+    /// The repair `kin doctor --fix` actually runs, against the install shape an
+    /// archive or Homebrew user has: no `~/.kin/bin`, and `kin` resolved from
+    /// somewhere else. It appended the PATH export anyway, so the rc named a
+    /// directory that did not exist before the repair or after it.
+    #[test]
+    #[serial]
+    fn the_shell_repair_neither_invents_a_bin_directory_nor_points_at_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive_home = tmp.path().join("archive-home");
+        let managed_home = tmp.path().join("managed-home");
+        let kin_home = tmp.path().join("kin-home");
+        fs::create_dir_all(&archive_home).unwrap();
+        fs::create_dir_all(&managed_home).unwrap();
+
+        let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvVarGuard::unset("KIN_DIR");
+        let bin_dir = kin_home.join("bin");
+
+        {
+            let _home = EnvVarGuard::set("HOME", &archive_home);
+            install_shell_hook("bash").unwrap();
+        }
+        let rc = fs::read_to_string(archive_home.join(".bashrc")).unwrap();
+        assert!(
+            rc.contains("kin-vfs"),
+            "the hook source line is the repair and must still land: {rc}"
+        );
+        assert!(
+            !rc.contains(&bin_dir.display().to_string()),
+            "a repair may not write a PATH reference to a directory it did not install: {rc}"
+        );
+        assert!(
+            !bin_dir.exists(),
+            "the repair must not conjure {} either",
+            bin_dir.display()
+        );
+
+        // Falsification: on the launcher-provisioned layout, where the binaries
+        // really are under ~/.kin/bin, the same repair still writes the line.
+        fs::create_dir_all(&bin_dir).unwrap();
+        {
+            let _home = EnvVarGuard::set("HOME", &managed_home);
+            install_shell_hook("bash").unwrap();
+        }
+        let managed_rc = fs::read_to_string(managed_home.join(".bashrc")).unwrap();
+        assert!(
+            managed_rc.contains(&bin_dir.display().to_string()),
+            "a provisioned bin directory must still reach PATH: {managed_rc}"
+        );
+    }
+
+    /// Setup wrote `~/.claude.json` and a global `~/.claude/CLAUDE.md` block and
+    /// called it "Claude Code configured". "Configured" is a claim about a
+    /// client that is installed; for one that is not, the only new thing is the
+    /// file Kin just wrote, and the line has to say so.
+    #[test]
+    fn an_absent_client_is_never_reported_as_configured() {
+        let path = Path::new("/home/u/.claude.json");
+
+        let installed = client_write_summary("Claude Code", true, path);
+        assert_eq!(installed, "Claude Code configured (/home/u/.claude.json)");
+
+        // Falsification: same client, same path, detection flipped.
+        let absent = client_write_summary("Claude Code", false, path);
+        assert!(
+            absent.contains("pre-configured for a client that is not installed"),
+            "an absent client must be named as absent: {absent}"
+        );
+        assert!(
+            !absent.contains("Claude Code configured"),
+            "no wording may read as a configured install: {absent}"
+        );
+        assert!(
+            absent.contains("/home/u/.claude.json"),
+            "the file that was written is still named: {absent}"
+        );
+    }
+
+    /// The reminder is a standing directive in a file every future session of
+    /// that client reads, so setup names the file and the block before it
+    /// appends, not only after.
+    #[test]
+    fn the_discovery_reminder_marker_is_the_heading_the_block_carries() {
+        assert!(
+            KIN_DISCOVERY_REMINDER.contains(KIN_DISCOVERY_MARKER),
+            "the announced heading must be the one the block actually carries"
+        );
+
+        let tmp = tempfile::tempdir().unwrap();
+        let instructions = tmp.path().join("CLAUDE.md");
+        assert!(!discovery_reminder_marker_present(&instructions));
+        inject_discovery_reminder(&instructions).unwrap();
+        assert!(
+            discovery_reminder_marker_present(&instructions),
+            "a written reminder must be recognized, so the announcement fires once"
+        );
+    }
+
     #[test]
     fn zsh_hook_clears_stale_preload_state() {
         assert!(ZSH_HOOK.contains("_kin_vfs_clear_preload"));
@@ -15576,13 +15745,13 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let bin_dir = Path::new("/home/u/.kin/bin");
         let source_line = "source /home/u/.kin/shell/kin-vfs.zsh";
 
-        let fresh = plan_rc_update("", "zsh", source_line, rc_path, bin_dir);
+        let fresh = plan_rc_update("", "zsh", source_line, rc_path, bin_dir, true);
         assert_eq!(fresh.applied.len(), 2, "{:?}", fresh.applied);
         assert!(fresh.already_present.is_empty());
         assert!(fresh.content.contains(source_line));
         assert!(fresh.content.contains(&rc_path_line("zsh", bin_dir)));
 
-        let settled = plan_rc_update(&fresh.content, "zsh", source_line, rc_path, bin_dir);
+        let settled = plan_rc_update(&fresh.content, "zsh", source_line, rc_path, bin_dir, true);
         assert!(
             settled.applied.is_empty(),
             "nothing is written on a second run, so nothing may be claimed: {:?}",
@@ -15592,6 +15761,47 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         assert_eq!(settled.content, fresh.content);
     }
 
+    /// A repair may not write a reference to something it did not install.
+    /// `kin doctor --fix` appended `export PATH="$HOME/.kin/bin:$PATH"` to a
+    /// `.bashrc` on an archive install, and `~/.kin/bin` did not exist before
+    /// that line or after it; only the launcher-provisioned layout populates it.
+    #[test]
+    fn plan_rc_update_writes_no_path_line_for_a_directory_this_install_never_made() {
+        let rc_path = Path::new("/home/u/.bashrc");
+        let bin_dir = Path::new("/home/u/.kin/bin");
+        let source_line = "source /home/u/.kin/shell/kin-vfs.bash";
+
+        let absent = plan_rc_update("", "bash", source_line, rc_path, bin_dir, false);
+        assert!(
+            !absent.content.contains(".kin/bin"),
+            "no PATH line may reference a directory that does not exist: {}",
+            absent.content
+        );
+        assert_eq!(absent.applied.len(), 1, "{:?}", absent.applied);
+        assert!(
+            absent.applied.iter().all(|line| !line.contains("PATH")),
+            "a skipped write may not be claimed: {:?}",
+            absent.applied
+        );
+        assert_eq!(absent.skipped.len(), 1, "{:?}", absent.skipped);
+        assert!(
+            absent.skipped[0].contains("does not exist")
+                && absent.skipped[0].contains("/home/u/.kin/bin"),
+            "the skip must name the directory and the reason: {:?}",
+            absent.skipped
+        );
+
+        // Falsification: the same rc on the layout that does populate the
+        // directory still gets the line, so this is not a blanket removal.
+        let present = plan_rc_update("", "bash", source_line, rc_path, bin_dir, true);
+        assert!(
+            present.content.contains(&rc_path_line("bash", bin_dir)),
+            "a provisioned ~/.kin/bin still earns its PATH line: {}",
+            present.content
+        );
+        assert!(present.skipped.is_empty(), "{:?}", present.skipped);
+    }
+
     #[test]
     fn plan_rc_update_claims_only_the_half_that_is_missing() {
         let rc_path = Path::new("/home/u/.bashrc");
@@ -15599,7 +15809,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         let source_line = "source /home/u/.kin/shell/kin-vfs.bash";
 
         let hook_only = format!("{}\n", rc_integration_block(source_line));
-        let update = plan_rc_update(&hook_only, "bash", source_line, rc_path, bin_dir);
+        let update = plan_rc_update(&hook_only, "bash", source_line, rc_path, bin_dir, true);
         assert_eq!(update.applied.len(), 1, "{:?}", update.applied);
         assert!(update.applied[0].contains("PATH"));
         assert_eq!(update.already_present.len(), 1);
@@ -16655,6 +16865,9 @@ $value = if ($env:KIN_TEST_PATH_PRESENT -eq '1') { $env:KIN_TEST_PATH_VALUE } el
         let home = tmp.path().join("home");
         let kin_home = tmp.path().join("kin-home");
         fs::create_dir_all(&home).unwrap();
+        // The PATH line is written for the layout that populates ~/.kin/bin, so
+        // that is the layout this idempotence contract is about.
+        fs::create_dir_all(kin_home.join("bin")).unwrap();
 
         let _home = EnvVarGuard::set("HOME", &home);
         let _kin_home = EnvVarGuard::set("KIN_HOME", &kin_home);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -441,10 +441,10 @@ The checks (IDs as emitted in `--json`):
 | --- | --- |
 | `kin_binary` | The `kin` binary resolved (reports version + path). |
 | `kin_daemon_binary` | `kin-daemon` found beside `kin` or on `PATH`. |
-| `vfs_projection` | The VFS shim is installed and non-zero in `~/.kin/lib` (macOS/Linux). On native Windows this is **unsupported**; use WSL2. |
+| `vfs_projection` | The VFS shim is installed and non-zero in `~/.kin/lib`, and the `kin-vfs` driver beside `kin`, in `~/.kin/bin`, or on PATH runs when probed (macOS/Linux). A driver that is present but will not load is **MISCONFIGURED** and the row quotes the loader; no driver and no shim is **n/a**. On native Windows this is **unsupported**; use WSL2. |
 | `repo_init` | The current directory is inside a Kin repository. |
-| `shell_path` | The `kin-vfs` shell hook is installed and sourced from your rc, and the managed `~/.kin/bin` directory is on PATH now or will be after shell restart. |
-| `mcp_client_*` (e.g. `mcp_client_claude`) | A detected AI client has the `kin` MCP server with the `agent-default` profile. With no client configs present, a single `mcp_clients` check reports ok ("nothing to configure"). |
+| `shell_path` | The `kin-vfs` shell hook is installed and sourced from your rc, and the managed `~/.kin/bin` directory is on PATH now or will be after shell restart. On an install that does not create `~/.kin/bin`, such as an archive or Homebrew one, no PATH line is written and the row says so. |
+| `mcp_client_*` (e.g. `mcp_client_claude`) | A detected AI client has the `kin` MCP server with the `agent-default` profile. With no client configs present, a single `mcp_clients` check reports ok when no client is installed either, and **n/a** naming the detected clients that `kin setup` would configure. |
 | `editor` | The `kin-editor` VS Code extension is detected in `~/.vscode/extensions`. **n/a** if not found / non-VS Code. |
 | `kinlab_connect` | A stored KinLab credential is present. **n/a** when nothing is stored; `kin auth login` connects this machine. |
 | `semantic_query_readiness` | The daemon is reachable and the vector index exists. **yellow/STALE** until you run `kin embed`; **MISSING** if the daemon isn't running. |


### PR DESCRIPTION
Three surfaces reported work they had not done. Each is fixed where it decided, and each state is now something a user can act on.

**`kin doctor` could not tell a broken kin-vfs driver from an absent one (FIR-2394).** The projection check inferred presence from one path: `projection_installed_under` (crates/kin-cli/src/commands/health.rs:665 on c4c26d65) tested `~/.kin/bin/kin-vfs` and nothing else, so an archive or Homebrew install, which puts the driver beside the `kin` binary, read as absent. The row then stated that guess as fact: "Neither is present here, so nothing is missing" (health.rs:776). On the 2026-08-18 stranger container both `kin-vfs` and `libkin_vfs_shim.so` sat in `/opt/kin` beside the binary doctor had just resolved by full path, and the driver could not load at all. Doctor now resolves the driver beside the running binary, in `~/.kin/bin`, and on PATH, runs the one it finds, and reports three distinct states: absent keeps the green n/a and now names where it looked, present and loadable says the driver runs, present and unloadable is a failure carrying the loader's literal message.

The probe runs `--help`, not `--version`, and judges on whether the process reached its own code rather than on a zero exit. The shipped `kin-vfs` takes a subcommand and declares no version, so `kin-vfs --version` exits 2 with a clap usage error on a healthy install: probing that way would have failed every install that works, which is the same shape of wrong answer this check exists to remove. A loader refusal looks different. `ld.so` prints its complaint and exits 127, dyld kills the process, and a wrong-architecture or unreadable file fails at spawn.

**`kin doctor --fix` wrote a PATH export for a directory it never created (FIR-2402).** `plan_rc_update` appended the `~/.kin/bin` export unconditionally (setup.rs:2345 on c4c26d65), and only the launcher-provisioned layout populates that directory, so an archive install ended up with a `.bashrc` naming a path that did not exist before the repair or after it. The repair now writes that line only when the directory exists, says out loud when it skips it, and the doctor row states which of the two cases the install is in instead of promising a PATH entry for nothing.

**`kin setup` reported a client as configured that doctor had just called absent (FIR-2406).** Doctor's AI-client row read config files only (health.rs:1612), so "no AI client config files detected, nothing to configure" was an answer about configuration, not about what is installed; `kin setup` uses a different detection and configured Claude Code seconds later on the same host. Both surfaces now read one detection, so they cannot disagree. Setup also stops calling a client "configured" when it is not installed, which is reachable through the advanced picker: that case now reads "pre-configured for a client that is not installed" and names the file. The discovery reminder, which is a standing directive in a file every future session of that client reads, is announced with its block heading and path before setup appends it, not only after.

Falsification, each guard broken in turn and restored:

- The unloadable arm removed: `a driver that cannot run must need attention, got Unsupported`, and `the_three_driver_states_are_three_different_rows` fails on `matches!(unloadable.status, HealthStatus::Misconfigured)`.
- The exe-directory candidate removed: `a driver beside the running binary must be probed: ["/tmp/.../kin-home/bin/kin-vfs", "/Users/.../.kin/bin/kin-vfs"]`.
- `driver_ran` replaced by `status.success()`: `a driver that ran and complained about arguments is installed and loadable`, left `Unloadable { message: "error: unexpected argument found" }`.
- The PATH skip removed: `no PATH line may reference a directory that does not exist`, and the repair test fails with `a repair may not write a PATH reference to a directory it did not install`.
- The row's directory test removed: `a hook installed by an archive install is not broken: Misconfigured`.
- Detection ignored in the client row: `a detected client must be named: no AI client detected and no client config files present, so there is nothing to configure`, and the end-to-end row fails with `an installed client must reach the row`.
- `client_write_summary` forced to the detected branch: `an absent client must be named as absent: Claude Code configured (/home/u/.claude.json)`.
- The reminder marker changed: the new test fails, and the pre-existing `discovery_reminder_injection_is_idempotent` appends the block twice.

Checked against the real binary, built from this branch. With an unloadable `kin-vfs` beside it and no shim, `kin doctor` prints:

```
  ✗ VFS projection    MISCONFIGURED  the kin-vfs driver at /tmp/dp-e2e/opt/kin-vfs is installed but will not run: kin-vfs: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by kin-vfs)
      fix:  reinstall kin for this platform: curl -fsSL https://get.kinlab.dev/install | sh. If the message names a system library version this host does not have, projection cannot run here, and the CLI and daemon are fully functional without it.
```

With the driver removed the row returns to the green n/a and names where it looked. `kin doctor --fix` against a home with no `~/.kin/bin` prints:

```
  Skipped the PATH line: /tmp/dp-e2e/kin-home/bin does not exist, and this install put nothing there
  Appended to /tmp/dp-e2e/home/.bashrc
  ✓ Shell integration    ok    bash hook installed and sourced from /tmp/dp-e2e/home/.bashrc; no PATH line was added because /tmp/dp-e2e/kin-home/bin does not exist on this host
```

The rc carries only the hook source line and `~/.kin/bin` is still not created. On that same run the client row reads `Cursor, Google Antigravity detected with no client config file yet`, where before it read "nothing to configure". On the developer machine, where a real driver is installed, the row reads `shim installed (928928 bytes, ~/.kin/lib/libkin_vfs_shim.dylib); kin-vfs driver at ~/.kin/bin/kin-vfs runs`.

Gate: `bin/kin-lane run doctorpaper kin -- bin/kin-dev local-test kin` on `/Users/.../.kin-coord/worktrees/doctorpaper-kin @ e1830c61 (chore/lane-doctorpaper-kin)`, 6010 tests run, 6010 passed, 11 skipped, exit 0, plus the doctest pass. `cargo fmt --all -- --check` clean and clippy clean under `RUSTFLAGS=-D warnings` with the ci.yml allowlist. `python3 scripts/test-release-workflow-authority.py` exits 0. That run predates the rebase onto 320cf57a (v0.5.39), which touched only release version strings and applied with no conflicts; `git diff origin/main --numstat` lists only the three files here, and `git diff origin/main -- Cargo.lock .cargo/` is empty.

Closes FIR-2394
Closes FIR-2402
Closes FIR-2406
