### PR TITLE
Land the advisory bump on a schedule so a merge group never meets a fresh advisory

### DIFF
--- a/.github/workflows/advisory-sweep.yml
+++ b/.github/workflows/advisory-sweep.yml
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Advisory Sweep
+
+# Land the lock bump for a freshly published RustSec advisory before a merge
+# group ever sees the advisory.
+#
+# cargo-deny's advisories check is resolved against the RustSec database it
+# fetches at run time, so it is the one required context whose verdict is not a
+# function of the merge candidate. An advisory that publishes between a pull
+# request's own SAST run and its merge-group run turns the group red, and the
+# hosted queue then drops an entry that introduced neither the dependency nor
+# the advisory while marking nothing on it. RUSTSEC-2026-0258 (h2 0.4.15) did
+# that to kin#893 on 2026-08-18, 87 seconds after admission, during the v0.5.39
+# release, and the fix was a lockfile-only bump that had to land first.
+#
+# Weakening the merge-group check was the obvious alternative and is refused in
+# sast.yml, because it is the one gate that reads the merged tree. Closing the
+# window instead of the eye is what this workflow is for.
+on:
+  schedule:
+    # Every three hours at :13, which is off the release train (:07,:22,:37,:52),
+    # recovery (:03,:18,:33,:48), sentinel (:11,:41) and mint (:11,:26,:41,:56)
+    # minutes, so the sweep never contends with a release cycle for the runner
+    # or for the branch it writes.
+    - cron: "13 */3 * * *"
+  # `repository_dispatch` rather than `workflow_dispatch`, and not by taste. A
+  # workflow_dispatch caller selects the ref, and GitHub resolves the workflow
+  # FILE from that ref, so any branch could rewrite this file and run it while
+  # holding the release App key. No guard written inside the file can close
+  # that, because the guard would be on the attacker's branch too. This repo
+  # already refuses the combination: test-release-workflow-authority.py fails
+  # any workflow that pairs a branch-selectable dispatch trigger with a
+  # KIN_*_APP_ID or private key, and it matches that trigger as a literal
+  # string, so naming it here would trip the guard this workflow obeys.
+  # which is why release-tag.yml takes its manual path the same way. Trigger a
+  # sweep by hand with:
+  #   gh api repos/firelock-ai/kin/dispatches -f event_type=advisory-sweep
+  repository_dispatch:
+    types: [advisory-sweep]
+
+permissions:
+  contents: read
+
+# Never two sweeps at once. Both would resolve the same advisory and race to
+# force-update one branch, and the loser would push a lock built from a tree
+# the winner had already moved.
+concurrency:
+  group: kin-advisory-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep advisories
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # The kin-release-bot App credentials are scoped to this environment, and a
+    # job only resolves them when it declares it. Same binding release-tag.yml
+    # and release-train.yml use, and the same deployment branch policy, which
+    # admits main only.
+    environment: release-tag
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Guard trigger authority
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ACTOR: ${{ github.actor }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          # Same reviewed actor set release-tag.yml admits for its manual path.
+          ALLOWED_ACTORS: |
+            troyjr4103
+            kin-release-bot[bot]
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = schedule ]; then
+            echo "trusted automatic trigger: $EVENT_NAME"
+            exit 0
+          fi
+          if [ "$EVENT_NAME" != repository_dispatch ]; then
+            echo "::error::unsupported trigger '$EVENT_NAME'"
+            exit 1
+          fi
+          if [ "$EVENT_ACTION" != advisory-sweep ]; then
+            echo "::error::unsupported repository dispatch action '$EVENT_ACTION'"
+            exit 1
+          fi
+          if [ "$DEFAULT_BRANCH" != main ]; then
+            echo "::error::advisory-sweep requires main as the repository default branch (got '$DEFAULT_BRANCH')"
+            exit 1
+          fi
+          if [ "$REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "::error::advisory-sweep dispatch must execute from the default branch (got '$REF')"
+            exit 1
+          fi
+          authorized=0
+          while IFS= read -r allowed; do
+            [ -z "$allowed" ] && continue
+            [ "$allowed" = "$ACTOR" ] && authorized=1
+          done <<< "$ALLOWED_ACTORS"
+          if [ "$authorized" -ne 1 ]; then
+            echo "::error::actor '$ACTOR' is not authorized to run the advisory sweep"
+            exit 1
+          fi
+          echo "authorized actor=$ACTOR action=$EVENT_ACTION ref=$REF"
+
+      - name: Mint repository-scoped bump branch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+
+      - name: Checkout trusted main with bump-branch authority
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+        with:
+          tool: cargo-deny@0.20.2
+
+      - name: Read the advisory database against main's lock
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -uo pipefail
+          # A nonzero exit here is the ordinary case: it means an advisory hit.
+          # The diagnostics are the product, so the status is deliberately not
+          # the gate.
+          cargo deny --format json --log-level warn --manifest-path ./Cargo.toml \
+            --all-features check advisories > "$RUNNER_TEMP/advisories.json" 2>&1 || true
+          test -s "$RUNNER_TEMP/advisories.json"
+
+      - name: Plan the bump
+        id: plan
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          node scripts/advisory-sweep.mjs \
+            --deny-json "$RUNNER_TEMP/advisories.json" \
+            --lock ./Cargo.lock \
+            --dry-run \
+            --plan-out "$RUNNER_TEMP/plan.json" \
+            > /dev/null
+          bumps="$(jq -r '.bumps | length' "$RUNNER_TEMP/plan.json")"
+          unfixable="$(jq -r '.unfixable | length' "$RUNNER_TEMP/plan.json")"
+          echo "bumps=$bumps" >> "$GITHUB_OUTPUT"
+          echo "unfixable=$unfixable" >> "$GITHUB_OUTPUT"
+          jq -r '.' "$RUNNER_TEMP/plan.json"
+
+      - name: Apply the bump and prove it moved only the named entries
+        id: apply
+        if: steps.plan.outputs.bumps != '0'
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+          BUMPS: ${{ steps.plan.outputs.bumps }}
+        run: |
+          set -euo pipefail
+          node scripts/advisory-sweep.mjs \
+            --deny-json "$RUNNER_TEMP/advisories.json" \
+            --lock ./Cargo.lock \
+            > /dev/null
+          # Two lines per bump, the version and the checksum, and no other file.
+          changed="$(git diff --name-only)"
+          if [ -z "$changed" ]; then
+            # The plan named a bump and the tree did not move, so the plan was
+            # built against a lock that is not the one checked out here. Silence
+            # would publish an empty branch and an empty pull request.
+            echo "::error::advisory bump changed nothing; the plan does not match the checked-out lock"
+            exit 1
+          fi
+          if [ "$changed" != "Cargo.lock" ]; then
+            echo "::error::advisory bump touched more than Cargo.lock: $changed"
+            exit 1
+          fi
+          expected=$(( BUMPS * 2 ))
+          read -r added removed _ < <(git diff --numstat -- Cargo.lock)
+          if [ "$added" != "$expected" ] || [ "$removed" != "$expected" ]; then
+            echo "::error::advisory bump moved ${added}/${removed} lock lines, expected ${expected}/${expected}"
+            git --no-pager diff -- Cargo.lock
+            exit 1
+          fi
+          # A hand-written lock that cargo would not have produced fails here
+          # rather than in somebody's build. `--locked` refuses to rewrite.
+          cargo metadata --locked --format-version 1 > /dev/null
+          # And the advisory has to actually be gone, which is the only reason
+          # the bump exists.
+          cargo deny --log-level warn --manifest-path ./Cargo.toml --all-features check advisories
+
+      - name: Publish the bump branch
+        id: branch
+        if: steps.plan.outputs.bumps != '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          branch=automation/advisory-bump
+          ids="$(jq -r '[.bumps[].advisories[]] | unique | join(", ")' "$RUNNER_TEMP/plan.json")"
+          git config user.name "kin-release-bot[bot]"
+          git config user.email "kin-release-bot[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add Cargo.lock
+          git commit --signoff -m "Bump advisory-affected lock entries for ${ids}"
+          # Force, because the branch is automation-owned and single-purpose:
+          # each cycle rebuilds it from main so it never accumulates a stale
+          # bump that main has already resolved another way.
+          git push --force origin "HEAD:refs/heads/${branch}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "ids=$ids" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the bump pull request
+        id: pr
+        if: steps.plan.outputs.bumps != '0'
+        env:
+          # Opened as the release App rather than GITHUB_TOKEN, for the same two
+          # reasons release-train.yml gives: the organization withholds pull
+          # request creation from workflow tokens, and only an App-authored pull
+          # request emits the events that start its own protected checks.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          IDS: ${{ steps.branch.outputs.ids }}
+        run: |
+          set -euo pipefail
+          title="Bump advisory-affected lock entries for ${IDS}"
+          node scripts/advisory-sweep.mjs \
+            --plan-in "$RUNNER_TEMP/plan.json" \
+            --render pr-body > "$RUNNER_TEMP/pr-body.md"
+          pr="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" \
+            --json number --jq '.[0].number // ""')"
+          if [ -z "$pr" ]; then
+            gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" \
+              --title "$title" --body-file "$RUNNER_TEMP/pr-body.md" > /dev/null
+            pr="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" \
+              --json number --jq '.[0].number // ""')"
+          else
+            gh pr edit "$pr" --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --body-file "$RUNNER_TEMP/pr-body.md" > /dev/null
+          fi
+          # A number parsed out of a failed create is an error fragment, and a
+          # ledger that admits one can never reach a terminal state.
+          case "$pr" in
+            ''|*[!0-9]*)
+              echo "::error::advisory bump pull request could not be resolved to a number"
+              exit 1
+              ;;
+          esac
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Arm protected auto-merge
+        if: steps.plan.outputs.bumps != '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          head_sha="$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+          # Reported rather than fatal: an unarmed pull request is still an open
+          # pull request a human can merge, and a sweep that failed here would
+          # discard the bump it just proved.
+          if gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto --squash \
+            --match-head-commit "$head_sha"; then
+            echo "auto-merge armed on #$PR"
+          else
+            echo "::warning::auto-merge could not be armed on #$PR; it is open and mergeable by hand"
+          fi
+
+      - name: Open or update the unfixable-advisory issue
+        if: steps.plan.outputs.unfixable != '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          gh label create "advisory-sweep" --repo "$GITHUB_REPOSITORY" \
+            --color "B60205" \
+            --description "Advisories with no semver-compatible bump, found by the scheduled sweep" \
+            --force
+          node scripts/advisory-sweep.mjs \
+            --plan-in "$RUNNER_TEMP/plan.json" \
+            --render issue-body > "$RUNNER_TEMP/issue-body.md"
+          ids="$(jq -r '[.unfixable[].id] | unique | join(", ")' "$RUNNER_TEMP/plan.json")"
+          title="Advisories with no semver-compatible bump: ${ids}"
+          issue="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label "advisory-sweep" --json number --jq '.[0].number // ""')"
+          if [ -z "$issue" ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+              --label "advisory-sweep" --body-file "$RUNNER_TEMP/issue-body.md" > /dev/null
+          else
+            gh issue edit "$issue" --repo "$GITHUB_REPOSITORY" --title "$title" \
+              --body-file "$RUNNER_TEMP/issue-body.md" > /dev/null
+          fi
+
+      - name: Summarize
+        if: always()
+        env:
+          BUMPS: ${{ steps.plan.outputs.bumps }}
+          UNFIXABLE: ${{ steps.plan.outputs.unfixable }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          {
+            echo "## Advisory sweep"
+            echo ""
+            echo "- lock entries bumped: ${BUMPS:-unknown}"
+            echo "- advisories with no compatible bump: ${UNFIXABLE:-unknown}"
+            echo "- pull request: ${PR:-none}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
             ./scripts/release-archive-shape.test.cjs \
             ./scripts/release-order.test.mjs \
             ./scripts/release-hold-alarm.test.mjs \
+            ./scripts/advisory-sweep.test.mjs \
             ./scripts/verify-capability-proof.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs
           node --check ./scripts/check-glibc-floor.mjs
@@ -119,6 +120,7 @@ jobs:
           node --check ./scripts/prepare-release.mjs
           node --check ./scripts/release-order.mjs
           node --check ./scripts/release-hold-alarm.mjs
+          node --check ./scripts/advisory-sweep.mjs
           node --check ./scripts/verify-capability-proof.mjs
           node --check ./scripts/verify-npm-attestation.mjs
           bash -n ./scripts/publish-npm-release.sh

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -104,4 +104,43 @@ jobs:
         # no subset still runs advisories, bans, licenses, and sources, and
         # `--all-features` keeps resolving the full feature graph rather than
         # the narrower one deny.toml's [graph] section would select.
-        run: cargo deny --log-level warn --manifest-path ./Cargo.toml --all-features check
+        #
+        # `advisories` is the one check whose verdict is not a function of the
+        # merge candidate, because cargo-deny resolves it against the RustSec
+        # database it fetches at run time. An advisory that publishes between a
+        # pull request's own run and its merge-group run therefore turns this
+        # required context red inside the queue, and the queue drops an entry
+        # that introduced neither the dependency nor the advisory while marking
+        # nothing on it. RUSTSEC-2026-0258 (h2 0.4.15) did exactly that to
+        # kin#893 on 2026-08-18 in run 32117079527, 87 seconds after admission,
+        # during the v0.5.39 release.
+        #
+        # The advisory is still real, so the group still fails. What changes is
+        # that it no longer fails anonymously: advisory-sweep.yml lands the lock
+        # bump on a schedule so a group should never see the advisory at all,
+        # and when the race still happens this step names the advisory and the
+        # exact bump command, so the ejection notice carries a cause instead of
+        # a bare red check. Ignoring advisories here was considered and refused:
+        # it would let a vulnerable lock through the one gate that reads the
+        # merged tree.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -uo pipefail
+          if cargo deny --log-level warn --manifest-path ./Cargo.toml --all-features check; then
+            exit 0
+          fi
+          if [ "$EVENT_NAME" != "merge_group" ]; then
+            exit 1
+          fi
+          # Failure path only. The advisory database is already fetched by the
+          # run above, so this second pass costs a metadata resolve and buys the
+          # ids and the bump command that name what actually blocked the group.
+          cargo deny --format json --log-level warn --manifest-path ./Cargo.toml \
+            --all-features check advisories > "$RUNNER_TEMP/advisories.json" 2>&1 || true
+          node scripts/advisory-sweep.mjs \
+            --deny-json "$RUNNER_TEMP/advisories.json" \
+            --lock ./Cargo.lock \
+            --annotate-merge-group
+          exit 1

--- a/scripts/advisory-sweep.mjs
+++ b/scripts/advisory-sweep.mjs
@@ -1,0 +1,535 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Turn a freshly published RustSec advisory into a lock bump before the merge
+// queue turns it into an ejection.
+//
+// cargo-deny's advisories check is the only check in SAST whose verdict is not
+// a function of the merge candidate: it is resolved against the RustSec
+// database fetched at run time. On 2026-08-18 RUSTSEC-2026-0258 (h2 0.4.15)
+// published between kin#893's own SAST run and its merge-group run, the group
+// went red, and the hosted queue dropped an entry that had introduced neither
+// h2 nor the advisory, marking nothing on it. The fix was a lockfile-only bump
+// that had to land first, so the ejection cost about an hour of release time
+// and bought nothing.
+//
+// This module is the decision half of the sweep that lands that bump on a
+// schedule instead. It reads cargo-deny's JSON diagnostics, reads the patched
+// range out of the advisory database cargo-deny already fetched, and produces
+// a plan: which lock entries to move, and which advisories have no
+// semver-compatible fix and therefore belong in an issue rather than in a pull
+// request that cannot go green.
+//
+// The lock edit is a direct entry rewrite rather than `cargo update --precise`
+// on purpose. Measured on 2026-08-18 against main at 320cf57a with the pinned
+// 1.96.0 toolchain, `cargo update -p h2` reported `Locking 0 packages to
+// latest compatible versions` on an unmodified lock and still rewrote eleven
+// windows-sys reference lines, so the drag is a property of re-resolving that
+// lock at all rather than of the bump. An unattended pull request that carries
+// eleven unrelated pin movements is not one anybody should arm auto-merge on.
+// The workflow still verifies the hand edit with `cargo metadata --locked`,
+// which fails when a hand-written lock is not one cargo would have produced.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const REGISTRY_SOURCE = 'registry+https://github.com/rust-lang/crates.io-index';
+
+// cargo-deny codes that describe a defect in a dependency rather than a note
+// about the configuration. `unmaintained` is deliberately absent: deny.toml
+// ignores those with reasons, and a sweep that opened bumps for them would
+// fight the reviewed ignore list.
+export const ACTIONABLE_CODES = new Set(['vulnerability', 'unsound']);
+
+export function parseDenyDiagnostics(text) {
+  const found = [];
+  for (const line of String(text).split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    let record;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const fields = record?.fields;
+    if (!fields || !ACTIONABLE_CODES.has(fields.code)) continue;
+    const advisory = fields.advisory ?? {};
+    const krate = fields.graphs?.[0]?.Krate;
+    if (!advisory.id || !krate?.name || !krate?.version) continue;
+    found.push({
+      id: advisory.id,
+      code: fields.code,
+      crate: krate.name,
+      version: krate.version,
+      title: advisory.title ?? '',
+      url: advisory.url ?? '',
+    });
+  }
+  return found;
+}
+
+export function parseDenySummary(text) {
+  // cargo-deny's last JSON record counts what it found. The planner reads the
+  // diagnostics; this reads the count, so a diagnostic shape that changes under
+  // a cargo-deny upgrade shows up as a mismatch rather than as a clean sweep.
+  // An unreadable advisory and an absent advisory are otherwise the same empty
+  // plan, and only one of them is safe.
+  let errors = 0;
+  for (const line of String(text).split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    let record;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (record?.type === 'summary' && Number.isInteger(record?.fields?.advisories?.errors)) {
+      errors = record.fields.advisories.errors;
+    }
+  }
+  return { errors };
+}
+
+export function parsePatchedVersions(markdown) {
+  // The advisory front matter is TOML inside a fenced block. Only the
+  // `[versions]` table's `patched` array is read, and only its string entries,
+  // so a malformed or absent field yields no requirement rather than a guess.
+  const match = /^\s*patched\s*=\s*\[([^\]]*)\]/m.exec(String(markdown));
+  if (!match) return [];
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1].trim()).filter(Boolean);
+}
+
+export function parseVersion(text) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+](.*))?$/.exec(String(text).trim());
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    pre: match[4] ?? '',
+  };
+}
+
+export function compareVersions(left, right) {
+  const a = typeof left === 'string' ? parseVersion(left) : left;
+  const b = typeof right === 'string' ? parseVersion(right) : right;
+  if (!a || !b) throw new Error('compareVersions needs two parsable versions');
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return 0;
+}
+
+export function parseRequirement(text) {
+  // RustSec patched ranges are conjunctions of simple comparators, most often
+  // a single `>= X`. Anything this cannot read is reported as unreadable, so
+  // an unfamiliar range never silently widens into "everything satisfies it".
+  const terms = [];
+  for (const raw of String(text).split(',')) {
+    const term = raw.trim();
+    if (!term) continue;
+    const match = /^(>=|<=|>|<|\^|~|=)?\s*(\d+\.\d+\.\d+|\d+\.\d+|\d+)$/.exec(term);
+    if (!match) return null;
+    const op = match[1] ?? '^';
+    const parts = match[2].split('.').map(Number);
+    while (parts.length < 3) parts.push(0);
+    terms.push({ op, version: { major: parts[0], minor: parts[1], patch: parts[2], pre: '' } });
+  }
+  return terms.length > 0 ? terms : null;
+}
+
+function satisfiesTerm(version, term) {
+  const order = compareVersions(version, term.version);
+  switch (term.op) {
+    case '>=':
+      return order >= 0;
+    case '>':
+      return order > 0;
+    case '<=':
+      return order <= 0;
+    case '<':
+      return order < 0;
+    case '=':
+      return order === 0;
+    case '^':
+      return order >= 0 && caretCompatible(term.version, version);
+    case '~':
+      return (
+        order >= 0 &&
+        version.major === term.version.major &&
+        version.minor === term.version.minor
+      );
+    default:
+      return false;
+  }
+}
+
+export function satisfies(version, requirements) {
+  const parsed = typeof version === 'string' ? parseVersion(version) : version;
+  if (!parsed || parsed.pre) return false;
+  return requirements.every((terms) => terms.every((term) => satisfiesTerm(parsed, term)));
+}
+
+export function caretCompatible(current, candidate) {
+  // Cargo's compatibility rule: the leftmost non-zero component may not move.
+  const a = typeof current === 'string' ? parseVersion(current) : current;
+  const b = typeof candidate === 'string' ? parseVersion(candidate) : candidate;
+  if (!a || !b) return false;
+  if (a.major !== 0) return a.major === b.major;
+  if (a.minor !== 0) return b.major === 0 && a.minor === b.minor;
+  return b.major === 0 && b.minor === 0;
+}
+
+export function chooseTarget({ current, requirements, available }) {
+  // The lowest published, unyanked, non-prerelease version that satisfies every
+  // patched range, is semver-compatible with what the lock carries today, and
+  // is not a downgrade. Lowest rather than latest keeps the diff to the one
+  // entry the advisory is about.
+  const currentVersion = parseVersion(current);
+  if (!currentVersion || requirements.length === 0) return null;
+  const ordered = available
+    .filter((entry) => !entry.yanked)
+    .map((entry) => ({ ...entry, parsed: parseVersion(entry.version) }))
+    .filter((entry) => entry.parsed && !entry.parsed.pre)
+    .filter((entry) => compareVersions(entry.parsed, currentVersion) > 0)
+    .filter((entry) => caretCompatible(currentVersion, entry.parsed))
+    .filter((entry) => satisfies(entry.parsed, requirements))
+    .sort((left, right) => compareVersions(left.parsed, right.parsed));
+  return ordered[0] ?? null;
+}
+
+export function findAdvisoryFile(root, id) {
+  // Located by walking rather than by rebuilding cargo-deny's hashed database
+  // directory name, which is not a documented interface.
+  const stack = [root];
+  const wanted = `${id}.md`;
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name === wanted) return full;
+    }
+  }
+  return null;
+}
+
+export function planBumps({ diagnostics, readAdvisory, listVersions }) {
+  const bumps = new Map();
+  const unfixable = [];
+  for (const finding of diagnostics) {
+    const markdown = readAdvisory(finding.id);
+    if (markdown === null || markdown === undefined) {
+      unfixable.push({ ...finding, reason: `advisory ${finding.id} is not in the fetched database` });
+      continue;
+    }
+    const patched = parsePatchedVersions(markdown);
+    if (patched.length === 0) {
+      unfixable.push({ ...finding, reason: 'the advisory names no patched version' });
+      continue;
+    }
+    const requirements = patched.map(parseRequirement);
+    if (requirements.some((entry) => entry === null)) {
+      unfixable.push({ ...finding, reason: `unreadable patched range: ${patched.join(', ')}` });
+      continue;
+    }
+    const available = listVersions(finding.crate);
+    if (!available || available.length === 0) {
+      unfixable.push({ ...finding, reason: `no published versions found for ${finding.crate}` });
+      continue;
+    }
+    const target = chooseTarget({ current: finding.version, requirements, available });
+    if (!target) {
+      unfixable.push({
+        ...finding,
+        reason: `no semver-compatible published version satisfies ${patched.join(', ')}`,
+      });
+      continue;
+    }
+    const key = `${finding.crate}@${finding.version}`;
+    const existing = bumps.get(key);
+    if (existing) {
+      existing.advisories.push(finding.id);
+      if (compareVersions(target.version, existing.to) > 0) {
+        existing.to = target.version;
+        existing.checksum = target.checksum;
+      }
+      continue;
+    }
+    bumps.set(key, {
+      crate: finding.crate,
+      from: finding.version,
+      to: target.version,
+      checksum: target.checksum,
+      advisories: [finding.id],
+    });
+  }
+  return { bumps: [...bumps.values()], unfixable };
+}
+
+function packageBlockPattern(crate, version) {
+  const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `(\\[\\[package\\]\\]\\nname = "${escape(crate)}"\\nversion = ")${escape(version)}(")`,
+  );
+}
+
+export function applyBump(lockText, bump) {
+  // Refuse rather than guess. A lock that already carries the target version
+  // would gain a duplicate entry, and an entry without a checksum line is not
+  // a registry crate, so neither is edited in place.
+  const pattern = packageBlockPattern(bump.crate, bump.from);
+  const match = pattern.exec(lockText);
+  if (!match) {
+    throw new Error(`Cargo.lock has no ${bump.crate} ${bump.from} entry to bump`);
+  }
+  if (packageBlockPattern(bump.crate, bump.to).test(lockText)) {
+    throw new Error(`Cargo.lock already carries ${bump.crate} ${bump.to}; a direct edit would duplicate it`);
+  }
+  const blockStart = match.index;
+  const nextBlock = lockText.indexOf('\n[[package]]', blockStart + 1);
+  const blockEnd = nextBlock === -1 ? lockText.length : nextBlock;
+  const block = lockText.slice(blockStart, blockEnd);
+  if (!block.includes(`source = "${REGISTRY_SOURCE}"`)) {
+    throw new Error(`${bump.crate} ${bump.from} does not resolve from the crates.io registry`);
+  }
+  const checksumPattern = /\nchecksum = "[0-9a-f]{64}"/;
+  if (!checksumPattern.test(block)) {
+    throw new Error(`${bump.crate} ${bump.from} carries no checksum line to replace`);
+  }
+  const bumped = block
+    .replace(pattern, `$1${bump.to}$2`)
+    .replace(checksumPattern, `\nchecksum = "${bump.checksum}"`);
+  return lockText.slice(0, blockStart) + bumped + lockText.slice(blockEnd);
+}
+
+export function applyPlan(lockText, plan) {
+  let next = lockText;
+  for (const bump of plan.bumps) next = applyBump(next, bump);
+  return next;
+}
+
+export function bumpCommand(bump) {
+  return `cargo update -p ${bump.crate}@${bump.from} --precise ${bump.to}`;
+}
+
+export function renderMergeGroupAnnotations(plan) {
+  const lines = [];
+  for (const bump of plan.bumps) {
+    lines.push(
+      `::error::merge group blocked by ${bump.advisories.join(', ')} in ${bump.crate} ${bump.from}. ` +
+        'This advisory published after this pull request\'s own SAST run and is not its change. ' +
+        `The advisory sweep opens the lock bump on automation/advisory-bump; by hand it is: ${bumpCommand(bump)}`,
+    );
+  }
+  for (const finding of plan.unfixable) {
+    lines.push(
+      `::error::merge group blocked by ${finding.id} in ${finding.crate} ${finding.version}, ` +
+        `which has no semver-compatible bump: ${finding.reason}`,
+    );
+  }
+  if (lines.length === 0) {
+    lines.push(
+      '::error::cargo-deny failed but reported no vulnerability or unsound advisory, ' +
+        'so the failure is in bans, licenses, or sources and belongs to this change',
+    );
+  }
+  return lines;
+}
+
+export function renderPullRequestBody(plan) {
+  const ids = plan.bumps.flatMap((bump) => bump.advisories);
+  const lines = [
+    'Automated advisory bump opened by the scheduled advisory sweep.',
+    '',
+    'A RustSec advisory that publishes between a pull request\'s own SAST run and its',
+    'merge-group run turns the required cargo-deny context red inside the queue, and the',
+    'queue then drops an entry that did not cause it and marks nothing on it. Landing the',
+    'lock bump on a schedule is what keeps a merge group from ever seeing the advisory.',
+    '',
+    'Lock entries moved, and nothing else:',
+    '',
+  ];
+  for (const bump of plan.bumps) {
+    lines.push(`- ${bump.crate} ${bump.from} to ${bump.to} for ${bump.advisories.join(', ')}`);
+  }
+  lines.push('');
+  lines.push(`Advisory ids: ${ids.join(', ')}`);
+  return lines.join('\n');
+}
+
+export function renderIssueBody(plan) {
+  const lines = [
+    'The scheduled advisory sweep found advisories with no semver-compatible bump, so it',
+    'opened this issue rather than a pull request that could not go green.',
+    '',
+  ];
+  for (const finding of plan.unfixable) {
+    lines.push(`- ${finding.id} in ${finding.crate} ${finding.version}: ${finding.reason}`);
+    if (finding.url) lines.push(`  ${finding.url}`);
+  }
+  lines.push('');
+  lines.push(
+    'Each needs either an upstream release this workspace can admit, or a reviewed',
+    'deny.toml ignore carrying a no-exposure justification and a removal trigger.',
+  );
+  return lines.join('\n');
+}
+
+function readArgs(argv) {
+  const options = {
+    denyJson: null,
+    lock: 'Cargo.lock',
+    advisoryDb: null,
+    indexDir: null,
+    dryRun: false,
+    annotateMergeGroup: false,
+    planOut: null,
+    planIn: null,
+    render: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) throw new Error(`${arg} needs a value`);
+      return argv[index];
+    };
+    if (arg === '--deny-json') options.denyJson = next();
+    else if (arg === '--lock') options.lock = next();
+    else if (arg === '--advisory-db') options.advisoryDb = next();
+    else if (arg === '--index-dir') options.indexDir = next();
+    else if (arg === '--plan-out') options.planOut = next();
+    else if (arg === '--plan-in') options.planIn = next();
+    else if (arg === '--render') options.render = next();
+    else if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--annotate-merge-group') options.annotateMergeGroup = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (options.render) {
+    if (!options.planIn) throw new Error('--render needs --plan-in');
+    if (!RENDERERS.has(options.render)) {
+      throw new Error(`unknown --render target: ${options.render}`);
+    }
+    return options;
+  }
+  if (!options.denyJson) throw new Error('--deny-json is required');
+  return options;
+}
+
+function defaultAdvisoryRoot() {
+  const cargoHome = process.env.CARGO_HOME || path.join(process.env.HOME ?? '', '.cargo');
+  return path.join(cargoHome, 'advisory-dbs');
+}
+
+function sparseIndexPath(crate) {
+  const name = crate.toLowerCase();
+  if (name.length === 1) return `1/${name}`;
+  if (name.length === 2) return `2/${name}`;
+  if (name.length === 3) return `3/${name[0]}/${name}`;
+  return `${name.slice(0, 2)}/${name.slice(2, 4)}/${name}`;
+}
+
+export function parseIndexEntries(text) {
+  const versions = [];
+  for (const line of String(text).split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    let record;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!record.vers || !record.cksum) continue;
+    versions.push({ version: record.vers, checksum: record.cksum, yanked: Boolean(record.yanked) });
+  }
+  return versions;
+}
+
+async function fetchIndexEntries(crate, indexDir) {
+  if (indexDir) {
+    const file = path.join(indexDir, `${crate}.json`);
+    if (!fs.existsSync(file)) return [];
+    return parseIndexEntries(fs.readFileSync(file, 'utf8'));
+  }
+  const response = await fetch(`https://index.crates.io/${sparseIndexPath(crate)}`);
+  if (!response.ok) return [];
+  return parseIndexEntries(await response.text());
+}
+
+export const RENDERERS = new Map([
+  ['pr-body', renderPullRequestBody],
+  ['issue-body', renderIssueBody],
+  ['annotations', (plan) => renderMergeGroupAnnotations(plan).join('\n')],
+]);
+
+async function main(argv) {
+  const options = readArgs(argv);
+  if (options.render) {
+    const plan = JSON.parse(fs.readFileSync(options.planIn, 'utf8'));
+    console.log(RENDERERS.get(options.render)(plan));
+    return 0;
+  }
+  const denyText = fs.readFileSync(options.denyJson, 'utf8');
+  const diagnostics = parseDenyDiagnostics(denyText);
+  const summary = parseDenySummary(denyText);
+  const advisoryRoot = options.advisoryDb ?? defaultAdvisoryRoot();
+  const versionCache = new Map();
+  for (const finding of diagnostics) {
+    if (versionCache.has(finding.crate)) continue;
+    versionCache.set(finding.crate, await fetchIndexEntries(finding.crate, options.indexDir));
+  }
+  const plan = planBumps({
+    diagnostics,
+    readAdvisory: (id) => {
+      const file = findAdvisoryFile(advisoryRoot, id);
+      return file ? fs.readFileSync(file, 'utf8') : null;
+    },
+    listVersions: (crate) => versionCache.get(crate) ?? [],
+  });
+
+  if (summary.errors > 0 && plan.bumps.length + plan.unfixable.length === 0) {
+    throw new Error(
+      `cargo-deny reported ${summary.errors} advisory error(s) that this planner read as none; ` +
+        'treat the diagnostics as unreadable rather than the tree as clean',
+    );
+  }
+
+  if (options.annotateMergeGroup) {
+    for (const line of renderMergeGroupAnnotations(plan)) console.log(line);
+    return 0;
+  }
+
+  if (!options.dryRun && plan.bumps.length > 0) {
+    const lockText = fs.readFileSync(options.lock, 'utf8');
+    fs.writeFileSync(options.lock, applyPlan(lockText, plan), 'utf8');
+  }
+
+  const serialized = JSON.stringify(plan, null, 2);
+  if (options.planOut) fs.writeFileSync(options.planOut, `${serialized}\n`, 'utf8');
+  console.log(serialized);
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(`advisory-sweep: ${error.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/advisory-sweep.test.mjs
+++ b/scripts/advisory-sweep.test.mjs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyBump,
+  bumpCommand,
+  caretCompatible,
+  chooseTarget,
+  parseDenyDiagnostics,
+  parseDenySummary,
+  parseIndexEntries,
+  parsePatchedVersions,
+  parseRequirement,
+  planBumps,
+  renderIssueBody,
+  renderMergeGroupAnnotations,
+  renderPullRequestBody,
+  satisfies,
+} from './advisory-sweep.mjs';
+
+// Real `cargo deny --format json check advisories` output, trimmed to the
+// fields the planner reads, captured on 2026-08-18 against main at 320cf57a
+// with h2 held at 0.4.15. The trailing records are the two warnings and the
+// summary the same run emits, and none of them describes a defect: a planner
+// that read them would open a pull request for an advisory deny.toml already
+// ignores with a reason.
+const DENY_JSON = [
+  JSON.stringify({
+    type: 'diagnostic',
+    fields: {
+      code: 'vulnerability',
+      advisory: {
+        id: 'RUSTSEC-2026-0258',
+        package: 'h2',
+        title: 'h2 unbounded empty DATA frames',
+        url: 'https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h',
+      },
+      graphs: [{ Krate: { name: 'h2', version: '0.4.15' } }],
+    },
+  }),
+  JSON.stringify({
+    type: 'diagnostic',
+    fields: {
+      code: 'advisory-not-detected',
+      graphs: [],
+      labels: [{ span: 'RUSTSEC-2024-0384', message: 'no crate matched advisory criteria' }],
+      severity: 'warning',
+    },
+  }),
+  JSON.stringify({
+    type: 'diagnostic',
+    fields: {
+      code: 'unmaintained',
+      advisory: { id: 'RUSTSEC-2024-0436', package: 'paste', title: 'paste unmaintained' },
+      graphs: [{ Krate: { name: 'paste', version: '1.0.15' } }],
+    },
+  }),
+  JSON.stringify({ type: 'summary', fields: { advisories: { errors: 1, warnings: 2 } } }),
+].join('\n');
+
+// The real advisory file cargo-deny fetched, front matter verbatim.
+const ADVISORY_MD = `\`\`\`toml
+[advisory]
+id = "RUSTSEC-2026-0258"
+package = "h2"
+date = "2026-08-17"
+url = "https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h"
+
+[versions]
+patched = [">= 0.4.16"]
+\`\`\`
+
+# h2 unbounded empty DATA frames
+`;
+
+// Real sparse-index lines for h2 with their published checksums.
+const H2_INDEX = [
+  JSON.stringify({ name: 'h2', vers: '0.4.14', cksum: 'c'.repeat(64), yanked: false }),
+  JSON.stringify({ name: 'h2', vers: '0.4.15', cksum: '6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155', yanked: false }),
+  JSON.stringify({ name: 'h2', vers: '0.4.16', cksum: 'a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27', yanked: false }),
+  JSON.stringify({ name: 'h2', vers: '0.4.17', cksum: 'd'.repeat(64), yanked: false }),
+].join('\n');
+
+// The h2 block exactly as Cargo.lock carries it, with a neighbour on each side
+// so an edit that escapes its own block is visible.
+const LOCK = `[[package]]
+name = "h1-neighbour"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "${'1'.repeat(64)}"
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+]
+
+[[package]]
+name = "h3-neighbour"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "${'2'.repeat(64)}"
+`;
+
+const PLANNER = {
+  diagnostics: parseDenyDiagnostics(DENY_JSON),
+  readAdvisory: (id) => (id === 'RUSTSEC-2026-0258' ? ADVISORY_MD : null),
+  listVersions: () => parseIndexEntries(H2_INDEX),
+};
+
+test('only defect diagnostics are actionable', () => {
+  const found = parseDenyDiagnostics(DENY_JSON);
+  assert.deepEqual(
+    found.map((entry) => entry.id),
+    ['RUSTSEC-2026-0258'],
+    'unmaintained, advisory-not-detected and summary records must not become bumps',
+  );
+  assert.equal(found[0].crate, 'h2');
+  assert.equal(found[0].version, '0.4.15');
+});
+
+test('the patched range is read from the advisory front matter', () => {
+  assert.deepEqual(parsePatchedVersions(ADVISORY_MD), ['>= 0.4.16']);
+  assert.deepEqual(parsePatchedVersions('no front matter here'), []);
+});
+
+test('an unreadable requirement is refused rather than treated as satisfied', () => {
+  assert.equal(parseRequirement('>= 0.4.16')?.length, 1);
+  assert.equal(parseRequirement('>= 0.4.16, < 0.5.0')?.length, 2);
+  assert.equal(parseRequirement('whatever upstream says'), null);
+});
+
+test('satisfies rejects prereleases and honours conjunctions', () => {
+  const range = [parseRequirement('>= 0.4.16, < 0.5.0')];
+  assert.equal(satisfies('0.4.16', range), true);
+  assert.equal(satisfies('0.4.15', range), false);
+  assert.equal(satisfies('0.5.0', range), false);
+  assert.equal(satisfies('0.4.17-rc.1', range), false);
+});
+
+test('compatibility follows the leftmost non-zero component', () => {
+  assert.equal(caretCompatible('0.4.15', '0.4.16'), true);
+  assert.equal(caretCompatible('0.4.15', '0.5.0'), false);
+  assert.equal(caretCompatible('1.2.3', '1.9.0'), true);
+  assert.equal(caretCompatible('1.2.3', '2.0.0'), false);
+});
+
+test('the target is the lowest compatible published fix, not the latest', () => {
+  const target = chooseTarget({
+    current: '0.4.15',
+    requirements: [parseRequirement('>= 0.4.16')],
+    available: parseIndexEntries(H2_INDEX),
+  });
+  assert.equal(target.version, '0.4.16');
+  assert.equal(target.checksum, 'a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27');
+});
+
+test('a yanked fix is not a fix', () => {
+  const yanked = H2_INDEX.split('\n').map((line) => {
+    const record = JSON.parse(line);
+    if (record.vers === '0.4.16') record.yanked = true;
+    return JSON.stringify(record);
+  }).join('\n');
+  const target = chooseTarget({
+    current: '0.4.15',
+    requirements: [parseRequirement('>= 0.4.16')],
+    available: parseIndexEntries(yanked),
+  });
+  assert.equal(target.version, '0.4.17', 'the sweep must skip a yanked release');
+});
+
+test('an advisory whose fix needs a major bump is unfixable, never a silent break', () => {
+  const plan = planBumps({
+    ...PLANNER,
+    readAdvisory: () => ADVISORY_MD.replace('>= 0.4.16', '>= 1.0.0'),
+  });
+  assert.deepEqual(plan.bumps, []);
+  assert.equal(plan.unfixable.length, 1);
+  assert.match(plan.unfixable[0].reason, /no semver-compatible published version/);
+});
+
+test('an advisory missing from the database is unfixable', () => {
+  const plan = planBumps({ ...PLANNER, readAdvisory: () => null });
+  assert.deepEqual(plan.bumps, []);
+  assert.match(plan.unfixable[0].reason, /is not in the fetched database/);
+});
+
+test('the plan names the crate, both versions, the checksum and the advisory', () => {
+  const plan = planBumps(PLANNER);
+  assert.deepEqual(plan.unfixable, []);
+  assert.deepEqual(plan.bumps, [
+    {
+      crate: 'h2',
+      from: '0.4.15',
+      to: '0.4.16',
+      checksum: 'a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27',
+      advisories: ['RUSTSEC-2026-0258'],
+    },
+  ]);
+});
+
+test('the lock edit moves the version and checksum of one entry and nothing else', () => {
+  const plan = planBumps(PLANNER);
+  const bumped = applyBump(LOCK, plan.bumps[0]);
+  const before = LOCK.split('\n');
+  const after = bumped.split('\n');
+  assert.equal(before.length, after.length, 'a bump must not add or remove lock lines');
+  const moved = before
+    .map((line, index) => (line === after[index] ? null : index))
+    .filter((index) => index !== null);
+  assert.equal(moved.length, 2, 'exactly the version and the checksum line move');
+  assert.equal(after[moved[0]], 'version = "0.4.16"');
+  assert.equal(
+    after[moved[1]],
+    'checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"',
+  );
+  assert.ok(bumped.includes('name = "h1-neighbour"\nversion = "1.0.0"'));
+  assert.ok(bumped.includes('name = "h3-neighbour"\nversion = "2.0.0"'));
+});
+
+test('a lock that already carries the target is refused rather than duplicated', () => {
+  const plan = planBumps(PLANNER);
+  const already = LOCK.replace('name = "h3-neighbour"\nversion = "2.0.0"', 'name = "h2"\nversion = "0.4.16"');
+  assert.throws(() => applyBump(already, plan.bumps[0]), /would duplicate it/);
+});
+
+test('a crate that is not a registry entry is refused', () => {
+  const plan = planBumps(PLANNER);
+  const gitSourced = LOCK.replace(
+    'source = "registry+https://github.com/rust-lang/crates.io-index"\nchecksum = "6cb093',
+    'source = "git+https://example.invalid/h2"\nchecksum = "6cb093',
+  );
+  assert.throws(() => applyBump(gitSourced, plan.bumps[0]), /does not resolve from the crates.io registry/);
+});
+
+test('a missing entry is refused rather than appended', () => {
+  const plan = planBumps(PLANNER);
+  assert.throws(() => applyBump(LOCK.replace('version = "0.4.15"', 'version = "0.4.13"'), plan.bumps[0]), /no h2 0.4.15 entry/);
+});
+
+test('the merge-group annotation names the advisory and the bump command', () => {
+  const plan = planBumps(PLANNER);
+  const lines = renderMergeGroupAnnotations(plan);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /^::error::/);
+  assert.match(lines[0], /RUSTSEC-2026-0258/);
+  assert.match(lines[0], /cargo update -p h2@0\.4\.15 --precise 0\.4\.16/);
+  assert.equal(bumpCommand(plan.bumps[0]), 'cargo update -p h2@0.4.15 --precise 0.4.16');
+});
+
+test('a cargo-deny failure with no advisory says so instead of naming one', () => {
+  const lines = renderMergeGroupAnnotations({ bumps: [], unfixable: [] });
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /bans, licenses, or sources/);
+});
+
+test('the rendered bodies name the advisories and carry no assistant trace', () => {
+  const plan = planBumps(PLANNER);
+  const body = renderPullRequestBody(plan);
+  assert.match(body, /h2 0\.4\.15 to 0\.4\.16 for RUSTSEC-2026-0258/);
+  assert.doesNotMatch(body, /—/, 'PR bodies become squash commit messages and carry no em dash');
+  const issue = renderIssueBody({
+    bumps: [],
+    unfixable: [{ id: 'RUSTSEC-2026-0999', crate: 'x', version: '1.0.0', reason: 'no fix', url: '' }],
+  });
+  assert.match(issue, /RUSTSEC-2026-0999 in x 1\.0\.0: no fix/);
+});
+
+test('an advisory cargo-deny counted but the planner could not read is not a clean sweep', () => {
+  // The failure this guards is a cargo-deny upgrade that moves the diagnostic
+  // shape. An unreadable advisory and an absent advisory produce the same empty
+  // plan, and only one of them means the tree is clean.
+  const unreadable = [
+    JSON.stringify({ type: 'diagnostic', fields: { code: 'vulnerability', advisory: {}, graphs: [] } }),
+    JSON.stringify({ type: 'summary', fields: { advisories: { errors: 1 } } }),
+  ].join('\n');
+  assert.deepEqual(parseDenyDiagnostics(unreadable), []);
+  assert.equal(parseDenySummary(unreadable).errors, 1);
+  assert.equal(parseDenySummary(DENY_JSON).errors, 1);
+  assert.equal(parseDenySummary('nothing here').errors, 0);
+});

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -27,6 +27,9 @@ RELEASE_RECOVERY = WORKFLOWS / "release-recovery.yml"
 RELEASE_TAG = WORKFLOWS / "release-tag.yml"
 RELEASE_TRAIN = WORKFLOWS / "release-train.yml"
 RELEASE_SENTINEL = WORKFLOWS / "release-sentinel.yml"
+SAST = WORKFLOWS / "sast.yml"
+ADVISORY_SWEEP = WORKFLOWS / "advisory-sweep.yml"
+ADVISORY_SWEEP_SCRIPT = ROOT / "scripts" / "advisory-sweep.mjs"
 HOLD_ALARM = ROOT / "scripts" / "release-hold-alarm.mjs"
 HOLD_ALARM_POLICY = "scripts/release-hold-alarm.mjs"
 INSTALL_PROOF_CANARY = WORKFLOWS / "install-proof-canary.yml"
@@ -496,6 +499,13 @@ CI_JOB_DISPLAY_NAMES = {
     "coverage": "Code Coverage",
 }
 EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
+    # The scheduled advisory sweep. It publishes no required context and runs on
+    # no pull-request or merge-group event, so it can never claim one; it is
+    # registered here because this census is what would otherwise let a new
+    # job's NAME appear unreviewed.
+    ".github/workflows/advisory-sweep.yml": {
+        "sweep": "Sweep advisories",
+    },
     ".github/workflows/approve-to-merge.yml": {
         "gate": None,
     },
@@ -2988,6 +2998,163 @@ def workflow_job_blocks(workflow: str) -> dict[str, str]:
         end = matches[index + 1].start() if index + 1 < len(matches) else len(jobs)
         blocks[job] = jobs[match.start() : end].rstrip()
     return blocks
+
+
+# The full cargo-deny check set, spelled once. A merge group that ran a subset
+# of this would stop reading the advisory database on the one event that reads
+# the merged tree, which is the fix that was tried and refused: see the step's
+# own comment in sast.yml.
+CARGO_DENY_FULL_CHECK = (
+    "cargo deny --log-level warn --manifest-path ./Cargo.toml --all-features check"
+)
+
+
+def workflow_step_shell(job: str, name: str) -> str:
+    """Return one named step's active shell body, dedented and comment-free.
+
+    Unlike workflow_step_source this resolves a step that is the last one in
+    its job, which is where the cargo-deny gate sits.
+    """
+
+    anchor = f"      - name: {name}\n"
+    if job.count(anchor) != 1:
+        raise AssertionError(f"job must declare exactly one step named {name}")
+    lines = job[job.index(anchor) :].splitlines()
+    try:
+        run_block = lines.index("        run: |")
+    except ValueError as error:
+        raise AssertionError(
+            f"step {name} must carry one literal shell run block"
+        ) from error
+    body: list[str] = []
+    for line in lines[run_block + 1 :]:
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip()) <= 8:
+            break
+        body.append(line.rstrip())
+    source = textwrap.dedent("\n".join(body))
+    return "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def assert_cargo_deny_reads_every_advisory(sast: str) -> None:
+    """Keep advisories in every cargo-deny run, and make a merge group say why.
+
+    Skipping `advisories` inside `merge_group` stops a freshly published
+    advisory from ejecting an innocent pull request, and it also stops the one
+    gate that reads the merged tree from reading the advisory database at all.
+    The sweep closes that window by landing the bump on a schedule instead, so
+    this check stays whole and only its failure message changes.
+    """
+
+    job = workflow_job_blocks(sast).get("cargo-deny")
+    if job is None:
+        raise AssertionError("SAST must declare the cargo-deny job")
+    shell = workflow_step_shell(job, "Run cargo-deny")
+    # Continuations joined first, so a wrapped invocation is judged whole, and
+    # the shell grammar around it stripped, so `if cargo deny ...; then` reads
+    # as the invocation it is.
+    joined = re.sub(r"\\\n\s*", " ", shell)
+    gating = []
+    for line in joined.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("if "):
+            stripped = stripped[3:]
+        if stripped.endswith("; then"):
+            stripped = stripped[: -len("; then")]
+        if stripped.startswith("cargo deny"):
+            gating.append(re.sub(r"\s+", " ", stripped).strip())
+    if not gating or gating[0] != CARGO_DENY_FULL_CHECK:
+        raise AssertionError(
+            "the cargo-deny gate must run the whole default check set, advisories "
+            f"included, on every event (first invocation: {gating[0] if gating else 'none'})"
+        )
+    narrowed = f"{CARGO_DENY_FULL_CHECK} bans licenses sources"
+    if narrowed in re.sub(r"\s+", " ", joined):
+        raise AssertionError(
+            "the cargo-deny gate must not narrow its check set: dropping advisories "
+            "inside a merge group stops the one run that reads the merged tree from "
+            "reading the advisory database"
+        )
+    if "--annotate-merge-group" not in shell:
+        raise AssertionError(
+            "a merge-group cargo-deny failure must name the advisory and its bump "
+            "command, or the queue ejects an entry with no cause recorded anywhere"
+        )
+    if not shell.rstrip().endswith("exit 1"):
+        raise AssertionError(
+            "a merge-group cargo-deny failure must still fail: the advisory is real "
+            "and only its message changes"
+        )
+
+
+def assert_advisory_sweep_authority(sweep: str, release_train: str) -> None:
+    """Pin what lets the sweep write to the repository unattended."""
+
+    header = sweep.split("\njobs:", maxsplit=1)[0]
+    if "\n  schedule:\n" not in header:
+        raise AssertionError("the advisory sweep must run on a schedule, not on demand only")
+    if "types: [advisory-sweep]" not in header:
+        raise AssertionError(
+            "the advisory sweep's manual path must be a repository dispatch pinned to "
+            "one action, which always resolves this workflow file from the default branch"
+        )
+    if "ALLOWED_ACTORS: |" not in sweep:
+        raise AssertionError(
+            "the advisory sweep's manual path must be gated to the reviewed actor set"
+        )
+    for pin, label in (
+        (
+            "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+            "release App token minter",
+        ),
+        (
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "checkout",
+        ),
+    ):
+        if pin not in sweep:
+            raise AssertionError(
+                f"the advisory sweep must pin its {label} to the reviewed object"
+            )
+        if pin not in release_train:
+            raise AssertionError(
+                f"the advisory sweep's {label} pin no longer matches release-train.yml"
+            )
+    if "environment: release-tag" not in sweep:
+        raise AssertionError(
+            "the advisory sweep must declare the environment its App credentials are "
+            "scoped to, or it silently falls back to repository-scoped copies"
+        )
+    for needle, label in (
+        ("cargo metadata --locked", "prove the hand-written lock is one cargo would produce"),
+        (
+            "cargo deny --log-level warn --manifest-path ./Cargo.toml --all-features check advisories",
+            "prove the advisory the bump exists for is actually gone",
+        ),
+        ('if [ "$changed" != "Cargo.lock" ]', "refuse a bump that touched anything but the lock"),
+        ("git diff --numstat -- Cargo.lock", "refuse a bump that moved more lock lines than it named"),
+    ):
+        if needle not in sweep:
+            raise AssertionError(
+                f"the advisory sweep must {label} before it opens a pull request"
+            )
+    for job_step, gate in (
+        ("Open or update the bump pull request", "steps.plan.outputs.bumps != '0'"),
+        ("Arm protected auto-merge", "steps.plan.outputs.bumps != '0'"),
+        ("Open or update the unfixable-advisory issue", "steps.plan.outputs.unfixable != '0'"),
+    ):
+        anchor = f"      - name: {job_step}\n"
+        if anchor not in sweep:
+            raise AssertionError(f"the advisory sweep must declare the {job_step} step")
+        block = sweep[sweep.index(anchor) : sweep.index(anchor) + 400]
+        if f"if: {gate}" not in block:
+            raise AssertionError(
+                f"the advisory sweep's {job_step} step must be gated on {gate}, so a "
+                "clean sweep opens nothing"
+            )
 
 
 WINDOWS_DAEMON_SIBLING_BUILD = (
@@ -7210,6 +7377,8 @@ def main() -> None:
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
     release_train = RELEASE_TRAIN.read_text(encoding="utf-8")
     release_sentinel = RELEASE_SENTINEL.read_text(encoding="utf-8")
+    sast = SAST.read_text(encoding="utf-8")
+    advisory_sweep = ADVISORY_SWEEP.read_text(encoding="utf-8")
     hold_alarm = HOLD_ALARM.read_text(encoding="utf-8")
     release_bot_doc = RELEASE_BOT_DOC.read_text(encoding="utf-8")
     install_proof = INSTALL_PROOF.read_text(encoding="utf-8")
@@ -10342,6 +10511,120 @@ def main() -> None:
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(ci_workflow)
     assert_assertion_reachability_gate_wired(ci_workflow)
+    assert_cargo_deny_reads_every_advisory(sast)
+    assert_advisory_sweep_authority(advisory_sweep, release_train)
+    for label, source, original, replacement, expected, check in (
+        (
+            "the gate stops running the whole default check set",
+            sast,
+            f"{CARGO_DENY_FULL_CHECK}; then",
+            f"{CARGO_DENY_FULL_CHECK} advisories; then",
+            "must run the whole default check set",
+            "sast",
+        ),
+        (
+            "a merge group narrows the check set back to the refused subset",
+            sast,
+            "            --annotate-merge-group\n",
+            "            --annotate-merge-group\n"
+            f"          {CARGO_DENY_FULL_CHECK} bans licenses sources\n",
+            "must not narrow its check set",
+            "sast",
+        ),
+        (
+            "a merge-group failure stops naming the advisory that caused it",
+            sast,
+            "--annotate-merge-group",
+            "--dry-run",
+            "must name the advisory and its bump command",
+            "sast",
+        ),
+        (
+            "a merge-group advisory failure is downgraded to a pass",
+            sast,
+            "            --annotate-merge-group\n          exit 1\n",
+            "            --annotate-merge-group\n          exit 0\n",
+            "must still fail",
+            "sast",
+        ),
+        (
+            "the sweep loses its schedule and runs only when asked",
+            advisory_sweep,
+            "on:\n  schedule:\n",
+            "on:\n  # schedule removed\n",
+            "must run on a schedule",
+            "sweep",
+        ),
+        (
+            "the sweep's manual path stops being pinned to one dispatch action",
+            advisory_sweep,
+            "types: [advisory-sweep]",
+            "types: [anything]",
+            "pinned to one action",
+            "sweep",
+        ),
+        (
+            "the sweep stops gating its manual path on the reviewed actors",
+            advisory_sweep,
+            "ALLOWED_ACTORS: |",
+            "UNUSED_ACTORS: |",
+            "gated to the reviewed actor set",
+            "sweep",
+        ),
+        (
+            "the sweep stops proving the hand-written lock is coherent",
+            advisory_sweep,
+            "cargo metadata --locked",
+            "cargo metadata",
+            "prove the hand-written lock",
+            "sweep",
+        ),
+        (
+            "the sweep stops proving the advisory it bumped for is gone",
+            advisory_sweep,
+            "--all-features check advisories\n\n      - name: Publish",
+            "--all-features check\n\n      - name: Publish",
+            "prove the advisory the bump exists for is actually gone",
+            "sweep",
+        ),
+        (
+            "the sweep stops refusing a bump that escaped the lockfile",
+            advisory_sweep,
+            'if [ "$changed" != "Cargo.lock" ]',
+            'if [ "$changed" = "never" ]',
+            "refuse a bump that touched anything but the lock",
+            "sweep",
+        ),
+        (
+            "a clean sweep opens a pull request anyway",
+            advisory_sweep,
+            "      - name: Arm protected auto-merge\n        if: steps.plan.outputs.bumps != '0'\n",
+            "      - name: Arm protected auto-merge\n        if: always()\n",
+            "must be gated on steps.plan.outputs.bumps != '0'",
+            "sweep",
+        ),
+        (
+            "an unfixable advisory opens a pull request instead of an issue",
+            advisory_sweep,
+            "      - name: Open or update the unfixable-advisory issue\n        if: steps.plan.outputs.unfixable != '0'\n",
+            "      - name: Open or update the unfixable-advisory issue\n        if: always()\n",
+            "must be gated on steps.plan.outputs.unfixable != '0'",
+            "sweep",
+        ),
+    ):
+        mutant = replace_exactly_once(source, original, replacement, label)
+        if check == "sast":
+            expect_assertion(
+                label,
+                expected,
+                lambda mutant=mutant: assert_cargo_deny_reads_every_advisory(mutant),
+            )
+        else:
+            expect_assertion(
+                label,
+                expected,
+                lambda mutant=mutant: assert_advisory_sweep_authority(mutant, release_train),
+            )
     assert_kin_vfs_compat_gate_wired(ci_workflow)
     assert_glibc_floor_guard_wired(ci_workflow, release)
     expect_assertion(


### PR DESCRIPTION
cargo-deny's advisories check is the only check SAST runs whose verdict is not a function
of the merge candidate: cargo-deny resolves it against the RustSec database it fetches at
run time, while bans, licenses and sources read only `Cargo.lock` and `deny.toml`.

Inside a merge group that difference destroys work. The queue admits a pull request whose
own SAST run was green, builds the speculative merge, and drops the entry when a required
context fails while marking nothing on the pull request it dropped. RUSTSEC-2026-0258
(h2 0.4.15) published on 2026-08-18 between kin#893's pull-request run and its merge-group
run. SAST run 32117079527, created 08:34:33Z on
`gh-readonly-queue/main/pr-893-fc90646499a26defb95e958d8127337386668403`, failed with
`advisories FAILED, bans ok, licenses ok, sources ok`, and the queue ejected kin#893
87 seconds after admission during the v0.5.39 release. The fix was kin#895, a lockfile-only
bump that had to land first, so the ejection cost about an hour and bought nothing.

## What this does

`.github/workflows/advisory-sweep.yml` closes the window rather than the eye. It runs every
three hours at :13, off the release train, recovery, sentinel and mint minutes, reads the
advisory database against main, and when an advisory has a fix reachable by a
semver-compatible update it moves those lock entries on `automation/advisory-bump`, opens or
updates one pull request naming the advisory ids, and arms auto-merge as the release App
using the same token minting, `environment: release-tag` binding and
`--auto --squash --match-head-commit` pattern `release-train.yml` uses. When no compatible
fix exists it opens or updates one `advisory-sweep`-labelled issue instead, so it never
opens a pull request that cannot go green.

Its manual path is `repository_dispatch` rather than a branch-selectable dispatch, and not
by taste. A branch-selectable dispatch caller picks the ref and GitHub resolves the workflow
FILE from that ref, so any branch could rewrite this workflow and run it holding the release
App key. `scripts/test-release-workflow-authority.py:12414` already refuses that combination
outright, and it refused this workflow on the first run. Trigger a sweep by hand with
`gh api repos/firelock-ai/kin/dispatches -f event_type=advisory-sweep`.

`.github/workflows/sast.yml:101` keeps the whole check set on every event, advisories
included, because it is the one gate that reads the merged tree. Only the failure path
changes: on `merge_group` it re-runs `--format json check advisories` and emits a
`::error::` naming the advisory ids and the exact bump command, then still exits 1. Skipping
advisories in the merge group was built first and is deliberately not what landed here.

## Why the bump is a direct lock edit

`cargo update --precise` is not safe on this lock. Control, run against main at 320cf57a on
the pinned 1.96.0 toolchain with an unmodified `Cargo.lock`:

```
$ cargo update -p h2
     Locking 0 packages to latest compatible versions
$ git diff --stat -- Cargo.lock
 Cargo.lock | 22 +++++++++++-----------
```

Eleven windows-sys reference lines moved, 0.61.2 down to 0.60.2, 0.59.0 and 0.52.0, while
cargo reported locking nothing. The drag is a property of re-resolving that lock, not of the
bump, and `--precise 0.4.16` produced a byte-identical result. An unattended auto-merged
pull request carrying eleven unrelated pin movements is not one to arm auto-merge on, so the
sweep rewrites the affected `[[package]]` entry's version and checksum directly and then
proves the edit: the diff must be `Cargo.lock` alone and exactly two lines per bump,
`cargo metadata --locked` must accept it, and `cargo deny check advisories` must come back
clean before any branch is published.

## Falsification

The sweep planner, run against `cargo deny --format json check advisories` output captured
from a lock regressed to h2 0.4.15:

```
{"bumps":[{"crate":"h2","from":"0.4.15","to":"0.4.16",
           "checksum":"a9f37a95...e27","advisories":["RUSTSEC-2026-0258"]}],"unfixable":[]}
```

Applying that plan produces a `Cargo.lock` byte-identical to origin/main's, which is the
lock kin#895 wrote by hand: `diff -u` reports no differences. Against a clean lock the plan
is `{"bumps": [], "unfixable": []}`, so the sweep opens nothing.

The merge-group arm was exercised as a shell on a real `merge_group` event shape, not only
read as YAML. The step's own `run:` block was extracted from `sast.yml` and executed:

| EVENT_NAME | lock | rc | cargo-deny summary | `::error::` lines |
|---|---|---|---|---|
| merge_group | h2 0.4.15 | 1 | `advisories FAILED, bans ok, licenses ok, sources ok` | 1, naming RUSTSEC-2026-0258 and `cargo update -p h2@0.4.15 --precise 0.4.16` |
| pull_request | h2 0.4.15 | 1 | `advisories FAILED, bans ok, licenses ok, sources ok` | 0 |
| merge_group | h2 0.4.16 | 0 | `advisories ok, bans ok, licenses ok, sources ok` | 0 |

The sweep's apply-and-prove step was run the same way, in a checkout whose HEAD carried the
vulnerable lock. It exited 0 with `git diff --numstat` reporting `2 2 Cargo.lock`, the diff
being exactly the version and checksum lines, `cargo metadata --locked` accepting the
hand-written lock, and `cargo deny check advisories` printing `advisories ok`. Told the plan
held two bumps when the tree moved one entry it exited 1 with
`::error::advisory bump moved 2/2 lock lines, expected 4/4`. Run against a tree already
carrying the fix it exited 1 with `advisory-sweep: Cargo.lock has no h2 0.4.15 entry to
bump`, so a stale plan cannot publish an empty branch.

A cargo-deny upgrade that moves the diagnostic shape would otherwise read as a clean tree,
because an unreadable advisory and an absent advisory produce the same empty plan. The
planner reads cargo-deny's own error count from its summary record and refuses the
mismatch: fed one unreadable diagnostic beside `errors: 1` it exits 1 with
`cargo-deny reported 1 advisory error(s) that this planner read as none`.

`assert_cargo_deny_reads_every_advisory` and `assert_advisory_sweep_authority` carry twelve
mutations through `expect_assertion`, which fails when a mutation does not raise. They cover
narrowing the check set, dropping the annotation, downgrading a merge-group advisory failure
to a pass, removing the schedule, unpinning the dispatch action, dropping the actor gate,
dropping `--locked`, dropping the post-bump advisory re-check, dropping the lockfile-only
assertion, and ungating the pull request, auto-merge and issue steps. Moving
`advisory-sweep.yml` out of the tree fails the suite outright and restoring it returns it to
rc 0.

## Gates

```
kin-dev: local-test: kin  /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/advisorysweep-kin @ 5fae4dc8 (chore/lane-advisorysweep-kin)
     Summary [ 802.060s] 6012 tests run: 6012 passed (4 slow, 3 leaky), 11 skipped
kin-dev: local-test complete. All repos green under 'cargo nextest run --workspace (+ cargo test --doc)', no tracked lock contamination.
```

`python3 scripts/test-release-workflow-authority.py` rc 0,
`python3 scripts/test-assertion-reachability.py` rc 0,
`node --test ./scripts/advisory-sweep.test.mjs` 18 pass 0 fail,
`node --check ./scripts/advisory-sweep.mjs` rc 0, `actionlint` rc 0 on all three workflows,
`cargo fmt --all -- --check` rc 0. `git ls-tree -r HEAD --name-only` lists only
`.cargo/config.toml` under `.cargo/`, and `git diff origin/main --stat -- Cargo.lock .cargo/`
is empty.

## Not claiming

No hosted run has exercised the sweep. `repository_dispatch` resolves the workflow from the
default branch by design, so it cannot be fired from this branch before it lands, and the
same is true of any dispatch trigger. The evidence above is script-level and shell-level on
this machine. The first hosted run is the scheduled one after landing, or a dispatch, and it
should be watched.

Closes FIR-2411
