### PR TITLE
Run the public install proof at pull-request time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1385,3 +1385,157 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: firelock-ai/kin
           fail_ci_if_error: false
+
+  # The public install proof is what caught v0.5.38, and it caught it on the
+  # tag, after the version was cut and the archives were built and published,
+  # because nothing before the tag ran it. These three jobs run that same
+  # reusable proof against the binaries this pull request builds, so the break
+  # is a red pull request instead of a burned tag.
+  install-proof-pr-build:
+    name: Install Proof (PR) Build
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The release builds the Linux core against musl and links it static, so
+      # one archive runs on every distribution. Building the same target here is
+      # what makes these bytes the release's bytes rather than a near-miss whose
+      # libc coupling the proof would never see.
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install the musl C toolchain
+        run: scripts/ci-apt-install.sh musl-tools
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # The build stamps its own source identity, and `kin bench-meta` reports
+      # it to the proof, which refuses a dirty build. Assert the tree here so
+      # that refusal names the cause instead of surfacing as an opaque
+      # capability failure three jobs later.
+      - name: Assert a clean source tree before compiling
+        run: |
+          set -euo pipefail
+          dirty="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$dirty" ]; then
+            printf '%s\n' "$dirty" >&2
+            echo "::error::install-proof build tree is not clean before compilation"
+            exit 1
+          fi
+
+      - name: Build the release binaries this pull request would ship
+        run: |
+          cargo build --locked --release \
+            --target x86_64-unknown-linux-musl -p kin-cli -p kin-daemon
+
+      # Assembled exactly as the release assembles it, down to the archive name,
+      # the single top-level directory, and the shasum-format sidecar, so the
+      # installer takes its ordinary path over these bytes. kin-vfs and its shim
+      # are absent on purpose: they are built from a separate repository at a
+      # commit the release pins, and a pull request produces no such bytes.
+      # The shape helper the release publishes with is what judges the result.
+      - name: Package the release archive layout
+        run: |
+          set -euo pipefail
+          artifact=kin-linux-x86_64
+          stage="$RUNNER_TEMP/install-proof-pr"
+          release=target/x86_64-unknown-linux-musl/release
+          mkdir -p "$stage/$artifact"
+          cp "$release/kin" "$release/kin-daemon" "$stage/$artifact/"
+          tar czf "$stage/$artifact.tar.gz" -C "$stage" "$artifact"
+          ( cd "$stage" && shasum -a 256 "$artifact.tar.gz" > "$artifact.tar.gz.sha256" )
+          ARCHIVE="$stage/$artifact.tar.gz" ARTIFACT="$artifact" node -e '
+            const { execFileSync } = require("node:child_process");
+            const { assertReleaseArchiveMemberPaths } = require("./scripts/release-archive-shape.cjs");
+            const listing = execFileSync("tar", ["-tzf", process.env.ARCHIVE], { encoding: "utf8" })
+              .split("\n")
+              .filter((line) => line !== "");
+            assertReleaseArchiveMemberPaths(listing, {
+              artifact: process.env.ARTIFACT,
+              target: "x86_64-unknown-linux-musl",
+            });
+          '
+          # The proof binds installed bytes to a public release tag, its commit,
+          # and the Cargo.lock at that commit. A pull request has no tag, so it
+          # states the same three facts about itself and the proof binds to
+          # those instead: the version the binaries stamp, the commit they were
+          # compiled at, and the digest of the lockfile they were compiled with.
+          "$stage/$artifact/kin" --version | awk '{print $2}' > "$stage/expected-version.txt"
+          git rev-parse HEAD > "$stage/expected-commit.txt"
+          sha256sum Cargo.lock | cut -d' ' -f1 > "$stage/expected-lock-sha.txt"
+          # The proof runs with no checkout, so the installer it must exercise
+          # travels with the archive.
+          cp scripts/install.sh "$stage/install.sh"
+          cat "$stage/expected-version.txt" "$stage/expected-commit.txt" \
+            "$stage/expected-lock-sha.txt" "$stage/$artifact.tar.gz.sha256"
+
+      - name: Upload the pull request release archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: install-proof-pr-binaries
+          if-no-files-found: error
+          retention-days: 3
+          path: |
+            ${{ runner.temp }}/install-proof-pr/kin-linux-x86_64.tar.gz
+            ${{ runner.temp }}/install-proof-pr/kin-linux-x86_64.tar.gz.sha256
+            ${{ runner.temp }}/install-proof-pr/expected-version.txt
+            ${{ runner.temp }}/install-proof-pr/expected-commit.txt
+            ${{ runner.temp }}/install-proof-pr/expected-lock-sha.txt
+            ${{ runner.temp }}/install-proof-pr/install.sh
+
+  install-proof-pr:
+    name: Install Proof (PR)
+    needs: [changes, install-proof-pr-build]
+    if: >-
+      ${{ !cancelled()
+      && needs.changes.outputs.docs_only != 'true'
+      && needs.install-proof-pr-build.result == 'success' }}
+    uses: ./.github/workflows/install-proof.yml
+    with:
+      release_tag: ""
+      expected_vfs_commit: ""
+      local_artifact: install-proof-pr-binaries
+    permissions:
+      contents: read
+      attestations: read
+
+  # A reusable-workflow call publishes its checks as `<caller> / <leg>`, and a
+  # caller that skips publishes no such check at all, so those names cannot be
+  # the required context: a documentation-only pull request would wait forever
+  # on a check nothing will ever report. This job always reports, under one
+  # stable name, and is the context to require.
+  install-proof-pr-gate:
+    name: Install Proof (PR) Gate
+    needs: [changes, install-proof-pr-build, install-proof-pr]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the pull request install proof
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          BUILD_RESULT: ${{ needs.install-proof-pr-build.result }}
+          PROOF_RESULT: ${{ needs.install-proof-pr.result }}
+        run: |
+          set -euo pipefail
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "documentation-only diff: no binaries changed, so the install proof has nothing to install"
+            exit 0
+          fi
+          if [ "$BUILD_RESULT" != "success" ]; then
+            echo "::error::install proof binaries did not build ($BUILD_RESULT); the pull request install proof never ran"
+            exit 1
+          fi
+          if [ "$PROOF_RESULT" != "success" ]; then
+            echo "::error::the install proof failed against this pull request's binaries ($PROOF_RESULT); the same proof gates every release tag"
+            exit 1
+          fi
+          echo "install proof passed against this pull request's binaries"

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -19,6 +19,16 @@ on:
         description: Reviewed kin-vfs commit pinned by the calling release workflow.
         required: true
         type: string
+      local_artifact:
+        description: >
+          Name of an artifact in the CALLING run holding binaries this pull
+          request built, packaged in the release archive layout with its
+          checksum sidecar, the public installer, and the version, commit, and
+          Cargo.lock digest they were built from. Blank runs the public-release
+          proof unchanged. Non-blank runs the same proof against those bytes.
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       release_tag:
@@ -50,22 +60,25 @@ jobs:
     continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       fail-fast: false
+      # The reviewed release matrix is what every public release still proves.
+      # A pull-request run installs binaries built from that pull request, which
+      # exist for exactly one platform, so it collapses to the Linux leg rather
+      # than installing a released archive on the other four. Both lists are
+      # decoded and pinned by the release authority suite, so neither can grow,
+      # shrink, or gain an experimental row unreviewed.
+      #
+      # The pull-request list is the OVERRIDE and the release list is what an
+      # absent input falls back to. That direction is the whole point: this
+      # workflow also runs on `release: published` and on a schedule, where the
+      # `inputs` context is empty, and a condition that read the empty case as
+      # the override would silently drop four reviewed platforms from the
+      # release gate. Truthiness answers null and "" identically, so neither
+      # spelling of absent can reach the one-platform list.
       matrix:
-        include:
-          - os: ubuntu-latest
-            setup-shell: bash
-          - os: ubuntu-24.04-arm
-            setup-shell: bash
-          - os: macos-latest
-            setup-shell: zsh
-          - os: macos-15-intel
-            setup-shell: zsh
-          - os: windows-latest
-            setup-shell: powershell
-            experimental: true
+        include: ${{ fromJSON(inputs.local_artifact && '[{"os":"ubuntu-latest","setup-shell":"bash"}]' || '[{"os":"ubuntu-latest","setup-shell":"bash"},{"os":"ubuntu-24.04-arm","setup-shell":"bash"},{"os":"macos-latest","setup-shell":"zsh"},{"os":"macos-15-intel","setup-shell":"zsh"},{"os":"windows-latest","setup-shell":"powershell","experimental":true}]') }}
     steps:
       - name: Public install (Unix)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && !inputs.local_artifact
         env:
           RELEASE_EVENT_TAG: ${{ inputs.release_tag || github.event.release.tag_name || '' }}
         run: |
@@ -95,11 +108,45 @@ jobs:
           irm https://get.kinlab.dev/install.ps1 | iex
           "$HOME\.kin\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Download the pull request release archive
+        if: inputs.local_artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: ${{ inputs.local_artifact }}
+          path: ${{ runner.temp }}/kin-pull-request-release
+
+      # A pull request has no published release to install from, so it serves
+      # its own archive over `file://` and hands it to the SAME installer the
+      # public proof runs. KIN_BASE_URL is the installer's own documented
+      # offline path, so nothing here reimplements extraction, the mandatory
+      # daemon assertion, the registry-authority check, or the binary moves:
+      # a break in any of them is a break here too.
+      - name: Pull request install (Unix)
+        if: runner.os != 'Windows' && inputs.local_artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$RUNNER_OS/$RUNNER_ARCH" in
+            Linux/X64) ;;
+            *) echo "pull-request install proof is built for Linux/X64 only, not $RUNNER_OS/$RUNNER_ARCH" >&2; exit 1 ;;
+          esac
+          staged="$RUNNER_TEMP/kin-pull-request-release"
+          version="$(cat "$staged/expected-version.txt")"
+          served="$RUNNER_TEMP/kin-pull-request-served"
+          mkdir -p "$served/download/v$version"
+          cp "$staged/kin-linux-x86_64.tar.gz" \
+            "$staged/kin-linux-x86_64.tar.gz.sha256" \
+            "$served/download/v$version/"
+          KIN_NO_SETUP=1 KIN_VERSION="$version" KIN_BASE_URL="file://$served" \
+            sh "$staged/install.sh"
+          echo "$HOME/.kin/bin" >> "$GITHUB_PATH"
+
       - name: Verify binaries installed + runnable
         shell: bash
         env:
           RELEASE_EVENT_TAG: ${{ inputs.release_tag || github.event.release.tag_name || '' }}
           REVIEWED_VFS_COMMIT: ${{ inputs.expected_vfs_commit || '' }}
+          LOCAL_ARTIFACT: ${{ inputs.local_artifact || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -131,6 +178,34 @@ jobs:
           fs.writeFileSync("installed-kin-command.txt", `${installedKin}\n`);
           NODE
 
+          installed_version="$(printf '%s\n' "$kin_version_line" | awk '{print $2}')"
+          installed_daemon_version="$(printf '%s\n' "$daemon_version_line" | awk '{print $2}')"
+
+          # Pull-request bytes carry no release tag, no public archive, and no
+          # attestation, so the release-only bindings below have nothing to bind
+          # to. What replaces them is not weaker: the calling build wrote the
+          # commit it compiled, the digest of the Cargo.lock it compiled with,
+          # and the version it stamped, and every later assertion reads those
+          # three files exactly as it reads the release's. The installed CLI and
+          # daemon must both report that version here, and the capability
+          # validator below still requires both binaries to report that commit,
+          # a clean tree, and that lock digest.
+          if [ -n "$LOCAL_ARTIFACT" ]; then
+            staged="$RUNNER_TEMP/kin-pull-request-release"
+            cp "$staged/expected-version.txt" "$staged/expected-commit.txt" \
+              "$staged/expected-lock-sha.txt" .
+            expected_version="$(cat expected-version.txt)"
+            if [ "$installed_version" != "$expected_version" ]; then
+              echo "installed kin $installed_version, expected pull request build $expected_version" >&2
+              exit 1
+            fi
+            if [ "$installed_daemon_version" != "$expected_version" ]; then
+              echo "installed kin-daemon $installed_daemon_version, expected pull request build $expected_version" >&2
+              exit 1
+            fi
+            exit 0
+          fi
+
           expected_tag="$RELEASE_EVENT_TAG"
           if [ -z "$expected_tag" ]; then
             latest_url="$(curl -fsSLI \
@@ -156,8 +231,6 @@ jobs:
             exit 1
           fi
 
-          installed_version="$(printf '%s\n' "$kin_version_line" | awk '{print $2}')"
-          installed_daemon_version="$(printf '%s\n' "$daemon_version_line" | awk '{print $2}')"
           expected_version="${expected_tag#v}"
           if [ "$installed_version" != "$expected_version" ]; then
             echo "installed kin $installed_version, expected latest release $expected_version" >&2
@@ -1125,8 +1198,13 @@ jobs:
           child.stdin.write(`${requests.map((request) => JSON.stringify(request)).join("\n")}\n`);
           NODE
 
+      # kin-vfs and its shim are built from a separate repository at a commit
+      # the release workflow pins, so a pull request produces no such bytes and
+      # its archive carries none. The installer says so out loud and the CLI
+      # reports the projection unsupported, which the capability validator below
+      # requires in that mode rather than tolerating any status.
       - name: Graph-backed VFS projection proof
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && !inputs.local_artifact
         shell: bash
         working-directory: kin-install-proof
         run: |
@@ -1513,6 +1591,8 @@ jobs:
       - name: Validate installed capability proof
         shell: bash
         working-directory: kin-install-proof
+        env:
+          LOCAL_ARTIFACT: ${{ inputs.local_artifact || '' }}
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1521,6 +1601,7 @@ jobs:
           const path = require("path");
           const runnerOs = process.env.RUNNER_OS;
           const isWindows = runnerOs === "Windows";
+          const isPullRequestBuild = (process.env.LOCAL_ARTIFACT ?? "") !== "";
           const expectedCommit = fs.readFileSync("../expected-commit.txt", "utf8").trim();
           const expectedLock = fs.readFileSync("../expected-lock-sha.txt", "utf8").trim();
           const installedKin = fs.readFileSync("../installed-kin-command.txt", "utf8").trim();
@@ -1670,7 +1751,7 @@ jobs:
             ["shell_path", "healthy"],
             ["setup_ledger", "healthy"],
             ["registry_authority", isWindows ? "unsupported" : "healthy"],
-            ["vfs_projection", isWindows ? "unsupported" : "healthy"],
+            ["vfs_projection", isWindows || isPullRequestBuild ? "unsupported" : "healthy"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],
             ["mcp_client_codex", "healthy"],

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -494,6 +494,9 @@ CI_JOB_DISPLAY_NAMES = {
     "check-docs-only": "Check & Test",
     "check": "Check & Test",
     "coverage": "Code Coverage",
+    "install-proof-pr-build": "Install Proof (PR) Build",
+    "install-proof-pr": "Install Proof (PR)",
+    "install-proof-pr-gate": "Install Proof (PR) Gate",
 }
 EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/approve-to-merge.yml": {
@@ -621,7 +624,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/install-proof.yml",
         "install-proof",
-    ): "91bbe7dd412df4ade467a53be2618eb8199bc746b682ae5f27552649009446b4",
+    ): "44b510d0d82f7b56b525b08f38a3f84916243c30e9c365b340718670f95af1ca",
     (
         ".github/workflows/release.yml",
         "build",
@@ -651,6 +654,14 @@ REQUIRED_CHECK_JOB_PRODUCERS = {
     },
     "Windows installer + vector release build": {
         (".github/workflows/ci.yml", "windows-installer"),
+    },
+    # The pull-request install proof's required context is this gate rather
+    # than the reusable call's per-leg checks. A reusable-workflow call
+    # publishes `<caller> / <leg>`, and a caller that skips publishes nothing
+    # under that name at all, so requiring a leg would hang every
+    # documentation-only pull request on a check that will never report.
+    "Install Proof (PR) Gate": {
+        (".github/workflows/ci.yml", "install-proof-pr-gate"),
     },
 }
 # Durable workflow IDs are GitHub's repository-scoped identity, while `path`
@@ -2577,6 +2588,154 @@ def assert_install_proof_embedding_settles_before_measurement(embedding: str) ->
             )
 
 
+INSTALL_PROOF_MATRIX_PATTERN = re.compile(
+    r"^include: \$\{\{ fromJSON\(inputs\.local_artifact "
+    r"&& '(?P<pull_request>\[.*?\])' \|\| '(?P<release>\[.*?\])'\) \}\}$"
+)
+
+
+def install_proof_matrix_rows(install_job: str) -> tuple[
+    list[dict[str, object]], list[dict[str, object]]
+]:
+    """Decode both reviewed install-proof matrices from their one expression.
+
+    The release matrix is the default and the pull-request matrix is the
+    override, and the job carries exactly one line that can produce either.
+    Decoding it here is what lets the posture assertions below judge rows
+    rather than YAML text, so neither list can gain a platform, lose one, or
+    grow a second tolerated leg without this failing. A matrix built any other
+    way (a second expression, a literal include, a computed list) is refused
+    outright rather than read past.
+    """
+
+    strategy_lines = active_lines(dynamic_job_context_source(install_job))
+    includes = [line for line in strategy_lines if line.startswith("include:")]
+    if len(includes) != 1:
+        raise AssertionError(
+            "install-proof must declare exactly one matrix include line; "
+            f"found {includes}"
+        )
+    match = INSTALL_PROOF_MATRIX_PATTERN.fullmatch(includes[0])
+    if match is None:
+        raise AssertionError(
+            "install-proof matrix must be the reviewed release-or-pull-request "
+            f"expression; found `{includes[0]}`"
+        )
+    try:
+        release = json.loads(match.group("release"))
+        pull_request = json.loads(match.group("pull_request"))
+    except json.JSONDecodeError as error:
+        raise AssertionError(
+            f"install-proof matrix does not decode as JSON: {error}"
+        ) from error
+    return release, pull_request
+
+
+INSTALL_PROOF_PULL_REQUEST_ARTIFACT = "install-proof-pr-binaries"
+INSTALL_PROOF_PULL_REQUEST_JOBS = (
+    "install-proof-pr-build",
+    "install-proof-pr",
+    "install-proof-pr-gate",
+)
+
+
+def assert_install_proof_runs_on_pull_requests(ci: str, install_proof: str) -> None:
+    """Require the release install proof to run before a tag exists.
+
+    v0.5.38 was versioned, built, published, and only then refused, on an
+    assertion no pull-request check ran: `kin locate` had to report complete
+    semantic coverage over a freshly installed probe repository, and the only
+    place that ran was the public install proof, which the release workflow
+    calls after publishing. The remedy is not a second copy of that assertion,
+    which would drift from the one the release enforces. It is the same
+    reusable proof, called from CI against binaries the pull request built.
+
+    So this pins the three properties that make that true and keeps each one
+    falsifiable. The proof must reach the reviewed reusable workflow rather
+    than a lookalike; the binaries it installs must be the ones the pull
+    request compiled and packaged in the release archive layout; and none of
+    the three jobs may exclude the pull request or the merge queue, which is
+    exactly how a heavy leg gets quietly moved back to main and how this class
+    of break returns. The semantic-coverage assertion itself is pinned last:
+    the step producing its capture stays on the ordinary Unix path, so a
+    pull-request run reaches it rather than skipping it as an optional extra.
+    """
+
+    jobs = workflow_job_blocks(ci)
+    missing = [job for job in INSTALL_PROOF_PULL_REQUEST_JOBS if job not in jobs]
+    if missing:
+        raise AssertionError(
+            "the install proof must run at pull-request time; CI lost "
+            f"{missing}"
+        )
+    build, call, gate = (jobs[job] for job in INSTALL_PROOF_PULL_REQUEST_JOBS)
+
+    call_lines = active_lines(call)
+    for policy in (
+        "uses: ./.github/workflows/install-proof.yml",
+        f"local_artifact: {INSTALL_PROOF_PULL_REQUEST_ARTIFACT}",
+    ):
+        if policy not in call_lines:
+            raise AssertionError(
+                "the pull-request install proof must call the reviewed reusable "
+                f"proof with the built artifact; missing `{policy}`"
+            )
+    build_lines = active_lines(build)
+    for policy in (
+        f"name: {INSTALL_PROOF_PULL_REQUEST_ARTIFACT}",
+        "--target x86_64-unknown-linux-musl -p kin-cli -p kin-daemon",
+        'tar czf "$stage/$artifact.tar.gz" -C "$stage" "$artifact"',
+        "assertReleaseArchiveMemberPaths(listing, {",
+        'cp scripts/install.sh "$stage/install.sh"',
+    ):
+        if policy not in build_lines:
+            raise AssertionError(
+                "the pull-request install proof must install release-layout "
+                f"binaries built by this pull request; missing `{policy}`"
+            )
+
+    for job_id, job in zip(INSTALL_PROOF_PULL_REQUEST_JOBS, (build, call, gate)):
+        for line in active_lines(job):
+            if "event_name" in line:
+                raise AssertionError(
+                    f"{job_id} must not exclude an event: the install proof "
+                    "exists to run on pull requests and merge groups, and a "
+                    f"job-level event filter silently returns it to the tag: {line}"
+                )
+
+    gate_lines = active_lines(gate)
+    for policy in (
+        'if [ "$BUILD_RESULT" != "success" ]; then',
+        'if [ "$PROOF_RESULT" != "success" ]; then',
+        "exit 1",
+    ):
+        if policy not in gate_lines:
+            raise AssertionError(
+                "the pull-request install proof gate must fail closed on a "
+                f"proof that did not pass; missing `{policy}`"
+            )
+
+    embedding = install_proof_step(
+        install_proof, "Unix embedding and semantic retrieval proof"
+    )
+    embedding_lines = active_lines(embedding)
+    conditioned = [line for line in embedding_lines if line.startswith("if:")]
+    if conditioned != ["if: runner.os != 'Windows'"]:
+        raise AssertionError(
+            "the semantic retrieval proof admits exactly the Unix condition, so "
+            "a pull-request run reaches the assertion that refused v0.5.38; "
+            f"found {conditioned}"
+        )
+    if (
+        'kin locate hello --json --explain --max-files 5 | tee "$captures/kin-semantic-locate.json"'
+        not in embedding_lines
+    ):
+        raise AssertionError(
+            "the semantic retrieval proof lost the locate capture the "
+            "capability validator reads"
+        )
+
+
 def assert_install_proof_windows_experimental_posture(install_proof: str) -> None:
     """Pin the declared experimental scope of the install-proof matrix.
 
@@ -2618,25 +2777,25 @@ def assert_install_proof_windows_experimental_posture(install_proof: str) -> Non
             "job-level matrix experimental guard; a step-level tolerance "
             f"would spare every leg; found {tolerance_mentions}"
         )
-    strategy_lines = active_lines(dynamic_job_context_source(install_job))
-    current_row: str | None = None
-    experimental_rows: list[str] = []
-    for line in strategy_lines:
-        if line.startswith("- os:"):
-            current_row = line.removeprefix("- os:").strip()
-        elif line == "experimental: true" and current_row is not None:
-            experimental_rows.append(current_row)
-        elif line.startswith("experimental"):
+    release_rows, pull_request_rows = install_proof_matrix_rows(install_job)
+    for label, rows in (("release", release_rows), ("pull request", pull_request_rows)):
+        experimental_rows = []
+        for row in rows:
+            if "experimental" not in row:
+                continue
+            if row["experimental"] is not True:
+                raise AssertionError(
+                    f"install-proof {label} matrix rows admit only a literal "
+                    f"`experimental: true`; found {row['experimental']!r} under "
+                    f"{row.get('os')}"
+                )
+            experimental_rows.append(row.get("os"))
+        expected = ["windows-latest"] if label == "release" else []
+        if experimental_rows != expected:
             raise AssertionError(
-                "install-proof matrix rows admit only a literal "
-                f"`experimental: true`; found `{line}` under "
-                f"{current_row or 'no row'}"
+                f"install-proof {label} experimental rows must be exactly "
+                f"{expected}; found {experimental_rows}"
             )
-    if experimental_rows != ["windows-latest"]:
-        raise AssertionError(
-            "install-proof experimental rows must be exactly "
-            f"['windows-latest']; found {experimental_rows}"
-        )
 
 
 def assert_install_proof_repo_steps_cover_windows(install_proof: str) -> None:
@@ -2669,8 +2828,7 @@ def assert_install_proof_repo_steps_cover_windows(install_proof: str) -> None:
             f"found runs-on={runs_on}"
         )
 
-    strategy = dynamic_job_context_source(install_job)
-    strategy_lines = active_lines(strategy)
+    strategy_lines = active_lines(dynamic_job_context_source(install_job))
     if any(
         line == "exclude:" or line.startswith("exclude:")
         for line in strategy_lines
@@ -2678,10 +2836,12 @@ def assert_install_proof_repo_steps_cover_windows(install_proof: str) -> None:
         raise AssertionError(
             "native Windows release proof matrix must not exclude a reviewed OS row"
         )
-    if strategy_lines.count("- os: windows-latest") != 1:
+    release_rows, _ = install_proof_matrix_rows(install_job)
+    windows_rows = [row for row in release_rows if row.get("os") == "windows-latest"]
+    if len(windows_rows) != 1:
         raise AssertionError(
             "native Windows release proof matrix must contain exactly one "
-            "windows-latest row"
+            f"windows-latest row; found {len(windows_rows)}"
         )
 
     for step in (
@@ -7359,20 +7519,16 @@ def main() -> None:
 
     install_proof_workflow = WORKFLOWS / "install-proof.yml"
     dynamic_context_spoof = dict(workflow_sources)
-    if (
-        dynamic_context_spoof[install_proof_workflow].count(
-            "          - os: ubuntu-latest"
-        )
-        != 1
-    ):
+    matrix_row = '{"os":"ubuntu-latest","setup-shell":"bash"}'
+    if dynamic_context_spoof[install_proof_workflow].count(matrix_row) != 2:
         raise AssertionError(
             "workflow census falsification could not identify install-proof matrix"
         )
     dynamic_context_spoof[install_proof_workflow] = dynamic_context_spoof[
         install_proof_workflow
     ].replace(
-        "          - os: ubuntu-latest",
-        "          - os: Check & Test (ubuntu-latest)",
+        matrix_row,
+        '{"os":"Check & Test (ubuntu-latest)","setup-shell":"bash"}',
         1,
     )
     expect_assertion(
@@ -8536,14 +8692,15 @@ def main() -> None:
         ),
         (
             "the Windows matrix row disappears",
-            "          - os: windows-latest\n            setup-shell: powershell\n",
+            ',{"os":"windows-latest","setup-shell":"powershell","experimental":true}',
             "",
             "windows-latest row",
         ),
         (
             "a matrix exclusion removes Windows after retaining its include row",
-            "        include:\n",
-            "        exclude:\n          - os: windows-latest\n        include:\n",
+            "        include: ${{ fromJSON(",
+            "        exclude:\n          - os: windows-latest\n"
+            "        include: ${{ fromJSON(",
             "must not exclude",
         ),
     ):
@@ -8563,10 +8720,9 @@ def main() -> None:
     for label, original, mutation, expected in (
         (
             "the experimental flag spreads to a Unix matrix row",
-            "          - os: ubuntu-latest\n            setup-shell: bash\n",
-            "          - os: ubuntu-latest\n            setup-shell: bash\n"
-            "            experimental: true\n",
-            "exactly ['windows-latest']",
+            '{"os":"ubuntu-latest","setup-shell":"bash"}',
+            '{"os":"ubuntu-latest","setup-shell":"bash","experimental":true}',
+            "experimental rows must be exactly",
         ),
         (
             "the install proof tolerates every leg unconditionally",
@@ -8576,14 +8732,14 @@ def main() -> None:
         ),
         (
             "the tolerance guard survives while the Windows flag disappears",
-            "            experimental: true\n",
+            ',"experimental":true',
             "",
             "exactly ['windows-latest']",
         ),
         (
             "an experimental value other than a literal true appears",
-            "            experimental: true\n",
-            "            experimental: yes\n",
+            '"experimental":true',
+            '"experimental":"yes"',
             "literal `experimental: true`",
         ),
         (
@@ -8617,6 +8773,103 @@ def main() -> None:
             expected,
             lambda mutated=install_proof.replace(original, mutation, 1): (
                 assert_install_proof_windows_experimental_posture(mutated)
+            ),
+        )
+
+    assert_install_proof_runs_on_pull_requests(ci_workflow, install_proof)
+    pull_request_gate = workflow_job_blocks(ci_workflow)["install-proof-pr-gate"]
+    for label, source, original, mutation, expected in (
+        (
+            "the pull-request install proof gate is deleted outright",
+            ci_workflow,
+            pull_request_gate,
+            "",
+            "CI lost",
+        ),
+        (
+            "the pull-request proof calls a lookalike workflow",
+            ci_workflow,
+            "uses: ./.github/workflows/install-proof.yml",
+            "uses: ./.github/workflows/daemon-smoke.yml",
+            "reviewed reusable",
+        ),
+        (
+            "the pull-request proof installs a released archive instead",
+            ci_workflow,
+            f"      local_artifact: {INSTALL_PROOF_PULL_REQUEST_ARTIFACT}\n",
+            '      local_artifact: ""\n',
+            "reviewed reusable",
+        ),
+        (
+            "the built binaries are uploaded under another name",
+            ci_workflow,
+            f"          name: {INSTALL_PROOF_PULL_REQUEST_ARTIFACT}\n",
+            "          name: install-proof-pr-other\n",
+            "built by this pull request",
+        ),
+        (
+            "the proof stops building the release target",
+            ci_workflow,
+            "--target x86_64-unknown-linux-musl -p kin-cli -p kin-daemon",
+            "-p kin-cli -p kin-daemon",
+            "built by this pull request",
+        ),
+        (
+            "the archive is no longer judged by the release shape contract",
+            ci_workflow,
+            "            assertReleaseArchiveMemberPaths(listing, {\n",
+            "            void listing && ((_) => {})({\n",
+            "built by this pull request",
+        ),
+        (
+            "the proof is moved off the pull request the way a slow leg was",
+            ci_workflow,
+            "  install-proof-pr-gate:\n    name: Install Proof (PR) Gate\n",
+            "  install-proof-pr-gate:\n    name: Install Proof (PR) Gate\n"
+            "    if: ${{ github.event_name != 'pull_request' }}\n",
+            "must not exclude an event",
+        ),
+        (
+            "the gate stops failing on a proof that did not pass",
+            ci_workflow,
+            '          if [ "$PROOF_RESULT" != "success" ]; then\n',
+            '          if false; then\n',
+            "fail closed",
+        ),
+        (
+            "the semantic retrieval proof becomes release-only",
+            install_proof,
+            "      - name: Unix embedding and semantic retrieval proof\n"
+            "        if: runner.os != 'Windows'\n",
+            "      - name: Unix embedding and semantic retrieval proof\n"
+            "        if: runner.os != 'Windows' && inputs.local_artifact == ''\n",
+            "exactly the Unix condition",
+        ),
+        (
+            "the locate capture the validator reads disappears",
+            install_proof,
+            '          kin locate hello --json --explain --max-files 5 '
+            '| tee "$captures/kin-semantic-locate.json"\n',
+            "",
+            "lost the locate capture",
+        ),
+    ):
+        if original not in source:
+            raise AssertionError(
+                "pull-request install proof falsification lost fixture for "
+                f"{label}: {original!r}"
+            )
+        mutated_ci = ci_workflow
+        mutated_proof = install_proof
+        if source is ci_workflow:
+            mutated_ci = ci_workflow.replace(original, mutation, 1)
+        else:
+            mutated_proof = install_proof.replace(original, mutation, 1)
+        expect_assertion(
+            label,
+            expected,
+            lambda ci=mutated_ci, proof=mutated_proof: (
+                assert_install_proof_runs_on_pull_requests(ci, proof)
             ),
         )
 


### PR DESCRIPTION
The install proof is the check that refused v0.5.38, and it refused it on the tag. The release workflow calls it from `install_proof` in `.github/workflows/release.yml:1783`, after `publish`, so the first signal that the binaries were broken arrived after the version was cut, built, signed, and published. Both the workflow and the binary resolve from the tag, so no fix on main can reach that run, and the tag was abandoned. The assertion that refused it lives in `.github/workflows/install-proof.yml`, in the step `Validate installed capability proof`, and reads `semanticLocate.semantic_coverage?.supported !== true || semanticLocate.semantic_coverage?.complete !== true || !semanticLocate.files?.some((entry) => entry.path === "probe.py")`. Nothing before the tag ran it.

This runs that same reusable proof from CI, against binaries the pull request builds, so the break is a red pull request instead of a burned tag.

## Mechanism

`ci.yml` gains three jobs. `Install Proof (PR) Build` compiles `kin` and `kin-daemon` with `cargo build --locked --release --target x86_64-unknown-linux-musl -p kin-cli -p kin-daemon`, which is the same command and the same target the release's Linux leg runs, packages them into `kin-linux-x86_64.tar.gz` with a `shasum -a 256` sidecar exactly as `Package (Unix)` does, and judges the result with `assertReleaseArchiveMemberPaths` from `scripts/release-archive-shape.cjs`, the helper the release publishes with. It also writes the version the binaries stamp, the commit they were compiled at, and the sha256 of the Cargo.lock they were compiled with, and ships `scripts/install.sh` beside them, because the proof runs with no checkout.

`Install Proof (PR)` calls `./.github/workflows/install-proof.yml` with `local_artifact: install-proof-pr-binaries`. That one input is the whole switch. Non-blank collapses the matrix to the Linux leg, downloads the archive, and installs it with the public installer over `KIN_BASE_URL=file://...`, which is the installer's own documented offline path, so extraction, the mandatory daemon assertion, the registry-authority preflight, the binary moves, and the checksum verification are the ones a real user gets rather than a reimplementation. Blank leaves every public release path unchanged, and the fallback direction is deliberate: this workflow also runs on `release: published` and on a schedule, where the `inputs` context is empty, so the reviewed five-platform list is what an absent input resolves to and no spelling of absent can reach the one-platform list.

`Install Proof (PR) Gate` is the context to require. A reusable-workflow call publishes its checks as `<caller> / <leg>`, and a caller that skips publishes nothing under that name at all, so requiring a leg would hang every documentation-only pull request on a check that will never report. `ci.yml` already carries that exact reasoning above `check-docs-only`. The gate always reports, and fails closed when the build failed, when the proof failed, or when either did not run on a diff that was not documentation-only.

## What is gated off in pull-request mode, and why

Three things, each because it is about a published release rather than about the binaries under test.

The release-tag resolution and the attestation and provenance verification in `Verify binaries installed + runnable` bind installed bytes to a public tag, a signed archive, and the Cargo.lock at that tag. A pull request has none of those. What replaces them is not weaker: the build stamps the commit it compiled, the digest of the lockfile it compiled with, and the version, and every later assertion reads those three files exactly as it reads the release's. The capability validator still requires both the CLI and the daemon to report that 40-hex commit, `dirty === false`, and that 64-hex lock digest, so bytes built from anything other than this pull request fail there.

The `Graph-backed VFS projection proof` is skipped, and `vfs_projection` is expected `unsupported` instead of `healthy`. kin-vfs and its shim are built from a separate repository at a commit the release pins in `expected_vfs_commit`, so a pull request produces no such bytes. That expectation is exact rather than tolerant: a projection that did appear would fail it.

Nothing else changes. The embed, settle, status, health, doctor, semantic search, and semantic locate sequence runs unchanged, and so does the whole `Validate installed capability proof` node block.

## Proof

Run: https://github.com/firelock-ai/kin/actions/runs/32150905584, on this pull request, all three jobs green.

`Install Proof (PR) Build` took 681 seconds (11m21s), `Install Proof (PR) / ubuntu-latest` took 20 seconds, and `Install Proof (PR) Gate` took 3 seconds. End to end the chain ran 14:51:48Z to 15:03:40Z, 11m52s. `Check & Test (macos-latest)` measured 39 minutes on the last main run and `Check & Test (ubuntu-latest)` 28 minutes, so this adds no wall clock to a round. The build is the whole cost and it was a cold cache: `save-if` restricts saving to main, so this is the slowest this job gets, and later pull requests restore from main.

The leg ran exactly the intended shape. `Public install (Unix)` skipped, `Download the pull request release archive` and `Pull request install (Unix)` succeeded, `Verify binaries installed + runnable` succeeded, `First-run repository, daemon, and setup proof`, `Graph query and MCP tool-call proof`, `Unix embedding and semantic retrieval proof`, and `Validate installed capability proof` all succeeded, and `Graph-backed VFS projection proof` skipped, which is the one gated set.

The assertion did not merely run, it had data. From the run's own uploaded `kin-semantic-locate.json`:

```
{"supported":true,"indexed":4,"total":4,"pending":0,"complete":true,
 "graph_bodies":{"source_paths":1,"with_body":1,"gap_paths":0}}   files: ["probe.py"]
```

That is the exact shape v0.5.38 could not produce, now produced by binaries this pull request built. The installed CLI and daemon both reported `kin 0.5.39 (77e53c7927d49de220a102de8d29c0569d93b9de detached ...)`, matching the `expected-commit.txt` the build wrote, with no `-dirty`, so the commit binding held.

The assertion that refused v0.5.38 is inside this job's path. The capture it reads is produced at `.github/workflows/install-proof.yml:1556` on this branch, `kin locate hello --json --explain --max-files 5 | tee "$captures/kin-semantic-locate.json"`, in the step `Unix embedding and semantic retrieval proof` (line 1391), whose only condition is `runner.os != 'Windows'`. The assertion itself is at `.github/workflows/install-proof.yml:1915`, in `Validate installed capability proof` (line 1591), which carries no condition at all. `assert_install_proof_runs_on_pull_requests` pins both facts.

On the v0.5.38 release run 32107626360, all four Unix legs failed at that same step, `Validate installed capability proof`, including `ubuntu-latest`, which is the leg this job runs. Windows failed elsewhere, at its own repo-free proof, which is consistent with Windows never running the Unix embedding path. That is why the Linux-only pull-request leg is enough and a macOS leg is not added: it would mean a second release-profile build on a runner billed at 10x, to re-catch a break the Linux leg already caught.

## Falsification

`scripts/test-release-workflow-authority.py` gains `assert_install_proof_runs_on_pull_requests`, wired into `main` and therefore covered by `scripts/test-assertion-reachability.py`, which passes with `3 gate suites run on pull requests and define no check that nothing calls`. Ten falsifications run in the suite itself, each mutating the workflow and requiring the named refusal:

- the gate job is deleted outright: `the install proof must run at pull-request time; CI lost ['install-proof-pr-gate']`
- the call points at a lookalike workflow, and the artifact input goes blank: `reviewed reusable`
- the built binaries are uploaded under another name, the release target is dropped from the build, and the archive stops being judged by the shape contract: `built by this pull request`
- an event filter is added to the gate the way a slow leg was once moved off pull requests: `must not exclude an event`
- the gate stops failing on a proof that did not pass: `fail closed`
- the semantic retrieval proof is made release-only: `exactly the Unix condition`
- the locate capture disappears: `lost the locate capture`

The existing Windows posture assertions now decode both matrices from the one expression rather than scanning YAML lines, and every falsification they carried still fails by name: a removed windows-latest row, an added exclusion, an experimental flag spreading to a Unix row, a non-literal `true`, and a tolerance guard removed or moved to a step.

The `file://` install path was falsified locally before this ran anywhere. A stub archive in the release layout installed cleanly through `scripts/install.sh` with `KIN_BASE_URL` pointed at a local directory, reporting `SHA-256 checksum verified`, `Binaries installed (kin, kin-daemon)`, and `Filesystem projection (kin-vfs) not bundled in this archive`, which is the pull-request case. Appending nine bytes to the served archive made the same command exit 1 with `SHA-256 checksum mismatch!` and install nothing, so the checksum guard is live on that path rather than bypassed by it.

Local gates: `python3 scripts/test-release-workflow-authority.py` exits 0, `python3 scripts/test-assertion-reachability.py` exits 0, and `test-install-checksum.py`, `test_installer_parity.py`, `test_install_optional_vfs.py`, `test-homebrew-release-gate.py`, `falsify-installer-archive-binaries.py`, and `falsify-installer-release-assets.py` all pass. No Rust source changed, so no crate gate applies. `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

## It fails when the coverage breaks

The mutations above prove the pins hold. They do not prove the job can go red on a real break, so that was run for real on a throwaway branch off this head, #914, closed unmerged. It adds one step that rewrites the locate capture into the shape v0.5.38 produced, `complete` false with `graph_bodies.with_body` 0 of 1, and changes nothing else. Run 32153257872: `Install Proof (PR) Build` success, `Install Proof (PR) / ubuntu-latest` **failure**, `Install Proof (PR) Gate` **failure**.

The leg failed at `Validate installed capability proof` with `Error: semantic kin locate did not prove complete coverage and return probe.py`, on this capture:

```
{"supported":true,"indexed":4,"total":4,"pending":0,"complete":false,
 "graph_bodies":{"source_paths":1,"with_body":0,"gap_paths":1}}   files: ["probe.py"]
```

`probe.py` is still in `files`, so the refusal came from `complete`. The gate then failed with `the install proof failed against this pull request's binaries (failure); the same proof gates every release tag`.

`complete` is the field that catches it because it is a conjunction rather than the embedding fraction: `SemanticCoverage::with_graph_bodies` in `crates/kin-cli/src/commands/locate.rs:1568` sets `complete = false` whenever `has_gap()` (line 244, `gap_paths > 0`). A body gap clears it on a fully embedded store, which is the v0.5.38 signature of 4/4 indexed with a body-less source path.

One limit worth naming: an unobserved body coverage does not clear the flag, because `graph_bodies` is optional and absent means "not looked at". A regression that stopped observing bodies would pass. Closing that means also requiring `graph_bodies` present with `gap_paths === 0`, in pull-request mode only, because this workflow also runs on a schedule against whatever release is Latest and an older binary predates the field. That is a follow-up, not this change.

## One thing a captain must do

Making `Install Proof (PR) Gate` a required context is a repository setting, not a file. Add the context `Install Proof (PR) Gate` to the ruleset `Require status checks on main` (id 19746451) in `firelock-ai/kin`, beside the six it already names. `REQUIRED_CHECK_JOB_PRODUCERS` in the authority suite now declares that name and pins `install-proof-pr-gate` as its only producer, so the file half is already reviewed. Adding it to `REQUIRED_CHECKS` in `release-tag.yml`, which would make the tag mint refuse without it, is deliberately left as a separate change: that gate decides whether a release can be minted at all, and it should move on its own.

Closes FIR-2412
