### PR TITLE
Give a CommonJS export assigned from a call result an entity

### DIFF
--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -625,6 +625,43 @@ fn extract_js_assignment_target(
             return;
         }
 
+        // `exports.X = <expr>` and `module.exports.X = <expr>` export X
+        // whatever the right-hand side is. A function literal is named by the
+        // tail of this function; every other right-hand side produced no entity
+        // at all, so express's `exports.etag = createETagGenerator({ weak: false })`
+        // was absent from the graph rather than merely unlinked. That is worse
+        // than an unresolved reference: an export sweep run from the graph over
+        // `lib/utils.js` returns six of its nine exports and reports nothing
+        // missing, because from the graph's side there is nothing to hedge about.
+        if matches!(receiver_path.as_str(), "exports" | "module.exports")
+            && !property.is_empty()
+            && !is_js_function_like_node(value)
+            // A `require(...)` re-export already reaches the graph as a
+            // `FileImport` specifier under this same name. Emitting a constant
+            // beside it would double every re-exported dependency, which is the
+            // shape that buried express's functions under 451 constants.
+            && js_require_target(value, source).is_none()
+        {
+            entities.push(ExtractedEntity {
+                kind: if value.kind() == "class" {
+                    EntityKind::Class
+                } else {
+                    EntityKind::Constant
+                },
+                name: property.clone(),
+                signature: node_signature(stmt, source),
+                visibility: Visibility::Public,
+                doc_summary: extract_preceding_comment(stmt, source),
+                fingerprint: compute_fingerprint(stmt, source),
+                span: span_from_node(stmt, file_id),
+            });
+            // The factory an export is built from is the one edge that makes
+            // it reachable: `exports.etag` calls `createETagGenerator`. The
+            // statement is what gets walked rather than the value, because the
+            // walk tests a node's children and the value here IS the call.
+            extract_calls_from_context(stmt, source, property, None, relations);
+        }
+
         // `module.exports = { parse() {}, print() {} }` is the CommonJS way of
         // exporting a set of functions. Give each property its own entity so
         // `require('./m').parse` has something to bind to.
@@ -1776,24 +1813,142 @@ exports.static = require('serve-static');
     }
 
     #[test]
-    fn parse_js_value_assignment_skipped() {
-        // exports.Router = Router — value assignment, not a function → should NOT produce entity
+    fn parse_js_value_assignment_is_an_exported_constant() {
+        // `exports.Router = Router` exports Router. The value is not callable
+        // here, so it is a Constant rather than a Function, but it is an export
+        // and has to exist: producing nothing leaves the name unaskable and an
+        // export sweep short by one with nothing to report.
         let adapter = JavaScriptAdapter;
         let source = b"exports.Router = Router;";
         let tree = adapter.parse(source).unwrap();
         let file_id = FilePathId::new("test.js");
         let output = adapter.extract(&tree, source, &file_id).unwrap();
-        let funcs: Vec<_> = output
+        let named: Vec<(EntityKind, &str)> = output
             .entities
             .iter()
-            .filter(|e| e.kind == EntityKind::Function)
+            .map(|e| (e.kind, e.name.as_str()))
             .collect();
-        assert_eq!(
-            funcs.len(),
-            0,
-            "value assignments should not produce entities, got {:?}",
-            funcs
+        assert_eq!(named, vec![(EntityKind::Constant, "Router")]);
+        assert_eq!(output.entities[0].visibility, Visibility::Public);
+    }
+
+    #[test]
+    fn parse_js_exports_call_result_is_an_exported_constant() {
+        // express `lib/utils.js:40`. The right-hand side is a call, so before
+        // the export rule this statement produced no entity at all.
+        let adapter = JavaScriptAdapter;
+        let source = b"exports.etag = createETagGenerator({ weak: false });";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert_eq!(named, vec![(EntityKind::Constant, "etag")]);
+        assert_eq!(output.entities[0].visibility, Visibility::Public);
+        assert!(
+            output.entities[0].signature.contains("createETagGenerator"),
+            "the assignment is the body of a call-result export, got {:?}",
+            output.entities[0].signature
         );
+        let calls: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Calls)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert_eq!(calls, vec![("etag", "createETagGenerator")]);
+    }
+
+    #[test]
+    fn parse_js_module_exports_property_call_result_is_an_exported_constant() {
+        // `module.exports.X` is the same export written the long way; the
+        // receiver path carries the dot, so a bare `exports` match misses it.
+        let adapter = JavaScriptAdapter;
+        let source = b"module.exports.wetag = createETagGenerator({ weak: true });";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert_eq!(named, vec![(EntityKind::Constant, "wetag")]);
+    }
+
+    #[test]
+    fn parse_js_exports_class_expression_is_kinded_class() {
+        let adapter = JavaScriptAdapter;
+        let source = b"exports.Router = class {};";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let named: Vec<(EntityKind, &str)> = output
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert_eq!(named, vec![(EntityKind::Class, "Router")]);
+    }
+
+    #[test]
+    fn parse_js_exports_require_reexport_stays_an_import() {
+        // `exports.static = require('serve-static')` already reaches the graph
+        // as an import specifier named `static`. A constant beside it would
+        // double every re-exported dependency, which is the shape that buried
+        // express's functions under 451 constants.
+        let adapter = JavaScriptAdapter;
+        let source = b"exports.static = require('serve-static');";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.js");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        assert!(
+            output.entities.is_empty(),
+            "a require re-export is a dependency line, got {:?}",
+            output
+                .entities
+                .iter()
+                .map(|e| (e.kind, e.name.as_str()))
+                .collect::<Vec<_>>()
+        );
+        let specifiers: Vec<&str> = output
+            .imports
+            .iter()
+            .filter(|i| i.module_path == "serve-static")
+            .flat_map(|i| i.specifiers.iter().map(|s| s.local_name.as_str()))
+            .collect();
+        assert_eq!(specifiers, vec!["static"]);
+    }
+
+    #[test]
+    fn parse_js_export_rule_fires_only_on_the_export_namespace() {
+        // Only `exports` and `module.exports` are the module's export surface.
+        // `window.handler = createHandler()` assigns to a global, and
+        // `module.exports = createApplication()` replaces the whole export
+        // rather than naming one, so neither yields an exported property: the
+        // second would otherwise be recorded under the name `exports`.
+        let adapter = JavaScriptAdapter;
+        for source in [
+            &b"window.handler = createHandler();"[..],
+            &b"module.exports = createApplication();"[..],
+        ] {
+            let tree = adapter.parse(source).unwrap();
+            let file_id = FilePathId::new("test.js");
+            let output = adapter.extract(&tree, source, &file_id).unwrap();
+            assert!(
+                output.entities.is_empty(),
+                "{:?} is not an exported property, got {:?}",
+                std::str::from_utf8(source).unwrap(),
+                output
+                    .entities
+                    .iter()
+                    .map(|e| (e.kind, e.name.as_str()))
+                    .collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -612,6 +612,199 @@ fn typescript_relational_shape() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// The CommonJS export surface.
+//
+// express's `lib/utils.js` exports nine names. Six are function literals and
+// three are call results, and the three produced no entity at all: not an
+// unresolved reference the absence machinery could hedge about, but nothing to
+// hedge about. An export sweep run from the graph returned six and reported
+// nothing missing.
+// ---------------------------------------------------------------------------
+
+/// The shape of express's `lib/utils.js`: require bindings at the top, then
+/// nine exports whose right-hand sides are a call on a required module, two
+/// factory calls, a member access, an identifier, a re-exported dependency and
+/// three function literals.
+const EXPORT_SURFACE_JS: &str = r#"
+var { METHODS } = require('node:http');
+var etag = require('etag');
+var bodyParser = require('body-parser');
+
+exports.methods = METHODS.map((method) => method.toLowerCase());
+exports.etag = createETagGenerator({ weak: false });
+exports.wetag = createETagGenerator({ weak: true });
+exports.json = bodyParser.json;
+exports.Router = Router;
+exports.static = require('serve-static');
+exports.normalizeType = function(type) { return acceptParams(type); };
+exports.compileETag = function(val) { return wrap(val); };
+exports.compileQueryParser = function compileQueryParser(val) { return wrap(val); };
+"#;
+
+/// The TypeScript mirror. Both adapters share `extract_js_assignment_function`,
+/// so a divergence here means one of them answers a question about the same
+/// CommonJS source differently from the other.
+const EXPORT_SURFACE_TS: &str = r#"
+var { METHODS } = require('node:http');
+var etag = require('etag');
+var bodyParser = require('body-parser');
+
+exports.methods = METHODS.map((method: string) => method.toLowerCase());
+exports.etag = createETagGenerator({ weak: false });
+exports.wetag = createETagGenerator({ weak: true });
+exports.json = bodyParser.json;
+exports.Router = Router;
+exports.static = require('serve-static');
+exports.normalizeType = function(type: string) { return acceptParams(type); };
+exports.compileETag = function(val: string) { return wrap(val); };
+exports.compileQueryParser = function compileQueryParser(val: string) { return wrap(val); };
+"#;
+
+/// Every name a CommonJS module exports must be reachable from the graph, and
+/// its kind must say what it is.
+fn assert_export_surface(out: &ParseOutput, lang: &str) {
+    let named: Vec<(EntityKind, &str)> = out
+        .entities
+        .iter()
+        .map(|e| (e.kind, e.name.as_str()))
+        .collect();
+
+    // A call result, a member access and a bare identifier are exports as much
+    // as a function literal is. Each is a value, so each is kinded Constant.
+    for want in [
+        (EntityKind::Constant, "methods"),
+        (EntityKind::Constant, "etag"),
+        (EntityKind::Constant, "wetag"),
+        (EntityKind::Constant, "json"),
+        (EntityKind::Constant, "Router"),
+        (EntityKind::Function, "normalizeType"),
+        (EntityKind::Function, "compileETag"),
+        (EntityKind::Function, "compileQueryParser"),
+    ] {
+        assert!(
+            named.contains(&want),
+            "{lang}: missing export {want:?}; have {named:?}"
+        );
+    }
+
+    // Every one of them is public; an export sweep keys on that.
+    for e in &out.entities {
+        assert_eq!(
+            e.visibility,
+            kin_model::Visibility::Public,
+            "{lang}: export {:?} should be public",
+            e.name
+        );
+    }
+
+    // `exports.static = require('serve-static')` is a re-exported dependency.
+    // It reaches the graph as an import specifier under that name, so a
+    // constant beside it would count the same dependency line twice.
+    assert!(
+        !named.iter().any(|(_, n)| *n == "static"),
+        "{lang}: a require re-export must stay an import; have {named:?}"
+    );
+    let static_specifiers: Vec<&str> = out
+        .imports
+        .iter()
+        .filter(|i| i.module_path == "serve-static")
+        .flat_map(|i| i.specifiers.iter().map(|s| s.local_name.as_str()))
+        .collect();
+    assert_eq!(
+        static_specifiers,
+        vec!["static"],
+        "{lang}: serve-static should bind one specifier"
+    );
+
+    // The factory a call-result export is built from is the edge that makes it
+    // reachable from the code that produces it.
+    let calls: Vec<(&str, &str)> = out
+        .relations
+        .iter()
+        .filter(|r| r.kind == kin_model::RelationKind::Calls)
+        .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+        .collect();
+    for want in [
+        ("etag", "createETagGenerator"),
+        ("wetag", "createETagGenerator"),
+        ("methods", "map"),
+    ] {
+        assert!(
+            calls.contains(&want),
+            "{lang}: missing Calls {want:?}; have {calls:?}"
+        );
+    }
+
+    // Nine exports in, nine reachable out. Reverting the rule that admits a
+    // non-function right-hand side drops this to six.
+    let exported = [
+        "methods",
+        "etag",
+        "wetag",
+        "json",
+        "Router",
+        "static",
+        "normalizeType",
+        "compileETag",
+        "compileQueryParser",
+    ];
+    let reachable = exported
+        .iter()
+        .filter(|name| {
+            named.iter().any(|(_, n)| n == *name)
+                || out
+                    .imports
+                    .iter()
+                    .any(|i| i.specifiers.iter().any(|s| s.local_name == **name))
+        })
+        .count();
+    assert_eq!(
+        reachable,
+        exported.len(),
+        "{lang}: {reachable} of {} exports reachable; have {named:?}",
+        exported.len()
+    );
+}
+
+#[test]
+fn javascript_commonjs_export_surface() {
+    assert_export_surface(
+        &extract(&JavaScriptAdapter, "utils.js", EXPORT_SURFACE_JS),
+        "javascript",
+    );
+}
+
+#[test]
+fn typescript_commonjs_export_surface() {
+    assert_export_surface(
+        &extract(&TypeScriptAdapter, "utils.ts", EXPORT_SURFACE_TS),
+        "typescript",
+    );
+}
+
+/// `export const X = f(...)` is the ESM form of the same export. It already
+/// produced an entity, and this pins that, so the CommonJS rule and the ESM
+/// path cannot drift into different answers about the same export.
+#[test]
+fn esm_export_const_from_a_call_result_is_a_constant() {
+    let src = "export const etag = createETagGenerator({ weak: false });";
+    for (lang, out) in [
+        ("javascript", extract(&JavaScriptAdapter, "utils.js", src)),
+        ("typescript", extract(&TypeScriptAdapter, "utils.ts", src)),
+    ] {
+        let named: Vec<(EntityKind, &str)> = out
+            .entities
+            .iter()
+            .map(|e| (e.kind, e.name.as_str()))
+            .collect();
+        assert!(
+            named.contains(&(EntityKind::Constant, "etag")),
+            "{lang}: ESM call-result export missing; have {named:?}"
+        );
+    }
+}
+
 #[test]
 #[ignore = "YELLOW: Ruby empty-body method keeps a trailing `end` in the signature (`def helper end`) because there is no `body` field to cut before"]
 fn ruby_empty_body_method_signature_should_exclude_end() {


### PR DESCRIPTION
On expressjs/express, `lib/utils.js` exports nine names and Kin's graph held six of
them. `exports.methods` (`lib/utils.js:29`), `exports.etag` (`:40`) and
`exports.wetag` (`:51`) assign a call result, and `extract_js_assignment_target` in
`crates/kin-parser/src/languages/javascript.rs` returned at its
`if !is_js_function_like_node(value)` guard (`javascript.rs:648` at the base commit)
before creating anything. That is worse
than an unresolved reference. The absence machinery can say "I could not link this",
but it has nothing to hedge about when the declaration never entered the graph, so an
export sweep run from the graph returns six of nine and reports nothing missing.

The rule this adds sits in the same function at
`crates/kin-parser/src/languages/javascript.rs:636`. A member assignment whose
receiver is `exports` or `module.exports` produces a public entity named after the
property whatever the right-hand side is. A class expression is kinded Class and
every other value is a Constant, with the assignment as the entity's signature. The
statement is also walked for calls, so `exports.etag` carries a Calls edge to
`createETagGenerator` and is reachable from the factory that builds it. A
`require(...)` re-export such as `exports.static = require('serve-static')` stays
out: it already reaches the graph as a `FileImport` specifier under that same name,
and a constant beside it would double every dependency line, which is the shape that
buried express's functions under 451 constants before kin#864.

TypeScript shares `extract_js_assignment_function`, so both adapters pick up the rule
and a mirrored fixture holds them to the same answer about the same source. ESM
`export const X = f(...)` already produced a Constant through the
`lexical_declaration` path, and a test now pins that so the two export forms cannot
drift apart.

## Before and after

Measured by driving the JavaScript adapter over the real `lib/utils.js` from the
mirrored stranger tree at
`.kin-coord/handoffs/stranger-rc-0.5.40/brown/work-full/express/lib/utils.js`:

| | entities in the file | of the nine exports |
|---|---|---|
| before | 9 | 6: normalizeType, normalizeTypes, compileETag, compileQueryParser, compileTrust, setCharset |
| after | 12 | 9: the six above plus methods, etag, wetag |

The ticket said two of the nine were missing. Three were. `exports.methods =
METHODS.map(...)` is a call result too, and the stranger noticed only `etag` and
`wetag`.

## Falsification

Each new rule was reverted in the source and the guard confirmed to fire with its
own message. Full output and exit codes were read, never a pipe.

1. Remove the export rule. `cargo test -p kin-parser --lib javascript` exits 101,
   4 failed of 39, and the matrix exits 101 with
   `javascript: missing export (Constant, "methods"); have [(Function,
   "normalizeType"), (Function, "compileETag"), (Function, "compileQueryParser")]`,
   the same for typescript.
2. Remove the `js_require_target` guard. Exits 101 with `a require re-export is a
   dependency line, got [(Constant, "static")]`, and the pre-existing
   `parse_js_require_binding_is_an_import_not_a_constant` fails beside it.
3. Widen the receiver test to any non-empty receiver. Exits 101 with
   `"window.handler = createHandler();" is not an exported property, got [(Constant,
   "handler")]`. The first version of this guard used `res.status = 200`, which is
   claimed by the receiver-method branch above and returns before the export rule
   runs, so the guard passed with the rule removed. It could not fail, and was
   replaced.
4. Kind a class expression Constant. Exits 101 with `left: [(Constant, "Router")]`
   against `[(Class, "Router")]`.
5. Walk the value instead of the statement for calls. Exits 101 with the Calls
   assertion empty, and the matrix reports `missing Calls ("etag",
   "createETagGenerator")`.

## Not covered here

`module.exports = <call>` replaces the whole export rather than naming a property,
so it still produces nothing; that is a different name shape and a different
question. A class expression exported this way is kinded Class without its members
being extracted. The `exports.`-qualified reference miss the ticket describes in its
second half (`return types.map(exports.normalizeType)` not reaching
`find_references`) is relation density and belongs to FIR-2362.

## Gate

`bin/kin-lane run jsexport kin -- bin/kin-dev local-test kin` on
`worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/jsexport-kin`:
`Summary [562.553s] 6301 tests run: 6301 passed (3 slow, 2 leaky), 12 skipped`, exit 0.
`cargo fmt --all -- --check` exit 0. Clippy with the exact `ci.yml` allowlist under
`RUSTFLAGS=-D warnings` exit 0. `scripts/verify-zero-file-search.py`,
`scripts/zero_file_search_guard.sh`, `scripts/verify-hydration-semantics.py`,
`scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh` and
`scripts/test-private-repo-coupling.py` all exit 0. `git ls-tree -r HEAD --name-only |
grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat
-- Cargo.lock .cargo/` is empty.

Closes FIR-2433
