### PR TITLE
Say whether an MCP answer's graph is recorded or live-only

### DIFF
--- a/crates/kin-agent/src/mcp.rs
+++ b/crates/kin-agent/src/mcp.rs
@@ -131,6 +131,11 @@ impl ToolOutcome {
             "envelope_version",
             "runtime",
             "graph_as_of",
+            // The trace sidecar is the artifact FIR-2421 was reconstructed
+            // from, and it recorded entity counts rising through a session
+            // whose work was never recorded. Summarizing durability beside them
+            // is what lets the next run's trace answer that on its own.
+            "durability",
             "graph_state",
             "semantic_coverage",
         ] {

--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Every MCP answer says whether the graph behind it survives the daemon
+//! (FIR-2421).
+//!
+//! The transcript this replays: an agent wrote a source file, called
+//! `kin_graph_status`, read `entity_count: 14`, located a class it had just
+//! written and got a real entity id back, wrote in its own log that its work
+//! was in the graph, and never committed. Every one of those payloads was
+//! true. The daemon admits host content into its live query graph
+//! continuously, so the entities and the id were real; nothing in any of them
+//! said the entity layer is rebuilt from zero on the next open. After the
+//! session `kin log` held one change carrying `entities=0` and a fresh open
+//! read the files back with no entities at all.
+//!
+//! So these cases drive the real stdio MCP surface against a real daemon over
+//! a real working copy, and assert on the disclosure rather than on the
+//! counts: a status and a locate taken while the work is uncommitted must both
+//! say so, and the same two calls after a commit must say the opposite. Both
+//! directions matter. A disclosure that always warns is noise an agent learns
+//! to skip, which is the failure mode that would make this fix worthless
+//! without ever failing a test.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::path::Path;
+use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// Wall-clock bound for one four-frame stdio session against a live daemon.
+const SESSION_BOUND: Duration = Duration::from_secs(60);
+
+/// How long ambient admission gets to pick up a host write before the fixture
+/// gives up. The loop polls at 100ms and the file is three functions.
+const ADMISSION_BOUND: Duration = Duration::from_secs(60);
+
+struct IsolatedDaemon {
+    child: Option<common::RuntimeOwnedChild>,
+}
+
+impl IsolatedDaemon {
+    fn spawn(repo: &Path, runtime: &common::IsolatedDaemonRuntime) -> Self {
+        let mut command = runtime.daemon_command();
+        let child = command
+            .arg("--repo")
+            .arg(repo)
+            .arg("--port")
+            .arg("0")
+            .env("KIN_DAEMON_DISABLE_LSP", "1")
+            .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn_owned()
+            .expect("spawn isolated kin-daemon");
+        Self { child: Some(child) }
+    }
+
+    fn wait_until_serving(&mut self, kin_root: &Path) -> u16 {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let child = self.child.as_mut().expect("daemon child exists");
+            if let Some(status) = child.try_wait().expect("inspect daemon child") {
+                panic!("isolated daemon exited before readiness: {status}");
+            }
+            if let Some(port) = fs::read_to_string(kin_root.join("daemon.port"))
+                .ok()
+                .and_then(|value| value.trim().parse::<u16>().ok())
+            {
+                let address = SocketAddr::from(([127, 0, 0, 1], port));
+                if TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok() {
+                    return port;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "isolated daemon did not become ready"
+            );
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn stop(mut self) {
+        let mut child = self.child.take().expect("daemon child exists");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for IsolatedDaemon {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A committed repository with entity source, so durable authority carries a
+/// nonzero entity count before anything uncommitted is written.
+///
+/// A repository whose durable count is zero would let a broken derivation pass
+/// by accident: with `durable == 0` the live-only count is just the live count,
+/// so a disclosure that ignored durable authority entirely would still print
+/// the right number.
+fn seed_repository(repo: &Path) {
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    run_git(repo, &["init", "--initial-branch=main"]);
+    run_git(repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(repo, &["config", "user.name", "Kin"]);
+    fs::write(
+        repo.join("src/storage.rs"),
+        b"pub fn open_store() -> u32 {\n    7\n}\n\npub fn close_store() -> u32 {\n    open_store() + 1\n}\n",
+    )
+    .expect("write entity source");
+    run_git(repo, &["add", "--all"]);
+    run_git(repo, &["commit", "-m", "storage"]);
+}
+
+/// The file the agent wrote and then located. Named for the transcript's
+/// `link_graph.py`, which is the write whose entities the second locate found
+/// seven seconds later.
+const UNCOMMITTED_SOURCE: &[u8] =
+    b"pub fn build_link_graph() -> u32 {\n    3\n}\n\npub fn walk_link_graph() -> u32 {\n    build_link_graph() + 1\n}\n\npub fn render_link_graph() -> u32 {\n    walk_link_graph() + 1\n}\n";
+
+fn kin(repo: &Path, home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("KIN_DAEMON_URL")
+        .current_dir(repo)
+        .output()
+        .expect("run kin")
+}
+
+fn kin_against_daemon(repo: &Path, home: &Path, port: u16, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("KIN_DAEMON_URL", format!("http://127.0.0.1:{port}"))
+        .current_dir(repo)
+        .output()
+        .expect("run kin against the isolated daemon")
+}
+
+fn stdout_of(output: &std::process::Output, what: &str) -> String {
+    assert!(
+        output.status.success(),
+        "{what} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// One `kin mcp start` session: handshake, then status, then locate.
+///
+/// The order is the transcript's. Both calls are made in one session because
+/// the claim is about every envelope rather than about the status tool alone:
+/// the locate is the call the agent actually believed, and it reaches its
+/// envelope through the generic `/health` lift rather than through graph
+/// status's own selected-graph observation, so the two exercise different
+/// code even though they must agree.
+fn session_frames() -> String {
+    [
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"kin-durability-test","version":"0"}}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"kin_graph_status","arguments":{}}}"#,
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"semantic_locate","arguments":{"query":"build_link_graph"}}}"#,
+    ]
+    .join("\n")
+        + "\n"
+}
+
+/// Drive the real stdio MCP binary against the running daemon and return the
+/// parsed payload of each `tools/call` response, keyed by request id.
+fn run_mcp_session(repo: &Path, home: &Path, port: u16) -> Vec<(u64, serde_json::Value)> {
+    let started = Instant::now();
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["mcp", "start"])
+        .current_dir(repo)
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("TMPDIR", std::env::temp_dir())
+        .env("KIN_VFS_DISABLE", "1")
+        .env("KIN_REGISTRY_PATH", home.join("registry.toml"))
+        .env("KIN_DAEMON_URL", format!("http://127.0.0.1:{port}"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn kin mcp start");
+
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(session_frames().as_bytes())
+        .expect("write session frames");
+
+    // Both pipes drain concurrently: a locate payload alone can exceed the
+    // pipe buffer, and a reader that waits for exit first deadlocks against a
+    // writer blocked on a full pipe.
+    let mut stdout_pipe = child.stdout.take().expect("piped stdout");
+    let stdout_reader = thread::spawn(move || {
+        let mut collected = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut collected);
+        collected
+    });
+    let mut stderr_pipe = child.stderr.take().expect("piped stderr");
+    let stderr_reader = thread::spawn(move || {
+        let mut collected = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut collected);
+        collected
+    });
+
+    let deadline = started + SESSION_BOUND;
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll kin mcp start") {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        thread::sleep(Duration::from_millis(25));
+    };
+    let stdout = stdout_reader.join().expect("join stdout reader");
+    let stderr =
+        String::from_utf8_lossy(&stderr_reader.join().expect("join stderr reader")).into_owned();
+    let status =
+        status.unwrap_or_else(|| panic!("kin mcp start did not finish; stderr:\n{stderr}"));
+    assert!(
+        status.success(),
+        "kin mcp start exited with {status}; stderr:\n{stderr}"
+    );
+
+    String::from_utf8(stdout)
+        .expect("stdout is UTF-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let frame: serde_json::Value =
+                serde_json::from_str(line).expect("stdout lines are JSON-RPC");
+            let id = frame.get("id")?.as_u64()?;
+            let text = frame
+                .get("result")?
+                .get("content")?
+                .get(0)?
+                .get("text")?
+                .as_str()?;
+            Some((
+                id,
+                serde_json::from_str(text).expect("tool payload is JSON"),
+            ))
+        })
+        .collect()
+}
+
+fn payload(session: &[(u64, serde_json::Value)], id: u64, what: &str) -> serde_json::Value {
+    session
+        .iter()
+        .find(|(frame_id, _)| *frame_id == id)
+        .unwrap_or_else(|| panic!("session carried no {what} response: {session:?}"))
+        .1
+        .clone()
+}
+
+/// The live entity count the daemon reports, read through `kin graph status`
+/// so the poll below does not have to spawn a whole MCP session per tick.
+fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
+    let text = stdout_of(
+        &kin_against_daemon(repo, home, port, &["graph", "status"]),
+        "kin graph status",
+    );
+    let line = text
+        .lines()
+        .find(|line| line.contains("Entities:"))
+        .unwrap_or_else(|| panic!("graph status printed no entity line:\n{text}"));
+    let after = line
+        .split("Entities:")
+        .nth(1)
+        .expect("the entity line carries a count");
+    after
+        .trim_start()
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .unwrap_or_else(|_| panic!("could not read an entity count from {line:?}"))
+}
+
+/// Wait until ambient admission has taken the host write into the live graph.
+fn wait_for_live_growth(repo: &Path, home: &Path, port: u16, above: u64) -> u64 {
+    let deadline = Instant::now() + ADMISSION_BOUND;
+    loop {
+        let live = live_entity_count(repo, home, port);
+        if live > above {
+            return live;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "ambient admission never took the host write: live entity count stayed at {live}, \
+             above={above}; graph status said:\n{}",
+            stdout_of(
+                &kin_against_daemon(repo, home, port, &["graph", "status"]),
+                "kin graph status"
+            )
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn durability(payload: &serde_json::Value) -> serde_json::Value {
+    payload
+        .get("_kin")
+        .unwrap_or_else(|| panic!("payload carries no _kin envelope: {payload}"))
+        .get("durability")
+        .unwrap_or_else(|| panic!("envelope carries no durability object: {payload}"))
+        .clone()
+}
+
+#[test]
+fn mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+    // Canonicalized before anything binds it. On macOS a temporary directory
+    // is reached through `/var`, which is a symlink to `/private/var`, and the
+    // daemon's file watcher reports host events under the resolved path. A
+    // repository bound to the unresolved one therefore never matches its own
+    // watcher events, and ambient admission silently takes nothing: the
+    // fixture would sit at the committed entity count with no error anywhere.
+    let repo = repo.canonicalize().expect("resolve the repository path");
+    let home = home.canonicalize().expect("resolve the home path");
+    seed_repository(&repo);
+
+    let init = kin(&repo, &home, &["init", ".", "--json"]);
+    let init_payload: serde_json::Value =
+        serde_json::from_slice(&stdout_of(&init, "kin init").into_bytes())
+            .expect("init emits JSON");
+    let durable_at_init = init_payload["semantic_enrichment"]["entity_count"]
+        .as_u64()
+        .expect("init reports a durable entity count");
+    assert!(
+        durable_at_init > 0,
+        "the fixture needs durable entities before the uncommitted write, got \
+         {durable_at_init}: {init_payload}"
+    );
+
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let mut daemon = IsolatedDaemon::spawn(&repo, &runtime);
+    let port = daemon.wait_until_serving(&repo.join(".kin"));
+
+    // The transcript's first move: write a file, through nothing but the
+    // filesystem, exactly as an agent's `write_file` tool does.
+    fs::write(repo.join("src/link_graph.rs"), UNCOMMITTED_SOURCE)
+        .expect("write the uncommitted source");
+    let live = wait_for_live_growth(&repo, &home, port, durable_at_init);
+
+    let uncommitted = run_mcp_session(&repo, &home, port);
+    let status = payload(&uncommitted, 2, "kin_graph_status");
+    let locate = payload(&uncommitted, 3, "semantic_locate");
+
+    assert_eq!(
+        status["entity_count"].as_u64(),
+        Some(live),
+        "the fixture and the status tool must be looking at one graph: {status}"
+    );
+    assert_eq!(
+        status["durable_entity_count"].as_u64(),
+        Some(durable_at_init),
+        "graph status must report the durable count `kin init` published, beside the live one \
+         it already reported: {status}"
+    );
+
+    let status_durability = durability(&status);
+    assert_eq!(
+        status_durability["state"], "live_uncommitted",
+        "the graph holds {live} entities against {durable_at_init} durable, so status must say \
+         the work is unrecorded: {status_durability}"
+    );
+    assert_eq!(
+        status_durability["live_only_entities"].as_u64(),
+        Some(live - durable_at_init),
+        "and must say how much of it: {status_durability}"
+    );
+    let note = status_durability["note"]
+        .as_str()
+        .expect("a durability object always carries a note");
+    assert!(
+        note.contains("uncommitted") && note.contains("Commit to record it"),
+        "the note is what an agent reads instead of the counts: {note:?}"
+    );
+
+    // The call the agent actually believed. It reaches its envelope through
+    // the generic `/health` lift rather than through graph status's own
+    // observation, so it is separate code that has to agree.
+    assert!(
+        locate["entities"]
+            .as_array()
+            .is_some_and(|found| !found.is_empty()),
+        "the fixture needs locate to find the uncommitted entity, or the disclosure beside it \
+         proves nothing: {locate}"
+    );
+    let locate_durability = durability(&locate);
+    assert_eq!(
+        locate_durability["state"], "live_uncommitted",
+        "locate returned an entity id for source no committed change carries, and must say so \
+         in the same envelope: {locate_durability}"
+    );
+    assert_eq!(
+        locate_durability["live_only_entities"].as_u64(),
+        Some(live - durable_at_init),
+        "and must count it the same way status does: {locate_durability}"
+    );
+
+    // The other direction. A disclosure that cannot go quiet is not a
+    // disclosure, and the commit is what the agent should have run.
+    let commit = kin_against_daemon(
+        &repo,
+        &home,
+        port,
+        &["commit", "-m", "record the link graph"],
+    );
+    stdout_of(&commit, "kin commit");
+
+    let recorded = run_mcp_session(&repo, &home, port);
+    let status_after = payload(&recorded, 2, "kin_graph_status");
+    let locate_after = payload(&recorded, 3, "semantic_locate");
+
+    let status_after_durability = durability(&status_after);
+    assert_eq!(
+        status_after_durability["state"], "recorded",
+        "after the commit durable authority carries the graph, so status must stop warning: \
+         {status_after_durability}"
+    );
+    assert_eq!(
+        status_after_durability["live_only_entities"].as_u64(),
+        Some(0),
+        "with nothing left uncommitted: {status_after_durability}"
+    );
+    assert_eq!(
+        status_after["durable_entity_count"].as_u64(),
+        status_after["entity_count"].as_u64(),
+        "and the two counts it reports must now agree: {status_after}"
+    );
+    assert_eq!(
+        durability(&locate_after)["state"],
+        "recorded",
+        "and every other envelope must agree with it: {locate_after}"
+    );
+
+    daemon.stop();
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -662,6 +662,17 @@ pub struct HealthResponse {
     pub version: String,
     pub uptime_seconds: u64,
     pub graph_entity_count: Option<usize>,
+    /// Entities durable repository authority carried when this daemon last
+    /// levelled its query graph with authority (FIR-2421).
+    ///
+    /// `graph_entity_count` above is the LIVE count, and the daemon admits host
+    /// content into that graph continuously without recording any of it, so the
+    /// two differ by exactly the work a daemon exit would lose. Absent, never
+    /// zero, when this daemon has never levelled: an unknown durable count and
+    /// an empty durable authority are different answers, and only one of them
+    /// means the live graph is entirely uncommitted.
+    #[serde(default)]
+    pub durable_entity_count: Option<u64>,
     pub graph_loaded: bool,
     pub reconciliation_status: String,
     pub repo_id: String,
@@ -2060,6 +2071,12 @@ async fn mcp_graph_status_with_stable_authority(
                     // a store whose every vector points at a retired entity reads
                     // as fully embedded with nothing pending.
                     embedding_index_keys: selected_graph_index_population(selected_graph),
+                    // Read under the same fence as the live counters above, so
+                    // the pair a reader subtracts describes one instant
+                    // (FIR-2421). The daemon levels this with authority only at
+                    // open and at commit, and neither can run while this fence
+                    // is held.
+                    durable_entity_count: state.durable_entity_count(),
                 }
             }
             Err(std::sync::TryLockError::WouldBlock) => {
@@ -2609,6 +2626,7 @@ async fn health(
         version: env!("CARGO_PKG_VERSION").to_string(),
         uptime_seconds,
         graph_entity_count: Some(entity_count),
+        durable_entity_count: state.durable_entity_count(),
         graph_loaded,
         reconciliation_status: state.reconciliation_status_str().to_string(),
         repo_id: primary_repo_id(&state),
@@ -4865,6 +4883,12 @@ fn command_commit_after_admission(
         graph.create_change(&committed.change)
     })
     .map_err(internal_error)?;
+    // The plan above was derived from this live graph under the coordination
+    // gate, and the transaction published it, so the two are level here and
+    // this is the count durable authority now carries (FIR-2421). Read from the
+    // live graph rather than from the plan, because a plan's `entity_count` is
+    // the size of its delta and this is the size of the whole.
+    state.record_durable_entity_count(graph.entity_count() as u64);
     state.bump_version();
     state.emit_event(DaemonEvent::GraphRootChanged {
         old_root_hash: None,

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1776,6 +1776,13 @@ fn finalize_committed_transaction(
     timed_finalize_step("install_authority_graph", || {
         install_authority_graph(state.graph.as_ref(), &authority.graph, &committed)
     })?;
+    // The live graph now carries what authority carries, so this is the moment
+    // the two are level and the only honest place to record the durable side's
+    // count (FIR-2421). Taken from the authority graph rather than the live one:
+    // an ambient admission may already have added entities to the live graph
+    // that this commit did not publish, and reading the live count here would
+    // record those as durable.
+    state.record_durable_entity_count(authority.graph.entity_count() as u64);
     let layouts = timed_finalize_step("rebuild_changed_layouts", || {
         if planned_layouts.is_empty() && committed.file_count > 0 {
             rebuild_changed_layouts(state, &authority, &committed.change)

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1046,6 +1046,30 @@ pub fn resolve_idle_timeout_floor(
 pub struct DaemonState {
     pub layout: KinLayout,
     pub graph: Arc<kin_db::InMemoryGraph>,
+    /// Entities durable repository authority carried the last time this daemon
+    /// levelled its query graph with authority, or `u64::MAX` when it never
+    /// has (FIR-2421).
+    ///
+    /// The live graph above admits host content continuously and records none
+    /// of it: an ambient admission publishes the exact workspace tree and then
+    /// writes derived entities into the live graph alone, so the entity layer
+    /// is rebuilt from zero on the next open. Serving a populated
+    /// `entity_count` without this to compare against is what let a real agent
+    /// read `entity_count: 14`, locate a class it had just written, and
+    /// conclude its work was in the graph.
+    ///
+    /// Recorded where the levelling actually happens and nowhere else: at open,
+    /// from the durable workspace snapshot the query graph is built out of, and
+    /// after a commit installs authority onto the live graph. A path that
+    /// levels without recording leaves this BELOW the live count, which reads
+    /// as uncommitted work that is in fact recorded. That direction is a false
+    /// alarm; the reverse, reporting recorded work that is not, is the defect
+    /// being fixed, and [`kin_mcp::Durability::observe`] refuses to derive a
+    /// count at all once this rises above the live count.
+    ///
+    /// `u64::MAX` rather than an `Option` so the sentinel and the counter share
+    /// one atomic read; [`Self::durable_entity_count`] is the only reader.
+    durable_entity_count: AtomicU64,
     pub blobs: Arc<BlobStore>,
     /// Why the derived ingestion CAS could not be hydrated from graph
     /// authority when this state was opened, if it could not.
@@ -2324,6 +2348,7 @@ impl DaemonState {
             cached_repo_id,
             cached_workspace_id: Some(workspace_id),
             is_shutdown: AtomicBool::new(false),
+            durable_entity_count: AtomicU64::new(loaded_entity_count as u64),
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             retired_graph_only_members: Default::default(),
@@ -2546,6 +2571,7 @@ impl DaemonState {
             cached_repo_id: repo_id.to_string(),
             cached_workspace_id: None,
             is_shutdown: AtomicBool::new(false),
+            durable_entity_count: AtomicU64::new(loaded_entity_count as u64),
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             retired_graph_only_members: Default::default(),
@@ -4879,6 +4905,36 @@ impl DaemonState {
         }
         sync_directory_metadata(parent).map_err(DaemonError::Io)?;
         Ok(())
+    }
+
+    /// How many entities durable repository authority carried when this daemon
+    /// last levelled its query graph with authority, or `None` when it never
+    /// has (FIR-2421).
+    ///
+    /// `None` is a real answer and must not be collapsed to zero. A daemon that
+    /// never levelled cannot say how much of its live graph is recorded, and
+    /// zero would report all of it as uncommitted.
+    pub fn durable_entity_count(&self) -> Option<u64> {
+        match self.durable_entity_count.load(Ordering::Relaxed) {
+            u64::MAX => None,
+            count => Some(count),
+        }
+    }
+
+    /// Record that the live query graph now carries everything durable
+    /// authority carries, and how much that is.
+    ///
+    /// Called from the paths that actually level the two: opening a graph out
+    /// of a durable workspace snapshot, and installing a committed authority
+    /// graph onto the live one. It takes the count rather than reading it back
+    /// off the live graph so the number is the durable side's, not a live side
+    /// an ambient admission may already have moved.
+    pub fn record_durable_entity_count(&self, count: u64) {
+        // The sentinel is a value the counter can never legitimately reach, so
+        // clamping is the only way a real store could ever be read as "never
+        // levelled". A repository with `u64::MAX` entities does not exist.
+        self.durable_entity_count
+            .store(count.min(u64::MAX - 1), Ordering::Relaxed);
     }
 
     /// Read the current durable authority head from

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -206,6 +206,125 @@ impl GraphState {
     }
 }
 
+/// A durability state's wire word. Three states, and `unknown` is a real
+/// answer rather than a placeholder for one of the other two.
+const DURABILITY_RECORDED: &str = "recorded";
+const DURABILITY_LIVE_UNCOMMITTED: &str = "live_uncommitted";
+const DURABILITY_UNKNOWN: &str = "unknown";
+
+/// Whether the graph that answered this call is recorded by durable repository
+/// authority, or lives only in the daemon's query layer (FIR-2421).
+///
+/// `completeness` says how much of the substrate the answer could see.
+/// This says whether the substrate survives the process serving it. They are
+/// independent: a graph can be complete, fully embedded, and gone the moment
+/// the daemon exits, which is exactly the state that produced this object.
+///
+/// A daemon admits host content into its live query graph continuously, so an
+/// agent that writes a file and locates it a second later gets a real entity id
+/// back. Nothing in that exchange said the entity was uncommitted, and an agent
+/// reading a populated `entity_count` beside a successful locate concluded its
+/// work was in the graph and never committed. The entities went with the
+/// daemon; the payloads it read were all true and all silent about it.
+///
+/// Nothing here is fabricated. `live_only_entities` is a difference between two
+/// counts the daemon observed, and when the two cannot be reconciled the state
+/// is `unknown` with no count rather than a number the reader would act on.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Durability {
+    /// `recorded` when durable authority carries every entity the selected
+    /// graph holds, `live_uncommitted` when it carries fewer, `unknown` when
+    /// the daemon reported no durable observation or the two counts cannot be
+    /// reconciled.
+    pub state: String,
+    /// Entities in the live query graph that answered this call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_entities: Option<u64>,
+    /// Entities durable repository authority carried when this daemon last
+    /// levelled its query graph with authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_entities: Option<u64>,
+    /// How many of `live_entities` no committed change carries. Absent
+    /// whenever `state` is `unknown`, because the whole point of that state is
+    /// that this number could not be derived.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_only_entities: Option<u64>,
+    /// One line an agent can act on without reading the counts.
+    pub note: String,
+}
+
+impl Durability {
+    /// Derive the durability state from the two counts the daemon observed.
+    ///
+    /// `durable` is `None` when the daemon has never levelled its query graph
+    /// with durable authority and therefore has nothing to report; that is
+    /// `unknown`, not zero. A durable count ABOVE the live count is also
+    /// `unknown`: the live graph has dropped entities authority still carries,
+    /// so the difference is not a count of uncommitted work and reporting
+    /// `recorded` there would be the false all-clear this object exists to
+    /// prevent.
+    pub fn observe(live: u64, durable: Option<u64>) -> Self {
+        let Some(durable) = durable else {
+            return Self {
+                state: DURABILITY_UNKNOWN.to_string(),
+                live_entities: Some(live),
+                durable_entities: None,
+                live_only_entities: None,
+                note: "This daemon has not levelled its query graph with durable repository \
+                       authority, so whether these entities are recorded is unknown. Run `kin \
+                       status` to read durable authority directly."
+                    .to_string(),
+            };
+        };
+        if durable > live {
+            return Self {
+                state: DURABILITY_UNKNOWN.to_string(),
+                live_entities: Some(live),
+                durable_entities: Some(durable),
+                live_only_entities: None,
+                note: format!(
+                    "The live query graph holds {live} entities and durable authority carries \
+                     {durable}, so this answer cannot say how much of it is recorded. Run `kin \
+                     status` to read durable authority directly."
+                ),
+            };
+        }
+        let live_only = live - durable;
+        if live_only == 0 {
+            return Self {
+                state: DURABILITY_RECORDED.to_string(),
+                live_entities: Some(live),
+                durable_entities: Some(durable),
+                live_only_entities: Some(0),
+                note: format!(
+                    "{live} entities, 0 uncommitted; durable repository authority records \
+                     everything answering here."
+                ),
+            };
+        }
+        Self {
+            state: DURABILITY_LIVE_UNCOMMITTED.to_string(),
+            live_entities: Some(live),
+            durable_entities: Some(durable),
+            live_only_entities: Some(live_only),
+            note: format!(
+                "{live} entities, {live_only} uncommitted; {} is recorded yet, and the \
+                 uncommitted work is lost when this daemon exits. Commit to record it.",
+                if durable == 0 {
+                    "nothing you wrote"
+                } else {
+                    "not all of what you wrote"
+                }
+            ),
+        }
+    }
+
+    /// True when durable authority does not carry everything the answer read.
+    pub fn is_live_uncommitted(&self) -> bool {
+        self.state == DURABILITY_LIVE_UNCOMMITTED
+    }
+}
+
 /// Which completeness gate governs whether an *absent* result can be trusted as
 /// a definitive negative. Different retrieval families depend on different
 /// substrates, so "is the index complete enough to trust an empty answer?" has
@@ -667,6 +786,14 @@ pub struct Envelope {
     /// from a tool payload's own `graph_as_of`/`as_of` marker when one is carried.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub graph_as_of: Option<Value>,
+    /// Whether the graph that answered survives the daemon serving it, beside
+    /// the freshness marker rather than inside it: `graph_as_of` names WHICH
+    /// graph state answered, and this names whether that state is recorded
+    /// anywhere. Absent when the runtime reported no durable observation at
+    /// all, which is the one case where saying nothing is more honest than
+    /// saying `unknown` for a runtime that has no durable layer to compare to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durability: Option<Durability>,
     /// Honest graph freshness context; omitted entirely when nothing is known.
     #[serde(default, skip_serializing_if = "GraphState::is_empty")]
     pub graph_state: GraphState,
@@ -697,6 +824,7 @@ impl Envelope {
             runtime: Runtime::OfflineInProcess,
             semantic_coverage: None,
             graph_as_of: None,
+            durability: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 offline_fallback: Some(true),
@@ -716,6 +844,7 @@ impl Envelope {
             runtime: Runtime::RepoDaemon,
             semantic_coverage: None,
             graph_as_of: None,
+            durability: None,
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
             completeness: None,
@@ -731,12 +860,17 @@ impl Envelope {
     /// would mix two graph views in one payload. Graph status instead supplies
     /// its own entity and embedding observations here. Fields that only
     /// `/health` knows stay absent rather than being borrowed from HEAD.
+    ///
+    /// `durable_entity_count` is the one durable reading graph status carries
+    /// itself, because the question it answers is about the selected graph and
+    /// not about HEAD. `None` reaches [`Durability::observe`] as `unknown`.
     pub fn with_selected_graph_observation(
         mut self,
         entity_count: u64,
         embeddings_indexed: u64,
         embeddings_pending: u64,
         embeddings_total: u64,
+        durable_entity_count: Option<u64>,
     ) -> Self {
         let complete = embeddings_pending == 0 && embeddings_indexed == embeddings_total;
         self.runtime = Runtime::RepoDaemon;
@@ -754,6 +888,7 @@ impl Envelope {
             graph_body_gap_paths: None,
         });
         self.graph_as_of = None;
+        self.durability = Some(Durability::observe(entity_count, durable_entity_count));
         self.graph_state = GraphState {
             entity_count: Some(entity_count),
             ..GraphState::default()
@@ -770,6 +905,7 @@ impl Envelope {
             runtime: Runtime::RepoDaemon,
             semantic_coverage: None,
             graph_as_of: None,
+            durability: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 daemon_unreachable: Some(true),
@@ -794,6 +930,7 @@ impl Envelope {
             runtime: Runtime::RepoDaemon,
             semantic_coverage: None,
             graph_as_of: None,
+            durability: None,
             graph_state: GraphState::default(),
             degraded: Degraded {
                 workspace_mismatch: Some(true),
@@ -826,6 +963,18 @@ impl Envelope {
         }
         if let Some(value) = health.get("initialized").and_then(Value::as_bool) {
             self.graph_state.initialized = Some(value);
+        }
+        // Derived from the pair rather than reported by the daemon, because the
+        // live count is the one this envelope already carries and deriving it
+        // here keeps the two numbers from describing different instants. A
+        // daemon that reports no live count has nothing to compare against, so
+        // the object stays absent instead of asserting `unknown` about a graph
+        // it never measured.
+        if let Some(live) = self.graph_state.entity_count {
+            self.durability = Some(Durability::observe(
+                live,
+                health.get("durable_entity_count").and_then(Value::as_u64),
+            ));
         }
         // The daemon `/health` `graph_generation` marker (monotonic snapshot
         // generation, bumped per committed snapshot) is a precise freshness
@@ -1244,6 +1393,84 @@ mod tests {
         assert_eq!(env.graph_state.loaded, Some(true));
         assert_eq!(env.graph_state.initialized, Some(true));
         assert!(env.degraded.any());
+    }
+
+    /// The four states a durability observation can be in, including the two
+    /// that must refuse to name a number.
+    ///
+    /// `durable > live` is the one worth writing down. The live graph has
+    /// dropped entities authority still carries, so the difference is not a
+    /// count of uncommitted work, and a `recorded` verdict there would be the
+    /// false all-clear this object exists to prevent. It is reachable: an
+    /// admission that evicts a removed path's entities shrinks the live graph
+    /// while authority still holds them.
+    #[test]
+    fn durability_names_a_count_only_when_the_two_counts_can_be_reconciled() {
+        let uncommitted = Durability::observe(14, Some(0));
+        assert_eq!(uncommitted.state, "live_uncommitted");
+        assert_eq!(uncommitted.live_only_entities, Some(14));
+        assert!(
+            uncommitted.note.contains("14 entities, 14 uncommitted")
+                && uncommitted.note.contains("nothing you wrote"),
+            "an empty durable authority means none of it is recorded: {}",
+            uncommitted.note
+        );
+
+        let partly = Durability::observe(14, Some(9));
+        assert_eq!(partly.state, "live_uncommitted");
+        assert_eq!(partly.live_only_entities, Some(5));
+        assert!(
+            partly.note.contains("not all of what you wrote"),
+            "a nonempty durable authority records some of it: {}",
+            partly.note
+        );
+
+        let recorded = Durability::observe(14, Some(14));
+        assert_eq!(recorded.state, "recorded");
+        assert_eq!(recorded.live_only_entities, Some(0));
+
+        let unmeasured = Durability::observe(14, None);
+        assert_eq!(unmeasured.state, "unknown");
+        assert_eq!(
+            unmeasured.live_only_entities, None,
+            "an unlevelled daemon must not report 14 uncommitted entities it cannot see"
+        );
+
+        let shrunk = Durability::observe(9, Some(14));
+        assert_eq!(
+            shrunk.state, "unknown",
+            "a live graph below durable authority cannot be read as recorded"
+        );
+        assert_eq!(shrunk.live_only_entities, None);
+    }
+
+    /// The generic tool path takes its envelope from `/health`, so the fold
+    /// there is what decides whether a locate carries the disclosure at all.
+    #[test]
+    fn with_health_derives_durability_from_the_live_and_durable_counts() {
+        let env = Envelope::daemon().with_health(&serde_json::json!({
+            "graph_entity_count": 22,
+            "durable_entity_count": 0,
+        }));
+        let durability = env
+            .durability
+            .expect("a measured live count carries durability");
+        assert_eq!(durability.state, "live_uncommitted");
+        assert_eq!(durability.live_only_entities, Some(22));
+
+        // A daemon that reports no durable reading is unknown, not recorded.
+        let unlevelled = Envelope::daemon()
+            .with_health(&serde_json::json!({ "graph_entity_count": 22 }))
+            .durability
+            .expect("a measured live count carries durability");
+        assert_eq!(unlevelled.state, "unknown");
+
+        // And a runtime that measured no live count has nothing to compare, so
+        // the object stays absent rather than asserting anything.
+        assert!(Envelope::daemon()
+            .with_health(&serde_json::json!({ "graph_loaded": true }))
+            .durability
+            .is_none());
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -3616,6 +3616,18 @@ pub struct GraphStatusReport {
     /// repository generation and not stable across daemon restarts.
     pub authority_epoch: u64,
     pub entity_count: usize,
+    /// Entities durable repository authority carried when the daemon last
+    /// levelled this graph with authority (FIR-2421).
+    ///
+    /// Beside `entity_count` because that is where it is misread. The live
+    /// count above is what the daemon can answer from right now, and a daemon
+    /// admits host content into that graph continuously without recording any
+    /// of it, so a populated `entity_count` says nothing about whether the work
+    /// survives this process. The difference between the two is what a daemon
+    /// exit would lose; `_kin.durability` states it as a sentence. Absent, not
+    /// zero, when the daemon has never levelled with durable authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_entity_count: Option<u64>,
     pub relation_count: usize,
     pub embedding_source: GraphStatusEmbeddingSource,
     pub embeddings_indexed: usize,
@@ -3656,6 +3668,8 @@ struct GraphStatusReportWire {
     sampling: GraphStatusSampling,
     authority_epoch: u64,
     entity_count: usize,
+    #[serde(default)]
+    durable_entity_count: Option<u64>,
     relation_count: usize,
     embedding_source: GraphStatusEmbeddingSource,
     embeddings_indexed: usize,
@@ -3685,6 +3699,7 @@ impl<'de> Deserialize<'de> for GraphStatusReport {
             sampling: wire.sampling,
             authority_epoch: wire.authority_epoch,
             entity_count: wire.entity_count,
+            durable_entity_count: wire.durable_entity_count,
             relation_count: wire.relation_count,
             embedding_source: wire.embedding_source,
             embeddings_indexed: wire.embeddings_indexed,
@@ -3854,6 +3869,10 @@ pub struct GraphStatusObservation {
     /// Vectors resident in the selected graph's index, sampled under the same
     /// fence as the counters above. `None` when there is no index to measure.
     pub embedding_index_keys: Option<usize>,
+    /// Entities durable repository authority carried when the daemon last
+    /// levelled this graph with authority (FIR-2421). `None` when it never has,
+    /// which is not zero.
+    pub durable_entity_count: Option<u64>,
 }
 
 pub fn handle_daemon_graph_status_observation(
@@ -3868,6 +3887,7 @@ pub fn handle_daemon_graph_status_observation(
         sampling: GraphStatusSampling::PointInTimeSelectedGraph,
         authority_epoch: observation.authority_epoch,
         entity_count: observation.entity_count,
+        durable_entity_count: observation.durable_entity_count,
         relation_count: observation.relation_count,
         embedding_source: GraphStatusEmbeddingSource::SelectedGraph,
         embeddings_indexed: observation.embeddings_indexed,
@@ -6441,6 +6461,7 @@ mod tests {
             embeddings_pending: embeddings.pending,
             embeddings_total: embeddings.total,
             embedding_index_keys: None,
+            durable_entity_count: None,
         };
         let result =
             handle_daemon_graph_status_observation(GraphStatusScope::TemporalSession, observation)
@@ -6481,6 +6502,7 @@ mod tests {
                 embeddings_pending: 0,
                 embeddings_total: 2,
                 embedding_index_keys: None,
+                durable_entity_count: None,
             },
         )
         .expect_err("the direct daemon boundary must reject impossible coverage");
@@ -6511,6 +6533,7 @@ mod tests {
                 embeddings_pending: 0,
                 embeddings_total: 49,
                 embedding_index_keys: Some(89),
+                durable_entity_count: None,
             },
         )
         .expect("a stale-but-covered graph is a reportable observation");
@@ -6531,6 +6554,7 @@ mod tests {
                 embeddings_pending: 0,
                 embeddings_total: 49,
                 embedding_index_keys: Some(49),
+                durable_entity_count: None,
             },
         )
         .unwrap();
@@ -6549,6 +6573,7 @@ mod tests {
                 embeddings_pending: 12,
                 embeddings_total: 12,
                 embedding_index_keys: None,
+                durable_entity_count: None,
             },
         )
         .unwrap();
@@ -6575,6 +6600,7 @@ mod tests {
                 embeddings_pending: 0,
                 embeddings_total: 10,
                 embedding_index_keys: Some(9),
+                durable_entity_count: None,
             },
         )
         .expect_err("an index below its own covered keys is not a reportable observation");

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1321,8 +1321,13 @@ fn finalize_daemon_graph_status(result: ToolCallResult, base_env: Envelope) -> T
             );
         }
     };
-    let selected_env =
-        base_env.with_selected_graph_observation(entity_count, indexed, pending, total);
+    let selected_env = base_env.with_selected_graph_observation(
+        entity_count,
+        indexed,
+        pending,
+        total,
+        report.durable_entity_count,
+    );
     let enveloped = envelope::finalize(result, selected_env, "kin_graph_status");
     if let Err(error) = daemon_delegate::parse_graph_status_report(&enveloped) {
         return envelope::finalize(


### PR DESCRIPTION
Every MCP answer now says whether the graph behind it survives the daemon that served it.

## The mechanism

A daemon admits host content into its live query graph continuously, and records none of it. The ambient loop publishes the exact workspace tree into repository authority and then writes derived entities into the live graph alone (`crates/kin-daemon/src/loop_runner.rs:874` applies a transaction delta carrying `tree_deltas` with `entity_deltas: Vec::new()`). The entity layer is therefore rebuilt from zero on the next open.

This is not a lazy startup scan that swept in whatever was lying around at the first tool call. It admits continuously, and the FIR-2421 transcript proves it twice over. In `agent/kin-trace.jsonl` the envelope's `entity_count` moves 0, 14, 16, 22, 28, 30 in lockstep with each write, at generations 1 through 9. The second `semantic_locate` ran at `17:31:41.975Z`, 7.6 seconds after `link_graph.py` was written at `17:31:34.387Z`, and returned `LinkGraph` with `entity_id 19fd8d9e-ae23-5016-afad-6c787ebdd548`, `name_match: exact`, at generation 7 with `entity_count: 22`, up from 16. The daemon log for that session carries the whole admission inside those seven seconds:

```
17:31:34.705343Z INFO kin_daemon::loop_runner: admitted exact workspace tree into repository authority ... generation=7 ... file_deltas=1
17:31:34.721635Z INFO kin_reconcile::reconciler: reconciled file edit file=/work/nk3/link_graph.py added=6 modified=0 removed=0
17:31:34.729960Z INFO kin_daemon::state: refreshed projection state for changed files upserted=1 graph_backed=1
17:31:35.024155Z INFO kin_daemon::state: saved snapshot to storage backend ... generation=7 committed=false
```

The `AdmittedFileEvent::Untracked` arm at `crates/kin-daemon/src/loop_runner.rs:2237` is not what governs. It skips untracked paths in the per-event ladder because the complete exact-tree scan above it already took them, which is exactly why a file becomes queryable from the act of writing it.

What that admission never produces is a change. The session's `kin log` held one change carrying `Deltas: entities=0 relations=0 tree=1`, and the next open of the same store read the files back with no entities at all:

```
18:46:55.436682Z INFO kin_daemon::state: loaded daemon query graph from workspace-scoped repository-v6 authority ... generation=10 ... workspace_artifacts=8 hydrated_source_bodies=8
18:46:55.443496Z INFO kin_db::engine::graph: pruned orphaned vectors from index evicted=39
18:46:55.443663Z INFO kin_reconcile::reconciler: seeded LKG entity baseline from graph snapshot count=0
18:46:57.045137Z INFO kin_daemon::state: rebuilt projection state from persisted graph truth files=0
```

The blobs and the tree were durable. The entities were not. Every payload the agent read was true, and none of them carried the one fact that would have made it commit.

## The fix

`_kin` gains a `durability` object beside `graph_as_of`, in the vocabulary `completeness` already established rather than a parallel one. `graph_as_of` names which graph state answered; `durability` names whether that state is recorded anywhere. It carries `state` (`recorded`, `live_uncommitted`, or `unknown`), the two counts it was derived from, `live_only_entities`, and a note an agent can act on without reading the counts: "14 entities, 14 uncommitted; nothing you wrote is recorded yet, and the uncommitted work is lost when this daemon exits. Commit to record it."

The durable side of that pair is a new `durable_entity_count` on the daemon, recorded only where the live graph is actually levelled with authority: at open, from the durable workspace snapshot the query graph is built out of, and after each commit installs authority onto the live graph, on both the MCP and the thin-client commit paths. Nothing is computed that was not already in hand, so this costs no additional authority read.

Generic tools reach it through `/health`, which is how their envelopes already get `graph_state` and `graph_as_of`. `kin_graph_status` carries its own reading instead, because its question is about the selected graph rather than about HEAD, so `durable_entity_count` sits in the report body beside `entity_count`, which is where it was misread.

Nothing here is fabricated. A daemon that has never levelled reports `unknown` rather than zero, and a durable count above the live count is `unknown` with no number at all: the live graph has dropped entities authority still carries, so the difference is not a count of uncommitted work, and calling it `recorded` would be the false all-clear this object exists to prevent. A path that levels without recording leaves the baseline low, which reads as uncommitted work that is in fact recorded. That direction is a false alarm rather than a false all-clear, and it is the one the derivation is allowed to be wrong in.

## Falsification

`crates/kin-cli/tests/live_graph_durability_disclosure.rs` replays the transcript's sequence against a real daemon over a real working copy: `kin init` a committed repository, write a file the repository does not carry, let ambient admission take it, then call `kin_graph_status` and `semantic_locate` over the real stdio MCP surface. Three ways of breaking it, each run to completion with the exit code read raw:

Removing the disclosure from both envelope paths fails with `envelope carries no durability object`, and the payload it prints is the shape this PR replaces: `"entity_count":5 ... "durable_entity_count":2` with nothing saying three of the five are unrecorded. Exit 101.

Deriving the state without consulting durable authority fails with `left: String("recorded"), right: "live_uncommitted"` on a graph holding 5 entities against 2 durable. Exit 101.

Never letting the disclosure go quiet fails on the post-commit assertion, `left: String("live_uncommitted"), right: "recorded"`. Exit 101. That direction matters as much as the other: a disclosure that always warns is noise an agent learns to skip, which would make this fix worthless without ever failing a test.

Restored byte-identical by sha256 and green again in 3.24s.

The unit half in `crates/kin-mcp/src/envelope.rs` pins all four states, including the two that must refuse to name a number, and the `/health` fold that decides whether a locate carries the disclosure at all.

The agent trace sidecar now summarizes `durability` beside `graph_as_of`. That sidecar is the artifact this ticket was reconstructed from, and it recorded entity counts rising through a session whose work was never recorded.

Closes FIR-2421
