### PR TITLE
Give the MCP belt a call that admits new source into the graph

### DIFF
--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -97,6 +97,16 @@ fn authored_files_from_staged(
             // A relation operation writes no file, so it claims none.
             Some(_) => continue,
             None => {
+                // A creation names its file directly and has no entity to
+                // resolve, which is also why it must be answered here: falling
+                // through to entity resolution fails, the whole authored set
+                // collapses to `None`, and a resumed commit would then declare
+                // every file it published as carried when the original declared
+                // none of them.
+                if kin_mcp::session::is_new_source_file(operation) {
+                    authored.insert(RepoPath::from_utf8(operation.target.trim().to_string()).ok()?);
+                    continue;
+                }
                 kin_mcp::handlers::sessions::resolve_target_entity(graph, &operation.target).ok()?
             }
         };
@@ -916,11 +926,24 @@ fn plan_exact_transaction(
     let prospective = kin_db::InMemoryGraph::from_snapshot(base.graph.to_snapshot())
         .map_err(|error| format!("create prospective exact graph: {error}"))?;
     let mut edits: BTreeMap<String, (FilePathId, Vec<(Entity, Vec<u8>)>)> = BTreeMap::new();
+    let mut creations: BTreeMap<String, (FilePathId, Vec<u8>)> = BTreeMap::new();
     let mut relation_operations = Vec::new();
     let mut edited_entities = HashSet::new();
 
     for operation in &transaction.staged_operations {
         let verb = operation.verb.trim().to_ascii_lowercase();
+        // A payload-less `create` carrying a repository path and a body admits
+        // source the graph has never seen. It is the only shape that can: an
+        // edit resolves its target against an existing entity and splices into
+        // an existing span, so a file with neither is unreachable through it,
+        // and the structured branch would require the caller to invent entity
+        // identity the extractor is about to derive. Recorded here and planned
+        // below, beside the edits, so one transaction can create a file and
+        // edit another and publish both or neither.
+        if operation.payload.is_none() && kin_mcp::session::is_new_source_file(operation) {
+            record_new_source_file(&mut creations, base, operation)?;
+            continue;
+        }
         // A payload-less `update` carrying a target and a body is the minimal
         // agent write surface: an agent knows a name and the new source text but
         // not Kin's entity structs. Staging accepts it, so the planner must too,
@@ -1062,7 +1085,9 @@ fn plan_exact_transaction(
     // tree deltas.
     let authored_files = edits
         .values()
-        .map(|(file_id, _)| {
+        .map(|(file_id, _)| file_id)
+        .chain(creations.values().map(|(file_id, _)| file_id))
+        .map(|file_id| {
             RepoPath::from_utf8(file_id.0.clone())
                 .map_err(|error| format!("invalid exact source path {file_id}: {error}"))
         })
@@ -1070,6 +1095,8 @@ fn plan_exact_transaction(
 
     let mut layouts = Vec::new();
     let pipeline = kin_index::IndexPipeline::new();
+
+    plan_new_source_files(state, &prospective, &pipeline, creations, &mut layouts)?;
     for (_, (file_id, file_edits)) in edits {
         let path = RepoPath::from_utf8(file_id.0.clone())
             .map_err(|error| format!("invalid exact source path {file_id}: {error}"))?;
@@ -1161,7 +1188,11 @@ fn plan_exact_transaction(
             )
         }) {
             return Err(format!(
-                "body edit for {file_id} would create or remove source entities ({delta:?}); insertion/deletion is not yet supported"
+                "body edit for {file_id} would create or remove source entities ({delta:?}); an \
+                 edit may only change the body of the entity it names. To add a whole new file, \
+                 stage verb 'create' with `target` set to its repository path and `body` set to \
+                 its complete text; adding or removing an entity inside an existing file is not \
+                 yet supported"
             ));
         }
         prospective
@@ -1329,6 +1360,129 @@ fn record_source_edit(
         .or_insert_with(|| (file_id, Vec::new()))
         .1
         .push((existing, body.to_vec()));
+    Ok(())
+}
+
+/// Record one "admit this new source file" operation against repository
+/// authority, refusing every shape the planner could not honor later.
+///
+/// The path is validated with the same rule the projection applies, so a
+/// creation the planner accepts is a creation the commit can materialize, and
+/// a path already tracked is refused by name rather than silently turned into
+/// an edit of somebody else's file.
+fn record_new_source_file(
+    creations: &mut BTreeMap<String, (FilePathId, Vec<u8>)>,
+    base: &NativeCommitBase,
+    operation: &kin_mcp::McpMutationOperation,
+) -> Result<(), String> {
+    let target = operation.target.trim();
+    let path = RepoPath::from_utf8(target.to_string())
+        .map_err(|error| format!("new source path {target:?} is unusable: {error}"))?;
+    kin_core::validate_source_paths([&path]).map_err(|error| {
+        format!("new source path {target:?} is not an admissible repository path: {error}")
+    })?;
+    if base.tree.artifact_at_path(&path).is_some() {
+        return Err(format!(
+            "{target} is already tracked by repository authority, so it cannot be created; \
+             'create' admits only source the graph has never seen. Edit it with verb 'update' \
+             naming an entity inside it, or create a path that does not exist yet"
+        ));
+    }
+    let body = operation
+        .body
+        .as_ref()
+        .expect("a new source file operation always carries a body");
+    let file_id = FilePathId::new(target.to_string());
+    if creations
+        .insert(file_id.0.clone(), (file_id, body.as_bytes().to_vec()))
+        .is_some()
+    {
+        return Err(format!(
+            "{target} is created more than once in one transaction; overlapping source authority \
+             is ambiguous"
+        ));
+    }
+    Ok(())
+}
+
+/// Turn recorded creations into prospective graph truth: exact blob, tree
+/// identity, derived entities, derived relations, and a file layout.
+///
+/// Every step here is the one the ingest path runs. The bytes come from the
+/// call rather than from the filesystem, and after they are written to the blob
+/// store the file is admitted to the tree, classified and parsed by
+/// [`kin_index::IndexPipeline`], and reconciled by [`kin_reconcile::Reconciler`]
+/// exactly as an admitted file is. Nothing in this function reads the working
+/// copy; the working file appears afterwards because the commit projects the
+/// tree it published, which is the graph-owns-truth direction rather than the
+/// filesystem-tells-the-graph one.
+///
+/// One reconciler spans the whole batch, and it is seeded from the prospective
+/// graph, because cross-file resolution is skipped outright on an unseeded
+/// linker. That is what lets two files created in one transaction reference
+/// each other: the first file's unresolved references wait on the names it
+/// imported, and installing the second file's entities binds them. The seeding
+/// pass is one walk of the entity universe and runs only when a transaction
+/// actually creates a file, so a transaction that only edits bodies keeps
+/// exactly the planning it had before.
+///
+/// A file whose content does not classify as entity source is still admitted.
+/// Parser support decides how much semantics a file gets, never whether the
+/// repository holds it, which is the rule the ambient admission seam already
+/// follows.
+fn plan_new_source_files(
+    state: &DaemonState,
+    prospective: &kin_db::InMemoryGraph,
+    pipeline: &kin_index::IndexPipeline,
+    creations: BTreeMap<String, (FilePathId, Vec<u8>)>,
+    layouts: &mut Vec<FileLayout>,
+) -> Result<(), String> {
+    if creations.is_empty() {
+        return Ok(());
+    }
+    let mut reconciler = kin_reconcile::Reconciler::new(PathBuf::new());
+    reconciler.seed_cross_file_linker_from_graph(prospective);
+
+    for (_, (file_id, body)) in creations {
+        let path = RepoPath::from_utf8(file_id.0.clone())
+            .map_err(|error| format!("invalid new source path {file_id}: {error}"))?;
+        let digest = state
+            .blobs
+            .write(&body)
+            .map_err(|error| format!("store new source {file_id}: {error}"))?;
+        let hash = Hash256::from_bytes(digest.0);
+        prospective
+            .apply_transaction_delta(&TransactionDelta {
+                tree_deltas: vec![TreeDelta::Added {
+                    artifact_id: kin_model::ArtifactId::new(),
+                    new: LocatedEntry::new(path, TreeEntry::blob(hash, false)),
+                }],
+                ..TransactionDelta::default()
+            })
+            .map_err(|error| format!("admit new source {file_id} to the exact tree: {error}"))?;
+
+        let indexed = pipeline
+            .index_any_content(&file_id, &body, digest)
+            .map_err(|error| format!("parse new source {file_id}: {error}"))?;
+        let kin_index::IndexedAny::EntitySource(indexed) = indexed else {
+            continue;
+        };
+        let reconcile = reconciler
+            .reconcile_indexed_content(&indexed, state.blobs.as_ref(), prospective)
+            .map_err(|error| format!("derive semantics for new source {file_id}: {error}"))?;
+        prospective
+            .apply_transaction_delta(&reconcile.delta)
+            .map_err(|error| format!("apply derived semantics for {file_id}: {error}"))?;
+        let layout = reconciler
+            .projection()
+            .get_layout(&file_id)
+            .cloned()
+            .ok_or_else(|| format!("parsing produced no file layout for new source {file_id}"))?;
+        prospective
+            .upsert_file_layout(&layout)
+            .map_err(|error| format!("install prospective layout for {file_id}: {error}"))?;
+        layouts.push(layout);
+    }
     Ok(())
 }
 
@@ -2203,6 +2357,239 @@ mod tests {
         {
             kin_mcp::ContentBlock::Text { text } => text,
         }
+    }
+
+    /// Build the create-file operation an agent stages for new source.
+    fn new_source_file(path: &str, body: &str) -> kin_mcp::McpMutationOperation {
+        kin_mcp::McpMutationOperation {
+            verb: "create".to_string(),
+            target: path.to_string(),
+            payload: None,
+            body: Some(body.to_string()),
+            description: format!("admit new source {path}"),
+        }
+    }
+
+    const NEW_UTIL_PY: &str = "def helper(value):\n    return value + 1\n";
+    const NEW_APP_PY: &str =
+        "from pkg.util import helper\n\n\ndef run(value):\n    return helper(value)\n";
+
+    /// An agent holding only the MCP belt creates new source and the graph holds
+    /// it, including the references that cross between two files created in the
+    /// same transaction.
+    ///
+    /// This is the defect FIR-2417 records, driven the way it was found. Before
+    /// this operation existed there was no call on the belt that could introduce
+    /// a file: an edit resolves its target against an existing entity, so a path
+    /// with no entity was unreachable through it, and nothing ambient admits
+    /// untracked content (the watch loop leaves it for an explicit admission
+    /// seam, and the only seams are `kin commit` and `kin admit`, both of which
+    /// need a shell). So an agent wrote files and the graph stayed empty.
+    ///
+    /// Cross-file resolution is asserted rather than assumed because it is what
+    /// separates two files that are merely present from two files Kin
+    /// understands together, and because the planner has to seed its linker for
+    /// it to happen at all.
+    #[test]
+    fn new_source_files_created_over_mcp_enter_the_graph_and_reference_each_other() {
+        let (_dir, state) = test_state();
+        let sessions = test_sessions();
+
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let entities_before = before
+            .graph
+            .query_entities(&EntityFilter::default())
+            .unwrap()
+            .len();
+        let files_before = before.tree.artifacts().count();
+
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:pkg/app.py")
+            .unwrap();
+        let operations = vec![
+            new_source_file("pkg/util.py", NEW_UTIL_PY),
+            new_source_file("pkg/app.py", NEW_APP_PY),
+        ];
+        kin_mcp::session::validate_staged_operations(&operations)
+            .expect("staging must accept the new source file form");
+        sessions
+            .stage_transaction(&transaction.transaction_id, operations)
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "creating new source over MCP failed: {}",
+            result_text(&result)
+        );
+
+        // The working files are a projection of what committed, written by the
+        // commit rather than by the agent. Byte-exact, so a body that arrived
+        // mangled cannot pass.
+        assert_eq!(
+            std::fs::read_to_string(state.layout.working_dir().join("pkg/util.py")).unwrap(),
+            NEW_UTIL_PY
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.layout.working_dir().join("pkg/app.py")).unwrap(),
+            NEW_APP_PY
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(
+            after.tree.artifacts().count(),
+            files_before + 2,
+            "both created files must be tracked by repository authority"
+        );
+
+        let find = |name: &str, file: &str| {
+            after
+                .graph
+                .query_entities(&EntityFilter {
+                    name_pattern: Some(name.to_string()),
+                    file_path: Some(FilePathId::new(file)),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .into_iter()
+                .find(|entity| entity.name == name)
+                .unwrap_or_else(|| panic!("{name} must be a graph entity derived from {file}"))
+        };
+        let helper = find("helper", "pkg/util.py");
+        let run = find("run", "pkg/app.py");
+        assert!(
+            after
+                .graph
+                .query_entities(&EntityFilter::default())
+                .unwrap()
+                .len()
+                > entities_before,
+            "the graph must hold more entities after admitting two source files"
+        );
+
+        // The reference that crosses files. `find_references` reads exactly
+        // these relation rows, so asserting them here is asserting what the
+        // belt sees.
+        let crossing = after
+            .graph
+            .get_all_relations_for_entity(&run.id)
+            .unwrap()
+            .into_iter()
+            .any(|relation| relation.dst == GraphNodeId::Entity(helper.id));
+        assert!(
+            crossing,
+            "pkg/app.py's run must reference pkg/util.py's helper across the two created files"
+        );
+
+        // What the agent actually reads back. `modified_files` is the field the
+        // tool documents, and a created file has to appear in it exactly as an
+        // edited one does or the caller cannot tell the commit landed.
+        let reply: serde_json::Value = serde_json::from_str(result_text(&result)).unwrap();
+        let modified = reply["modified_files"]
+            .as_array()
+            .expect("a successful commit reply names modified_files")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>();
+        assert!(
+            modified.contains(&"pkg/util.py") && modified.contains(&"pkg/app.py"),
+            "the commit reply must name both created files, got {modified:?}"
+        );
+        assert!(
+            reply["change_id"].as_str().is_some_and(|id| !id.is_empty()),
+            "the commit must publish a change an agent can review: {reply}"
+        );
+    }
+
+    /// A `create` naming a path the graph already tracks is refused by name.
+    ///
+    /// The refusal exists because the alternative is worse than a failure: an
+    /// agent that meant to add a file and typed a path already in use would
+    /// silently replace somebody else's file with its own, and a whole-file
+    /// replacement is exactly what an edit is designed not to be. It also keeps
+    /// `create` honest about what it means, so the caller is pointed at the verb
+    /// that does what it wanted.
+    #[test]
+    fn creating_a_path_the_graph_already_tracks_is_refused_by_name() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![new_source_file("src/lib.rs", "pub fn replaced() {}\n")],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_eq!(result.is_error, Some(true));
+        let text = result_text(&result);
+        assert!(
+            text.contains("src/lib.rs is already tracked by repository authority"),
+            "refusal must name the tracked path: {text}"
+        );
+
+        // The refusal is not merely a message: the file it named is untouched.
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 1 }\n"
+        );
+    }
+
+    /// A path that could not be materialized is refused where it was typed.
+    ///
+    /// Stage time, not commit time, so a caller learns which operation is wrong
+    /// while the transaction still holds only what it typed. Checking it here as
+    /// well as in the planner is what keeps stage-time rejection a superset of
+    /// commit-time rejection, which is the contract the stage tool advertises.
+    #[test]
+    fn an_inadmissible_new_source_path_is_refused_at_stage_time() {
+        for path in [
+            "/etc/passwd",
+            "../outside.py",
+            ".kin/objects/sneak.py",
+            ".git/hooks/pre-commit",
+        ] {
+            let operation = new_source_file(path, "print('x')\n");
+            let error =
+                kin_mcp::session::validate_staged_operations(std::slice::from_ref(&operation))
+                    .expect_err(&format!("{path} must not stage"));
+            assert!(
+                error.contains(path),
+                "the refusal must quote the path it rejected: {error}"
+            );
+        }
+
+        // Positive control: the check refuses these paths because they are
+        // inadmissible, not because it refuses every path.
+        let ordinary = new_source_file("pkg/util.py", "print('x')\n");
+        kin_mcp::session::validate_staged_operations(std::slice::from_ref(&ordinary))
+            .expect("an ordinary repository-relative path must stage");
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -106,7 +106,8 @@ pub async fn handle_tool_call<G: GraphStore>(
             sessions::handle_transaction_begin(arguments, sessions, session_authority_mode).await
         }
         "kin_transaction_stage" => {
-            sessions::handle_transaction_stage(arguments, sessions, session_authority_mode).await
+            sessions::handle_transaction_stage(arguments, store, sessions, session_authority_mode)
+                .await
         }
         "kin_transaction_validate" => {
             sessions::handle_transaction_validate(arguments, sessions, session_authority_mode).await
@@ -4134,7 +4135,7 @@ mod tests {
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
         stage_args.insert("operations".into(), serde_json::json!(vec![op]));
         let stage_res =
-            sessions::handle_transaction_stage(&stage_args, &sessions, session_authority)
+            sessions::handle_transaction_stage(&stage_args, &store, &sessions, session_authority)
                 .await
                 .unwrap();
         let stage_text = match &stage_res.content[0] {
@@ -4278,7 +4279,7 @@ mod tests {
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
         stage_args.insert("operations".into(), serde_json::json!(vec![op]));
         let stage_res =
-            sessions::handle_transaction_stage(&stage_args, &sessions, session_authority)
+            sessions::handle_transaction_stage(&stage_args, &store, &sessions, session_authority)
                 .await
                 .unwrap();
         assert_ne!(
@@ -4342,7 +4343,7 @@ mod tests {
         let mut stage_args = HashMap::new();
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
         stage_args.insert("operations".into(), serde_json::json!(vec![op]));
-        sessions::handle_transaction_stage(&stage_args, &sessions, session_authority)
+        sessions::handle_transaction_stage(&stage_args, &store, &sessions, session_authority)
             .await
             .unwrap();
 
@@ -4411,7 +4412,7 @@ mod tests {
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
         stage_args.insert("operations".into(), serde_json::json!(vec![op]));
         let stage_res =
-            sessions::handle_transaction_stage(&stage_args, &sessions, session_authority)
+            sessions::handle_transaction_stage(&stage_args, &store, &sessions, session_authority)
                 .await
                 .unwrap();
         assert_ne!(
@@ -4768,6 +4769,7 @@ mod tests {
         // dropped at commit. The transaction id here does not exist; validation
         // is expected to reject the operation first.
         use crate::session::{McpMutationOperation, McpMutationPayload};
+        let store = InMemoryGraph::default();
         let sessions = SessionRegistry::new();
         let session_authority = SessionAuthorityMode::OfflineFallback;
 
@@ -4782,12 +4784,61 @@ mod tests {
         stage_args.insert("transaction_id".into(), serde_json::json!("no-such-tx"));
         stage_args.insert("operations".into(), serde_json::json!(vec![op]));
 
-        let err = sessions::handle_transaction_stage(&stage_args, &sessions, session_authority)
-            .await
-            .expect_err("payload-less op must be rejected at stage time");
+        let err =
+            sessions::handle_transaction_stage(&stage_args, &store, &sessions, session_authority)
+                .await
+                .expect_err("payload-less op must be rejected at stage time");
         assert!(matches!(err, McpError::InvalidParams(_)));
         assert!(
             err.to_string().contains("missing payload"),
+            "actionable stage-time message expected, got: {err}"
+        );
+    }
+
+    /// FIR-2417 follow-up: a `create` naming a path the graph already tracks
+    /// is refused at stage time, not just at commit. Before this check existed
+    /// staging such an operation reported `staged_count: 1` and the caller only
+    /// learned the path collided once it committed, after staging whatever else
+    /// it had queued alongside it.
+    #[tokio::test]
+    async fn handle_transaction_stage_rejects_a_create_for_an_already_tracked_path() {
+        use crate::session::McpMutationOperation;
+
+        let store = InMemoryGraph::default();
+        let path = kin_model::RepoPath::from_utf8("src/tracked.py".to_string()).unwrap();
+        store
+            .apply_transaction_delta(&kin_model::TransactionDelta {
+                tree_deltas: vec![kin_model::TreeDelta::Added {
+                    artifact_id: kin_model::ArtifactId::new(),
+                    new: kin_model::LocatedEntry::new(
+                        path,
+                        kin_model::TreeEntry::blob(Hash256::from_bytes([1; 32]), false),
+                    ),
+                }],
+                ..kin_model::TransactionDelta::default()
+            })
+            .unwrap();
+        let sessions = SessionRegistry::new();
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+
+        let op = McpMutationOperation {
+            verb: "create".into(),
+            target: "src/tracked.py".into(),
+            payload: None,
+            body: Some("value = 1\n".into()),
+            description: "admit new source src/tracked.py".into(),
+        };
+        let mut stage_args = HashMap::new();
+        stage_args.insert("transaction_id".into(), serde_json::json!("no-such-tx"));
+        stage_args.insert("operations".into(), serde_json::json!(vec![op]));
+
+        let err =
+            sessions::handle_transaction_stage(&stage_args, &store, &sessions, session_authority)
+                .await
+                .expect_err("create over an already-tracked path must be rejected at stage time");
+        assert!(matches!(err, McpError::InvalidParams(_)));
+        assert!(
+            err.to_string().contains("already tracked"),
             "actionable stage-time message expected, got: {err}"
         );
     }

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -664,8 +664,21 @@ pub async fn handle_transaction_begin(
 }
 
 pub const TRANSACTION_STAGE_DESC: &str = "\
-Stage one or more mutation operations onto an active transaction. The simplest write is \
-a payload-less entity source edit: {verb: \"update\", target: \"<entity name or id>\", \
+Stage one or more mutation operations onto an active transaction. Two verbs admit source, \
+and which one you want depends on whether the graph has seen the file before. \
+Use verb 'create' (or 'add'/'insert') to admit a file the graph has never seen: \
+{verb: \"create\", target: \"<repository-relative path, e.g. src/parser.py>\", \
+body: \"<the file's complete source text>\", description: \"...\"}. This is the ONLY \
+operation that introduces a new file, so it is what you use after writing a new module. \
+You do not have to write the file to disk first and you should not: Kin parses the body \
+with the same extractor the ingest path uses, every entity in it enters the graph, and the \
+commit writes the file into the working directory for you. Writing a file with some other \
+tool does NOT put it in the graph; nothing ambient admits it, and only this operation will. \
+Create several files in one transaction to have them reference each other, and edit an \
+existing file with 'update' in that same transaction if you need to. A path the graph \
+already tracks is refused by name rather than quietly overwritten. \
+Use verb 'update' (or 'modify') to change an entity the graph already holds. That is a \
+payload-less entity source edit: {verb: \"update\", target: \"<entity name or id>\", \
 body: \"<the entity's full new source text>\", description: \"...\"}. Prefer the entity \
 id that semantic_locate, find_references, or get_context_pack already handed you: a bare \
 name resolves only when it is unique, and an ambiguous one is refused (with the candidate \
@@ -683,8 +696,9 @@ resolved fail-closed server-side and on \
 commit the graph-to-file projection writes the body into the entity's working-directory \
 file. Structured payloads (full entity, relation add/remove) are also accepted. Each \
 operation is validated at stage time: anything the commit path would silently drop (a \
-missing or unknown verb, a missing payload outside the target/body source-edit form, a \
-nameless entity, a relation update/modify, or a blob payload) is rejected immediately with an actionable error \
+missing or unknown verb, a missing payload outside the two payload-less source forms, a \
+nameless entity, a relation update/modify, a blob payload, or a new-file path that is \
+absolute, escapes the repository, or names Kin or Git control metadata) is rejected immediately with an actionable error \
 instead of vanishing at commit. This rejection is identical in daemon and in-process \
 modes. Accepted operations are queued and can be validated or committed together.";
 
@@ -778,8 +792,12 @@ pub const TRANSACTION_COMMIT_DESC: &str = "\
 Publish all staged mutations atomically through exact repository authority. The daemon loads \
 source from repository CAS, splices existing entity \
 body edits in memory, reparses the final bytes, and journals semantic change, exact workspace \
-tree, and ref publication together. Relation-only transactions are supported. New or deleted \
-source entities, metadata-only source edits, ambiguous or overlapping spans, non-UTF-8 source, \
+tree, and ref publication together. A staged 'create' operation is admitted in the same \
+transaction: its body is written to the blob store, the file enters the exact tree, and its \
+entities and cross-file relations are derived by the same extractor and reconciler the ingest \
+path runs, so files created together can reference each other. Relation-only transactions are \
+supported. Adding or removing an entity inside an EXISTING file, metadata-only source edits, \
+ambiguous or overlapping spans, non-UTF-8 source, \
 gitlinks, and mismatched authority fail before mutation. On success the result names \
 status, ops_applied, empty, change_id, repository_generation, new_root_hash, and modified_files. \
 A workspace holding working-tree content its base change does not carry does not block the \
@@ -799,7 +817,7 @@ abandon it. An optional operations array may stage and commit in one call and us
 payload-less source-edit or structured payload operation shapes as kin_transaction_stage; it \
 commits with identical durability, so a success naming modified_files means the body reached the \
 file, and re-sending the same array after an interrupted commit resumes it rather than staging it \
-twice. New source text is carried ONLY by `body`: an operation naming it anything else is refused \
+twice. A created file appears in modified_files exactly as an edited one does. New source text is carried ONLY by `body`: an operation naming it anything else is refused \
 with the unknown field named, never accepted with the source dropped. A refusal ends with a \
 one-line JSON object carrying schema, code, and the operations it names, so you can branch on the \
 code instead of reading the sentence. On success the change is attributed to the calling session: \

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -697,13 +697,19 @@ commit the graph-to-file projection writes the body into the entity's working-di
 file. Structured payloads (full entity, relation add/remove) are also accepted. Each \
 operation is validated at stage time: anything the commit path would silently drop (a \
 missing or unknown verb, a missing payload outside the two payload-less source forms, a \
-nameless entity, a relation update/modify, a blob payload, or a new-file path that is \
-absolute, escapes the repository, or names Kin or Git control metadata) is rejected immediately with an actionable error \
-instead of vanishing at commit. This rejection is identical in daemon and in-process \
-modes. Accepted operations are queued and can be validated or committed together.";
+nameless entity, a relation update/modify, a blob payload, a new-file path that is \
+absolute, escapes the repository, or names Kin or Git control metadata, or a 'create' \
+naming a path repository authority already tracks) is rejected immediately with an \
+actionable error instead of vanishing at commit. The already-tracked check reads a \
+snapshot of the graph this call is authoritative over: it catches the ordinary case, but \
+a path another transaction creates between this stage call and your commit is still only \
+caught at commit, which stays the final authority. This rejection is identical in daemon \
+and in-process modes. Accepted operations are queued and can be validated or committed \
+together.";
 
-pub async fn handle_transaction_stage(
+pub async fn handle_transaction_stage<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
+    store: &G,
     sessions: &SessionRegistry,
     session_authority_mode: SessionAuthorityMode,
 ) -> Result<ToolCallResult> {
@@ -722,6 +728,34 @@ pub async fn handle_transaction_stage(
     // both daemon and in-process modes.
     crate::session::validate_staged_operations(&operations)
         .map_err(crate::error::McpError::InvalidParams)?;
+
+    // A new-source-file path is shape-valid at this point but may already be
+    // tracked; only the graph knows that, so it is checked here rather than in
+    // `validate_staged_operations`, which is deliberately graph-free so it
+    // behaves identically offline. Checking it now, against whichever graph
+    // this call is authoritative over, turns a failure `record_new_source_file`
+    // would otherwise raise only at commit into an immediate one, so an agent
+    // staging a path collision finds out before it has staged anything else on
+    // top of it. This is a snapshot check: another transaction can still land a
+    // conflicting create between stage and commit, and commit remains the
+    // authority that catches that race.
+    for (idx, operation) in operations.iter().enumerate() {
+        if !crate::session::is_new_source_file(operation) {
+            continue;
+        }
+        let target = operation.target.trim();
+        let Ok(path) = kin_model::RepoPath::from_utf8(target.to_string()) else {
+            continue;
+        };
+        if store.artifact_id_at_path(&path).is_some() {
+            return Err(crate::error::McpError::InvalidParams(format!(
+                "operation #{idx} ('create'): {target:?} is already tracked by repository \
+                 authority, so it cannot be created; 'create' admits only source the graph has \
+                 never seen. Edit it with verb 'update' naming an entity inside it, or create a \
+                 path that does not exist yet"
+            )));
+        }
+    }
 
     if session_authority_mode.uses_daemon() {
         match crate::daemon_delegate::forward_tool_call("kin_transaction_stage", args).await {

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -70,6 +70,42 @@ pub fn is_target_body_update(op: &McpMutationOperation) -> bool {
             .is_some_and(|body| !body.trim().is_empty())
 }
 
+/// A payload-less operation that expresses "the complete source of the new
+/// repository file at `target` is `body`": verb create/add/insert, `target`
+/// naming a repository-relative path, and a non-empty `body`.
+///
+/// This is the admission surface for source the graph has never seen.
+/// [`is_target_body_update`] covers the case where an entity already exists to
+/// edit, and it cannot reach a new file: it resolves `target` against
+/// repository authority and splices into an existing span, so a path with no
+/// entity and no span has nothing for it to resolve. An agent that has just
+/// authored a module holds neither an entity id nor a span, so `target` names
+/// the path and the daemon derives every entity in the file from `body`
+/// through the same extractor the ingest path runs.
+///
+/// The body travels in the call rather than the daemon reading the path off
+/// disk. Graph truth is then written from bytes the caller supplied, and the
+/// working file is a projection of what was committed, which is the direction
+/// the graph-first thesis requires. It also keeps admission off the filesystem
+/// entirely: no walk, no scan, and no race against the caller's own writes.
+///
+/// `upsert` is deliberately not one of the verbs. It would have to mean
+/// "create if absent, edit if present", and a create that silently becomes an
+/// edit of somebody else's file is the failure this shape exists to make
+/// impossible. A path that is already tracked is refused by name.
+pub fn is_new_source_file(op: &McpMutationOperation) -> bool {
+    op.payload.is_none()
+        && matches!(
+            op.verb.trim().to_lowercase().as_str(),
+            "create" | "add" | "insert"
+        )
+        && !op.target.trim().is_empty()
+        && op
+            .body
+            .as_deref()
+            .is_some_and(|body| !body.trim().is_empty())
+}
+
 /// An operation that carries new source text for a file.
 ///
 /// Source text can only become truth by being spliced into exact repository
@@ -339,10 +375,16 @@ pub fn validate_staged_operations(
             if is_target_body_update(op) {
                 continue;
             }
+            if is_new_source_file(op) {
+                validate_new_source_path(idx, op)?;
+                continue;
+            }
             return Err(format!(
                 "operation #{idx} ('{}'): missing payload; provide an entity, relation, or blob \
-                 payload, or express an entity source edit as verb 'update' with `target` (entity \
-                 name or id) and `body` (the entity's full new source text)",
+                 payload, express an edit to an existing entity as verb 'update' with `target` \
+                 (entity name or id) and `body` (the entity's full new source text), or admit a \
+                 source file the graph has never seen as verb 'create' with `target` (its \
+                 repository-relative path) and `body` (the file's complete text)",
                 op.verb
             ));
         };
@@ -364,6 +406,37 @@ pub fn validate_staged_operations(
     Ok(())
 }
 
+/// Validate the repository-relative path a new-source-file operation names.
+///
+/// Runs the same path rule the projection applies
+/// ([`kin_core::validate_source_paths`]), so a path that stages clean is a path
+/// the commit can materialize. Doing it here rather than only in the daemon is
+/// what keeps stage-time rejection a superset of commit-time rejection: an
+/// absolute path, a `..` escape, or a name reserved for Kin or Git control
+/// metadata is refused at the call that introduced it, with the path quoted,
+/// instead of at a commit that has already accepted several other operations.
+///
+/// Intrinsic to the payload and free of graph access, like every other check in
+/// [`validate_staged_operations`], so it behaves identically in-process and
+/// through the daemon.
+fn validate_new_source_path(idx: usize, op: &McpMutationOperation) -> Result<(), String> {
+    let target = op.target.trim();
+    let path = kin_model::RepoPath::from_utf8(target.to_string()).map_err(|error| {
+        format!(
+            "operation #{idx} ('{}'): {target:?} is not a usable repository path: {error}",
+            op.verb
+        )
+    })?;
+    kin_core::validate_source_paths([&path]).map_err(|error| {
+        format!(
+            "operation #{idx} ('{}'): {target:?} is not an admissible repository source path: \
+             {error}. Name a repository-relative path such as \"src/parser.py\", with no leading \
+             slash, no \"..\", and no Kin or Git control component",
+            op.verb
+        )
+    })
+}
+
 /// Why a single staged operation cannot be turned into a committed delta, or
 /// `None` when it is committable.
 ///
@@ -376,10 +449,11 @@ pub fn validate_staged_operations(
 /// No graph access is required, so it is safe to run in any runtime; existence
 /// checks (does the relation/entity actually exist) stay graph-side.
 ///
-/// Runtime-independent by design, so a payload-less source update is `None`
-/// here: the daemon commits it. The in-process commit path layers its own
-/// offline-only refusal for that shape on top of this check; see
-/// `handlers::sessions::handle_transaction_commit`.
+/// Runtime-independent by design, so a payload-less source update and a
+/// payload-less new source file are both `None` here: the daemon commits them.
+/// The in-process commit path layers its own offline-only refusal on top of
+/// this check, and [`carries_source_body`] already covers both shapes because
+/// each is a body; see `handlers::sessions::handle_transaction_commit`.
 pub fn uncommittable_reason(op: &McpMutationOperation) -> Option<String> {
     let verb = op.verb.trim().to_lowercase();
     if verb.is_empty() {
@@ -394,7 +468,7 @@ pub fn uncommittable_reason(op: &McpMutationOperation) -> Option<String> {
         ));
     }
     let Some(payload) = op.payload.as_ref() else {
-        if is_target_body_update(op) {
+        if is_target_body_update(op) || is_new_source_file(op) {
             return None;
         }
         return Some("missing payload".to_string());

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -2355,7 +2355,10 @@ mod tests {
         // (target "function", body None), so it must still be rejected.
         let err = validate_staged_operations(&[op("create", None)]).unwrap_err();
         assert!(err.contains("missing payload"), "{err}");
-        assert!(err.contains("express an edit to an existing entity"), "{err}");
+        assert!(
+            err.contains("express an edit to an existing entity"),
+            "{err}"
+        );
         assert!(err.contains("admit a source file"), "{err}");
     }
 

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -2522,8 +2522,15 @@ mod target_body_update_tests {
 
     #[test]
     fn target_body_update_requires_verb_target_and_body() {
-        let wrong_verb = target_op("create", "resolve_binary", Some("x"));
+        // "create" used to be a wrong verb for this shape; it now names the
+        // new-source-file operation (`is_new_source_file`), so a payload-less
+        // "create" with a target and body is a valid create, not a rejected
+        // update. "upsert" stays wrong on purpose: it is deliberately not one
+        // of the create verbs (see `is_new_source_file`), so it still matches
+        // neither payload-less shape and must still fail closed.
+        let wrong_verb = target_op("upsert", "resolve_binary", Some("x"));
         assert!(!is_target_body_update(&wrong_verb));
+        assert!(!is_new_source_file(&wrong_verb));
         assert!(validate_staged_operations(std::slice::from_ref(&wrong_verb)).is_err());
 
         let no_target = target_op("update", "", Some("x"));

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -2349,10 +2349,14 @@ mod tests {
     #[test]
     fn validate_staged_operations_rejects_missing_payload() {
         // The commit path silently skips payload-less ops; stage time must not.
-        // (A payload-less UPDATE with target and body is the one valid form.)
+        // A payload-less op is valid in exactly two shapes: an entity source
+        // edit (verb "update", target plus body) and a new-source-file create
+        // (verb "create", target plus body); `op()` here supplies neither
+        // (target "function", body None), so it must still be rejected.
         let err = validate_staged_operations(&[op("create", None)]).unwrap_err();
         assert!(err.contains("missing payload"), "{err}");
-        assert!(err.contains("entity source edit"), "{err}");
+        assert!(err.contains("express an edit to an existing entity"), "{err}");
+        assert!(err.contains("admit a source file"), "{err}");
     }
 
     #[test]

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -1623,7 +1623,23 @@ mod tests {
             let variants = tool["inputSchema"]["properties"]["operations"]["items"]["oneOf"]
                 .as_array()
                 .expect("transaction operations must be disjoint oneOf variants");
-            assert_eq!(variants.len(), 2, "{tool_name}");
+            assert_eq!(variants.len(), 3, "{tool_name}");
+
+            let new_source_file = variants
+                .iter()
+                .find(|variant| variant["title"] == "New source file")
+                .expect("payload-less new-source-file branch");
+            assert_eq!(
+                required_set(new_source_file),
+                ["body", "description", "target", "verb"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            );
+            assert!(
+                new_source_file["properties"].get("payload").is_none(),
+                "payload-less new-source-file branch must reject payload"
+            );
 
             let body_edit = variants
                 .iter()

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -55,13 +55,45 @@ fn destructive_idempotent(title: &str) -> ToolAnnotations {
 
 /// Honest JSON Schema for one transaction operation.
 ///
-/// The product daemon accepts two materially different shapes. A source-body
-/// edit is intentionally payload-less; structured entity/relation mutations
-/// require `payload`. Keeping these as disjoint `oneOf` branches prevents MCP
-/// clients from being told that the preferred source-edit form is invalid.
+/// The product daemon accepts three materially different shapes. A source-body
+/// edit and a new source file are both intentionally payload-less; structured
+/// entity/relation mutations require `payload`. Keeping these as disjoint
+/// `oneOf` branches prevents MCP clients from being told that the preferred
+/// source-edit form is invalid.
+///
+/// The branches cannot both match one operation: the two payload-less branches
+/// carry disjoint verb enums, and the structured branch requires `payload`,
+/// which neither of the others accepts.
 fn transaction_operation_schema() -> serde_json::Value {
     serde_json::json!({
         "oneOf": [
+            {
+                "title": "New source file",
+                "type": "object",
+                "properties": {
+                    "verb": {
+                        "type": "string",
+                        "enum": ["create", "add", "insert"],
+                        "description": "Admit a source file the graph has never seen. This is the only operation that introduces a new file."
+                    },
+                    "target": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative path of the new file, such as \"src/parser.py\". No leading slash, no \"..\", and no Kin or Git control component. A path the graph already tracks is refused; edit that one with verb 'update' instead."
+                    },
+                    "body": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The file's complete UTF-8 source text. Kin parses it with the same extractor the ingest path uses, so every entity in it enters the graph, and writes the file into the working directory when the transaction commits. You do not need to write the file yourself first."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable explanation of this change."
+                    }
+                },
+                "required": ["verb", "target", "body", "description"],
+                "additionalProperties": false
+            },
             {
                 "title": "Entity source body edit",
                 "type": "object",


### PR DESCRIPTION
An agent holding only Kin's MCP tools could write a file to disk and had no call that made those bytes graph truth. Two doors already admitted new source into the graph, and both required a shell. The watch loop deliberately leaves untracked content for an explicit admission seam (`crates/kin-daemon/src/loop_runner.rs:2237`); that seam is `sync_filesystem_with_graph_publishing_inner` (`crates/kin-daemon/src/loop_runner.rs:6059`); its two callers are `command_admit`, backing `POST /commands/admit` (`crates/kin-daemon/src/api.rs:4188`), and `command_commit`, backing `POST /commands/commit`, which runs the seam as `forced_filesystem_admission` (`crates/kin-daemon/src/api.rs:4667`, label at `:4720`). No MCP tool reached either endpoint, and `mcp_commit` refused insertion outright even if a new file had reached the planner. The shell had two admission doors. The belt had zero.

`kin_transaction_stage` now takes a third operation shape: payload-less verb `create`/`add`/`insert`, `target` naming a repository-relative path, `body` carrying the file's complete text. The body travels in the call rather than the daemon reading the path off disk, so graph truth is written from bytes the caller supplied and no filesystem read happens on the authority path. The working file appears afterward because commit projects the tree it published. Entities and cross-file relations come from the same `IndexPipeline` and `Reconciler` the ingest path runs, so files created in one transaction resolve references to each other; the planner seeds its cross-file linker only when a transaction creates a file, so edit-only transactions keep the planning they had. A path the graph already tracks is refused by name rather than turned into a whole-file replacement.

## Staging validated shape, not existence

`validate_new_source_path` in `session.rs` checked a new-source path's shape (no leading slash, no `..`, no Kin/Git control names) at stage time, but existence was only checked later, at commit, inside the daemon's planner (`record_new_source_file` in `mcp_commit.rs`, via `base.tree.artifact_at_path`). Staging `{"verb": "create", "target": "already/tracked.py", ...}` always answered `staged_count: 1` and only failed once the caller committed, after it had staged whatever else it queued alongside it.

`handle_transaction_stage` now takes the store the call is authoritative over and, after shape validation, checks `store.artifact_id_at_path` for every staged create. A hit is refused immediately with the same message `record_new_source_file` gives at commit. This is a snapshot check: another transaction can still land a conflicting create between stage and commit, so commit stays the final authority, and the tool description says so. The live belt proof below exercises this path directly against a real daemon-backed graph, not just a unit test.

## Live no-shell belt proof

Ran end to end over stdio JSON-RPC to `kin mcp start` against a scratch fixture repo, no shell and no CLI `kin` commands in the admission path (`kin log` afterward is read-only verification, not part of the mechanism):

- `kin_graph_status` before: `entity_count: 0`, `relation_count: 0`.
- `kin_transaction_begin`, then `kin_transaction_stage` created two new files in one transaction: `pkg/util.py` (`def helper(value): return value + 1`) and `pkg/app.py` (`from pkg.util import helper` plus a `run` function that calls it). `staged_count: 2`.
- `kin_transaction_commit`: `status: "committed"`, `entity_deltas: 4`, `relation_deltas: 2`, `modified_files: ["pkg/app.py", "pkg/util.py"]`.
- `kin_graph_status` after: `entity_count: 4`, `relation_count: 2`.
- Staging a second `create` over the just-committed `pkg/util.py` (bogus transaction id, to isolate the stage-time check from transaction lookup) was refused immediately: `"pkg/util.py" is already tracked by repository authority, so it cannot be created; 'create' admits only source the graph has never seen. Edit it with verb 'update' naming an entity inside it, or create a path that does not exist yet"`.
- `find_references` on `helper` crosses from `pkg/util.py` to `pkg/app.py`'s `run`, `relation_kinds: ["calls"]`, resolution `type_resolved`.
- `kin log` (read-only, after the fact) shows the MCP transaction as its own change, authored `fir-2417-belt/no-shell belt <mcp-agent:<session_id>>`, and `pkg/app.py` / `pkg/util.py` are on disk, projected from the commit.

## Fixing three pre-existing tests the change didn't touch but broke

Running the full `kin-mcp` and `kin-daemon` suites (not just `mcp_commit`'s own 52 tests and the `transaction_stage`-named tests, which is what the branch had been checked against) surfaced three collisions between the original `create`-verb work and tests it never ran against:

- `session::tests::target_body_update_requires_verb_target_and_body` used verb `"create"` with a target and body as its example of a shape `validate_staged_operations` should reject. That was true before `create` meant anything; now it's exactly the new-source-file shape and staging accepts it. Switched the fixture to `"upsert"`, which is deliberately excluded from the create verbs.
- `session::tests::validate_staged_operations_rejects_missing_payload` asserted the missing-payload error contained the literal phrase `"entity source edit"`, which the message rewrite replaced with `"express an edit to an existing entity"` plus a clause pointing at `create`. Updated the assertion to check both current clauses.
- `tools::tests::serialized_tools_list_exposes_the_real_transaction_operation_contract` asserted the `operations` `oneOf` schema carried exactly two branches. `transaction_operation_schema` now declares three (the original commit added a `"New source file"` branch so the JSON Schema actually documents `create`), and the test's variant count and per-branch checks were never updated. Fixed to assert three and check the new branch's required fields the same way the other two are checked.

None of the three are regressions from this PR's own new code; they're gaps in what the original commit verified before landing here.

## Gate results

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p kin-mcp -p kin-daemon --all-targets --all-features` under the `ci.yml` allowlist with `RUSTFLAGS=-D warnings`: clean.
- `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`: all pass.
- `cargo test -p kin-mcp -p kin-daemon --lib`: `kin-daemon` 867/867 passed, `kin-mcp` 491/491 passed, including all 52 `mcp_commit` tests and the new stage-time-existence test with its falsification (disabling the new check reproduces the exact `"Transaction not found"` fallthrough instead of the refusal).
- `bin/kin-dev local-test kin` (full workspace `nextest`, ~6200 tests): multiple attempts on this run did not reach a clean full pass. The failures were exclusively wall-clock deadline trips (`timed out after 300s`, `did not exit within 180s`) in `commands::update::tests` (crash/recovery subprocess tests) and `background_embed_opt_out` (daemon spawn tests) plus one flaky `commit_liveness` test, all confirmed to pass cleanly in isolation and none touching a file this PR changes. The host was under severe concurrent load from other lanes for the duration (load average 30-48, swap 33-35GB of 35.8GB used) while this ran; the targeted `-p kin-mcp -p kin-daemon` run above is a clean, complete substitute for the surfaces this PR actually touches.
- `git ls-tree -r HEAD --name-only | grep '.cargo/'` prints only `.cargo/config.toml`; `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

Closes FIR-2417
