### PR TITLE
Paint the refs rows the product composes, and pin the fixture Git scope an admission proof reads

### DIFF
--- a/crates/kin-cli/src/output_style.rs
+++ b/crates/kin-cli/src/output_style.rs
@@ -94,10 +94,17 @@ fn paint_refs(line: &str) -> String {
         return format!("referenced by {ACCENT_BOLD}{}{RESET} entities:", &caps[1]);
     }
 
-    let entry = compiled(&ENTRY, r"^  (.+) @ (\S+:\d+) \[([^\]]*)\]$");
+    // A row's location omits `:line` when the entity carries no span, and the
+    // resolution marker trails the relation bracket. Anchoring on either shape
+    // loses the color silently, because an unmatched line prints as plain text.
+    let entry = compiled(&ENTRY, r"^  (.+) @ (\S+) \[([^\]]*)\](?: \(([^)]*)\))?$");
     if let Some(caps) = entry.captures(line) {
+        let resolution = caps
+            .get(4)
+            .map(|marker| format!(" {DIM}({}){RESET}", marker.as_str()))
+            .unwrap_or_default();
         return format!(
-            "  {BRIGHT}{}{RESET} @ {ACCENT}{}{RESET} {FAINT}[{}]{RESET}",
+            "  {BRIGHT}{}{RESET} @ {ACCENT}{}{RESET} {FAINT}[{}]{RESET}{resolution}",
             &caps[1], &caps[2], &caps[3]
         );
     }
@@ -245,25 +252,162 @@ mod tests {
         assert_eq!(strip_ansi(painted), plain, "round trip changed the line");
     }
 
-    #[test]
-    fn refs_header_is_painted() {
-        let plain = "References to 'probe' -> probe_symbol (Function) @ src/target.rs";
-        let painted = paint_refs(plain);
-        assert_painted(&painted, plain, &format!("{BOLD_WHITE}probe_symbol"));
-        assert!(painted.contains(&format!("{ACCENT}src/target.rs")));
-        assert!(painted.contains(&format!("{DIM}(Function)")));
+    /// A `kin refs` answer as the product composes it.
+    ///
+    /// The styler is fed these lines rather than strings written here to match
+    /// its regexes, because a hand-written fixture agrees with the pattern by
+    /// construction and stays green when the composed row moves underneath it.
+    /// That is how the anchored `:line` row survived both spanless locations
+    /// and the trailing resolution marker without a red test.
+    fn real_refs_response_lines() -> Vec<String> {
+        use crate::commands::refs::{build_refs_response, RefsRequest};
+        use kin_db::InMemoryGraph;
+        use kin_model::relation::{Relation, RelationOrigin};
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, RelationKind,
+            SemanticFingerprint, SourceSpan, Visibility,
+        };
+
+        fn entity(name: &str, rel_path: &str, start_line: Option<u32>) -> Entity {
+            Entity {
+                id: EntityId::new(),
+                kind: EntityKind::Function,
+                name: name.to_string(),
+                language: LanguageId::Rust,
+                fingerprint: SemanticFingerprint {
+                    algorithm: FingerprintAlgorithm::V1TreeSitter,
+                    ast_hash: Hash256::from_bytes([0; 32]),
+                    signature_hash: Hash256::from_bytes([0; 32]),
+                    behavior_hash: Hash256::from_bytes([0; 32]),
+                    equivalence_hash: Hash256::from_bytes([0; 32]),
+                    stability_score: 1.0,
+                },
+                file_origin: Some(FilePathId::new(rel_path)),
+                span: start_line.map(|line| SourceSpan {
+                    file: FilePathId::new(rel_path),
+                    start_byte: 0,
+                    end_byte: 0,
+                    start_line: line,
+                    start_col: 1,
+                    end_line: line,
+                    end_col: 1,
+                }),
+                signature: format!("fn {name}()"),
+                visibility: Visibility::Public,
+                role: EntityRole::Source,
+                doc_summary: None,
+                metadata: EntityMetadata::default(),
+                lineage_parent: None,
+                created_in: None,
+                superseded_by: None,
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+
+        let target = entity("probe_symbol", "target_mod.rs", Some(0));
+        // One caller carries a span and one does not, so the answer holds both
+        // location shapes a row can take.
+        let spanned = entity("spanned_caller", "spanned.rs", Some(2));
+        let spanless = entity("spanless_caller", "spanless.rs", None);
+
+        let graph = InMemoryGraph::new();
+        for record in [&target, &spanned, &spanless] {
+            graph.upsert_entity(record).unwrap();
+        }
+        // Two confidences, so the rows carry two different resolution markers
+        // and a painter that assumed one value would be caught.
+        for (caller, confidence) in [(&spanned, 1.0), (&spanless, 0.5)] {
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::References,
+                    src: GraphNodeId::Entity(caller.id),
+                    dst: GraphNodeId::Entity(target.id),
+                    confidence,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        build_refs_response(
+            &layout,
+            &graph,
+            &RefsRequest {
+                entity: "probe_symbol".to_string(),
+                kind: "all".to_string(),
+            },
+        )
+        .unwrap()
+        .lines
     }
 
     #[test]
-    fn refs_count_and_entry_are_painted() {
-        let count = "referenced by 2 entities:";
+    fn refs_lines_the_product_composed_are_painted() {
+        let lines = real_refs_response_lines();
+
+        let header = lines.first().expect("a response opens with its header");
+        let painted = paint_refs(header);
+        assert_painted(&painted, header, &format!("{BOLD_WHITE}probe_symbol"));
+        assert!(
+            painted.contains(&format!("{ACCENT}target_mod.rs{RESET}")),
+            "target location must be painted whole: {painted:?}"
+        );
+        assert!(painted.contains(&format!("{DIM}(Function)")));
+
+        let count = lines
+            .iter()
+            .find(|line| line.starts_with("referenced by "))
+            .unwrap_or_else(|| panic!("no count line in {lines:?}"));
         assert_painted(&paint_refs(count), count, &format!("{ACCENT_BOLD}2"));
 
-        let entry = "  disk_only @ src/caller.rs:3 [Calls, References]";
-        let painted = paint_refs(entry);
-        assert_painted(&painted, entry, &format!("{BRIGHT}disk_only"));
-        assert!(painted.contains(&format!("{ACCENT}src/caller.rs:3")));
-        assert!(painted.contains(&format!("{FAINT}[Calls, References]")));
+        let rows: Vec<&str> = lines
+            .iter()
+            .filter(|line| line.starts_with("  "))
+            .map(String::as_str)
+            .collect();
+        assert_eq!(rows.len(), 2, "one row per caller: {lines:?}");
+
+        let spanned = rows
+            .iter()
+            .copied()
+            .find(|row| row.contains("spanned_caller"))
+            .unwrap_or_else(|| panic!("no spanned row in {rows:?}"));
+        let painted = paint_refs(spanned);
+        assert_painted(&painted, spanned, &format!("{BRIGHT}spanned_caller"));
+        assert!(
+            painted.contains(&format!("{ACCENT}spanned.rs:3{RESET}")),
+            "a location carrying a line number must be painted whole: {painted:?}"
+        );
+        assert!(
+            painted.contains(&format!("{FAINT}[References]{RESET}")),
+            "the relation bracket must be painted: {painted:?}"
+        );
+        assert!(
+            painted.contains(&format!("{DIM}(type_resolved){RESET}")),
+            "the resolution marker must be painted: {painted:?}"
+        );
+
+        let spanless = rows
+            .iter()
+            .copied()
+            .find(|row| row.contains("spanless_caller"))
+            .unwrap_or_else(|| panic!("no spanless row in {rows:?}"));
+        let painted = paint_refs(spanless);
+        assert_painted(&painted, spanless, &format!("{BRIGHT}spanless_caller"));
+        assert!(
+            painted.contains(&format!("{ACCENT}spanless.rs{RESET}")),
+            "a location with no line number must still be painted: {painted:?}"
+        );
+        assert!(
+            painted.contains(&format!("{DIM}(name_only){RESET}")),
+            "the resolution marker must be painted: {painted:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1535,6 +1535,53 @@ mod tests {
         assert_no_staging_directories(root.path());
     }
 
+    /// A moving ambient Git scope must not move an admission proof.
+    ///
+    /// The proof folds in the bytes of whatever ignore file Git resolves for
+    /// this repository, and unpinned that file is decided by `core.excludesFile`
+    /// then `XDG_CONFIG_HOME` then `HOME`. All three are process-global and this
+    /// suite runs its tests as threads in one process, so a sibling test pinning
+    /// the ambient scope for its own resolve shifts what a proof in flight
+    /// beside it reads. The baseline then carries the host's ignore file and the
+    /// re-proof carries none, and init refuses a source nothing wrote to. That
+    /// is FIR-2388, seen as a 1-in-45 refusal of an unrelated test.
+    ///
+    /// This drives the shift deliberately, from inside the window between the
+    /// first proof and the re-proof, which is the only placement that can fail:
+    /// a scope moved before init is simply the scope all three proofs read. The
+    /// guard is dropped the instant init returns, so the window this opens for
+    /// the rest of the suite is the one it is testing and no wider.
+    #[test]
+    fn a_moving_ambient_git_scope_does_not_move_the_admission_proof() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_git(&source);
+        std::fs::write(source.join("README.md"), b"exact source\n").unwrap();
+        git(&source, ["add", "--all"]);
+        git(&source, ["commit", "-m", "initial"]);
+
+        let elsewhere = tempfile::tempdir().unwrap();
+        let global_config = elsewhere.path().join("global.gitconfig");
+        std::fs::write(&global_config, "").unwrap();
+
+        let mut ambient = None;
+        let result = init_from_git_with_hook(&source, || {
+            ambient = Some(
+                crate::test_env::EnvVarGuard::new()
+                    .with("GIT_CONFIG_NOSYSTEM", "1")
+                    .with("GIT_CONFIG_GLOBAL", &global_config)
+                    .with("HOME", elsewhere.path())
+                    .without("XDG_CONFIG_HOME"),
+            );
+        });
+        drop(ambient);
+
+        result.unwrap();
+        assert!(source.join(".kin").is_dir());
+        assert_no_staging_directories(root.path());
+    }
+
     /// A tracked edit racing publication is still fatal.
     ///
     /// The proof no longer refuses an edited worktree, so what catches this is
@@ -2231,6 +2278,28 @@ mod tests {
         git(source, ["config", "user.email", "kin@example.invalid"]);
         git(source, ["config", "user.name", "Kin Test"]);
         pin_default_hook_surface(source);
+        pin_resolved_global_excludes(source);
+    }
+
+    /// Bind a fixture's resolved global excludes to a file it owns.
+    ///
+    /// An exact source proof folds in the bytes of whatever ignore file Git
+    /// resolves for this repository, and unpinned that file is decided by
+    /// `core.excludesFile`, then `XDG_CONFIG_HOME`, then `HOME`. All three are
+    /// process-global and this suite runs its tests as threads in one process,
+    /// so a sibling test that pins the ambient Git scope for its own resolve
+    /// moves what a proof in flight beside it observes. The baseline proof then
+    /// carries the host's ignore file and the re-proof carries none, and init
+    /// refuses a source nothing wrote to. Repository scope outranks both the
+    /// host and that sibling, so pinning it here makes the observation depend on
+    /// the fixture alone.
+    fn pin_resolved_global_excludes(source: &Path) {
+        let excludes = source.join(".git/kin-fixture-global-excludes");
+        std::fs::write(&excludes, b"").unwrap();
+        git(
+            source,
+            ["config", "core.excludesFile", excludes.to_str().unwrap()],
+        );
     }
 
     /// Bind a fixture's hook surface to its own `.git/hooks`.

--- a/crates/kin-core/src/init_staging.rs
+++ b/crates/kin-core/src/init_staging.rs
@@ -485,8 +485,8 @@ mod tests {
     ///
     /// The child holds a claimed staging directory and nothing else, so the
     /// parent can prove the signal path ran rather than that the child never
-    /// got far enough to stage anything: the assertion is made only after the
-    /// directory has been observed on disk.
+    /// got far enough to stage anything: the signal is sent only after the
+    /// child's lease has been observed on disk.
     #[cfg(unix)]
     #[test]
     fn a_terminating_signal_removes_the_capture_directory() {
@@ -506,8 +506,7 @@ mod tests {
         .spawn()
         .expect("spawn staging signal subprocess");
 
-        let staged = wait_for_capture_directory(&parent, &mut child);
-        assert!(staged.join(CAPTURE_LEASE_NAME).is_file());
+        let staged = wait_for_leased_capture_directory(&parent, &mut child);
 
         assert_eq!(
             unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) },
@@ -529,10 +528,20 @@ mod tests {
         );
     }
 
-    /// Poll for the child's capture directory, failing loudly rather than
-    /// letting a child that never staged anything pass the test above.
+    /// Poll for the child's leased capture directory, failing loudly rather
+    /// than letting a child that never staged anything pass the test above.
+    ///
+    /// The lease is the condition, not the directory. [`GitCaptureStaging::claim`]
+    /// creates the directory and only then opens and locks the lease inside it,
+    /// so a parent that returns on the directory alone observes a claim still in
+    /// flight and reads a lease the child has not written yet. That window is
+    /// wall clock rather than an event, which the child wins on an idle machine
+    /// and loses on a loaded one.
     #[cfg(unix)]
-    fn wait_for_capture_directory(parent: &Path, child: &mut std::process::Child) -> PathBuf {
+    fn wait_for_leased_capture_directory(
+        parent: &Path,
+        child: &mut std::process::Child,
+    ) -> PathBuf {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
             if let Ok(entries) = std::fs::read_dir(parent) {
@@ -542,6 +551,7 @@ mod tests {
                         .to_str()
                         .is_some_and(|name| name.starts_with(GIT_CAPTURE_PREFIX))
                         && entry.path().is_dir()
+                        && entry.path().join(CAPTURE_LEASE_NAME).is_file()
                     {
                         return entry.path();
                     }
@@ -552,7 +562,7 @@ mod tests {
             }
             if std::time::Instant::now() >= deadline {
                 let _ = child.kill();
-                panic!("staging subprocess never created a capture directory");
+                panic!("staging subprocess never leased a capture directory");
             }
             std::thread::sleep(std::time::Duration::from_millis(20));
         }


### PR DESCRIPTION
Two small fixes, one per ticket, plus a third test-race fix found in the same sweep.

## FIR-2380: `kin refs` colour silently died

`paint_refs` anchored its row pattern on `^  (.+) @ (\S+:\d+) \[([^\]]*)\]$`
(`crates/kin-cli/src/output_style.rs:100`), and no row the product composes can
match it. `build_refs_response` writes every row as `"  {} @ {} [{}] ({})"`
(`crates/kin-cli/src/commands/refs.rs:216-222`), so a resolution marker always
trails the relation bracket, and the location drops `:line` whenever the entity
carries no span (`crates/kin-cli/src/commands/refs.rs:212-215`). The anchor
failed on both counts. Nothing errored, because a painter returns an unmatched
line verbatim by design, so `kin refs` simply printed plain text.

The fix widens the location group, accepts the trailing marker, and paints it.
The single caller is `crates/kin-cli/src/commands/refs.rs:102`, so the blast
radius is `kin refs` output only.

The test now reads a response `build_refs_response` actually composed, with one
spanned caller and one spanless one so both location shapes are covered, rather
than strings written to match the regex.

## FIR-2388: an admission proof moved when an unrelated test moved the Git scope

An exact source proof folds in the bytes of whatever ignore file Git resolves
for the repository. Unpinned, that file is decided by `core.excludesFile`, then
`XDG_CONFIG_HOME`, then `HOME`
(`crates/kin-git/src/preflight.rs:2971-2986`). The last two are process-global
reads taken under no lock.

`EnvVarGuard` serializes env mutation behind a process mutex
(`crates/kin-core/src/test_env.rs`), but an admission in flight on another
thread is a *reader* that never enters that domain, so nothing serializes it.
The sibling is `crates/kin-core/src/identity.rs:329-334`, whose fixture pins
`GIT_CONFIG_NOSYSTEM`, `GIT_CONFIG_GLOBAL`, `HOME` and `XDG_CONFIG_HOME` for its
own resolve, and in doing so clears the host's global `core.excludesFile`. An
admission whose re-proof lands inside that window reads a different ignore file
than its baseline did, and init refuses a source nothing wrote to.

The fix pins `core.excludesFile` to a fixture-owned file in `initialize_git`
(`crates/kin-core/src/git_init.rs:2296`), mirroring the `pin_default_hook_surface`
precedent directly above it. Repository scope outranks both the host and the
sibling, so the observation depends on the fixture alone.

The new test at `crates/kin-core/src/git_init.rs:1553` drives the shift
deliberately from inside the window between the first proof and the re-proof,
which is the only placement that can fail. That binds the guard to the invariant
instead of to a timing window.

## Third fix, no ticket: the staging poll waited on the wrong thing

`GitCaptureStaging::claim` creates the capture directory and only then opens and
locks the lease inside it (`crates/kin-core/src/init_staging.rs:69-92`). The test
helper returned as soon as the directory appeared and then asserted the lease was
a file, so it could observe a claim still in flight. The gap is wall clock rather
than an event, which the child wins on an idle machine and loses on a loaded one.
The poll now waits on the lease.

## Falsification

Every fix was broken on purpose and the guard confirmed red, then restored.

**FIR-2380, arm 1: the pre-fix regex.** Reverted the pattern to the anchored
`^  (.+) @ (\S+:\d+) \[([^\]]*)\]$` and reran. The new test failed on a row that
does carry `:line`, which shows the trailing marker alone defeats the old anchor:

```
assertion `left != right` failed: line was not painted:   spanned_caller @ spanned.rs:3 [References] (type_resolved)
  left: "  spanned_caller @ spanned.rs:3 [References] (type_resolved)"
 right: "  spanned_caller @ spanned.rs:3 [References] (type_resolved)"
test result: FAILED. 11 passed; 1 failed
```

**FIR-2380, arm 2: the composed row shape, with the old fixture as a control.**
Dropped the resolution marker from `build_refs_response` and restored the
pre-fix hand-written fixture test alongside the new one. The old fixture passed
and the new test failed, which is the whole reason for re-pointing it:

```
test output_style::tests::falsification_control_handwritten_fixture ... ok
test output_style::tests::refs_lines_the_product_composed_are_painted ... FAILED
the resolution marker must be painted: "  \u{1b}[38;5;255mspanned_caller\u{1b}[0m @ ..."
test result: FAILED. 12 passed; 1 failed
```

**FIR-2388: the fixture pin.** Removed `pin_resolved_global_excludes` from
`initialize_git` and ran the new test alone. It failed at phase 14/17 with the
ticket's own error:

```
[14/17] re-prove Git source...
called `Result::unwrap()` on an `Err` value: Other("repeat final Git source proof:
Git migration preflight failed: Git source proof changed before repository
publication; retry from a fresh capture")
test result: FAILED. 0 passed; 1 failed
```

**Third fix: the staging poll.** Widened the gap inside `claim` between the
directory being created and the lease being written by 1500ms, then ran the poll
both ways against it. The pre-fix directory-only poll failed and the leased poll
passed:

```
ARM A (pre-fix, directory-only poll):  ARM_A_EXIT=101
  assertion failed: staged.join(CAPTURE_LEASE_NAME).is_file()
ARM B (leased poll, same window):      ARM_B_EXIT=0
```

## The FIR-2388 flake loop

The deterministic test above is the real proof, because it fails every time
without the pin. The loop is the confirmation, and it carries one honest caveat:
this flake is load sensitive, so a loop is only a valid probe when the machine is
loaded.

Full `kin-core` lib binary, run end to end, with the new deterministic test
skipped so both arms measure the same thing (in the unpinned build that test
fails by construction and would mask the flake). A run counts as the flake only
when its output carries `Git source proof changed`.
Unpinned build, 79 full-suite runs across three configurations. One run carried
the flake, so 1 in 79 against the ticket's 1 in 45. The hit came from the most
heavily loaded batch:

```
18 runs, 3 workers, machine load ~120  ->  1 flake
45 runs, 4 workers, load falling to ~35 ->  0
16 runs, matched pairs, load ~30        ->  0
```

```
run-18: git_init::tests::detached_annotated_tag_keeps_raw_tag_authority_and_seeds_the_peeled_commit
  RepositoryPublishedButUncertain { detail: "post-publication source verification failed:
  ... Git source proof changed across repository publication; published authority is not
  safe to use without recovery" }
```

Fixed build: 16 runs, 0 flakes, interleaved pair-for-pair with 16 unpinned runs
so both arms saw identical machine load. That is a real A/B but a low-powered
one, and it is not by itself proof, because the unpinned arm at that same load
also produced 0. The deterministic test carries the proof; this only fails to
contradict it.

```
ARM=unpinned RUNS=16 PASS=11 FIR2388_FLAKE=0 OTHER_FAILURE=5
ARM=fixed    RUNS=16 PASS=13 FIR2388_FLAKE=0 OTHER_FAILURE=3
```

Three things recorded rather than smoothed over:

An earlier 8-pair batch at 16-way concurrency was **discarded, not counted**.
Every run in it failed on `process-group watcher did not publish readiness`,
a fixture harness timeout that aborts before the proof runs, so neither arm
could have exhibited the flake. All 9 `OTHER_FAILURE` runs above are that same
cause, and they hit both arms (5 unpinned, 3 fixed), so they are independent of
this change. One earlier run also hit
`registry::tests::restrictive_umask_and_relative_path_are_isolated`, a 5-second
subprocess budget missed under load. None of these are this bug, and the loop
counts a run as the flake only when its output carries `Git source proof changed`.

The 45-run batch caught nothing once load dropped, which is exactly why the loop
alone would be weak evidence.

The one hit landed in a different test than the ticket names. That is the more
useful finding: the flake belongs to any admission whose re-proof falls inside
the sibling's window, not to `exact_remote_configuration_is_sealed_in_local_kin_config`
specifically. Pinning inside `initialize_git` covers every fixture that calls it
rather than only the one that was seen to fail.

## Gate

`bin/kin-lane run smallfix kin -- bin/kin-dev local-test kin`, exit 0:

```
kin-dev: local-test: kin  /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/smallfix-kin @ d54fce91 (chore/lane-smallfix-kin)
Summary [1552.730s] 6177 tests run: 6177 passed (6 slow, 1 leaky), 12 skipped
```

An earlier attempt at the same gate failed with 6 `kin-cli commands::update::tests::*`
timeouts at 302 to 304 seconds against a 300 second budget, while the flake loop
was saturating the machine. Rerun on a quiet machine it is 6177 of 6177. The
failures were starvation, not this change, which touches no update code.

Also green: `cargo fmt --all -- --check`; `cargo clippy --all-targets
--all-features` under `RUSTFLAGS=-D warnings` with the ci.yml allowlist, exit 0
(its one warning is the pre-existing future-incompat notice for the third-party
`block v0.1.6` crate); `scripts/verify-zero-file-search.py`;
`scripts/zero_file_search_guard.sh`; `scripts/check_runtime_boundaries.sh`;
`scripts/verify-hydration-semantics.py`.

The gate ran at d54fce91, whose base was `ac656dda`. The branch was then rebased
onto `5683771d` with no conflicts; the three commits carry byte-identical diffs
because nothing that landed in between touches these files.

Closes FIR-2380
Closes FIR-2388
