### PR TITLE
Add kin agent, a Kin-native provider-neutral agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kin-agent"
+version = "0.5.39"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "kin-blobs"
 version = "0.1.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
@@ -3088,6 +3102,7 @@ dependencies = [
  "fs2",
  "hex",
  "keyring",
+ "kin-agent",
  "kin-blobs",
  "kin-buildinfo",
  "kin-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/kin-buildinfo",
     "crates/kin-notify",
     "crates/kin-notifier-macos",
+    "crates/kin-agent",
     "crates/kin-cli",
     "crates/kin-daemon-spawn",
     "crates/kin-daemon",
@@ -141,6 +142,7 @@ kin-migrate = { path = "crates/kin-migrate" }
 kin-runtime = { path = "crates/kin-runtime" }
 kin-buildinfo = { path = "crates/kin-buildinfo" }
 kin-notify = { path = "crates/kin-notify" }
+kin-agent = { path = "crates/kin-agent" }
 kin-cli = { path = "crates/kin-cli", default-features = false }
 kin-daemon = { path = "crates/kin-daemon" }
 kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }

--- a/README.md
+++ b/README.md
@@ -283,9 +283,32 @@ add local vector similarity over them, and confirm coverage with
 
 ## Works with your agent
 
-Kin ships an MCP server, so any agent that speaks MCP can read the graph.
-`kin setup --intent agent` configures every client it detects in one pass. These
-are the per-client one-liners when you would rather install Kin directly.
+Kin ships its own agent, and it is the path we recommend for agent work. `kin
+agent run` drives any OpenAI-compatible endpoint, so a local model in LM Studio,
+Ollama, llama.cpp or vLLM works from the same flags as a hosted one, and it
+reaches the graph over the same MCP server every other client uses.
+
+```sh
+kin agent run --task "Find where the retry backoff is computed and document it" \
+  --model qwen/qwen3.6-35b-a3b --base-url http://127.0.0.1:1234/v1
+```
+
+What makes it different from pointing another agent at the MCP server is that the
+rule is enforced inside the agent rather than borrowed from a vendor's permission
+layer. It has Kin's tools plus exactly two local ones, `edit_file` and
+`write_file`. There is no shell, no grep and no file-reading tool, so it cannot
+answer a repository question from raw file search, and a tool it invents is
+refused by name. When Kin reports that an empty result cannot be trusted, the
+agent is told the answer is unknown and given the named gap instead of concluding
+the thing does not exist. Every edit runs inside a Kin transaction under a Kin
+session, so the change carries provenance naming the agent. Run `kin agent doctor
+--base-url <url>` first to check both halves answer. See
+[the CLI reference](docs/cli-reference.md#kin-agent) for the full surface.
+
+Working with Claude Code, Codex, Cursor, Gemini and anything else that speaks MCP
+stays first class. `kin setup --intent agent` configures every client it detects
+in one pass. These are the per-client one-liners when you would rather install Kin
+directly.
 
 Claude Code, from inside a session:
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ reaches the graph over the same MCP server every other client uses.
 
 ```sh
 kin agent run --task "Find where the retry backoff is computed and document it" \
-  --model qwen/qwen3.6-35b-a3b --base-url http://127.0.0.1:1234/v1
+  --model qwen/qwen3.6-35b-a3b --base-url http://localhost:1234/v1
 ```
 
 What makes it different from pointing another agent at the MCP server is that the

--- a/crates/kin-agent/Cargo.toml
+++ b/crates/kin-agent/Cargo.toml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+[package]
+name = "kin-agent"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Kin-native, provider-neutral agent loop that drives Kin over MCP"
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "json"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The toolbelt and the router that enforces it.
+//!
+//! The policy is enforced by absence and by refusal. There is no shell tool, no file-read
+//! tool and no file-search tool anywhere in the belt, so there is nothing to fall back to,
+//! and the router refuses by name any tool the model invents. Both halves matter: a model
+//! that hallucinates a `bash` tool must be told no rather than quietly handed an empty
+//! result it will read as "the command produced nothing".
+
+use serde_json::{json, Map, Value};
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+/// The two local tools. Everything else the agent can do, it does through Kin.
+pub const EDIT_FILE: &str = "edit_file";
+pub const WRITE_FILE: &str = "write_file";
+
+/// Prefix that marks a Kin tool in the model's belt and in the transcript. `usage.py`
+/// classifies `mcp__<server>__<tool>` as an MCP call, so this is what makes a Kin call
+/// countable by the analyzers the fleet already runs.
+pub const KIN_TOOL_PREFIX: &str = "mcp__kin__";
+
+/// Where a routed call goes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Route {
+    /// A Kin tool, named without the transcript prefix.
+    Kin(String),
+    /// One of the two local tools.
+    Local(LocalTool),
+    /// Not in the belt. Carries the refusal the model is told.
+    Refused(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalTool {
+    Edit,
+    Write,
+}
+
+/// The belt: every name the model may call this run.
+#[derive(Debug, Clone)]
+pub struct Belt {
+    kin_tools: Vec<(String, Value)>,
+    names: BTreeSet<String>,
+}
+
+impl Belt {
+    /// Build the belt from what the MCP server declared, plus the two local tools.
+    pub fn new(kin_tools: Vec<(String, Value)>) -> Self {
+        let mut names: BTreeSet<String> = kin_tools
+            .iter()
+            .map(|(name, _)| format!("{KIN_TOOL_PREFIX}{name}"))
+            .collect();
+        names.insert(EDIT_FILE.to_string());
+        names.insert(WRITE_FILE.to_string());
+        Belt { kin_tools, names }
+    }
+
+    /// Every callable name, which is also what the text-shape parsers match against.
+    pub fn names(&self) -> &BTreeSet<String> {
+        &self.names
+    }
+
+    /// The schema a named tool declares, for argument validation.
+    pub fn schema_for(&self, name: &str) -> Option<Value> {
+        if let Some(bare) = name.strip_prefix(KIN_TOOL_PREFIX) {
+            return self
+                .kin_tools
+                .iter()
+                .find(|(tool, _)| tool == bare)
+                .map(|(_, schema)| schema.clone());
+        }
+        match name {
+            EDIT_FILE => Some(edit_file_schema()),
+            WRITE_FILE => Some(write_file_schema()),
+            _ => None,
+        }
+    }
+
+    /// Route a name the model produced.
+    pub fn route(&self, name: &str) -> Route {
+        if let Some(bare) = name.strip_prefix(KIN_TOOL_PREFIX) {
+            if self.kin_tools.iter().any(|(tool, _)| tool == bare) {
+                return Route::Kin(bare.to_string());
+            }
+        }
+        match name {
+            EDIT_FILE => return Route::Local(LocalTool::Edit),
+            WRITE_FILE => return Route::Local(LocalTool::Write),
+            _ => {}
+        }
+        // A bare Kin tool name is a near miss worth naming precisely, because the model
+        // very likely meant the prefixed one and a generic refusal would not say so.
+        if self.kin_tools.iter().any(|(tool, _)| tool == name) {
+            return Route::Refused(format!(
+                "There is no tool named `{name}`. The Kin tool is called `{KIN_TOOL_PREFIX}{name}`. \
+                 Call it by that exact name."
+            ));
+        }
+        Route::Refused(format!(
+            "There is no tool named `{name}` and it will not be run. This agent has no shell, \
+             no file-search and no file-read tool on purpose: repository questions are answered \
+             from the Kin graph, not from the filesystem. Available tools: {}.",
+            self.names.iter().cloned().collect::<Vec<_>>().join(", ")
+        ))
+    }
+
+    /// The `tools` array sent to the chat endpoint.
+    pub fn to_specs(&self, descriptions: &[(String, String)]) -> Vec<Value> {
+        let mut specs = Vec::new();
+        for (name, schema) in &self.kin_tools {
+            let description = descriptions
+                .iter()
+                .find(|(tool, _)| tool == name)
+                .map(|(_, text)| text.clone())
+                .unwrap_or_default();
+            specs.push(json!({
+                "type": "function",
+                "function": {
+                    "name": format!("{KIN_TOOL_PREFIX}{name}"),
+                    "description": description,
+                    "parameters": schema,
+                }
+            }));
+        }
+        specs.push(json!({
+            "type": "function",
+            "function": {
+                "name": EDIT_FILE,
+                "description": "Replace one exact snippet of text in one file. The `find` text \
+                                must appear exactly once in the file unless `replace_all` is true. \
+                                Use this for a small, surgical change once Kin has told you where \
+                                the code is.",
+                "parameters": edit_file_schema(),
+            }
+        }));
+        specs.push(json!({
+            "type": "function",
+            "function": {
+                "name": WRITE_FILE,
+                "description": "Write a file in full, creating it if it does not exist. Use this \
+                                for a new file; prefer edit_file for a change to an existing one.",
+                "parameters": write_file_schema(),
+            }
+        }));
+        specs
+    }
+}
+
+fn edit_file_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Repository-relative path of the file to change." },
+            "find": { "type": "string", "description": "The exact text to replace, including indentation." },
+            "replace": { "type": "string", "description": "The exact text to put in its place." },
+            "replace_all": { "type": "boolean", "description": "Replace every occurrence instead of requiring exactly one.", "default": false }
+        },
+        "required": ["path", "find", "replace"]
+    })
+}
+
+fn write_file_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Repository-relative path of the file to write." },
+            "content": { "type": "string", "description": "The file's complete new UTF-8 contents." }
+        },
+        "required": ["path", "content"]
+    })
+}
+
+/// A bounded schema check: required properties present, and declared scalar types honored.
+///
+/// It deliberately stops short of full JSON Schema. What it catches is the failure that
+/// actually happens with small local models, which is a missing required argument or a
+/// number sent as prose, and it names the offending field so the repair turn can be
+/// specific. It is not a validity proof and nothing here should be read as one.
+pub fn validate_arguments(schema: &Value, arguments: &Value) -> Result<(), String> {
+    let Some(object) = arguments.as_object() else {
+        return Err("the arguments were not a JSON object".to_string());
+    };
+    let mut problems = Vec::new();
+
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        for field in required {
+            let Some(name) = field.as_str() else { continue };
+            match object.get(name) {
+                None | Some(Value::Null) => {
+                    problems.push(format!("required argument `{name}` was missing"))
+                }
+                Some(Value::String(text)) if text.is_empty() => {
+                    problems.push(format!("required argument `{name}` was an empty string"))
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+        for (name, value) in object {
+            if name.starts_with("__kin_agent_") {
+                continue;
+            }
+            let Some(declared) = properties.get(name).and_then(|p| p.get("type")) else {
+                continue;
+            };
+            let Some(expected) = declared.as_str() else {
+                continue;
+            };
+            if !type_matches(expected, value) {
+                problems.push(format!(
+                    "argument `{name}` should be a {expected} but was {}",
+                    describe(value)
+                ));
+            }
+        }
+    }
+
+    if problems.is_empty() {
+        Ok(())
+    } else {
+        Err(problems.join("; "))
+    }
+}
+
+fn type_matches(expected: &str, value: &Value) -> bool {
+    match expected {
+        "string" => value.is_string(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        "null" => value.is_null(),
+        _ => true,
+    }
+}
+
+fn describe(value: &Value) -> &'static str {
+    match value {
+        Value::String(_) => "a string",
+        Value::Number(_) => "a number",
+        Value::Bool(_) => "a boolean",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+        Value::Null => "null",
+    }
+}
+
+/// What a local tool did, or why it did not.
+#[derive(Debug, Clone)]
+pub struct LocalOutcome {
+    pub text: String,
+    pub is_error: bool,
+    /// The repository-relative path that changed, when one did.
+    pub changed: Option<String>,
+}
+
+/// Resolve a model-supplied path inside the repository, refusing every escape.
+///
+/// A harness with no shell tool has exactly two write surfaces, and if either can be
+/// pointed outside the repository then the sandbox is decorative.
+pub fn resolve_in_repo(repo: &Path, raw: &str) -> Result<PathBuf, String> {
+    let candidate = Path::new(raw);
+    let relative = if candidate.is_absolute() {
+        match candidate.strip_prefix(repo) {
+            Ok(rest) => rest.to_path_buf(),
+            Err(_) => {
+                return Err(format!(
+                    "`{raw}` is outside the repository at {}. Paths must be repository-relative.",
+                    repo.display()
+                ))
+            }
+        }
+    } else {
+        candidate.to_path_buf()
+    };
+
+    let mut resolved = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => resolved.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(format!(
+                    "`{raw}` walks out of the repository with `..`, which is refused."
+                ))
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(format!("`{raw}` is not a repository-relative path."))
+            }
+        }
+    }
+    if resolved.as_os_str().is_empty() {
+        return Err("the path was empty".to_string());
+    }
+    Ok(repo.join(resolved))
+}
+
+/// Run `edit_file`.
+pub fn run_edit(repo: &Path, arguments: &Value) -> LocalOutcome {
+    let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
+    let find = arguments.get("find").and_then(Value::as_str).unwrap_or("");
+    let replace = arguments
+        .get("replace")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let replace_all = arguments
+        .get("replace_all")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let path = match resolve_in_repo(repo, raw_path) {
+        Ok(path) => path,
+        Err(message) => return LocalOutcome::error(message),
+    };
+    let original = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) => {
+            return LocalOutcome::error(format!(
+                "could not read `{raw_path}`: {err}. Use Kin to find the file before editing it."
+            ))
+        }
+    };
+    let occurrences = original.matches(find).count();
+    if occurrences == 0 {
+        return LocalOutcome::error(format!(
+            "the `find` text does not appear in `{raw_path}`. Read the exact current text with \
+             {KIN_TOOL_PREFIX}get_entity_source before editing, and match it byte for byte."
+        ));
+    }
+    if occurrences > 1 && !replace_all {
+        return LocalOutcome::error(format!(
+            "the `find` text appears {occurrences} times in `{raw_path}`. Give a longer, unique \
+             snippet, or set replace_all to true if every occurrence should change."
+        ));
+    }
+    let updated = if replace_all {
+        original.replace(find, replace)
+    } else {
+        original.replacen(find, replace, 1)
+    };
+    if let Err(err) = std::fs::write(&path, &updated) {
+        return LocalOutcome::error(format!("could not write `{raw_path}`: {err}"));
+    }
+    LocalOutcome {
+        text: format!(
+            "Edited `{raw_path}`: replaced {} occurrence{} ({} bytes before, {} after).",
+            if replace_all { occurrences } else { 1 },
+            if replace_all && occurrences != 1 { "s" } else { "" },
+            original.len(),
+            updated.len()
+        ),
+        is_error: false,
+        changed: Some(raw_path.to_string()),
+    }
+}
+
+/// Run `write_file`.
+pub fn run_write(repo: &Path, arguments: &Value) -> LocalOutcome {
+    let raw_path = arguments.get("path").and_then(Value::as_str).unwrap_or("");
+    let content = arguments
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let path = match resolve_in_repo(repo, raw_path) {
+        Ok(path) => path,
+        Err(message) => return LocalOutcome::error(message),
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            return LocalOutcome::error(format!("could not create `{}`: {err}", parent.display()));
+        }
+    }
+    let existed = path.exists();
+    if let Err(err) = std::fs::write(&path, content) {
+        return LocalOutcome::error(format!("could not write `{raw_path}`: {err}"));
+    }
+    LocalOutcome {
+        text: format!(
+            "{} `{raw_path}` ({} bytes).",
+            if existed { "Rewrote" } else { "Created" },
+            content.len()
+        ),
+        is_error: false,
+        changed: Some(raw_path.to_string()),
+    }
+}
+
+impl LocalOutcome {
+    fn error(message: String) -> Self {
+        LocalOutcome {
+            text: message,
+            is_error: true,
+            changed: None,
+        }
+    }
+}
+
+/// Strip Kin tools the harness drives itself out of the model's belt.
+///
+/// Session and transaction lifecycle is the harness's job, so exposing those tools would
+/// let the model open a second session or commit a transaction the harness is holding.
+pub fn is_harness_owned(name: &str) -> bool {
+    matches!(
+        name,
+        "kin_session_start"
+            | "kin_session_end"
+            | "kin_session_heartbeat"
+            | "kin_transaction_begin"
+            | "kin_transaction_commit"
+            | "kin_transaction_abort"
+    )
+}
+
+/// Empty map, for calls that take no arguments.
+pub fn empty_arguments() -> Value {
+    Value::Object(Map::new())
+}

--- a/crates/kin-agent/src/belt.rs
+++ b/crates/kin-agent/src/belt.rs
@@ -351,7 +351,11 @@ pub fn run_edit(repo: &Path, arguments: &Value) -> LocalOutcome {
         text: format!(
             "Edited `{raw_path}`: replaced {} occurrence{} ({} bytes before, {} after).",
             if replace_all { occurrences } else { 1 },
-            if replace_all && occurrences != 1 { "s" } else { "" },
+            if replace_all && occurrences != 1 {
+                "s"
+            } else {
+                ""
+            },
             original.len(),
             updated.len()
         ),

--- a/crates/kin-agent/src/lib.rs
+++ b/crates/kin-agent/src/lib.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin-agent` is a Kin-native, provider-neutral agent loop.
+//!
+//! It speaks the OpenAI chat-completions wire format, so one adapter reaches LM Studio,
+//! Ollama, llama.cpp, vLLM, OpenRouter and OpenAI, and it drives Kin over MCP rather than
+//! over a translated CLI bridge, so it inherits the real tool registry, the `_kin`
+//! envelope and the `negative` verdict instead of reimplementing them.
+//!
+//! The policy the loop enforces is the product's own thesis: repository questions are
+//! answered from the graph. There is no shell tool, no file-search tool and no file-read
+//! tool in the belt, so there is nothing to fall back to, and the router refuses by name
+//! anything the model invents. Enforcement lives in this process rather than in a vendor's
+//! permission layer, which is what makes it hold on every model rather than on one CLI.
+
+pub mod belt;
+pub mod mcp;
+pub mod parse;
+pub mod provider;
+pub mod run;
+pub mod transcript;
+
+pub use provider::{Provider, ProviderConfig, ProviderError};
+pub use run::{run, DEFAULT_SYSTEM_PROMPT};
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// How a run ended. The codes are the process exit codes, and they distinguish the
+/// failures that must never be pooled: a task the agent could not do, a budget it spent,
+/// an endpoint that was not there, and a graph server that was not there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitStatus {
+    Success,
+    HarnessError,
+    CapReached,
+    Deadline,
+    EndpointError,
+    McpError,
+}
+
+impl ExitStatus {
+    pub fn code(self) -> i32 {
+        match self {
+            ExitStatus::Success => 0,
+            ExitStatus::HarnessError => 1,
+            ExitStatus::CapReached => 2,
+            ExitStatus::Deadline => 3,
+            ExitStatus::EndpointError => 4,
+            ExitStatus::McpError => 5,
+        }
+    }
+
+    pub fn subtype(self) -> &'static str {
+        match self {
+            ExitStatus::Success => "success",
+            ExitStatus::HarnessError => "harness_error",
+            ExitStatus::CapReached => "cap_reached",
+            ExitStatus::Deadline => "deadline",
+            ExitStatus::EndpointError => "endpoint_error",
+            ExitStatus::McpError => "mcp_error",
+        }
+    }
+}
+
+/// Everything one run needs.
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    pub task: String,
+    pub system_prompt: Option<String>,
+    pub repo: PathBuf,
+    pub out_dir: PathBuf,
+    pub provider: ProviderConfig,
+    pub mcp_command: Vec<String>,
+    pub mcp_timeout: Duration,
+    pub max_tool_calls: u32,
+    pub deadline: Duration,
+    pub tool_profile: Option<String>,
+}
+
+/// What a finished run produced.
+#[derive(Debug, Clone)]
+pub struct RunOutcome {
+    pub status: ExitStatus,
+    pub final_text: String,
+    pub transcript_path: PathBuf,
+    pub trace_path: PathBuf,
+    pub result: serde_json::Value,
+}
+
+/// Default tool-call budget.
+pub const DEFAULT_MAX_TOOL_CALLS: u32 = 40;
+/// Default wall deadline, in seconds.
+pub const DEFAULT_DEADLINE_S: u64 = 900;
+/// Default per-request timeout for one MCP call, in seconds. Generous, because a cold
+/// graph build behind the first call is normal and killing it would report a Kin failure
+/// that was really a harness impatience.
+pub const DEFAULT_MCP_TIMEOUT_S: u64 = 300;
+/// Default per-request timeout for one chat completion, in seconds. Local models on a
+/// laptop are slow, and a short timeout here reads as an endpoint failure.
+pub const DEFAULT_REQUEST_TIMEOUT_S: u64 = 600;

--- a/crates/kin-agent/src/lib.rs
+++ b/crates/kin-agent/src/lib.rs
@@ -21,6 +21,9 @@ pub mod provider;
 pub mod run;
 pub mod transcript;
 
+#[cfg(test)]
+mod tests;
+
 pub use provider::{Provider, ProviderConfig, ProviderError};
 pub use run::{run, DEFAULT_SYSTEM_PROMPT};
 

--- a/crates/kin-agent/src/mcp.rs
+++ b/crates/kin-agent/src/mcp.rs
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A minimal MCP stdio client, enough to drive `kin mcp start`.
+//!
+//! One request is in flight at a time, every read is bounded by a timeout that fails the
+//! run rather than hanging it, and the child's stderr is drained on its own thread so a
+//! chatty server cannot deadlock on a full pipe. Tool results are unwrapped through
+//! `content[0].text`, which is where the real payload lives, and the `_kin` envelope and
+//! `negative` verdict are read off that payload rather than off the wrapper. A payload
+//! that cannot be read is reported as unreadable and never collapsed to a default, because
+//! "the graph said zero" and "we could not read what the graph said" are different answers.
+
+use serde_json::{json, Map, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
+
+/// The MCP protocol revision this client declares at initialize.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+#[derive(Debug, thiserror::Error)]
+pub enum McpError {
+    #[error("could not start the MCP server ({command}): {source}")]
+    Spawn {
+        command: String,
+        source: std::io::Error,
+    },
+    #[error("the MCP server did not answer {method} within {timeout_s}s")]
+    Timeout { method: String, timeout_s: u64 },
+    #[error("the MCP server closed its output during {method}")]
+    Closed { method: String },
+    #[error("the MCP server rejected {method}: {message}")]
+    Rejected { method: String, message: String },
+    #[error("could not write to the MCP server during {method}: {source}")]
+    Write {
+        method: String,
+        source: std::io::Error,
+    },
+}
+
+/// A tool the server declares, carried through unchanged so its schema is the server's.
+#[derive(Debug, Clone)]
+pub struct McpTool {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+/// What one `tools/call` produced.
+#[derive(Debug, Clone)]
+pub struct ToolOutcome {
+    /// The text the model will see.
+    pub text: String,
+    /// The server's own error flag. An MCP error is a successful JSON-RPC response, so
+    /// this must be read off the result rather than inferred from transport success.
+    pub is_error: bool,
+    /// The `_kin` envelope, when the payload carried one.
+    pub envelope: Option<Value>,
+    /// The `negative` object, when the payload carried one.
+    pub negative: Option<Value>,
+    /// True when the payload could not be parsed, so envelope and negative say nothing.
+    pub unreadable: bool,
+    pub wall_ms: u128,
+}
+
+impl ToolOutcome {
+    /// The verdict on an empty retrieval: `Some(false)` means Kin says the absence cannot
+    /// be trusted. `None` means the result carried no verdict, which is not the same thing.
+    pub fn safe_to_conclude_absent(&self) -> Option<bool> {
+        self.negative
+            .as_ref()?
+            .get("safe_to_conclude_absent")?
+            .as_bool()
+    }
+
+    /// The named reason an absence cannot be trusted, when the server named one.
+    pub fn limiting_factor(&self) -> Option<String> {
+        let negative = self.negative.as_ref()?;
+        for key in ["limiting_factor", "reason", "why", "explanation"] {
+            if let Some(text) = negative.get(key).and_then(Value::as_str) {
+                return Some(text.to_string());
+            }
+        }
+        // Some shapes name the gap as a list of missing edge classes.
+        for key in ["missing_edge_classes", "gaps", "missing"] {
+            if let Some(items) = negative.get(key).and_then(Value::as_array) {
+                let named: Vec<String> = items
+                    .iter()
+                    .filter_map(|item| item.as_str().map(ToString::to_string))
+                    .collect();
+                if !named.is_empty() {
+                    return Some(named.join(", "));
+                }
+            }
+        }
+        None
+    }
+
+    /// Degraded components the envelope named, empty when it named none.
+    pub fn degraded(&self) -> Vec<String> {
+        let Some(envelope) = self.envelope.as_ref() else {
+            return Vec::new();
+        };
+        match envelope.get("degraded") {
+            Some(Value::Array(items)) => items
+                .iter()
+                .map(|item| match item {
+                    Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                })
+                .collect(),
+            Some(Value::Bool(true)) => vec!["degraded".to_string()],
+            Some(Value::Object(map)) => map
+                .iter()
+                .filter(|(_, value)| value.as_bool().unwrap_or(false))
+                .map(|(key, _)| key.clone())
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// A compact envelope summary for the trace sidecar.
+    pub fn envelope_summary(&self) -> Option<Value> {
+        let envelope = self.envelope.as_ref()?;
+        let mut summary = Map::new();
+        for key in [
+            "envelope_version",
+            "runtime",
+            "graph_as_of",
+            "graph_state",
+            "semantic_coverage",
+        ] {
+            if let Some(value) = envelope.get(key) {
+                summary.insert(key.to_string(), value.clone());
+            }
+        }
+        let degraded = self.degraded();
+        if !degraded.is_empty() {
+            summary.insert(
+                "degraded".to_string(),
+                Value::Array(degraded.into_iter().map(Value::String).collect()),
+            );
+        }
+        Some(Value::Object(summary))
+    }
+}
+
+/// A live MCP server subprocess.
+pub struct McpClient {
+    child: Child,
+    stdin: ChildStdin,
+    lines: Receiver<std::io::Result<String>>,
+    next_id: u64,
+    timeout: Duration,
+    command: String,
+}
+
+impl McpClient {
+    /// The default command for a repository: the server this product already ships.
+    pub fn default_command(repo: &Path) -> Vec<String> {
+        vec![
+            "kin".to_string(),
+            "mcp".to_string(),
+            "start".to_string(),
+            "--repo".to_string(),
+            repo.display().to_string(),
+        ]
+    }
+
+    /// Spawn the server and complete `initialize`.
+    pub fn start(argv: &[String], cwd: &Path, timeout: Duration) -> Result<Self, McpError> {
+        let command = argv.join(" ");
+        let (program, args) = argv
+            .split_first()
+            .ok_or_else(|| McpError::Spawn {
+                command: command.clone(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "the MCP command was empty",
+                ),
+            })?;
+        let mut child = Command::new(program)
+            .args(args)
+            .current_dir(cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|source| McpError::Spawn {
+                command: command.clone(),
+                source,
+            })?;
+
+        let stdin = child.stdin.take().expect("stdin was piped");
+        let stdout = child.stdout.take().expect("stdout was piped");
+        // Drain stderr so a server that logs heavily cannot block on a full pipe.
+        if let Some(stderr) = child.stderr.take() {
+            thread::spawn(move || {
+                let reader = BufReader::new(stderr);
+                for line in reader.lines() {
+                    if line.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+        let lines = spawn_line_reader(stdout);
+
+        let mut client = McpClient {
+            child,
+            stdin,
+            lines,
+            next_id: 0,
+            timeout,
+            command,
+        };
+        client.request(
+            "initialize",
+            json!({
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": { "name": "kin-agent", "version": env!("CARGO_PKG_VERSION") },
+            }),
+        )?;
+        client.notify("notifications/initialized", json!({}))?;
+        Ok(client)
+    }
+
+    pub fn command(&self) -> &str {
+        &self.command
+    }
+
+    /// Every tool the server declares.
+    pub fn list_tools(&mut self) -> Result<Vec<McpTool>, McpError> {
+        let result = self.request("tools/list", json!({}))?;
+        let mut tools = Vec::new();
+        for tool in result
+            .get("tools")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+        {
+            let Some(name) = tool.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            tools.push(McpTool {
+                name: name.to_string(),
+                description: tool
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                input_schema: tool
+                    .get("inputSchema")
+                    .or_else(|| tool.get("input_schema"))
+                    .cloned()
+                    .unwrap_or_else(|| json!({ "type": "object" })),
+            });
+        }
+        Ok(tools)
+    }
+
+    /// Call a tool and unwrap what came back.
+    pub fn call_tool(&mut self, name: &str, arguments: &Value) -> Result<ToolOutcome, McpError> {
+        let started = std::time::Instant::now();
+        let result = self.request(
+            "tools/call",
+            json!({ "name": name, "arguments": arguments }),
+        )?;
+        let wall_ms = started.elapsed().as_millis();
+        Ok(unwrap_tool_result(&result, wall_ms))
+    }
+
+    fn notify(&mut self, method: &str, params: Value) -> Result<(), McpError> {
+        let line = json!({ "jsonrpc": "2.0", "method": method, "params": params }).to_string();
+        writeln!(self.stdin, "{line}").map_err(|source| McpError::Write {
+            method: method.to_string(),
+            source,
+        })?;
+        self.stdin.flush().map_err(|source| McpError::Write {
+            method: method.to_string(),
+            source,
+        })
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, McpError> {
+        self.next_id += 1;
+        let id = self.next_id;
+        let line = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        })
+        .to_string();
+        writeln!(self.stdin, "{line}").map_err(|source| McpError::Write {
+            method: method.to_string(),
+            source,
+        })?;
+        self.stdin.flush().map_err(|source| McpError::Write {
+            method: method.to_string(),
+            source,
+        })?;
+
+        let deadline = std::time::Instant::now() + self.timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(McpError::Timeout {
+                    method: method.to_string(),
+                    timeout_s: self.timeout.as_secs(),
+                });
+            }
+            let line = match self.lines.recv_timeout(remaining) {
+                Ok(Ok(line)) => line,
+                Ok(Err(_)) | Err(RecvTimeoutError::Disconnected) => {
+                    return Err(McpError::Closed {
+                        method: method.to_string(),
+                    })
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(McpError::Timeout {
+                        method: method.to_string(),
+                        timeout_s: self.timeout.as_secs(),
+                    })
+                }
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(message) = serde_json::from_str::<Value>(trimmed) else {
+                // A server that prints a banner on stdout is not a protocol error yet.
+                continue;
+            };
+            if message.get("id").and_then(Value::as_u64) != Some(id) {
+                continue;
+            }
+            if let Some(error) = message.get("error") {
+                let text = error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("no message")
+                    .to_string();
+                return Err(McpError::Rejected {
+                    method: method.to_string(),
+                    message: text,
+                });
+            }
+            return Ok(message.get("result").cloned().unwrap_or(Value::Null));
+        }
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_line_reader(stdout: ChildStdout) -> Receiver<std::io::Result<String>> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+/// Unwrap `{content:[{type:"text",text:"<payload>"}],isError:bool}` into what the loop needs.
+pub fn unwrap_tool_result(result: &Value, wall_ms: u128) -> ToolOutcome {
+    let is_error = result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .or_else(|| result.get("is_error").and_then(Value::as_bool))
+        .unwrap_or(false);
+
+    let mut text = String::new();
+    if let Some(blocks) = result.get("content").and_then(Value::as_array) {
+        for block in blocks {
+            if let Some(part) = block.get("text").and_then(Value::as_str) {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(part);
+            }
+        }
+    }
+    if text.is_empty() {
+        if let Some(structured) = result.get("structuredContent") {
+            text = serde_json::to_string(structured).unwrap_or_default();
+        }
+    }
+
+    // The payload lives inside the text block. Read the envelope off the payload, not off
+    // the wrapper, because the wrapper never carries it.
+    let payload = serde_json::from_str::<Value>(text.trim()).ok();
+    let (envelope, negative, unreadable) = match payload.as_ref() {
+        Some(Value::Object(map)) => (
+            map.get("_kin").cloned(),
+            map.get("negative").cloned(),
+            false,
+        ),
+        Some(_) => (None, None, false),
+        // Non-JSON text is a legitimate tool result shape, so it is only unreadable when
+        // the result also claims to be structured. Plain prose is simply prose.
+        None => (None, None, text.trim_start().starts_with('{')),
+    };
+
+    ToolOutcome {
+        text,
+        is_error,
+        envelope,
+        negative,
+        unreadable,
+        wall_ms,
+    }
+}

--- a/crates/kin-agent/src/mcp.rs
+++ b/crates/kin-agent/src/mcp.rs
@@ -174,15 +174,13 @@ impl McpClient {
     /// Spawn the server and complete `initialize`.
     pub fn start(argv: &[String], cwd: &Path, timeout: Duration) -> Result<Self, McpError> {
         let command = argv.join(" ");
-        let (program, args) = argv
-            .split_first()
-            .ok_or_else(|| McpError::Spawn {
-                command: command.clone(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "the MCP command was empty",
-                ),
-            })?;
+        let (program, args) = argv.split_first().ok_or_else(|| McpError::Spawn {
+            command: command.clone(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "the MCP command was empty",
+            ),
+        })?;
         let mut child = Command::new(program)
             .args(args)
             .current_dir(cwd)

--- a/crates/kin-agent/src/parse.rs
+++ b/crates/kin-agent/src/parse.rs
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Tool-call extraction from an OpenAI-compatible chat response.
+//!
+//! Three shapes are recognized. The structured `tool_calls` array every compliant
+//! server emits, the Qwen text shape `<tool_call><function=name><parameter=k>v</parameter>`,
+//! and the Gemma text shape `<|tool_call>call: name{args}<tool_call|>`. The two text
+//! shapes are what local servers hand back when a model answers in prose instead of
+//! filling the protocol field, and a loop that cannot read them stalls on every local
+//! model that does it. The text-shape readers follow the ones proven in kin-bench's
+//! `crates/kin-bench-engine/src/live/agent/openai_compat.rs`.
+
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+
+/// One tool call the model asked for, already normalized across wire shapes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: Value,
+    pub shape: CallShape,
+}
+
+/// Which wire shape a call arrived in. Recorded so a transcript can show that a
+/// model never used the protocol field, which is a model fact rather than a Kin fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallShape {
+    Native,
+    QwenText,
+    GemmaText,
+    JsonText,
+}
+
+impl CallShape {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CallShape::Native => "native",
+            CallShape::QwenText => "qwen_text",
+            CallShape::GemmaText => "gemma_text",
+            CallShape::JsonText => "json_text",
+        }
+    }
+}
+
+/// What a single model turn amounted to.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Turn {
+    /// The model answered without asking for a tool.
+    Final { text: String },
+    /// The model asked for one or more tools, with whatever prose came alongside.
+    ToolCalls { text: String, calls: Vec<ToolCall> },
+    /// Nothing usable came back. Carries why, for the repair turn's message.
+    Unusable { reason: String, text: String },
+}
+
+/// A tool name safe to route: it cannot be a path, a flag, or a shell fragment.
+pub fn is_safe_tool_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch == '-' || ch.is_ascii_alphanumeric())
+}
+
+/// Read one `choices[0]` object into a turn.
+///
+/// `known` is the belt: every name the router will accept. Text-shaped calls are only
+/// recognized for names in the belt, because the text shapes are ambiguous enough that
+/// an unconstrained reader would mint calls out of prose that merely discusses a tool.
+pub fn parse_choice(choice: &Value, known: &BTreeSet<String>) -> Turn {
+    let message = choice.get("message").unwrap_or(&Value::Null);
+    let text = message
+        .get("content")
+        .and_then(content_to_text)
+        .unwrap_or_default();
+
+    let native = message
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .map(|calls| parse_native_tool_calls(calls))
+        .unwrap_or_default();
+    if !native.is_empty() {
+        return Turn::ToolCalls {
+            text,
+            calls: native,
+        };
+    }
+
+    for (parser, shape) in [
+        (parse_qwen_text_calls as fn(&str, &BTreeSet<String>) -> Vec<ToolCall>, CallShape::QwenText),
+        (parse_gemma_text_calls, CallShape::GemmaText),
+        (parse_json_text_calls, CallShape::JsonText),
+    ] {
+        let calls = parser(&text, known);
+        if !calls.is_empty() {
+            let _ = shape;
+            return Turn::ToolCalls {
+                text: strip_tool_call_markup(&text),
+                calls,
+            };
+        }
+    }
+
+    let finish = choice
+        .get("finish_reason")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if text.trim().is_empty() {
+        return Turn::Unusable {
+            reason: format!(
+                "the response carried no content and no tool_calls (finish_reason: {})",
+                if finish.is_empty() { "absent" } else { finish }
+            ),
+            text,
+        };
+    }
+    if finish == "length" {
+        return Turn::Unusable {
+            reason: "the response was cut off by the output token limit before it finished"
+                .to_string(),
+            text,
+        };
+    }
+    if finish == "tool_calls" {
+        return Turn::Unusable {
+            reason: "finish_reason was tool_calls but no readable tool call was present"
+                .to_string(),
+            text,
+        };
+    }
+    Turn::Final { text }
+}
+
+/// Flatten a `content` field, which is a string on most servers and a block array on some.
+fn content_to_text(content: &Value) -> Option<String> {
+    match content {
+        Value::String(s) => Some(s.clone()),
+        Value::Array(blocks) => {
+            let mut out = String::new();
+            for block in blocks {
+                if let Some(text) = block.get("text").and_then(Value::as_str) {
+                    out.push_str(text);
+                }
+            }
+            Some(out)
+        }
+        Value::Null => None,
+        _ => None,
+    }
+}
+
+fn parse_native_tool_calls(calls: &[Value]) -> Vec<ToolCall> {
+    let mut out = Vec::new();
+    for (index, call) in calls.iter().enumerate() {
+        let function = call.get("function").unwrap_or(&Value::Null);
+        let Some(name) = function.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let arguments = match function.get("arguments") {
+            // Servers send arguments as a JSON string; a few send the object directly.
+            Some(Value::String(raw)) => parse_arguments_string(raw),
+            Some(Value::Object(map)) => Value::Object(map.clone()),
+            _ => Value::Object(Map::new()),
+        };
+        out.push(ToolCall {
+            id: call
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+                .unwrap_or_else(|| format!("native_call_{index}")),
+            name: name.to_string(),
+            arguments,
+            shape: CallShape::Native,
+        });
+    }
+    out
+}
+
+/// An arguments string that is not valid JSON becomes an explicit marker rather than an
+/// empty object, so schema validation reports a malformed call instead of a call with no
+/// arguments. Those are different failures and the repair turn says different things.
+fn parse_arguments_string(raw: &str) -> Value {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Value::Object(Map::new());
+    }
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value @ Value::Object(_)) => value,
+        Ok(other) => {
+            let mut map = Map::new();
+            map.insert("__kin_agent_non_object_arguments".into(), other);
+            Value::Object(map)
+        }
+        Err(err) => {
+            let mut map = Map::new();
+            map.insert(
+                "__kin_agent_unparsed_arguments".into(),
+                Value::String(trimmed.to_string()),
+            );
+            map.insert(
+                "__kin_agent_parse_error".into(),
+                Value::String(err.to_string()),
+            );
+            Value::Object(map)
+        }
+    }
+}
+
+/// True when arguments could not be read off the wire at all.
+pub fn arguments_are_malformed(arguments: &Value) -> Option<String> {
+    let object = arguments.as_object()?;
+    if let Some(raw) = object.get("__kin_agent_unparsed_arguments") {
+        let err = object
+            .get("__kin_agent_parse_error")
+            .and_then(Value::as_str)
+            .unwrap_or("not valid JSON");
+        return Some(format!(
+            "the arguments were not valid JSON ({}): {}",
+            err,
+            raw.as_str().unwrap_or_default()
+        ));
+    }
+    if object.contains_key("__kin_agent_non_object_arguments") {
+        return Some("the arguments were valid JSON but not a JSON object".to_string());
+    }
+    None
+}
+
+/// Qwen: `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>`
+fn parse_qwen_text_calls(text: &str, known: &BTreeSet<String>) -> Vec<ToolCall> {
+    let mut calls = Vec::new();
+    let mut offset = 0;
+    while let Some(start_rel) = text[offset..].find("<tool_call>") {
+        let body_start = offset + start_rel + "<tool_call>".len();
+        let Some(end_rel) = text[body_start..].find("</tool_call>") else {
+            break;
+        };
+        let body_end = body_start + end_rel;
+        if let Some(call) = parse_qwen_block(&text[body_start..body_end], known, calls.len()) {
+            calls.push(call);
+        }
+        offset = body_end + "</tool_call>".len();
+    }
+    calls
+}
+
+fn parse_qwen_block(block: &str, known: &BTreeSet<String>, index: usize) -> Option<ToolCall> {
+    let function_start = block.find("<function=")? + "<function=".len();
+    let rest = &block[function_start..];
+    let name_end = rest.find('>')?;
+    let mut name = rest[..name_end].trim();
+    // Some templates qualify the name, as in `functions.semantic_locate`.
+    if let Some(dot) = name.rfind('.') {
+        name = &name[dot + 1..];
+    }
+    if !known.contains(name) || !is_safe_tool_name(name) {
+        return None;
+    }
+    let body_start = function_start + name_end + 1;
+    let body_end = block[body_start..]
+        .find("</function>")
+        .map(|end| body_start + end)
+        .unwrap_or(block.len());
+    Some(ToolCall {
+        id: format!("qwen_text_call_{index}"),
+        name: name.to_string(),
+        arguments: Value::Object(parse_qwen_parameters(&block[body_start..body_end])),
+        shape: CallShape::QwenText,
+    })
+}
+
+fn parse_qwen_parameters(text: &str) -> Map<String, Value> {
+    let mut args = Map::new();
+    let mut offset = 0;
+    while let Some(start_rel) = text[offset..].find("<parameter=") {
+        let name_start = offset + start_rel + "<parameter=".len();
+        let rest = &text[name_start..];
+        let Some(name_end_rel) = rest.find('>') else {
+            break;
+        };
+        let name = rest[..name_end_rel].trim().to_string();
+        let value_start = name_start + name_end_rel + 1;
+        let Some(value_end_rel) = text[value_start..].find("</parameter>") else {
+            break;
+        };
+        let value_end = value_start + value_end_rel;
+        let raw = text[value_start..value_end].trim();
+        args.insert(name, scalar_from_text(raw));
+        offset = value_end + "</parameter>".len();
+    }
+    args
+}
+
+/// Gemma: `<|tool_call>call: name{"k": "v"}<tool_call|>`
+fn parse_gemma_text_calls(text: &str, known: &BTreeSet<String>) -> Vec<ToolCall> {
+    let mut calls = Vec::new();
+    let mut offset = 0;
+    while let Some(start_rel) = text[offset..].find("<|tool_call>") {
+        let body_start = offset + start_rel + "<|tool_call>".len();
+        let close = text[body_start..]
+            .find("<tool_call|>")
+            .or_else(|| text[body_start..].find("<|tool_call|>"));
+        let body_end = body_start + close.unwrap_or(text.len() - body_start);
+        if let Some(call) = parse_gemma_block(&text[body_start..body_end], known, calls.len()) {
+            calls.push(call);
+        }
+        let Some(_) = close else { break };
+        offset = body_end
+            + if text[body_end..].starts_with("<tool_call|>") {
+                "<tool_call|>".len()
+            } else {
+                "<|tool_call|>".len()
+            };
+        if offset >= text.len() {
+            break;
+        }
+    }
+    calls
+}
+
+fn parse_gemma_block(block: &str, known: &BTreeSet<String>, index: usize) -> Option<ToolCall> {
+    let block = block.trim();
+    let call_start = block.find("call:")?;
+    let rest = &block[call_start + "call:".len()..];
+    let brace_start = rest.find('{')?;
+    let mut name = rest[..brace_start].trim();
+    if let Some(dot) = name.rfind('.') {
+        name = &name[dot + 1..];
+    }
+    if !known.contains(name) || !is_safe_tool_name(name) {
+        return None;
+    }
+    let args_str = &rest[brace_start..];
+    let brace_end = args_str.rfind('}')?;
+    // Gemma escapes quotes with its own special tokens rather than backslashes.
+    let body = args_str[1..brace_end]
+        .replace("<|\"|>", "\"")
+        .replace("<|\\\"|>", "\"")
+        .replace("<|'|>", "'")
+        .replace("<|\\'|>", "'");
+    Some(ToolCall {
+        id: format!("gemma_text_call_{index}"),
+        name: name.to_string(),
+        arguments: Value::Object(parse_gemma_arguments(&body)),
+        shape: CallShape::GemmaText,
+    })
+}
+
+/// Gemma's argument body is usually valid JSON once the quote tokens are normalized.
+/// When it is not, fall back to reading `key: value` pairs at the top level.
+fn parse_gemma_arguments(body: &str) -> Map<String, Value> {
+    let wrapped = format!("{{{body}}}");
+    if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(&wrapped) {
+        return map;
+    }
+    let mut args = Map::new();
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut current = String::new();
+    let mut fields = Vec::new();
+    for ch in body.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => {
+                current.push(ch);
+                escaped = true;
+            }
+            '"' => {
+                in_string = !in_string;
+                current.push(ch);
+            }
+            '{' | '[' if !in_string => {
+                depth += 1;
+                current.push(ch);
+            }
+            '}' | ']' if !in_string => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if !in_string && depth == 0 => {
+                fields.push(std::mem::take(&mut current));
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.trim().is_empty() {
+        fields.push(current);
+    }
+    for field in fields {
+        let Some(colon) = split_top_level_colon(&field) else {
+            continue;
+        };
+        let key = field[..colon].trim().trim_matches('"').to_string();
+        if key.is_empty() {
+            continue;
+        }
+        args.insert(key, scalar_from_text(field[colon + 1..].trim()));
+    }
+    args
+}
+
+fn split_top_level_colon(field: &str) -> Option<usize> {
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut depth = 0usize;
+    for (idx, ch) in field.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => escaped = true,
+            '"' => in_string = !in_string,
+            '{' | '[' if !in_string => depth += 1,
+            '}' | ']' if !in_string => depth = depth.saturating_sub(1),
+            ':' if !in_string && depth == 0 => return Some(idx),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Read a bare text value into the JSON scalar it obviously is, string otherwise.
+fn scalar_from_text(raw: &str) -> Value {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+            return value;
+        }
+    }
+    if trimmed.len() >= 2 && trimmed.starts_with('"') && trimmed.ends_with('"') {
+        if let Ok(Value::String(s)) = serde_json::from_str::<Value>(trimmed) {
+            return Value::String(s);
+        }
+    }
+    match trimmed {
+        "true" => return Value::Bool(true),
+        "false" => return Value::Bool(false),
+        "null" => return Value::Null,
+        _ => {}
+    }
+    if let Ok(int) = trimmed.parse::<i64>() {
+        return Value::from(int);
+    }
+    if let Ok(float) = trimmed.parse::<f64>() {
+        if float.is_finite() {
+            return Value::from(float);
+        }
+    }
+    Value::String(trimmed.to_string())
+}
+
+/// The plain shape: `<tool_call>{"name": "x", "arguments": {...}}</tool_call>`, which is
+/// what several LM Studio templates emit under a tool_choice constraint.
+fn parse_json_text_calls(text: &str, known: &BTreeSet<String>) -> Vec<ToolCall> {
+    let mut calls = Vec::new();
+    let mut offset = 0;
+    while let Some(start_rel) = text[offset..].find("<tool_call>") {
+        let body_start = offset + start_rel + "<tool_call>".len();
+        let (body_end, next) = match text[body_start..].find("</tool_call>") {
+            Some(end) => (body_start + end, body_start + end + "</tool_call>".len()),
+            None => (text.len(), text.len()),
+        };
+        let body = text[body_start..body_end].trim();
+        if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(body) {
+            let name = map
+                .get("name")
+                .or_else(|| map.get("tool"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let mut name = name;
+            if let Some(dot) = name.rfind('.') {
+                name = &name[dot + 1..];
+            }
+            if known.contains(name) && is_safe_tool_name(name) {
+                let arguments = map
+                    .get("arguments")
+                    .or_else(|| map.get("parameters"))
+                    .cloned()
+                    .unwrap_or_else(|| Value::Object(Map::new()));
+                let arguments = match arguments {
+                    Value::String(raw) => parse_arguments_string(&raw),
+                    other @ Value::Object(_) => other,
+                    _ => Value::Object(Map::new()),
+                };
+                let index = calls.len();
+                calls.push(ToolCall {
+                    id: format!("json_text_call_{index}"),
+                    name: name.to_string(),
+                    arguments,
+                    shape: CallShape::JsonText,
+                });
+            }
+        }
+        if next >= text.len() {
+            break;
+        }
+        offset = next;
+    }
+    calls
+}
+
+/// Remove the tool-call markup from prose so the transcript's text block reads as text.
+fn strip_tool_call_markup(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    loop {
+        let qwen = rest.find("<tool_call>");
+        let gemma = rest.find("<|tool_call>");
+        let (start, open, close) = match (qwen, gemma) {
+            (Some(q), Some(g)) if q <= g => (q, "<tool_call>", "</tool_call>"),
+            (Some(_), Some(g)) => (g, "<|tool_call>", "<tool_call|>"),
+            (Some(q), None) => (q, "<tool_call>", "</tool_call>"),
+            (None, Some(g)) => (g, "<|tool_call>", "<tool_call|>"),
+            (None, None) => {
+                out.push_str(rest);
+                break;
+            }
+        };
+        out.push_str(&rest[..start]);
+        let after_open = start + open.len();
+        match rest[after_open..].find(close) {
+            Some(end) => rest = &rest[after_open + end + close.len()..],
+            None => break,
+        }
+    }
+    out.trim().to_string()
+}

--- a/crates/kin-agent/src/parse.rs
+++ b/crates/kin-agent/src/parse.rs
@@ -89,17 +89,15 @@ pub fn parse_choice(choice: &Value, known: &BTreeSet<String>) -> Turn {
         };
     }
 
-    for (parser, shape) in [
-        (
-            parse_qwen_text_calls as fn(&str, &BTreeSet<String>) -> Vec<ToolCall>,
-            CallShape::QwenText,
-        ),
-        (parse_gemma_text_calls, CallShape::GemmaText),
-        (parse_json_text_calls, CallShape::JsonText),
+    // Each reader stamps its own CallShape on the calls it produces, so the order here is
+    // only about which markup is looked for first.
+    for parser in [
+        parse_qwen_text_calls as fn(&str, &BTreeSet<String>) -> Vec<ToolCall>,
+        parse_gemma_text_calls,
+        parse_json_text_calls,
     ] {
         let calls = parser(&text, known);
         if !calls.is_empty() {
-            let _ = shape;
             return Turn::ToolCalls {
                 text: strip_tool_call_markup(&text),
                 calls,

--- a/crates/kin-agent/src/parse.rs
+++ b/crates/kin-agent/src/parse.rs
@@ -90,7 +90,10 @@ pub fn parse_choice(choice: &Value, known: &BTreeSet<String>) -> Turn {
     }
 
     for (parser, shape) in [
-        (parse_qwen_text_calls as fn(&str, &BTreeSet<String>) -> Vec<ToolCall>, CallShape::QwenText),
+        (
+            parse_qwen_text_calls as fn(&str, &BTreeSet<String>) -> Vec<ToolCall>,
+            CallShape::QwenText,
+        ),
         (parse_gemma_text_calls, CallShape::GemmaText),
         (parse_json_text_calls, CallShape::JsonText),
     ] {

--- a/crates/kin-agent/src/provider.rs
+++ b/crates/kin-agent/src/provider.rs
@@ -164,7 +164,11 @@ impl Provider {
 
     /// One turn. `tools` empty means a tool-free turn, which is how the forced final
     /// answer is asked for: the model is given nothing to call.
-    pub fn complete(&self, messages: &[Value], tools: &[Value]) -> Result<Completion, ProviderError> {
+    pub fn complete(
+        &self,
+        messages: &[Value],
+        tools: &[Value],
+    ) -> Result<Completion, ProviderError> {
         let url = self.config.chat_url();
         let mut body = json!({
             "model": self.config.model,
@@ -221,7 +225,10 @@ impl Provider {
         })
     }
 
-    fn request(&self, builder: reqwest::blocking::RequestBuilder) -> reqwest::blocking::RequestBuilder {
+    fn request(
+        &self,
+        builder: reqwest::blocking::RequestBuilder,
+    ) -> reqwest::blocking::RequestBuilder {
         match self.config.api_key.as_deref() {
             Some(key) => builder.bearer_auth(key),
             None => builder,

--- a/crates/kin-agent/src/provider.rs
+++ b/crates/kin-agent/src/provider.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! An OpenAI-compatible chat-completions client.
+//!
+//! One adapter reaches LM Studio, Ollama, llama.cpp, vLLM, OpenRouter and OpenAI, because
+//! they all speak the same wire format for `tools` and `tool_calls`. The API key is read
+//! from a named environment variable and never accepted on argv, so it cannot land in a
+//! process listing or a transcript.
+
+use serde_json::{json, Value};
+use std::time::Duration;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    #[error("the chat endpoint at {url} could not be reached: {source}")]
+    Transport { url: String, source: reqwest::Error },
+    #[error("the chat endpoint at {url} answered {status}: {body}")]
+    Status {
+        url: String,
+        status: u16,
+        body: String,
+    },
+    #[error("the chat endpoint at {url} answered with a body that is not JSON: {source}")]
+    Body { url: String, source: reqwest::Error },
+    #[error("the chat endpoint answered with no choices")]
+    NoChoices,
+    #[error("the environment variable {name} names an API key but is not set")]
+    MissingKey { name: String },
+}
+
+/// How to reach a model.
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    pub base_url: String,
+    pub model: String,
+    pub api_key: Option<String>,
+    pub temperature: Option<f32>,
+    pub request_timeout: Duration,
+}
+
+impl ProviderConfig {
+    /// Normalize a base URL: trailing slashes go, and a bare host gains `/v1`, so
+    /// `http://127.0.0.1:1234` and `http://127.0.0.1:1234/v1/` mean the same endpoint.
+    pub fn normalize_base_url(raw: &str) -> String {
+        let trimmed = raw.trim().trim_end_matches('/');
+        if trimmed.ends_with("/v1") || trimmed.ends_with("/openai") || trimmed.contains("/v1/") {
+            trimmed.to_string()
+        } else {
+            format!("{trimmed}/v1")
+        }
+    }
+
+    /// Read the key from the named variable, failing loudly when it is named and absent.
+    pub fn api_key_from_env(name: Option<&str>) -> Result<Option<String>, ProviderError> {
+        let Some(name) = name else { return Ok(None) };
+        match std::env::var(name) {
+            Ok(value) if !value.trim().is_empty() => Ok(Some(value)),
+            _ => Err(ProviderError::MissingKey {
+                name: name.to_string(),
+            }),
+        }
+    }
+
+    pub fn chat_url(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+
+    pub fn models_url(&self) -> String {
+        format!("{}/models", self.base_url)
+    }
+}
+
+/// What one completion cost, when the endpoint said.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Usage {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+}
+
+impl Usage {
+    pub fn is_empty(&self) -> bool {
+        self.input_tokens.is_none() && self.output_tokens.is_none()
+    }
+
+    pub fn to_json(&self) -> Option<Value> {
+        if self.is_empty() {
+            return None;
+        }
+        let mut map = serde_json::Map::new();
+        if let Some(value) = self.input_tokens {
+            map.insert("input_tokens".into(), Value::from(value));
+        }
+        if let Some(value) = self.output_tokens {
+            map.insert("output_tokens".into(), Value::from(value));
+        }
+        Some(Value::Object(map))
+    }
+}
+
+/// One completion.
+#[derive(Debug, Clone)]
+pub struct Completion {
+    pub choice: Value,
+    pub usage: Usage,
+    pub api_ms: u128,
+}
+
+pub struct Provider {
+    client: reqwest::blocking::Client,
+    config: ProviderConfig,
+}
+
+impl Provider {
+    pub fn new(config: ProviderConfig) -> Result<Self, ProviderError> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(config.request_timeout)
+            .build()
+            .map_err(|source| ProviderError::Transport {
+                url: config.base_url.clone(),
+                source,
+            })?;
+        Ok(Provider { client, config })
+    }
+
+    pub fn config(&self) -> &ProviderConfig {
+        &self.config
+    }
+
+    /// The model ids the endpoint serves, used by `kin agent doctor`.
+    pub fn list_models(&self) -> Result<Vec<String>, ProviderError> {
+        let url = self.config.models_url();
+        let response = self
+            .request(self.client.get(&url))
+            .send()
+            .map_err(|source| ProviderError::Transport {
+                url: url.clone(),
+                source,
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(ProviderError::Status {
+                url,
+                status: status.as_u16(),
+                body: truncate(&body, 400),
+            });
+        }
+        let body: Value = response
+            .json()
+            .map_err(|source| ProviderError::Body { url, source })?;
+        Ok(body
+            .get("data")
+            .and_then(Value::as_array)
+            .map(|models| {
+                models
+                    .iter()
+                    .filter_map(|model| model.get("id").and_then(Value::as_str))
+                    .map(ToString::to_string)
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    /// One turn. `tools` empty means a tool-free turn, which is how the forced final
+    /// answer is asked for: the model is given nothing to call.
+    pub fn complete(&self, messages: &[Value], tools: &[Value]) -> Result<Completion, ProviderError> {
+        let url = self.config.chat_url();
+        let mut body = json!({
+            "model": self.config.model,
+            "messages": messages,
+            "stream": false,
+        });
+        if let Some(temperature) = self.config.temperature {
+            body["temperature"] = json!(temperature);
+        }
+        if !tools.is_empty() {
+            body["tools"] = Value::Array(tools.to_vec());
+            body["tool_choice"] = json!("auto");
+        }
+
+        let started = std::time::Instant::now();
+        let response = self
+            .request(self.client.post(&url))
+            .json(&body)
+            .send()
+            .map_err(|source| ProviderError::Transport {
+                url: url.clone(),
+                source,
+            })?;
+        let api_ms = started.elapsed().as_millis();
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().unwrap_or_default();
+            return Err(ProviderError::Status {
+                url,
+                status: status.as_u16(),
+                body: truncate(&text, 400),
+            });
+        }
+        let payload: Value = response
+            .json()
+            .map_err(|source| ProviderError::Body { url, source })?;
+        let choice = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .cloned()
+            .ok_or(ProviderError::NoChoices)?;
+        let usage = payload
+            .get("usage")
+            .map(|usage| Usage {
+                input_tokens: usage.get("prompt_tokens").and_then(Value::as_u64),
+                output_tokens: usage.get("completion_tokens").and_then(Value::as_u64),
+            })
+            .unwrap_or_default();
+        Ok(Completion {
+            choice,
+            usage,
+            api_ms,
+        })
+    }
+
+    fn request(&self, builder: reqwest::blocking::RequestBuilder) -> reqwest::blocking::RequestBuilder {
+        match self.config.api_key.as_deref() {
+            Some(key) => builder.bearer_auth(key),
+            None => builder,
+        }
+    }
+}
+
+fn truncate(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    text.chars().take(limit).collect::<String>() + "..."
+}

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -132,11 +132,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
     });
 
     // Connect to Kin first. A run that could not attach must be loud, not quietly scored.
-    let mut mcp = match McpClient::start(
-        &config.mcp_command,
-        &config.repo,
-        config.mcp_timeout,
-    ) {
+    let mut mcp = match McpClient::start(&config.mcp_command, &config.repo, config.mcp_timeout) {
         Ok(client) => client,
         Err(err) => {
             let message = err.to_string();
@@ -431,11 +427,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                 "is_error": true,
                                                 "transport_error": err.to_string(),
                                             }))?;
-                                            writer.tool_result(
-                                                &call.id,
-                                                &err.to_string(),
-                                                true,
-                                            )?;
+                                            writer.tool_result(&call.id, &err.to_string(), true)?;
                                             status = ExitStatus::McpError;
                                             stop_reason = "mcp_transport".into();
                                             final_text = err.to_string();
@@ -568,7 +560,12 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
         }
     }
 
-    end_kin_session(&mut mcp, kin_session.as_deref(), &server_tool_names, &mut writer)?;
+    end_kin_session(
+        &mut mcp,
+        kin_session.as_deref(),
+        &server_tool_names,
+        &mut writer,
+    )?;
     finish(
         writer,
         &config,
@@ -583,7 +580,11 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
 
 /// Append what Kin said about its own answer, so an untrusted absence cannot be read as
 /// an absence and a degraded graph is stated once rather than silently.
-fn annotate(outcome: &ToolOutcome, counters: &mut Counters, surfaced_degraded: &mut bool) -> String {
+fn annotate(
+    outcome: &ToolOutcome,
+    counters: &mut Counters,
+    surfaced_degraded: &mut bool,
+) -> String {
     let mut text = outcome.text.clone();
     if outcome.safe_to_conclude_absent() == Some(false) {
         counters.unsafe_absence_events += 1;
@@ -784,7 +785,10 @@ fn begin_transaction(
             reason: Some("no Kin session was open".into()),
         });
     };
-    if !server_tools.iter().any(|name| name == "kin_transaction_begin") {
+    if !server_tools
+        .iter()
+        .any(|name| name == "kin_transaction_begin")
+    {
         return Ok(Bracket {
             transaction_id: None,
             reason: Some("the server does not expose kin_transaction_begin".into()),

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -252,6 +252,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
             }));
             match complete_with_retry(&provider, &messages, &[], &mut counters) {
                 Ok(completion) => {
+                    counters.absorb(&completion.usage);
                     let turn = parse::parse_choice(&completion.choice, belt.names());
                     let text = match turn {
                         Turn::Final { text } => text,

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -1,0 +1,964 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The agent loop.
+
+use crate::belt::{self, Belt, LocalTool, Route};
+use crate::mcp::{McpClient, ToolOutcome};
+use crate::parse::{self, Turn};
+use crate::provider::{Provider, ProviderError, Usage};
+use crate::transcript::{now_iso, TranscriptWriter};
+use crate::{AgentConfig, ExitStatus, RunOutcome};
+use serde_json::{json, Map, Value};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// How many consecutive turns the model may fail to produce a usable call before the run
+/// stops. Two, so a single bad turn is repaired and a model that cannot hold the protocol
+/// is not allowed to burn the whole budget saying nothing.
+const MAX_CONSECUTIVE_UNUSABLE: u32 = 2;
+/// Bounded retries for a transport hiccup on the chat endpoint.
+const ENDPOINT_ATTEMPTS: u32 = 3;
+
+pub const DEFAULT_SYSTEM_PROMPT: &str = "\
+You are a software engineering agent working in a repository through Kin, a semantic graph \
+of the code. Kin is your only way to look at the repository.
+
+You have no shell, no grep, no find and no file-reading tool. This is deliberate. Every \
+question about where code lives, what calls what, or what a symbol does is answered from \
+the graph with the mcp__kin__ tools. Start with mcp__kin__semantic_locate or \
+mcp__kin__semantic_search to find things by meaning, use mcp__kin__get_context_pack or \
+mcp__kin__get_entity_source to read exact source, and use mcp__kin__find_references or \
+mcp__kin__trace_data_flow to follow relationships.
+
+When a Kin result is empty, read what Kin says about that emptiness. If it reports the \
+absence cannot be trusted, the honest answer is that you do not know, and you should say \
+what the gap is. Never turn an untrusted absence into a claim that something does not exist.
+
+To change code, use edit_file for a surgical change to an existing file and write_file for \
+a new one. Read the exact current text through Kin first so your edit matches byte for byte. \
+Your edits are recorded through Kin's transaction tools, so the change carries provenance \
+naming this agent.
+
+Work in small steps. Call one or two tools, read what came back, then decide. When you have \
+the answer, say it in plain text without calling a tool.";
+
+struct Counters {
+    tool_calls: u32,
+    kin_calls: u32,
+    local_calls: u32,
+    refused_calls: u32,
+    repairs: u32,
+    unsafe_absence_events: u32,
+    unreadable_results: u32,
+    turns: u32,
+    input_tokens: u64,
+    output_tokens: u64,
+    saw_usage: bool,
+    api_ms: u128,
+    edits: Vec<String>,
+}
+
+impl Counters {
+    fn new() -> Self {
+        Counters {
+            tool_calls: 0,
+            kin_calls: 0,
+            local_calls: 0,
+            refused_calls: 0,
+            repairs: 0,
+            unsafe_absence_events: 0,
+            unreadable_results: 0,
+            turns: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            saw_usage: false,
+            api_ms: 0,
+            edits: Vec::new(),
+        }
+    }
+
+    fn absorb(&mut self, usage: &Usage) {
+        if let Some(value) = usage.input_tokens {
+            self.input_tokens += value;
+            self.saw_usage = true;
+        }
+        if let Some(value) = usage.output_tokens {
+            self.output_tokens += value;
+            self.saw_usage = true;
+        }
+    }
+
+    fn usage_json(&self) -> Option<Value> {
+        if !self.saw_usage {
+            return None;
+        }
+        Some(json!({
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+        }))
+    }
+
+    fn to_json(&self, exit_code: i32, stop_reason: &str) -> Value {
+        json!({
+            "exit_code": exit_code,
+            "stop_reason": stop_reason,
+            "tool_calls": self.tool_calls,
+            "kin_calls": self.kin_calls,
+            "local_calls": self.local_calls,
+            "refused_calls": self.refused_calls,
+            "repairs": self.repairs,
+            "unsafe_absence_events": self.unsafe_absence_events,
+            "unreadable_results": self.unreadable_results,
+            "files_changed": self.edits,
+        })
+    }
+}
+
+/// Run one task to completion.
+pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
+    let started = Instant::now();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let mut writer = TranscriptWriter::create(&config.out_dir, &session_id)?;
+    let mut counters = Counters::new();
+
+    let agent_meta = json!({
+        "base_url": config.provider.base_url,
+        "max_tool_calls": config.max_tool_calls,
+        "deadline_s": config.deadline.as_secs(),
+        "tool_profile": config.tool_profile.clone().unwrap_or_else(|| "server-default".into()),
+        "policy": "no-shell-no-file-search",
+        "mcp_command": config.mcp_command.join(" "),
+    });
+
+    // Connect to Kin first. A run that could not attach must be loud, not quietly scored.
+    let mut mcp = match McpClient::start(
+        &config.mcp_command,
+        &config.repo,
+        config.mcp_timeout,
+    ) {
+        Ok(client) => client,
+        Err(err) => {
+            let message = err.to_string();
+            writer.init(
+                &config.provider.model,
+                &config.repo,
+                &[],
+                "failed",
+                std::slice::from_ref(&message),
+                agent_meta,
+            )?;
+            return finish(
+                writer,
+                &config,
+                ExitStatus::McpError,
+                "the MCP server did not start",
+                &message,
+                counters,
+                started,
+                None,
+            );
+        }
+    };
+
+    let declared = match mcp.list_tools() {
+        Ok(tools) => tools,
+        Err(err) => {
+            let message = err.to_string();
+            writer.init(
+                &config.provider.model,
+                &config.repo,
+                &[],
+                "failed",
+                std::slice::from_ref(&message),
+                agent_meta,
+            )?;
+            return finish(
+                writer,
+                &config,
+                ExitStatus::McpError,
+                "the MCP server did not list its tools",
+                &message,
+                counters,
+                started,
+                None,
+            );
+        }
+    };
+
+    let server_tool_names: Vec<String> = declared.iter().map(|tool| tool.name.clone()).collect();
+    let exposed: Vec<_> = declared
+        .iter()
+        .filter(|tool| !belt::is_harness_owned(&tool.name))
+        .collect();
+    let belt = Belt::new(
+        exposed
+            .iter()
+            .map(|tool| (tool.name.clone(), tool.input_schema.clone()))
+            .collect(),
+    );
+    let descriptions: Vec<(String, String)> = exposed
+        .iter()
+        .map(|tool| (tool.name.clone(), tool.description.clone()))
+        .collect();
+    let specs = belt.to_specs(&descriptions);
+    let tool_names: Vec<String> = belt.names().iter().cloned().collect();
+
+    writer.init(
+        &config.provider.model,
+        &config.repo,
+        &tool_names,
+        "connected",
+        &[],
+        agent_meta,
+    )?;
+
+    let provider = Provider::new(config.provider.clone())?;
+
+    // Open a Kin session so every mutation this run makes names this agent rather than an
+    // anonymous file write. A server without the tool is not an error; it just means the
+    // provenance bracket is unavailable and the trace says so.
+    let kin_session = start_kin_session(&mut mcp, &config, &server_tool_names, &mut writer)?;
+
+    let system_prompt = config
+        .system_prompt
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SYSTEM_PROMPT.to_string());
+    let mut messages = vec![
+        json!({ "role": "system", "content": system_prompt }),
+        json!({ "role": "user", "content": config.task }),
+    ];
+
+    let mut next_tool_id = 0u64;
+    let mut consecutive_unusable = 0u32;
+    let mut surfaced_degraded = false;
+    let mut final_text = String::new();
+    let mut status = ExitStatus::Success;
+    let mut stop_reason = "final_answer".to_string();
+
+    loop {
+        if started.elapsed() >= config.deadline {
+            status = ExitStatus::Deadline;
+            stop_reason = "wall_deadline".into();
+            break;
+        }
+        if counters.tool_calls >= config.max_tool_calls {
+            // The budget is spent. Ask for an answer with nothing to call, so the run ends
+            // with what the model actually learned rather than with silence.
+            messages.push(json!({
+                "role": "user",
+                "content": format!(
+                    "You have used your budget of {} tool calls. Do not call any more tools. \
+                     Answer now in plain text with what you have learned, and say plainly what \
+                     you were not able to determine.",
+                    config.max_tool_calls
+                ),
+            }));
+            match complete_with_retry(&provider, &messages, &[], &mut counters) {
+                Ok(completion) => {
+                    let turn = parse::parse_choice(&completion.choice, belt.names());
+                    let text = match turn {
+                        Turn::Final { text } => text,
+                        Turn::ToolCalls { text, .. } => text,
+                        Turn::Unusable { text, .. } => text,
+                    };
+                    counters.turns += 1;
+                    writer.assistant(
+                        &config.provider.model,
+                        &format!("msg_{:08}", counters.turns),
+                        &text,
+                        &[],
+                        completion.usage.to_json(),
+                    )?;
+                    final_text = text;
+                }
+                Err(err) => {
+                    final_text = format!("(no final answer: {err})");
+                }
+            }
+            status = ExitStatus::CapReached;
+            stop_reason = "tool_call_cap".into();
+            break;
+        }
+
+        let completion = match complete_with_retry(&provider, &messages, &specs, &mut counters) {
+            Ok(completion) => completion,
+            Err(err) => {
+                status = ExitStatus::EndpointError;
+                stop_reason = "endpoint_unreachable".into();
+                final_text = err.to_string();
+                break;
+            }
+        };
+        counters.absorb(&completion.usage);
+        counters.turns += 1;
+        let turn = parse::parse_choice(&completion.choice, belt.names());
+
+        match turn {
+            Turn::Final { text } => {
+                writer.assistant(
+                    &config.provider.model,
+                    &format!("msg_{:08}", counters.turns),
+                    &text,
+                    &[],
+                    completion.usage.to_json(),
+                )?;
+                final_text = text;
+                status = ExitStatus::Success;
+                stop_reason = "final_answer".into();
+                break;
+            }
+            Turn::Unusable { reason, text } => {
+                consecutive_unusable += 1;
+                writer.assistant(
+                    &config.provider.model,
+                    &format!("msg_{:08}", counters.turns),
+                    &text,
+                    &[],
+                    completion.usage.to_json(),
+                )?;
+                writer.trace(json!({
+                    "surface": "policy",
+                    "policy": "unparsed",
+                    "reason": reason,
+                    "attempt": consecutive_unusable,
+                }))?;
+                if consecutive_unusable >= MAX_CONSECUTIVE_UNUSABLE {
+                    status = ExitStatus::EndpointError;
+                    // Named apart from an unreachable endpoint on purpose: a model that
+                    // cannot hold the tool protocol is a model failure, and a run that
+                    // died this way must never be scored as a task the toolset failed.
+                    stop_reason = "model_format_failure".into();
+                    final_text = text;
+                    break;
+                }
+                counters.repairs += 1;
+                messages.push(json!({ "role": "assistant", "content": text }));
+                messages.push(json!({
+                    "role": "user",
+                    "content": format!(
+                        "That turn could not be used: {reason}. Either call one tool using the \
+                         tool-calling format, or answer in plain text. Do not describe a tool \
+                         call in prose."
+                    ),
+                }));
+                continue;
+            }
+            Turn::ToolCalls { text, mut calls } => {
+                consecutive_unusable = 0;
+                // Canonical ids, used in the transcript and echoed back to the model, so a
+                // trace row and a conversation entry name the same call.
+                for call in calls.iter_mut() {
+                    next_tool_id += 1;
+                    call.id = format!("toolu_{next_tool_id:08}");
+                }
+                let tool_uses: Vec<(String, String, Value)> = calls
+                    .iter()
+                    .map(|call| (call.id.clone(), call.name.clone(), call.arguments.clone()))
+                    .collect();
+                writer.assistant(
+                    &config.provider.model,
+                    &format!("msg_{:08}", counters.turns),
+                    &text,
+                    &tool_uses,
+                    completion.usage.to_json(),
+                )?;
+                messages.push(json!({
+                    "role": "assistant",
+                    "content": text,
+                    "tool_calls": calls.iter().map(|call| json!({
+                        "id": call.id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": call.arguments.to_string(),
+                        }
+                    })).collect::<Vec<_>>(),
+                }));
+
+                for call in &calls {
+                    counters.tool_calls += 1;
+                    let route = belt.route(&call.name);
+                    let (result_text, is_error) = match route {
+                        Route::Refused(message) => {
+                            counters.refused_calls += 1;
+                            writer.trace(json!({
+                                "tool_use_id": call.id,
+                                "surface": "policy",
+                                "tool": call.name,
+                                "args": call.arguments,
+                                "policy": "refused",
+                                "call_shape": call.shape.as_str(),
+                                "is_error": true,
+                            }))?;
+                            (message, true)
+                        }
+                        Route::Kin(name) => {
+                            match check_arguments(&belt, &call.name, &call.arguments) {
+                                Err(problem) => {
+                                    counters.repairs += 1;
+                                    writer.trace(json!({
+                                        "tool_use_id": call.id,
+                                        "surface": "kin",
+                                        "tool": name,
+                                        "args": call.arguments,
+                                        "policy": "repaired",
+                                        "call_shape": call.shape.as_str(),
+                                        "problem": problem,
+                                        "is_error": true,
+                                    }))?;
+                                    (
+                                        format!(
+                                            "The call was not run because its arguments were \
+                                             rejected: {problem}. Send the call again with that \
+                                             corrected."
+                                        ),
+                                        true,
+                                    )
+                                }
+                                Ok(()) => {
+                                    let outcome = mcp.call_tool(&name, &call.arguments);
+                                    match outcome {
+                                        Err(err) => {
+                                            // The server died or stopped answering. Nothing
+                                            // downstream can be trusted, so stop here.
+                                            writer.trace(json!({
+                                                "tool_use_id": call.id,
+                                                "surface": "kin",
+                                                "tool": name,
+                                                "args": call.arguments,
+                                                "policy": "allowed",
+                                                "is_error": true,
+                                                "transport_error": err.to_string(),
+                                            }))?;
+                                            writer.tool_result(
+                                                &call.id,
+                                                &err.to_string(),
+                                                true,
+                                            )?;
+                                            status = ExitStatus::McpError;
+                                            stop_reason = "mcp_transport".into();
+                                            final_text = err.to_string();
+                                            return finish(
+                                                writer,
+                                                &config,
+                                                status,
+                                                &stop_reason,
+                                                &final_text,
+                                                counters,
+                                                started,
+                                                None,
+                                            );
+                                        }
+                                        Ok(outcome) => {
+                                            counters.kin_calls += 1;
+                                            if outcome.unreadable {
+                                                counters.unreadable_results += 1;
+                                            }
+                                            let annotated = annotate(
+                                                &outcome,
+                                                &mut counters,
+                                                &mut surfaced_degraded,
+                                            );
+                                            writer.trace(json!({
+                                                "tool_use_id": call.id,
+                                                "surface": "kin",
+                                                "tool": name,
+                                                "args": call.arguments,
+                                                "wall_ms": outcome.wall_ms as u64,
+                                                "is_error": outcome.is_error,
+                                                "policy": "allowed",
+                                                "call_shape": call.shape.as_str(),
+                                                "envelope": outcome.envelope_summary(),
+                                                "negative": negative_summary(&outcome),
+                                                "unreadable": outcome.unreadable,
+                                            }))?;
+                                            (annotated, outcome.is_error)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Route::Local(tool) => {
+                            match check_arguments(&belt, &call.name, &call.arguments) {
+                                Err(problem) => {
+                                    counters.repairs += 1;
+                                    writer.trace(json!({
+                                        "tool_use_id": call.id,
+                                        "surface": "local",
+                                        "tool": call.name,
+                                        "args": redact_content(&call.arguments),
+                                        "policy": "repaired",
+                                        "problem": problem,
+                                        "is_error": true,
+                                    }))?;
+                                    (
+                                        format!(
+                                            "The call was not run because its arguments were \
+                                             rejected: {problem}. Send the call again with that \
+                                             corrected."
+                                        ),
+                                        true,
+                                    )
+                                }
+                                Ok(()) => {
+                                    counters.local_calls += 1;
+                                    let started_call = Instant::now();
+                                    let bracket = begin_transaction(
+                                        &mut mcp,
+                                        kin_session.as_deref(),
+                                        &server_tool_names,
+                                        &call.arguments,
+                                        &mut writer,
+                                    )?;
+                                    let outcome = match tool {
+                                        LocalTool::Edit => {
+                                            belt::run_edit(&config.repo, &call.arguments)
+                                        }
+                                        LocalTool::Write => {
+                                            belt::run_write(&config.repo, &call.arguments)
+                                        }
+                                    };
+                                    let provenance = close_transaction(
+                                        &mut mcp,
+                                        bracket,
+                                        !outcome.is_error,
+                                        &mut writer,
+                                    )?;
+                                    if let Some(path) = outcome.changed.clone() {
+                                        if !counters.edits.contains(&path) {
+                                            counters.edits.push(path);
+                                        }
+                                    }
+                                    writer.trace(json!({
+                                        "tool_use_id": call.id,
+                                        "surface": "local",
+                                        "tool": call.name,
+                                        "args": redact_content(&call.arguments),
+                                        "wall_ms": started_call.elapsed().as_millis() as u64,
+                                        "is_error": outcome.is_error,
+                                        "policy": "allowed",
+                                        "call_shape": call.shape.as_str(),
+                                        "changed": outcome.changed,
+                                        "provenance": provenance,
+                                    }))?;
+                                    (outcome.text, outcome.is_error)
+                                }
+                            }
+                        }
+                    };
+
+                    writer.tool_result(&call.id, &result_text, is_error)?;
+                    messages.push(json!({
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "content": result_text,
+                    }));
+
+                    if started.elapsed() >= config.deadline {
+                        status = ExitStatus::Deadline;
+                        stop_reason = "wall_deadline".into();
+                        break;
+                    }
+                }
+                if matches!(status, ExitStatus::Deadline) {
+                    break;
+                }
+            }
+        }
+    }
+
+    end_kin_session(&mut mcp, kin_session.as_deref(), &server_tool_names, &mut writer)?;
+    finish(
+        writer,
+        &config,
+        status,
+        &stop_reason,
+        &final_text,
+        counters,
+        started,
+        None,
+    )
+}
+
+/// Append what Kin said about its own answer, so an untrusted absence cannot be read as
+/// an absence and a degraded graph is stated once rather than silently.
+fn annotate(outcome: &ToolOutcome, counters: &mut Counters, surfaced_degraded: &mut bool) -> String {
+    let mut text = outcome.text.clone();
+    if outcome.safe_to_conclude_absent() == Some(false) {
+        counters.unsafe_absence_events += 1;
+        let gap = outcome
+            .limiting_factor()
+            .unwrap_or_else(|| "Kin did not name the limiting factor".to_string());
+        text.push_str(&format!(
+            "\n\n[kin] This result is empty and Kin reports the absence CANNOT be trusted: {gap}. \
+             Treat this as unknown rather than absent. Say what is unknown and name the gap. Do \
+             not conclude the thing does not exist, and do not try to answer it another way."
+        ));
+    }
+    if !*surfaced_degraded {
+        let degraded = outcome.degraded();
+        if !degraded.is_empty() {
+            *surfaced_degraded = true;
+            text.push_str(&format!(
+                "\n\n[kin] Coverage note, reported once for this run: {}. Answers may be \
+                 incomplete; say so where it matters.",
+                degraded.join(", ")
+            ));
+        }
+    }
+    if outcome.unreadable {
+        text.push_str(
+            "\n\n[kin] The response payload could not be parsed, so no coverage or absence \
+             verdict is available for this call. Treat it as unread rather than empty.",
+        );
+    }
+    text
+}
+
+fn negative_summary(outcome: &ToolOutcome) -> Value {
+    match outcome.negative.as_ref() {
+        None => Value::Null,
+        Some(_) => {
+            let mut map = Map::new();
+            map.insert("present".into(), Value::Bool(true));
+            map.insert(
+                "safe_to_conclude_absent".into(),
+                match outcome.safe_to_conclude_absent() {
+                    Some(value) => Value::Bool(value),
+                    None => Value::Null,
+                },
+            );
+            if let Some(factor) = outcome.limiting_factor() {
+                map.insert("limiting_factor".into(), Value::String(factor));
+            }
+            Value::Object(map)
+        }
+    }
+}
+
+/// Keep a whole written file out of the trace row; the transcript already carries it.
+fn redact_content(arguments: &Value) -> Value {
+    let Some(object) = arguments.as_object() else {
+        return arguments.clone();
+    };
+    let mut copy = object.clone();
+    for key in ["content", "replace", "find"] {
+        if let Some(Value::String(text)) = copy.get(key) {
+            let len = text.len();
+            copy.insert(key.into(), Value::String(format!("<{len} bytes>")));
+        }
+    }
+    Value::Object(copy)
+}
+
+fn check_arguments(belt: &Belt, name: &str, arguments: &Value) -> Result<(), String> {
+    if let Some(problem) = parse::arguments_are_malformed(arguments) {
+        return Err(problem);
+    }
+    match belt.schema_for(name) {
+        Some(schema) => belt::validate_arguments(&schema, arguments),
+        None => Ok(()),
+    }
+}
+
+fn complete_with_retry(
+    provider: &Provider,
+    messages: &[Value],
+    tools: &[Value],
+    counters: &mut Counters,
+) -> Result<crate::provider::Completion, ProviderError> {
+    let mut last: Option<ProviderError> = None;
+    for attempt in 0..ENDPOINT_ATTEMPTS {
+        match provider.complete(messages, tools) {
+            Ok(completion) => {
+                counters.api_ms += completion.api_ms;
+                return Ok(completion);
+            }
+            Err(err) => {
+                // A rejected request will be rejected again; only a transport hiccup is
+                // worth a second try.
+                let retryable = matches!(err, ProviderError::Transport { .. });
+                last = Some(err);
+                if !retryable || attempt + 1 == ENDPOINT_ATTEMPTS {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(500 * (attempt as u64 + 1)));
+            }
+        }
+    }
+    Err(last.expect("at least one attempt was made"))
+}
+
+fn start_kin_session(
+    mcp: &mut McpClient,
+    config: &AgentConfig,
+    server_tools: &[String],
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<Option<String>> {
+    if !server_tools.iter().any(|name| name == "kin_session_start") {
+        writer.trace(json!({
+            "surface": "policy",
+            "policy": "allowed",
+            "event": "session_unavailable",
+            "detail": "the server does not expose kin_session_start; edits will carry no session provenance",
+        }))?;
+        return Ok(None);
+    }
+    let arguments = json!({
+        "vendor": "kin-agent",
+        "client_name": format!("kin-agent ({})", config.provider.model),
+        "transport": "mcp",
+        "pid": std::process::id(),
+        "cwd": config.repo.display().to_string(),
+        "capabilities": { "can_read": true, "can_write": true, "can_commit": true },
+    });
+    match mcp.call_tool("kin_session_start", &arguments) {
+        Ok(outcome) => {
+            let session = extract_id(&outcome, &["session_id", "id"]);
+            writer.trace(json!({
+                "surface": "kin",
+                "tool": "kin_session_start",
+                "policy": "allowed",
+                "event": "session_start",
+                "wall_ms": outcome.wall_ms as u64,
+                "is_error": outcome.is_error,
+                "kin_session_id": session.clone(),
+            }))?;
+            Ok(if outcome.is_error { None } else { session })
+        }
+        Err(err) => {
+            writer.trace(json!({
+                "surface": "kin",
+                "tool": "kin_session_start",
+                "policy": "allowed",
+                "event": "session_start",
+                "is_error": true,
+                "transport_error": err.to_string(),
+            }))?;
+            Ok(None)
+        }
+    }
+}
+
+fn end_kin_session(
+    mcp: &mut McpClient,
+    session: Option<&str>,
+    server_tools: &[String],
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<()> {
+    let Some(session) = session else {
+        return Ok(());
+    };
+    if !server_tools.iter().any(|name| name == "kin_session_end") {
+        return Ok(());
+    }
+    let outcome = mcp.call_tool("kin_session_end", &json!({ "session_id": session }));
+    writer.trace(json!({
+        "surface": "kin",
+        "tool": "kin_session_end",
+        "policy": "allowed",
+        "event": "session_end",
+        "is_error": outcome.as_ref().map(|o| o.is_error).unwrap_or(true),
+        "transport_error": outcome.as_ref().err().map(|e| e.to_string()),
+    }))?;
+    Ok(())
+}
+
+/// An open provenance bracket around one local edit.
+struct Bracket {
+    transaction_id: Option<String>,
+    reason: Option<String>,
+}
+
+fn begin_transaction(
+    mcp: &mut McpClient,
+    session: Option<&str>,
+    server_tools: &[String],
+    arguments: &Value,
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<Bracket> {
+    let Some(session) = session else {
+        return Ok(Bracket {
+            transaction_id: None,
+            reason: Some("no Kin session was open".into()),
+        });
+    };
+    if !server_tools.iter().any(|name| name == "kin_transaction_begin") {
+        return Ok(Bracket {
+            transaction_id: None,
+            reason: Some("the server does not expose kin_transaction_begin".into()),
+        });
+    }
+    let scope = arguments
+        .get("path")
+        .and_then(Value::as_str)
+        .unwrap_or("repository")
+        .to_string();
+    match mcp.call_tool(
+        "kin_transaction_begin",
+        &json!({ "session_id": session, "scope": scope }),
+    ) {
+        Ok(outcome) if !outcome.is_error => {
+            let transaction_id = extract_id(&outcome, &["transaction_id", "id"]);
+            writer.trace(json!({
+                "surface": "kin",
+                "tool": "kin_transaction_begin",
+                "policy": "allowed",
+                "event": "transaction_begin",
+                "scope": scope,
+                "wall_ms": outcome.wall_ms as u64,
+                "is_error": false,
+                "transaction_id": transaction_id.clone(),
+            }))?;
+            Ok(Bracket {
+                reason: transaction_id
+                    .is_none()
+                    .then(|| "the server returned no transaction id".to_string()),
+                transaction_id,
+            })
+        }
+        Ok(outcome) => {
+            writer.trace(json!({
+                "surface": "kin",
+                "tool": "kin_transaction_begin",
+                "policy": "allowed",
+                "event": "transaction_begin",
+                "scope": scope,
+                "is_error": true,
+                "detail": truncate(&outcome.text, 300),
+            }))?;
+            Ok(Bracket {
+                transaction_id: None,
+                reason: Some(truncate(&outcome.text, 200)),
+            })
+        }
+        Err(err) => Ok(Bracket {
+            transaction_id: None,
+            reason: Some(err.to_string()),
+        }),
+    }
+}
+
+/// Close the bracket. The recorded provenance says what actually happened, including a
+/// refusal, so a run never claims a provenance it did not get.
+fn close_transaction(
+    mcp: &mut McpClient,
+    bracket: Bracket,
+    succeeded: bool,
+    writer: &mut TranscriptWriter,
+) -> anyhow::Result<Value> {
+    let Some(transaction_id) = bracket.transaction_id else {
+        return Ok(json!({
+            "bracketed": false,
+            "reason": bracket.reason,
+        }));
+    };
+    let tool = if succeeded {
+        "kin_transaction_commit"
+    } else {
+        "kin_transaction_abort"
+    };
+    let outcome = mcp.call_tool(tool, &json!({ "transaction_id": transaction_id }));
+    let (is_error, detail) = match &outcome {
+        Ok(outcome) => (outcome.is_error, truncate(&outcome.text, 300)),
+        Err(err) => (true, err.to_string()),
+    };
+    writer.trace(json!({
+        "surface": "kin",
+        "tool": tool,
+        "policy": "allowed",
+        "event": if succeeded { "transaction_commit" } else { "transaction_abort" },
+        "transaction_id": transaction_id,
+        "is_error": is_error,
+        "detail": detail,
+    }))?;
+    Ok(json!({
+        "bracketed": true,
+        "transaction_id": transaction_id,
+        "closed_with": tool,
+        "closed_cleanly": !is_error,
+        "detail": if is_error { Value::String(detail) } else { Value::Null },
+    }))
+}
+
+fn extract_id(outcome: &ToolOutcome, keys: &[&str]) -> Option<String> {
+    let payload: Value = serde_json::from_str(outcome.text.trim()).ok()?;
+    let object = payload.as_object()?;
+    for key in keys {
+        if let Some(Value::String(value)) = object.get(*key) {
+            return Some(value.clone());
+        }
+    }
+    // Some handlers nest the identity one level down.
+    for nested in ["session", "transaction", "result"] {
+        if let Some(inner) = object.get(nested).and_then(Value::as_object) {
+            for key in keys {
+                if let Some(Value::String(value)) = inner.get(*key) {
+                    return Some(value.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn truncate(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    text.chars().take(limit).collect::<String>() + "..."
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish(
+    mut writer: TranscriptWriter,
+    config: &AgentConfig,
+    status: ExitStatus,
+    stop_reason: &str,
+    final_text: &str,
+    counters: Counters,
+    started: Instant,
+    _reserved: Option<()>,
+) -> anyhow::Result<RunOutcome> {
+    let record = writer.result(
+        status.subtype(),
+        status != ExitStatus::Success,
+        counters.turns,
+        started.elapsed().as_millis(),
+        counters.api_ms,
+        final_text,
+        counters.usage_json(),
+        counters.to_json(status.code(), stop_reason),
+    )?;
+    std::fs::write(
+        config.out_dir.join("result.json"),
+        serde_json::to_string_pretty(&record)?,
+    )?;
+    Ok(RunOutcome {
+        status,
+        final_text: final_text.to_string(),
+        transcript_path: config.out_dir.join("transcript.jsonl"),
+        trace_path: config.out_dir.join("kin-trace.jsonl"),
+        result: record,
+    })
+}
+
+/// Used by `kin agent doctor` to prove the MCP side answers.
+pub fn probe_mcp(
+    argv: &[String],
+    repo: &Path,
+    timeout: Duration,
+) -> Result<Vec<String>, crate::mcp::McpError> {
+    let mut client = McpClient::start(argv, repo, timeout)?;
+    Ok(client
+        .list_tools()?
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect())
+}
+
+/// Timestamp helper re-exported so callers can stamp their own records the same way.
+pub fn timestamp() -> String {
+    now_iso()
+}

--- a/crates/kin-agent/src/tests.rs
+++ b/crates/kin-agent/src/tests.rs
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Unit tests for the parsers, the router, the envelope reading and path safety.
+
+use crate::belt::{self, Belt, LocalTool, Route};
+use crate::mcp::unwrap_tool_result;
+use crate::parse::{self, CallShape, Turn};
+use serde_json::json;
+use std::collections::BTreeSet;
+
+fn belt_names() -> BTreeSet<String> {
+    ["mcp__kin__semantic_locate", "edit_file", "write_file"]
+        .into_iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[test]
+fn native_tool_calls_are_read() {
+    let choice = json!({
+        "message": {
+            "role": "assistant",
+            "content": "Looking that up.",
+            "tool_calls": [{
+                "id": "call_abc",
+                "type": "function",
+                "function": {
+                    "name": "mcp__kin__semantic_locate",
+                    "arguments": "{\"query\": \"where is parse_choice\"}"
+                }
+            }]
+        },
+        "finish_reason": "tool_calls"
+    });
+    let Turn::ToolCalls { text, calls } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(text, "Looking that up.");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "mcp__kin__semantic_locate");
+    assert_eq!(calls[0].shape, CallShape::Native);
+    assert_eq!(calls[0].arguments["query"], "where is parse_choice");
+}
+
+#[test]
+fn qwen_text_shaped_tool_calls_are_read() {
+    // Qwen answers in prose with the call marked up rather than filling tool_calls.
+    let choice = json!({
+        "message": {
+            "role": "assistant",
+            "content": "I will search.\n<tool_call>\n<function=mcp__kin__semantic_locate>\n<parameter=query>\nauthentication middleware\n</parameter>\n<parameter=limit>\n5\n</parameter>\n</function>\n</tool_call>"
+        },
+        "finish_reason": "stop"
+    });
+    let Turn::ToolCalls { text, calls } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].shape, CallShape::QwenText);
+    assert_eq!(calls[0].arguments["query"], "authentication middleware");
+    // A bare number in a parameter block becomes a number, not the string "5".
+    assert_eq!(calls[0].arguments["limit"], 5);
+    // The markup is stripped out of the prose the transcript records.
+    assert_eq!(text, "I will search.");
+}
+
+#[test]
+fn gemma_text_shaped_tool_calls_are_read() {
+    let choice = json!({
+        "message": {
+            "role": "assistant",
+            "content": "<|tool_call>call: mcp__kin__semantic_locate{\"query\": \"token refresh\"}<tool_call|>"
+        },
+        "finish_reason": "stop"
+    });
+    let Turn::ToolCalls { calls, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].shape, CallShape::GemmaText);
+    assert_eq!(calls[0].arguments["query"], "token refresh");
+}
+
+#[test]
+fn gemma_special_quote_tokens_are_normalized() {
+    let choice = json!({
+        "message": {
+            "role": "assistant",
+            "content": "<|tool_call>call: functions.mcp__kin__semantic_locate{<|\"|>query<|\"|>: <|\"|>retry backoff<|\"|>}<tool_call|>"
+        }
+    });
+    let Turn::ToolCalls { calls, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(calls[0].name, "mcp__kin__semantic_locate");
+    assert_eq!(calls[0].arguments["query"], "retry backoff");
+}
+
+#[test]
+fn json_text_shaped_tool_calls_are_read() {
+    let choice = json!({
+        "message": {
+            "role": "assistant",
+            "content": "<tool_call>{\"name\": \"mcp__kin__semantic_locate\", \"arguments\": {\"query\": \"cache eviction\"}}</tool_call>"
+        }
+    });
+    let Turn::ToolCalls { calls, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(calls[0].shape, CallShape::JsonText);
+    assert_eq!(calls[0].arguments["query"], "cache eviction");
+}
+
+#[test]
+fn a_text_shaped_call_for_an_unknown_tool_is_not_minted() {
+    // Prose that merely mentions a tool must not become a call, which is why the text
+    // readers only recognize names that are actually in the belt.
+    let choice = json!({
+        "message": {
+            "role": "assistant",
+            "content": "<tool_call><function=run_shell><parameter=cmd>ls</parameter></function></tool_call>"
+        }
+    });
+    let turn = parse::parse_choice(&choice, &belt_names());
+    assert!(
+        !matches!(turn, Turn::ToolCalls { .. }),
+        "an off-belt name must not become a call: {turn:?}"
+    );
+}
+
+#[test]
+fn plain_prose_is_a_final_answer() {
+    let choice = json!({
+        "message": { "role": "assistant", "content": "The parser lives in parse.rs." },
+        "finish_reason": "stop"
+    });
+    assert_eq!(
+        parse::parse_choice(&choice, &belt_names()),
+        Turn::Final {
+            text: "The parser lives in parse.rs.".into()
+        }
+    );
+}
+
+#[test]
+fn an_empty_turn_is_unusable_and_says_why() {
+    let choice =
+        json!({ "message": { "role": "assistant", "content": "" }, "finish_reason": "stop" });
+    let Turn::Unusable { reason, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected unusable");
+    };
+    assert!(reason.contains("no content"), "reason was: {reason}");
+}
+
+#[test]
+fn a_truncated_turn_is_unusable_and_says_why() {
+    let choice = json!({
+        "message": { "role": "assistant", "content": "I was about to call" },
+        "finish_reason": "length"
+    });
+    let Turn::Unusable { reason, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected unusable");
+    };
+    assert!(reason.contains("cut off"), "reason was: {reason}");
+}
+
+#[test]
+fn malformed_arguments_are_reported_not_silently_emptied() {
+    let choice = json!({
+        "message": {
+            "tool_calls": [{
+                "id": "call_1",
+                "function": { "name": "mcp__kin__semantic_locate", "arguments": "{query: broken" }
+            }]
+        }
+    });
+    let Turn::ToolCalls { calls, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    let problem = parse::arguments_are_malformed(&calls[0].arguments)
+        .expect("malformed arguments must be reported");
+    assert!(problem.contains("not valid JSON"), "problem was: {problem}");
+}
+
+#[test]
+fn well_formed_arguments_are_not_reported_as_malformed() {
+    // The control for the test above: the same check must stay quiet on a good call.
+    let choice = json!({
+        "message": {
+            "tool_calls": [{
+                "id": "call_1",
+                "function": { "name": "mcp__kin__semantic_locate", "arguments": "{\"query\": \"fine\"}" }
+            }]
+        }
+    });
+    let Turn::ToolCalls { calls, .. } = parse::parse_choice(&choice, &belt_names()) else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(parse::arguments_are_malformed(&calls[0].arguments), None);
+}
+
+fn test_belt() -> Belt {
+    Belt::new(vec![(
+        "semantic_locate".to_string(),
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["query"]
+        }),
+    )])
+}
+
+#[test]
+fn the_router_refuses_a_tool_that_is_not_on_the_belt() {
+    let belt = test_belt();
+    for name in [
+        "bash",
+        "Bash",
+        "run_shell",
+        "grep",
+        "Grep",
+        "read_file",
+        "Read",
+        "glob",
+    ] {
+        let Route::Refused(message) = belt.route(name) else {
+            panic!("`{name}` must be refused, not routed");
+        };
+        assert!(
+            message.contains("no shell") || message.contains("no tool named"),
+            "the refusal must say why: {message}"
+        );
+    }
+}
+
+#[test]
+fn the_router_routes_what_is_on_the_belt() {
+    // The control: the same router must still route the real tools.
+    let belt = test_belt();
+    assert_eq!(
+        belt.route("mcp__kin__semantic_locate"),
+        Route::Kin("semantic_locate".into())
+    );
+    assert_eq!(belt.route("edit_file"), Route::Local(LocalTool::Edit));
+    assert_eq!(belt.route("write_file"), Route::Local(LocalTool::Write));
+}
+
+#[test]
+fn a_bare_kin_tool_name_is_refused_with_the_prefixed_name() {
+    let belt = test_belt();
+    let Route::Refused(message) = belt.route("semantic_locate") else {
+        panic!("the unprefixed name is not callable");
+    };
+    assert!(
+        message.contains("mcp__kin__semantic_locate"),
+        "the refusal must name the real tool: {message}"
+    );
+}
+
+#[test]
+fn harness_owned_tools_never_reach_the_model() {
+    for name in [
+        "kin_session_start",
+        "kin_session_end",
+        "kin_transaction_begin",
+        "kin_transaction_commit",
+        "kin_transaction_abort",
+    ] {
+        assert!(belt::is_harness_owned(name), "{name} must be harness owned");
+    }
+    assert!(!belt::is_harness_owned("semantic_locate"));
+    assert!(!belt::is_harness_owned("get_context_pack"));
+}
+
+#[test]
+fn missing_required_arguments_are_named() {
+    let belt = test_belt();
+    let schema = belt.schema_for("mcp__kin__semantic_locate").unwrap();
+    let problem = belt::validate_arguments(&schema, &json!({ "limit": 5 })).unwrap_err();
+    assert!(problem.contains("`query`"), "problem was: {problem}");
+    // The control: the same schema accepts a good call.
+    assert!(belt::validate_arguments(&schema, &json!({ "query": "x", "limit": 5 })).is_ok());
+}
+
+#[test]
+fn a_wrongly_typed_argument_is_named() {
+    let belt = test_belt();
+    let schema = belt.schema_for("mcp__kin__semantic_locate").unwrap();
+    let problem =
+        belt::validate_arguments(&schema, &json!({ "query": "x", "limit": "five" })).unwrap_err();
+    assert!(problem.contains("`limit`"), "problem was: {problem}");
+    assert!(problem.contains("integer"), "problem was: {problem}");
+}
+
+#[test]
+fn an_untrusted_absence_is_read_off_the_payload() {
+    // The payload lives inside content[0].text; reading the wrapper's top level finds
+    // nothing, which is how an unreadable value once became a confident zero.
+    let result = json!({
+        "content": [{
+            "type": "text",
+            "text": json!({
+                "results": [],
+                "_kin": { "envelope_version": "1", "runtime": "RepoDaemon", "semantic_coverage": 0.4 },
+                "negative": { "safe_to_conclude_absent": false, "limiting_factor": "python bodies are not indexed" }
+            }).to_string()
+        }],
+        "isError": false
+    });
+    let outcome = unwrap_tool_result(&result, 12);
+    assert_eq!(outcome.safe_to_conclude_absent(), Some(false));
+    assert_eq!(
+        outcome.limiting_factor().as_deref(),
+        Some("python bodies are not indexed")
+    );
+    assert!(!outcome.unreadable);
+    let summary = outcome.envelope_summary().expect("an envelope was present");
+    assert_eq!(summary["runtime"], "RepoDaemon");
+}
+
+#[test]
+fn a_trusted_absence_reads_as_trusted() {
+    // The control: the same reader must report true when the verdict is true, or the
+    // check above would pass for a reader that always says false.
+    let result = json!({
+        "content": [{ "type": "text", "text": json!({
+            "results": [],
+            "negative": { "safe_to_conclude_absent": true }
+        }).to_string() }],
+        "isError": false
+    });
+    let outcome = unwrap_tool_result(&result, 3);
+    assert_eq!(outcome.safe_to_conclude_absent(), Some(true));
+}
+
+#[test]
+fn a_result_with_no_verdict_reports_none_not_false() {
+    let result = json!({
+        "content": [{ "type": "text", "text": json!({ "results": [1, 2] }).to_string() }],
+        "isError": false
+    });
+    let outcome = unwrap_tool_result(&result, 3);
+    assert_eq!(outcome.safe_to_conclude_absent(), None);
+    assert!(outcome.negative.is_none());
+}
+
+#[test]
+fn an_mcp_error_survives_into_the_outcome() {
+    // An MCP error is a successful JSON-RPC response, so isError must be read off the
+    // result rather than inferred from transport success.
+    let result = json!({
+        "content": [{ "type": "text", "text": "no such entity" }],
+        "isError": true
+    });
+    assert!(unwrap_tool_result(&result, 1).is_error);
+}
+
+#[test]
+fn an_unparsable_structured_payload_is_unreadable_not_empty() {
+    let result = json!({
+        "content": [{ "type": "text", "text": "{\"results\": [ truncated" }],
+        "isError": false
+    });
+    let outcome = unwrap_tool_result(&result, 1);
+    assert!(outcome.unreadable, "a truncated payload must be unreadable");
+    assert!(outcome.envelope.is_none());
+    // Plain prose is not a structured payload and is not unreadable.
+    let prose = json!({ "content": [{ "type": "text", "text": "3 results" }] });
+    assert!(!unwrap_tool_result(&prose, 1).unreadable);
+}
+
+#[test]
+fn degraded_flags_are_read_in_every_shape_the_envelope_uses() {
+    let array = json!({ "content": [{ "type": "text", "text": json!({
+        "_kin": { "degraded": ["embeddings", "lsp"] }
+    }).to_string() }] });
+    assert_eq!(
+        unwrap_tool_result(&array, 1).degraded(),
+        vec!["embeddings".to_string(), "lsp".to_string()]
+    );
+
+    let object = json!({ "content": [{ "type": "text", "text": json!({
+        "_kin": { "degraded": { "embeddings": true, "lsp": false } }
+    }).to_string() }] });
+    assert_eq!(
+        unwrap_tool_result(&object, 1).degraded(),
+        vec!["embeddings".to_string()]
+    );
+
+    // The control: an envelope with nothing degraded reports nothing.
+    let clean = json!({ "content": [{ "type": "text", "text": json!({
+        "_kin": { "degraded": [] }
+    }).to_string() }] });
+    assert!(unwrap_tool_result(&clean, 1).degraded().is_empty());
+}
+
+#[test]
+fn a_path_cannot_escape_the_repository() {
+    let repo = std::path::Path::new("/tmp/kin-agent-fixture");
+    for raw in ["../outside.txt", "a/../../outside.txt", "/etc/passwd", "/"] {
+        assert!(
+            belt::resolve_in_repo(repo, raw).is_err(),
+            "`{raw}` must be refused"
+        );
+    }
+    // The control: an ordinary relative path resolves, and so does an absolute path that
+    // is genuinely inside the repository.
+    assert_eq!(
+        belt::resolve_in_repo(repo, "src/main.rs").unwrap(),
+        repo.join("src/main.rs")
+    );
+    assert_eq!(
+        belt::resolve_in_repo(repo, "/tmp/kin-agent-fixture/src/lib.rs").unwrap(),
+        repo.join("src/lib.rs")
+    );
+}
+
+#[test]
+fn edit_file_refuses_an_ambiguous_find() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.txt"), "x\nx\n").unwrap();
+    let outcome = belt::run_edit(
+        dir.path(),
+        &json!({ "path": "a.txt", "find": "x", "replace": "y" }),
+    );
+    assert!(outcome.is_error);
+    assert!(outcome.text.contains("2 times"), "{}", outcome.text);
+    // The file is untouched, so an ambiguous edit cannot half-apply.
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("a.txt")).unwrap(),
+        "x\nx\n"
+    );
+    // The control: a unique find lands.
+    std::fs::write(dir.path().join("b.txt"), "hello world\n").unwrap();
+    let ok = belt::run_edit(
+        dir.path(),
+        &json!({ "path": "b.txt", "find": "world", "replace": "kin" }),
+    );
+    assert!(!ok.is_error, "{}", ok.text);
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("b.txt")).unwrap(),
+        "hello kin\n"
+    );
+    assert_eq!(ok.changed.as_deref(), Some("b.txt"));
+}
+
+#[test]
+fn edit_file_refuses_a_find_that_is_not_present() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    let outcome = belt::run_edit(
+        dir.path(),
+        &json!({ "path": "a.txt", "find": "goodbye", "replace": "y" }),
+    );
+    assert!(outcome.is_error);
+    assert!(outcome.text.contains("does not appear"), "{}", outcome.text);
+}
+
+#[test]
+fn write_file_creates_parents_and_reports_which_path_changed() {
+    let dir = tempfile::tempdir().unwrap();
+    let outcome = belt::run_write(
+        dir.path(),
+        &json!({ "path": "docs/new.md", "content": "# hi\n" }),
+    );
+    assert!(!outcome.is_error, "{}", outcome.text);
+    assert_eq!(outcome.changed.as_deref(), Some("docs/new.md"));
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("docs/new.md")).unwrap(),
+        "# hi\n"
+    );
+}
+
+#[test]
+fn the_belt_exposes_only_kin_tools_plus_the_two_local_ones() {
+    let belt = test_belt();
+    let names: Vec<&str> = belt.names().iter().map(String::as_str).collect();
+    assert_eq!(
+        names,
+        vec!["edit_file", "mcp__kin__semantic_locate", "write_file"]
+    );
+    // No shell, search or read tool exists to be routed, which is the policy.
+    for absent in ["bash", "shell", "grep", "rg", "find", "read_file", "cat"] {
+        assert!(
+            !belt.names().contains(absent),
+            "`{absent}` must not be in the belt"
+        );
+    }
+}
+
+#[test]
+fn base_urls_normalize_to_one_endpoint() {
+    use crate::provider::ProviderConfig;
+    for raw in [
+        "http://127.0.0.1:1234",
+        "http://127.0.0.1:1234/",
+        "http://127.0.0.1:1234/v1",
+        "http://127.0.0.1:1234/v1/",
+    ] {
+        assert_eq!(
+            ProviderConfig::normalize_base_url(raw),
+            "http://127.0.0.1:1234/v1",
+            "for {raw}"
+        );
+    }
+}
+
+#[test]
+fn a_named_api_key_variable_that_is_unset_fails_loudly() {
+    use crate::provider::ProviderConfig;
+    // Silently sending no key would surface later as a 401 that reads like a bad model id.
+    assert!(ProviderConfig::api_key_from_env(Some("KIN_AGENT_KEY_THAT_IS_NOT_SET")).is_err());
+    assert_eq!(ProviderConfig::api_key_from_env(None).unwrap(), None);
+}

--- a/crates/kin-agent/src/transcript.rs
+++ b/crates/kin-agent/src/transcript.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Transcript writers.
+//!
+//! Two files. `transcript.jsonl` is the Claude Code stream-json shape, because that is
+//! what the fleet's analyzers already read, and emitting anything else would mean writing
+//! new analyzers to measure a run. Every record carries a timestamp, because per-call
+//! latency is derived by subtracting a `tool_use` stamp from its matching `tool_result`
+//! and a record without one silently drops out of the timing.
+//!
+//! `kin-trace.jsonl` is the sidecar, one row per tool call, joinable on `tool_use_id`.
+//! Everything Kin-specific lives there rather than in the stream, so a strict reader of
+//! the stream never chokes and the existing analyzers keep working untouched.
+
+use serde_json::{json, Map, Value};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+/// An RFC3339 UTC timestamp with milliseconds, the shape the analyzers parse.
+pub fn now_iso() -> String {
+    chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
+pub struct TranscriptWriter {
+    stream: BufWriter<File>,
+    trace: BufWriter<File>,
+    session_id: String,
+}
+
+impl TranscriptWriter {
+    pub fn create(out_dir: &Path, session_id: &str) -> std::io::Result<Self> {
+        std::fs::create_dir_all(out_dir)?;
+        Ok(TranscriptWriter {
+            stream: BufWriter::new(File::create(out_dir.join("transcript.jsonl"))?),
+            trace: BufWriter::new(File::create(out_dir.join("kin-trace.jsonl"))?),
+            session_id: session_id.to_string(),
+        })
+    }
+
+    fn write_stream(&mut self, mut record: Value) -> std::io::Result<()> {
+        if let Some(object) = record.as_object_mut() {
+            object.insert("session_id".into(), Value::String(self.session_id.clone()));
+            object.entry("timestamp").or_insert_with(|| Value::String(now_iso()));
+        }
+        writeln!(self.stream, "{record}")?;
+        self.stream.flush()
+    }
+
+    /// The init record. `mcp_server_errors` is non-empty exactly when Kin never attached,
+    /// which is the one condition under which a run must not be scored as a Kin run.
+    #[allow(clippy::too_many_arguments)]
+    pub fn init(
+        &mut self,
+        model: &str,
+        cwd: &Path,
+        tools: &[String],
+        mcp_status: &str,
+        mcp_errors: &[String],
+        agent_meta: Value,
+    ) -> std::io::Result<()> {
+        self.write_stream(json!({
+            "type": "system",
+            "subtype": "init",
+            "model": model,
+            "cwd": cwd.display().to_string(),
+            "permissionMode": "kin-agent",
+            "tools": tools,
+            "mcp_servers": [{ "name": "kin", "status": mcp_status }],
+            "mcp_server_errors": mcp_errors,
+            "kin_agent": agent_meta,
+        }))
+    }
+
+    /// One model turn: its prose and the tool calls it asked for.
+    pub fn assistant(
+        &mut self,
+        model: &str,
+        message_id: &str,
+        text: &str,
+        tool_uses: &[(String, String, Value)],
+        usage: Option<Value>,
+    ) -> std::io::Result<()> {
+        let mut content = Vec::new();
+        if !text.trim().is_empty() {
+            content.push(json!({ "type": "text", "text": text }));
+        }
+        for (id, name, input) in tool_uses {
+            content.push(json!({
+                "type": "tool_use",
+                "id": id,
+                "name": name,
+                "input": input,
+            }));
+        }
+        let mut message = Map::new();
+        message.insert("id".into(), Value::String(message_id.to_string()));
+        message.insert("type".into(), Value::String("message".into()));
+        message.insert("role".into(), Value::String("assistant".into()));
+        message.insert("model".into(), Value::String(model.to_string()));
+        message.insert("content".into(), Value::Array(content));
+        // Usage is written only when the endpoint reported it. An absent count stays
+        // absent rather than becoming a zero that reads like a measured value.
+        if let Some(usage) = usage {
+            message.insert("usage".into(), usage);
+        }
+        self.write_stream(json!({ "type": "assistant", "message": Value::Object(message) }))
+    }
+
+    /// One observation, written immediately after the call it answers.
+    pub fn tool_result(
+        &mut self,
+        tool_use_id: &str,
+        content: &str,
+        is_error: bool,
+    ) -> std::io::Result<()> {
+        self.write_stream(json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": content,
+                    "is_error": is_error,
+                }]
+            }
+        }))
+    }
+
+    /// The terminal record. Written on every exit path, including the failures, so a run
+    /// that died is still measurable rather than a truncated file.
+    #[allow(clippy::too_many_arguments)]
+    pub fn result(
+        &mut self,
+        subtype: &str,
+        is_error: bool,
+        num_turns: u32,
+        duration_ms: u128,
+        duration_api_ms: u128,
+        final_text: &str,
+        usage: Option<Value>,
+        kin_agent: Value,
+    ) -> std::io::Result<Value> {
+        let mut record = json!({
+            "type": "result",
+            "subtype": subtype,
+            "is_error": is_error,
+            "num_turns": num_turns,
+            "duration_ms": duration_ms as u64,
+            "duration_api_ms": duration_api_ms as u64,
+            "result": final_text,
+            "total_cost_usd": Value::Null,
+            "kin_agent": kin_agent,
+            "session_id": self.session_id.clone(),
+            "timestamp": now_iso(),
+        });
+        if let Some(usage) = usage {
+            record["usage"] = usage;
+        }
+        writeln!(self.stream, "{record}")?;
+        self.stream.flush()?;
+        Ok(record)
+    }
+
+    /// One sidecar row.
+    pub fn trace(&mut self, mut row: Value) -> std::io::Result<()> {
+        if let Some(object) = row.as_object_mut() {
+            object.entry("ts").or_insert_with(|| Value::String(now_iso()));
+            object.insert("session_id".into(), Value::String(self.session_id.clone()));
+        }
+        writeln!(self.trace, "{row}")?;
+        self.trace.flush()
+    }
+}

--- a/crates/kin-agent/src/transcript.rs
+++ b/crates/kin-agent/src/transcript.rs
@@ -44,7 +44,9 @@ impl TranscriptWriter {
     fn write_stream(&mut self, mut record: Value) -> std::io::Result<()> {
         if let Some(object) = record.as_object_mut() {
             object.insert("session_id".into(), Value::String(self.session_id.clone()));
-            object.entry("timestamp").or_insert_with(|| Value::String(now_iso()));
+            object
+                .entry("timestamp")
+                .or_insert_with(|| Value::String(now_iso()));
         }
         writeln!(self.stream, "{record}")?;
         self.stream.flush()
@@ -169,7 +171,9 @@ impl TranscriptWriter {
     /// One sidecar row.
     pub fn trace(&mut self, mut row: Value) -> std::io::Result<()> {
         if let Some(object) = row.as_object_mut() {
-            object.entry("ts").or_insert_with(|| Value::String(now_iso()));
+            object
+                .entry("ts")
+                .or_insert_with(|| Value::String(now_iso()));
             object.insert("session_id".into(), Value::String(self.session_id.clone()));
         }
         writeln!(self.trace, "{row}")?;

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -1,0 +1,831 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end tests for the loop.
+//!
+//! The model is a scripted OpenAI-compatible responder on a loopback socket, so a turn
+//! sequence is exact rather than sampled. The graph server is a scripted MCP stdio server
+//! for the hermetic tests and a real `kin mcp start` for the ignored one, so the wire
+//! contract is proven against the product rather than only against a stand-in.
+
+use kin_agent::{AgentConfig, ExitStatus, ProviderConfig};
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A scripted chat endpoint. Each request pops the next response off the script, so a
+/// test asserts on a fixed turn sequence instead of a model's mood.
+struct FakeEndpoint {
+    base_url: String,
+    handle: Option<std::thread::JoinHandle<Vec<Value>>>,
+}
+
+impl FakeEndpoint {
+    fn start(script: Vec<Value>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let mut seen = Vec::new();
+            for response in script.into_iter() {
+                let Ok((stream, _)) = listener.accept() else {
+                    break;
+                };
+                match serve_one(stream, &response) {
+                    Some(request) => seen.push(request),
+                    None => break,
+                }
+            }
+            seen
+        });
+        FakeEndpoint {
+            base_url: format!("http://127.0.0.1:{port}/v1"),
+            handle: Some(handle),
+        }
+    }
+
+    /// Every request body the endpoint received, in order.
+    fn requests(mut self) -> Vec<Value> {
+        self.handle
+            .take()
+            .expect("started")
+            .join()
+            .expect("endpoint thread")
+    }
+}
+
+fn serve_one(mut stream: TcpStream, response: &Value) -> Option<Value> {
+    let mut reader = BufReader::new(stream.try_clone().ok()?);
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some(value) = trimmed
+            .strip_prefix("Content-Length:")
+            .or_else(|| trimmed.strip_prefix("content-length:"))
+        {
+            content_length = value.trim().parse().ok()?;
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body).ok()?;
+    let request: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+
+    let payload = response.to_string();
+    let http = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        payload.len(),
+        payload
+    );
+    stream.write_all(http.as_bytes()).ok()?;
+    stream.flush().ok()?;
+    Some(request)
+}
+
+fn completion(content: &str, tool_calls: Option<Value>) -> Value {
+    let mut message = json!({ "role": "assistant", "content": content });
+    let finish = if tool_calls.is_some() {
+        "tool_calls"
+    } else {
+        "stop"
+    };
+    if let Some(calls) = tool_calls {
+        message["tool_calls"] = calls;
+    }
+    json!({
+        "id": "chatcmpl-test",
+        "choices": [{ "index": 0, "message": message, "finish_reason": finish }],
+        "usage": { "prompt_tokens": 100, "completion_tokens": 20 }
+    })
+}
+
+fn tool_call(id: &str, name: &str, arguments: Value) -> Value {
+    json!([{
+        "id": id,
+        "type": "function",
+        "function": { "name": name, "arguments": arguments.to_string() }
+    }])
+}
+
+/// Write a scripted MCP stdio server that speaks the real wire shapes: an `initialize`
+/// reply, a `tools/list` carrying the session and transaction tools, and tool results
+/// whose payload sits inside `content[0].text` with a `_kin` envelope.
+fn write_fake_mcp_server(dir: &Path) -> PathBuf {
+    let path = dir.join("fake_mcp_server.py");
+    std::fs::write(&path, FAKE_SERVER).expect("write fake server");
+    path
+}
+
+const FAKE_SERVER: &str = r#"#!/usr/bin/env python3
+import json, sys
+
+LOG = sys.argv[1]
+
+TOOLS = [
+    {"name": "semantic_locate", "description": "Find entities by meaning.",
+     "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}},
+                     "required": ["query"]}},
+    {"name": "get_entity_source", "description": "Read exact source.",
+     "inputSchema": {"type": "object", "properties": {"entity": {"type": "string"}},
+                     "required": ["entity"]}},
+    {"name": "kin_session_start", "description": "Start a session.",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "kin_session_end", "description": "End a session.",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "kin_transaction_begin", "description": "Begin a transaction.",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "kin_transaction_commit", "description": "Commit a transaction.",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "kin_transaction_abort", "description": "Abort a transaction.",
+     "inputSchema": {"type": "object", "properties": {}}},
+]
+
+ENVELOPE = {"envelope_version": "1", "runtime": "RepoDaemon",
+            "graph_as_of": "2026-08-18T00:00:00Z",
+            "semantic_coverage": 0.91, "degraded": []}
+
+
+def payload(obj, is_error=False):
+    return {"content": [{"type": "text", "text": json.dumps(obj)}], "isError": is_error}
+
+
+def call(name, args):
+    with open(LOG, "a") as fh:
+        fh.write(json.dumps({"tool": name, "args": args}) + "\n")
+    if name == "semantic_locate":
+        if args.get("query") == "nothing at all":
+            return payload({"results": [], "_kin": ENVELOPE,
+                            "negative": {"safe_to_conclude_absent": False,
+                                         "limiting_factor": "markdown bodies are not indexed"}})
+        return payload({"results": [{"name": "greet", "path": "src/greet.py", "line": 1}],
+                        "_kin": ENVELOPE})
+    if name == "get_entity_source":
+        return payload({"source": "def greet(name):\n    return name\n", "_kin": ENVELOPE})
+    if name == "kin_session_start":
+        return payload({"session_id": "sess-fixture-1", "_kin": ENVELOPE})
+    if name == "kin_session_end":
+        return payload({"ended": True, "_kin": ENVELOPE})
+    if name == "kin_transaction_begin":
+        return payload({"transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
+    if name == "kin_transaction_commit":
+        return payload({"committed": True, "transaction_id": "txn-fixture-1", "_kin": ENVELOPE})
+    if name == "kin_transaction_abort":
+        return payload({"aborted": True, "_kin": ENVELOPE})
+    return payload({"error": "unknown tool " + name}, is_error=True)
+
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method = msg.get("method")
+    if "id" not in msg:
+        continue
+    if method == "initialize":
+        result = {"protocolVersion": "2025-06-18", "capabilities": {"tools": {}},
+                  "serverInfo": {"name": "fake-kin", "version": "0"}}
+    elif method == "tools/list":
+        result = {"tools": TOOLS}
+    elif method == "tools/call":
+        params = msg.get("params", {})
+        result = call(params.get("name", ""), params.get("arguments", {}))
+    else:
+        result = {}
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg["id"], "result": result}) + "\n")
+    sys.stdout.flush()
+"#;
+
+fn fixture_repo(dir: &Path) -> PathBuf {
+    let repo = dir.join("repo");
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(
+        repo.join("src/greet.py"),
+        "def greet(name):\n    return f\"hello {name}\"\n",
+    )
+    .unwrap();
+    std::fs::write(repo.join("README.md"), "# fixture\n").unwrap();
+    repo
+}
+
+fn config(repo: &Path, out: &Path, base_url: &str, mcp_command: Vec<String>) -> AgentConfig {
+    AgentConfig {
+        task: "Find where greet is defined and add a one-line docstring.".into(),
+        system_prompt: Some("You are a test agent.".into()),
+        repo: repo.to_path_buf(),
+        out_dir: out.to_path_buf(),
+        provider: ProviderConfig {
+            base_url: ProviderConfig::normalize_base_url(base_url),
+            model: "fixture-model".into(),
+            api_key: None,
+            temperature: None,
+            request_timeout: Duration::from_secs(20),
+        },
+        mcp_command,
+        mcp_timeout: Duration::from_secs(60),
+        max_tool_calls: 10,
+        deadline: Duration::from_secs(120),
+        tool_profile: None,
+    }
+}
+
+fn read_jsonl(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("every transcript line is JSON"))
+        .collect()
+}
+
+/// A reader that mirrors what `usage.py` and `analyze.py` take off a transcript, so the
+/// shape is asserted against the fields the fleet's analyzers actually read.
+struct AnalyzerView {
+    init: Value,
+    result: Value,
+    tool_uses: Vec<(String, String, Value)>,
+    tool_results: Vec<(String, String, bool)>,
+    assistant_text: String,
+}
+
+fn analyze(records: &[Value]) -> AnalyzerView {
+    let mut init = Value::Null;
+    let mut result = Value::Null;
+    let mut tool_uses = Vec::new();
+    let mut tool_results = Vec::new();
+    let mut assistant_text = String::new();
+    for record in records {
+        // Every record must carry a timestamp or the analyzers lose their latency.
+        assert!(
+            record.get("timestamp").and_then(Value::as_str).is_some(),
+            "record without a timestamp: {record}"
+        );
+        match record.get("type").and_then(Value::as_str) {
+            Some("system") => init = record.clone(),
+            Some("result") => result = record.clone(),
+            Some("assistant") => {
+                for block in record
+                    .pointer("/message/content")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default()
+                {
+                    match block.get("type").and_then(Value::as_str) {
+                        Some("tool_use") => tool_uses.push((
+                            block["id"].as_str().unwrap().to_string(),
+                            block["name"].as_str().unwrap().to_string(),
+                            block["input"].clone(),
+                        )),
+                        Some("text") => {
+                            assistant_text.push_str(block["text"].as_str().unwrap_or_default())
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Some("user") => {
+                for block in record
+                    .pointer("/message/content")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default()
+                {
+                    if block.get("type").and_then(Value::as_str) == Some("tool_result") {
+                        tool_results.push((
+                            block["tool_use_id"].as_str().unwrap().to_string(),
+                            block["content"].as_str().unwrap_or_default().to_string(),
+                            block["is_error"].as_bool().unwrap_or(false),
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    AnalyzerView {
+        init,
+        result,
+        tool_uses,
+        tool_results,
+        assistant_text,
+    }
+}
+
+/// The log path travels as an argument rather than an environment variable, because the
+/// test binary runs its tests as threads in one process and a shared variable would race.
+fn mcp_command(server: &Path, log: &Path) -> Vec<String> {
+    vec![
+        "python3".to_string(),
+        server.display().to_string(),
+        log.display().to_string(),
+    ]
+}
+
+fn mcp_log(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn a_tool_call_reaches_kin_the_edit_is_bracketed_and_the_transcript_records_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "Let me find it.",
+            Some(tool_call(
+                "c1",
+                "mcp__kin__semantic_locate",
+                json!({ "query": "greet" }),
+            )),
+        ),
+        completion(
+            "Now the edit.",
+            Some(tool_call(
+                "c2",
+                "edit_file",
+                json!({
+                    "path": "src/greet.py",
+                    "find": "def greet(name):",
+                    "replace": "def greet(name):\n    \"\"\"Return a greeting for name.\"\"\""
+                }),
+            )),
+        ),
+        completion(
+            "greet is in src/greet.py and now carries a docstring.",
+            None,
+        ),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+
+    assert_eq!(outcome.status, ExitStatus::Success);
+    assert_eq!(
+        outcome.final_text,
+        "greet is in src/greet.py and now carries a docstring."
+    );
+
+    // The edit landed on disk.
+    let edited = std::fs::read_to_string(repo.join("src/greet.py")).unwrap();
+    assert!(
+        edited.contains("\"\"\"Return a greeting for name.\"\"\""),
+        "the docstring must be in the file: {edited}"
+    );
+
+    // The call reached the graph server, and the edit was bracketed by a transaction
+    // under a session, in that order.
+    let calls = mcp_log(&log);
+    let names: Vec<&str> = calls
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "kin_session_start",
+            "semantic_locate",
+            "kin_transaction_begin",
+            "kin_transaction_commit",
+            "kin_session_end"
+        ],
+        "the edit must be bracketed by begin/commit under a session"
+    );
+    assert_eq!(calls[1]["args"]["query"], "greet");
+
+    // The transcript records it in the shape the analyzers read.
+    let records = read_jsonl(&outcome.transcript_path);
+    let view = analyze(&records);
+    assert_eq!(view.init["subtype"], "init");
+    assert_eq!(view.init["model"], "fixture-model");
+    assert_eq!(view.init["mcp_servers"][0]["status"], "connected");
+    assert_eq!(view.init["mcp_server_errors"].as_array().unwrap().len(), 0);
+    let tools: Vec<&str> = view.init["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t.as_str().unwrap())
+        .collect();
+    assert!(tools.contains(&"mcp__kin__semantic_locate"));
+    assert!(tools.contains(&"edit_file"));
+    // The session and transaction tools are the harness's, never the model's.
+    assert!(!tools.iter().any(|name| name.contains("kin_transaction")));
+    assert!(!tools.iter().any(|name| name.contains("kin_session")));
+
+    assert_eq!(view.tool_uses.len(), 2);
+    assert_eq!(view.tool_uses[0].1, "mcp__kin__semantic_locate");
+    assert_eq!(view.tool_uses[1].1, "edit_file");
+    assert_eq!(view.tool_results.len(), 2);
+    // Each result is joinable to its call, which is how latency is derived.
+    assert_eq!(view.tool_uses[0].0, view.tool_results[0].0);
+    assert_eq!(view.tool_uses[1].0, view.tool_results[1].0);
+    assert!(!view.tool_results[0].2 && !view.tool_results[1].2);
+    assert!(view.assistant_text.contains("Let me find it."));
+
+    assert_eq!(view.result["subtype"], "success");
+    assert_eq!(view.result["kin_agent"]["exit_code"], 0);
+    assert_eq!(view.result["kin_agent"]["tool_calls"], 2);
+    assert_eq!(view.result["kin_agent"]["kin_calls"], 1);
+    assert_eq!(view.result["kin_agent"]["local_calls"], 1);
+    assert_eq!(view.result["kin_agent"]["files_changed"][0], "src/greet.py");
+    // Usage is carried through from the endpoint rather than defaulted.
+    assert_eq!(view.result["usage"]["input_tokens"], 300);
+
+    // The sidecar carries the envelope and the provenance, joinable on tool_use_id.
+    let trace = read_jsonl(&outcome.trace_path);
+    let locate = trace
+        .iter()
+        .find(|row| row["tool"] == "semantic_locate" && row["surface"] == "kin")
+        .expect("the Kin call is traced");
+    assert_eq!(locate["tool_use_id"], view.tool_uses[0].0);
+    assert_eq!(locate["envelope"]["runtime"], "RepoDaemon");
+    assert_eq!(locate["envelope"]["semantic_coverage"], 0.91);
+    assert_eq!(locate["policy"], "allowed");
+    let edit = trace
+        .iter()
+        .find(|row| row["surface"] == "local" && row["tool"] == "edit_file")
+        .expect("the local edit is traced");
+    assert_eq!(edit["provenance"]["bracketed"], true);
+    assert_eq!(edit["provenance"]["transaction_id"], "txn-fixture-1");
+    assert_eq!(edit["provenance"]["closed_with"], "kin_transaction_commit");
+    assert_eq!(edit["provenance"]["closed_cleanly"], true);
+    // The whole written body stays out of the trace row; the transcript already has it.
+    assert!(edit["args"]["replace"]
+        .as_str()
+        .unwrap()
+        .ends_with(" bytes>"));
+
+    let requests = endpoint.requests();
+    assert_eq!(requests.len(), 3);
+    // The belt reached the model, and the shell never did.
+    let sent: Vec<&str> = requests[0]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|spec| spec["function"]["name"].as_str().unwrap())
+        .collect();
+    assert!(sent.contains(&"mcp__kin__semantic_locate"));
+    assert!(sent.contains(&"edit_file"));
+    assert!(!sent.iter().any(|name| name.contains("bash")));
+    // The observation went back as a tool message keyed on the same id.
+    assert_eq!(
+        requests[1]["messages"].as_array().unwrap().last().unwrap()["role"],
+        "tool"
+    );
+}
+
+#[test]
+fn an_untrusted_absence_is_handed_to_the_model_as_unknown_with_the_named_gap() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "",
+            Some(tool_call(
+                "c1",
+                "mcp__kin__semantic_locate",
+                json!({ "query": "nothing at all" }),
+            )),
+        ),
+        completion(
+            "I do not know; the graph does not index markdown bodies.",
+            None,
+        ),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+    assert_eq!(outcome.status, ExitStatus::Success);
+
+    let records = read_jsonl(&outcome.transcript_path);
+    let view = analyze(&records);
+    let (_, observation, _) = &view.tool_results[0];
+    assert!(
+        observation.contains("CANNOT be trusted"),
+        "the model must be told the absence is untrusted: {observation}"
+    );
+    assert!(
+        observation.contains("markdown bodies are not indexed"),
+        "the named gap must be handed through: {observation}"
+    );
+    assert!(
+        observation.contains("unknown"),
+        "the model must be told to treat it as unknown: {observation}"
+    );
+    assert_eq!(view.result["kin_agent"]["unsafe_absence_events"], 1);
+
+    let trace = read_jsonl(&outcome.trace_path);
+    let row = trace
+        .iter()
+        .find(|row| row["tool"] == "semantic_locate")
+        .unwrap();
+    assert_eq!(row["negative"]["safe_to_conclude_absent"], false);
+    assert_eq!(
+        row["negative"]["limiting_factor"],
+        "markdown bodies are not indexed"
+    );
+}
+
+#[test]
+fn an_off_belt_tool_is_refused_and_never_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+    let canary = repo.join("canary.txt");
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "",
+            Some(tool_call(
+                "c1",
+                "bash",
+                json!({ "command": format!("touch {}", canary.display()) }),
+            )),
+        ),
+        completion("There is no shell, so I used Kin instead.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+
+    assert!(
+        !canary.exists(),
+        "a refused shell call must not have run anything"
+    );
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    let (_, observation, is_error) = &view.tool_results[0];
+    assert!(*is_error, "a refusal is an error result");
+    assert!(
+        observation.contains("no shell"),
+        "the refusal must say why: {observation}"
+    );
+    assert_eq!(view.result["kin_agent"]["refused_calls"], 1);
+    // Nothing reached the graph server except the session bracket.
+    let names: Vec<String> = mcp_log(&log)
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !names.iter().any(|name| name == "bash"),
+        "the refused call must not reach Kin: {names:?}"
+    );
+}
+
+#[test]
+fn malformed_arguments_get_one_repair_turn_and_the_call_does_not_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    let endpoint = FakeEndpoint::start(vec![
+        // A missing required argument, which is the failure small local models actually
+        // produce, rather than an invented one.
+        completion(
+            "",
+            Some(tool_call("c1", "mcp__kin__semantic_locate", json!({}))),
+        ),
+        completion(
+            "",
+            Some(tool_call(
+                "c2",
+                "mcp__kin__semantic_locate",
+                json!({ "query": "greet" }),
+            )),
+        ),
+        completion("Found it.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let outcome = kin_agent::run(config(&repo, &out, &base_url, mcp_command(&server, &log)))
+        .expect("the run completes");
+
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    let (_, first, is_error) = &view.tool_results[0];
+    assert!(*is_error);
+    assert!(
+        first.contains("`query`") && first.contains("was missing"),
+        "the repair must name the field: {first}"
+    );
+    assert_eq!(view.result["kin_agent"]["repairs"], 1);
+    // The bad call never reached the graph; the corrected one did.
+    let names: Vec<String> = mcp_log(&log)
+        .iter()
+        .map(|call| call["tool"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        names
+            .iter()
+            .filter(|name| *name == "semantic_locate")
+            .count(),
+        1,
+        "only the corrected call runs: {names:?}"
+    );
+}
+
+#[test]
+fn the_tool_call_cap_forces_a_tool_free_final_answer_and_exits_two() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    let mut script = Vec::new();
+    for index in 0..3 {
+        script.push(completion(
+            "",
+            Some(tool_call(
+                &format!("c{index}"),
+                "mcp__kin__semantic_locate",
+                json!({ "query": "greet" }),
+            )),
+        ));
+    }
+    script.push(completion(
+        "I ran out of budget; greet is in src/greet.py.",
+        None,
+    ));
+    let endpoint = FakeEndpoint::start(script);
+    let base_url = endpoint.base_url.clone();
+
+    let mut cfg = config(&repo, &out, &base_url, mcp_command(&server, &log));
+    cfg.max_tool_calls = 3;
+    let outcome = kin_agent::run(cfg).expect("the run completes");
+
+    assert_eq!(outcome.status, ExitStatus::CapReached);
+    assert_eq!(outcome.status.code(), 2);
+    assert_eq!(
+        outcome.final_text,
+        "I ran out of budget; greet is in src/greet.py."
+    );
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    assert_eq!(view.result["subtype"], "cap_reached");
+    assert_eq!(view.result["kin_agent"]["stop_reason"], "tool_call_cap");
+    assert_eq!(view.result["kin_agent"]["tool_calls"], 3);
+    // The forced turn was asked with nothing to call.
+    let requests = endpoint.requests();
+    let last = requests.last().unwrap();
+    assert!(
+        last.get("tools").is_none(),
+        "the forced final turn must offer no tools"
+    );
+}
+
+#[test]
+fn a_dead_endpoint_exits_four_and_still_closes_the_transcript() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+    let server = write_fake_mcp_server(dir.path());
+    let log = dir.path().join("mcp-calls.jsonl");
+
+    // A port nothing is listening on.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let outcome = kin_agent::run(config(
+        &repo,
+        &out,
+        &format!("http://127.0.0.1:{port}/v1"),
+        mcp_command(&server, &log),
+    ))
+    .expect("the run returns rather than panicking");
+
+    assert_eq!(outcome.status, ExitStatus::EndpointError);
+    assert_eq!(outcome.status.code(), 4);
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    assert_eq!(view.result["subtype"], "endpoint_error");
+    assert_eq!(view.result["is_error"], true);
+}
+
+#[test]
+fn a_missing_mcp_server_exits_five_and_says_kin_never_attached() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+
+    let endpoint = FakeEndpoint::start(vec![completion("unreachable", None)]);
+    let base_url = endpoint.base_url.clone();
+    let outcome = kin_agent::run(config(
+        &repo,
+        &out,
+        &base_url,
+        vec!["kin-agent-no-such-binary".to_string()],
+    ))
+    .expect("the run returns rather than panicking");
+
+    assert_eq!(outcome.status, ExitStatus::McpError);
+    assert_eq!(outcome.status.code(), 5);
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    assert_eq!(view.init["mcp_servers"][0]["status"], "failed");
+    assert!(
+        !view.init["mcp_server_errors"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "a run where Kin never attached must be loud"
+    );
+    assert_eq!(view.result["subtype"], "mcp_error");
+}
+
+/// The same loop against a real `kin mcp start` on a two-file fixture repository.
+///
+/// Ignored by default because it builds a real graph and starts a real daemon, which the
+/// default suite must never trigger. Run it with the binary named:
+///
+/// ```text
+/// KIN_AGENT_TEST_KIN_BIN=/path/to/kin cargo test -p kin-agent -- --ignored
+/// ```
+#[test]
+#[ignore = "starts a real daemon and builds a real graph"]
+fn the_loop_drives_a_real_kin_mcp_server() {
+    let binary = std::env::var("KIN_AGENT_TEST_KIN_BIN").expect(
+        "KIN_AGENT_TEST_KIN_BIN must name the kin binary; the test refuses to pass without one",
+    );
+    let dir = tempfile::tempdir().unwrap();
+    let repo = fixture_repo(dir.path());
+    let out = dir.path().join("out");
+
+    let init = std::process::Command::new(&binary)
+        .args(["init"])
+        .current_dir(&repo)
+        .output()
+        .expect("kin init runs");
+    assert!(
+        init.status.success(),
+        "kin init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let endpoint = FakeEndpoint::start(vec![
+        completion(
+            "",
+            Some(tool_call(
+                "c1",
+                "mcp__kin__semantic_locate",
+                json!({ "query": "greet" }),
+            )),
+        ),
+        completion("greet is defined in src/greet.py.", None),
+    ]);
+    let base_url = endpoint.base_url.clone();
+
+    let mut cfg = config(
+        &repo,
+        &out,
+        &base_url,
+        vec![
+            binary,
+            "mcp".into(),
+            "start".into(),
+            "--repo".into(),
+            repo.display().to_string(),
+        ],
+    );
+    cfg.mcp_timeout = Duration::from_secs(300);
+    cfg.deadline = Duration::from_secs(600);
+    let outcome = kin_agent::run(cfg).expect("the run completes");
+
+    assert_eq!(outcome.status, ExitStatus::Success, "{:?}", outcome.result);
+    let view = analyze(&read_jsonl(&outcome.transcript_path));
+    assert_eq!(view.init["mcp_servers"][0]["status"], "connected");
+    assert_eq!(view.result["kin_agent"]["kin_calls"], 1);
+    // The real server's envelope reached the sidecar, which is the whole point of
+    // speaking MCP rather than a translated CLI bridge.
+    let trace = read_jsonl(&outcome.trace_path);
+    let row = trace
+        .iter()
+        .find(|row| row["tool"] == "semantic_locate")
+        .expect("the Kin call is traced");
+    assert!(
+        row["envelope"].is_object(),
+        "the real server must carry a _kin envelope: {row}"
+    );
+}

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -70,6 +70,7 @@ serde_json = { workspace = true }
 semver = { workspace = true }
 chrono = { workspace = true }
 filetime = { workspace = true }
+kin-agent = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json"] }
 hex = { workspace = true }
 sha2.workspace = true

--- a/crates/kin-cli/src/commands/agent.rs
+++ b/crates/kin-cli/src/commands/agent.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin agent`: run a task through Kin's own agent loop.
+
+use anyhow::{Context, Result};
+use kin_agent::{
+    AgentConfig, ExitStatus, ProviderConfig, DEFAULT_DEADLINE_S, DEFAULT_MAX_TOOL_CALLS,
+    DEFAULT_MCP_TIMEOUT_S, DEFAULT_REQUEST_TIMEOUT_S,
+};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Everything the `run` subcommand accepts.
+#[allow(clippy::too_many_arguments)]
+pub struct RunArgs {
+    pub task: String,
+    pub model: String,
+    pub base_url: String,
+    pub api_key_env: Option<String>,
+    pub repo: Option<PathBuf>,
+    pub mcp_command: Option<String>,
+    pub out: Option<PathBuf>,
+    pub max_tool_calls: Option<u32>,
+    pub deadline: Option<u64>,
+    pub system: Option<PathBuf>,
+    pub temperature: Option<f32>,
+    pub tool_profile: Option<String>,
+}
+
+/// Run one task. Returns the process exit code; the caller exits with it.
+pub fn run(args: RunArgs) -> Result<i32> {
+    let repo = match args.repo {
+        Some(path) => path,
+        None => std::env::current_dir().context("could not resolve the current directory")?,
+    };
+    let repo = repo
+        .canonicalize()
+        .with_context(|| format!("no such directory: {}", repo.display()))?;
+
+    // `--task` takes a file when the value names one, and the literal text otherwise, so a
+    // short task needs no file and a long mission is not pasted onto a command line.
+    let task = read_task(&args.task)?;
+    let system_prompt =
+        match args.system.as_deref() {
+            Some(path) => Some(std::fs::read_to_string(path).with_context(|| {
+                format!("could not read the system prompt at {}", path.display())
+            })?),
+            None => None,
+        };
+
+    let session_stamp = kin_agent::run::timestamp().replace(':', "-");
+    let out = args
+        .out
+        .unwrap_or_else(|| repo.join(".kin").join("agent").join(session_stamp));
+    std::fs::create_dir_all(&out)
+        .with_context(|| format!("could not create the output directory {}", out.display()))?;
+
+    let provider = ProviderConfig {
+        base_url: ProviderConfig::normalize_base_url(&args.base_url),
+        model: args.model,
+        api_key: ProviderConfig::api_key_from_env(args.api_key_env.as_deref())?,
+        temperature: args.temperature,
+        request_timeout: Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_S),
+    };
+
+    let mcp_command = resolve_mcp_command(
+        args.mcp_command.as_deref(),
+        &repo,
+        args.tool_profile.as_deref(),
+    );
+
+    let config = AgentConfig {
+        task,
+        system_prompt,
+        repo: repo.clone(),
+        out_dir: out.clone(),
+        provider,
+        mcp_command,
+        mcp_timeout: Duration::from_secs(DEFAULT_MCP_TIMEOUT_S),
+        max_tool_calls: args.max_tool_calls.unwrap_or(DEFAULT_MAX_TOOL_CALLS),
+        deadline: Duration::from_secs(args.deadline.unwrap_or(DEFAULT_DEADLINE_S)),
+        tool_profile: args.tool_profile,
+    };
+
+    eprintln!(
+        "kin agent: model={} endpoint={} repo={} out={}",
+        config.provider.model,
+        config.provider.base_url,
+        config.repo.display(),
+        out.display()
+    );
+
+    let outcome = kin_agent::run(config)?;
+    println!("{}", outcome.final_text);
+    eprintln!(
+        "kin agent: {} ({} tool calls, {} to Kin) transcript={}",
+        outcome.status.subtype(),
+        outcome
+            .result
+            .pointer("/kin_agent/tool_calls")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+        outcome
+            .result
+            .pointer("/kin_agent/kin_calls")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+        outcome.transcript_path.display()
+    );
+    Ok(outcome.status.code())
+}
+
+/// Check both halves of the run are reachable before anyone spends a GPU on a task.
+pub fn doctor(
+    base_url: String,
+    model: Option<String>,
+    repo: Option<PathBuf>,
+    mcp_command: Option<String>,
+    api_key_env: Option<String>,
+    tool_profile: Option<String>,
+) -> Result<i32> {
+    let repo = match repo {
+        Some(path) => path,
+        None => std::env::current_dir().context("could not resolve the current directory")?,
+    };
+    let repo = repo
+        .canonicalize()
+        .with_context(|| format!("no such directory: {}", repo.display()))?;
+
+    let provider = ProviderConfig {
+        base_url: ProviderConfig::normalize_base_url(&base_url),
+        model: model.clone().unwrap_or_default(),
+        api_key: ProviderConfig::api_key_from_env(api_key_env.as_deref())?,
+        temperature: None,
+        request_timeout: Duration::from_secs(60),
+    };
+    println!("endpoint: {}", provider.models_url());
+    let provider_ok =
+        match kin_agent::Provider::new(provider.clone()).and_then(|client| client.list_models()) {
+            Ok(models) => {
+                println!("  answered with {} model(s)", models.len());
+                if let Some(model) = model.as_deref() {
+                    if models.iter().any(|id| id == model) {
+                        println!("  `{model}` is served");
+                    } else {
+                        // Not fatal: a gateway may serve a model it does not list.
+                        println!(
+                            "  `{model}` is NOT in the list; served ids are: {}",
+                            models.join(", ")
+                        );
+                    }
+                }
+                true
+            }
+            Err(err) => {
+                println!("  FAILED: {err}");
+                false
+            }
+        };
+
+    let command = resolve_mcp_command(mcp_command.as_deref(), &repo, tool_profile.as_deref());
+    println!("mcp: {}", command.join(" "));
+    let mcp_ok = match kin_agent::run::probe_mcp(
+        &command,
+        &repo,
+        Duration::from_secs(DEFAULT_MCP_TIMEOUT_S),
+    ) {
+        Ok(tools) => {
+            let exposed = tools
+                .iter()
+                .filter(|name| !kin_agent::belt::is_harness_owned(name))
+                .count();
+            println!(
+                "  initialize and tools/list answered: {} tool(s), {} exposed to the model",
+                tools.len(),
+                exposed
+            );
+            true
+        }
+        Err(err) => {
+            println!("  FAILED: {err}");
+            false
+        }
+    };
+
+    if !provider_ok {
+        return Ok(ExitStatus::EndpointError.code());
+    }
+    if !mcp_ok {
+        return Ok(ExitStatus::McpError.code());
+    }
+    println!("both halves answered; `kin agent run` can start");
+    Ok(0)
+}
+
+fn read_task(value: &str) -> Result<String> {
+    let path = Path::new(value);
+    if path.is_file() {
+        return std::fs::read_to_string(path)
+            .with_context(|| format!("could not read the task file at {value}"));
+    }
+    if value.trim().is_empty() {
+        anyhow::bail!("--task was empty");
+    }
+    Ok(value.to_string())
+}
+
+/// The MCP command: an override split on whitespace, or this binary serving the repo.
+fn resolve_mcp_command(
+    override_command: Option<&str>,
+    repo: &Path,
+    tool_profile: Option<&str>,
+) -> Vec<String> {
+    if let Some(raw) = override_command {
+        let parts: Vec<String> = raw.split_whitespace().map(ToString::to_string).collect();
+        if !parts.is_empty() {
+            return parts;
+        }
+    }
+    // Prefer this exact binary over whatever `kin` resolves to on PATH, so a run cannot
+    // silently drive a different build than the one the operator launched.
+    let program = std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "kin".to_string());
+    let mut command = vec![
+        program,
+        "mcp".to_string(),
+        "start".to_string(),
+        "--repo".to_string(),
+        repo.display().to_string(),
+    ];
+    if let Some(profile) = tool_profile {
+        command.push("--tool-profile".to_string());
+        command.push(profile.to_string());
+    }
+    command
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 pub mod admit;
+pub mod agent;
 pub mod approvals;
 pub mod assistant;
 pub mod assistant_adapter;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -3020,7 +3020,10 @@ fn main() -> Result<()> {
                     commands::blame::run(entity, reference).await
                 }
                 Command::Agent { action } => {
-                    let code = match action {
+                    // The agent loop is blocking, and a blocking HTTP client builds and
+                    // drops its own runtime. Dropping one inside an async context panics,
+                    // so the whole command runs on a plain thread outside this runtime.
+                    let code = std::thread::spawn(move || match action {
                         AgentAction::Run {
                             task,
                             model,
@@ -3063,7 +3066,9 @@ fn main() -> Result<()> {
                             api_key_env,
                             tool_profile,
                         ),
-                    }?;
+                    })
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("the agent thread panicked"))??;
                     // The run's own taxonomy is reported through the exit code: 2 budget,
                     // 3 deadline, 4 endpoint, 5 MCP. A caller must be able to tell a task
                     // the agent could not do from an endpoint that was never there.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -617,6 +617,17 @@ enum Command {
         #[command(subcommand)]
         action: McpAction,
     },
+    /// Run a task through Kin's own agent loop, or check that it can start.
+    ///
+    /// The agent answers repository questions from the Kin graph over MCP and has no
+    /// shell, no grep and no file-reading tool, so it cannot fall back to raw file
+    /// search. Its only writes are edit_file and write_file, and each one runs inside a
+    /// Kin transaction under a Kin session, so the change carries provenance naming the
+    /// agent rather than landing as an anonymous file write.
+    Agent {
+        #[command(subcommand)]
+        action: AgentAction,
+    },
     /// Authenticate with KinLab for native remotes
     Auth {
         #[command(subcommand)]
@@ -1720,6 +1731,71 @@ enum StashAction {
         /// Output the machine-readable stash report
         #[arg(long)]
         json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentAction {
+    /// Run one task to completion against an OpenAI-compatible endpoint
+    Run {
+        /// The task: a path to a file holding it, or the text itself
+        #[arg(long, value_name = "FILE|TEXT")]
+        task: String,
+        /// Model id as the endpoint names it
+        #[arg(long, value_name = "ID")]
+        model: String,
+        /// OpenAI-compatible base URL, with or without a trailing /v1
+        #[arg(long = "base-url", value_name = "URL")]
+        base_url: String,
+        /// Name of an environment variable holding the API key. The key itself is never
+        /// accepted on the command line, so it cannot land in a process listing.
+        #[arg(long = "api-key-env", value_name = "NAME")]
+        api_key_env: Option<String>,
+        /// Repository to work in (default: the current directory)
+        #[arg(long, value_name = "PATH")]
+        repo: Option<PathBuf>,
+        /// Override the MCP server command (default: this binary serving --repo)
+        #[arg(long = "mcp-command", value_name = "CMD")]
+        mcp_command: Option<String>,
+        /// Directory for the transcript, the Kin trace and the result record
+        #[arg(long, value_name = "DIR")]
+        out: Option<PathBuf>,
+        /// Tool-call budget before the agent is asked for a final answer
+        #[arg(long = "max-tool-calls", value_name = "N")]
+        max_tool_calls: Option<u32>,
+        /// Wall-clock deadline in seconds
+        #[arg(long, value_name = "S")]
+        deadline: Option<u64>,
+        /// File holding a system prompt that replaces the built-in one
+        #[arg(long, value_name = "FILE")]
+        system: Option<PathBuf>,
+        /// Sampling temperature passed through to the endpoint
+        #[arg(long, value_name = "F")]
+        temperature: Option<f32>,
+        /// Tool surface the MCP server should serve
+        #[arg(long = "tool-profile", value_name = "PROFILE")]
+        tool_profile: Option<String>,
+    },
+    /// Check that the model endpoint and the Kin MCP server both answer
+    Doctor {
+        /// OpenAI-compatible base URL
+        #[arg(long = "base-url", value_name = "URL")]
+        base_url: String,
+        /// Model id to look for in the endpoint's list
+        #[arg(long, value_name = "ID")]
+        model: Option<String>,
+        /// Repository to serve (default: the current directory)
+        #[arg(long, value_name = "PATH")]
+        repo: Option<PathBuf>,
+        /// Override the MCP server command
+        #[arg(long = "mcp-command", value_name = "CMD")]
+        mcp_command: Option<String>,
+        /// Name of an environment variable holding the API key
+        #[arg(long = "api-key-env", value_name = "NAME")]
+        api_key_env: Option<String>,
+        /// Tool surface the MCP server should serve
+        #[arg(long = "tool-profile", value_name = "PROFILE")]
+        tool_profile: Option<String>,
     },
 }
 
@@ -2942,6 +3018,59 @@ fn main() -> Result<()> {
                 },
                 Command::Blame { entity, reference } => {
                     commands::blame::run(entity, reference).await
+                }
+                Command::Agent { action } => {
+                    let code = match action {
+                        AgentAction::Run {
+                            task,
+                            model,
+                            base_url,
+                            api_key_env,
+                            repo,
+                            mcp_command,
+                            out,
+                            max_tool_calls,
+                            deadline,
+                            system,
+                            temperature,
+                            tool_profile,
+                        } => commands::agent::run(commands::agent::RunArgs {
+                            task,
+                            model,
+                            base_url,
+                            api_key_env,
+                            repo,
+                            mcp_command,
+                            out,
+                            max_tool_calls,
+                            deadline,
+                            system,
+                            temperature,
+                            tool_profile,
+                        }),
+                        AgentAction::Doctor {
+                            base_url,
+                            model,
+                            repo,
+                            mcp_command,
+                            api_key_env,
+                            tool_profile,
+                        } => commands::agent::doctor(
+                            base_url,
+                            model,
+                            repo,
+                            mcp_command,
+                            api_key_env,
+                            tool_profile,
+                        ),
+                    }?;
+                    // The run's own taxonomy is reported through the exit code: 2 budget,
+                    // 3 deadline, 4 endpoint, 5 MCP. A caller must be able to tell a task
+                    // the agent could not do from an endpoint that was never there.
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                    Ok(())
                 }
                 Command::Mcp { action } => match action {
                     McpAction::Start {

--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -12,6 +12,7 @@
 # conscious decision to keep a name out of the registry, not a place to silence a
 # real gap.
 #
+KIN_AGENT_TEST_KIN_BIN
 KIN_GIT_TEST_NO_SYMLINK_PRIVILEGE
 KIN_INIT_INTERRUPTED_TEST_BARRIER
 KIN_INIT_INTERRUPTED_TEST_SOURCE

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,10 @@ repository, and walks the everyday loop end to end. Once Kin is running, the
 4. **[Session runtime](session-runtime.md)** explains how `kin exec`,
    `kin shell`, `kin with`, and `kin open` run ordinary tools against
    materialized graph truth, and what happens when one of them fails.
+5. **[`kin agent`](cli-reference.md#kin-agent)** is Kin's own agent and the path
+   we recommend for agent work. It drives any OpenAI-compatible endpoint, local
+   or hosted, answers only from the graph, and records every run as a transcript
+   plus a Kin trace.
 
 ## Reference
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ Kin is pre-1.0 and the command surface moves. Where this page and your build dis
 
 Descriptions are the command's own help text. A `--json` flag switches that command to machine-readable output. Angle brackets mark a required argument, square brackets an optional one, and a trailing `...` an argument that takes the rest of the line.
 
-81 commands are documented below. 4 further commands (`bench-meta`, `contextbench-locate`, `prepared-state`, `semantic-only-guard`) are hidden from `kin --help` because they exist for benchmark and internal orchestration, and they are not part of the supported surface.
+82 commands are documented below. 4 further commands (`bench-meta`, `contextbench-locate`, `prepared-state`, `semantic-only-guard`) are hidden from `kin --help` because they exist for benchmark and internal orchestration, and they are not part of the supported surface.
 
 `kin capabilities` prints the readiness matrix for the Git-replacement command set, and `kin capabilities --json` gives the same inventory to a machine. Reach for it before scripting against a command you have not used.
 
@@ -32,7 +32,7 @@ These apply to every command.
 - [More graph queries](#more-graph-queries): `history`, `blame`, `overview`, `deps`, `xref`, `dead-code`, `trace-data-flow`, `security`, `languages`, `scope`, `locate-debug`
 - [Branches, merges, and exact trees](#branches-merges-and-exact-trees): `branch`, `checkout`, `merge`, `conflicts`, `resolve`, `stash`, `rollback`, `tag`, `semver`, `purge-ignored`, `admit`, `reconcile`, `migrate`, `eject`, `git`
 - [Review and verification](#review-and-verification): `review`, `approvals`, `verify`, `spec`, `audit`, `rename`
-- [Sessions and agents](#sessions-and-agents): `exec`, `shell`, `open`, `with`, `mcp`, `assistant`, `intent`, `traffic`, `work`, `note`, `todo`, `feature`
+- [Sessions and agents](#sessions-and-agents): `agent`, `exec`, `shell`, `open`, `with`, `mcp`, `assistant`, `intent`, `traffic`, `work`, `note`, `todo`, `feature`
 - [Remotes and publishing](#remotes-and-publishing): `auth`, `remote`, `push`, `pull`, `publish`, `release`, `hosted-release`, `pipeline`, `secret`
 - [Graph, store, and daemon operations](#graph-store-and-daemon-operations): `graph`, `embed`, `cache`, `backup`, `resources`, `support`, `daemon`, `registry`, `telemetry`, `notify`, `bench`
 - [Install and health](#install-and-health): `capabilities`, `setup`, `doctor`, `update`, `completions`
@@ -1123,6 +1123,87 @@ kin rename <symbol> <new-name> [options]
 ## Sessions and agents
 
 Running tools and assistants against materialized graph truth.
+
+### `kin agent`
+
+Run a task through Kin's own agent loop, or check that it can start
+
+```
+kin agent <subcommand>
+```
+
+`kin agent` is Kin's own agent, and the path the product recommends for agent work.
+It drives any OpenAI-compatible endpoint, so a local model in LM Studio, Ollama,
+llama.cpp or vLLM works from the same flags as a hosted one, and it reaches the graph
+over the same MCP server `kin mcp start` serves, so it sees the real tools, the `_kin`
+freshness envelope, and the `negative` verdict on an empty result.
+
+The policy is the product's thesis, enforced in the agent's own process rather than
+borrowed from a vendor's permission layer. The belt is Kin's tools plus exactly two
+local tools, `edit_file` and `write_file`. There is no shell, no grep and no
+file-reading tool, so there is nothing to fall back to, and a tool the model invents is
+refused by name. When a result reports `safe_to_conclude_absent` false, the agent is
+told the answer is unknown and given the named gap rather than being allowed to conclude
+the thing does not exist. Every edit runs inside a Kin transaction under a Kin session,
+so the change carries provenance naming the agent.
+
+Working with Claude Code, Codex, Cursor and Gemini stays first class; `kin setup
+--intent agent` still configures every client it detects.
+
+Subcommands:
+
+#### `kin agent run`
+
+Run one task to completion against an OpenAI-compatible endpoint
+
+```
+kin agent run --task <FILE|TEXT> --model <ID> --base-url <URL> [options]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--task <file\|text>` | required | The task: a path to a file holding it, or the text itself |
+| `--model <id>` | required | Model id as the endpoint names it |
+| `--base-url <url>` | required | OpenAI-compatible base URL, with or without a trailing `/v1` |
+| `--api-key-env <name>` |  | Name of an environment variable holding the API key. The key itself is never accepted on the command line, so it cannot land in a process listing. |
+| `--repo <path>` | current directory | Repository to work in |
+| `--mcp-command <cmd>` | this binary serving `--repo` | Override the MCP server command |
+| `--out <dir>` | `.kin/agent/<timestamp>` | Directory for the transcript, the Kin trace and the result record |
+| `--max-tool-calls <n>` | `40` | Tool-call budget before the agent is asked for a final answer |
+| `--deadline <s>` | `900` | Wall-clock deadline in seconds |
+| `--system <file>` |  | File holding a system prompt that replaces the built-in one |
+| `--temperature <f>` |  | Sampling temperature passed through to the endpoint |
+| `--tool-profile <profile>` |  | Tool surface the MCP server should serve |
+
+Three files land under `--out`. `transcript.jsonl` is the run, one JSON object per line,
+in the same stream-json shape Claude Code emits, so existing transcript analyzers read it
+unchanged. `kin-trace.jsonl` is one row per tool call carrying the `_kin` envelope, the
+`negative` verdict and the policy decision, joinable to the transcript on `tool_use_id`.
+`result.json` is the terminal record on its own.
+
+The exit code is the run's outcome: `0` a final answer, `1` a harness error, `2` the
+tool-call budget was spent, `3` the deadline expired, `4` the endpoint was unreachable or
+answered with nothing usable, `5` the MCP server failed. A transcript is written and
+closed on every one of them, so a failed run is still measurable.
+
+#### `kin agent doctor`
+
+Check that the model endpoint and the Kin MCP server both answer
+
+```
+kin agent doctor --base-url <URL> [options]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--base-url <url>` | required | OpenAI-compatible base URL |
+| `--model <id>` |  | Model id to look for in the endpoint's list |
+| `--repo <path>` | current directory | Repository to serve |
+| `--mcp-command <cmd>` | this binary serving `--repo` | Override the MCP server command |
+| `--api-key-env <name>` |  | Name of an environment variable holding the API key |
+| `--tool-profile <profile>` |  | Tool surface the MCP server should serve |
+
+Exit `0` when both answer, `4` when the endpoint does not, `5` when the MCP server does not.
 
 ### `kin exec`
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -7984,7 +7984,10 @@ def main() -> None:
                 f"release recovery contains forbidden authority or retry state: {forbidden}"
             )
 
-    pinned_readme_version = re.search(r"\bv?\d+\.\d+\.\d+\b", readme)
+    # A dotted quad is not a version. `\b\d+\.\d+\.\d+\b` matches "127.0.0" inside
+    # "127.0.0.1", so documenting a loopback endpoint tripped this guard with a message
+    # about pinning a release. Refuse a match that has a digit or dot on either side.
+    pinned_readme_version = re.search(r"(?<![\d.])v?\d+\.\d+\.\d+(?![\d.])", readme)
     if pinned_readme_version:
         raise AssertionError(
             "README must follow the proven latest release instead of pinning "

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -532,6 +532,49 @@
         "let _ = std::fs::remove_file(&tmp);",
         "let _ = std::fs::remove_file(self.kin_root.join(TRANSACTION_FILE_NAME));"
       ]
+    },
+    {
+      "file": "crates/kin-agent/src/belt.rs",
+      "reason": "kin-agent is a CLIENT of graph authority, never a source of it. It reaches Kin only through the MCP server over stdio, so every tool result it hands a model comes from the graph, and it deliberately ships no file-read, file-search or shell tool for a model to call. The filesystem and subprocess touches here are the two explicit boundaries the zero-file-search rule allows: materializing an edit the model asked for, and writing the run's own transcript. This module is the write boundary. `edit_file` reads the one file it is about to change so a find-and-replace can be exact and can refuse an ambiguous match, and `write_file` writes the one file it was given; both resolve the path inside the repository first and refuse any escape. Neither answers a question: the model has already been told where the code is by `mcp__kin__semantic_locate` and what it says by `mcp__kin__get_entity_source`, and nothing derived from these reads reaches a tool result. Pinned rather than whole-file so a newly added filesystem primitive in this module fails the guard, which is exactly what should happen if anyone ever adds a read or search tool to the belt.",
+      "owner": "kin-agent",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::fs::read_to_string(&path)",
+        "std::fs::write(&path, &updated)",
+        "std::fs::create_dir_all(parent)",
+        "path.exists()",
+        "std::fs::write(&path, content)"
+      ]
+    },
+    {
+      "file": "crates/kin-agent/src/mcp.rs",
+      "reason": "kin-agent is a CLIENT of graph authority, never a source of it. It reaches Kin only through the MCP server over stdio, so every tool result it hands a model comes from the graph, and it deliberately ships no file-read, file-search or shell tool for a model to call. The filesystem and subprocess touches here are the two explicit boundaries the zero-file-search rule allows: materializing an edit the model asked for, and writing the run's own transcript. This module is the transport that reaches authority rather than a substitute for it: it spawns the MCP server as a child process and speaks JSON-RPC to it over stdio. The subprocess is the graph, so forbidding it here would forbid consulting the graph at all. It touches no path of its own. Pinned so any filesystem primitive added to this module fails the guard.",
+      "owner": "kin-agent",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::process::{Child, ChildStdin, ChildStdout, Command, Stdio}",
+        "Command::new(program)"
+      ]
+    },
+    {
+      "file": "crates/kin-agent/src/run.rs",
+      "reason": "kin-agent is a CLIENT of graph authority, never a source of it. It reaches Kin only through the MCP server over stdio, so every tool result it hands a model comes from the graph, and it deliberately ships no file-read, file-search or shell tool for a model to call. The filesystem and subprocess touches here are the two explicit boundaries the zero-file-search rule allows: materializing an edit the model asked for, and writing the run's own transcript. Two touches in the loop itself. `std::process::id()` is this agent's own pid, reported to `kin_session_start` so the graph's session record names the process that made the change; it spawns nothing. The `std::fs::write` emits `result.json`, the run's terminal record, into the output directory the caller named. Pinned so any retrieval-shaped filesystem call added to the loop fails the guard.",
+      "owner": "kin-agent",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::process::id()",
+        "std::fs::write("
+      ]
+    },
+    {
+      "file": "crates/kin-agent/src/transcript.rs",
+      "reason": "kin-agent is a CLIENT of graph authority, never a source of it. It reaches Kin only through the MCP server over stdio, so every tool result it hands a model comes from the graph, and it deliberately ships no file-read, file-search or shell tool for a model to call. The filesystem and subprocess touches here are the two explicit boundaries the zero-file-search rule allows: materializing an edit the model asked for, and writing the run's own transcript. This module only writes. It creates the output directory and the two output files, `transcript.jsonl` and `kin-trace.jsonl`, and reads nothing at all. A transcript is a record of a run, never an input to an answer. Pinned so a read added to this module fails the guard.",
+      "owner": "kin-agent",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::fs::File",
+        "std::fs::create_dir_all(out_dir)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Kin has no agent of its own today. Every agent story is "point someone else's CLI at our MCP server", and the strongest claim in the product, that an agent physically cannot answer from raw file search, is built out of one vendor's permission system: `crates/kin-cli/src/commands/assistant_adapter.rs:29` declares an `EnforcementTier`, and only the Claude adapter reaches `Enforced`, because it writes a settings file denying `Grep`, `Glob` and `Read` and installs a `PreToolUse` hook; the Codex adapter refuses outright rather than overclaim. That makes the guarantee rented rather than owned, and it cannot follow us onto a local model. This adds `crates/kin-agent`, a provider-neutral agent loop, plus a `kin agent` subcommand in kin-cli, so Kin ships its own agent and enforces its own rule in its own process. It speaks the OpenAI chat-completions wire format, which is what LM Studio, Ollama, llama.cpp, vLLM, OpenRouter and OpenAI all speak, so one adapter reaches a laptop model and a hosted one from the same two flags, and it drives Kin over MCP stdio rather than a translated CLI bridge, so it inherits the real tool registry, the `_kin` freshness envelope and the `negative` verdict instead of reimplementing them.

The policy is enforced by absence and by refusal. The belt is Kin's tools plus exactly two local tools, `edit_file` and `write_file`; there is no shell tool, no file-search tool and no file-read tool anywhere in the belt or the router, so there is nothing to fall back to, and a tool the model invents is refused by name with a refusal that says why. Both halves matter, because a hallucinated `bash` call that silently returned nothing would read to the model as a command that produced no output. When a result reports `safe_to_conclude_absent` false, the loop appends Kin's verdict and its named limiting factor to what the model sees and tells it to treat the answer as unknown, so an untrusted absence cannot become a claim that something does not exist; a degraded-coverage note is surfaced once per run rather than on every call. Every local edit is bracketed by `kin_transaction_begin` and `kin_transaction_commit` under a `kin_session_start`, and those lifecycle tools are stripped from the model's belt so the harness owns them. Envelope and verdict are read by piercing `content[0].text`, because the wrapper never carries them and a reader that looks at the wrapper's top level comes back empty for every key; a payload that cannot be parsed is reported unreadable rather than collapsed to a default.

Runs emit the Claude Code stream-json transcript the fleet's analyzers already read, with an RFC3339 timestamp on every record because per-call latency is derived by subtracting a `tool_use` stamp from its matching `tool_result`, and Kin tools named `mcp__kin__<tool>` so `usage.py` classifies them as MCP calls. A `kin-trace.jsonl` sidecar carries the envelope summary, the negative verdict, the policy decision and each edit's provenance, joinable on `tool_use_id`, so everything Kin-specific stays out of the stream and existing readers keep working untouched. Exit codes are the run's own taxonomy: 0 a final answer, 1 a harness error, 2 the tool-call budget spent, 3 the deadline expired, 4 the endpoint unreachable, 5 the MCP server failed, with a finer `stop_reason` separating an endpoint that was not there from a model that could not hold the tool-calling protocol, because a run that died the second way must never score as a task the toolset failed.

Provenance. The text-shaped tool-call readers for Qwen and Gemma follow the ones proven in kin-bench at `crates/kin-bench-engine/src/live/agent/openai_compat.rs:1547` and `:1378`, including Gemma's special quote tokens. kin-bench is founder-owned and stays private; this is a lift of that design into Apache-2.0 code that ships. They earn their place because a loop that cannot read those shapes stalls on every local model that answers in prose instead of filling the protocol field.

Because this is a subcommand of the `kin` binary, it ships in every release archive and through npm with no release-workflow change at all. Nothing in `.github/workflows/` is touched.

Evidence from a real run of the built binary, against a scripted OpenAI-compatible endpoint and a scripted MCP server on a two-file fixture repository. It exited 0 with `stop_reason` `final_answer`, 5 tool calls of which 3 reached Kin, 1 local edit and 1 refusal, over 6 turns. The edit landed: `src/backoff.py` gained the docstring directly under `def compute_retry_backoff`. The refusal held: the model asked for `bash` with `grep -rn compute_retry_backoff .` and got back "There is no tool named `bash` and it will not be run. This agent has no shell, no file-search and no file-read tool on purpose", with the trace row recording `surface: policy, policy: refused, is_error: true` and nothing executed. The untrusted absence was handed through as unknown: the model saw the empty payload followed by "[kin] This result is empty and Kin reports the absence CANNOT be trusted: markdown bodies are not indexed. Treat this as unknown rather than absent", and the result record counts `unsafe_absence_events: 1`. The edit was bracketed: the trace runs `kin_session_start`, the two reads, `kin_transaction_begin`, `kin_transaction_commit`, then the `edit_file` row carrying `provenance: {bracketed: true, closed_with: "kin_transaction_commit", closed_cleanly: true}`, then `kin_session_end`. Both fleet analyzers read that transcript unmodified and exited 0: `usage.py` reported `5 tool calls: mcp=3, other=2` with rows for `mcp/kin/semantic_locate n=2`, `mcp/kin/get_entity_source n=1`, `other/bash n=1 err=1`, `other/edit_file n=1`, and `analyze.py` reported 13 events, `mcp_calls: 3`, `errors: {bash: 1}` and per-tool latency percentiles. There is no `fallback` row in either, which is the policy showing up in the measurement rather than in a claim, because `usage.py`'s fallback classifier fires on rg, grep, git, find, ctags and ag inside a Bash call and on the Read, Grep and Glob tools, and none of those exist here to be called.

The two local-model runs the design calls for are not claimed here, and they are now the sibling lane's. `kin agent doctor` reaches LM Studio and reports "answered with 8 model(s)" with `qwen/qwen3.6-35b-a3b@q8_0` among them, then exits 5 on a deliberately absent MCP command, which is the contract's endpoint-good, MCP-bad case. The runs themselves are being driven by lane `kinagent-stranger`, which holds the GPU lock against this binary with reason "kin agent stranger arms, qwen then gemma", so its results are its own deliverable rather than a duplicate. What follows from that for this pull request: the Qwen and Gemma text-shape readers are proven by unit tests against captured shapes, not against those two models live, and that is a real gap rather than a formality.

Falsification. Every new guard was broken in turn, run, and restored, and each failed with its named assertion: the router returning `Route::Kin` for unknown names broke "the refusal must say why"; dropping the belt check in the Qwen reader let prose mint a call; disabling the negative branch broke "the model must be told the absence is untrusted"; making `begin_transaction` return no bracket dropped the observed MCP sequence to `["kin_session_start", "semantic_locate", "kin_session_end"]` against the expected five; removing the transcript timestamp broke "record without a timestamp"; swapping the Qwen and Gemma readers for each other broke each other's test; passing tool specs on the forced final turn broke "the forced final turn must offer no tools"; dropping the required-argument check let a malformed call through; letting `..` through let a path escape the repository; forcing `isError` false lost an MCP error. The restored tree re-ran green. That last step is not a formality: the first pass of the falsification harness restored each file from a backup, which gave it the backup's older mtime, so cargo skipped the rebuild and the restored run passed against a stale binary. The suite was re-run with a `touch` after every restore.

Two bugs were found and fixed in this branch, neither visible to the tests. `kin agent doctor` aborted with exit 101 and "Cannot drop a runtime in a context where blocking is not allowed", because the CLI dispatches inside its tokio runtime and a blocking HTTP client drops its own runtime there; the subcommand now runs on a plain thread outside it. And `KIN_AGENT_TEST_KIN_BIN`, the ignored integration test's binary variable, was missing from `crates/kin-core/env_var_allowlist.txt`, which the registry-completeness guard caught.

Working with Claude Code, Codex, Cursor and Gemini through `kin setup` and MCP stays first class. `kin agent` is the premier path, not the only one, and the README and CLI reference say so in those words.

Closes FIR-2413
