### PR TITLE
Probe the documentation-only fast path context names

### DIFF
--- a/docs/docs-only-probe.md
+++ b/docs/docs-only-probe.md
@@ -1,0 +1,4 @@
+# Docs-only classification probe
+
+Throwaway probe verifying that the documentation-only fast path still reports every
+required context name. Delete with the branch.


### PR DESCRIPTION
Throwaway probe, do not merge, will be closed once read.

This exists to answer one question with evidence rather than by reading the workflow: on a real documentation-only diff, do `Falsify guards`, `Feature permutation tests (ubuntu-latest)` and `Feature permutation tests (macos-latest)` appear in the check set with a skipped or successful conclusion, or do they not appear at all? A required context that never appears waits forever rather than passing, so the answer decides whether those three names can safely be added to the main ruleset.

It touches one markdown file and nothing else, so `Classify diff scope` should report `docs_only=true`.