### PR TITLE
Resolve a Rust method call by its receiver and refuse a bare prelude call

### DIFF
--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -465,6 +465,18 @@ pub struct TraceDataFlowResponse {
     pub bodies_omitted: usize,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub steps_omitted: usize,
+    /// Steps this response reached through a `name_only` edge, out of
+    /// `total_steps`.
+    ///
+    /// A chain that lists three callees looks equally complete whether all three
+    /// were proven or all three were guessed from a bare name, and a reader who
+    /// does not scan every step's `resolution` cannot tell. The count says it
+    /// once, at the top, so a chain narrowed by a resolution gate is not mistaken
+    /// for a complete proven one. Zero — and omitted — when every hop was
+    /// proven, which is the only case where the chain is a claim about what runs
+    /// rather than about what might.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub unproven_steps: usize,
     /// File-less duplicates of a symbol the graph also holds with a file, merged
     /// into the located record so one symbol carries one identity in one
     /// response. Zero — and omitted — when no name arrived both ways.
@@ -923,12 +935,48 @@ pub fn build_trace_data_flow_response_within(
         clipped_steps,
         bodies_omitted: 0,
         steps_omitted: 0,
+        unproven_steps: 0,
         external_identities_merged,
         max_response_chars: request.budget_chars(),
         degradations,
     };
     enforce_response_budget(&mut response);
+    record_unproven_steps(&mut response);
     Ok(response)
+}
+
+/// Count the hops this response rests on that were matched by name alone, and
+/// disclose the count rather than leaving it to be inferred per step.
+///
+/// Run after the response budget has cut whatever it cuts, so the number
+/// describes the chain the caller actually receives. A resolution gate that
+/// refuses an edge makes the chain shorter without saying so anywhere; this is
+/// what keeps a shortened chain from reading as a proven one.
+fn record_unproven_steps(response: &mut TraceDataFlowResponse) {
+    let name_only = RelationResolution::NameOnly.as_str();
+    response.unproven_steps = response
+        .chain
+        .iter()
+        .filter(|step| step.resolution == name_only)
+        .count();
+    if response.unproven_steps == 0 {
+        return;
+    }
+    let total = response.chain.len();
+    record_degradation(
+        &mut response.degradations,
+        RetrievalDegradation {
+            component: "call_resolution".to_string(),
+            reason: "name_only_steps".to_string(),
+            detail: format!(
+                "{} of {total} steps were reached through an edge matched by name alone, so the flow each claims may not exist",
+                response.unproven_steps
+            ),
+            remediation:
+                "read each step's `resolution` field, and treat a `name_only` hop as a candidate rather than a call"
+                    .to_string(),
+        },
+    );
 }
 
 /// One node of the walk, carrying the file and directory its fan-out is scored
@@ -2085,6 +2133,7 @@ mod tests {
             clipped_steps: Vec::new(),
             bodies_omitted: 0,
             steps_omitted: 0,
+            unproven_steps: 0,
             external_identities_merged: 0,
             max_response_chars: DEFAULT_MAX_RESPONSE_CHARS,
             degradations: Vec::new(),

--- a/crates/kin-cli/tests/rust_receiver_method_call_resolution.rs
+++ b/crates/kin-cli/tests/rust_receiver_method_call_resolution.rs
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Acceptance reproduction for the two defects FIR-1581 names: a Rust method
+//! call resolving to a same-named method in a crate the caller never sees, and
+//! a callee listed in a data-flow walk that nothing calls.
+//!
+//! The fixture is the shape the ticket measured on a ripgrep clone. A `HiArgs`
+//! method imports one builder and calls `.multi_line(..)` on it; a second crate
+//! defines a builder spelling the same method; and a third crate defines an
+//! enum whose variant is spelled `Ok`. Before the fix the trace from
+//! `HiArgs::searcher` listed `RegexMatcherBuilder::multi_line`, and the trace
+//! from `HiArgs::checked` listed `ParseResult::Ok` for a `Ok(..)` that is the
+//! Rust prelude's.
+//!
+//! Everything here runs through the real Rust adapter, the real cross-file
+//! linker, and a real `InMemoryGraph`, which is what `kin init` builds over an
+//! existing tree. The positive controls sit in the same fixture on purpose: a
+//! file that DOES import the regex builder must still reach its `multi_line`,
+//! and a file that imports the enum's variants must still reach `ParseResult::Ok`,
+//! so a gate that simply deleted those entities from the graph would fail here.
+
+use std::sync::Arc;
+
+use kin_cli::commands::refs::{build_refs_response, RefsRequest};
+use kin_cli::commands::repository_authority::RequestRepositoryAuthority;
+use kin_cli::commands::trace_data_flow::{
+    build_trace_data_flow_response, TraceDataFlowRequest, TraceDataFlowResponse, TraceDirection,
+};
+use kin_db::InMemoryGraph;
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{ArtifactId, Entity, EntityStore, FilePathId};
+use kin_parser::{LanguageAdapter, RustAdapter};
+
+/// The crate the focal imports. `multi_line` here is the true callee.
+const SEARCHER_RS: &str = r#"
+pub struct Searcher {
+    multi_line: bool,
+}
+
+pub struct SearcherBuilder {
+    multi_line: bool,
+}
+
+impl SearcherBuilder {
+    pub fn new() -> SearcherBuilder {
+        SearcherBuilder { multi_line: false }
+    }
+
+    pub fn multi_line(&mut self, yes: bool) -> &mut SearcherBuilder {
+        self.multi_line = yes;
+        self
+    }
+
+    pub fn build(&self) -> Searcher {
+        Searcher {
+            multi_line: self.multi_line,
+        }
+    }
+}
+"#;
+
+/// The crate the focal never imports, spelling the same method name. This is
+/// the wrong-crate callee the ticket measured.
+const MATCHER_RS: &str = r#"
+pub struct RegexMatcher {
+    multi_line: bool,
+}
+
+pub struct RegexMatcherBuilder {
+    multi_line: bool,
+}
+
+impl RegexMatcherBuilder {
+    pub fn new() -> RegexMatcherBuilder {
+        RegexMatcherBuilder { multi_line: false }
+    }
+
+    pub fn multi_line(&mut self, yes: bool) -> &mut RegexMatcherBuilder {
+        self.multi_line = yes;
+        self
+    }
+
+    pub fn build(&self) -> RegexMatcher {
+        RegexMatcher {
+            multi_line: self.multi_line,
+        }
+    }
+}
+"#;
+
+/// The focal's file. It imports the searcher builder and nothing else, so the
+/// only `multi_line` it can dispatch to is that builder's. `checked` returns a
+/// prelude `Ok`, and `width` is its own method reached through `self`.
+const HIARGS_RS: &str = r#"
+use grep::searcher::SearcherBuilder;
+
+pub struct HiArgs {
+    multiline: bool,
+}
+
+impl HiArgs {
+    pub fn searcher(&self) -> Searcher {
+        let mut builder = SearcherBuilder::new();
+        builder.multi_line(self.multiline);
+        builder.build()
+    }
+
+    pub fn checked(&self) -> Result<u32, u32> {
+        Ok(self.width())
+    }
+
+    pub fn width(&self) -> u32 {
+        7
+    }
+}
+"#;
+
+/// The positive control for the receiver path. This file DOES import the regex
+/// builder, so its `.multi_line(..)` must still resolve to that crate.
+const MATCHER_BUILDER_RS: &str = r#"
+use grep::regex::RegexMatcherBuilder;
+
+pub struct MatcherBuilder {
+    multiline: bool,
+}
+
+impl MatcherBuilder {
+    pub fn matcher(&self) -> RegexMatcher {
+        let mut builder = RegexMatcherBuilder::new();
+        builder.multi_line(self.multiline);
+        builder.build()
+    }
+}
+"#;
+
+/// The enum whose variant is spelled like the prelude's.
+const PARSER_RS: &str = r#"
+pub enum ParseResult {
+    Ok(u32),
+    Err(u32),
+}
+
+pub fn parse_width(text: &str) -> u32 {
+    text.len() as u32
+}
+"#;
+
+/// The positive control for the variant path. A glob import of the enum's
+/// variants binds `Ok` here, so the bare call must still resolve, and the bare
+/// call to a free function must resolve whether or not anything is imported.
+const REPORT_RS: &str = r#"
+use crate::parser::parse_width;
+use crate::parser::ParseResult::*;
+
+pub fn report(text: &str) -> ParseResult {
+    Ok(parse_width(text))
+}
+"#;
+
+fn parse_rs(file_path: &str, source: &str) -> FileParseData {
+    let adapter = RustAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("fixture parses");
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("fixture extracts");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|entity| entity.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn ripgrep_shaped_workspace() -> (InMemoryGraph, Vec<FileParseData>) {
+    let files = vec![
+        parse_rs("crates/cli/src/parser.rs", PARSER_RS),
+        parse_rs("crates/cli/src/report.rs", REPORT_RS),
+        parse_rs("crates/core/src/flags/hiargs.rs", HIARGS_RS),
+        parse_rs("crates/core/src/matcher_builder.rs", MATCHER_BUILDER_RS),
+        parse_rs("crates/regex/src/matcher.rs", MATCHER_RS),
+        parse_rs("crates/searcher/src/searcher/mod.rs", SEARCHER_RS),
+    ];
+    let artifact_ids = files
+        .iter()
+        .map(|file| (file.file_path.clone(), ArtifactId::new()))
+        .collect();
+    let relations = link_cross_file(&files, &artifact_ids).expect("link fixture");
+
+    let graph = InMemoryGraph::new();
+    for entity in files.iter().flat_map(|file| file.entities.iter()) {
+        graph.upsert_entity(entity).expect("upsert entity");
+    }
+    for relation in &relations {
+        graph.upsert_relation(relation).expect("upsert relation");
+    }
+    (graph, files)
+}
+
+fn entity_id(files: &[FileParseData], name: &str) -> String {
+    files
+        .iter()
+        .flat_map(|file| file.entities.iter())
+        .find(|entity| entity.name == name)
+        .unwrap_or_else(|| panic!("fixture entity `{name}` not found"))
+        .id
+        .0
+        .to_string()
+}
+
+fn absent_binding() -> kin_core::LocalRepositoryAuthorityBinding {
+    let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
+    kin_core::LocalRepositoryAuthorityBinding::from_parts(
+        kin_model::RepositoryId::new("absent-rust-receiver-method").unwrap(),
+        kin_model::WorkspaceId::new(),
+        Arc::new(kin_db::LocalFileBackend::new(layout.kindb_dir())),
+    )
+}
+
+fn trace_callees(
+    graph: &InMemoryGraph,
+    files: &[FileParseData],
+    focal: &str,
+) -> TraceDataFlowResponse {
+    build_trace_data_flow_response(
+        &RequestRepositoryAuthority::pinned(absent_binding()),
+        graph,
+        &TraceDataFlowRequest {
+            focal: entity_id(files, focal),
+            depth: Some(3),
+            direction: Some(TraceDirection::Calls),
+            limit_per_step: Some(25),
+            include_body: Some(false),
+            max_response_chars: None,
+        },
+    )
+    .expect("trace fixture")
+}
+
+/// Every entity name `trace_data_flow` reports when it walks callees from
+/// `focal`, at the ticket's own depth and direction.
+fn callee_chain(graph: &InMemoryGraph, files: &[FileParseData], focal: &str) -> Vec<String> {
+    trace_callees(graph, files, focal)
+        .chain
+        .iter()
+        .map(|step| step.entity.entity_name.clone())
+        .collect()
+}
+
+/// The first defect, reproduced and closed. `hiargs.rs` imports one builder, so
+/// `builder.multi_line(..)` can only reach that builder's method. The regex
+/// crate's identically named method was reached by matching the bare leaf
+/// against every `multi_line` in the repository.
+#[test]
+fn tracing_calls_reaches_only_the_builder_method_the_focal_file_imports() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let chain = callee_chain(&graph, &files, "HiArgs::searcher");
+
+    assert!(
+        chain
+            .iter()
+            .any(|name| name == "SearcherBuilder::multi_line"),
+        "the imported builder's method is the true callee and must be walked, got {chain:?}"
+    );
+    assert!(
+        !chain
+            .iter()
+            .any(|name| name == "RegexMatcherBuilder::multi_line"),
+        "a same-named method in a crate this file never imports must not be a callee, got {chain:?}"
+    );
+    assert!(
+        !chain.iter().any(|name| name == "RegexMatcher"),
+        "nothing under the wrong-crate edge may be reached, got {chain:?}"
+    );
+}
+
+/// The receiver path this fix must leave working. `matcher_builder.rs` imports
+/// the regex builder and calls the same method through it, so the entity the
+/// previous test refuses is exactly what this trace must reach.
+#[test]
+fn tracing_calls_from_the_importing_caller_still_reaches_the_regex_builder() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let chain = callee_chain(&graph, &files, "MatcherBuilder::matcher");
+
+    assert!(
+        chain
+            .iter()
+            .any(|name| name == "RegexMatcherBuilder::multi_line"),
+        "`builder.multi_line(..)` in a file importing RegexMatcherBuilder must resolve, got {chain:?}"
+    );
+    assert!(
+        !chain
+            .iter()
+            .any(|name| name == "SearcherBuilder::multi_line"),
+        "the searcher crate's method is not reachable from this file, got {chain:?}"
+    );
+}
+
+/// The second defect, reproduced and closed. `Ok(self.width())` is the Rust
+/// prelude's `Result::Ok`. A repository enum spelling a variant the same way
+/// captured the call and carried the walk into a module `hiargs.rs` never names.
+#[test]
+fn tracing_calls_never_crosses_a_prelude_ok_into_the_parser_module() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let chain = callee_chain(&graph, &files, "HiArgs::checked");
+
+    assert!(
+        !chain.iter().any(|name| name == "ParseResult::Ok"),
+        "a prelude `Ok` must not resolve to a repository enum variant, got {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|name| name == "HiArgs::width"),
+        "`self.width()` is the one real call in this body and must be walked, got {chain:?}"
+    );
+}
+
+/// The variant path this fix must leave working. `report.rs` glob-imports the
+/// enum's variants, which is the binding Rust allows, so its bare `Ok(..)` must
+/// still resolve. The bare call to a free function beside it is the control that
+/// the gate did not simply stop resolving bare Rust calls.
+#[test]
+fn tracing_calls_from_a_variant_importing_caller_still_reaches_the_variant() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let chain = callee_chain(&graph, &files, "report");
+
+    assert!(
+        chain.iter().any(|name| name == "ParseResult::Ok"),
+        "a file importing the enum's variants must still reach `ParseResult::Ok`, got {chain:?}"
+    );
+    assert!(
+        chain.iter().any(|name| name == "parse_width"),
+        "a bare call to an imported free function must still resolve, got {chain:?}"
+    );
+}
+
+/// `self.width()` inside `impl HiArgs` can only be `HiArgs`'s own `width`, and
+/// the edge is proven rather than guessed: the receiver is settled by the
+/// syntax, so the destination is the entity the graph already stores under
+/// `HiArgs::width`.
+#[test]
+fn a_self_receiver_call_resolves_to_the_owning_type_at_full_strength() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let response = trace_callees(&graph, &files, "HiArgs::checked");
+    let step = response
+        .chain
+        .iter()
+        .find(|step| step.entity.entity_name == "HiArgs::width")
+        .unwrap_or_else(|| panic!("`self.width()` must be walked, got {:?}", response.chain));
+
+    assert_eq!(
+        step.resolution, "type_resolved",
+        "a receiver the syntax settles proves its destination, got {}",
+        step.resolution
+    );
+}
+
+/// `find_references` and `trace_data_flow` read the same edges, so the two must
+/// agree about who calls the regex builder's method: the file importing it does,
+/// and the file importing the searcher builder never did.
+#[test]
+fn find_references_on_the_regex_builder_method_lists_only_the_importing_caller() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
+    let response = build_refs_response(
+        &layout,
+        &graph,
+        &RefsRequest {
+            entity: entity_id(&files, "RegexMatcherBuilder::multi_line"),
+            kind: "all".to_string(),
+        },
+    )
+    .expect("refs fixture");
+    let listing = response.lines.join("\n");
+
+    assert!(
+        listing.contains("MatcherBuilder::matcher"),
+        "the importing caller must be listed, got:\n{listing}"
+    );
+    assert!(
+        !listing.contains("HiArgs::searcher"),
+        "a file that never imports this builder must not appear as a caller, got:\n{listing}"
+    );
+}
+
+/// A chain narrowed by a resolution gate must not read as a complete proven
+/// one. `HiArgs::searcher` still reaches its callees by matching a bare method
+/// leaf, so the response says how many of its steps rest on that.
+#[test]
+fn the_response_counts_the_steps_it_reached_by_name_alone() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let response = trace_callees(&graph, &files, "HiArgs::searcher");
+
+    let name_only = response
+        .chain
+        .iter()
+        .filter(|step| step.resolution == "name_only")
+        .count();
+    assert!(
+        name_only > 0,
+        "this fixture is only a control while some hop is name-only, got {:?}",
+        response.chain
+    );
+    assert_eq!(
+        response.unproven_steps, name_only,
+        "the response must count every name-only hop it returned"
+    );
+    assert!(
+        response.degradations.iter().any(|degradation| {
+            degradation.component == "call_resolution" && degradation.reason == "name_only_steps"
+        }),
+        "a chain resting on name-only hops must disclose that, got {:?}",
+        response.degradations
+    );
+}
+
+/// The proven case, so the disclosure above cannot be a constant. Every hop out
+/// of `HiArgs::checked` is settled by the syntax, so nothing is counted and no
+/// degradation is raised.
+#[test]
+fn a_fully_proven_chain_raises_no_name_only_disclosure() {
+    let (graph, files) = ripgrep_shaped_workspace();
+    let response = trace_callees(&graph, &files, "HiArgs::checked");
+
+    assert_eq!(
+        response.unproven_steps, 0,
+        "every hop here is proven, got {:?}",
+        response.chain
+    );
+    assert!(
+        !response
+            .degradations
+            .iter()
+            .any(|degradation| degradation.component == "call_resolution"),
+        "a proven chain must raise no resolution degradation, got {:?}",
+        response.degradations
+    );
+}

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -1141,6 +1141,20 @@ fn resolve_one_file(
                 // Python identifier has none, so no method here is a dispatch
                 // target for it.
                 drop_method_candidates(candidates, &ctx.entity_kind_by_id)
+            } else if is_rust_bare_identifier_call(rel, src_id, &ctx.entity_language_by_id)
+                && !rust_bare_call_may_reach_owned(
+                    rel.dst_name.as_str(),
+                    file,
+                    ctx.import_map.get(file.file_path.as_str()),
+                )
+            {
+                debug!(
+                    src = %rel.src_name,
+                    dst = %rel.dst_name,
+                    file = %file.file_path,
+                    "linker: bare Rust call cannot reach an owner-qualified entity this file does not import, leaving unlinked"
+                );
+                Vec::new()
             } else {
                 candidates
             };
@@ -2861,6 +2875,49 @@ fn is_unbound_python_builtin_call(
         && !defined_in_file
         && !file_imports.is_some_and(|imports| imports.contains_key(rel.dst_name.as_str()))
         && imports_are_name_complete(&file.imports)
+}
+
+/// Whether this relation is a Rust call written as a plain `name(..)`.
+///
+/// The Rust adapter records a dispatch through an object with its receiver as
+/// written, and folds `self.m()` / `Self::m()` into the `Owner::m` key the
+/// method entity is stored under. So a Rust call arriving with neither a
+/// receiver nor a path is the one shape that genuinely has no receiver.
+fn is_rust_bare_identifier_call(
+    rel: &ExtractedRelation,
+    src_id: EntityId,
+    languages: &HashMap<EntityId, LanguageId>,
+) -> bool {
+    rel.kind == RelationKind::Calls
+        && rel.receiver.is_none()
+        && !rel.dst_name.contains('.')
+        && !rel.dst_name.contains("::")
+        && languages.get(&src_id) == Some(&LanguageId::Rust)
+}
+
+/// Whether a bare Rust call may reach the owner-qualified entities the
+/// bare-name index holds.
+///
+/// Every entry in that index is stored under an owner (`Type::method`,
+/// `Enum::Variant`), and Rust reaches none of those from a plain `name(..)`.
+/// An inherent or trait method needs a receiver or a `Type::` path, and a
+/// variant or associated item needs the `use` that binds its short name here.
+/// That is how `Ok(self.width())` acquired a `Calls` edge to a repository
+/// `ParseResult::Ok` in a module the caller never names: `Ok` is
+/// `core::result::Result::Ok`, and the one entity in the graph spelling the
+/// same leaf captured the call, carrying a `trace_data_flow` subtree with it.
+///
+/// A `use` of that exact name is the binding Rust does allow, and it wins. A
+/// glob import binds names this parse cannot see, so a file carrying one has no
+/// answer to "does this file bind that name" and the gate stands down rather
+/// than guessing, exactly as the Python builtin gate does for `import *`.
+fn rust_bare_call_may_reach_owned(
+    dst_name: &str,
+    file: &FileParseData,
+    file_imports: Option<&HashMap<&str, (&str, &str)>>,
+) -> bool {
+    !imports_are_name_complete(&file.imports)
+        || file_imports.is_some_and(|imports| imports.contains_key(dst_name))
 }
 
 /// Drop the method candidates a bare Python call can never dispatch to.
@@ -5150,6 +5207,20 @@ fn resolve_one_file_incremental(
                     // A bare Python identifier carries no receiver, and this
                     // tier resolves calls that have one.
                     drop_method_candidates(candidates, &linker.entity_kind_by_id)
+                } else if is_rust_bare_identifier_call(rel, src_id, &linker.entity_language_by_id)
+                    && !rust_bare_call_may_reach_owned(
+                        rel.dst_name.as_str(),
+                        file,
+                        import_map.get(file.file_path.as_str()),
+                    )
+                {
+                    debug!(
+                        src = %rel.src_name,
+                        dst = %rel.dst_name,
+                        file = %file.file_path,
+                        "linker: bare Rust call cannot reach an owner-qualified entity this file does not import, leaving unlinked"
+                    );
+                    Vec::new()
                 } else {
                     candidates
                 };
@@ -6253,10 +6324,19 @@ mod tests {
             }
             vec![
                 FileParseData {
+                    // Load-bearing: a bare Rust call reaches the bare-name tier
+                    // only from a file whose import list cannot answer whether it
+                    // binds that name. With no imports at all the list is
+                    // name-complete, and the bare `make` is refused before it can
+                    // merge with the qualified one, which is the FIR-1581 gate
+                    // doing its job rather than this test's subject.
                     file_path: "src/caller.rs".to_string(),
                     entities: vec![caller.clone()],
                     relations,
-                    imports: vec![],
+                    imports: vec![FileImport {
+                        module_path: "crate::model".to_string(),
+                        specifiers: vec![],
+                    }],
                 },
                 FileParseData {
                     file_path: "src/model.rs".to_string(),

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -27,7 +27,7 @@ use kin_model::{
     SemanticFingerprint, SourceSpan, Visibility,
 };
 use kin_parser::{
-    CSharpAdapter, ExtractedRelation, JavaAdapter, JavaScriptAdapter, LanguageAdapter,
+    CSharpAdapter, ExtractedRelation, FileImport, JavaAdapter, JavaScriptAdapter, LanguageAdapter,
     PythonAdapter, TypeScriptAdapter,
 };
 
@@ -266,7 +266,16 @@ fn receiver_fanout_call_count(n: usize) -> usize {
         file_path: "caller.rs".to_string(),
         entities: vec![caller],
         relations: vec![calls_relation("build", "make")],
-        imports: vec![],
+        // Load-bearing. These entities are Rust, and a bare Rust `make()` reaches
+        // the owner-qualified `Impl0::make` only from a file whose import list
+        // cannot answer whether it binds that name. An empty list is
+        // name-complete, so the call would be refused before it could fan out at
+        // all, and this helper would measure the FIR-1581 gate instead of the cap
+        // it exists to measure. A glob import is the stand-down that gate documents.
+        imports: vec![FileImport {
+            module_path: "crate::impls".to_string(),
+            specifiers: vec![],
+        }],
     }];
     for i in 0..n {
         let path = format!("impl{i}.rs");

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -143,7 +143,7 @@ fn extract_rust_node(
                     fingerprint: compute_fingerprint(node, source),
                     span: span_from_node(node, file_id),
                 });
-                extract_calls_from_context(node, source, &name, relations);
+                extract_calls_from_context(node, source, &name, None, relations);
             }
         }
         "struct_item" => {
@@ -329,7 +329,13 @@ fn extract_rust_node(
                                 fingerprint: compute_fingerprint(&member, source),
                                 span: span_from_node(&member, file_id),
                             });
-                            extract_calls_from_context(&member, source, &qualified, relations);
+                            extract_calls_from_context(
+                                &member,
+                                source,
+                                &qualified,
+                                (!type_name.is_empty()).then_some(type_name.as_str()),
+                                relations,
+                            );
                             // A method declared in `impl Trait for Type` satisfies
                             // the trait's contract, so a caller holding the trait
                             // reaches it without any edge naming the method. Only
@@ -542,6 +548,7 @@ fn extract_calls_from_context(
     node: &tree_sitter::Node,
     source: &[u8],
     context_name: &str,
+    owner: Option<&str>,
     relations: &mut Vec<ExtractedRelation>,
 ) {
     let mut cursor = node.walk();
@@ -549,19 +556,10 @@ fn extract_calls_from_context(
         if child.kind() == "call_expression" {
             // The callee is the `function` field
             if let Some(function) = child.child_by_field_name("function") {
-                let callee_name = match function.kind() {
-                    "field_expression" => {
-                        // obj.method() — extract just the method name (field)
-                        function
-                            .child_by_field_name("field")
-                            .map(|f| f.utf8_text(source).unwrap_or("").to_string())
-                            .unwrap_or_default()
-                    }
-                    _ => function.utf8_text(source).unwrap_or("").to_string(),
-                };
+                let (callee_name, receiver) = rust_callee_and_receiver(&function, source, owner);
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
-                        receiver: None,
+                        receiver,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
@@ -581,12 +579,18 @@ fn extract_calls_from_context(
             let mut macro_cursor = child.walk();
             for macro_child in child.children(&mut macro_cursor) {
                 if macro_child.kind() == "token_tree" {
-                    extract_calls_from_token_tree(&macro_child, source, context_name, relations);
+                    extract_calls_from_token_tree(
+                        &macro_child,
+                        source,
+                        context_name,
+                        owner,
+                        relations,
+                    );
                 }
             }
         }
         // Recurse into child nodes
-        extract_calls_from_context(&child, source, context_name, relations);
+        extract_calls_from_context(&child, source, context_name, owner, relations);
     }
 }
 
@@ -609,6 +613,7 @@ fn extract_calls_from_token_tree(
     node: &tree_sitter::Node,
     source: &[u8],
     context_name: &str,
+    owner: Option<&str>,
     relations: &mut Vec<ExtractedRelation>,
 ) {
     let mut cursor = node.walk();
@@ -616,7 +621,7 @@ fn extract_calls_from_token_tree(
 
     for (index, token) in tokens.iter().enumerate() {
         if token.kind() == "token_tree" {
-            extract_calls_from_token_tree(token, source, context_name, relations);
+            extract_calls_from_token_tree(token, source, context_name, owner, relations);
             continue;
         }
         if token.kind() != "identifier" {
@@ -630,7 +635,19 @@ fn extract_calls_from_token_tree(
             continue;
         }
         // `x.method(..)`: bare method name, matching the field_expression arm.
+        // The token before the dot is the receiver, so a macro-body dispatch
+        // carries the same receiver evidence a `call_expression` one does. With
+        // no such token there is nothing to attribute the call to, and recording
+        // it receiverless would present a dispatch as a bare call.
         let is_method_call = index > 0 && tokens[index - 1].kind() == ".";
+        let receiver = if is_method_call {
+            let Some(receiver_token) = index.checked_sub(2).and_then(|at| tokens.get(at)) else {
+                continue;
+            };
+            Some(receiver_token.utf8_text(source).unwrap_or("").to_string())
+        } else {
+            None
+        };
         let mut callee_name = token.utf8_text(source).unwrap_or("").to_string();
         if !is_method_call {
             // Reconstruct a leading `a::b::` path so qualified callees keep
@@ -648,9 +665,10 @@ fn extract_calls_from_token_tree(
                 );
             }
         }
+        let (callee_name, receiver) = fold_settled_rust_receiver(callee_name, receiver, owner);
         if is_valid_callee_name(&callee_name) {
             relations.push(ExtractedRelation {
-                receiver: None,
+                receiver,
                 call_shape: None,
                 kind: kin_model::RelationKind::Calls,
                 src_name: context_name.to_string(),
@@ -658,6 +676,69 @@ fn extract_calls_from_token_tree(
                 import_source: None,
             });
         }
+    }
+}
+
+/// The callee name and receiver one Rust call site records.
+///
+/// A method reached through an object keeps its bare leaf and carries the
+/// receiver as written, which is what lets the linker tell a dispatch from a
+/// free-function call: without it, `builder.multi_line(..)` and a module-level
+/// `multi_line(..)` are the same relation, and every same-named method in the
+/// repository is an equally good answer.
+///
+/// A receiver the syntax settles is folded into the callee instead. Inside
+/// `impl Type`, `self.m()` and `Self::m()` can only reach `Type`'s own `m`, and
+/// `Type::m` is the exact key the method entity is stored under, so the call
+/// resolves to that definition rather than fanning out by name. `self.field.m()`
+/// is deliberately not folded: it dispatches on the field's type, which the
+/// syntax does not settle.
+fn rust_callee_and_receiver(
+    function: &tree_sitter::Node,
+    source: &[u8],
+    owner: Option<&str>,
+) -> (String, Option<String>) {
+    if function.kind() == "field_expression" {
+        let method = function
+            .child_by_field_name("field")
+            .map(|field| field.utf8_text(source).unwrap_or("").to_string())
+            .unwrap_or_default();
+        let receiver = function
+            .child_by_field_name("value")
+            .map(|value| value.utf8_text(source).unwrap_or("").to_string());
+        return fold_settled_rust_receiver(method, receiver, owner);
+    }
+    let name = function.utf8_text(source).unwrap_or("").to_string();
+    (fold_self_path(name, owner), None)
+}
+
+/// Fold a `self.m()` receiver into `Owner::m`, or keep the receiver as written.
+///
+/// Shared by the `call_expression` and macro-token-tree extraction paths so a
+/// call inside `assert!(..)` records the same shape as the identical call
+/// outside it.
+fn fold_settled_rust_receiver(
+    method: String,
+    receiver: Option<String>,
+    owner: Option<&str>,
+) -> (String, Option<String>) {
+    match (owner, receiver.as_deref()) {
+        (Some(owner), Some("self")) if !method.is_empty() => (format!("{owner}::{method}"), None),
+        _ => (method, receiver.filter(|value| !value.is_empty())),
+    }
+}
+
+/// Rewrite a `Self::m` path callee as `Owner::m`.
+///
+/// `Self` names the impl's own type, so the call reaches that type's method and
+/// nothing else. Left alone outside an impl, and for every other path.
+fn fold_self_path(name: String, owner: Option<&str>) -> String {
+    let Some(owner) = owner else {
+        return name;
+    };
+    match name.strip_prefix("Self::") {
+        Some(rest) if !rest.is_empty() => format!("{owner}::{rest}"),
+        _ => name,
     }
 }
 
@@ -686,6 +767,25 @@ fn extract_rust_use(node: &tree_sitter::Node, source: &[u8]) -> Option<FileImpor
             "scoped_use_list" => {
                 // use foo::{bar, baz};
                 return extract_scoped_use_list_import(&child, source);
+            }
+            "use_wildcard" => {
+                // `use foo::*;` binds every public name in `foo`, and none of
+                // them is written here. Recording the module with no specifier
+                // is what tells a consumer this file's import list cannot answer
+                // "does this file bind that name", the same shape the Python
+                // adapter records `from foo import *` as. Dropping the import
+                // entirely would leave the file looking name-complete.
+                let module_path = child
+                    .children(&mut child.walk())
+                    .find(|node| {
+                        matches!(node.kind(), "scoped_identifier" | "identifier" | "crate")
+                    })
+                    .map(|node| node.utf8_text(source).unwrap_or("").to_string())
+                    .unwrap_or_default();
+                return Some(FileImport {
+                    module_path,
+                    specifiers: Vec::new(),
+                });
             }
             "identifier" => {
                 // use foo;

--- a/crates/kin-parser/tests/language_matrix_calls.rs
+++ b/crates/kin-parser/tests/language_matrix_calls.rs
@@ -10,7 +10,11 @@
 //! uses — probed for what the adapter *actually* emits.
 //!
 //! GREEN cells are locked as regression tests, including the rightmost-name
-//! narrowing of dotted method calls in every adapter. Several callback shapes
+//! narrowing of dotted method calls in every adapter. Rust's `self.` call is
+//! the deliberate exception: the receiver is settled by the syntax, so it is
+//! folded into an owner-qualified `Type::method` destination rather than left
+//! as a bare leaf. That destination is still simple and index-matchable, which
+//! is the property this matrix exists to lock. Several callback shapes
 //! are not wired to edges; those cells are written and `#[ignore]`d with the
 //! observed behavior named on the reason line.
 
@@ -211,14 +215,27 @@ fn go_selector_call_emits_rightmost_name() {
     no_dotted_call_dst(&out);
 }
 
+/// Rust is the one cell in this matrix that does not narrow to the bare
+/// rightmost name, because `self` settles the receiver. Inside `impl S`,
+/// `self.helper()` can only reach `S`'s own `helper`, and `S::helper` is the
+/// exact key that method entity is stored under, so folding the receiver into
+/// the callee resolves the call to its definition. The bare leaf is what let a
+/// `self.` call match every same-named method in the repository. The matrix
+/// invariant that matters is unchanged: the destination is still simple and
+/// index-matchable, and still never the dotted `self.helper` form. FIR-1581.
 #[test]
-fn rust_self_method_call_emits_rightmost_name() {
+fn rust_self_method_call_folds_the_receiver_into_the_owner() {
     let out = extract(
         &RustAdapter,
         "s.rs",
         "struct S;\nimpl S {\n    fn run(&self) { self.helper(); }\n    fn helper(&self) {}\n}\n",
     );
-    assert!(has_edge(&out, RelationKind::Calls, "S::run", "helper"));
+    assert!(has_edge(&out, RelationKind::Calls, "S::run", "S::helper"));
+    assert!(
+        !has_edge(&out, RelationKind::Calls, "S::run", "helper"),
+        "the bare leaf is what made a `self.` call ambiguous across crates"
+    );
+    no_dotted_call_dst(&out);
 }
 
 #[test]


### PR DESCRIPTION
`trace_data_flow` answered a Rust `obj.method()` by matching the bare method leaf against every same-named method in the repository, because the Rust adapter extracted that leaf and threw the receiver away. On the ripgrep shape the ticket measured, `HiArgs::searcher` sits in a file importing only `SearcherBuilder` and still listed `RegexMatcherBuilder::multi_line`, a method in a crate that file never sees. Separately, `Ok(self.width())` acquired a call edge to a repository `ParseResult::Ok`, and a trace subtree underneath it, because the bare-name index holds owner-qualified entities and a plain `Ok(..)` matched one by its leaf.

## Mechanism

`crates/kin-parser/src/languages/rust_lang.rs:696` (`rust_callee_and_receiver`) records the receiver as written instead of discarding it. That turns on the narrowing the linker already applied to Python and JavaScript at `crates/kin-index/src/linker.rs:1138` (`narrow_pairs_by_receiver_reach`), which is gated on `receiver_is_object` and so could never fire for Rust while every Rust relation carried `receiver: None`. A candidate whose owning type the calling file neither binds by name nor imports is no longer a dispatch target there.

A receiver the syntax settles is folded into the callee instead, at `rust_lang.rs:720` (`fold_settled_rust_receiver`) and `:735` (`fold_self_path`). Inside `impl Type`, `self.m()` and `Self::m()` can only reach that type's own `m`, and `Type::m` is the exact key the method entity is stored under, so those calls now resolve to the definition rather than fanning out by name. `self.field.m()` is deliberately not folded, because it dispatches on the field's type and the syntax does not settle that.

A bare Rust call is separately refused from reaching the owner-qualified entities the bare-name index holds, at `linker.rs:2886` (`is_rust_bare_identifier_call`) and `:2914` (`rust_bare_call_may_reach_owned`), wired into the batch tier at `:1144` and the incremental tier at `:5210`. Rust reaches none of those from a plain `name(..)`: a method needs a receiver or a `Type::` path, and a variant needs the `use` that binds its short name. A `use` of the name still wins, and a glob import stands the gate down, which is why `use foo::*` is now recorded as a name-incomplete import at `rust_lang.rs:771` rather than dropped entirely.

`trace_data_flow` counts the steps it reached through a `name_only` edge and discloses the count at `crates/kin-cli/src/commands/trace_data_flow.rs:955` (`record_unproven_steps`), so a chain these gates shortened is not mistaken for a complete proven one.

## Three existing tests moved

Two linker fixtures made a bare Rust call from a file declaring no imports at all. An empty import list is name-complete, so the gate now refuses the call before the tier under test can see it. Each gains the glob import that is the stand-down the gate documents, and each still asserts its own subject: `repeated_call_metadata_keeps_strongest_resolution_independent_of_source_order` is about the merged edge keeping the strongest resolution regardless of source order, and `receiver_fanout_call_count` in `crates/kin-index/tests/language_matrix_linker.rs` backs two tests whose subject is the fan-out cap rather than Rust reachability.

The third is a deliberate behavior change rather than a fixture repair. `crates/kin-parser/tests/language_matrix_calls.rs` asserted that a Rust `self.helper()` emits the bare rightmost name `helper`. It now emits `S::helper`, so the test asserts the new destination, proves the bare leaf is gone, and is renamed `rust_self_method_call_folds_the_receiver_into_the_owner`. That file's header stated the matrix premise that every adapter narrows to the rightmost name, so the header now names Rust's `self.` call as the exception. The property the matrix exists to lock is unchanged: the destination is still simple, index-matchable, and never the dotted form.

## Falsification

Each guarded behavior was broken in turn and `cargo test -p kin-cli --test rust_receiver_method_call_resolution` re-run against the break. All five breaks exited 101, and every one of the eight new tests dies under at least one break, so none is green by accident.

Dropping the receiver from the relation while leaving the folding intact killed three tests, including `tracing_calls_reaches_only_the_builder_method_the_focal_file_imports` with `the imported builder's method is the true callee and must be walked, got ["SearcherBuilder::new"]`. Disabling the bare Rust call gate killed `tracing_calls_never_crosses_a_prelude_ok_into_the_parser_module` with ``a prelude `Ok` must not resolve to a repository enum variant, got ["HiArgs::width", "ParseResult::Ok"]``, which is the ticket's second defect reappearing verbatim. Removing the `self` fold killed `a_self_receiver_call_resolves_to_the_owning_type_at_full_strength`. Skipping the name-only count killed `the_response_counts_the_steps_it_reached_by_name_alone`. Dropping the glob import again killed `tracing_calls_from_a_variant_importing_caller_still_reaches_the_variant` with ``a file importing the enum's variants must still reach `ParseResult::Ok`, got ["parse_width"]``, the positive control proving the gate did not simply stop resolving bare Rust calls.

## Gate

`cargo fmt --all -- --check` exits 0, after it caught two spots in the new test file that would have failed Check formatting. `cargo clippy --all-targets --all-features` with the ci.yml allowlist exits 0 under `RUSTFLAGS=-D warnings`. All five guard scripts ci.yml drives pass on this branch: `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh` and `scripts/verify-hydration-semantics.py`.

The local workspace gate needed `--no-fail-fast` to be worth anything here. nextest cancels on first failure, so three separate runs stopped at 4053, 1566 and 1557 tests of roughly 6200 and hid everything past their first failure, which is how the two fixture problems above reached CI instead of being caught locally. A full `--no-fail-fast` run on this sha reports 18 failures, and every one is a subprocess timeout rather than an assertion: 6 carry `timed out after 300s` from the update worker, 11 carry `kin did not exit within` its timeout, and 1 is a failed host `git worktree list`. None is an assertion about entities, edges, or resolution, which is the discriminator that matters, since a real regression here would fail on graph content and not on process scheduling. That host carried a load average between 37 and 85 on 18 cores with another lane running its own full workspace nextest at the same time.

Closes FIR-1581
