### PR TITLE
Carry a completeness signal on every retrieval answer, not just empty ones

### DIFF
--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -64,6 +64,12 @@ use kin_model::relation::RelationKind;
 /// attached to.
 pub const EDGE_COVERAGE_KEY: &str = "edge_coverage";
 
+/// Key inside the observation carrying the parsed-versus-resolved reading for
+/// the focal's language, when one could be measured. Read by
+/// [`crate::envelope::Completeness`] so a partial answer can say "1 of 5"
+/// instead of an unqualified "1".
+pub const REFERENCE_RESOLUTION_KEY: &str = "reference_resolution";
+
 /// How many entities may have their relations read while looking for a witness.
 ///
 /// A healthy graph answers in single digits, so this bound is only reached on a
@@ -126,7 +132,42 @@ pub fn observe_cross_file_reference_coverage<S: EntityStore>(
     focal: &Entity,
     kinds: &[RelationKind],
 ) -> Value {
-    observe_cross_file_reference_coverage_for_languages(store, &[focal.language], kinds)
+    observe_cross_file_reference_coverage_witnessed(store, focal, kinds, &[])
+}
+
+/// [`observe_cross_file_reference_coverage`], told which classes the ANSWER
+/// itself already proved.
+///
+/// The observation is now attached to populated answers too (FIR-2357 item 1),
+/// because an answer that returned one row proved one edge exists and proved
+/// nothing about the class a missing caller would have come through. That is
+/// the founding case exactly: a single intra-file caller came back for a symbol
+/// five call sites reached, and the classes carrying the other four were absent.
+///
+/// Paying a full language scan on every populated answer would be a real cost
+/// for a fact the answer often already carries, so a caller that holds a
+/// cross-file row of class K passes K here and the scan is spared. A witness
+/// only ever raises a class from `unknown` to `present`; it never overturns a
+/// completed scan that observed one absent, so a witness the caller scoped
+/// wrongly can slow this down but cannot make it certify anything.
+///
+/// The caller's contract: pass a class only for an edge whose two endpoints sit
+/// in different files and whose source entity carries the focal's language,
+/// which is the same thing the scan below looks for.
+pub fn observe_cross_file_reference_coverage_witnessed<S: EntityStore>(
+    store: &S,
+    focal: &Entity,
+    kinds: &[RelationKind],
+    witnessed: &[RelationKind],
+) -> Value {
+    let mut observation = observe_cross_file_reference_coverage_for_languages_witnessed(
+        store,
+        &[focal.language],
+        kinds,
+        witnessed,
+    );
+    attach_reference_resolution(store, focal.language, &mut observation);
+    observation
 }
 
 /// Observe cross-file coverage across every language a batch of focals spans.
@@ -141,11 +182,35 @@ pub fn observe_cross_file_reference_coverage_for_languages<S: EntityStore>(
     languages: &[kin_model::ids::LanguageId],
     kinds: &[RelationKind],
 ) -> Value {
+    observe_cross_file_reference_coverage_for_languages_witnessed(store, languages, kinds, &[])
+}
+
+/// [`observe_cross_file_reference_coverage_for_languages`] with the answer's own
+/// witnesses, as documented on
+/// [`observe_cross_file_reference_coverage_witnessed`].
+pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntityStore>(
+    store: &S,
+    languages: &[kin_model::ids::LanguageId],
+    kinds: &[RelationKind],
+    witnessed: &[RelationKind],
+) -> Value {
     let requested = requested_classes(kinds);
+    let witnessed: Vec<RelationKind> = requested
+        .iter()
+        .copied()
+        .filter(|kind| witnessed.contains(kind))
+        .collect();
     let mut merged: Vec<(RelationKind, ClassState)> = requested
         .iter()
         .copied()
-        .map(|kind| (kind, ClassState::Unknown))
+        .map(|kind| {
+            let state = if witnessed.contains(&kind) {
+                ClassState::Present
+            } else {
+                ClassState::Unknown
+            };
+            (kind, state)
+        })
         .collect();
     let mut examined_total = 0usize;
     let mut any_budget_exhausted = false;
@@ -157,16 +222,34 @@ pub fn observe_cross_file_reference_coverage_for_languages<S: EntityStore>(
         observed_languages.push(*language);
     }
 
-    for (index, language) in observed_languages.iter().enumerate() {
-        let (states, examined, budget_exhausted) = observe_language(store, *language, &requested);
-        examined_total += examined;
-        any_budget_exhausted |= budget_exhausted;
-        for (slot, (_, state)) in merged.iter_mut().zip(states.iter()) {
-            slot.1 = if index == 0 {
-                *state
-            } else {
-                weakest(slot.1, *state)
-            };
+    // The scan exists to decide the classes the verdict rests on. When the
+    // answer already carried a witness for every one of them, running it buys a
+    // disclosure about classes nothing decides and costs a language-wide relation
+    // walk on the populated path, where there was no scan at all before.
+    let scan_needed = !deciding_classes_all_present(&merged);
+    if scan_needed {
+        for (index, language) in observed_languages.iter().enumerate() {
+            let (states, examined, budget_exhausted) =
+                observe_language(store, *language, &requested);
+            examined_total += examined;
+            any_budget_exhausted |= budget_exhausted;
+            for (slot, (_, state)) in merged.iter_mut().zip(states.iter()) {
+                slot.1 = if index == 0 {
+                    *state
+                } else {
+                    weakest(slot.1, *state)
+                };
+            }
+        }
+        // A witness raises `unknown` to `present` and stops there. A scan that
+        // ran to completion and observed a class absent is a stronger statement
+        // than one row's provenance, so a caller that scoped its witness wrongly
+        // can cost this a scan it did not need but can never buy an absence a
+        // certification would rest on.
+        for (kind, state) in merged.iter_mut() {
+            if *state == ClassState::Unknown && witnessed.contains(kind) {
+                *state = ClassState::Present;
+            }
         }
     }
 
@@ -205,7 +288,120 @@ pub fn observe_cross_file_reference_coverage_for_languages<S: EntityStore>(
         "reference_enrichment": reference_enrichment(&observed_languages),
         "budget_exhausted": any_budget_exhausted,
         "entities_examined": examined_total,
+        // How each verdict was reached, because "present" from a witness the
+        // answer carried and "present" from a completed scan are the same word
+        // for two different amounts of evidence.
+        "witnessed_by_answer": witnessed
+            .iter()
+            .map(|kind| class_name(*kind))
+            .collect::<Vec<_>>(),
+        "scan": if scan_needed {
+            "ran"
+        } else {
+            "skipped_answer_witnessed"
+        },
     })
+}
+
+/// Whether every class the absence verdict rests on is already `present`.
+///
+/// Narrowed by [`crate::negative::load_bearing_classes`] rather than by a rule
+/// of its own: Kin mints no entity-level `Imports` edge, so a rule that waited
+/// for every requested class would never skip a scan and would report every
+/// answer on every healthy graph as short of coverage.
+fn deciding_classes_all_present(merged: &[(RelationKind, ClassState)]) -> bool {
+    let requested: Vec<String> = merged
+        .iter()
+        .map(|(kind, _)| class_name(*kind).to_string())
+        .collect();
+    let deciding = crate::negative::load_bearing_classes(&requested);
+    if deciding.is_empty() {
+        return false;
+    }
+    deciding.iter().all(|class| {
+        merged
+            .iter()
+            .any(|(kind, state)| class_name(*kind) == class && *state == ClassState::Present)
+    })
+}
+
+/// Attach the parsed-versus-resolved reading for `language` when the observation
+/// says a deciding class was not available (FIR-2357 item 2).
+///
+/// This is the count side of the completeness contract. `kin graph status`
+/// already reports it per language through
+/// [`kin_core::reference_coverage`], and that shipped measurement is reused here
+/// rather than re-derived, because two counters for one fact is precisely how a
+/// coverage figure and a coverage verdict come to disagree inside one response.
+///
+/// Scoped to the focal's language, which makes exactly the fields this reads
+/// exact: `parsed_call_sites` and `parsed_import_statements` are tallied off
+/// entities of that language, and `resolved_call_edges` / `resolved_import_edges`
+/// off their outgoing relations. The cross-file, intra-file and external split is
+/// NOT read here, because classifying a target requires the target's own entity
+/// and a language-scoped list does not carry targets in other languages, which
+/// would report a cross-language edge as external.
+///
+/// Attached only when a deciding class is short, so a healthy answer pays
+/// nothing for a ratio it does not need, and a shortfall gets the number that
+/// says how big it is.
+fn attach_reference_resolution<S: EntityStore>(
+    store: &S,
+    language: LanguageId,
+    observation: &mut Value,
+) {
+    let already_covered = observation
+        .get("classes")
+        .and_then(Value::as_object)
+        .map(|classes| {
+            let requested: Vec<String> = classes.keys().cloned().collect();
+            let deciding = crate::negative::load_bearing_classes(&requested);
+            !deciding.is_empty()
+                && deciding.iter().all(|class| {
+                    classes.get(class).and_then(Value::as_str) == Some(ClassState::Present.as_str())
+                })
+        })
+        .unwrap_or(false);
+    if already_covered {
+        return;
+    }
+
+    let Ok(entities) = store.query_entities(&EntityFilter {
+        languages: Some(vec![language]),
+        ..EntityFilter::default()
+    }) else {
+        return;
+    };
+    let Ok(coverage) =
+        kin_core::reference_coverage::collect_reference_edge_coverage_from(store, &entities)
+    else {
+        return;
+    };
+    let Some(measured) = coverage
+        .languages
+        .into_iter()
+        .find(|entry| entry.language == language.to_string())
+    else {
+        return;
+    };
+
+    // No `language` key here on purpose. The observation names the language one
+    // level up, and `kin_core` spells it lowercase where this object spells it
+    // capitalised, so carrying both would put two spellings of one fact inside
+    // one response for a reader to reconcile.
+    observation[REFERENCE_RESOLUTION_KEY] = json!({
+        "files": measured.files,
+        "files_measured": measured.files_measured,
+        // `null` when no file of this language carries a parse-side count. An
+        // unmeasured parse side is not a zero, and publishing it as one would
+        // turn "nothing counted the source" into "the source had no calls".
+        "parsed_call_sites": measured.parsed_call_sites,
+        "resolved_call_edges": measured.resolved_call_edges,
+        "call_percent": measured.call_percent(),
+        "parsed_import_statements": measured.parsed_import_statements,
+        "resolved_import_edges": measured.resolved_import_edges,
+        "resolution": measured.resolution.label(),
+    });
 }
 
 /// Whether this build can produce cross-file reference and override edges for

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -225,6 +225,432 @@ pub enum NegativeClass {
     Structural,
 }
 
+/// Which substrate an answer was drawn from, and therefore what "complete"
+/// means for it.
+///
+/// Derived from the two registries that already exist rather than declared in a
+/// third: a tool that names cross-file edge classes in
+/// [`crate::negative::absence_cross_file_classes`] answers from edges, a tool
+/// whose [`NegativeClass`] is `Semantic` answers from embeddings, and every
+/// other retrieval tool answers from the entity/relation index. A third list
+/// would drift from the two, which is the failure the per-tool maps in
+/// [`crate::negative`] were written to avoid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoverageSubstrate {
+    Edges,
+    Embeddings,
+    Graph,
+}
+
+impl CoverageSubstrate {
+    fn as_str(self) -> &'static str {
+        match self {
+            CoverageSubstrate::Edges => "edges",
+            CoverageSubstrate::Embeddings => "embeddings",
+            CoverageSubstrate::Graph => "graph",
+        }
+    }
+
+    /// The substrate as it reads inside a sentence, which is not the same word
+    /// as the wire value: "the edges classes" is not English, and the note is
+    /// read by whoever has to act on a partial answer.
+    fn noun(self) -> &'static str {
+        match self {
+            CoverageSubstrate::Edges => "edge",
+            CoverageSubstrate::Embeddings => "embedding",
+            CoverageSubstrate::Graph => "graph",
+        }
+    }
+}
+
+/// A coverage class's observed state, spelled the same way
+/// [`crate::edge_coverage`] spells it so a reader never has to reconcile two
+/// vocabularies for one fact.
+const STATE_PRESENT: &str = "present";
+const STATE_ABSENT: &str = "absent";
+const STATE_UNKNOWN: &str = "unknown";
+
+/// The completeness signal every retrieval response carries, empty or not
+/// (FIR-2357 item 1).
+///
+/// The `negative` object guards the LOUD failure: an empty answer, which makes a
+/// careful agent suspicious on its own. This guards the quiet one. A partial
+/// answer looks exactly like a complete one, so `find_references` returned a
+/// single caller for a symbol five call sites reached and carried nothing at all
+/// saying the answer was a floor. An agent that reads one file back and
+/// concludes the function is local is reasoning correctly from what it was
+/// given, which is what makes the missing signal the defect rather than the
+/// agent.
+///
+/// One shape across every retrieval tool. What varies between them is which
+/// substrate they read, named in `substrate`, and which classes of it their
+/// answer depended on, named in `classes`. Nothing here is fabricated: a class
+/// nothing was observed about is `unknown`, and `unknown` is not `absent`.
+///
+/// ## What decides `status`
+///
+/// `decided_by` is a subset of `classes`, and the gap between them is
+/// deliberate. `classes` DISCLOSES every class the query read; `decided_by`
+/// carries only the ones whose absence would actually have hidden an answer.
+/// Kin mints no entity-level `Imports` edge at all, so requiring every requested
+/// class to be present would report every answer on every healthy graph as
+/// partial, which is the "mark everything uncertain" regression FIR-2357 item 4
+/// bars by test. [`crate::negative::load_bearing_classes`] is the same narrowing
+/// the absence verdict already uses, and it is reused here rather than
+/// re-derived.
+///
+/// ## What decides `bound`
+///
+/// `status` is about the substrate; `bound` is about the numbers the answer
+/// printed. They come apart in both directions: a complete substrate still
+/// yields a floor when the response budget dropped rows, and a partial substrate
+/// still counts exactly what it holds. `at_least` is the field that kills the
+/// unqualified count the ticket names, so it is set whenever the answer cannot
+/// be shown to be whole.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Completeness {
+    /// `complete` when every deciding class was observed present, `partial` when
+    /// one was observed absent, `unknown` when the observation could not say.
+    pub status: String,
+    /// `exact` when the counts in this answer are the whole set, `at_least` when
+    /// they are a floor. Never omitted: a caller reading a bare number is the
+    /// failure this object exists to prevent.
+    pub bound: String,
+    /// Which substrate this answer was drawn from: `edges`, `embeddings`, or
+    /// `graph`.
+    pub substrate: String,
+    /// Every coverage class the answer depended on, each `present`, `absent`, or
+    /// `unknown`.
+    pub classes: Map<String, Value>,
+    /// The subset of `classes` whose state decided `status`.
+    pub decided_by: Vec<String>,
+    /// What the answer counted and whether that count is the whole set, lifted
+    /// from the payload's own accounting rather than recomputed here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub counted: Option<Value>,
+    /// Parsed call sites against resolved reference edges for the focal's
+    /// language, when the graph carries a parse-side count to compare against
+    /// (FIR-2357 item 2). This is the reading that makes "1 of 5" sayable;
+    /// absent when nothing measured it, never a fabricated ratio.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference_resolution: Option<Value>,
+    /// Machine-stable labels for every shortfall this answer's own observation
+    /// names, including ones that did not decide `status`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limits: Vec<String>,
+    /// One line an agent can act on without knowing the ground truth.
+    pub note: String,
+}
+
+impl Completeness {
+    /// Build the signal for `tool` from its payload and the envelope beside it,
+    /// or `None` for a tool that is not retrieval.
+    ///
+    /// Retrieval membership is derived, not listed: a tool qualifies when it has
+    /// a negative spec or when it declares cross-file edge classes. Both
+    /// registries live in [`crate::negative`], so a new retrieval tool earns a
+    /// completeness signal by declaring what it reads, exactly as it earns an
+    /// absence verdict.
+    fn for_tool(tool: &str, payload: &Value, envelope: &Envelope) -> Option<Self> {
+        let edge_classes = crate::negative::absence_cross_file_classes(tool, payload);
+        let substrate = if !edge_classes.is_empty() {
+            CoverageSubstrate::Edges
+        } else {
+            match crate::negative::negative_class_for(tool)? {
+                NegativeClass::Semantic => CoverageSubstrate::Embeddings,
+                NegativeClass::Structural => CoverageSubstrate::Graph,
+            }
+        };
+
+        let (classes, decided_by, mut limits) = match substrate {
+            CoverageSubstrate::Edges => edge_class_states(tool, payload, &edge_classes),
+            CoverageSubstrate::Embeddings => embedding_class_states(envelope),
+            CoverageSubstrate::Graph => graph_class_states(envelope),
+        };
+
+        // Runtime facts are disclosed and never decide. The question this object
+        // answers is whether the substrate was whole, and `_kin.runtime` plus
+        // `_kin.degraded` already answer the separate question of who served it.
+        // Folding them in would make every offline answer uncertain regardless
+        // of its coverage, which is the barred regression wearing a different
+        // costume.
+        for label in envelope.degraded.active_labels() {
+            limits.push(format!("degraded:{label}"));
+        }
+
+        let deciding_states: Vec<&str> = decided_by
+            .iter()
+            .map(|class| {
+                classes
+                    .get(class)
+                    .and_then(Value::as_str)
+                    .unwrap_or(STATE_UNKNOWN)
+            })
+            .collect();
+        let status = if deciding_states.is_empty() {
+            STATE_UNKNOWN
+        } else if deciding_states.iter().any(|state| *state == STATE_ABSENT) {
+            "partial"
+        } else if deciding_states.iter().any(|state| *state == STATE_UNKNOWN) {
+            STATE_UNKNOWN
+        } else {
+            "complete"
+        };
+
+        let mut counted = counted_for(tool, payload);
+        // A payload that says it stopped early is a floor whatever its substrate
+        // looked like, so its own truncation flag can veto a complete verdict.
+        let walk_truncated = counted
+            .as_ref()
+            .and_then(|counted| counted.get("floor_reason"))
+            .is_some();
+        let bound = if status == "complete" && !walk_truncated {
+            "exact"
+        } else {
+            "at_least"
+        };
+        // One authority for one fact. `bound` decides, and the count restates it
+        // where a reader looking at the number will actually see it, because a
+        // `counted` reading `exact: true` beside a `bound` of `at_least` is the
+        // same contradiction inside one object that this object exists to end
+        // between two.
+        if let Some(counted) = counted.as_mut().and_then(Value::as_object_mut) {
+            counted.insert("exact".to_string(), json!(bound == "exact"));
+        }
+
+        let reference_resolution = payload
+            .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+            .and_then(|coverage| coverage.get(crate::edge_coverage::REFERENCE_RESOLUTION_KEY))
+            .cloned();
+
+        Some(Completeness {
+            note: completeness_note(status, bound, substrate, &limits),
+            status: status.to_string(),
+            bound: bound.to_string(),
+            substrate: substrate.as_str().to_string(),
+            classes,
+            decided_by,
+            counted,
+            reference_resolution,
+            limits,
+        })
+    }
+
+    /// Downgrade the signal to a floor because the response budget removed rows.
+    ///
+    /// The budget runs after this object is serialized, so the cut cannot be
+    /// known when the verdict is built. A response shortened by the budget is
+    /// partial by exactly the definition this object uses, and letting it keep
+    /// `exact` would reintroduce the unqualified count through the one path that
+    /// removes answers on purpose.
+    fn mark_response_bounded(value: &mut Value) {
+        let Some(object) = value.as_object_mut() else {
+            return;
+        };
+        object.insert("bound".to_string(), json!("at_least"));
+        if let Some(counted) = object.get_mut("counted").and_then(Value::as_object_mut) {
+            counted.insert("exact".to_string(), json!(false));
+        }
+        let limits = object
+            .entry("limits".to_string())
+            .or_insert_with(|| json!([]));
+        if let Some(limits) = limits.as_array_mut() {
+            let label = json!("response_bounded");
+            if !limits.contains(&label) {
+                limits.push(label);
+            }
+        }
+        object.insert(
+            "note".to_string(),
+            json!(
+                "The response budget withheld part of this answer, so its counts are a lower \
+                 bound. `_kin.response` names what was cut and how to ask for the rest."
+            ),
+        );
+    }
+}
+
+/// The edge-class states this answer depended on, read off the observation the
+/// payload carries.
+///
+/// A payload with no observation leaves every class `unknown` rather than
+/// healthy. That is the same reading [`crate::negative::edge_coverage_gap`]
+/// takes, and it is what makes a tool publish the observation before it can
+/// report itself complete.
+fn edge_class_states(
+    tool: &str,
+    payload: &Value,
+    requested: &[String],
+) -> (Map<String, Value>, Vec<String>, Vec<String>) {
+    let observation = payload
+        .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+        .and_then(Value::as_object);
+    let states = observation.and_then(|observation| {
+        observation
+            .get("classes")
+            .and_then(Value::as_object)
+            .cloned()
+    });
+    let mut classes = Map::new();
+    for class in requested {
+        let state = states
+            .as_ref()
+            .and_then(|states| states.get(class))
+            .and_then(Value::as_str)
+            .unwrap_or(STATE_UNKNOWN);
+        classes.insert(class.clone(), json!(state));
+    }
+    let decided_by = crate::negative::load_bearing_classes(requested);
+    let limits = crate::negative::edge_coverage_degradation_labels(tool, payload);
+    (classes, decided_by, limits)
+}
+
+/// The embedding class state, from the coverage the envelope already lifted.
+fn embedding_class_states(envelope: &Envelope) -> (Map<String, Value>, Vec<String>, Vec<String>) {
+    let mut limits = Vec::new();
+    let state = match &envelope.semantic_coverage {
+        None => STATE_UNKNOWN,
+        Some(coverage) if coverage.complete => STATE_PRESENT,
+        Some(coverage) => {
+            if coverage.graph_body_gap_paths.is_some_and(|gaps| gaps > 0) {
+                limits.push("graph_body_gap".to_string());
+            }
+            STATE_ABSENT
+        }
+    };
+    let mut classes = Map::new();
+    classes.insert("embeddings".to_string(), json!(state));
+    if state != STATE_PRESENT {
+        limits.push(format!("embeddings_{state}"));
+    }
+    (classes, vec!["embeddings".to_string()], limits)
+}
+
+/// The graph class state, from the freshness signals the envelope observed.
+///
+/// Both halves have to be affirmatively true. `initialized` says first
+/// reconciliation finished and `loaded` says a graph is actually mounted; either
+/// one false means the index a structural answer read is not the whole one.
+fn graph_class_states(envelope: &Envelope) -> (Map<String, Value>, Vec<String>, Vec<String>) {
+    let state = match (
+        envelope.graph_state.initialized,
+        envelope.graph_state.loaded,
+    ) {
+        (Some(true), Some(true)) => STATE_PRESENT,
+        (Some(false), _) | (_, Some(false)) => STATE_ABSENT,
+        _ => STATE_UNKNOWN,
+    };
+    let mut classes = Map::new();
+    classes.insert("graph".to_string(), json!(state));
+    let limits = if state == STATE_PRESENT {
+        Vec::new()
+    } else {
+        vec![format!("graph_{state}")]
+    };
+    (classes, vec!["graph".to_string()], limits)
+}
+
+/// What this answer counted and whether the count is the whole set, lifted from
+/// the payload's own accounting.
+///
+/// Nothing is recounted here. The handlers already publish what their number
+/// means (`counts.counted` names the unit, `counts.reference_sites_complete`
+/// says whether the finer number is whole), and recomputing it in the envelope
+/// is how two counters come to disagree about one answer.
+fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
+    let (unit, reported) = match tool {
+        "find_references" => (
+            payload
+                .get("counts")
+                .and_then(|counts| counts.get("counted"))
+                .and_then(Value::as_str)
+                .unwrap_or("referencing_entities"),
+            payload.get("total_upstream").and_then(Value::as_u64)?,
+        ),
+        "trace_data_flow" => ("steps", payload.get("total_steps").and_then(Value::as_u64)?),
+        "bulk_check_references" => (
+            "entities",
+            payload
+                .get("results")
+                .and_then(Value::as_array)
+                .map(|rows| rows.len() as u64)?,
+        ),
+        _ => return None,
+    };
+
+    // A response that says it stopped early is a floor whatever its substrate
+    // looked like, so the payload's own truncation flag outranks the class
+    // verdict for this field.
+    let truncated = payload.get("truncated").and_then(Value::as_bool) == Some(true);
+    let mut counted = json!({
+        "unit": unit,
+        "reported": reported,
+        "exact": !truncated,
+    });
+    if truncated {
+        counted["floor_reason"] = json!("walk_truncated");
+    }
+    // The site numbers FIR-2398 added answer a narrower question than this
+    // object does: whether every RETURNED row could be located at a line, not
+    // whether the row set is whole. They are carried verbatim rather than folded
+    // into `exact`, because collapsing the two is how a complete row set with one
+    // unlocatable site would come to read as an incomplete answer.
+    if let Some(sites) = payload.get("counts").and_then(|counts| {
+        let object = counts.as_object()?;
+        let mut sites = Map::new();
+        for key in [
+            "reference_sites",
+            "known_reference_sites",
+            "reference_sites_complete",
+        ] {
+            if let Some(value) = object.get(key) {
+                sites.insert(key.to_string(), value.clone());
+            }
+        }
+        (!sites.is_empty()).then_some(Value::Object(sites))
+    }) {
+        counted["sites"] = sites;
+    }
+    Some(counted)
+}
+
+/// One line an agent can act on. Says what the answer is worth and, when it is
+/// worth less than it looks, what limited it.
+fn completeness_note(
+    status: &str,
+    bound: &str,
+    substrate: CoverageSubstrate,
+    limits: &[String],
+) -> String {
+    let named = if limits.is_empty() {
+        String::new()
+    } else {
+        format!(" Limited by: {}.", limits.join(", "))
+    };
+    match (status, bound) {
+        ("complete", "exact") => format!(
+            "Every {} class this answer depended on was observed present, so the counts here are \
+             the whole set.",
+            substrate.noun()
+        ),
+        ("complete", _) => format!(
+            "Every {} class this answer depended on was observed present, but the counts are a \
+             lower bound.{named}",
+            substrate.noun()
+        ),
+        ("partial", _) => format!(
+            "One of the {} classes this answer depended on was observed absent, so what came back \
+             is a lower bound and its absence proves nothing about the code.{named}",
+            substrate.noun()
+        ),
+        _ => format!(
+            "Whether the {} classes this answer depended on were available could not be \
+             established, so treat the counts as a lower bound.{named}",
+            substrate.noun()
+        ),
+    }
+}
+
 /// The versioned MCP response envelope shared by every tool family.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Envelope {
@@ -247,6 +673,12 @@ pub struct Envelope {
     /// Degraded-state flags (always present; individual flags omitted when not
     /// observed).
     pub degraded: Degraded,
+    /// The completeness signal (FIR-2357): what this answer's substrate could
+    /// have found, present on every retrieval response whether it came back
+    /// empty or full. `negative` guards only the empty case; this guards the
+    /// partial one, which is the case an agent cannot see.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completeness: Option<Completeness>,
     /// What the response budget did to this payload: the budget applied and what
     /// the response measured before it. Present only on the retrieval tools the
     /// budget governs, and written by [`finalize_bounded`] AFTER this struct is
@@ -270,6 +702,7 @@ impl Envelope {
                 offline_fallback: Some(true),
                 ..Degraded::default()
             },
+            completeness: None,
             response: None,
         }
     }
@@ -285,6 +718,7 @@ impl Envelope {
             graph_as_of: None,
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
+            completeness: None,
             response: None,
         }
     }
@@ -341,6 +775,7 @@ impl Envelope {
                 daemon_unreachable: Some(true),
                 ..Degraded::default()
             },
+            completeness: None,
             response: None,
         }
     }
@@ -364,6 +799,7 @@ impl Envelope {
                 workspace_mismatch: Some(true),
                 ..Degraded::default()
             },
+            completeness: None,
             response: None,
         }
     }
@@ -619,10 +1055,17 @@ pub fn finalize_bounded(
     budget: &ResponseBudget,
 ) -> ToolCallResult {
     let payload = first_payload_value(&result);
-    let envelope = match &payload {
+    let mut envelope = match &payload {
         Some(payload) => base.with_payload_metadata(payload),
         None => base,
     };
+    // Built for every retrieval answer that carried a payload at all, empty or
+    // full. A call that failed before producing one has no substrate to report
+    // on, and the `negative` synthesized for it below is the signal that case
+    // needs.
+    if let Some(payload) = &payload {
+        envelope.completeness = Completeness::for_tool(tool_name, payload, &envelope);
+    }
     let negative = match &payload {
         Some(payload) => crate::negative::negative_for(tool_name, payload, &envelope),
         None if result.is_error == Some(true) => first_message_text(&result).and_then(|message| {
@@ -703,6 +1146,15 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
         accounting.chars_before = chars_before;
     }
     write_response_accounting(annotated, &accounting);
+    if accounting.bounded {
+        if let Some(completeness) = annotated
+            .get_mut(ENVELOPE_KEY)
+            .and_then(Value::as_object_mut)
+            .and_then(|envelope| envelope.get_mut("completeness"))
+        {
+            Completeness::mark_response_bounded(completeness);
+        }
+    }
 }
 
 fn write_response_accounting(annotated: &mut Value, accounting: &crate::budget::BudgetAccounting) {
@@ -946,6 +1398,260 @@ mod tests {
         assert_eq!(whole[ENVELOPE_KEY]["degraded"]["daemon_unreachable"], true);
         // Human substring is still findable inside the wrapped JSON.
         assert!(text.contains("daemon is unreachable"));
+    }
+
+    /// A daemon envelope over a graph that reports itself ready, which is the
+    /// state every one of these fixtures answers from.
+    fn ready_daemon_envelope() -> Envelope {
+        Envelope::daemon().with_health(&json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "reconciliation_status": "clean",
+        }))
+    }
+
+    fn completeness_of(result: &ToolCallResult) -> Value {
+        envelope_of(result)
+            .get("completeness")
+            .cloned()
+            .expect("every retrieval response carries a completeness signal")
+    }
+
+    fn annotated_value(result: &ToolCallResult) -> Value {
+        let ContentBlock::Text { text } = result.content.first().expect("one content block");
+        serde_json::from_str(text).expect("annotated payload is JSON")
+    }
+
+    /// One reference answer, parameterised by what the graph could see.
+    fn reference_payload(returned: u64, calls_state: &str) -> ToolCallResult {
+        ToolCallResult::text(
+            json!({
+                "total_upstream": returned,
+                "counts": {
+                    "counted": "referencing_entities",
+                    "referencing_entities": returned,
+                    "reference_sites": returned,
+                    "known_reference_sites": returned,
+                    "reference_sites_complete": true,
+                },
+                "references": vec![json!({"name": "extract_links"}); returned as usize],
+                "relation_kinds": ["calls", "imports", "references"],
+                "edge_coverage": {
+                    "scope": "language",
+                    "language": "Python",
+                    "classes": {
+                        "calls": calls_state,
+                        "imports": "absent",
+                        "references": "absent",
+                    },
+                    "reference_enrichment": "unknown",
+                    "budget_exhausted": false,
+                },
+            })
+            .to_string(),
+        )
+    }
+
+    /// The FIR-2357 headline at the envelope layer. A NON-empty answer over a
+    /// graph holding no cross-file call edges is 20% complete and used to ship
+    /// with nothing at all saying so: no negative, no trust field, no caveat.
+    /// The signal has to be there, and it has to say the count is a floor.
+    #[test]
+    fn a_partial_non_empty_answer_carries_a_completeness_signal() {
+        let annotated = finalize(
+            reference_payload(1, "absent"),
+            ready_daemon_envelope(),
+            "find_references",
+        );
+        let completeness = completeness_of(&annotated);
+
+        assert_eq!(
+            completeness["status"], "partial",
+            "a graph holding no cross-file calls cannot have found the other callers: \
+             {completeness}"
+        );
+        assert_eq!(
+            completeness["bound"], "at_least",
+            "and the count it did return is a floor, not a fact: {completeness}"
+        );
+        assert_eq!(completeness["substrate"], "edges");
+        assert_eq!(completeness["counted"]["reported"], 1);
+        assert_eq!(completeness["counted"]["unit"], "referencing_entities");
+        assert!(
+            completeness["limits"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("edge_coverage:calls_absent")),
+            "the limiting class is named rather than left to be inferred: {completeness}"
+        );
+
+        // The payload is not empty, so the object that used to be the only trust
+        // signal is absent by design. That asymmetry is the defect this closes:
+        // without the completeness object this response carries nothing.
+        assert!(
+            !annotated_value(&annotated)
+                .as_object()
+                .unwrap()
+                .contains_key(crate::negative::NEGATIVE_KEY),
+            "a populated answer synthesizes no negative, which is why it needed this"
+        );
+    }
+
+    /// The regression FIR-2357 item 4 bars, held in the opposite direction. A
+    /// graph that demonstrably links calls across files answers completely, and
+    /// a fix that marked everything uncertain would fail here while passing the
+    /// test above.
+    #[test]
+    fn a_fully_resolved_answer_reports_complete_and_exact() {
+        let annotated = finalize(
+            reference_payload(5, "present"),
+            ready_daemon_envelope(),
+            "find_references",
+        );
+        let completeness = completeness_of(&annotated);
+
+        assert_eq!(completeness["status"], "complete", "{completeness}");
+        assert_eq!(completeness["bound"], "exact", "{completeness}");
+        assert_eq!(completeness["counted"]["reported"], 5);
+        assert_eq!(completeness["counted"]["exact"], true);
+        // `imports` and `references` are absent in this fixture and always are
+        // on a real graph, since Kin mints no entity-level import edge. They are
+        // disclosed and they do not decide, which is the only way both
+        // directions of this contract can hold at once.
+        assert_eq!(completeness["classes"]["imports"], "absent");
+        assert_eq!(completeness["decided_by"], json!(["calls"]));
+    }
+
+    /// Unobserved is not healthy. A payload carrying no observation leaves every
+    /// class unknown and the answer a floor, so a tool cannot earn a complete
+    /// verdict by declining to measure.
+    #[test]
+    fn an_unobserved_answer_is_unknown_rather_than_complete() {
+        let payload = ToolCallResult::text(
+            json!({
+                "total_upstream": 3,
+                "references": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
+                "relation_kinds": ["calls"],
+            })
+            .to_string(),
+        );
+        let completeness = completeness_of(&finalize(
+            payload,
+            ready_daemon_envelope(),
+            "find_references",
+        ));
+
+        assert_eq!(completeness["status"], "unknown", "{completeness}");
+        assert_eq!(completeness["bound"], "at_least", "{completeness}");
+        assert_eq!(completeness["classes"]["calls"], "unknown");
+        assert!(completeness["limits"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("edge_coverage:unreported")));
+    }
+
+    /// The budget removes rows on purpose, and a response it shortened is
+    /// partial by exactly the definition this object uses. The cut happens after
+    /// the verdict is built, so the downgrade has to be applied to the
+    /// serialized signal or the one path that removes answers deliberately would
+    /// be the one path that reports them as whole.
+    #[test]
+    fn a_budget_shortened_answer_reports_a_floor() {
+        let rows: Vec<Value> = (0..400)
+            .map(|index| {
+                json!({
+                    "name": format!("caller_{index}"),
+                    "body": "x".repeat(200),
+                })
+            })
+            .collect();
+        let payload = ToolCallResult::text(
+            json!({
+                "total_upstream": rows.len(),
+                "counts": {
+                    "counted": "referencing_entities",
+                    "reference_sites_complete": true,
+                },
+                "references": rows,
+                "relation_kinds": ["calls"],
+                "edge_coverage": {
+                    "language": "Python",
+                    "classes": { "calls": "present" },
+                    "reference_enrichment": "unknown",
+                    "budget_exhausted": false,
+                },
+            })
+            .to_string(),
+        );
+        let budget = ResponseBudget {
+            max_chars: 4_000,
+            ..ResponseBudget::default()
+        };
+        let annotated =
+            finalize_bounded(payload, ready_daemon_envelope(), "find_references", &budget);
+        let envelope = envelope_of(&annotated);
+        assert_eq!(
+            envelope["response"]["bounded"], true,
+            "the fixture has to actually trip the budget: {}",
+            envelope["response"]
+        );
+
+        let completeness = &envelope["completeness"];
+        assert_eq!(
+            completeness["bound"], "at_least",
+            "a response the budget cut is a floor however healthy its graph was: {completeness}"
+        );
+        assert_eq!(completeness["counted"]["exact"], false);
+        assert!(completeness["limits"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("response_bounded")));
+    }
+
+    /// One shape, but not one substrate. A ranked answer depends on embeddings
+    /// and never traverses an edge, so its classes name embeddings and an
+    /// incomplete index makes it partial.
+    #[test]
+    fn a_ranked_answer_reports_the_embedding_substrate() {
+        let payload = ToolCallResult::text(
+            json!({
+                "results": [{"name": "normalize_title"}],
+                "semantic_coverage": {
+                    "indexed": 40,
+                    "total": 100,
+                    "pending": 60,
+                    "complete": false,
+                },
+            })
+            .to_string(),
+        );
+        let completeness = completeness_of(&finalize(
+            payload,
+            ready_daemon_envelope(),
+            "semantic_locate",
+        ));
+
+        assert_eq!(completeness["substrate"], "embeddings");
+        assert_eq!(completeness["classes"]["embeddings"], "absent");
+        assert_eq!(completeness["status"], "partial", "{completeness}");
+        assert_eq!(completeness["bound"], "at_least");
+    }
+
+    /// A mutation is not retrieval and carries no completeness object, so the
+    /// signal means something where it appears rather than becoming a field
+    /// every response has to carry an answer for.
+    #[test]
+    fn a_non_retrieval_tool_carries_no_completeness_signal() {
+        let annotated = finalize(
+            ToolCallResult::text(json!({"committed": true}).to_string()),
+            ready_daemon_envelope(),
+            "kin_transaction_commit",
+        );
+        assert!(
+            envelope_of(&annotated).get("completeness").is_none(),
+            "{}",
+            envelope_of(&annotated)
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1093,6 +1093,66 @@ fn reference_filter_covers_unknown_subtypes(relation_kinds: &[RelationKind]) -> 
         && defaults.iter().all(|kind| relation_kinds.contains(kind))
 }
 
+/// The reference classes this answer itself proves the graph holds across files.
+///
+/// A returned row IS a resolved edge, so a row whose caller sits in a different
+/// file from the focal and carries the focal's language is exactly the witness
+/// the language scan in [`crate::edge_coverage`] goes looking for. Handing it
+/// over spares that scan on the healthy path, which matters now that an
+/// observation is taken on every answer rather than only on empty ones.
+///
+/// The language check is not optional. The scan is scoped to the focal's
+/// language because extraction gaps are per-language, so a caller written in
+/// another language proves nothing about whether THIS language's edges resolve,
+/// and a witness taken from one would let a well-linked language lend coverage
+/// to a language whose edges were never produced.
+///
+/// A row this cannot confirm contributes nothing and the scan runs, so the
+/// failure direction is a scan that was not needed rather than a class reported
+/// present on evidence that did not support it.
+fn answer_witnessed_classes<G: GraphStore>(
+    store: &G,
+    focal: &kin_model::entity::Entity,
+    rows: &[ReferenceRow],
+) -> Vec<RelationKind> {
+    let focal_file = focal.file_origin.as_ref().map(|path| path.0.clone());
+    let mut witnessed: Vec<RelationKind> = Vec::new();
+    for row in rows {
+        if row
+            .relation_kinds
+            .iter()
+            .all(|kind| witnessed.contains(kind))
+        {
+            continue;
+        }
+        let Some(file_path) = row.file_path.as_ref() else {
+            continue;
+        };
+        if focal_file.as_ref() == Some(file_path) {
+            continue;
+        }
+        let Some(entity_id) = row
+            .entity_id
+            .as_deref()
+            .and_then(|id| parse_entity_id(id).ok())
+        else {
+            continue;
+        };
+        let Ok(Some(caller)) = store.get_entity(&entity_id) else {
+            continue;
+        };
+        if caller.language != focal.language {
+            continue;
+        }
+        for kind in &row.relation_kinds {
+            if !witnessed.contains(kind) {
+                witnessed.push(*kind);
+            }
+        }
+    }
+    witnessed
+}
+
 /// What a reference answer counted, stated rather than left to be inferred.
 ///
 /// `total_upstream` is a bare number, and a reader who does not know its unit
@@ -1452,6 +1512,9 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     // is one referencing entity, so `referencing_entities` is the row count and
     // `files` is what the pre-FIR-2398 `total_upstream` was reporting.
     let counts = reference_counts(&rows);
+    // Read off the rows before they are projected, where the caller's entity id
+    // is still addressable.
+    let witnessed = answer_witnessed_classes(store, &target, &rows);
 
     // `entity_id` remains the local drill-through keystone. Federated rows use
     // repo-qualified paths and carry no local entity id.
@@ -1461,17 +1524,24 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         .collect::<Vec<_>>();
 
     // What the graph can structurally answer over the edge classes this query
-    // reads. An empty reference list is only evidence about the code when the
-    // graph demonstrably holds cross-file edges of those classes for the focal's
+    // reads. A reference list is only evidence about the code when the graph
+    // demonstrably holds cross-file edges of those classes for the focal's
     // language, and nothing else in this payload reports that.
     //
-    // Observed only for an empty answer, which is the only answer whose trust
-    // depends on it: an answer that returned rows has proved the edges exist by
-    // returning them, and paying a language scan on the populated path would be
-    // a cost with nothing to buy.
-    let edge_coverage = references.is_empty().then(|| {
-        crate::edge_coverage::observe_cross_file_reference_coverage(store, &target, &relation_kinds)
-    });
+    // Observed on EVERY answer, empty or not (FIR-2357 item 1). The reasoning
+    // that limited it to empty answers is the defect: an answer that returned
+    // rows proved the classes those rows came through, and proved nothing about
+    // the class a caller it missed would have come through. `normalize_title`
+    // came back with one intra-file caller for a symbol five call sites reached,
+    // and an unqualified `1` is the answer an agent cannot tell from a complete
+    // one. The witnesses the rows already carry keep the healthy path from
+    // paying a language scan for a fact it is holding.
+    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage_witnessed(
+        store,
+        &target,
+        &relation_kinds,
+        &witnessed,
+    );
 
     let mut result = serde_json::json!({
         "focal_entity": {
@@ -1496,9 +1566,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         "references": references,
         "cross_repo": cross_repo,
     });
-    if let Some(edge_coverage) = edge_coverage {
-        result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
-    }
+    result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -3163,17 +3231,22 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     }
 
     let total_steps = chain.len();
-    // The walk expands exactly the reference kinds above, so an empty chain is
-    // only evidence about the focal when the graph holds cross-file edges of
-    // those kinds for its language. A walk that returned steps needs no such
-    // evidence and pays no scan for it.
-    let edge_coverage = chain.is_empty().then(|| {
-        crate::edge_coverage::observe_cross_file_reference_coverage(
-            store,
-            &focal_entity,
-            &reference_kinds,
-        )
-    });
+    // The walk expands exactly the reference kinds above, so a chain is only
+    // evidence about the focal when the graph holds cross-file edges of those
+    // kinds for its language. Observed on every walk rather than only on an
+    // empty one (FIR-2357 item 1): a walk that returned three steps over a graph
+    // holding no cross-file calls has stayed inside one file, and reporting that
+    // as an unqualified chain is the same quiet partial the reference tool had.
+    //
+    // No witness is passed here, unlike `find_references`. A chain step records
+    // the entity reached, not which class of edge reached it, and a witness
+    // asserted for the wrong class is the one thing this observation must never
+    // accept.
+    let edge_coverage = crate::edge_coverage::observe_cross_file_reference_coverage(
+        store,
+        &focal_entity,
+        &reference_kinds,
+    );
     let mut result = serde_json::json!({
         "focal_id": focal_entity.id.to_string(),
         "focal_name": focal_entity.name.clone(),
@@ -3195,9 +3268,7 @@ pub fn handle_trace_data_flow<G: GraphStore>(
             "same_name_candidates": same_name_candidates,
         },
     });
-    if let Some(edge_coverage) = edge_coverage {
-        result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
-    }
+    result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
     if !clipped_steps.is_empty() {
         result["clipped_steps"] = serde_json::Value::Array(clipped_steps);
     }
@@ -4838,11 +4909,18 @@ mod tests {
         );
     }
 
-    /// An answer that returned rows proved the edges exist by returning them, so
-    /// it pays no language scan and carries no observation. Stating it as a test
-    /// keeps the populated path from silently acquiring one.
+    /// A populated answer over a graph that demonstrably links calls across
+    /// files reports itself complete, and its count is exact.
+    ///
+    /// This test asserted the opposite until FIR-2357: that a populated answer
+    /// carried no observation at all, on the reasoning that rows prove the edges
+    /// exist by existing. They prove the classes those rows came through and
+    /// nothing about the class a caller the answer MISSED would have come
+    /// through, which is how a 20%-complete answer shipped with no signal. The
+    /// observation is now taken on every answer, and this is the direction that
+    /// stops it from degrading into marking everything uncertain.
     #[tokio::test]
-    async fn a_populated_reference_answer_carries_no_edge_observation() {
+    async fn a_populated_cross_file_answer_reports_itself_complete() {
         let store = InMemoryGraph::new();
         let caller = make_entity("caller", "src/a.rs");
         let target = make_entity("target", "src/b.rs");
@@ -4862,16 +4940,143 @@ mod tests {
             "find_references",
         ));
         assert_eq!(response["total_upstream"], 1);
+
+        let completeness = &response["_kin"]["completeness"];
+        assert_eq!(completeness["status"], "complete", "{completeness}");
+        assert_eq!(completeness["bound"], "exact", "{completeness}");
+        assert_eq!(completeness["counted"]["reported"], 1);
+
+        // The row itself was the witness, so the language scan never ran. That
+        // is what keeps an observation on every answer from costing a
+        // language-wide relation walk per call on a healthy graph.
+        let coverage = &response[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        assert_eq!(coverage["scan"], "skipped_answer_witnessed", "{coverage}");
+        assert_eq!(
+            coverage["witnessed_by_answer"],
+            serde_json::json!(["calls"])
+        );
+        assert_eq!(coverage["entities_examined"], 0);
+
         assert!(
-            response
-                .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
-                .is_none(),
-            "a populated answer needs no coverage observation: {response}"
+            response.get("negative").is_none(),
+            "a populated answer still synthesizes no negative, which is why the \
+             completeness signal is the one that has to carry this case"
+        );
+    }
+
+    /// The FIR-2357 headline end to end. A graph holding one intra-file call
+    /// edge answers for a symbol a sibling file also calls, and returns exactly
+    /// one caller. Ground truth is more, and every freshness signal reads
+    /// healthy, so nothing in the response used to suggest the answer was a
+    /// fifth of the truth.
+    ///
+    /// This is the shape the isolated stranger hit on `normalize_title`: one
+    /// reference back, `total_upstream: 1`, no negative because the answer was
+    /// not empty, and an agent that reasonably concluded the function was local.
+    #[tokio::test]
+    async fn a_partial_reference_answer_says_its_count_is_a_floor() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("normalize_title", "nk/parsing.rs");
+        let same_file_caller = make_entity("extract_links", "nk/parsing.rs");
+        // The sibling file that really calls the target. The extractor linked
+        // nothing across files, so no edge represents it and the answer cannot
+        // find it. That gap is the fact the response has to report.
+        let cross_file_caller = make_entity("render_note", "nk/render.rs");
+        store.upsert_entity(&target).unwrap();
+        store.upsert_entity(&same_file_caller).unwrap();
+        store.upsert_entity(&cross_file_caller).unwrap();
+        store
+            .upsert_relation(&make_relation(
+                same_file_caller.id,
+                target.id,
+                RelationKind::Calls,
+            ))
+            .unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert_eq!(
+            response["total_upstream"], 1,
+            "the answer itself is unchanged; what changes is what rides beside it"
         );
         assert!(
             response.get("negative").is_none(),
-            "and carries no negative to consume one"
+            "non-empty, so the negative object never fires here"
         );
+
+        let completeness = &response["_kin"]["completeness"];
+        assert_eq!(
+            completeness["status"], "partial",
+            "a graph with no cross-file call edge could not have found the sibling \
+             caller: {completeness}"
+        );
+        assert_eq!(
+            completeness["bound"], "at_least",
+            "so the 1 is a floor rather than a fact: {completeness}"
+        );
+        assert_eq!(completeness["classes"]["calls"], "absent");
+        assert_eq!(completeness["decided_by"], serde_json::json!(["calls"]));
+        assert!(
+            completeness["limits"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!("edge_coverage:calls_absent")),
+            "{completeness}"
+        );
+        // The row's own caller sits in the target's file, so it witnesses
+        // nothing cross-file and the scan runs.
+        let coverage = &response[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        assert_eq!(coverage["scan"], "ran", "{coverage}");
+        assert_eq!(coverage["witnessed_by_answer"], serde_json::json!([]));
+    }
+
+    /// The count side (FIR-2357 item 2). When the graph carries a parse-side
+    /// call-site count, a short answer says how short: parsed call sites against
+    /// the reference edges that resolved, so "1 of 5" is readable off the
+    /// response instead of an unqualified "1".
+    #[tokio::test]
+    async fn a_partial_reference_answer_reports_parsed_against_resolved() {
+        let store = InMemoryGraph::new();
+        let mut target = make_entity("normalize_title", "nk/parsing.rs");
+        let mut caller = make_entity("extract_links", "nk/parsing.rs");
+        // What extraction recorded for the file: five call sites read from the
+        // source, against the one edge that resolved.
+        for entity in [&mut target, &mut caller] {
+            entity.metadata.extra.insert(
+                kin_parser::FILE_PARSED_CALL_SITES_KEY.to_string(),
+                serde_json::json!(5),
+            );
+        }
+        store.upsert_entity(&target).unwrap();
+        store.upsert_entity(&caller).unwrap();
+        store
+            .upsert_relation(&make_relation(caller.id, target.id, RelationKind::Calls))
+            .unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        let resolution = &response["_kin"]["completeness"]["reference_resolution"];
+        assert_eq!(resolution["parsed_call_sites"], 5, "{resolution}");
+        assert_eq!(resolution["resolved_call_edges"], 1, "{resolution}");
+        assert_eq!(resolution["call_percent"], 20, "{resolution}");
+        assert_eq!(resolution["resolution"], "partial", "{resolution}");
+        assert_eq!(response["_kin"]["completeness"]["bound"], "at_least");
     }
 
     /// The other half of the same claim, on the daemon authority path so nothing

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -176,6 +176,18 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
     Some(spec)
 }
 
+/// Which substrate's completeness gates this tool, or `None` for a tool that is
+/// not negative-capable retrieval.
+///
+/// The one reader outside this module is [`crate::envelope::Completeness`],
+/// which needs the same per-tool substrate answer to say what "complete" means
+/// for an answer. Serving it from [`spec_for`] keeps one registry: a retrieval
+/// tool declares what it reads once and both the absence verdict and the
+/// completeness signal follow from that declaration.
+pub(crate) fn negative_class_for(tool: &str) -> Option<NegativeClass> {
+    spec_for(tool).map(|spec| spec.class)
+}
+
 /// The cross-file edge classes each tool's ABSENCE claim depends on: the
 /// per-tool dependency map, in code, so authority can only be granted for a
 /// substrate the tool actually reads.
@@ -202,7 +214,7 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
 /// A tool absent from the map contributes no classes, so a new retrieval tool
 /// starts with no edge-derived authority to inherit and has to declare what it
 /// reads to earn one.
-fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<String> {
+pub(crate) fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<String> {
     match tool {
         "find_references" | "bulk_check_references" => payload
             .get("relation_kinds")
@@ -260,7 +272,7 @@ fn reference_classes() -> Vec<String> {
 /// A query that asked for no load-bearing class falls back to the classes it did
 /// ask for, so an `imports`-only or `references`-only query is still gated on
 /// what it actually read rather than on nothing.
-fn load_bearing_classes(requested: &[String]) -> Vec<String> {
+pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
     let load_bearing: Vec<String> = requested
         .iter()
         .filter(|class| class.as_str() == "calls")
@@ -427,7 +439,7 @@ fn classes_in_state<'a>(
 /// `edge_coverage:references_absent` beside it is saying something exact: the
 /// graph links calls and imports across files, it holds no reference edges, and
 /// the claim rests on the first fact rather than the second.
-fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> Vec<String> {
+pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> Vec<String> {
     let requested = absence_cross_file_classes(tool, payload);
     if requested.is_empty() {
         return Vec::new();


### PR DESCRIPTION
The negative envelope guards the loud failure and leaves the quiet one open. An empty answer makes a careful agent suspicious on its own. A partial answer looks exactly like a complete one. `find_references("normalize_title")` returned a single caller for a symbol five call sites reached, and because the answer was not empty it carried no `negative` object, no trust field and no coverage caveat. An agent that reads one file back and concludes the function is local is reasoning correctly from what it was given, which is what makes the missing signal the defect rather than the agent.

Every retrieval response now carries one `completeness` object on the `_kin` envelope, whether it came back empty or full.

## Mechanism

`Completeness::for_tool` at `crates/kin-mcp/src/envelope.rs:354` builds the signal and `finalize_bounded` attaches it at `crates/kin-mcp/src/envelope.rs:1067`. The object names `status` (complete, partial or unknown), `bound` (exact or at_least), `substrate` (edges, embeddings or graph), a `classes` map giving every coverage class the answer depended on as present, absent or unknown, `decided_by` naming the subset that decided the status, `counted`, `reference_resolution`, `limits`, and a one-line `note`. A class nothing was observed about is `unknown`, and `unknown` is not `absent`.

Retrieval membership is derived rather than declared in a third list. A tool qualifies when it has a negative spec or declares cross-file edge classes, both of which already live in `crates/kin-mcp/src/negative.rs`, so a new retrieval tool earns a completeness signal by declaring what it reads exactly as it earns an absence verdict. `negative_class_for` at `crates/kin-mcp/src/negative.rs:187` is the one function added there; `absence_cross_file_classes`, `load_bearing_classes` and `edge_coverage_degradation_labels` were only widened to `pub(crate)`.

`handle_find_references_with_authority_source` at `crates/kin-mcp/src/handlers/entities.rs:1539` and `handle_trace_data_flow` at `crates/kin-mcp/src/handlers/entities.rs:3245` now observe edge coverage on every answer rather than only on empty ones. That is the actual defect: an answer that returned rows proved the classes those rows came through and proved nothing about the class a caller it missed would have come through.

Observing on every answer would have put a language-wide relation walk on the healthy path, where there was no scan at all before. `answer_witnessed_classes` at `crates/kin-mcp/src/handlers/entities.rs:1113` reads witnesses off the returned rows instead, since a row whose caller sits in a different file and carries the focal's language is itself a resolved cross-file edge, and `observe_cross_file_reference_coverage_witnessed` at `crates/kin-mcp/src/edge_coverage.rs:157` skips the scan when every deciding class is already witnessed. A witness only ever raises a class from `unknown` to `present`. It never overturns a completed scan that observed one absent, so a caller that scoped a witness wrongly can cost a scan it did not need but can never buy an absence a certification would rest on.

The count side is `attach_reference_resolution` at `crates/kin-mcp/src/edge_coverage.rs:348`, which reuses the shipped `kin_core::reference_coverage` measurement rather than deriving a second one. Two counters for one fact is how a coverage figure and a coverage verdict come to disagree inside one response. It attaches only when a deciding class is short, so a healthy answer pays nothing for a ratio it does not need.

`decided_by` is deliberately narrower than `classes`. Kin mints no entity-level `Imports` edge, so requiring every requested class to be present would report every answer on every healthy graph as partial. That is the regression item 4 of the ticket bars, and it is excluded by test in both directions.

## Ticket items

Item 1 (a signal on every retrieval response) and item 2 (report the count where knowable, so "1 of 5" is expressible) are this change. Item 4 (both directions tested) is covered below.

Item 3 of FIR-2357, the empty `reference_lines` on a returned reference, already landed in kin#913. The test at `crates/kin-mcp/src/handlers/entities.rs:4513` names FIR-2357 item 3 explicitly and asserts both directions of it. This PR adds nothing there and does not claim it.

## Response shape, before and after

Both fixtures are `find_references` on a Rust graph, dumped from the real handler through `finalize_with_envelope`. The partial one has a target in `nk/parsing.rs` called by a sibling in `nk/render.rs` that the extractor never linked, so only the same-file caller comes back. The complete one has a caller in `src/a.rs` and a target in `src/b.rs` with the cross-file call edge present.

Before, on the partial fixture, the whole response was this:

```
top-level keys: _kin, counts, cross_repo, focal_entity, references, relation_kinds, total_upstream
total_upstream: 1
_kin keys:      degraded, envelope_version, graph_as_of, graph_state, response, runtime
negative:       absent (the answer is not empty)
edge_coverage:  absent (the answer is not empty)
```

One caller, and nothing anywhere saying it was one of several. That is the ticket verbatim.

After, the same fixture carries this on `_kin.completeness`:

```json
{
  "status": "partial",
  "bound": "at_least",
  "substrate": "edges",
  "classes": { "calls": "absent", "imports": "absent", "references": "absent" },
  "decided_by": ["calls"],
  "counted": {
    "unit": "referencing_entities",
    "reported": 1,
    "exact": false,
    "sites": { "reference_sites": null, "known_reference_sites": 0, "reference_sites_complete": false }
  },
  "reference_resolution": {
    "files": 2, "files_measured": 0,
    "parsed_call_sites": null, "resolved_call_edges": 1, "call_percent": null,
    "parsed_import_statements": null, "resolved_import_edges": 0,
    "resolution": "unmeasured"
  },
  "limits": ["edge_coverage:calls_absent", "edge_coverage:imports_absent", "edge_coverage:references_absent"],
  "note": "One of the edge classes this answer depended on was observed absent, so what came back is a lower bound and its absence proves nothing about the code. Limited by: edge_coverage:calls_absent, edge_coverage:imports_absent, edge_coverage:references_absent."
}
```

`parsed_call_sites` is `null` here rather than `0` because this fixture's entities carry no parse-side count. An unmeasured parse side is not a zero, and publishing it as one would turn "nothing counted the source" into "the source had no calls". The unit test `a_partial_reference_answer_reports_parsed_against_resolved` seeds that count and gets `parsed_call_sites: 5`, `resolved_call_edges: 1`, `call_percent: 20`, `resolution: "partial"`, which is the "1 of 5" the ticket asks for.

The complete fixture, same code path, does not degrade:

```json
{
  "status": "complete",
  "bound": "exact",
  "substrate": "edges",
  "classes": { "calls": "present", "imports": "unknown", "references": "unknown" },
  "decided_by": ["calls"],
  "counted": { "unit": "referencing_entities", "reported": 1, "exact": true },
  "limits": ["edge_coverage:imports_unknown", "edge_coverage:references_unknown"],
  "note": "Every edge class this answer depended on was observed present, so the counts here are the whole set."
}
```

`imports` and `references` are disclosed as `unknown` and do not decide, which is what lets both directions hold at once. Its `edge_coverage` reports `"scan": "skipped_answer_witnessed"` with `"witnessed_by_answer": ["calls"]` and `"entities_examined": 0`, so the healthy path pays no language scan. The partial fixture reports `"scan": "ran"` and `"entities_examined": 3`.

## Gate

Every command below ran through `bin/kin-lane run completeness kin`, whose printed tree line was `worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/completeness-kin target=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/cargo-target/completeness-kin` on every pass. Exit codes were read raw, never through a pipe.

`cargo fmt --all -- --check`, exit 0. Clippy exactly as `.github/workflows/ci.yml` runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the workflow's 45-lint allowlist, exit 0 with zero errors. All six guard scripts CI runs pass locally, each exit 0: `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `verify-hydration-semantics.py`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`, `test-private-repo-coupling.py`. `cargo test -p kin-mcp`, exit 0, `490 passed; 0 failed`.

The full workspace gate `bin/kin-dev local-test kin` did not complete cleanly on the development host, and the reason is the host rather than this branch. Two passes failed, both entirely in `kin-cli` subprocess tests that carry wall-clock deadlines, while the machine sat at load 45 to 98 under other lanes' concurrent gates. The first pass failed `repository_tag declared_release_policy_is_a_refusal_and_never_a_warning` with `process-group watcher did not publish readiness before the deadline`. The second failed six `commands::update::tests` cases, every one of them at 300 to 302 seconds against the same helper's 300 second deadline at `crates/kin-cli/src/commands/update.rs:13803` and `:13438`. None is an assertion failure and none is in a crate this branch touches.

Three independent things say those are host artifacts. The single first-pass failure passes in isolation on this exact tree, exit 0, taking 169.71 seconds against the 8.8 seconds at which it timed out under load. The whole `commands::update::tests` module, all six included, passes in isolation on this tree, exit 0, `160 passed; 0 failed`. And a different lane on a different branch failed a different test in the same `kin-cli::repository_*` family at the same point in its own run on the same host at the same time.

CI is the contention-free answer and it is green. All 31 checks pass with four skipped, and `gh pr checks 921` exits 0. That includes `Check & Test (ubuntu-latest)` and `Check & Test (macos-latest)`, which are the jobs that run fmt, clippy, the guard scripts and the full `cargo test --workspace` without fleet contention, plus `Falsify guards`, `Windows authority tests`, `Windows authority runtime tests` and `Windows authority CLI tests`.

## Falsification

Every new test was broken deliberately and confirmed to fail. Each case ran through `bin/kin-lane run completeness kin -- cargo test -p kin-mcp`, and every exit code below was read raw rather than through a pipe.

`F1`, the signal removed at `envelope.rs:1067`: exit 101, `1 passed; 8 failed`. The eight are every test that asserts a signal is present. The one that still passed is `a_non_retrieval_tool_carries_no_completeness_signal`, which asserts absence and correctly does not care.

`F2`, `status` forced to never say `complete`, which is the lazy regression item 4 of the ticket bars: exit 101, `0 passed; 2 failed`, failing `a_fully_resolved_answer_reports_complete_and_exact` and `a_populated_cross_file_answer_reports_itself_complete`. A fix that marked everything uncertain cannot pass this branch.

`F3`, a signal handed to every tool including non-retrieval ones: exit 101, `0 passed; 1 failed`, failing `a_non_retrieval_tool_carries_no_completeness_signal`. This is the direction `F1` cannot reach.

`F4`, `attach_reference_resolution` removed: exit 101, `0 passed; 1 failed`, failing `a_partial_reference_answer_reports_parsed_against_resolved`.

`F5`, the observation put back on the empty path only, which is the pre-fix behavior exactly: exit 101, `0 passed; 3 failed`, failing `a_partial_reference_answer_says_its_count_is_a_floor`, `a_populated_cross_file_answer_reports_itself_complete` and `a_partial_reference_answer_reports_parsed_against_resolved`.

`F6`, the budget downgrade removed at `envelope.rs:1155`: exit 101, `0 passed; 1 failed`, failing `a_budget_shortened_answer_reports_a_floor`.

Across `F1` and `F3` every one of the nine new tests has been shown capable of failing, and `F2` through `F6` pin each behavior individually rather than relying on the blanket case.

## File coordination

Lane `locatecost` (FIR-2415) also edits `crates/kin-mcp/src/envelope.rs`, for the `snippet` duplicating `body`, the per-hit `matched_variants` copy, and the `semantic_coverage` name and type collision. This change only READS `envelope.semantic_coverage` in `embedding_class_states`, taking its `complete` and `graph_body_gap_paths` fields, and neither renames nor retypes it. The overlap is a read against their rename rather than a competing edit, so whichever lands first, the other rebases on top and follows the surviving name. Their one-name-one-type cleanup is a prerequisite for this object's single shape, not a conflict with it.

Closes FIR-2357
