### PR TITLE
Register a repository with kin init so cross-repo commands can see it

### DIFF
--- a/crates/kin-cli/src/commands/deps.rs
+++ b/crates/kin-cli/src/commands/deps.rs
@@ -102,10 +102,11 @@ pub fn registered_id_for_path<'a>(
                 String::new()
             };
             anyhow::bail!(
-                "no registry entry records the repository at {};{named} no shipped command writes \
-                 one, so the scoped view cannot answer here: `kin registry` only lists and cleans, \
-                 and the migration writer that records an entry has no caller. Use `kin deps \
-                 --all` to list the repositories that are registered",
+                "no registry entry records the repository at {};{named} `kin init` registers a \
+                 repository when it runs, so this one either predates that registration or was \
+                 never initialized with `kin init` here; `kin registry` only lists and cleans \
+                 rather than adding an entry after the fact. Use `kin deps --all` to list the \
+                 repositories that are registered",
                 working_dir.display()
             )
         }
@@ -137,9 +138,11 @@ pub fn repo_dependency_view(registry: &KinRegistry, repo_id: &str) -> Result<Rep
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "repository '{repo_id}' is not in the Kin registry, so no cross-repo dependency \
-                 records exist for it, and no shipped command writes an entry that would create \
-                 them: `kin registry` only lists and cleans. Use `kin deps --all` to list the \
-                 repositories that are registered"
+                 records exist for it. `kin init` registers a repository when it runs; this one \
+                 either predates that registration or was never initialized with `kin init` \
+                 here, and `kin registry` only lists and cleans rather than adding an entry \
+                 after the fact. Use `kin deps --all` to list the repositories that are \
+                 registered"
             )
         })?;
 
@@ -213,9 +216,9 @@ pub fn render_repo_view_lines(view: &RepoDependencyView) -> Vec<String> {
     if view.depends_on.is_empty() || view.consumers.is_empty() {
         lines.push(String::new());
         lines.push(
-            "note: dependency records are written when a repository is registered, and no \
-             shipped command writes a registry entry today, so empty directions here may mean \
-             the records were never written rather than that none exist."
+            "note: dependency records are written when `kin init` registers a repository, so \
+             empty directions here may mean this repository predates that registration rather \
+             than that none exist."
                 .to_string(),
         );
     }
@@ -236,7 +239,8 @@ fn report_every_registered_repo(registry: &KinRegistry, json: bool) -> Result<()
         } else {
             println!("No registered repositories.");
             println!(
-                "hint: no shipped command writes a registry entry; `kin registry` only lists and cleans"
+                "hint: `kin init` registers a repository when it runs; a repository \
+                 initialized before this build predates that and has no entry"
             );
         }
         return Ok(());
@@ -292,7 +296,9 @@ fn report_every_registered_repo(registry: &KinRegistry, json: bool) -> Result<()
 
     if !unrecorded.is_empty() {
         println!(
-            "note: dependency records are written at registration, and no shipped command writes a registry entry today, so these may be unrecorded rather than dependency-free: {}",
+            "note: dependency records are written when `kin init` registers a repository, so a \
+             repository initialized before this build may show no records rather than no \
+             dependencies: {}",
             unrecorded.join(", ")
         );
     }
@@ -608,10 +614,13 @@ mod tests {
 
         assert!(message.contains("not in the Kin registry"), "{message}");
         assert!(
-            message.contains("no shipped command writes an entry"),
-            "the refusal must not name a remedy that cannot register: {message}"
+            message.contains("kin init") && message.contains("registers a repository"),
+            "the refusal must explain that registration comes from `kin init`: {message}"
         );
-        assert!(!message.contains("kin init"), "{message}");
+        assert!(
+            message.contains("kin registry") && message.contains("only lists and cleans"),
+            "the refusal must still say `kin registry` cannot add an entry after the fact: {message}"
+        );
         assert!(message.contains("kin deps --all"), "{message}");
     }
 
@@ -658,10 +667,13 @@ mod tests {
         assert!(message.contains("/other/place/kin"), "{message}");
         assert!(message.contains("same directory name"), "{message}");
         assert!(
-            message.contains("no shipped command writes"),
-            "the refusal must not name a remedy that cannot register: {message}"
+            message.contains("kin init") && message.contains("registers a repository"),
+            "the refusal must explain that registration comes from `kin init`: {message}"
         );
-        assert!(!message.contains("kin init"), "{message}");
+        assert!(
+            message.contains("kin registry") && message.contains("only lists and cleans"),
+            "the refusal must still say `kin registry` cannot add an entry after the fact: {message}"
+        );
         assert!(message.contains("kin deps --all"), "{message}");
     }
 
@@ -695,7 +707,6 @@ mod tests {
 
         assert!(rendered.contains("no cross-repo dependencies recorded"));
         assert!(rendered.contains("no registered repository records this one as a provider"));
-        assert!(rendered.contains("no shipped command writes a registry entry"));
-        assert!(!rendered.contains("kin init"));
+        assert!(rendered.contains("kin init") && rendered.contains("registers a repository"));
     }
 }

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -146,6 +146,18 @@ pub async fn run(path: Option<String>, json: bool) -> Result<()> {
 
     let enrichment =
         SemanticEnrichmentStatus::from_durable_summary(&result.authority.semantic_enrichment);
+
+    if let Err(error) =
+        kin_migrate::update_registry(result.layout.working_dir(), enrichment.entity_count)
+    {
+        eprintln!(
+            "warning: {} was not added to the local repository registry, so cross-repo \
+             commands (`kin deps`, `kin xref`) will not see it from sibling repositories: \
+             {error:#}",
+            result.layout.root().display()
+        );
+    }
+
     if json {
         print_json_result(&result, boundary, enrichment)?;
     } else {
@@ -1218,6 +1230,44 @@ mod tests {
         assert!(
             overridden_notice.contains("fetches the model from huggingface.co"),
             "the fetch is still named without a size: {overridden_notice}"
+        );
+    }
+
+    /// The registration defect, made visible under a scratch registry with
+    /// nothing in it. On a developer machine a leftover registry.toml from an
+    /// old migration hides that nothing calls `update_registry`; this test
+    /// starts from empty, so it cannot be fooled the same way.
+    #[tokio::test]
+    async fn init_registers_the_repository_under_a_scratch_registry() {
+        let scratch = tempfile::tempdir().unwrap();
+        let repo = scratch.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-q"]);
+        git(&repo, &["config", "user.email", "kin-test@example.invalid"]);
+        git(&repo, &["config", "user.name", "Kin Test"]);
+        std::fs::write(repo.join("seed"), b"seed").unwrap();
+        git(&repo, &["add", "seed"]);
+        git(&repo, &["commit", "-qm", "seed"]);
+
+        let kin_home = scratch.path().join("kin-home");
+        let registry_path = kin_home.join("registry.toml");
+        let _home = kin_core::test_env::EnvVarGuard::set("HOME", &kin_home);
+        let _kin_home_var = kin_core::test_env::EnvVarGuard::set("KIN_HOME", &kin_home);
+        let _registry = kin_core::test_env::EnvVarGuard::set("KIN_REGISTRY_PATH", &registry_path);
+
+        run(Some(repo.to_str().unwrap().to_string()), false)
+            .await
+            .expect("kin init must succeed under a scratch registry");
+
+        let registry = kin_core::registry::KinRegistry::load_from(&registry_path)
+            .expect("registry must be readable after init");
+        let canonical = repo.canonicalize().unwrap();
+        assert!(
+            registry.repos.iter().any(|entry| entry.path == canonical),
+            "kin init must register the repository it just admitted, so a second \
+             repository's registration can later find it as a cross-repo sibling; \
+             registry entries: {:?}",
+            registry.repos
         );
     }
 }

--- a/crates/kin-cli/src/commands/registry.rs
+++ b/crates/kin-cli/src/commands/registry.rs
@@ -72,7 +72,10 @@ pub async fn list() -> Result<()> {
 
     if registry.repos.is_empty() {
         println!("No registered repositories.");
-        println!("hint: no shipped command writes a registry entry yet; the registry lists and cleans only");
+        println!(
+            "hint: `kin init` registers a repository when it runs; a repository initialized \
+             before this build predates that and has no entry"
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
Cross-repo commands returned nothing on every fresh install, and this makes them answer.

`kin_migrate::finalize::update_registry` was the only function that adds a repo to
`~/.kin/registry.toml`, and it had zero production call sites. An unfiltered grep across the
whole repository found only its own definition and its own test, plus the crate's re-export
of the function name. Nothing else touched it. No other production writer existed either:
`kin registry` has no add subcommand, `registry.rs` only cleans stale entries, and
`kin-core/src/registry.rs` only writes an empty default file.

The consequence ran the whole chain. `pin_registered_local_repository_authorities` loads the
registry, iterates `registry.repos`, and pins each sibling as a repository authority, which
is then registered in the spine. On a fresh install the registry is empty, zero siblings pin,
the spine holds only the current repo, and both `kin xref` and `kin deps` answer with nothing.

This was invisible on the maintainer's machine because a leftover `registry.toml` from an old
migration made broken cross-repo look like working cross-repo.

## What changed

`kin init` now registers the repository it just admitted, warn-and-continue on failure, in the
same shape as the existing `exclude_store_from_git` side effect so a registration failure can
never fail `kin init`. It reuses the existing `update_registry` rather than adding a second
writer, because a second writer is how this class of bug returns.

`kin deps` and `kin registry` text was updated in the same change. Five user-facing strings
and three test assertions asserted that nothing registers a repository, which this change
makes false. Copy that contradicts what this PR does is not a follow-up.

## Proof

A test under a scratch `KIN_REGISTRY_PATH` calls the real async `run()` entrypoint and reads
the registry back. It panics with `registry entries: []` against the unfixed code and passes
after. The registry path comes from `KIN_REGISTRY_PATH`, not `KIN_HOME`, so a test isolating
only `KIN_HOME` would have passed for the wrong reason.

End to end, two fixture repos each admitted by a separate `kin init` under a scratch home:
`kin deps` from the consumer reports `depends on (1) demo-provider-repo (cargo manifest)`, and
from the provider reports `consumed by (1) demo-consumer-repo`. `kin deps` only reads the
registry file locally, so the demo never touches the daemon or the embedding pipeline.

## What this PR does not claim

The local gate was green at 6141/6141 on the pre-rebase tip. This branch has since been
rebased onto a main that added `kin agent` (#917), 4854 insertions across 23 files, cleanly
with no conflicts. The full workspace gate has not been re-run against this exact tip, but
`kin-cli`'s own lib suite was, standalone: 1512/1512 passed, 0 failed, in 793s, on this exact
tip after the rebase. CI, which builds the PR merged into main, is still the first full
workspace re-run against the merged content.

`kin migrate` is a second live admission path with the identical gap. It uses a different
pipeline and calls none of `finalize.rs`'s three functions, all of which have zero production
callers. A repository admitted through `kin migrate` still will not register itself. That is
deliberately out of scope here and needs its own change.

`crates/kin-cli/src/commands/mcp.rs` carries the same stale claim in its `kin mcp` startup
message, the same shape this PR fixes elsewhere. Left untouched here since it sits next to
MCP surfaces another branch owns right now.

The registry id is the directory's basename, not a generated repository identity. Two on-disk
repos sharing a basename collide on that id and overwrite each other's entry on the second
`kin init`. This is how `update_registry` already worked before this change. Redesigning its
identity scheme is a separate piece of work.

Opened as a draft and handed to the `kin` merge captain. No merge-authority lock was taken and
nothing was enqueued.
