### PR TITLE
Move the kin registry pins to kin-db 0.7.35, kin-model 0.7.9, and kin-vector 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.7.31"
+version = "0.7.35"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "67d0045bdd2c3aa4f3fb0acbc055bb0a7df5e02a17cb12eb49c107d02a54bc6c"
+checksum = "5b18910b72d016935672f59e17477b15ead9ca46e0b66c8692edea58f7c910ac"
 dependencies = [
  "bincode",
  "bstr",
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.8"
+version = "0.7.9"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "75c237b19289638e728e70048011c5d5731d9ef45878f078e7663f2b0e9475e1"
+checksum = "859744dbb2855216be40ea258c0ff608888f00f19435d1bdf3714314176d93d3"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.11"
+version = "0.1.12"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "c1904ba13d244810b195168b04ada8884094f8d5374c54f36e9b9375ac6e625a"
+checksum = "455de2428eef80e8496e1963a24a8469ca3c15702dc4bfb46bd5182e1f3bdda3"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -6643,7 +6643,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.7.8", registry = "kin" }
+kin-model = { version = "=0.7.9", registry = "kin" }
 kin-blobs = { version = "=0.1.5", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -155,7 +155,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.7.31", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.35", registry = "kin", default-features = false }
 kin-vfs-core = { version = "=0.4.2", registry = "kin" }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.7.8"
+version = "0.7.9"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "75c237b19289638e728e70048011c5d5731d9ef45878f078e7663f2b0e9475e1"
+checksum = "859744dbb2855216be40ea258c0ff608888f00f19435d1bdf3714314176d93d3"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.11"
+version = "0.1.12"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "c1904ba13d244810b195168b04ada8884094f8d5374c54f36e9b9375ac6e625a"
+checksum = "455de2428eef80e8496e1963a24a8469ca3c15702dc4bfb46bd5182e1f3bdda3"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",


### PR DESCRIPTION
kin shipped v0.5.39 against `kin-db = "=0.7.31"`, which predates four kin-db
releases and one kin-vector release. None of their fixes could reach a binary
while the pin stayed where it was. This moves the exact pins and re-locks both
tracked lockfiles patch-off.

## What moved and what it carries

`kin-db` goes 0.7.31 to 0.7.35, which brings kin-db #194: the bootstrap commit
materialized the full recursive Git tree of every projected commit three times,
once in `apply_git_authority`, once at successor-snapshot storage admission, and
once in `GraphSnapshot::from_bytes` on the durable write path. That is three
recursive walks per commit in history. kin-db #198 and #200 persist repository
authority successors as journaled authority frames instead of rewriting the whole
snapshot.

`kin-vector` goes 0.1.11 to 0.1.12, where `VectorIndex::save` canonicalizes the
HNSW graph off the lock.

`kin-model` goes 0.7.8 to 0.7.9 because kin-db 0.7.35 requires `=0.7.9`.
kin-blobs, kin-search, and kin-infer are already newest and do not move.
kin-lsp 0.6.12 requires kin-model ^0.7.8, which 0.7.9 satisfies, so it stays.

No API drift. Clippy under the full ci.yml allowlist with `RUSTFLAGS=-D warnings`,
`--all-targets --all-features`, finished in 3m22s with zero errors.

## Lock integrity

Every changed `kin-*` entry keeps its `sparse+https://kinlab.ai/registry/cargo/`
source; no `source` line changes at all, only `version` and `checksum`. Each new
checksum was verified against the sha256 of the actual `.crate` cargo downloaded
rather than taken from the lock describing itself:

```
kin-db-0.7.35     5b18910b72d016935672f59e17477b15ead9ca46e0b66c8692edea58f7c910ac
kin-model-0.7.9   859744dbb2855216be40ea258c0ff608888f00f19435d1bdf3714314176d93d3
kin-vector-0.1.12 455de2428eef80e8496e1963a24a8469ca3c15702dc4bfb46bd5182e1f3bdda3
```

All three match their `Cargo.lock` entries. `cargo metadata --locked` succeeds.

## Measured init delta

Both arms ran back to back on the same host, CPU only, `KIN_DAEMON_AUTO_EMBED=0`,
throwaway `HOME` and `KIN_HOME`, `KIN_VFS_DISABLE=1`, on a fresh clone of
psf/requests at 6491 commits. Commands:

```
/usr/bin/time -l <bin>/kin init . --profile-out prof.json --profile-summary
```

Baseline binary `/private/tmp/kin-dogfood-0538/gate/0.5.39/kinhome/bin/kin`
(sha256 a9d74e77203d5c7bf68735f087ea021f91aa048fd75db50457781a48cccb620f).
New binary built from this branch at 87523bd9
(sha256 75a7851e95eda90d194e42cb41f64bab0a7f08b83e8485dfe50b2106fe7198bc).

| metric | shipped v0.5.39 (kin-db 0.7.31) | this branch (kin-db 0.7.35) | delta |
|---|---|---|---|
| wall | 2238.11 s (37m18s) | 1136.36 s (18m56s) | -49.2% |
| user | 451.40 s | 411.95 s | -8.7% |
| sys | 318.90 s | 195.08 s | -38.8% |
| user+sys | 770.30 s | 607.03 s | -21.2% |
| cycles elapsed | 3157351542310 | 2533349330222 | -19.8% |
| instructions retired | 7550492847675 | 7041370548788 | -6.7% |
| max RSS | 6794477568 B (6.33 GiB) | 9698050048 B (9.03 GiB) | +42.7% |
| peak memory footprint | 12505441712 B | 12556723632 B | +0.4% |
| `.kin` store | 1028204 KB | 1028272 KB | +68 KB |
| `.kin-git-capture-*` left | 0 | 0 | none |

Host load average, quoted beside each run: baseline started at 38.33 and ended at
54.19; the new binary started at 40.37 and ended at 26.38. The host has 18 CPUs
and other lanes were active throughout, so wall clock carries real noise.

The stage profile is where the tree-walk fix shows up, self ms:

| stage | 0.7.31 | 0.7.35 | delta |
|---|---|---|---|
| `kin.init.copy_captured_authority` | 427148 | 65795 | -84.6% |
| `kin.init.commit.authority_commit` | 284540 | 111628 | -60.8% |
| `kin.init.build_bootstrap_transaction` | 82529 | 37055 | -55.1% |
| `kin.init.bind_historical_semantics` | 294228 | 334757 | +13.8% |

The three stages that walk projected Git trees all drop sharply. The one stage
that rises is semantic linking, which #194 does not touch, and it rose during a
window when the new-binary arm was demonstrably starved on IO: its main process
sat in uninterruptible sleep at 2% CPU while other lanes ran seven `kin_git` test
binaries and a VFS suite against the same filesystem. Its
`capture_git_repository > kin_blobs.write` cost 353493 ms self, a phase the
baseline completed in about 90 seconds. Both arms wrote a byte-identical 214580
KB capture, so the work was the same and the difference there was contention, not
the pin.

The store lands within 68 KB of the baseline and no `.kin-git-capture-*`
directory survives either run.

Closes FIR-2414
