### PR TITLE
Make the new CI jobs release-required so the mint still verifies them

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -790,6 +790,9 @@ jobs:
           REQUIRED_CHECKS: |
             Check & Test (ubuntu-latest)
             Check & Test (macos-latest)
+            Falsify guards
+            Feature permutation tests (ubuntu-latest)
+            Feature permutation tests (macos-latest)
             DCO Sign-off
             cargo-deny
             gitleaks (full history)
@@ -881,6 +884,24 @@ jobs:
                   release_branch,
               ),
               "Check & Test (macos-latest)": (
+                  245803170,
+                  ".github/workflows/ci.yml",
+                  "push",
+                  release_branch,
+              ),
+              "Falsify guards": (
+                  245803170,
+                  ".github/workflows/ci.yml",
+                  "push",
+                  release_branch,
+              ),
+              "Feature permutation tests (ubuntu-latest)": (
+                  245803170,
+                  ".github/workflows/ci.yml",
+                  "push",
+                  release_branch,
+              ),
+              "Feature permutation tests (macos-latest)": (
                   245803170,
                   ".github/workflows/ci.yml",
                   "push",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -298,6 +298,9 @@ jobs:
 REQUIRED_RELEASE_CHECKS = (
     "Check & Test (ubuntu-latest)",
     "Check & Test (macos-latest)",
+    "Falsify guards",
+    "Feature permutation tests (ubuntu-latest)",
+    "Feature permutation tests (macos-latest)",
     "DCO Sign-off",
     "cargo-deny",
     "gitleaks (full history)",
@@ -660,6 +663,13 @@ REQUIRED_CHECK_JOB_PRODUCERS = {
         (".github/workflows/ci.yml", "check-docs-only"),
         (".github/workflows/ci.yml", "check"),
     },
+    "Falsify guards": {
+        (".github/workflows/ci.yml", "falsify-guards"),
+    },
+    "Feature permutation tests": {
+        (".github/workflows/ci.yml", "feature-tests-docs-only"),
+        (".github/workflows/ci.yml", "feature-tests"),
+    },
     "DCO Sign-off": {
         (".github/workflows/ci.yml", "dco"),
     },
@@ -691,6 +701,17 @@ REQUIRED_RELEASE_CHECK_PROVENANCE = {
         "push",
     ),
     "Check & Test (macos-latest)": (
+        245_803_170,
+        ".github/workflows/ci.yml",
+        "push",
+    ),
+    "Falsify guards": (245_803_170, ".github/workflows/ci.yml", "push"),
+    "Feature permutation tests (ubuntu-latest)": (
+        245_803_170,
+        ".github/workflows/ci.yml",
+        "push",
+    ),
+    "Feature permutation tests (macos-latest)": (
         245_803_170,
         ".github/workflows/ci.yml",
         "push",


### PR DESCRIPTION
This lands after #912, which is now on main as 85ee771f, and before the next tag. It is rebased onto main and contains only its own commit.

## Why this is needed

`Falsify guards`, `Feature permutation tests (ubuntu-latest)` and `Feature permutation tests (macos-latest)` were steps inside `Check & Test` until #912. A green `Check & Test` at mint time therefore implied they had passed. Once they became jobs of their own that implication was gone, and `.github/workflows/release-tag.yml` re-verifies six named contexts that did not include them.

The branch ruleset and the mint gate are different things. The ruleset refuses a merge on a red required job, and it now names all three. The mint gate is a separate check on the commit being tagged, it is not cross-checked against the live ruleset, and its own comment says so: the reviewed source declaration is the mint's authority rather than mutable live configuration. So the ruleset edit alone leaves the mint gate blind to these three, and this closes that.

## A note for whoever reads this later, so it does not get "fixed"

This PR was originally cut from #912's head rather than from main, which looks wrong and was deliberate. Cut from main it is red, not green, and the redness is correct behavior: `REQUIRED_CHECK_JOB_PRODUCERS` would name jobs that do not exist in a tree without #912, so `assert_workflow_job_census` fails with `workflow-wide required-check producer census requires the exact reviewed workflow paths, job ids, and display names`. The census failing there is the census working. That was verified directly by putting main's `ci.yml` under this branch's authority test rather than assumed. Now that #912 is on main the point is historical, and this branch is rebased onto main with `git rebase --onto origin/main 6e33c342`.

## What changed

The three names join the reviewed required set in the same order in all four places that carry it: `REQUIRED_RELEASE_CHECKS`, the `REQUIRED_CHECKS` env block in `release-tag.yml`, that workflow's `expected_provenance` table, and `REQUIRED_RELEASE_CHECK_PROVENANCE`. They are inserted after the two `Check & Test` entries so the contexts sourced from `ci.yml` stay together.

Order is load bearing. `assert_required_check_set_is_single_sourced` compares ordered tuples across the first three, and `release-tag.yml` checks at runtime that its own two blocks agree, failing with `required check order does not match its provenance contract`.

`REQUIRED_CHECK_JOB_PRODUCERS` is keyed on the base display name rather than the expanded context, so `Feature permutation tests` names both `feature-tests` and `feature-tests-docs-only` as producers. That is the same shape `Check & Test` already uses for `check` and `check-docs-only`, and it is what stops `assert_workflow_job_census` firing its `reserved_expanded_names` check.

All three resolve from `ci.yml` on push with workflow id 245803170, the same provenance the existing `Check & Test` contexts carry.

## Falsification

Each of the four surfaces was broken independently and the failure confirmed, then restored.

- Dropping `Falsify guards` from `REQUIRED_RELEASE_CHECKS` only fails with `required check order does not match its provenance contract`.
- Dropping it from the `REQUIRED_CHECKS` env block only fails with `the release gate's REQUIRED_CHECKS env no longer matches the reviewed required set`, printing the eight names it found.
- Dropping it from `release-tag.yml`'s `expected_provenance` only fails with `current release check provenance fixture was rejected` wrapping `KeyError: 'Falsify guards'`.
- Reordering the new names in the env block only, without removing any, fails with the same env mismatch message, which is what proves ordering is enforced and not just membership.
- Dropping it from `REQUIRED_RELEASE_CHECK_PROVENANCE` only fails with `KeyError: 'Falsify guards'`.

One correction worth recording, because it nearly produced a false result. The first pass at this falsification read each run through `tail -1`, and two of the five cases printed an empty line and looked like passes. They were failing the whole time: the assertion message is multi-line and ends with a newline, so `tail -1` returned the blank. The runs above are read from full output and exit codes instead.

## The documentation-only path was proven, not assumed

Making these names required is only safe if they appear on a documentation-only diff, because a required context that never appears waits forever rather than passing. That was checked on a real markdown-only pull request rather than by reading the workflow. All ten required contexts appeared and were satisfied: `Feature permutation tests (ubuntu-latest)` and `(macos-latest)` reported SUCCESS from the documentation-only twin `feature-tests-docs-only`, and `Falsify guards` reported SKIPPED. Zero required contexts were absent. `cargo-deny` and `Windows installer + vector release build` were already required before any of this and already report SKIPPED on such diffs, so a skipped required context satisfying its requirement is established behavior here rather than a new assumption.

## Not claiming

This does not make the jobs block a merge. The branch ruleset does that and already names all three. This closes the other half, so a release cannot mint on a commit where one of these three was red or absent.

Closes FIR-2409
