### PR TITLE
Report an unbuilt vector index, and hand the reranker the cache it probed

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2626,7 +2626,9 @@ fn check_retrieval_profile() -> HealthCheck {
     let profile = crate::retrieval_profile::RetrievalProfile::from_env();
     let ce_model = env::var("KIN_LOCATE_CROSS_ENCODER_MODEL")
         .unwrap_or_else(|_| "BAAI/bge-reranker-base".to_string());
-    let ce_cached = crate::retrieval_profile::cross_encoder_model_cached(&ce_model);
+    let ce_revision =
+        env::var("KIN_LOCATE_CROSS_ENCODER_REVISION").unwrap_or_else(|_| "main".to_string());
+    let ce_cached = crate::retrieval_profile::cross_encoder_model_cached(&ce_model, &ce_revision);
     // Report the daemon-serving default (the state queries actually run
     // under), not this one-shot CLI process's own gate. The accessor answers
     // exactly that question, so this check cannot drift from the profile's

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1468,22 +1468,83 @@ fn embedding_strict_mode() -> bool {
         && !locate_env_bool("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", false)
 }
 
+/// What the cross-encoder loader is asked to load: the snapshot directory this
+/// process resolved, or the bare repo id when it resolved none.
+///
+/// Named rather than inlined because it is the whole of the handoff. The
+/// loader takes one `&str` and decides from it alone whether to read a
+/// directory or to go to the Hub, so passing the repo id where a resolved
+/// directory exists is the entire defect restored, and a decision that lives
+/// in a `match` argument cannot be asserted on without a model on disk.
+///
+/// A path that is not UTF-8 falls back to the repo id for the same reason a
+/// missing snapshot does: it cannot be spelled as the `&str` the loader takes.
+#[cfg(feature = "embeddings")]
+fn cross_encoder_load_target(model_id: &str, snapshot: Option<&std::path::Path>) -> String {
+    snapshot
+        .and_then(std::path::Path::to_str)
+        .unwrap_or(model_id)
+        .to_string()
+}
+
+/// Whether a graph has a vector index attached at all.
+///
+/// `embedding_status` cannot answer this. Its `indexed` count is derived by
+/// testing every retrievable key against the index and it answers zero for all
+/// of them when there is no index to test against, so an index that was never
+/// built and an index that is attached and empty produce identical counters.
+/// `vector_index_stats()` is the call that separates them, and reading it is a
+/// lock and an `Option` map rather than a walk of graph truth.
+#[cfg(feature = "vector")]
+fn vector_index_attached(graph: &kin_db::InMemoryGraph) -> bool {
+    graph.vector_index_stats().is_some()
+}
+
+/// Without vector support there is no index to attach. The `supported: false`
+/// arm of the coverage report is what callers read in this build; this exists
+/// so the two arms share one call shape.
+#[cfg(not(feature = "vector"))]
+fn vector_index_attached(_graph: &kin_db::InMemoryGraph) -> bool {
+    false
+}
+
+/// The embedding status backing this query's semantic signal, paired with
+/// whether the graph it came from has a vector index attached.
+///
+/// The pairing is the point. Both facts are read from the SAME graph in one
+/// place, so a caller cannot take the counters from the scoped-session vector
+/// source and the attachment from the primary graph and report a state neither
+/// of them is in.
+struct EffectiveEmbedding {
+    status: kin_db::EmbeddingStatus,
+    index_attached: bool,
+}
+
 /// Pick the embedding status that actually backs the semantic signal for this
 /// query — the primary graph when it carries embeddings (or has no entities at
 /// all), otherwise the HEAD vector source used for scoped-session search.
 /// Mirrors the graph-selection logic in `extract_embedding_signals`.
-fn effective_embedding_status(
+fn effective_embedding(
     graph: &kin_db::InMemoryGraph,
     vector_source: Option<&kin_db::InMemoryGraph>,
-) -> kin_db::EmbeddingStatus {
+) -> EffectiveEmbedding {
     let primary_status = graph.embedding_status();
     if primary_status.total == 0 || primary_status.indexed > 0 {
-        return primary_status;
+        return EffectiveEmbedding {
+            status: primary_status,
+            index_attached: vector_index_attached(graph),
+        };
     }
     if let Some(source) = vector_source.filter(|source| !std::ptr::eq(*source, graph)) {
-        return source.embedding_status();
+        return EffectiveEmbedding {
+            status: source.embedding_status(),
+            index_attached: vector_index_attached(source),
+        };
     }
-    primary_status
+    EffectiveEmbedding {
+        status: primary_status,
+        index_attached: vector_index_attached(graph),
+    }
 }
 
 /// Evaluate embedding coverage for a locate query.
@@ -1494,30 +1555,43 @@ fn effective_embedding_status(
 /// ran. Strict (benchmark) behavior, gated behind
 /// `KIN_REQUIRE_COMPLETE_EMBEDDINGS=1`: bails on incomplete coverage exactly as
 /// before, so benchmarks refuse to score a half-embedded repo.
+///
+/// The strict gate keeps reading the counters alone, deliberately. It is a
+/// benchmark-integrity check on how much of a store got embedded, and a
+/// benchmark that reaches it is running against a populated store where an
+/// absent index already shows up as `indexed < total`. What changes is the
+/// REPORT the gate does not consume.
 fn evaluate_embedding_coverage(
     graph: &kin_db::InMemoryGraph,
     vector_source: Option<&kin_db::InMemoryGraph>,
-) -> Result<SemanticCoverage> {
-    let status = effective_embedding_status(graph, vector_source);
+) -> Result<(SemanticCoverage, bool)> {
+    let effective = effective_embedding(graph, vector_source);
 
     #[cfg(feature = "vector")]
-    if !embedding_status_complete(&status) && embedding_strict_mode() {
+    if !embedding_status_complete(&effective.status) && embedding_strict_mode() {
         anyhow::bail!(
             "semantic locate requires complete embeddings; graph has {}. Run `kin embed` until `kin status --json` reports embeddingsIndexed == embeddingsTotal and embeddingsPending == 0. (Set KIN_REQUIRE_COMPLETE_EMBEDDINGS=0 to allow graceful degradation.)",
-            embedding_status_summary(&status)
+            embedding_status_summary(&effective.status)
         );
     }
 
-    Ok(coverage_from_status(&status))
+    Ok((
+        coverage_from_status(&effective.status, effective.index_attached),
+        effective.index_attached,
+    ))
 }
 
 /// Build the non-gating [`SemanticCoverage`] report from an embedding status.
 /// This is the default (non-strict) coverage `evaluate_embedding_coverage`
 /// returns, factored out so post-retrieval surfaces can re-report coverage
 /// without re-running the strict benchmark gate.
-fn coverage_from_status(status: &kin_db::EmbeddingStatus) -> SemanticCoverage {
+fn coverage_from_status(
+    status: &kin_db::EmbeddingStatus,
+    index_attached: bool,
+) -> SemanticCoverage {
     #[cfg(not(feature = "vector"))]
     {
+        let _ = index_attached;
         return SemanticCoverage {
             supported: false,
             indexed: status.indexed,
@@ -1534,9 +1608,20 @@ fn coverage_from_status(status: &kin_db::EmbeddingStatus) -> SemanticCoverage {
 
     #[cfg(feature = "vector")]
     {
-        let complete = embedding_status_complete(status);
+        // An absent index is never complete coverage, whatever the counters
+        // say. `embedding_status_complete` answers true for `total == 0`, and
+        // `total` is zero on a graph with nothing retrievable, so a store with
+        // no index at all could report complete semantic coverage and let a
+        // caller treat an empty result as a definitive absence. There is no
+        // index behind that answer to be definitive about.
+        let complete = index_attached && embedding_status_complete(status);
         let note = if complete {
             None
+        } else if !index_attached {
+            Some(format!(
+            "no vector index is attached, so nothing is embedded and semantic ranking did not run ({} entities eligible). Lexical + graph results returned; run `kin embed` to build the index.",
+            status.total
+        ))
         } else {
             Some(format!(
             "semantic signal partial: {} embedded. Lexical + graph results returned; run `kin embed` for full semantic ranking.",
@@ -1591,7 +1676,8 @@ pub fn local_semantic_coverage(
     graph: &kin_db::InMemoryGraph,
     vector_source: Option<&kin_db::InMemoryGraph>,
 ) -> SemanticCoverage {
-    coverage_from_status(&effective_embedding_status(graph, vector_source))
+    let effective = effective_embedding(graph, vector_source);
+    coverage_from_status(&effective.status, effective.index_attached)
 }
 
 /// Push a degradation once per (component, reason); repeated hits within one
@@ -1607,12 +1693,21 @@ pub fn record_degradation(sink: &mut Vec<RetrievalDegradation>, event: Retrieval
 }
 
 /// Record the vector-index state for this query as a structured degradation
-/// when it is empty or partial. The `SemanticCoverage` object already carries
-/// the numbers; this adds the machine-readable component/reason/remediation
-/// entry so an empty vector index can never read as a clean lexical answer.
+/// when it is absent, empty or partial. The `SemanticCoverage` object already
+/// carries the numbers; this adds the machine-readable
+/// component/reason/remediation entry so a vector index that is missing or
+/// unfinished can never read as a clean lexical answer.
+///
+/// `absent` is its own reason and not a shade of `empty`, because they have
+/// different remediations and only one of them is reachable by waiting. An
+/// index that is attached and empty is being filled; an index that was never
+/// built is not, and on a freshly converted repository that is the state every
+/// first query runs in. Telling them apart needs `index_attached`: the
+/// `indexed` counter reads zero for both, so a reason picked from the counters
+/// alone can neither name the absent case nor fail to name it.
 fn record_vector_index_degradation(
     coverage: &SemanticCoverage,
-    vector_source: Option<&kin_db::InMemoryGraph>,
+    index_attached: bool,
     sink: &mut Vec<RetrievalDegradation>,
 ) {
     if coverage.complete {
@@ -1631,24 +1726,62 @@ fn record_vector_index_degradation(
         );
         return;
     }
-    let vector_arm_present = coverage.indexed > 0
-        || vector_source.is_some_and(|source| source.embedding_status().indexed > 0);
-    let (reason, detail) = if vector_arm_present {
+    let (reason, detail, remediation) = if !index_attached {
+        let detail = format!(
+            "no vector index has been built for this graph, so none of its {} entities \
+             are embedded and only lexical and graph signals ranked this query",
+            coverage.total
+        );
+        // The opt-out is read from this process's own environment, which is the
+        // daemon's environment on the serving path, where the daemon reads the same
+        // variable at its own start to decide the pass. Saying which of the two
+        // states holds is the whole difference between "this fills in on its
+        // own" and "this stays as it is until someone asks".
+        if kin_daemon_spawn::auto_embed_enabled_from(
+            std::env::var(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV)
+                .ok()
+                .as_deref(),
+        ) {
+            (
+                "absent",
+                detail,
+                "wait for the background embedding pass to build the index, or run 'kin embed' \
+                 to build it now"
+                    .to_string(),
+            )
+        } else {
+            (
+                "absent_opt_out",
+                format!(
+                    "{detail}; {} opts out of the background embedding pass, so nothing will \
+                     build the index on its own",
+                    kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV
+                ),
+                format!(
+                    "run 'kin embed' to build the index, or clear {} and restart the daemon to \
+                     let the background pass run",
+                    kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV
+                ),
+            )
+        }
+    } else if coverage.indexed > 0 {
         (
             "partial",
             format!(
                 "semantic signal partial: {}/{} entities embedded ({} pending)",
                 coverage.indexed, coverage.total, coverage.pending
             ),
+            "run 'kin embed' until kin status reports full embedding coverage".to_string(),
         )
     } else {
         (
             "empty",
             format!(
-                "vector index empty: 0/{} entities embedded — semantic ranking disabled, \
-                 lexical + graph signals only",
+                "vector index empty: 0/{} entities embedded, so semantic ranking is off \
+                 and only lexical and graph signals ranked this query",
                 coverage.total
             ),
+            "run 'kin embed' until kin status reports full embedding coverage".to_string(),
         )
     };
     record_degradation(
@@ -1657,8 +1790,7 @@ fn record_vector_index_degradation(
             component: "vector_index".to_string(),
             reason: reason.to_string(),
             detail,
-            remediation: "run 'kin embed' until kin status reports full embedding coverage"
-                .to_string(),
+            remediation,
         },
     );
 }
@@ -2206,7 +2338,8 @@ fn run_with_graph_capture_budgeted(
     let cleaned_text = clean_issue_text(text);
     let semantic_text = strip_pr_template_boilerplate(&cleaned_text);
     let text = semantic_text.as_str();
-    let semantic_coverage = evaluate_embedding_coverage(graph, vector_source)?;
+    let (semantic_coverage, vector_index_attached) =
+        evaluate_embedding_coverage(graph, vector_source)?;
 
     // Quality profile: supplies the DEFAULT for each retrieval lever below;
     // explicit env vars always win. Resolved once per query so one run cannot
@@ -2214,7 +2347,7 @@ fn run_with_graph_capture_budgeted(
     let quality = crate::retrieval_profile::RetrievalProfile::from_env();
     // No-silent-degradation ledger for this query (attached to the result).
     let mut degradations: Vec<RetrievalDegradation> = Vec::new();
-    record_vector_index_degradation(&semantic_coverage, vector_source, &mut degradations);
+    record_vector_index_degradation(&semantic_coverage, vector_index_attached, &mut degradations);
     // Per-stage prune attribution, recorded only under --explain.
     let mut prune_ledger: Vec<PruneEvent> = Vec::new();
 
@@ -3792,7 +3925,15 @@ fn run_with_graph_capture_budgeted(
     {
         let ce_model_id = std::env::var("KIN_LOCATE_CROSS_ENCODER_MODEL")
             .unwrap_or_else(|_| "BAAI/bge-reranker-base".to_string());
-        let ce_model_cached = crate::retrieval_profile::cross_encoder_model_cached(&ce_model_id);
+        // Resolved beside the model id, not inside the arming branch below,
+        // because the cache probe needs it: a snapshot is addressed by the
+        // commit its revision ref names, so probing without the revision asks a
+        // different question than the one the loader will ask.
+        let ce_revision = std::env::var("KIN_LOCATE_CROSS_ENCODER_REVISION")
+            .unwrap_or_else(|_| "main".to_string());
+        let ce_snapshot =
+            crate::retrieval_profile::cross_encoder_model_snapshot(&ce_model_id, &ce_revision);
+        let ce_model_cached = ce_snapshot.is_some();
         if quality.cross_encoder_default(true)
             && !ce_model_cached
             && std::env::var("KIN_LOCATE_CROSS_ENCODER_ENABLED").is_err()
@@ -3825,8 +3966,13 @@ fn run_with_graph_capture_budgeted(
                 // effective in that mode.
                 if cross_encoder_has_graph_candidates(graph) {
                     let model_id = ce_model_id.clone();
-                    let revision = std::env::var("KIN_LOCATE_CROSS_ENCODER_REVISION")
-                        .unwrap_or_else(|_| "main".to_string());
+                    let revision = ce_revision.clone();
+                    // Load from the directory the cache probe resolved rather
+                    // than from the repo id, so the loader reads the snapshot
+                    // this process just verified instead of rediscovering a
+                    // root of its own. `CrossEncoder::new` takes a local
+                    // directory whenever its model id names one.
+                    let load_target = cross_encoder_load_target(&model_id, ce_snapshot.as_deref());
 
                     // 1.7 latency gate: time model acquisition + rerank so an
                     // over-budget rerank can fall back to the pre-rerank order (see
@@ -3835,7 +3981,7 @@ fn run_with_graph_capture_budgeted(
                     // here; after that the model is resident (see model_residency)
                     // and this window is the rerank itself.
                     let rerank_started = std::time::Instant::now();
-                    match crate::model_residency::cross_encoder(&model_id, &revision) {
+                    match crate::model_residency::cross_encoder(&load_target, &revision) {
                         Ok(encoder) => {
                             let mut docs = Vec::new();
                             let mut candidates = Vec::new();
@@ -20299,6 +20445,203 @@ mod tests {
         assert!(
             format!("{err}").contains("semantic locate requires complete embeddings"),
             "unexpected error: {err:#}"
+        );
+    }
+
+    /// The reranker is asked for the directory this process resolved, not for
+    /// the repo id it started from.
+    ///
+    /// `CrossEncoder::new` decides from its one string argument whether to read
+    /// a local directory or to fetch from the Hub, so which string reaches it
+    /// IS the fix. Passing the repo id where a snapshot resolved is the defect
+    /// restored in full: the loader would go back to `Cache::default()`, miss a
+    /// relocated cache, and download inside the query.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn the_reranker_is_asked_for_the_resolved_snapshot_when_there_is_one() {
+        let snapshot = std::path::Path::new("/models/hub/models--org--name/snapshots/abc123");
+
+        assert_eq!(
+            cross_encoder_load_target("org/name", Some(snapshot)),
+            snapshot.to_str().unwrap(),
+            "a resolved snapshot must be what the loader is handed"
+        );
+        assert_eq!(
+            cross_encoder_load_target("org/name", None),
+            "org/name",
+            "with nothing resolved the bare repo id still reaches hf-hub, so an \
+             explicit prefetch on a cold machine keeps working"
+        );
+    }
+
+    /// Identical counters, two different states, and only one of them fills in
+    /// on its own.
+    ///
+    /// `embedding_status` derives `indexed` by testing every retrievable key
+    /// against the vector index and answers zero for all of them when there is
+    /// no index to test against, so an index nothing has filled yet and an
+    /// index nobody built produce the same numbers. A reason picked from those
+    /// numbers cannot name the second case, which is the state every freshly
+    /// converted repository serves its first queries in.
+    ///
+    /// The `complete` half is the sharper edge. It was true whenever `total`
+    /// was zero, so a store with no vector index behind it could report
+    /// complete semantic coverage, and the envelope's semantic negative gate
+    /// reads exactly that flag to decide whether an empty result may be
+    /// reported as a definitive absence.
+    #[cfg(feature = "vector")]
+    #[test]
+    #[serial_test::serial]
+    fn coverage_separates_an_index_nobody_built_from_one_nothing_has_filled() {
+        let _opt_out =
+            kin_core::test_env::EnvVarGuard::unset(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV);
+
+        let nothing_retrievable = kin_db::EmbeddingStatus {
+            pending: 0,
+            indexed: 0,
+            total: 0,
+        };
+        assert!(
+            coverage_from_status(&nothing_retrievable, true).complete,
+            "an attached index with nothing to embed is genuinely complete"
+        );
+        assert!(
+            !coverage_from_status(&nothing_retrievable, false).complete,
+            "with no index behind it there is nothing for a negative to be definitive about"
+        );
+
+        let unfilled = kin_db::EmbeddingStatus {
+            pending: 12,
+            indexed: 0,
+            total: 12,
+        };
+        let partial = kin_db::EmbeddingStatus {
+            pending: 7,
+            indexed: 5,
+            total: 12,
+        };
+        let mut sink = Vec::new();
+        record_vector_index_degradation(&coverage_from_status(&unfilled, false), false, &mut sink);
+        record_vector_index_degradation(&coverage_from_status(&unfilled, true), true, &mut sink);
+        record_vector_index_degradation(&coverage_from_status(&partial, true), true, &mut sink);
+
+        let reasons = sink
+            .iter()
+            .map(|entry| entry.reason.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            reasons,
+            vec!["absent", "empty", "partial"],
+            "the same 0/12 counters must read as absent or empty depending on the index"
+        );
+        assert!(
+            sink[0].remediation.contains("kin embed"),
+            "an unbuilt index must name the command that builds it: {}",
+            sink[0].remediation
+        );
+    }
+
+    /// An operator who turned the background pass off is in a different state
+    /// from one waiting for it, and the remediation is the difference.
+    #[cfg(feature = "vector")]
+    #[test]
+    #[serial_test::serial]
+    fn an_absent_index_nothing_will_build_is_reported_as_its_own_reason() {
+        let unfilled = kin_db::EmbeddingStatus {
+            pending: 12,
+            indexed: 0,
+            total: 12,
+        };
+
+        let mut waiting = Vec::new();
+        {
+            let _on =
+                kin_core::test_env::EnvVarGuard::unset(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV);
+            record_vector_index_degradation(
+                &coverage_from_status(&unfilled, false),
+                false,
+                &mut waiting,
+            );
+        }
+        assert_eq!(waiting[0].reason, "absent");
+        assert!(
+            waiting[0].remediation.contains("background embedding pass"),
+            "a pass that is coming is worth waiting for: {}",
+            waiting[0].remediation
+        );
+
+        let mut opted_out = Vec::new();
+        {
+            let _off =
+                kin_core::test_env::EnvVarGuard::set(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV, "0");
+            record_vector_index_degradation(
+                &coverage_from_status(&unfilled, false),
+                false,
+                &mut opted_out,
+            );
+        }
+        assert_eq!(opted_out[0].reason, "absent_opt_out");
+        assert!(
+            opted_out[0]
+                .detail
+                .contains(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV),
+            "the lever that decided this must be named: {}",
+            opted_out[0].detail
+        );
+    }
+
+    /// The pipeline itself reports the unbuilt index, not only the helper that
+    /// formats the entry.
+    ///
+    /// A graph with entities and no vector index is what `kin init` leaves
+    /// behind, and the whole defect was that a query against it came back
+    /// looking clean. This drives the real locate path over that fixture and
+    /// reads the ledger it attaches.
+    #[cfg(feature = "vector")]
+    #[test]
+    #[serial_test::serial]
+    fn locate_reports_an_unbuilt_vector_index_on_a_fresh_store() {
+        let graph = kin_db::InMemoryGraph::new();
+        let entity = test_entity("handler", "src/lib.py", 1, 5);
+        graph.upsert_entity(&entity).unwrap();
+        admit_test_source(&graph, "src/lib.py", "def handler():\n    pass\n");
+        assert!(
+            graph.vector_index_stats().is_none(),
+            "fixture control: this store must carry no vector index"
+        );
+
+        let _strict = kin_core::test_env::EnvVarGuard::unset("KIN_REQUIRE_COMPLETE_EMBEDDINGS")
+            .without(kin_daemon_spawn::DAEMON_AUTO_EMBED_ENV);
+
+        let result = run_with_graph_capture_in_workspace_budgeted(
+            &graph,
+            None,
+            "handler failure",
+            true,
+            10,
+            true,
+            LocateBudget::unbounded(),
+        )
+        .expect("locate must still serve lexical and graph signals");
+
+        let coverage = result
+            .semantic_coverage
+            .expect("locate must report semantic coverage");
+        assert!(
+            !coverage.complete,
+            "a store with no vector index must not report complete semantic coverage"
+        );
+
+        let entry = result
+            .degradations
+            .iter()
+            .find(|degradation| degradation.component == "vector_index")
+            .expect("an unbuilt vector index must reach the degradation ledger");
+        assert_eq!(entry.reason, "absent");
+        assert!(
+            entry.detail.contains("no vector index"),
+            "the detail must say which state this is: {}",
+            entry.detail
         );
     }
 

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -240,14 +240,57 @@ pub fn cosine_to_relevance(cosine: f32) -> f32 {
     ((1.0 + cosine) / 2.0).max(0.0)
 }
 
+/// The three files [`kin_db::embed::rerank::CrossEncoder`] loads for a model,
+/// in the order its own local-directory resolver requires them.
+///
+/// This list is the contract between the probe below and the loader. The loader
+/// takes a directory and fails outright when one of these is missing, so a
+/// probe that reported a directory usable on any weaker test would hand the
+/// loader a directory it cannot read. Weights are `model.safetensors` only:
+/// that is the single weight file the loader asks for.
+const CROSS_ENCODER_ARTIFACTS: [&str; 3] = ["config.json", "tokenizer.json", "model.safetensors"];
+
+/// The resolved snapshot directory for `model_id` at `revision`, or `None` when
+/// this machine cannot serve the model from disk.
+///
+/// This is the path the loader is HANDED, not a path it is trusted to
+/// rediscover. `kin-db` builds its cross-encoder through
+/// `hf_hub::api::sync::Api::new()`, which resolves its root through
+/// `Cache::default()`, which is `dirs::home_dir()/.cache/huggingface/hub` and
+/// never reads `HF_HOME` (`hf-hub-0.5.0/src/lib.rs:203`). The probe here reads
+/// `HF_HOME` first. Two resolvers, two answers, and the disagreement is only
+/// visible when the variable is set: the probe found the model, armed the
+/// reranker, and the loader then found nothing at its own root and downloaded
+/// 1.1 GB inside a query's latency budget, which tripped the budget and
+/// discarded the rerank that download had just paid for.
+///
+/// Handing the loader a resolved directory removes the second resolver rather
+/// than aligning it. `CrossEncoder::new` takes a local directory whenever its
+/// `model_id` names one, so the directory this function returns is read
+/// verbatim and `hf-hub` never runs. Probe and loader cannot disagree about a
+/// path only one of them computes.
+///
+/// `None` keeps today's behavior exactly: the caller passes the bare repo id
+/// and `hf-hub` resolves it as before, which is what an explicit prefetch
+/// (`KIN_LOCATE_CROSS_ENCODER_ENABLED=1` on a cold machine) still needs.
+pub fn cross_encoder_model_snapshot(model_id: &str, revision: &str) -> Option<PathBuf> {
+    snapshot_under_base(resolved_hf_cache_base().as_deref(), model_id, revision)
+}
+
 /// True when the cross-encoder model is already present in the local
 /// Hugging Face hub cache, so constructing it cannot trigger a network
 /// download. Mirrors the `hf-hub` cache layout (`$HF_HOME` or
 /// `~/.cache/huggingface`, `hub/models--{org}--{name}`) without taking the
 /// dependency; a false negative merely means the reranker stays off by
 /// default until the model is fetched explicitly.
-pub fn cross_encoder_model_cached(model_id: &str) -> bool {
-    cached_under_base(resolved_hf_cache_base().as_deref(), model_id)
+///
+/// Answered by the same resolution that produces the loader's directory, so
+/// "cached" now means the exact thing the loader needs and not one byte less.
+/// The looser test it replaces, any entry under `snapshots/`, reported a
+/// pruned or half-downloaded model usable, and a false POSITIVE here is the
+/// expensive direction: it costs a download in the middle of a query.
+pub fn cross_encoder_model_cached(model_id: &str, revision: &str) -> bool {
+    cross_encoder_model_snapshot(model_id, revision).is_some()
 }
 
 /// True when this install has ever fetched `model_id` into the local Hugging
@@ -327,16 +370,6 @@ fn hf_cache_base(
         .map(|home| home.join(".cache").join("huggingface"))
 }
 
-/// Whether `model_id` has a resolved snapshot under an already-resolved cache
-/// root. Split from the root lookup so the layout and the home policy fail
-/// independently.
-fn cached_under_base(base: Option<&Path>, model_id: &str) -> bool {
-    let Some(base) = base else {
-        return false;
-    };
-    snapshot_present(&model_cache_dir(base, model_id))
-}
-
 /// Whether a model cache directory holds a usable entry, which is at least one
 /// resolved snapshot directory.
 pub(crate) fn snapshot_present(model_dir: &Path) -> bool {
@@ -344,6 +377,34 @@ pub(crate) fn snapshot_present(model_dir: &Path) -> bool {
         Ok(mut entries) => entries.any(|entry| entry.is_ok()),
         Err(_) => false,
     }
+}
+
+/// The snapshot directory `model_id`@`revision` resolves to under an
+/// already-resolved cache root, or `None`. Split from the root lookup so the
+/// layout and the home policy fail independently.
+///
+/// Walks the layout `hf-hub` walks: `refs/{revision}` holds the commit hash and
+/// `snapshots/{commit}` holds the files (`hf-hub-0.5.0/src/lib.rs:140-198`).
+/// A missing ref answers `None` rather than guessing at whichever snapshot
+/// happens to be on disk, because `hf-hub` cannot resolve one either. It reads
+/// the same ref and downloads when it is absent.
+///
+/// The commit hash is a single path component by construction. Rejecting
+/// anything else keeps a hand-edited or truncated ref file from resolving
+/// outside the model's own directory, which is a cheap guard on a file this
+/// process did not write.
+fn snapshot_under_base(base: Option<&Path>, model_id: &str, revision: &str) -> Option<PathBuf> {
+    let model_dir = model_cache_dir(base?, model_id);
+    let commit = std::fs::read_to_string(model_dir.join("refs").join(revision)).ok()?;
+    let commit = commit.trim();
+    if commit.is_empty() || Path::new(commit).components().count() != 1 {
+        return None;
+    }
+    let snapshot = model_dir.join("snapshots").join(commit);
+    CROSS_ENCODER_ARTIFACTS
+        .iter()
+        .all(|artifact| snapshot.join(artifact).is_file())
+        .then_some(snapshot)
 }
 
 /// Where `hf-hub` keeps everything it has fetched for `model_id`. Expressed
@@ -558,18 +619,36 @@ mod tests {
         }
     }
 
-    fn stage_cached_model(home: &Path, model_id: &str) {
-        let dir = home
-            .join(".cache")
-            .join("huggingface")
-            .join("hub")
-            .join(format!("models--{}", model_id.replace('/', "--")))
-            .join("snapshots")
-            .join("0123456789abcdef");
-        std::fs::create_dir_all(&dir).unwrap();
+    const CE_MODEL: &str = "cross-encoder/ms-marco-MiniLM-L-6-v2";
+    const CE_REVISION: &str = "main";
+    const CE_COMMIT: &str = "0123456789abcdef";
+
+    /// Stage a complete, resolvable snapshot under a cache ROOT, exactly as a
+    /// finished `hf-hub` download leaves one: a `refs/{revision}` file naming
+    /// the commit, and a `snapshots/{commit}` directory carrying every artifact
+    /// the loader asks for. Returns the snapshot directory.
+    fn stage_cached_snapshot(base: &Path, model_id: &str) -> PathBuf {
+        let model_dir = model_cache_dir(base, model_id);
+        std::fs::create_dir_all(model_dir.join("refs")).unwrap();
+        std::fs::write(model_dir.join("refs").join(CE_REVISION), CE_COMMIT).unwrap();
+        let snapshot = model_dir.join("snapshots").join(CE_COMMIT);
+        std::fs::create_dir_all(&snapshot).unwrap();
+        for artifact in CROSS_ENCODER_ARTIFACTS {
+            std::fs::write(snapshot.join(artifact), b"").unwrap();
+        }
+        snapshot
     }
 
-    const CE_MODEL: &str = "cross-encoder/ms-marco-MiniLM-L-6-v2";
+    /// The same, under the `.cache/huggingface` root a resolved HOME implies.
+    fn stage_cached_model(home: &Path, model_id: &str) {
+        stage_cached_snapshot(&home.join(".cache").join("huggingface"), model_id);
+    }
+
+    /// Whether the reranker model resolves under an already-resolved root.
+    /// Named once so every probe assertion asks the loader's question.
+    fn cached_under_base(base: Option<&Path>, model_id: &str) -> bool {
+        snapshot_under_base(base, model_id, CE_REVISION).is_some()
+    }
 
     /// Windows names the profile root `USERPROFILE` and does not set `HOME`, so
     /// a `HOME`-only lookup reports every model absent no matter what is on
@@ -626,7 +705,7 @@ mod tests {
             !cross_encoder_model_ever_fetched(CE_MODEL),
             "an untouched cache root must read as never fetched"
         );
-        assert!(!cross_encoder_model_cached(CE_MODEL));
+        assert!(!cross_encoder_model_cached(CE_MODEL, CE_REVISION));
 
         std::fs::create_dir_all(model_dir.join("blobs")).unwrap();
         assert!(
@@ -634,13 +713,26 @@ mod tests {
             "a model directory left behind means this install fetched the model once"
         );
         assert!(
-            !cross_encoder_model_cached(CE_MODEL),
+            !cross_encoder_model_cached(CE_MODEL, CE_REVISION),
             "with no resolved snapshot the model is not usable now"
         );
 
-        std::fs::create_dir_all(model_dir.join("snapshots").join("0123456789abcdef")).unwrap();
+        // A ref resolving to an empty snapshot directory is what an interrupted
+        // download leaves, and a snapshot directory alone is the shape the
+        // previous probe called usable. The loader opens files, so a directory
+        // holding none of them must not read as usable here either.
+        std::fs::create_dir_all(model_dir.join("refs")).unwrap();
+        std::fs::write(model_dir.join("refs").join(CE_REVISION), CE_COMMIT).unwrap();
+        std::fs::create_dir_all(model_dir.join("snapshots").join(CE_COMMIT)).unwrap();
         assert!(
-            cross_encoder_model_ever_fetched(CE_MODEL) && cross_encoder_model_cached(CE_MODEL),
+            !cross_encoder_model_cached(CE_MODEL, CE_REVISION),
+            "an empty snapshot directory holds none of the files the loader opens"
+        );
+
+        stage_cached_snapshot(temp.path(), CE_MODEL);
+        assert!(
+            cross_encoder_model_ever_fetched(CE_MODEL)
+                && cross_encoder_model_cached(CE_MODEL, CE_REVISION),
             "a resolved snapshot is both fetched and usable"
         );
     }
@@ -713,14 +805,7 @@ mod tests {
         let hf_home = temp.path().join("hf");
         let profile = temp.path().join("profile");
         std::fs::create_dir_all(&profile).unwrap();
-        std::fs::create_dir_all(
-            hf_home
-                .join("hub")
-                .join(format!("models--{}", CE_MODEL.replace('/', "--")))
-                .join("snapshots")
-                .join("0123456789abcdef"),
-        )
-        .unwrap();
+        stage_cached_snapshot(&hf_home, CE_MODEL);
 
         for windows in [true, false] {
             let base = hf_cache_base(
@@ -755,5 +840,126 @@ mod tests {
             assert_eq!(base, None);
             assert!(!cached_under_base(base.as_deref(), CE_MODEL));
         }
+    }
+
+    /// A relocated cache resolves to the relocated root and to nothing else.
+    ///
+    /// This is the defect stated as an assertion. The probe reads `HF_HOME`;
+    /// `hf-hub`'s `Cache::default()` reads `dirs::home_dir()/.cache/huggingface`
+    /// and never reads `HF_HOME`. With the variable set the two answers differ,
+    /// which is how a probe said "cached" for a model the loader would then
+    /// download inside a query. Handing the loader the resolved directory is
+    /// what removes the disagreement, so the assertion is on the resolved path
+    /// itself rather than on a boolean that hides which root produced it.
+    ///
+    /// The negative control is the same fixture with the weights removed. A
+    /// probe that cannot say no to a half-downloaded snapshot would arm the
+    /// reranker on a directory the loader cannot open.
+    #[test]
+    #[serial_test::serial]
+    fn a_relocated_cache_resolves_under_hf_home_and_never_under_the_home_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let hf_home = temp.path().join("relocated");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let staged = stage_cached_snapshot(&hf_home, CE_MODEL);
+
+        let _hf = kin_core::test_env::EnvVarGuard::set("HF_HOME", &hf_home);
+        let _home = kin_core::test_env::EnvVarGuard::set("HOME", &home);
+
+        assert_eq!(
+            cross_encoder_model_snapshot(CE_MODEL, CE_REVISION).as_deref(),
+            Some(staged.as_path()),
+            "the resolved snapshot must be the one staged under HF_HOME"
+        );
+        assert!(
+            !staged.starts_with(&home),
+            "the fixture must place the cache away from the home root, or this proves nothing"
+        );
+        assert!(
+            cross_encoder_model_cached(CE_MODEL, CE_REVISION),
+            "a complete relocated snapshot arms the reranker"
+        );
+
+        std::fs::remove_file(staged.join("model.safetensors")).unwrap();
+        assert_eq!(
+            cross_encoder_model_snapshot(CE_MODEL, CE_REVISION),
+            None,
+            "a snapshot missing the weights is not a snapshot the loader can read"
+        );
+        assert!(!cross_encoder_model_cached(CE_MODEL, CE_REVISION));
+    }
+
+    /// A snapshot with no ref pointing at it resolves to nothing.
+    ///
+    /// `hf-hub` addresses a snapshot through `refs/{revision}` and downloads
+    /// when that file is absent, so a probe that answered from the presence of
+    /// a snapshot directory alone would report a model usable that the loader
+    /// would fetch over the network. The second half asks for a revision this
+    /// cache has never resolved, which is the same absence reached from the
+    /// other side.
+    #[test]
+    #[serial_test::serial]
+    fn a_snapshot_without_its_ref_reads_as_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let _hf = kin_core::test_env::EnvVarGuard::set("HF_HOME", temp.path());
+        stage_cached_snapshot(temp.path(), CE_MODEL);
+        let model_dir = model_cache_dir(temp.path(), CE_MODEL);
+
+        assert!(
+            cross_encoder_model_cached(CE_MODEL, CE_REVISION),
+            "positive control: the staged fixture resolves before the ref is removed"
+        );
+        assert_eq!(
+            cross_encoder_model_snapshot(CE_MODEL, "a-revision-nobody-fetched"),
+            None,
+            "a revision this cache never fetched has no ref to resolve"
+        );
+
+        std::fs::remove_file(model_dir.join("refs").join(CE_REVISION)).unwrap();
+        assert_eq!(
+            cross_encoder_model_snapshot(CE_MODEL, CE_REVISION),
+            None,
+            "with no ref there is no commit to address the snapshot by"
+        );
+    }
+
+    /// The loader reads the directory the probe resolved.
+    ///
+    /// The two halves of this defect were a probe and a loader that resolved
+    /// separately, so an assertion about the probe alone cannot close it. This
+    /// drives `CrossEncoder::new` on the resolved path and reads the error it
+    /// returns: the staged artifacts are empty, so a loader that opened them
+    /// fails parsing the config, while a loader that ignored the directory and
+    /// went to the Hub fails somewhere else entirely. The model id is one that
+    /// does not exist on the Hub, so the wrong branch cannot download anything
+    /// even if it runs.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    #[serial_test::serial]
+    fn the_loader_opens_the_directory_the_probe_resolved() {
+        const ABSENT_FROM_THE_HUB: &str = "kin-test/no-such-reranker";
+
+        let temp = tempfile::tempdir().unwrap();
+        let hf_home = temp.path().join("relocated");
+        let _hf = kin_core::test_env::EnvVarGuard::set("HF_HOME", &hf_home);
+        let staged = stage_cached_snapshot(&hf_home, ABSENT_FROM_THE_HUB);
+
+        let resolved = cross_encoder_model_snapshot(ABSENT_FROM_THE_HUB, CE_REVISION)
+            .expect("the staged snapshot must resolve");
+        assert_eq!(resolved, staged);
+
+        let outcome = kin_db::embed::rerank::CrossEncoder::new(
+            resolved.to_str().expect("a temp path is UTF-8"),
+            CE_REVISION,
+        );
+        let message = match outcome {
+            Ok(_) => panic!("empty artifacts cannot build a cross-encoder"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            message.contains("failed to parse model config"),
+            "the loader must have opened the resolved directory's own config; got: {message}"
+        );
     }
 }

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -68,6 +68,28 @@ pub const MCP_IDLE_TIMEOUT_SECS: &str = "1800";
 /// what the authority scrub happens not to remove.
 pub const DAEMON_AUTO_EMBED_ENV: &str = "KIN_DAEMON_AUTO_EMBED";
 
+/// Whether [`DAEMON_AUTO_EMBED_ENV`] holding `value` lets the background
+/// embedding pass run. Default ON: unset, or any value outside the documented
+/// falsy set, keeps the pass exactly as it was.
+///
+/// Lives here, beside the name, so the daemon that acts on the variable and any
+/// surface that REPORTS on it read one spelling of it. Two copies of this match
+/// would let a report say a pass is coming while the daemon that would run it
+/// has already stood down, and a wrong answer about a lever nobody can see is
+/// indistinguishable from a right one.
+///
+/// The falsy set matches `KIN_DAEMON_REQUIRE_TOKEN`, the sibling boolean knob,
+/// so one spelling works across the daemon's env surface.
+pub fn auto_embed_enabled_from(value: Option<&str>) -> bool {
+    match value {
+        Some(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
 /// File the daemon writes its bound port into once it is listening.
 pub const PORT_FILE_NAME: &str = "daemon.port";
 

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -449,14 +449,7 @@ pub(crate) const AUTO_EMBED_ENV: &str = "KIN_DAEMON_AUTO_EMBED";
 /// The falsy set matches `KIN_DAEMON_REQUIRE_TOKEN`, the sibling boolean knob,
 /// so one spelling works across the daemon's env surface.
 pub(crate) fn auto_embed_enabled() -> bool {
-    std::env::var(AUTO_EMBED_ENV)
-        .map(|value| {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "0" | "false" | "no" | "off"
-            )
-        })
-        .unwrap_or(true)
+    kin_daemon_spawn::auto_embed_enabled_from(std::env::var(AUTO_EMBED_ENV).ok().as_deref())
 }
 
 /// Build the background embedding backlog and announce it, or defer the whole


### PR DESCRIPTION
A graph with no vector index reported complete semantic coverage, and the reranker
downloaded a cache its own arming gate had already found. Both paths now report what they
are doing, and each fix carries a guard that fails when the behavior is removed.

## An unbuilt vector index reported complete semantic coverage (FIR-2373)

`InMemoryGraph::embedding_status` derives `indexed` by testing every retrievable key
against the vector index, and it answers zero for all of them when there is no index to
test against (`kin-db-0.7.31/src/engine/graph.rs:6027-6037`). An index nobody built and
an index nothing has filled yet produce identical counters.
`embedding_status_complete` then answered true whenever `total` was zero, and that flag
is what the MCP envelope's semantic negative gate reads to decide whether an empty
result may be reported as a definitive absence. A freshly converted repository could
authorize one with no index behind it.

`vector_index_attached` at `crates/kin-cli/src/commands/locate.rs:1499` reads
`vector_index_stats()` (`kin-db-0.7.31/src/engine/graph.rs:4462`), which is an `Option`
and separates absent from empty. `effective_embedding` at
`crates/kin-cli/src/commands/locate.rs:1527` returns it beside the counters from the
same graph, so a caller cannot pair one graph's numbers with another graph's
attachment. `coverage_from_status` at `crates/kin-cli/src/commands/locate.rs:1588`
takes it and clears `complete`. `record_vector_index_degradation` at
`crates/kin-cli/src/commands/locate.rs:1708` reports `absent` or `absent_opt_out` where
it previously reported nothing at all, each with the remediation that state actually
needs. The strict benchmark gate keeps reading the counters alone, and that is
deliberate. A benchmark that reaches it runs against a populated store, where an absent
index already shows up as `indexed < total`.

`auto_embed_enabled_from` at `crates/kin-daemon-spawn/src/lib.rs:83` moves the
`KIN_DAEMON_AUTO_EMBED` parse next to the name, so the daemon that acts on the lever and
the degradation that reports on it read one spelling of it.

## The reranker downloaded a cache it had already found (FIR-2264)

The arming gate read `HF_HOME` and the loader did not. `CrossEncoder::new` builds
through `hf_hub::api::sync::Api::new()` (`kin-db-0.7.31/src/embed/rerank.rs:13`), which
goes to `ApiBuilder::new()` and `Cache::default()` (`hf-hub-0.5.0/src/api/sync.rs:464`
and `:233-235`), and that resolves `dirs::home_dir()/.cache/huggingface/hub` without
ever reading `HF_HOME` (`hf-hub-0.5.0/src/lib.rs:202-210`). `Cache::from_env()` at
`hf-hub-0.5.0/src/lib.rs:42-51` is the constructor that does read it, and `Api::new()`
does not call it. With the variable set, the probe found the model, armed the reranker,
and the loader then found nothing at its own root and downloaded 1.1 GB inside the
query's rerank latency budget, which tripped the budget and discarded the rerank that
download had paid for.

`cross_encoder_model_snapshot` at `crates/kin-cli/src/retrieval_profile.rs:276` resolves
the snapshot the way `hf-hub` does, through `refs/{revision}` to `snapshots/{commit}`,
and requires the three files the loader opens
(`crates/kin-cli/src/retrieval_profile.rs:251`, matching `resolve_local_model_artifacts`
at `kin-db-0.7.31/src/embed/mod.rs:2197-2216`). Locate hands that directory to the
loader at `crates/kin-cli/src/commands/locate.rs:3975`, and `local_model_dir`
(`kin-db-0.7.31/src/embed/mod.rs:2187-2194`) takes the local branch whenever the model
id names an existing directory, so `hf-hub` never runs and the two cannot disagree about
a path only one of them computes. With no resolved snapshot the bare repo id is passed
through exactly as before, which is what an explicit prefetch on a cold machine still
needs.

## Falsification

Each guard was broken in the production code, re-run, and the tree restored to zero
dirty files afterwards. Exit codes were read raw, never through a pipe. Every case
failed with the message it names.

| Break | Guard that fired | rc | Failure message |
|---|---|---|---|
| `coverage_from_status` stops consulting `index_attached` | `coverage_separates_an_index_nobody_built_from_one_nothing_has_filled` | 101 | `with no index behind it there is nothing for a negative to be definitive about` |
| the degradation reason is picked from the counters alone (`if !index_attached` becomes `if false`) | `an_absent_index_nothing_will_build_is_reported_as_its_own_reason` | 101 | `left: "empty"`, `right: "absent"` |
| `vector_index_attached` infers attachment from the counters (`embedding_status().total > 0`) | `locate_reports_an_unbuilt_vector_index_on_a_fresh_store` | 101 | `left: "empty"`, `right: "absent"` |
| `cross_encoder_load_target` hands the loader the repo id again | `the_reranker_is_asked_for_the_resolved_snapshot_when_there_is_one` | 101 | `a resolved snapshot must be what the loader is handed` |
| `snapshot_under_base` drops the artifact requirement | `a_relocated_cache_resolves_under_hf_home_and_never_under_the_home_root` | 101 | `a snapshot missing the weights is not a snapshot the loader can read` |
| the same break, second guard | `a_pruned_model_reads_as_fetched_but_not_cached` | 101 | `an empty snapshot directory holds none of the files the loader opens` |
| `hf_cache_base` stops reading `HF_HOME` | `a_relocated_cache_resolves_under_hf_home_and_never_under_the_home_root` | 101 | `the resolved snapshot must be the one staged under HF_HOME`, `left: None` |
| the resolved directory is given a config the loader can parse | `the_loader_opens_the_directory_the_probe_resolved` | 101 | `got: index error: failed to load tokenizer: EOF while parsing a value` |

The last row is the one that proves the loader reads the directory the probe resolved.
The staged artifacts are empty, so the intact test asserts on `failed to parse model
config`. Writing a parseable config into the resolved snapshot moved the failure to the
tokenizer, which only reading that directory's own bytes could produce.

No network call is made on any of these paths. The model id used in the loader test does
not exist on the Hub, and `local_model_dir` takes the local branch before `hf_hub`
is constructed at all. Those tests finish in 0.40s.

One falsification attempt was itself wrong and is worth recording. The first run of the
`snapshot_under_base` break used a test filter that matched five unrelated tests and none
of the guards, so it exited 0 and read exactly like a passing falsification. It was
caught by reading the per-test lines rather than the exit code, and re-run against the two
guards that actually cover the behavior.

## Gate

`bin/kin-lane run vectorgap kin -- bin/kin-dev local-test kin` is green on the rebased
tree, printing
`worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/vectorgap-kin` at
`fb2f3c49` on `chore/lane-vectorgap-kin`, with
`Summary [790.092s] 6184 tests run: 6184 passed (19 slow, 3 leaky), 12 skipped` and exit
code 0. The working tree was clean afterwards and the tracked `Cargo.lock` carries no
path-patch contamination.

An earlier run of that same gate is worth recording, because its result was worthless and
looked like a real one. It reached 1306 of 6184 tests and cancelled on six failures, all
in `commands::update::tests`, each dying at about 302 seconds on the 300 second
crash-worker timeout raised from `crates/kin-cli/src/commands/update.rs:13803`. This
branch does not touch `update.rs`. The machine was at load average 90.87 with a dozen
other lanes running the same kin-cli suite, and the `smallfix-kin` and `pinbump35-kin`
lanes were running those exact tests at that moment. Re-running the six alone on this
branch passed, 6 passed and 0 failed in 133.11 seconds at exit code 0, and the clean
full-suite run above covers them again. A test suite result taken under that load says nothing
about the branch.

`cargo fmt --all -- --check` exits 0. Clippy with the `ci.yml` allowlist under
`RUSTFLAGS=-D warnings` exits 0. The guard scripts `verify-zero-file-search.py`,
`zero_file_search_guard.sh`, `check_runtime_boundaries.sh` and
`check_private_repo_coupling.sh` each exit 0.

Closes FIR-2373
Closes FIR-2264
