### PR TITLE
Run the guard falsification and the feature permutations beside Check & Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,111 +1009,6 @@ jobs:
       - name: Check Zero File-Search Invariant (answer modules)
         run: bash scripts/zero_file_search_guard.sh
 
-      - name: Falsify Zero File-Search guards
-        # Both guards above still run on both platforms. Only this meta-proof,
-        # that the guards are not vacuous, is single-legged. Falsifiability is
-        # a property of the guards' logic, and neither the Python checker nor
-        # the shell guard branches on platform: they carry no `sys.platform` /
-        # `os.name` / `darwin` / `linux` test and no GNU-only shell construct.
-        # The harness is self-contained, poisoning a `mktemp -d` copy of
-        # `crates` and `scripts` rather than the checkout, so skipping it
-        # leaves no state for later steps and does not reorder them. It costs
-        # 5.9 min of the macOS leg, which is the merge queue's critical path.
-        if: runner.os == 'Linux'
-        run: |
-          set -euo pipefail
-          poisoned="$(mktemp -d)"
-          trap 'rm -rf "$poisoned"' EXIT
-          cp -a crates scripts "$poisoned/"
-
-          fail_expected() {
-            local label="$1" want="$2"; shift 2
-            local out rc=0
-            out="$("$@" 2>&1)" || rc=$?
-            if [[ $rc -eq 0 ]]; then
-              echo "::error::falsification failed. $label passed when it should have failed"; echo "$out"; exit 1
-            fi
-            if ! grep -qF "$want" <<<"$out"; then
-              echo "::error::falsification failed. $label failed but never named '$want'"
-              echo "$out"; exit 1
-            fi
-            echo "  ok: $label"
-          }
-
-          # [1/3] Every answer module, poisoned at several sites including
-          # end-of-file, against both guards. This step used to plant one probe
-          # in one module, at the top of a file it had truncated to three lines.
-          # That proved the guards worked at that spot and nowhere else, and it
-          # passed for as long as a comment-tracking desync left the last third
-          # of the largest answer module unscanned.
-          #
-          # The harness also probes the two ways an EXEMPTION can lose scope
-          # rather than a pattern losing a site: a brace inside a literal or a
-          # comment planted in an allowlisted function body, which a raw brace
-          # counter reads as an unclosed body and silently excuses to end of
-          # file, and a counted pin paid for by a rename in test code the guard
-          # never reads. Both are the same failure as [2/3] reached through the
-          # exemption mechanism instead of a stale pin.
-          echo "[1/3] every answer module, every probe site, both guards"
-          python3 scripts/falsify-zero-file-search.py "$poisoned"
-
-          # [2/3] A broken pin must not hide the scan. Allowlist validation used
-          # to exit before the walk, so a stale pin reported itself and nothing
-          # else; two stale pins once masked ten real violations in a newly
-          # covered crate, which made a red allowlist useless as a measure of
-          # remaining work. Break one pin's count deliberately and require the
-          # run to report the violations that pin was masking AS WELL AS the pin
-          # error. Runs before [3/3], which mutates the allowlist irreversibly.
-          echo "[2/3] a broken pin must not hide the scan"
-          python3 - "$poisoned/scripts/zero-file-search-allowlist.json" <<'PY'
-          import json, sys
-          path = sys.argv[1]
-          data = json.load(open(path))
-          target = "crates/kin-daemon/src/repository_branch.rs"
-          for entry in data["allowlist"]:
-              if entry["file"] == target:
-                  entry["allow_match"] = [{"expr": ".metadata()", "count": 999}]
-                  break
-          else:
-              raise SystemExit(f"::error::falsification setup: no pin on {target}")
-          json.dump(data, open(path, "w"))
-          PY
-          out=""; rc=0
-          out="$(python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned" 2>&1)" || rc=$?
-          for want in \
-            "[VIOLATION] crates/kin-daemon/src/repository_branch.rs" \
-            "want 999" \
-            "Scanned "; do
-            if ! grep -qF "$want" <<<"$out"; then
-              echo "::error::falsification failed: a broken pin hid the scan (missing '$want')"
-              echo "$out"; exit 1
-            fi
-          done
-          if [[ $rc -eq 0 ]]; then
-            echo "::error::falsification failed: a broken pin did not fail the guard"
-            echo "$out"; exit 1
-          fi
-          echo "  ok: broken pin reported its masked violations and still failed"
-          # Restore the real policy; [3/3] starts from an unbroken allowlist.
-          cp scripts/zero-file-search-allowlist.json "$poisoned/scripts/"
-
-          echo "[3/3] allowlist entry naming a path that no longer exists"
-          python3 - "$poisoned/scripts/zero-file-search-allowlist.json" <<'PY'
-          import json, sys
-          path = sys.argv[1]
-          data = json.load(open(path))
-          data["allowlist"].append({
-              "file": "crates/kin-core/src/text_refs.rs",
-              "reason": "resurrected stale exemption",
-              "owner": "ci-falsification",
-              "expiration": "2026-12-31",
-          })
-          json.dump(data, open(path, "w"))
-          PY
-          fail_expected "python guard" "text_refs.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
-
-          echo "Zero File-Search guards are falsifiable: every probe was caught."
-
       # Deep history is a PROJECTION re-authored at ingest, not a stored fact:
       # a merge change's entity/relation deltas are discarded and recomputed by
       # the replay algorithm. Editing that algorithm changes what Kin reports
@@ -1279,9 +1174,215 @@ jobs:
         # nextest does not run doctests; keep them covered explicitly.
         run: cargo test --doc --locked
 
-      # `gcs` is a non-default feature, so the passes above never execute the
-      # hosted-storage code it gates, and Clippy's `--all-features` pass only
-      # type-checks it. Without this step a behavioral regression in the
+  # Two sets of steps used to run inside Check & Test and gate nothing that
+  # needed them to be there. Both sat on the merge queue's critical path: five
+  # merge_group runs sampled on 2026-08-18 spent 9.9 min of the average ubuntu
+  # leg falsifying the Zero File-Search guards, and 15.7 min of the average
+  # macOS leg on the three feature permutations. Neither set consumes anything
+  # Check & Test builds. The falsification harness runs no cargo at all, and
+  # each feature permutation resolves its own feature set, so it recompiles the
+  # workspace crates whether it runs here or there. Running them beside Check &
+  # Test rather than behind it changes when they run and nothing about what
+  # they assert.
+  falsify-guards:
+    name: Falsify guards
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # The harness and both guards it drives locate a function body textually,
+      # by the indentation of its declaration and the matching closing brace.
+      # scripts/falsify-zero-file-search.py and scripts/zero_file_search_guard.sh
+      # each record `cargo fmt --check` running in the same CI job as the reason
+      # that location is reliable, so this job carries that obligation with the
+      # harness rather than inheriting it from a job it no longer shares. An
+      # unformatted tree could otherwise move a probe site, leave the harness
+      # nothing to probe, and let it report success having proved nothing.
+      # It needs no cache and no registry index: `cargo fmt -- --check` resolves
+      # no dependencies and runs against an empty CARGO_HOME.
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Falsify Zero File-Search guards
+        # Both guards still run on both platforms in Check & Test. Only this
+        # meta-proof, that the guards are not vacuous, is single-legged.
+        # Falsifiability is a property of the guards' logic, and neither the
+        # Python checker nor the shell guard branches on platform: they carry no
+        # `sys.platform` / `os.name` / `darwin` / `linux` test and no GNU-only
+        # shell construct. The harness is self-contained, poisoning a
+        # `mktemp -d` copy of `crates` and `scripts` rather than the checkout.
+        run: |
+          set -euo pipefail
+          poisoned="$(mktemp -d)"
+          trap 'rm -rf "$poisoned"' EXIT
+          cp -a crates scripts "$poisoned/"
+
+          fail_expected() {
+            local label="$1" want="$2"; shift 2
+            local out rc=0
+            out="$("$@" 2>&1)" || rc=$?
+            if [[ $rc -eq 0 ]]; then
+              echo "::error::falsification failed. $label passed when it should have failed"; echo "$out"; exit 1
+            fi
+            if ! grep -qF "$want" <<<"$out"; then
+              echo "::error::falsification failed. $label failed but never named '$want'"
+              echo "$out"; exit 1
+            fi
+            echo "  ok: $label"
+          }
+
+          # [1/3] Every answer module, poisoned at several sites including
+          # end-of-file, against both guards. This step used to plant one probe
+          # in one module, at the top of a file it had truncated to three lines.
+          # That proved the guards worked at that spot and nowhere else, and it
+          # passed for as long as a comment-tracking desync left the last third
+          # of the largest answer module unscanned.
+          #
+          # The harness also probes the two ways an EXEMPTION can lose scope
+          # rather than a pattern losing a site: a brace inside a literal or a
+          # comment planted in an allowlisted function body, which a raw brace
+          # counter reads as an unclosed body and silently excuses to end of
+          # file, and a counted pin paid for by a rename in test code the guard
+          # never reads. Both are the same failure as [2/3] reached through the
+          # exemption mechanism instead of a stale pin.
+          echo "[1/3] every answer module, every probe site, both guards"
+          python3 scripts/falsify-zero-file-search.py "$poisoned"
+
+          # [2/3] A broken pin must not hide the scan. Allowlist validation used
+          # to exit before the walk, so a stale pin reported itself and nothing
+          # else; two stale pins once masked ten real violations in a newly
+          # covered crate, which made a red allowlist useless as a measure of
+          # remaining work. Break one pin's count deliberately and require the
+          # run to report the violations that pin was masking AS WELL AS the pin
+          # error. Runs before [3/3], which mutates the allowlist irreversibly.
+          echo "[2/3] a broken pin must not hide the scan"
+          python3 - "$poisoned/scripts/zero-file-search-allowlist.json" <<'PY'
+          import json, sys
+          path = sys.argv[1]
+          data = json.load(open(path))
+          target = "crates/kin-daemon/src/repository_branch.rs"
+          for entry in data["allowlist"]:
+              if entry["file"] == target:
+                  entry["allow_match"] = [{"expr": ".metadata()", "count": 999}]
+                  break
+          else:
+              raise SystemExit(f"::error::falsification setup: no pin on {target}")
+          json.dump(data, open(path, "w"))
+          PY
+          out=""; rc=0
+          out="$(python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned" 2>&1)" || rc=$?
+          for want in \
+            "[VIOLATION] crates/kin-daemon/src/repository_branch.rs" \
+            "want 999" \
+            "Scanned "; do
+            if ! grep -qF "$want" <<<"$out"; then
+              echo "::error::falsification failed: a broken pin hid the scan (missing '$want')"
+              echo "$out"; exit 1
+            fi
+          done
+          if [[ $rc -eq 0 ]]; then
+            echo "::error::falsification failed: a broken pin did not fail the guard"
+            echo "$out"; exit 1
+          fi
+          echo "  ok: broken pin reported its masked violations and still failed"
+          # Restore the real policy; [3/3] starts from an unbroken allowlist.
+          cp scripts/zero-file-search-allowlist.json "$poisoned/scripts/"
+
+          echo "[3/3] allowlist entry naming a path that no longer exists"
+          python3 - "$poisoned/scripts/zero-file-search-allowlist.json" <<'PY'
+          import json, sys
+          path = sys.argv[1]
+          data = json.load(open(path))
+          data["allowlist"].append({
+              "file": "crates/kin-core/src/text_refs.rs",
+              "reason": "resurrected stale exemption",
+              "owner": "ci-falsification",
+              "expiration": "2026-12-31",
+          })
+          json.dump(data, open(path, "w"))
+          PY
+          fail_expected "python guard" "text_refs.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
+
+          echo "Zero File-Search guards are falsifiable: every probe was caught."
+  # A skipped matrix job never expands, so its per-leg context names do not
+  # appear at all rather than appearing skipped. `check-docs-only` exists for
+  # exactly that reason and this is its counterpart: once the branch ruleset
+  # requires `Feature permutation tests (ubuntu-latest)` and its macOS leg, a
+  # documentation-only diff would otherwise wait forever for two contexts that
+  # were never going to be created. Both legs run here on one ubuntu runner
+  # because the point is the name, not the work.
+  feature-tests-docs-only:
+    name: Feature permutation tests
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Report the documentation-only fast path
+        run: echo "documentation-only diff; feature permutation tests not applicable"
+
+  feature-tests:
+    name: Feature permutation tests
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    # Same bounds as Check & Test: the feature permutations compile the same
+    # workspace and would otherwise retain more than a hosted runner's
+    # available disk in incremental objects and debug symbols.
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+
+      - name: Verify kin cargo registry config
+        run: |
+          test -f .cargo/config.toml
+          grep -q '^\[registries\.kin\]' .cargo/config.toml
+          if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"; exit 1; fi
+
+      # `shared-key: check` is the key Check & Test's own cache already writes,
+      # so these permutations start from that warm third-party dependency graph
+      # instead of compiling it from nothing. Only the workspace crates rebuild
+      # for the changed feature set, which is what they cost inside Check & Test
+      # too. `save-if: false` because this job must never write that entry: it
+      # resolves a different feature set, and a save from here would hand
+      # Check & Test a target directory missing the artifacts its steps expect.
+      # A rename of the `check` job silently costs this job its warm start, so
+      # the cache-hit line in this step's log is the thing to read if it slows.
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check
+          save-if: false
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # `gcs` is a non-default feature, so the default-feature passes in Check &
+      # Test never execute the hosted-storage code it gates, and the
+      # `--all-features` Clippy pass there only type-checks it. Without this
+      # step a behavioral regression in the
       # GCS-mode startup admission path compiles clean and reaches main with a
       # green required context. The whole package runs rather than just the
       # binary target: the feature gates only `bin/kin-daemon.rs` today, and

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -140,6 +140,16 @@ BASE_IMAGE_PINS = WORKFLOWS / "base-image-pins.yml"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
 MAIN_ONLY_CACHE_SAVE_VALUE = "${{ github.ref == 'refs/heads/main' }}"
+# A job that reads the cache entry another job writes, and must never write it
+# itself, saves on no ref at all. That is strictly narrower than the main-only
+# scalar and never broader, so it cannot become the way an untrusted ref
+# poisons a cache. These two values are the whole allowlist and anything else
+# is still rejected. Nothing here has to re-prove that a saver still exists:
+# the falsification below pins the check job's own main-only save by count.
+RESTORE_ONLY_CACHE_SAVE_VALUE = "false"
+CACHE_SAVE_VALUES = frozenset(
+    {MAIN_ONLY_CACHE_SAVE_VALUE, RESTORE_ONLY_CACHE_SAVE_VALUE}
+)
 RUST_CACHE_REFERENCE = re.compile(r"Swatinem/rust-cache@", re.IGNORECASE)
 CANONICAL_STEP_FIELDS = frozenset(
     {
@@ -493,6 +503,13 @@ CI_JOB_DISPLAY_NAMES = {
     "changes": "Classify diff scope",
     "check-docs-only": "Check & Test",
     "check": "Check & Test",
+    # Both were steps inside `check` and are jobs so they stop sitting on the
+    # merge queue's critical path. Neither is a required context until the
+    # branch ruleset names it, so each is listed here to be reviewed as a
+    # producer, and the ruleset is what makes it block.
+    "falsify-guards": "Falsify guards",
+    "feature-tests-docs-only": "Feature permutation tests",
+    "feature-tests": "Feature permutation tests",
     "coverage": "Code Coverage",
 }
 EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
@@ -4388,10 +4405,10 @@ def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
                 )
             _, save_value = save
             save_value = save_value.split(" #", 1)[0].rstrip()
-            if save_value != MAIN_ONLY_CACHE_SAVE_VALUE:
+            if save_value not in CACHE_SAVE_VALUES:
                 raise AssertionError(
                     f"{workflow.name} rust-cache save-if must be the exact "
-                    "main-only scalar"
+                    "main-only scalar or the exact restore-only scalar"
                 )
 
         for action in canonical_job_action_uses(workflow, content):
@@ -11719,7 +11736,10 @@ def main() -> None:
 
     ci_path = WORKFLOWS / "ci.yml"
     check_start = ci_workflow.index("\n  check:")
-    check_end = ci_workflow.index("\n  coverage:", check_start)
+    # `falsify-guards` and `feature-tests` sit between `check` and `coverage`,
+    # so slicing to `coverage:` would hand this falsification three jobs and
+    # count save lines that are not the check job's.
+    check_end = ci_workflow.index("\n  falsify-guards:", check_start)
     check_job = ci_workflow[check_start:check_end]
     save_line = f"          {MAIN_ONLY_CACHE_SAVE}\n"
     if check_job.count(save_line) != 1:


### PR DESCRIPTION
Every landing waits on the merge-group CI run, and every ejection pays it again. Five successful `merge_group` runs sampled on 2026-08-18 (32138521335, 32130976909, 32128602288, 32128046266 and 32128044249) took 34 to 41 minutes end to end, and the last job to finish was always one of the two `Check & Test` legs. The Windows jobs were never the constraint at 11.3 to 27.4 minutes.

## What the measurement said

Averaged per step across those five runs, the two critical-path legs spend their time like this.

| Step | ubuntu leg | macOS leg |
| --- | --- | --- |
| Falsify Zero File-Search guards | 9.9 min | not run |
| Test | 6.8 min | 13.9 min |
| Test featureless kin-cli | 7.4 min | 10.2 min |
| Build | 2.0 min | 4.0 min |
| Test gcs feature | 2.0 min | 3.0 min |
| Test featureless kin-daemon | 1.7 min | 2.5 min |
| Clippy | 1.1 min | 1.6 min |
| Doc tests | 0.6 min | 0.9 min |
| Check the Linux release targets (musl, both) | 2.3 min | not run |

Two candidate causes turned out not to be the problem, and saying so is part of the result. The cache is already healthy: both legs log `Restored from cache key ... full match: true` on merge_group runs, so scoping `save-if` to main is working and there is nothing to win there. The compile profile is already bounded too, because the job sets `CARGO_INCREMENTAL: 0` and zero debug for the dev and test profiles, so a lower `[profile.ci]` has nothing left to take.

The real shape is that four steps run serially inside a job that nothing in them waits on. `Test featureless kin-cli` on macOS is 1m38s of compile followed by 8m29s of test execution, because `cargo test` runs its test binaries one after another.

## The change

`Falsify Zero File-Search guards` and the three feature permutations move into their own jobs and run beside `Check & Test` instead of behind it. Neither set consumes what `Check & Test` builds. The falsification harness runs no cargo at all, poisoning a `mktemp -d` copy of `crates` and `scripts` and driving the two guards as subprocesses. Each feature permutation resolves its own feature set, so it recompiles the workspace crates wherever it runs.

Nothing changes about what is asserted. Every moved `run` body is byte identical, and a full step inventory of the workflow before and after shows no step lost. The only header differences are the job each step now lives in and the removal of `if: runner.os == 'Linux'` from the falsification step, which is redundant now that its job is ubuntu-only.

The falsification job carries its own `cargo fmt -- --check`. Both guards locate a function body textually, and `scripts/falsify-zero-file-search.py:465` and `scripts/zero_file_search_guard.sh:80` each record `cargo fmt --check` running in the same CI job as the reason that location is reliable. That obligation moves with the harness rather than being inherited from a job it no longer shares. It costs about 12 seconds and needs no cache or registry index, because `cargo fmt -- --check` resolves no dependencies and returns 0 against an empty `CARGO_HOME`.

`feature-tests` reads the cache entry `Check & Test` already writes, through `shared-key: check`, and never writes it, through `save-if: false`. That gives the permutations a warm third-party dependency graph without handing `Check & Test` a target directory built for a different feature set. `assert_rust_cache_steps` previously accepted only the main-only scalar, so it now takes a two value allowlist in which the restore-only value is strictly narrower than main-only and never broader.

`feature-tests-docs-only` mirrors the existing `check-docs-only`. A skipped matrix job never expands, so its per-leg context names would not appear at all rather than appearing skipped, and a documentation-only diff would wait forever for them once the ruleset requires them.

The job census in `scripts/test-release-workflow-authority.py` is an exact bidirectional compare rather than a lookup, so it names both new jobs and the stub. The cache falsification below it sliced `ci.yml` from `check:` to `coverage:`, which would now cover three jobs, so it slices to the job that actually follows `check` instead.

## Falsification

Each guard change was broken and the failure confirmed by message, then restored.

- A permissive `save-if: true` is rejected: `ci.yml rust-cache save-if must be the exact main-only scalar or the exact restore-only scalar`.
- Removing the check job's main-only save is rejected: `ci.yml rust-cache step must contain one canonical with mapping and one main-only save-if`.
- Dropping either new job from the census is rejected: `workflow-wide required-check producer census requires the exact reviewed workflow paths, job ids, and display names`.
- Renaming a new job in `ci.yml` alone is rejected with the same census message.
- An earlier version of this change added a counter asserting some step still saves from main. It was removed rather than shipped, because an existing assertion already pins the check job's own main-only save by count, so the counter could not fire and would have been a check that cannot fail.

The moved falsification step was also run verbatim outside CI and returned 0 through all three of its phases, ending `Zero File-Search guards are falsifiable: every probe was caught.`

## Gates

`actionlint` is clean, `python3 scripts/test-release-workflow-authority.py` and `python3 scripts/test-assertion-reachability.py` both pass, and `cargo fmt --all -- --check` is clean. The workspace test suite was not run because the diff contains no Rust and no Rust test reads the workflow. The files that match `.github/workflows/ci.yml` under `crates/` use it as a synthetic fixture path, for example `(".github/workflows/ci.yml", &b"name: ci\n"[..])` at `crates/kin-daemon/src/api.rs:20088`, and the `featureless` matches are doc comments about a featureless build. `git diff origin/main --stat -- Cargo.lock .cargo/` is empty and the tracked `.cargo` entry is only `.cargo/config.toml`.

## What this does not claim, and what a captain still has to do

These jobs do not block anything until the branch ruleset names them. Until then a red `Falsify guards` or `Feature permutation tests` leaves the merge queue willing to land the change, which is a real gap for as long as it lasts. The ruleset for `main` needs `Falsify guards`, `Feature permutation tests (ubuntu-latest)` and `Feature permutation tests (macos-latest)` added to its required status checks.

Separately, `.github/workflows/release-tag.yml` re-verifies six named contexts at mint time and is not cross-checked against the live ruleset. These gates used to sit inside `Check & Test`, so a green `Check & Test` at mint time implied they had passed, and after this change it no longer does. Closing that needs the new names added to `REQUIRED_RELEASE_CHECKS`, `REQUIRED_CHECK_JOB_PRODUCERS`, `REQUIRED_RELEASE_CHECK_PROVENANCE` and both blocks in `release-tag.yml`, in the same order in each. That is deliberately not in this PR, because a tag cut from a commit whose CI run predates these jobs would fail a gate that demands contexts that commit never produced, and sequencing that against an active release wave is a release-captain call.

No end-to-end number is claimed here yet. The measurement is on this PR's own run and is reported in `.kin-coord/reports/cifast-20260818.md`.

Closes FIR-2409
