### PR TITLE
Route every absence through one gate, so a name filter cannot certify what a reference query refused

### DIFF
--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -303,6 +303,71 @@ pub fn observe_cross_file_reference_coverage_for_languages_witnessed<S: EntitySt
     })
 }
 
+/// Observe the language scope an absence claim covers, for a tool that
+/// traverses no edge to make it.
+///
+/// `semantic_search`, `find_dead_code_seeded` and `graph_neighborhood` answer
+/// from the entity index and the walk, not from a cross-file reference class, so
+/// the witness scan above measures nothing their verdict rests on. What their
+/// verdict does rest on is which languages the claim spans and whether this
+/// build can resolve their programs, which is the one fact
+/// [`reference_enrichment`] already answers. Publishing it under the same key
+/// the reference tools publish means one gate reads one observation rather than
+/// two shapes drifting apart.
+///
+/// `classes` is deliberately empty rather than absent: this observation asserts
+/// nothing about cross-file edges, and a class map full of `unknown` would read
+/// as a scan that failed instead of one that was never the question.
+///
+/// `scope_entities` is the count of entities the query's own filter selects with
+/// its name pattern removed, so a kind-filtered absence can state the coverage
+/// of that kind. `None` leaves it out entirely, because a region nothing counted
+/// is unknown rather than empty. A resolved count of zero says the filter
+/// selected a region the index never populated, which is a fact about the index.
+pub fn observe_absence_scope(languages: &[LanguageId], scope_entities: Option<usize>) -> Value {
+    let mut observed: Vec<LanguageId> = Vec::new();
+    for language in languages {
+        if !observed.contains(language) {
+            observed.push(*language);
+        }
+    }
+    let language = if observed.is_empty() {
+        "no resolved language".to_string()
+    } else {
+        observed
+            .iter()
+            .map(|language| format!("{language:?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let mut observation = json!({
+        "scope": "absence_scope",
+        "language": language,
+        "requested_classes": Vec::<&str>::new(),
+        "classes": Map::new(),
+        "cross_file_classes": Vec::<&str>::new(),
+        "reference_enrichment": reference_enrichment(&observed),
+        "budget_exhausted": false,
+        "entities_examined": 0,
+        "scan": "skipped_no_edge_dependency",
+    });
+    if let Some(count) = scope_entities {
+        observation["scope_entities"] = json!(count);
+    }
+    observation
+}
+
+/// The distinct languages a resolved entity set spans, in first-seen order.
+pub fn languages_of(entities: &[Entity]) -> Vec<LanguageId> {
+    let mut languages: Vec<LanguageId> = Vec::new();
+    for entity in entities {
+        if !languages.contains(&entity.language) {
+            languages.push(entity.language);
+        }
+    }
+    languages
+}
+
 /// Whether every class the absence verdict rests on is already `present`.
 ///
 /// Narrowed by [`crate::negative::load_bearing_classes`] rather than by a rule

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -36,7 +36,13 @@ On an empty result the response carries an additive `negative` object: its \
 (daemon-owned graph, initialized and loaded, holding entities, no degraded signals) \
 or merely \"not indexed yet\" — check it before treating \"none found\" as ground \
 truth. This filter reads the entity index rather than the vector index, so its \
-absence is gated on the graph being complete, not on embedding coverage.";
+absence is gated on the graph being complete, not on embedding coverage. An empty \
+answer also carries `edge_coverage`, naming the languages the filter's own scope \
+spans and how many entities it holds with the name pattern removed, and the absence \
+is NOT certified when that scope is empty or when its language is one this build \
+wires no language-server adapter for: nothing then resolves the program behind the \
+declarations, so a miss cannot separate a symbol the repository lacks from one the \
+extractor never admitted as an entity of that kind.";
 
 pub fn handle_semantic_search<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
@@ -48,13 +54,13 @@ pub fn handle_semantic_search<G: GraphStore>(
     let entities = store.query_entities(&filter).map_err(McpError::graph)?;
     let total_matches = entities.len();
 
-    let json = if compact {
+    let mut payload = if compact {
         let limited: Vec<_> = entities
             .into_iter()
             .take(limit)
             .map(CompactSearchResult::from)
             .collect();
-        serde_json::to_string_pretty(&CompactSearchResponse {
+        serde_json::to_value(CompactSearchResponse {
             query,
             limit,
             total_matches,
@@ -68,7 +74,7 @@ pub fn handle_semantic_search<G: GraphStore>(
             .take(limit)
             .map(SemanticSearchResult::from)
             .collect();
-        serde_json::to_string_pretty(&SemanticSearchResponse {
+        serde_json::to_value(SemanticSearchResponse {
             query,
             limit,
             total_matches,
@@ -78,6 +84,32 @@ pub fn handle_semantic_search<G: GraphStore>(
         .map_err(McpError::Json)?
     };
 
+    // FIR-2430. An empty search is a claim about the region this filter selected,
+    // and until this observation existed the claim was certified from daemon
+    // health alone: `semantic_search(query: "utils", kind: "module")` on
+    // expressjs/express reported `safe_to_conclude_absent: true` while
+    // `lib/utils.js` sat in the tree holding nine entities, minutes after
+    // `find_references` had refused to certify an absence on the same repository
+    // because JavaScript has no reference enrichment in this build.
+    //
+    // The scope query is the same filter with the name pattern removed, so the
+    // count is the coverage of the kind/language/role the caller asked about
+    // rather than of the name they asked for. Paid only on the empty path, which
+    // is the only answer whose trust depends on it.
+    if total_matches == 0 {
+        let scope = kin_model::graph::EntityFilter {
+            name_pattern: None,
+            ..filter.clone()
+        };
+        let scoped = store.query_entities(&scope).map_err(McpError::graph)?;
+        payload[crate::edge_coverage::EDGE_COVERAGE_KEY] =
+            crate::edge_coverage::observe_absence_scope(
+                &crate::edge_coverage::languages_of(&scoped),
+                Some(scoped.len()),
+            );
+    }
+
+    let json = serde_json::to_string_pretty(&payload).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
 }
 
@@ -2616,7 +2648,12 @@ value is that it fuses three steps — semantic_search, then a reference count p
 then the dead filter — into one response, so you don't loop find_references over every \
 candidate and exhaust your round-trips on a large repo. Use dead_code instead when you \
 want a whole-repo or file-scoped sweep rather than a concept-seeded one, and \
-bulk_check_references when you already hold the exact set of entity IDs to classify.";
+bulk_check_references when you already hold the exact set of entity IDs to classify. \
+When the seed matches nothing the response carries an additive `negative` object beside \
+an `edge_coverage` naming the languages the graph holds, and that absence is not \
+certified on a language this build wires no language-server adapter for, because a seed \
+that matched no declaration cannot then separate a symbol the repository lacks from one \
+the extractor never admitted.";
 
 /// Seeded find-dead-code primitive: `semantic_search(query)` + per-candidate
 /// reference counting + dead-filter, returned as one structured response, so
@@ -2724,11 +2761,26 @@ pub fn handle_find_dead_code_seeded<G: GraphStore>(
     });
 
     let total_searched = candidates.len();
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "query": trimmed,
         "total_searched": total_searched,
         "candidates": candidates,
     });
+
+    // The seed match is the same name filter over the same entity index
+    // `semantic_search` reads, so an empty seed carries the same observation and
+    // answers to the same gate (FIR-2430). The scope is the whole graph because
+    // the seed filter constrains nothing but the name.
+    if total_searched == 0 {
+        let scoped = store
+            .query_entities(&kin_model::graph::EntityFilter::default())
+            .map_err(McpError::graph)?;
+        result[crate::edge_coverage::EDGE_COVERAGE_KEY] =
+            crate::edge_coverage::observe_absence_scope(
+                &crate::edge_coverage::languages_of(&scoped),
+                Some(scoped.len()),
+            );
+    }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -3371,7 +3423,9 @@ a directional ordered chain with bodies inlined, use trace_data_flow. \
 When no neighbors come back, the additive `negative` object's `safe_to_conclude_absent` \
 flag says whether that absence is authoritative or merely \"not indexed yet\", and its \
 `subject` scopes the absence to the side that was walked, so an empty 'in' result is never \
-read as \"no dependencies\". A focal that is not in the graph is reported as that gap \
+read as \"no dependencies\". A walk that expanded no edge also carries `edge_coverage` \
+naming the focal's language, and the absence is not certified when this build wires no \
+language-server adapter for it. A focal that is not in the graph is reported as that gap \
 rather than as an isolated entity. Every edge also carries `resolution` \
 (`type_resolved`, `import_scoped`, `name_only`) saying how strongly its destination was \
 proven; a `name_only` edge was matched by bare name and is a candidate, not structure you \
@@ -3506,7 +3560,7 @@ pub fn handle_graph_neighborhood<G: GraphStore>(
     // Cap relations to match the entity limit to avoid unbounded output.
     relations.truncate(limit * 3);
 
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "focal_id": entity_id.to_string(),
         "direction": direction,
         "depth": depth,
@@ -3516,6 +3570,22 @@ pub fn handle_graph_neighborhood<G: GraphStore>(
         "entities": entities,
         "relations": relations,
     });
+
+    // A walk that expanded no edge is claiming the focal has no neighbors on the
+    // side that was walked, and for an incoming walk that is the same claim
+    // `find_references` makes. It answers to the same gate (FIR-2430), scoped to
+    // the focal's own language. A focal that did not resolve names no language,
+    // and the observation says so rather than guessing one, so the
+    // focal-not-in-graph gap stays the limiting factor a reader is handed.
+    if total_relations == 0 {
+        let focal_languages = store
+            .get_entity(&entity_id)
+            .map_err(McpError::graph)?
+            .map(|entity| vec![entity.language])
+            .unwrap_or_default();
+        result[crate::edge_coverage::EDGE_COVERAGE_KEY] =
+            crate::edge_coverage::observe_absence_scope(&focal_languages, None);
+    }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -4265,6 +4335,233 @@ mod tests {
         assert_eq!(env["total_requested"], 50);
         assert_eq!(env["returned"], 0);
         assert_eq!(env["results"][0]["reason"], "not_found");
+    }
+
+    fn search_args(query: &str, kind: Option<&str>) -> HashMap<String, serde_json::Value> {
+        let mut args = HashMap::new();
+        args.insert("query".to_string(), serde_json::json!(query));
+        if let Some(kind) = kind {
+            args.insert("kind".to_string(), serde_json::json!(kind));
+        }
+        args
+    }
+
+    /// A daemon envelope reporting the graph initialized, loaded and populated:
+    /// the state in which a structural absence is otherwise certifiable, so the
+    /// verdicts below turn on the scope observation and nothing else.
+    fn ready_daemon_envelope(entity_count: u64) -> crate::envelope::Envelope {
+        crate::envelope::Envelope::daemon().with_health(&serde_json::json!({
+            "graph_loaded": true,
+            "initialized": true,
+            "graph_entity_count": entity_count,
+            "graph_generation": 1,
+        }))
+    }
+
+    fn module_entity(language: LanguageId, name: &str, file: &str) -> Entity {
+        let mut entity = make_entity_in(language, name, file);
+        entity.kind = EntityKind::Module;
+        entity
+    }
+
+    /// FIR-2430, end to end through the handler that built the bad answer.
+    ///
+    /// The store is shaped like expressjs/express as the stranger run found it:
+    /// JavaScript, with a `Module` entity for one file and none for
+    /// `lib/utils.js`, which still holds entities of other kinds. That is the
+    /// state in which `semantic_search(query: "utils", kind: "module")` returned
+    /// zero and stamped it `safe_to_conclude_absent: true`, `trust:
+    /// "authoritative"`, minutes after `find_references` refused to certify an
+    /// absence on the same repository because this build wires no
+    /// language-server adapter for JavaScript.
+    #[test]
+    fn a_javascript_search_absence_is_inconclusive_while_a_python_one_still_certifies() {
+        let store = InMemoryGraph::new();
+        store
+            .upsert_entity(&module_entity(
+                LanguageId::JavaScript,
+                "express",
+                "lib/express.js",
+            ))
+            .unwrap();
+        store
+            .upsert_entity(&make_entity_in(
+                LanguageId::JavaScript,
+                "createETagGenerator",
+                "lib/utils.js",
+            ))
+            .unwrap();
+
+        // Positive control on the same call: a module that IS in the graph comes
+        // back populated and carries no scope observation, because an answer
+        // that returned a row proved the region can answer.
+        let found = parsed_response(
+            &handle_semantic_search(&search_args("express", Some("module")), &store).unwrap(),
+        );
+        assert_eq!(found["total_matches"], 1);
+        assert!(
+            found.get(crate::edge_coverage::EDGE_COVERAGE_KEY).is_none(),
+            "a populated answer needs no scope observation: {found}"
+        );
+
+        // The reported call, verbatim. The region is populated (one module), so
+        // what stops the certification is that nothing resolves the program
+        // behind these declarations, which is exactly what the stranger's own
+        // find_references had just said about the same repository.
+        let empty = parsed_response(
+            &handle_semantic_search(&search_args("utils", Some("module")), &store).unwrap(),
+        );
+        assert_eq!(empty["total_matches"], 0);
+        let coverage = &empty[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        assert_eq!(coverage["language"], "JavaScript");
+        assert_eq!(coverage["reference_enrichment"], "unsupported");
+        assert_eq!(
+            coverage["scope_entities"], 1,
+            "the kind-filtered absence states the coverage of that kind: {coverage}"
+        );
+        let negative =
+            crate::negative::negative_for("semantic_search", &empty, &ready_daemon_envelope(2))
+                .expect("an empty search carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], false);
+        assert_eq!(negative["trust"], "inconclusive");
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("entity_index_unresolved"),
+            "{negative}"
+        );
+
+        // The other direction on the same code path. Python is a language this
+        // build wires an adapter for, so a name nothing carries is still a
+        // certifiable absence and the fix has not degraded into marking
+        // everything uncertain.
+        let python = InMemoryGraph::new();
+        python
+            .upsert_entity(&module_entity(LanguageId::Python, "utils", "app/utils.py"))
+            .unwrap();
+        python
+            .upsert_entity(&make_entity_in(
+                LanguageId::Python,
+                "render_page",
+                "app/views.py",
+            ))
+            .unwrap();
+        let found = parsed_response(
+            &handle_semantic_search(&search_args("utils", Some("module")), &python).unwrap(),
+        );
+        assert_eq!(
+            found["total_matches"], 1,
+            "control: the module the Python graph holds is findable, so the absence below \
+             is a real absence rather than a broken filter"
+        );
+
+        let absent = parsed_response(
+            &handle_semantic_search(&search_args("zzz_not_a_symbol", None), &python).unwrap(),
+        );
+        assert_eq!(absent["total_matches"], 0);
+        let coverage = &absent[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        assert_eq!(coverage["language"], "Python");
+        assert_eq!(coverage["reference_enrichment"], "unknown");
+        assert_eq!(coverage["scope_entities"], 2);
+        let negative =
+            crate::negative::negative_for("semantic_search", &absent, &ready_daemon_envelope(2))
+                .expect("an empty search carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], true);
+        assert_eq!(negative["trust"], "authoritative");
+    }
+
+    /// A filter that selected a region the extractor never populated says
+    /// nothing about the repository, whatever language it is over.
+    #[test]
+    fn a_search_filtered_into_an_unpopulated_region_certifies_nothing() {
+        let store = InMemoryGraph::new();
+        store
+            .upsert_entity(&make_entity_in(
+                LanguageId::Python,
+                "render_page",
+                "app/views.py",
+            ))
+            .unwrap();
+
+        let empty = parsed_response(
+            &handle_semantic_search(&search_args("utils", Some("module")), &store).unwrap(),
+        );
+        assert_eq!(
+            empty[crate::edge_coverage::EDGE_COVERAGE_KEY]["scope_entities"],
+            0,
+            "this graph holds no module entity at all: {empty}"
+        );
+        let negative =
+            crate::negative::negative_for("semantic_search", &empty, &ready_daemon_envelope(1))
+                .expect("an empty search carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], false);
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("absence_scope_empty"),
+            "{negative}"
+        );
+    }
+
+    /// The neighborhood publishes the same observation, and a focal that did not
+    /// resolve names no language rather than borrowing one, so the
+    /// focal-not-in-graph gap stays the limiting factor a reader is handed.
+    #[test]
+    fn an_empty_neighborhood_publishes_the_scope_it_walked() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity_in(
+            LanguageId::JavaScript,
+            "createETagGenerator",
+            "lib/utils.js",
+        );
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        );
+        args.insert("direction".to_string(), serde_json::json!("in"));
+        let walked = parsed_response(&handle_graph_neighborhood(&args, &store).unwrap());
+        assert_eq!(walked["relation_count"], 0);
+        let coverage = &walked[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        assert_eq!(coverage["language"], "JavaScript");
+        assert_eq!(coverage["reference_enrichment"], "unsupported");
+        assert!(
+            coverage.get("scope_entities").is_none(),
+            "a walk counts no region, so it publishes no count: {coverage}"
+        );
+        let negative =
+            crate::negative::negative_for("graph_neighborhood", &walked, &ready_daemon_envelope(1))
+                .expect("an empty walk carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], false);
+
+        let mut missing = HashMap::new();
+        missing.insert(
+            "entity_id".to_string(),
+            serde_json::json!(EntityId::new().to_string()),
+        );
+        let unresolved = parsed_response(&handle_graph_neighborhood(&missing, &store).unwrap());
+        assert_eq!(
+            unresolved[crate::edge_coverage::EDGE_COVERAGE_KEY]["language"],
+            "no resolved language"
+        );
+        let negative = crate::negative::negative_for(
+            "graph_neighborhood",
+            &unresolved,
+            &ready_daemon_envelope(1),
+        )
+        .expect("an unresolved focal carries a negative");
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("focal_not_in_graph"),
+            "the focal miss stays the limiting factor: {negative}"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -233,6 +233,44 @@ pub(crate) fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<Str
     }
 }
 
+/// Whether `tool`'s ABSENCE claim is a statement about one language's extracted
+/// graph, and so cannot outrun what this build can resolve for that language.
+///
+/// Separate from [`absence_cross_file_classes`] because the two facts are
+/// independent: a tool can traverse no edge at all and still be claiming
+/// something about a language's graph. `semantic_search` is exactly that shape,
+/// and it is why FIR-2430 happened. It filters declarations by name, kind,
+/// language and role, declares no edge class, and therefore cleared the whole
+/// gate `find_references` had just refused to clear on the same repository in
+/// the same session: `semantic_search(query: "utils", kind: "module")` on
+/// expressjs/express certified `safe_to_conclude_absent: true` while
+/// `lib/utils.js` sat in the tree holding nine entities.
+///
+/// | tool | language-scoped | why |
+/// |---|---|---|
+/// | `semantic_search` | yes | "no declaration carries this name/kind" is a claim about what the extractor admitted as an entity for that language |
+/// | `find_dead_code_seeded` | yes | its seed match is the same name/kind filter over the same entity index |
+/// | `graph_neighborhood` | yes | an empty neighborhood for a focal that IS in the graph claims nothing reaches it, which is a claim about that language's edges |
+/// | `find_references`, `bulk_check_references`, `trace_data_flow`, `impact_analysis` | yes | already gated this way by FIR-2404; the flag records the fact rather than changing it |
+/// | `semantic_locate` | no | its payload is built by the daemon's own locate route and publishes no observation, so declaring a dependency here would make every empty ranking inconclusive on evidence nothing collected; its absence stays gated on complete embedding coverage, and its unnamed-ranking arm is never certifiable at all |
+/// | `dead_code` | no | its empty result is the INVERSE claim ("nothing unreachable"), and a language this build cannot resolve produces MORE candidates rather than fewer |
+/// | `entity_history` | no | reads change history, which no language server contributes to |
+///
+/// A tool absent from this list is not language-scoped, so a new retrieval tool
+/// starts with no authority to inherit and has to declare what it reads.
+fn absence_is_language_scoped(tool: &str) -> bool {
+    matches!(
+        tool,
+        "find_references"
+            | "bulk_check_references"
+            | "trace_data_flow"
+            | "impact_analysis"
+            | "semantic_search"
+            | "find_dead_code_seeded"
+            | "graph_neighborhood"
+    )
+}
+
 /// The default reference edge classes, matching `default_reference_kinds` on the
 /// handler side. Kept as the fallback for a payload that does not report the
 /// scope it ran with, because assuming a narrower scope than the query used
@@ -285,14 +323,25 @@ pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
     }
 }
 
-/// Why the graph cannot certify this absence over the edge classes the query
-/// reads, or `None` when every class the focal could plausibly be reached
-/// through is demonstrably present.
+/// Why the graph cannot certify this absence, or `None` when every substrate the
+/// claim actually rests on is demonstrably present.
 ///
-/// Two gates, and an answer has to clear both. Every load-bearing requested class
-/// must be observed present ([`load_bearing_classes`] says which, and why the set
-/// is narrower than it looks), and the language must be one this build can
-/// produce reference edges for at all.
+/// This is the one gate. Every negative-capable tool passes through it and is
+/// checked against what it DECLARES it reads: [`absence_cross_file_classes`] for
+/// the edges an absence is read off, and [`absence_is_language_scoped`] for
+/// whether the claim is about a language's extracted graph at all. A tool that
+/// declares either and publishes no observation is inconclusive by construction,
+/// so authority can never be inherited by a tool that has not earned it. Before
+/// FIR-2430 the whole gate was skipped for any tool declaring no edge class,
+/// which is how `semantic_search` reached `structural_authoritative` from daemon
+/// health alone, minutes after `find_references` refused the same absence on the
+/// same repository.
+///
+/// Three gates, and an answer has to clear all of them. Every load-bearing
+/// requested class must be observed present ([`load_bearing_classes`] says which,
+/// and why the set is narrower than it looks); a filter must have selected a
+/// region the index actually populated; and the language must be one this build
+/// can resolve at all.
 ///
 /// The second gate is what FIR-2404 added. A witness proves the extractor links
 /// SOME class across files for the language; it never proved the language's
@@ -324,9 +373,10 @@ pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
 /// `absent` for every class and a language's zero to `absent` for that language;
 /// [`crate::edge_coverage`] can then be retired, since it is called from exactly
 /// three payload builders.
-fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
+fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
     let requested = absence_cross_file_classes(tool, payload);
-    if requested.is_empty() {
+    let language_scoped = absence_is_language_scoped(tool);
+    if requested.is_empty() && !language_scoped {
         return None;
     }
     let named = requested.join(", ");
@@ -335,11 +385,18 @@ fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
         .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
         .and_then(Value::as_object)
     else {
-        return Some(format!(
-            "edge_coverage_unreported: this answer did not report whether the graph holds \
-             cross-file {named} edges, so an empty result cannot be distinguished from a graph \
-             that could not have found a reference in the first place"
-        ));
+        return Some(if requested.is_empty() {
+            "absence_coverage_unreported: this answer did not report which languages the absence \
+             claim spans or whether this build can resolve their programs, so an empty result \
+             cannot be distinguished from a scope the extractor never populated"
+                .to_string()
+        } else {
+            format!(
+                "edge_coverage_unreported: this answer did not report whether the graph holds \
+                 cross-file {named} edges, so an empty result cannot be distinguished from a graph \
+                 that could not have found a reference in the first place"
+            )
+        });
     };
     let language = coverage
         .get("language")
@@ -348,56 +405,90 @@ fn edge_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
         .unwrap_or("an unreported language");
     let states = coverage.get("classes").and_then(Value::as_object);
 
-    let required = load_bearing_classes(&requested);
-    let absent = classes_in_state(&required, states, "absent");
-    let unknown = classes_in_state(&required, states, "unknown");
-    let present = classes_in_state(&requested, states, "present");
-
     let mut gaps: Vec<String> = Vec::new();
-    if !absent.is_empty() {
-        let missing = absent.join(", ");
-        // Naming what IS present matters as much as naming what is missing. The
-        // reader's next question after "no imports edges" is "then what did the
-        // 258 entities this scan examined prove", and leaving that unanswered is
-        // how a present sibling class came to look like coverage for the absent
-        // one in the first place.
-        let observed = if present.is_empty() {
-            String::new()
-        } else {
-            format!(
-                " (cross-file {} edges are present and do not stand in for {missing}: an entity \
-                 other files reach only through {missing} is invisible to a graph holding none)",
-                present.join(", ")
-            )
-        };
+
+    if !requested.is_empty() {
+        let required = load_bearing_classes(&requested);
+        let absent = classes_in_state(&required, states, "absent");
+        let unknown = classes_in_state(&required, states, "unknown");
+        let present = classes_in_state(&requested, states, "present");
+
+        if !absent.is_empty() {
+            let missing = absent.join(", ");
+            // Naming what IS present matters as much as naming what is missing. The
+            // reader's next question after "no imports edges" is "then what did the
+            // 258 entities this scan examined prove", and leaving that unanswered is
+            // how a present sibling class came to look like coverage for the absent
+            // one in the first place.
+            let observed = if present.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " (cross-file {} edges are present and do not stand in for {missing}: an \
+                     entity other files reach only through {missing} is invisible to a graph \
+                     holding none)",
+                    present.join(", ")
+                )
+            };
+            gaps.push(format!(
+                "cross_file_edges_absent: the graph holds no cross-file {missing} edges for \
+                 {language}{observed}, so a use that reaches the target through {missing} could \
+                 not have been found and an empty result says nothing about whether the target is \
+                 used; the gap is in extraction/enrichment for that language, not in the code"
+            ));
+        } else if !unknown.is_empty()
+            || coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true)
+        {
+            gaps.push(format!(
+                "edge_coverage_unknown: whether the graph holds cross-file {named} edges for \
+                 {language} could not be established, so an empty result may mean the query had \
+                 no edges to answer from rather than that the target is unused"
+            ));
+        }
+    }
+
+    // A filter that selected a region the graph does not populate answers every
+    // query in that region identically, so its empty result is a fact about the
+    // index. This is the gate the `kind` filter needed: certifying "no module
+    // named utils" is a statement about the modules the extractor admitted, and
+    // it cannot be read as one about the repository until the region holds
+    // something. Reported only when the answer measured it, because an
+    // unmeasured region is unknown rather than empty.
+    if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
         gaps.push(format!(
-            "cross_file_edges_absent: the graph holds no cross-file {missing} edges for \
-             {language}{observed}, so a use that reaches the target through {missing} could not \
-             have been found and an empty result says nothing about whether the target is used; \
-             the gap is in extraction/enrichment for that language, not in the code"
-        ));
-    } else if !unknown.is_empty()
-        || coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true)
-    {
-        gaps.push(format!(
-            "edge_coverage_unknown: whether the graph holds cross-file {named} edges for \
-             {language} could not be established, so an empty result may mean the query had no \
-             edges to answer from rather than that the target is unused"
+            "absence_scope_empty: the graph holds no entity at all under the filter this query \
+             applied for {language}, so an empty result describes the region the index populated \
+             rather than the code"
         ));
     }
 
-    // Independent of what the scan measured. A class that cannot be produced at
-    // all is not a class that happened to come back empty, and no amount of
-    // scanning or re-indexing will ever move it, so an absence over a language
-    // this build cannot enrich is never certifiable however healthy its calls and
-    // imports look.
+    // Independent of what any scan measured. A language this build cannot
+    // resolve is not one that happened to come back empty, and no amount of
+    // scanning or re-indexing will ever move it.
+    //
+    // The wording splits on what the tool actually claimed, because a correct
+    // verdict beside an unrelated reason is the failure this module exists to
+    // prevent. For a tool reading reference edges the limit is that those edges
+    // cannot exist; for a tool reading the entity index the limit is that
+    // nothing resolved the program behind the declarations it filtered, so a
+    // name-and-kind miss cannot separate a declaration the repository lacks from
+    // one the extractor never admitted as an entity of that kind.
     if coverage.get("reference_enrichment").and_then(Value::as_str) == Some("unsupported") {
-        gaps.push(format!(
-            "reference_enrichment_unsupported: this build wires no language-server adapter for \
-             {language}, so cross-file reference and override edges cannot exist for it at all, \
-             and an empty result cannot separate a symbol nothing uses from one this graph could \
-             never have linked"
-        ));
+        gaps.push(if requested.is_empty() {
+            format!(
+                "entity_index_unresolved: this build wires no language-server adapter for \
+                 {language}, so nothing resolves the program behind its parsed declarations, and \
+                 an empty name/kind filter cannot separate a declaration the repository does not \
+                 have from one the extractor did not admit as an entity of that kind"
+            )
+        } else {
+            format!(
+                "reference_enrichment_unsupported: this build wires no language-server adapter \
+                 for {language}, so cross-file reference and override edges cannot exist for it \
+                 at all, and an empty result cannot separate a symbol nothing uses from one this \
+                 graph could never have linked"
+            )
+        });
     }
 
     (!gaps.is_empty()).then(|| gaps.join("; "))
@@ -441,14 +532,19 @@ fn classes_in_state<'a>(
 /// the claim rests on the first fact rather than the second.
 pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> Vec<String> {
     let requested = absence_cross_file_classes(tool, payload);
-    if requested.is_empty() {
+    let language_scoped = absence_is_language_scoped(tool);
+    if requested.is_empty() && !language_scoped {
         return Vec::new();
     }
     let Some(coverage) = payload
         .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
         .and_then(Value::as_object)
     else {
-        return vec!["edge_coverage:unreported".to_string()];
+        return vec![if requested.is_empty() {
+            "absence_coverage:unreported".to_string()
+        } else {
+            "edge_coverage:unreported".to_string()
+        }];
     };
     let states = coverage.get("classes").and_then(Value::as_object);
     let mut labels: Vec<String> = requested
@@ -458,6 +554,9 @@ pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> V
             state => Some(format!("edge_coverage:{class}_{state}")),
         })
         .collect();
+    if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
+        labels.push("absence_coverage:scope_empty".to_string());
+    }
     if coverage.get("reference_enrichment").and_then(Value::as_str) == Some("unsupported") {
         labels.push("edge_coverage:reference_enrichment_unsupported".to_string());
     }
@@ -808,6 +907,85 @@ fn degraded_signals(tool: &str, payload: &Value, envelope: &Envelope) -> Vec<Str
     labels
 }
 
+/// Which substrate's completeness this verdict actually rests on.
+///
+/// Published beside the verdict because the pairing FIR-2430 objected to was a
+/// true statement of the wrong fact: the express negative certified an absence
+/// in the same sentence that read "semantic coverage unknown", and both halves
+/// were accurate. Embedding coverage was never what backed that claim. A
+/// negative that names its basis and recites THAT can no longer put an unknown
+/// coverage beside a certification the coverage did not back.
+fn coverage_basis(class: NegativeClass) -> &'static str {
+    match class {
+        NegativeClass::Semantic => "embeddings",
+        NegativeClass::Structural => "graph_structure",
+    }
+}
+
+/// The coverage the verdict rests on, as the clause [`build_advice`] recites.
+///
+/// The embedding wording is unchanged for the tools embedding coverage actually
+/// gates. A structural claim recites the observation its own gate read, and when
+/// no observation is in hand it recites the graph state the structural gate
+/// checked, which is exactly as much as that verdict knows.
+fn coverage_clause(class: NegativeClass, payload: &Value, envelope: &Envelope) -> String {
+    match class {
+        NegativeClass::Semantic => match &envelope.semantic_coverage {
+            Some(coverage) if coverage.total > 0 => {
+                let percent = (coverage.indexed as f64 / coverage.total as f64) * 100.0;
+                format!("semantic coverage {percent:.1}%")
+            }
+            Some(_) => "semantic coverage complete".to_string(),
+            None => "semantic coverage unknown".to_string(),
+        },
+        NegativeClass::Structural => structural_coverage_clause(payload, envelope),
+    }
+}
+
+/// What a structural absence observed about the graph it is claiming over.
+fn structural_coverage_clause(payload: &Value, envelope: &Envelope) -> String {
+    if let Some(coverage) = payload
+        .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+        .and_then(Value::as_object)
+    {
+        let language = coverage
+            .get("language")
+            .and_then(Value::as_str)
+            .filter(|language| !language.trim().is_empty())
+            .unwrap_or("an unreported language");
+        let classes = coverage
+            .get("classes")
+            .and_then(Value::as_object)
+            .map(|states| {
+                states
+                    .iter()
+                    .map(|(class, state)| {
+                        format!("{class} {}", state.as_str().unwrap_or("unknown"))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .filter(|rendered| !rendered.is_empty())
+            .unwrap_or_else(|| "this answer reads no edge class".to_string());
+        let enrichment = match coverage.get("reference_enrichment").and_then(Value::as_str) {
+            Some("unsupported") => "no language-server adapter for it in this build",
+            Some("available") => "a language server available for it",
+            Some("no_language_server") => {
+                "an adapter wired for it but no language server installed"
+            }
+            _ => "its language-server availability unprobed",
+        };
+        return format!("graph coverage for {language} ({classes}; {enrichment})");
+    }
+    match (
+        envelope.graph_state.initialized,
+        envelope.graph_state.loaded,
+    ) {
+        (Some(true), Some(true)) => "a graph reported initialized and loaded".to_string(),
+        _ => "an unconfirmed graph state".to_string(),
+    }
+}
+
 /// A human sentence spelling out "absent as-of X, coverage Y%, degraded Z" and
 /// the actionable consequence, so the negative is legible without cross-reading
 /// the envelope. `subject` and `consequence` are passed rather than read off a
@@ -819,20 +997,13 @@ fn degraded_signals(tool: &str, payload: &Value, envelope: &Envelope) -> Vec<Str
 fn build_advice(
     subject: &str,
     consequence: &str,
+    coverage: &str,
     envelope: &Envelope,
     degraded: &[String],
 ) -> String {
     let as_of = match &envelope.graph_as_of {
         Some(value) => format!("graph as-of {value}"),
         None => "an unversioned graph snapshot".to_string(),
-    };
-    let coverage = match &envelope.semantic_coverage {
-        Some(coverage) if coverage.total > 0 => {
-            let percent = (coverage.indexed as f64 / coverage.total as f64) * 100.0;
-            format!("semantic coverage {percent:.1}%")
-        }
-        Some(_) => "semantic coverage complete".to_string(),
-        None => "semantic coverage unknown".to_string(),
     };
     let degraded = if degraded.is_empty() {
         "no degraded signals".to_string()
@@ -1077,13 +1248,14 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     let (mut trustworthy, trust_reason) = envelope.negative_trust(spec.class);
     let mut trust_reason = trust_reason.to_string();
 
-    // The edge-class gate leads every other gap because it is the one that can
+    // The coverage gate leads every other gap because it is the one that can
     // make the query structurally unable to answer. A graph holding no
-    // cross-file edges of the class a reference query reads returns an empty
-    // array for every symbol in it, healthy or not, so no later gap is the
+    // cross-file edges of the class a reference query reads, or no resolved
+    // program behind the declarations a name filter reads, returns an empty
+    // answer for every symbol in it, healthy or not, so no later gap is the
     // limiting factor when this one applies and none of them may be reported as
     // if it were.
-    if let Some(gap) = edge_coverage_gap(tool, payload) {
+    if let Some(gap) = absence_coverage_gap(tool, payload) {
         push_gap(&mut trustworthy, &mut trust_reason, gap);
     }
 
@@ -1277,6 +1449,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     };
 
     let degraded_signals = degraded_signals(tool, payload, envelope);
+    let coverage_clause = coverage_clause(spec.class, payload, envelope);
 
     let mut negative = Map::new();
     negative.insert("kind".to_string(), json!(kind));
@@ -1298,11 +1471,19 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         envelope.graph_as_of.clone().unwrap_or(Value::Null),
     );
     negative.insert("semantic_coverage".to_string(), coverage_value(envelope));
+    // Which coverage the verdict rests on. `semantic_coverage` above stays what
+    // it always was, the envelope's embedding reading, and this says whether it
+    // is the reading that decided anything here.
+    negative.insert(
+        "coverage_basis".to_string(),
+        json!(coverage_basis(spec.class)),
+    );
     negative.insert(
         "advice".to_string(),
         json!(build_advice(
             subject,
             &consequence,
+            &coverage_clause,
             envelope,
             &degraded_signals
         )),
@@ -1435,10 +1616,15 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
     );
     negative.insert("semantic_coverage".to_string(), coverage_value(envelope));
     negative.insert(
+        "coverage_basis".to_string(),
+        json!(coverage_basis(NegativeClass::Structural)),
+    );
+    negative.insert(
         "advice".to_string(),
         json!(build_advice(
             subject,
             &consequence,
+            &coverage_clause(NegativeClass::Structural, &Value::Null, envelope),
             envelope,
             &degraded_signals
         )),
@@ -1503,6 +1689,55 @@ mod tests {
             "reference_enrichment": "unknown",
             "budget_exhausted": false,
             "entities_examined": 2,
+        })
+    }
+
+    /// The scope observation a tool that traverses no edge publishes for an
+    /// absence, over a language this build CAN resolve.
+    ///
+    /// The shape is the one [`crate::edge_coverage::observe_absence_scope`]
+    /// emits: no edge classes, because this claim is not about edges, and the
+    /// one fact the verdict rests on. Without it in the payload an absence has
+    /// no evidence that the query could have found anything, which is the
+    /// FIR-2430 failure, so every fixture asserting an authoritative absence for
+    /// one of these tools carries it.
+    fn resolvable_language_scope(scope_entities: Option<usize>) -> Value {
+        let mut observation = json!({
+            "scope": "absence_scope",
+            "language": "Python",
+            "requested_classes": [],
+            "classes": {},
+            "cross_file_classes": [],
+            "reference_enrichment": "unknown",
+            "budget_exhausted": false,
+            "entities_examined": 0,
+            "scan": "skipped_no_edge_dependency",
+        });
+        if let Some(count) = scope_entities {
+            observation["scope_entities"] = json!(count);
+        }
+        observation
+    }
+
+    /// The same observation over a language this build wires no adapter for:
+    /// the express shape, where `imports` and `references` cannot exist at all.
+    fn unresolvable_language_scope(scope_entities: Option<usize>) -> Value {
+        let mut observation = resolvable_language_scope(scope_entities);
+        observation["language"] = json!("JavaScript");
+        observation["reference_enrichment"] = json!("unsupported");
+        observation
+    }
+
+    /// An empty `semantic_search` page over `scope`, the payload shape the
+    /// handler builds for a filter that matched no declaration.
+    fn empty_search_page(scope: Value) -> Value {
+        json!({
+            "query": "utils",
+            "limit": 20,
+            "total_matches": 0,
+            "truncated": false,
+            "results": [],
+            "edge_coverage": scope,
         })
     }
 
@@ -1664,8 +1899,10 @@ mod tests {
         // made every empty search report `coverage_unknown` and advise
         // "re-check after embedding is complete" — including on a store whose
         // embeddings were complete. It answers to the graph gate instead, which
-        // is the substrate it actually reads.
-        let payload = json!({ "results": [] });
+        // is the substrate it actually reads. Since FIR-2430 that substrate has
+        // to be OBSERVED rather than assumed, so the page carries the scope its
+        // filter selected; embedding coverage is still not what decides.
+        let payload = empty_search_page(resolvable_language_scope(Some(12)));
         let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
             .expect("empty results yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
@@ -1674,11 +1911,211 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("structural_authoritative"));
+        assert_eq!(negative["semantic_coverage"], Value::Null);
+        assert_eq!(negative["coverage_basis"], json!("graph_structure"));
         // Negative control on the same tool: an unloaded graph must still be
         // inconclusive, so the gate is one that can fail.
         let unloaded = Envelope::daemon().with_health(&json!({ "graph_loaded": false }));
         let negative = negative_for("semantic_search", &payload, &unloaded).unwrap();
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+    }
+
+    #[test]
+    fn a_javascript_search_absence_is_not_certified_without_reference_enrichment() {
+        // FIR-2430, the reported payload. `semantic_search(query: "utils",
+        // kind: "module")` on expressjs/express came back
+        // `safe_to_conclude_absent: true`, `trust: "authoritative"` while
+        // `lib/utils.js` sat in the tree holding nine entities. Minutes earlier
+        // `find_references` had refused to certify an absence on the same
+        // repository in the same session, because this build wires no
+        // language-server adapter for JavaScript. The gate reached one tool and
+        // not its sibling.
+        let payload = empty_search_page(unresolvable_language_scope(Some(29)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("entity_index_unresolved"),
+            "the limiting factor leads the reason: {reason}"
+        );
+        assert!(
+            reason.contains("JavaScript"),
+            "the reason names the language it is about: {reason}"
+        );
+        // The reason has to be about what this tool actually read. A name/kind
+        // filter traverses no reference edge, so borrowing the sibling's
+        // sentence would hand back a correct verdict beside an explanation of a
+        // mechanism this query never used.
+        assert!(
+            !reason.contains("cross-file reference and override edges"),
+            "semantic_search reads no edge, so its reason must not claim one: {reason}"
+        );
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(advice.contains("Absence is NOT authoritative"), "{advice}");
+        assert!(
+            advice.contains("Limiting factor: entity_index_unresolved"),
+            "{advice}"
+        );
+        assert!(
+            negative["degraded_signals"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("edge_coverage:reference_enrichment_unsupported")),
+            "the shortfall the verdict rests on is disclosed: {negative}"
+        );
+    }
+
+    #[test]
+    fn a_resolvable_language_still_certifies_a_genuinely_absent_declaration() {
+        // The other direction, and the regression bar FIR-2404 set: the fix must
+        // not degrade into marking everything inconclusive. Python is a language
+        // this build wires an adapter for, so an empty name filter over a
+        // populated region is still a certifiable absence.
+        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        assert_eq!(negative["trust"], json!("authoritative"));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("structural_authoritative"));
+    }
+
+    #[test]
+    fn a_kind_filter_that_selected_an_empty_region_certifies_nothing() {
+        // The second half of the FIR-2430 contract: a kind-filtered absence is a
+        // statement about the kind the index holds. Certifying "no schema named
+        // X" against a graph the extractor admitted no schema entity into at all
+        // answers for the index and not for the repository, and the language
+        // being one this build resolves does not change that.
+        let payload = empty_search_page(resolvable_language_scope(Some(0)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(reason.starts_with("absence_scope_empty"), "{reason}");
+        assert!(negative["degraded_signals"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("absence_coverage:scope_empty")));
+        // Positive control on the same payload shape: one entity in the region
+        // and the same absence certifies, so the gate reads the count.
+        let populated = empty_search_page(resolvable_language_scope(Some(1)));
+        let negative = negative_for("semantic_search", &populated, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+    }
+
+    #[test]
+    fn an_authoritative_absence_never_recites_a_coverage_it_did_not_rest_on() {
+        // FIR-2430 contract item 3. The express envelope certified an absence in
+        // the same sentence that read "semantic coverage unknown". Both halves
+        // were true and the pairing was still wrong, because embedding coverage
+        // was never what backed a structural claim. A negative names the basis
+        // its verdict rests on and recites THAT, so an unknown coverage can no
+        // longer sit beside a certification it did not back.
+        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(negative["trust"], json!("authoritative"));
+        assert_eq!(negative["semantic_coverage"], Value::Null);
+        assert_eq!(negative["coverage_basis"], json!("graph_structure"));
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            !advice.contains("semantic coverage"),
+            "a structural verdict must not recite embedding coverage: {advice}"
+        );
+        assert!(
+            advice.contains("graph coverage for Python"),
+            "it recites the observation its own gate read: {advice}"
+        );
+
+        // The embedding-backed tools keep reciting embedding coverage, because
+        // for them it IS the basis.
+        let ranked = json!({ "query": "auth", "results": [], "total_ranked": 0 });
+        let negative = negative_for(
+            "semantic_locate",
+            &ranked,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("empty results yields a negative");
+        assert_eq!(negative["coverage_basis"], json!("embeddings"));
+        assert!(negative["advice"]
+            .as_str()
+            .unwrap()
+            .contains("semantic coverage 100.0%"));
+    }
+
+    #[test]
+    fn the_neighborhood_and_the_seeded_scan_answer_to_the_same_gate() {
+        // The two siblings the same audit found. An empty neighborhood claims
+        // nothing reaches the focal, which for an incoming walk is the claim
+        // `find_references` makes; an empty seed match is the same name filter
+        // over the same entity index `semantic_search` reads. Both were
+        // certifying from daemon health alone.
+        let mut neighborhood = neighborhood_payload("in", 0);
+        neighborhood["edge_coverage"] = unresolvable_language_scope(None);
+        let negative = negative_for(
+            "graph_neighborhood",
+            &neighborhood,
+            &structural_ready_envelope(),
+        )
+        .expect("an indexed focal with no neighbors carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("entity_index_unresolved"));
+
+        let seeded = json!({
+            "query": "utils",
+            "total_searched": 0,
+            "candidates": [],
+            "edge_coverage": unresolvable_language_scope(Some(29)),
+        });
+        let negative = negative_for(
+            "find_dead_code_seeded",
+            &seeded,
+            &structural_ready_envelope(),
+        )
+        .expect("an empty seed match carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("entity_index_unresolved"));
+
+        // Positive control for both: a resolvable language certifies, so
+        // neither gate is one that always fires.
+        let mut neighborhood = neighborhood_payload("in", 0);
+        neighborhood["edge_coverage"] = resolvable_language_scope(None);
+        assert_eq!(
+            negative_for(
+                "graph_neighborhood",
+                &neighborhood,
+                &structural_ready_envelope()
+            )
+            .unwrap()["safe_to_conclude_absent"],
+            json!(true)
+        );
+        let seeded = json!({
+            "query": "utils",
+            "total_searched": 0,
+            "candidates": [],
+            "edge_coverage": resolvable_language_scope(Some(29)),
+        });
+        assert_eq!(
+            negative_for(
+                "find_dead_code_seeded",
+                &seeded,
+                &structural_ready_envelope()
+            )
+            .unwrap()["safe_to_conclude_absent"],
+            json!(true)
+        );
     }
 
     #[test]
@@ -1769,7 +2206,7 @@ mod tests {
             "initialized": true,
             "graph_entity_count": 0,
         }));
-        let payload = json!({ "results": [] });
+        let payload = empty_search_page(resolvable_language_scope(Some(12)));
         let negative = negative_for("semantic_search", &payload, &empty_graph)
             .expect("empty results yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
@@ -2083,20 +2520,74 @@ mod tests {
         );
     }
 
-    /// Tools that read no edges must not be gated by an edge observation they
-    /// have no way to publish. `semantic_locate` ranks embeddings and
-    /// `semantic_search` filters declarations, so their absences answer to their
-    /// own substrates and stay reachable.
+    /// The one gate reads two independent declarations, and a tool that
+    /// traverses no edge is still gated when its absence is a claim about a
+    /// language's extracted graph (FIR-2430). Before this, declaring no edge
+    /// class skipped the gate entirely, which is how `semantic_search` reached
+    /// `structural_authoritative` from daemon health alone.
     #[test]
-    fn tools_that_traverse_no_edges_are_not_gated_by_edge_coverage() {
-        assert!(edge_coverage_gap("semantic_locate", &json!({ "results": [] })).is_none());
-        assert!(edge_coverage_gap("semantic_search", &json!({ "results": [] })).is_none());
-        assert!(edge_coverage_gap("graph_neighborhood", &json!({ "relations": [] })).is_none());
-        assert!(edge_coverage_gap("entity_history", &json!([])).is_none());
-        assert!(edge_coverage_gap("dead_code", &json!([])).is_none());
+    fn a_tool_that_traverses_no_edges_is_still_gated_on_its_language_scope() {
+        // Language-scoped and publishing nothing: inconclusive by construction,
+        // and the reason names the missing observation rather than an edge class
+        // the tool never reads.
+        for tool in [
+            "semantic_search",
+            "find_dead_code_seeded",
+            "graph_neighborhood",
+        ] {
+            let gap = absence_coverage_gap(tool, &json!({ "results": [] }))
+                .unwrap_or_else(|| panic!("{tool} is language-scoped and must be gated"));
+            assert!(
+                gap.starts_with("absence_coverage_unreported"),
+                "{tool} names the missing scope observation: {gap}"
+            );
+            assert!(
+                !gap.contains("cross-file"),
+                "{tool} reads no edge class, so the reason must not name one: {gap}"
+            );
+        }
+        // Not language-scoped: `semantic_locate` publishes no observation from
+        // the daemon's own locate route and answers to embedding coverage;
+        // `dead_code`'s empty result is the inverse claim; `entity_history`
+        // reads change history. None of them may be gated on evidence nothing
+        // collected.
+        assert!(absence_coverage_gap("semantic_locate", &json!({ "results": [] })).is_none());
+        assert!(absence_coverage_gap("entity_history", &json!([])).is_none());
+        assert!(absence_coverage_gap("dead_code", &json!([])).is_none());
         // And an unknown tool inherits nothing: it declares no dependency, so it
         // is neither gated nor granted authority by this map.
-        assert!(edge_coverage_gap("some_future_tool", &json!({})).is_none());
+        assert!(absence_coverage_gap("some_future_tool", &json!({})).is_none());
+    }
+
+    /// The language-scope map is the contract, asserted directly rather than
+    /// only through the tools that consume it today.
+    #[test]
+    fn the_language_scope_map_names_every_absence_that_claims_over_a_language() {
+        for tool in [
+            "find_references",
+            "bulk_check_references",
+            "trace_data_flow",
+            "impact_analysis",
+            "semantic_search",
+            "find_dead_code_seeded",
+            "graph_neighborhood",
+        ] {
+            assert!(
+                absence_is_language_scoped(tool),
+                "{tool}'s absence is a claim about one language's extracted graph"
+            );
+        }
+        for tool in [
+            "semantic_locate",
+            "dead_code",
+            "entity_history",
+            "some_future_tool",
+        ] {
+            assert!(
+                !absence_is_language_scoped(tool),
+                "{tool} must not be gated on a language scope it never claims over"
+            );
+        }
     }
 
     /// The map is the contract, so it is asserted directly rather than only
@@ -2499,7 +2990,7 @@ mod tests {
             entities.push(json!({ "id": focal, "name": format!("neighbor{index}") }));
             relations.push(json!({ "src": focal, "dst": focal, "direction": "outgoing" }));
         }
-        json!({
+        let mut payload = json!({
             "focal_id": focal,
             "direction": direction,
             "depth": 2,
@@ -2507,7 +2998,15 @@ mod tests {
             "relation_count": relations.len(),
             "entities": entities,
             "relations": relations,
-        })
+        });
+        // The handler observes the focal's language on every walk that expanded
+        // no edge, so the fixture does too. Scoped without a count: a walk
+        // measures no region, and a count it did not take must not be published
+        // as a zero.
+        if relations.is_empty() {
+            payload["edge_coverage"] = resolvable_language_scope(None);
+        }
+        payload
     }
 
     /// The neighborhood always returns the focal itself, so keying its absence


### PR DESCRIPTION
`semantic_search` could certify an absence because the absence gate was entered only by tools that declared a cross-file edge class, and `semantic_search` declares none. Every negative-capable tool whose answer carries a payload now passes through one gate that reads two independent declarations: the edge classes an absence is read off, and whether the absence is a claim about one language's extracted graph at all.

## Mechanism

`crates/kin-mcp/src/negative.rs` `edge_coverage_gap` opened with `if requested.is_empty() { return None; }`, and `absence_cross_file_classes` (`crates/kin-mcp/src/negative.rs:217`) returns an empty vector for `semantic_search`. So the whole gate, including the `reference_enrichment` half kin#905 added for FIR-2404, was skipped, and the verdict fell through to `Envelope::negative_trust(NegativeClass::Structural)` (`crates/kin-mcp/src/envelope.rs:939`), which answers `structural_authoritative` from daemon health alone.

That is the entire distance between the two calls the stranger run made minutes apart on expressjs/express in one session. `find_references` on `createETagGenerator` refused to certify with `reference_enrichment: "unsupported"` and `trust: "inconclusive"`, correctly. `semantic_search(query: "utils", kind: "module")` certified `safe_to_conclude_absent: true`, `trust: "authoritative"`, `semantic_coverage: null`, while `lib/utils.js` sat in the tree holding nine entities.

It was not a missing case in a table. It was the gate's entry condition, which made "declares no edge class" mean "needs no evidence" rather than "reads a different substrate".

## The fix

`absence_is_language_scoped` (`crates/kin-mcp/src/negative.rs:261`) is the second declaration, with a per-tool table and its exclusions in the doc comment. `absence_coverage_gap` (`:376`) is the one gate, renamed from `edge_coverage_gap` because it now gates more than edges: load-bearing classes (wording unchanged), a filter region the index never populated, and language resolvability. The enrichment reason splits on what the tool actually read, so a name filter is never handed the reference-edge sentence for a mechanism it never used.

`edge_coverage::observe_absence_scope` (`crates/kin-mcp/src/edge_coverage.rs:327`) is the observation for a claim that traverses no edge: the languages it spans, their enrichment, and the entity count of the filter's own region. It pays no witness scan, because that scan measures nothing those verdicts rest on. `semantic_search` (`crates/kin-mcp/src/handlers/entities.rs:99`), `find_dead_code_seeded` (`:2774`) and `graph_neighborhood` (`:3580`) publish it on the empty path only.

A negative also names the coverage its verdict rests on and recites that one (`coverage_basis` at `crates/kin-mcp/src/negative.rs:918`, `structural_coverage_clause` at `:946`).

## Tool by tool

| tool | negative kind | edge classes declared | gate before | gate after |
|---|---|---|---|---|
| `semantic_search` | `no_entity_match` | none | **no** | **yes** |
| `find_dead_code_seeded` | `no_seed_match` | none | **no** | **yes** |
| `graph_neighborhood` | `no_neighbors`, `focal_not_in_graph`, `no_traversal` | none | **no** | **yes** |
| `find_references` | `no_references` | the query's `relation_kinds` | yes | yes, unchanged |
| `bulk_check_references` | `reachability_verdicts` | the query's `relation_kinds` | yes | yes, unchanged |
| `trace_data_flow` | `no_flow` | calls, imports, references | yes | yes, unchanged |
| `semantic_locate` | `no_ranked_match`, `no_named_match` | none | no | no, by declaration |
| `dead_code` | `no_dead_code` | none | no | no, deliberately |
| `entity_history` | `no_history` | none | no | no, deliberately |

`semantic_locate` is the one that could not be routed honestly here. Its payload is built by the daemon's own locate route in `crates/kin-daemon/src/api.rs`, not by `handlers/entities.rs`, so it publishes no observation, and declaring a dependency it cannot back would make every empty ranking inconclusive on evidence nothing collected. It stays gated on complete embedding coverage, and its unnamed-ranking arm is never certifiable at any coverage. `dead_code`'s empty result is the inverse claim, so a gate there would be wrong-signed. `entity_history` reads change history.

`resolution_miss_for` (`crates/kin-mcp/src/negative.rs:1557`), which qualifies `impact_analysis` / `semantic_diff` / `semantic_review` `scope_not_resolved`, the `focal_not_resolved` arms of `find_references` and `trace_data_flow`, and `kin_provenance_query` `entity_not_resolved`, is unchanged. A resolution miss carries no payload at all, so there is nowhere to publish an observation without changing the error wire shape, and making the error body JSON would route it to `negative_for` instead, which returns `None` for it and would delete the negative entirely. That family needs an envelope-level language fact and is a separate change.

## Contract item 3

The ticket asks that `semantic_coverage: null` and `trust: "authoritative"` never co-occur. This PR implements the justification, not the literal rule, and the difference is worth stating.

`envelope.semantic_coverage` is null for every `semantic_search` call on the MCP path by construction: `Envelope::with_health` (`crates/kin-mcp/src/envelope.rs:811`) never sets it, and `with_payload_metadata` (`:856`) lifts it from a key the search payload does not carry. A blanket rule would make `semantic_search` unable to certify any absence ever, which makes contract item 4 unsatisfiable in production and would leave the Python fixture asserting behavior the product cannot produce.

Instead a negative names its basis and recites that coverage. The express sentence is gone in both directions:

- JavaScript: `...with graph coverage for JavaScript (this answer reads no edge class; no language-server adapter for it in this build) and degraded signals [edge_coverage:reference_enrichment_unsupported]. Absence is NOT authoritative...`
- Python: `...with graph coverage for Python (this answer reads no edge class; its language-server availability unprobed) and no degraded signals. Absence is authoritative...`

Under the old code that same Python payload read `...with semantic coverage unknown and no degraded signals. Absence is authoritative: safe to treat the target as genuinely absent/unused.` That exact string is what falsification F4 printed.

If the literal rule is wanted instead, it is a one-line change that turns `semantic_search` absences permanently inconclusive.

## Falsification

Eight falsifications, each applied to the committed code, run to completion, and reverted; full output and exit codes read from files, never through a pipe. Restored tree re-verified green before commit.

| # | what was broken | observed |
|---|---|---|
| F1 | enrichment gate no longer reaches existence claims | EXIT=101, the 4 enrichment guards failed |
| F2 | empty-region gate disabled | EXIT=101, exactly the 2 scope guards failed |
| F3 | gate entry reverted to the literal pre-fix condition | EXIT=101, 7 failed |
| F4 | a structural verdict recites embedding coverage again | EXIT=101, 1 failed, printing the express advice string verbatim |
| F5 | `semantic_search` publishes no observation | EXIT=101, exactly the 2 handler guards failed |
| F6 | `graph_neighborhood` publishes no observation | EXIT=101, 2 failed, including a pre-existing neighborhood test |
| F7 | the two siblings dropped from the language-scope map | EXIT=101, 4 failed |
| F8 | gate fires on every unprobed language, the over-firing degradation | EXIT=101, 27 failed, including the pre-existing FIR-2404 Python fixture |

F8 is the regression bar: a fix that degraded into marking everything inconclusive would show up as those 27.

## Gate

`cargo fmt --all -- --check` exit 0. Clippy exactly as `ci.yml` runs it, 45-lint allowlist under `RUSTFLAGS=-D warnings`, exit 0. `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh` and `scripts/test-private-repo-coupling.py` all exit 0.

`bin/kin-lane run absencegate kin -- bin/kin-dev local-test kin` exit 0, run after rebasing onto the `origin/main` carrying #931 and #932. `bin/kin-dev` does not honour `--no-fail-fast` (its `local-test` usage takes only `[--repo-dir <repo>=<path>]... [repo...]` and builds `DEV_TEST_ARGV=(nextest run --workspace)` with no pass-through), so the run count is the evidence nothing was hidden:

```
Summary [ 332.486s] 6302 tests run: 6302 passed (3 slow, 3 leaky), 12 skipped
kin-dev: local-test: kin  .kin-coord/worktrees/absencegate-kin @ bce63342 (chore/lane-absencegate-kin)
```

After the gate exited, `git diff --stat HEAD -- Cargo.lock .cargo/` is empty and `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`.

Closes FIR-2430
