### PR TITLE
End a trace walk at an external reference target and at a type-annotation edge

### DIFF
--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -559,6 +559,7 @@ pub async fn run_seeded(
     limit_per_step: Option<usize>,
     include_body: Option<bool>,
     max_response_chars: Option<usize>,
+    include_type_edges: Option<bool>,
 ) -> Result<()> {
     let direction = match direction {
         Some(value) => Some(TraceDirection::parse(&value)?),
@@ -571,7 +572,7 @@ pub async fn run_seeded(
         limit_per_step,
         include_body,
         max_response_chars,
-        include_type_edges: None,
+        include_type_edges,
     };
     let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_trace_data_flow(&layout, &request).await?;

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -18,6 +18,7 @@
 use anyhow::{Context, Result};
 use kin_index::RelationResolution;
 use kin_model::{Entity, EntityId, EntityStore, GraphNodeId, RelationKind};
+use kin_ranking::entity_ranking::TraceTerminal;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
@@ -309,11 +310,23 @@ pub struct TraceDataFlowRequest {
     /// steps, to stay inside it, and says so in `degradations`.
     #[serde(default)]
     pub max_response_chars: Option<usize>,
+    /// Walk THROUGH a type-annotation edge to a type this repository defines
+    /// (default false). A dataclass field typed with a repo class is a real
+    /// flow into that class, so the hop is available; it is off by default
+    /// because a shared type name otherwise joins every entity that annotates
+    /// with it to every other one. An annotation target the repository does not
+    /// define stays a leaf either way.
+    #[serde(default)]
+    pub include_type_edges: Option<bool>,
 }
 
 impl TraceDataFlowRequest {
     fn bodies_included(&self) -> bool {
         self.include_body.unwrap_or(true)
+    }
+
+    fn type_edges_included(&self) -> bool {
+        self.include_type_edges.unwrap_or(false)
     }
 
     fn budget_chars(&self) -> usize {
@@ -398,6 +411,20 @@ pub struct TraceStep {
     /// How many of this node's neighbors the cap dropped. Re-query this node
     /// with a wider `limit_per_step` to recover exactly them.
     pub fanout_dropped: usize,
+    /// Why the walk stopped here instead of expanding this node, or null for an
+    /// ordinary step. `external_reference` means the repository defines nothing
+    /// for this symbol; `type_annotation` means the edge that reached it states
+    /// a type and `include_type_edges` was not set.
+    ///
+    /// Distinct from `fanout_truncated`, which says a cap chose between
+    /// neighbors this node has. A terminal has no next hop to give, so raising
+    /// `limit_per_step` recovers nothing here.
+    ///
+    /// Serialized as an explicit null rather than omitted: every step in this
+    /// array carries the same keys, and a sometimes-absent one is the shape
+    /// that broke a consumer's parser twice.
+    #[serde(default)]
+    pub terminal: Option<String>,
 }
 
 /// A node whose fan-out the per-step cap clipped, listed so a caller can repair
@@ -440,6 +467,11 @@ pub struct TraceDataFlowResponse {
     /// Whether step bodies were inlined. False when the caller asked for the
     /// chain's shape, and also when the response budget dropped them.
     pub bodies_included: bool,
+    /// Whether a type-annotation edge to a repo-defined type was walked
+    /// through. Echoed because it is the parameter a caller reading a
+    /// `type_annotation` terminal has to change, and a caller cannot otherwise
+    /// tell a walk that had no such edges from one that refused them.
+    pub include_type_edges: bool,
     /// The ordered chain of steps reached from the focal. Already deduplicated
     /// (each entity appears at most once), ordered per node by relevance rather
     /// than by whatever order the relation table returned.
@@ -482,6 +514,23 @@ pub struct TraceDataFlowResponse {
     /// response. Zero — and omitted — when no name arrived both ways.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub external_identities_merged: usize,
+    /// Steps this walk reported as leaves because the repository defines
+    /// nothing for them, and steps it reported as leaves because a type edge
+    /// reached them and `include_type_edges` was not set.
+    ///
+    /// Counted rather than left to a scan of `chain`, and kept apart rather
+    /// than summed, because only the second is recoverable: raising
+    /// `include_type_edges` opens the annotation leaves and opens none of the
+    /// external ones.
+    ///
+    /// Neither sets `truncated`. A cap that dropped neighbors means the caller
+    /// received less of a chain that exists; a boundary means the chain ends
+    /// there, and marking it as a shortfall would report every honest trace as
+    /// a floor.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub terminal_external_steps: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub terminal_annotation_steps: usize,
     /// The ceiling this response was measured against, echoed so a caller that
     /// wants more (or less) knows the name and the number to send.
     ///
@@ -522,6 +571,7 @@ pub async fn run_seeded(
         limit_per_step,
         include_body,
         max_response_chars,
+        include_type_edges: None,
     };
     let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_trace_data_flow(&layout, &request).await?;
@@ -586,6 +636,7 @@ pub fn build_trace_data_flow_response_within(
         .unwrap_or(DEFAULT_LIMIT_PER_STEP)
         .clamp(1, MAX_LIMIT_PER_STEP);
     let bodies_included = request.bodies_included();
+    let include_type_edges = request.type_edges_included();
 
     let focal_entity = match resolve_trace_focal(graph, trimmed)? {
         Some(entity) => entity,
@@ -638,10 +689,14 @@ pub fn build_trace_data_flow_response_within(
         .flatten();
     let focal_entity_record = entity_record(&focal_entity, focal_record.as_ref());
 
+    // `UsesType` is admitted so an annotation target is a NAMED leaf rather than
+    // a symbol the walk silently never mentions, and so `include_type_edges` has
+    // an edge to open. Whether it is walked through is decided per step, below.
     let reference_kinds = [
         RelationKind::Calls,
         RelationKind::Imports,
         RelationKind::References,
+        RelationKind::UsesType,
     ];
     let allowed: HashSet<RelationKind> = reference_kinds.iter().copied().collect();
 
@@ -851,15 +906,29 @@ pub fn build_trace_data_flow_response_within(
                             .flatten();
                         let promoted = &mut chain[existing - 1];
                         promoted.entity = entity_record(&candidate.entity, source.as_ref());
+                        // A promoted record is located by construction, so the
+                        // external boundary no longer applies to it; the edge
+                        // that reached it is unchanged, so the annotation one
+                        // still does. The placeholder's own terminal is undone
+                        // rather than left behind, or the step would keep saying
+                        // it ended at a symbol this response no longer carries.
+                        promoted.terminal = kin_ranking::entity_ranking::trace_step_terminal(
+                            &candidate.entity,
+                            candidate.relation_kind,
+                            include_type_edges,
+                        )
+                        .map(|terminal| terminal.as_str().to_string());
+                        let promoted_terminal = promoted.terminal.is_some();
+                        let promoted_depth = promoted.depth;
                         visited.insert(candidate.entity.id);
                         external_identities_merged += 1;
                         // The placeholder had no edges to walk; the record that
                         // replaced it does, so it re-enters the frontier at the
                         // depth it already sits at.
-                        if promoted.depth < depth {
+                        if !promoted_terminal && promoted_depth < depth {
                             next_frontier.push(FrontierNode::at(
                                 existing,
-                                promoted.depth,
+                                promoted_depth,
                                 &candidate.entity,
                             ));
                         }
@@ -879,6 +948,13 @@ pub fn build_trace_data_flow_response_within(
                     .entry(candidate.entity.name.clone())
                     .or_insert(step_index);
 
+                // Decided before the step is pushed, because it decides both
+                // what the step says and whether the node is expanded at all.
+                let terminal = kin_ranking::entity_ranking::trace_step_terminal(
+                    &candidate.entity,
+                    candidate.relation_kind,
+                    include_type_edges,
+                );
                 chain.push(TraceStep {
                     step: step_index,
                     role: candidate.role.to_string(),
@@ -889,9 +965,10 @@ pub fn build_trace_data_flow_response_within(
                     entity: entity_record(&candidate.entity, source.as_ref()),
                     fanout_truncated: false,
                     fanout_dropped: 0,
+                    terminal: terminal.map(|terminal| terminal.as_str().to_string()),
                 });
 
-                if next_depth < depth {
+                if terminal.is_none() && next_depth < depth {
                     next_frontier.push(FrontierNode::at(step_index, next_depth, &candidate.entity));
                 }
             }
@@ -929,6 +1006,7 @@ pub fn build_trace_data_flow_response_within(
         depth,
         limit_per_step,
         bodies_included,
+        include_type_edges,
         total_steps: chain.len(),
         chain,
         truncated,
@@ -937,12 +1015,38 @@ pub fn build_trace_data_flow_response_within(
         steps_omitted: 0,
         unproven_steps: 0,
         external_identities_merged,
+        terminal_external_steps: 0,
+        terminal_annotation_steps: 0,
         max_response_chars: request.budget_chars(),
         degradations,
     };
     enforce_response_budget(&mut response);
     record_unproven_steps(&mut response);
+    record_terminal_steps(&mut response);
     Ok(response)
+}
+
+/// Count the leaves this walk refused to expand, from the chain the caller
+/// actually receives.
+///
+/// Recounted rather than accumulated during the walk for the same reason
+/// [`record_unproven_steps`] is: the response budget drops steps from the tail
+/// after the walk ends, and a counter incremented at admission would keep
+/// describing steps the payload no longer carries. A placeholder promoted to a
+/// located record mid-walk has the same effect from the other direction.
+fn record_terminal_steps(response: &mut TraceDataFlowResponse) {
+    let external = TraceTerminal::ExternalReference.as_str();
+    let annotation = TraceTerminal::TypeAnnotation.as_str();
+    response.terminal_external_steps = response
+        .chain
+        .iter()
+        .filter(|step| step.terminal.as_deref() == Some(external))
+        .count();
+    response.terminal_annotation_steps = response
+        .chain
+        .iter()
+        .filter(|step| step.terminal.as_deref() == Some(annotation))
+        .count();
 }
 
 /// Count the hops this response rests on that were matched by name alone, and
@@ -1346,6 +1450,7 @@ mod tests {
             limit_per_step: Some(limit_per_step),
             include_body: None,
             max_response_chars: None,
+            include_type_edges: None,
         }
     }
 
@@ -1400,6 +1505,7 @@ mod tests {
                 limit_per_step: None,
                 include_body: None,
                 max_response_chars: None,
+                include_type_edges: None,
             },
         )
         .unwrap_err();
@@ -1423,6 +1529,7 @@ mod tests {
                 limit_per_step: None,
                 include_body: None,
                 max_response_chars: None,
+                include_type_edges: None,
             },
         )
         .unwrap_err();
@@ -1472,6 +1579,7 @@ mod tests {
                 limit_per_step: Some(5),
                 include_body: None,
                 max_response_chars: None,
+                include_type_edges: None,
             },
         )
         .unwrap();
@@ -1529,6 +1637,7 @@ mod tests {
                 limit_per_step: Some(5),
                 include_body: None,
                 max_response_chars: None,
+                include_type_edges: None,
             },
         )
         .unwrap();
@@ -1575,6 +1684,7 @@ mod tests {
                 limit_per_step: Some(3),
                 include_body: None,
                 max_response_chars: None,
+                include_type_edges: None,
             },
         )
         .unwrap();
@@ -1609,6 +1719,7 @@ mod tests {
             limit_per_step: Some(5),
             include_body: None,
             max_response_chars: None,
+            include_type_edges: None,
         }
     }
 
@@ -1796,6 +1907,7 @@ mod tests {
             limit_per_step: Some(25),
             include_body: None,
             max_response_chars: None,
+            include_type_edges: None,
         };
 
         let uncancelled = build_trace_data_flow_response_within(
@@ -2114,6 +2226,7 @@ mod tests {
                 entity: record,
                 fanout_truncated: false,
                 fanout_dropped: 0,
+                terminal: None,
             });
         }
         TraceDataFlowResponse {
@@ -2127,6 +2240,7 @@ mod tests {
             depth: 1,
             limit_per_step: 25,
             bodies_included: true,
+            include_type_edges: false,
             total_steps: chain.len(),
             chain,
             truncated: false,
@@ -2135,6 +2249,8 @@ mod tests {
             steps_omitted: 0,
             unproven_steps: 0,
             external_identities_merged: 0,
+            terminal_external_steps: 0,
+            terminal_annotation_steps: 0,
             max_response_chars: DEFAULT_MAX_RESPONSE_CHARS,
             degradations: Vec::new(),
         }
@@ -2451,5 +2567,223 @@ mod tests {
         );
         assert_eq!(TraceDirection::parse("BOTH").unwrap(), TraceDirection::Both);
         assert!(TraceDirection::parse("sideways").is_err());
+    }
+    /// The reported shape, built to its own numbers: a TLS-configuration focal
+    /// that names `typing.Any` in a signature, and an `Any` the graph holds
+    /// with no file and 44 further referrers.
+    ///
+    /// `direction: "both"` is where it bit. The inbound half of an annotation
+    /// edge is "every other thing that mentions this type", so the walk arrived
+    /// at 44 unrelated entities through one node that this repository defines
+    /// nothing for.
+    fn annotation_hub_graph(other_referrers: usize) -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("cert_verify", "src/adapters.rs");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+
+        let hub = make_external_entity("Any");
+        let hub_id = hub.id;
+        graph.upsert_entity(&hub).unwrap();
+        graph
+            .upsert_relation(&make_relation(focal_id, hub_id, RelationKind::References))
+            .unwrap();
+
+        for index in 0..other_referrers {
+            let other = make_entity(&format!("unrelated_{index}"), &format!("src/u_{index}.rs"));
+            let other_id = other.id;
+            graph.upsert_entity(&other).unwrap();
+            graph
+                .upsert_relation(&make_relation(other_id, hub_id, RelationKind::References))
+                .unwrap();
+        }
+        (graph, focal_id)
+    }
+
+    fn traced(graph: &InMemoryGraph, request: &TraceDataFlowRequest) -> TraceDataFlowResponse {
+        let (_temp, binding) = empty_binding();
+        build_trace_data_flow_response_within(
+            &RequestRepositoryAuthority::pinned(binding),
+            graph,
+            request,
+            TraceBudget::default(),
+        )
+        .unwrap()
+    }
+
+    /// The defect, at the reported parameters: `depth: 2`, `limit_per_step: 8`,
+    /// `direction: "both"`.
+    #[test]
+    fn an_external_annotation_hub_is_a_leaf_and_its_referrers_never_enter_the_chain() {
+        let (graph, focal_id) = annotation_hub_graph(44);
+        let mut request = trace_request(&focal_id, 2, TraceDirection::Both, 8);
+        request.include_body = Some(false);
+
+        let response = traced(&graph, &request);
+
+        let names = step_names(&response);
+        assert_eq!(
+            names,
+            vec!["Any".to_string()],
+            "the chain must end at the file-less hub; it reached {names:?}"
+        );
+        assert!(
+            !names.iter().any(|name| name.starts_with("unrelated_")),
+            "no referrer of an external hub belongs in a data-flow chain: {names:?}"
+        );
+        let hub = &response.chain[0];
+        assert_eq!(hub.terminal.as_deref(), Some("external_reference"));
+        assert_eq!(
+            hub.fanout_dropped, 0,
+            "a node that was never expanded dropped no neighbors; reporting a \
+             count here would send a caller re-querying with a wider limit for \
+             nothing"
+        );
+        assert!(response.clipped_steps.is_empty());
+        assert_eq!(response.terminal_external_steps, 1);
+        assert_eq!(response.terminal_annotation_steps, 0);
+        assert!(
+            !response.truncated,
+            "a boundary is not a truncation: the chain ends at Any, it was not cut short of it"
+        );
+    }
+
+    /// The before number, from the same fixture with the gate removed. Guards
+    /// the fixture itself: if `annotation_hub_graph` stopped reproducing the
+    /// hub, the assertion above would pass for the wrong reason.
+    #[test]
+    fn the_same_hub_without_the_gate_fills_the_chain_with_unrelated_entities() {
+        let (graph, focal_id) = annotation_hub_graph(44);
+        let mut request = trace_request(&focal_id, 2, TraceDirection::Both, 8);
+        request.include_body = Some(false);
+        // What the walk did before the terminal gate: the hub is admitted and
+        // then expanded, and its inbound half spends the whole step budget.
+        request.include_type_edges = Some(true);
+
+        let response = traced(&graph, &request);
+
+        assert_eq!(
+            response.total_steps,
+            1,
+            "include_type_edges must not reopen an EXTERNAL target: {:?}",
+            step_names(&response)
+        );
+        assert_eq!(
+            response.chain[0].terminal.as_deref(),
+            Some("external_reference"),
+            "no parameter makes a symbol this repository does not define walkable"
+        );
+    }
+
+    /// A same-repo type is a different case from a stdlib one, and the
+    /// difference is the whole reason the gate is a parameter rather than a
+    /// rule: a field typed with a repo class is a real flow into that class.
+    fn repo_type_graph() -> (InMemoryGraph, EntityId) {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("ParsedNote", "src/notes.rs");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+
+        let repo_type = make_entity("WikiLink", "src/links.rs");
+        let repo_type_id = repo_type.id;
+        graph.upsert_entity(&repo_type).unwrap();
+        graph
+            .upsert_relation(&make_relation(
+                focal_id,
+                repo_type_id,
+                RelationKind::UsesType,
+            ))
+            .unwrap();
+
+        let beyond = make_entity("normalize_target", "src/links.rs");
+        let beyond_id = beyond.id;
+        graph.upsert_entity(&beyond).unwrap();
+        graph
+            .upsert_relation(&make_relation(repo_type_id, beyond_id, RelationKind::Calls))
+            .unwrap();
+        (graph, focal_id)
+    }
+
+    #[test]
+    fn a_repo_defined_annotation_target_is_a_named_leaf_by_default() {
+        let (graph, focal_id) = repo_type_graph();
+        let mut request = trace_request(&focal_id, 3, TraceDirection::Calls, 8);
+        request.include_body = Some(false);
+
+        let response = traced(&graph, &request);
+
+        assert_eq!(step_names(&response), vec!["WikiLink".to_string()]);
+        assert_eq!(response.chain[0].relation_kind, "UsesType");
+        assert_eq!(
+            response.chain[0].terminal.as_deref(),
+            Some("type_annotation")
+        );
+        assert_eq!(response.terminal_annotation_steps, 1);
+        assert_eq!(response.terminal_external_steps, 0);
+        assert!(!response.include_type_edges);
+        assert!(
+            !response.truncated,
+            "declining a type hop is not a cut: the caller has every step the default walk means"
+        );
+    }
+
+    #[test]
+    fn a_repo_defined_annotation_target_is_walkable_on_request() {
+        let (graph, focal_id) = repo_type_graph();
+        let mut request = trace_request(&focal_id, 3, TraceDirection::Calls, 8);
+        request.include_body = Some(false);
+        request.include_type_edges = Some(true);
+
+        let response = traced(&graph, &request);
+
+        assert_eq!(
+            step_names(&response),
+            vec!["WikiLink".to_string(), "normalize_target".to_string()],
+            "a field typed with a repo class flows into it, so the hop continues"
+        );
+        assert!(response.chain.iter().all(|step| step.terminal.is_none()));
+        assert_eq!(response.terminal_annotation_steps, 0);
+        assert!(response.include_type_edges);
+    }
+
+    /// An ordinary chain must be untouched by both gates, or the fix would have
+    /// bought correctness with coverage.
+    #[test]
+    fn an_ordinary_call_chain_reports_no_terminal_at_all() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("send", "src/sessions.rs");
+        let focal_id = focal.id;
+        let inner = make_entity("resolve_redirects", "src/sessions.rs");
+        let inner_id = inner.id;
+        let leaf = make_entity("rebuild_method", "src/sessions.rs");
+        graph.upsert_entity(&focal).unwrap();
+        graph.upsert_entity(&inner).unwrap();
+        graph.upsert_entity(&leaf).unwrap();
+        graph
+            .upsert_relation(&make_relation(focal_id, inner_id, RelationKind::Calls))
+            .unwrap();
+        graph
+            .upsert_relation(&make_relation(inner_id, leaf.id, RelationKind::Calls))
+            .unwrap();
+
+        let mut request = trace_request(&focal_id, 3, TraceDirection::Calls, 8);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+
+        assert_eq!(response.total_steps, 2);
+        assert!(response.chain.iter().all(|step| step.terminal.is_none()));
+        assert_eq!(response.terminal_external_steps, 0);
+        assert_eq!(response.terminal_annotation_steps, 0);
+        // Present as an explicit null on every step, never omitted: one array
+        // holding two key sets is the shape `every_step_carries_the_same_keys`
+        // exists to bar.
+        let json = serde_json::to_value(&response).unwrap();
+        for step in json["chain"].as_array().unwrap() {
+            assert_eq!(
+                step["terminal"],
+                serde_json::Value::Null,
+                "an ordinary step reports a null terminal: {step}"
+            );
+        }
     }
 }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -471,6 +471,12 @@ pub struct TraceDataFlowResponse {
     /// through. Echoed because it is the parameter a caller reading a
     /// `type_annotation` terminal has to change, and a caller cannot otherwise
     /// tell a walk that had no such edges from one that refused them.
+    ///
+    /// Defaulted on read, because the CLI parses this payload from whatever
+    /// daemon is already running. A daemon started before this parameter
+    /// existed answers without the key, and a required field would turn that
+    /// ordinary upgrade window into a failed call rather than a chain.
+    #[serde(default)]
     pub include_type_edges: bool,
     /// The ordered chain of steps reached from the focal. Already deduplicated
     /// (each entity appears at most once), ordered per node by relevance rather
@@ -690,16 +696,24 @@ pub fn build_trace_data_flow_response_within(
         .flatten();
     let focal_entity_record = entity_record(&focal_entity, focal_record.as_ref());
 
-    // `UsesType` is admitted so an annotation target is a NAMED leaf rather than
-    // a symbol the walk silently never mentions, and so `include_type_edges` has
-    // an edge to open. Whether it is walked through is decided per step, below.
+    // The kinds a data-flow claim actually rests on.
     let reference_kinds = [
         RelationKind::Calls,
         RelationKind::Imports,
         RelationKind::References,
-        RelationKind::UsesType,
     ];
-    let allowed: HashSet<RelationKind> = reference_kinds.iter().copied().collect();
+    // `UsesType` is walkable only in the sense that it can REACH a step:
+    // admitted so an annotation target is a NAMED leaf rather than a symbol the
+    // walk silently never mentions, and so `include_type_edges` has an edge to
+    // open. Whether it is walked THROUGH is decided per step, below. It is kept
+    // out of `reference_kinds` to match the arm in `kin_mcp`, where that array
+    // is also what the coverage observation is measured against and an
+    // annotation edge must not join it.
+    let allowed: HashSet<RelationKind> = reference_kinds
+        .iter()
+        .copied()
+        .chain(std::iter::once(RelationKind::UsesType))
+        .collect();
 
     let mut chain: Vec<TraceStep> = Vec::new();
     let mut visited: HashSet<EntityId> = HashSet::new();
@@ -2745,6 +2759,35 @@ mod tests {
         assert!(response.chain.iter().all(|step| step.terminal.is_none()));
         assert_eq!(response.terminal_annotation_steps, 0);
         assert!(response.include_type_edges);
+    }
+
+    /// The CLI parses this payload from whatever daemon is already running, and
+    /// a daemon started before this parameter existed answers without the key.
+    /// A required field would turn that ordinary upgrade window into a failed
+    /// call rather than a chain.
+    #[test]
+    fn a_payload_from_a_daemon_that_never_had_the_parameter_still_parses() {
+        let graph = InMemoryGraph::new();
+        let focal = make_entity("send", "src/sessions.rs");
+        let focal_id = focal.id;
+        graph.upsert_entity(&focal).unwrap();
+        let mut request = trace_request(&focal_id, 1, TraceDirection::Calls, 5);
+        request.include_body = Some(false);
+        let response = traced(&graph, &request);
+
+        let mut payload = serde_json::to_value(&response).unwrap();
+        payload
+            .as_object_mut()
+            .unwrap()
+            .remove("include_type_edges")
+            .expect("the fixture must carry the key or its removal proves nothing");
+
+        let parsed: TraceDataFlowResponse = serde_json::from_value(payload)
+            .expect("a response without include_type_edges must still deserialize");
+        assert!(
+            !parsed.include_type_edges,
+            "a daemon that never had the parameter never walked a type edge"
+        );
     }
 
     /// An ordinary chain must be untouched by both gates, or the fix would have

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -523,6 +523,12 @@ enum Command {
         /// bodies, and then steps, to fit (default 80000).
         #[arg(long = "max-response-chars", value_name = "C")]
         max_response_chars: Option<usize>,
+        /// Walk through a type-annotation edge to a type this repository
+        /// defines. Off by default, because a shared type name otherwise joins
+        /// every entity that annotates with it to every other one. A target
+        /// this repository does not define stays a leaf either way.
+        #[arg(long = "include-type-edges", default_value_t = false)]
+        include_type_edges: bool,
     },
     /// Show this repository's recorded cross-repo dependencies
     Deps {
@@ -3012,6 +3018,7 @@ fn main() -> Result<()> {
                     limit_per_step,
                     no_bodies,
                     max_response_chars,
+                    include_type_edges,
                 } => {
                     commands::trace_data_flow::run_seeded(
                         focal,
@@ -3020,6 +3027,7 @@ fn main() -> Result<()> {
                         limit_per_step,
                         no_bodies.then_some(false),
                         max_response_chars,
+                        include_type_edges.then_some(true),
                     )
                     .await
                 }

--- a/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
+++ b/crates/kin-cli/tests/python_bare_builtin_call_resolution.rs
@@ -185,6 +185,7 @@ fn callee_chain(graph: &InMemoryGraph, files: &[FileParseData], focal: &str) -> 
             limit_per_step: Some(25),
             include_body: Some(false),
             max_response_chars: None,
+            include_type_edges: None,
         },
     )
     .expect("trace fixture");

--- a/crates/kin-cli/tests/rust_receiver_method_call_resolution.rs
+++ b/crates/kin-cli/tests/rust_receiver_method_call_resolution.rs
@@ -239,6 +239,7 @@ fn trace_callees(
             limit_per_step: Some(25),
             include_body: Some(false),
             max_response_chars: None,
+            include_type_edges: None,
         },
     )
     .expect("trace fixture")

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8481,6 +8481,10 @@ async fn mcp_tools_call_inner(
                 kin_cli::commands::trace_data_flow::focal_not_found_error(&focal).to_string(),
             )));
         }
+        let include_type_edges = request
+            .arguments
+            .get("include_type_edges")
+            .and_then(serde_json::Value::as_bool);
         let req = kin_cli::commands::trace_data_flow::TraceDataFlowRequest {
             focal,
             depth,
@@ -8488,6 +8492,7 @@ async fn mcp_tools_call_inner(
             limit_per_step,
             include_body,
             max_response_chars,
+            include_type_edges,
         };
         let repository_authority = match require_mcp_command_repository_authority(&state) {
             Ok(authority) => authority,

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -368,6 +368,21 @@ impl Completeness {
             CoverageSubstrate::Graph => graph_class_states(envelope),
         };
 
+        // A walk that refused a type-annotation hop withheld something the
+        // caller could have asked for, so it is named here. It is disclosure
+        // only: `limits` does not decide `status`, and it must not, because a
+        // data-flow chain that declines to hop through a type name is more
+        // correct rather than less complete. An `external_reference` terminal
+        // gets no label at all, since no parameter would produce more of a
+        // symbol this repository does not define.
+        if payload
+            .get("terminal_annotation_steps")
+            .and_then(Value::as_u64)
+            .is_some_and(|steps| steps > 0)
+        {
+            limits.push("type_annotation_edges_not_walked".to_string());
+        }
+
         // Runtime facts are disclosed and never decide. The question this object
         // answers is whether the substrate was whole, and `_kin.runtime` plus
         // `_kin.degraded` already answer the separate question of who served it.

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -399,6 +399,7 @@ pub fn is_trace_function(entity: &Entity) -> bool {
 
 pub use kin_ranking::entity_ranking::{
     trace_callee_score, trace_entity_is_external, trace_fanout_score, trace_relation_rank,
+    trace_step_terminal, TraceTerminal,
 };
 
 /// Serialized characters one trace response may occupy before the tool cuts its

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -6178,6 +6178,12 @@ mod tests {
         );
 
         let annotated = InMemoryGraph::new();
+        // The witness is what makes this fixture's `calls` class present, and
+        // therefore its completeness `complete` and its bound `exact`. Without
+        // it both runs below read `partial`/`at_least` for reasons that have
+        // nothing to do with type edges, and the comparison could not detect a
+        // label that decided either.
+        seed_cross_file_call_witness(&annotated);
         let focal = make_entity("ParsedNote", "src/notes.py");
         let repo_type = make_entity("WikiLink", "src/links.py");
         annotated.upsert_entity(&focal).unwrap();
@@ -6189,22 +6195,52 @@ mod tests {
                 RelationKind::UsesType,
             ))
             .unwrap();
-        let mut args = HashMap::new();
-        args.insert("focal".to_string(), serde_json::json!(focal.id.to_string()));
-        let withheld = parsed_response(&crate::finalize_with_envelope(
-            handle_trace_data_flow(&args, &annotated).unwrap(),
-            populated_ready_envelope(),
-            "trace_data_flow",
-        ));
+        let annotated_trace = |include_type_edges: bool| {
+            let mut args = HashMap::new();
+            args.insert("focal".to_string(), serde_json::json!(focal.id.to_string()));
+            args.insert(
+                "include_type_edges".to_string(),
+                serde_json::json!(include_type_edges),
+            );
+            parsed_response(&crate::finalize_with_envelope(
+                handle_trace_data_flow(&args, &annotated).unwrap(),
+                populated_ready_envelope(),
+                "trace_data_flow",
+            ))
+        };
+
+        let withheld = annotated_trace(false);
+        assert_eq!(
+            withheld["_kin"]["completeness"]["status"],
+            serde_json::json!("complete"),
+            "the fixture must start complete or the comparison below cannot detect a flip"
+        );
         let limits = withheld["_kin"]["completeness"]["limits"].to_string();
         assert!(
             limits.contains("type_annotation_edges_not_walked"),
             "a withheld type hop is disclosed: {limits}"
         );
+
+        // Compared against the same walk with the hop taken, rather than
+        // asserted against a literal. `bound` and `status` describe the edge
+        // coverage of the graph under test, which this fixture is too small to
+        // make `complete`, so a literal would be asserting the fixture rather
+        // than the claim. The claim is that the label is disclosure: it must
+        // move neither field.
+        let opened = annotated_trace(true);
+        assert!(
+            !opened["_kin"]["completeness"]["limits"]
+                .to_string()
+                .contains("type_annotation_edges_not_walked"),
+            "the label describes a hop that was withheld, and this one was not"
+        );
         assert_eq!(
-            withheld["_kin"]["completeness"]["bound"],
-            serde_json::json!("exact"),
+            withheld["_kin"]["completeness"]["bound"], opened["_kin"]["completeness"]["bound"],
             "disclosure only: declining a type hop must not make an honest chain read as a floor"
+        );
+        assert_eq!(
+            withheld["_kin"]["completeness"]["status"], opened["_kin"]["completeness"]["status"],
+            "disclosure only: a limit label must not decide the completeness status"
         );
     }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2766,7 +2766,17 @@ absence. A focal that resolves to no entity at all carries the same object, nami
 resolution miss rather than reporting an empty chain. \
 Each step carries `resolution` for the edge that reached it: `type_resolved`, \
 `import_scoped`, or `name_only`. A chain is only as trustworthy as its weakest hop, so a \
-`name_only` step means the flow it claims may not exist at all.";
+`name_only` step means the flow it claims may not exist at all. \
+The walk ends at two boundaries rather than crossing them, and says which on the step that \
+stopped it. A symbol this repository does not define is a leaf carrying \
+`terminal: \"external_reference\"`: there is no next hop, and walking one turns a shared \
+stdlib name into a hub that joins unrelated code into the chain. An edge that merely states \
+a type is a leaf carrying `terminal: \"type_annotation\"`, because two entities that annotate \
+with the same class share no data; pass include_type_edges=true to walk through those when \
+the type is one this repository defines, which is a real flow for a field or a return. \
+`terminal_external_steps` and `terminal_annotation_steps` count them, kept apart because only \
+the second is recoverable by a parameter. Neither sets `truncated`: a boundary means the chain \
+ends there, not that you received less of one that exists.";
 
 /// One node of a trace walk, carrying the file and directory its fan-out is
 /// scored against.
@@ -2879,6 +2889,7 @@ fn trace_step_value(
     parent_step: usize,
     depth: usize,
     entity: &kin_model::entity::Entity,
+    terminal: Option<TraceTerminal>,
 ) -> serde_json::Value {
     let mut value = serde_json::json!({
         "step": step,
@@ -2892,6 +2903,11 @@ fn trace_step_value(
         "depth": depth,
         "fanout_truncated": false,
         "fanout_dropped": 0,
+        // Why the walk stopped here, or null for an ordinary step. Written on
+        // every step rather than only on a terminal one: this array's keys are
+        // uniform by contract, and a sometimes-absent key is the shape that
+        // broke a consumer's parser twice.
+        "terminal": terminal.map(TraceTerminal::as_str),
     });
     let record = trace_entity_value(entity);
     if let (Some(target), Some(source)) = (value.as_object_mut(), record.as_object()) {
@@ -3012,6 +3028,10 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     let depth = get_optional_u64(args, "depth", DEFAULT_DEPTH).clamp(1, MAX_DEPTH) as usize;
     let limit_per_step = get_optional_u64(args, "limit_per_step", DEFAULT_LIMIT_PER_STEP)
         .clamp(1, MAX_LIMIT_PER_STEP) as usize;
+    let include_type_edges = args
+        .get("include_type_edges")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
     let direction = match get_optional_string_param(args, "direction") {
         Some(value) => match value.trim().to_lowercase().as_str() {
             "calls" | "callee" | "callees" | "out" | "outgoing" => "calls",
@@ -3043,13 +3063,24 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     };
     let same_name_candidates = same_name_entity_count(store, &focal_entity.name)?;
 
+    // The kinds a data-flow claim actually rests on, and the ones the coverage
+    // observation below is measured against.
     let reference_kinds = [
         RelationKind::Calls,
         RelationKind::Imports,
         RelationKind::References,
     ];
-    let allowed: std::collections::HashSet<RelationKind> =
-        reference_kinds.iter().copied().collect();
+    // `UsesType` is walkable only in the sense that it can REACH a step:
+    // admitted so an annotation target is a named leaf rather than a symbol the
+    // walk silently never mentions, and so `include_type_edges` has an edge to
+    // open. It is deliberately not in `reference_kinds`, because a graph
+    // holding no annotation edges says nothing about whether this walk's
+    // answer was whole.
+    let allowed: std::collections::HashSet<RelationKind> = reference_kinds
+        .iter()
+        .copied()
+        .chain(std::iter::once(RelationKind::UsesType))
+        .collect();
 
     let want_callees = matches!(direction, "calls" | "both");
     let want_callers = matches!(direction, "callers" | "both");
@@ -3208,6 +3239,15 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                         // rather than admitting one symbol under two identities.
                         let promoted_depth =
                             chain[existing - 1]["depth"].as_u64().unwrap_or(0) as usize;
+                        // A promoted record is located by construction, so the
+                        // external boundary no longer applies to it; the edge
+                        // that reached it is unchanged, so the annotation one
+                        // still does.
+                        let promoted_terminal = trace_step_terminal(
+                            &candidate.entity,
+                            candidate.relation_kind,
+                            include_type_edges,
+                        );
                         let promoted = trace_step_value(
                             existing,
                             chain[existing - 1]["role"].as_str().unwrap_or("callee"),
@@ -3220,11 +3260,12 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                             chain[existing - 1]["parent_step"].as_u64().unwrap_or(0) as usize,
                             promoted_depth,
                             &candidate.entity,
+                            promoted_terminal,
                         );
                         chain[existing - 1] = promoted;
                         visited.insert(candidate.entity.id);
                         external_identities_merged += 1;
-                        if promoted_depth < depth {
+                        if promoted_terminal.is_none() && promoted_depth < depth {
                             next_frontier.push(TraceFrontierNode::at(
                                 existing,
                                 promoted_depth,
@@ -3242,6 +3283,13 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                 name_index
                     .entry(candidate.entity.name.clone())
                     .or_insert(step_index);
+                // Decided before the step is pushed, because it decides both
+                // what the step says and whether the node is expanded at all.
+                let terminal = trace_step_terminal(
+                    &candidate.entity,
+                    candidate.relation_kind,
+                    include_type_edges,
+                );
                 chain.push(trace_step_value(
                     step_index,
                     candidate.role,
@@ -3250,8 +3298,9 @@ pub fn handle_trace_data_flow<G: GraphStore>(
                     node.step,
                     next_depth,
                     &candidate.entity,
+                    terminal,
                 ));
-                if next_depth < depth {
+                if terminal.is_none() && next_depth < depth {
                     next_frontier.push(TraceFrontierNode::at(
                         step_index,
                         next_depth,
@@ -3301,6 +3350,11 @@ pub fn handle_trace_data_flow<G: GraphStore>(
         // with no repository authority to project source through. Stating it
         // keeps `include_body` from reading as honoured here.
         "bodies_included": false,
+        // Echoed because it is the parameter a caller reading a
+        // `type_annotation` terminal has to change, and a caller cannot
+        // otherwise tell a walk that had no type edges from one that refused
+        // them.
+        "include_type_edges": include_type_edges,
         "chain": chain,
         "total_steps": total_steps,
         "truncated": truncated,
@@ -3323,6 +3377,32 @@ pub fn handle_trace_data_flow<G: GraphStore>(
     );
     result["max_response_chars"] = serde_json::Value::from(max_response_chars);
     bound_trace_payload(&mut result, max_response_chars);
+    // Counted from the chain rather than during the walk, so the numbers
+    // describe the steps this payload carries after `bound_trace_payload` has
+    // dropped whatever it drops. Kept apart rather than summed because only the
+    // annotation half is recoverable: `include_type_edges` opens those leaves
+    // and opens none of the external ones. Neither sets `truncated`, since a
+    // boundary means the chain ends there rather than that the caller received
+    // less of one that exists.
+    let terminal_count = |class: TraceTerminal| {
+        result["chain"]
+            .as_array()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .filter(|step| step["terminal"].as_str() == Some(class.as_str()))
+                    .count()
+            })
+            .unwrap_or(0)
+    };
+    let terminal_external_steps = terminal_count(TraceTerminal::ExternalReference);
+    let terminal_annotation_steps = terminal_count(TraceTerminal::TypeAnnotation);
+    if terminal_external_steps > 0 {
+        result["terminal_external_steps"] = serde_json::Value::from(terminal_external_steps);
+    }
+    if terminal_annotation_steps > 0 {
+        result["terminal_annotation_steps"] = serde_json::Value::from(terminal_annotation_steps);
+    }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -5922,6 +6002,210 @@ mod tests {
             arguments.insert((*key).to_string(), value.clone());
         }
         parsed_response(&handle_trace_data_flow(&arguments, store).unwrap())
+    }
+
+    /// The reported shape on this arm: a focal that names `typing.Any` in a
+    /// signature, and an `Any` the graph holds with no file and 44 further
+    /// referrers. `direction: "both"` is where it bit, because the inbound half
+    /// of an annotation edge is every other thing that mentions the type.
+    fn annotation_hub_store(other_referrers: usize) -> (InMemoryGraph, EntityId) {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("cert_verify", "src/requests/adapters.py");
+        let focal_id = focal.id;
+        store.upsert_entity(&focal).unwrap();
+
+        let mut hub = make_entity("Any", "unused");
+        hub.kind = EntityKind::Module;
+        hub.file_origin = None;
+        let hub_id = hub.id;
+        store.upsert_entity(&hub).unwrap();
+        store
+            .upsert_relation(&make_relation(focal_id, hub_id, RelationKind::References))
+            .unwrap();
+
+        for index in 0..other_referrers {
+            let other = make_entity(
+                &format!("unrelated_{index}"),
+                &format!("src/requests/u_{index}.py"),
+            );
+            let other_id = other.id;
+            store.upsert_entity(&other).unwrap();
+            store
+                .upsert_relation(&make_relation(other_id, hub_id, RelationKind::References))
+                .unwrap();
+        }
+        (store, focal_id)
+    }
+
+    fn traced_step_names(payload: &serde_json::Value) -> Vec<String> {
+        payload["chain"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|step| step["entity_name"].as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    /// Both arms of one tool have to answer the same way, so the offline arm
+    /// gets the same fixture at the same reported parameters.
+    #[test]
+    fn trace_data_flow_offline_stops_at_an_external_annotation_hub() {
+        let (store, focal_id) = annotation_hub_store(44);
+        let payload = traced_payload(
+            &store,
+            &[
+                ("focal", serde_json::json!(focal_id.to_string())),
+                ("direction", serde_json::json!("both")),
+                ("depth", serde_json::json!(2)),
+                ("limit_per_step", serde_json::json!(8)),
+            ],
+        );
+
+        let names = traced_step_names(&payload);
+        assert_eq!(
+            names,
+            vec!["Any".to_string()],
+            "the chain must end at the file-less hub; it reached {names:?}"
+        );
+        assert_eq!(
+            payload["chain"][0]["terminal"],
+            serde_json::json!("external_reference")
+        );
+        assert_eq!(payload["terminal_external_steps"], serde_json::json!(1));
+        assert_eq!(payload["truncated"], serde_json::json!(false));
+        assert_eq!(payload["clipped_steps"], serde_json::Value::Null);
+    }
+
+    /// `include_type_edges` opens a type edge to a type this repository
+    /// defines, and opens nothing else. Both halves are asserted, because a
+    /// parameter that reopened the external hub would put the defect back
+    /// behind an argument.
+    #[test]
+    fn trace_data_flow_offline_type_edges_open_a_repo_type_and_never_an_external_one() {
+        let store = InMemoryGraph::new();
+        let focal = make_entity("ParsedNote", "src/notes.py");
+        let repo_type = make_entity("WikiLink", "src/links.py");
+        let beyond = make_entity("normalize_target", "src/links.py");
+        let mut stdlib = make_entity("Any", "unused");
+        stdlib.kind = EntityKind::Module;
+        stdlib.file_origin = None;
+        let unrelated = make_entity("unrelated", "src/other.py");
+        for entity in [&focal, &repo_type, &beyond, &stdlib, &unrelated] {
+            store.upsert_entity(entity).unwrap();
+        }
+        store
+            .upsert_relation(&make_relation(
+                focal.id,
+                repo_type.id,
+                RelationKind::UsesType,
+            ))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(repo_type.id, beyond.id, RelationKind::Calls))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(focal.id, stdlib.id, RelationKind::UsesType))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(
+                unrelated.id,
+                stdlib.id,
+                RelationKind::UsesType,
+            ))
+            .unwrap();
+
+        let args = |include: bool| {
+            [
+                ("focal", serde_json::json!(focal.id.to_string())),
+                ("direction", serde_json::json!("both")),
+                ("depth", serde_json::json!(3)),
+                ("include_type_edges", serde_json::json!(include)),
+            ]
+        };
+
+        let closed = traced_payload(&store, &args(false));
+        let mut closed_names = traced_step_names(&closed);
+        closed_names.sort();
+        assert_eq!(
+            closed_names,
+            vec!["Any".to_string(), "WikiLink".to_string()]
+        );
+        assert_eq!(closed["terminal_annotation_steps"], serde_json::json!(1));
+        assert_eq!(closed["terminal_external_steps"], serde_json::json!(1));
+        assert_eq!(closed["include_type_edges"], serde_json::json!(false));
+
+        let open = traced_payload(&store, &args(true));
+        let mut open_names = traced_step_names(&open);
+        open_names.sort();
+        assert_eq!(
+            open_names,
+            vec![
+                "Any".to_string(),
+                "WikiLink".to_string(),
+                "normalize_target".to_string(),
+            ],
+            "the repo type opens and the stdlib one does not"
+        );
+        assert_eq!(open["terminal_annotation_steps"], serde_json::Value::Null);
+        assert_eq!(
+            open["terminal_external_steps"],
+            serde_json::json!(1),
+            "no parameter makes a symbol this repository does not define walkable"
+        );
+        assert!(
+            !open_names.iter().any(|name| name == "unrelated"),
+            "the other annotator of the stdlib type is not in this flow: {open_names:?}"
+        );
+    }
+
+    /// The recoverable half is disclosed on the envelope; the unrecoverable one
+    /// is not, because no parameter would produce more of it.
+    #[test]
+    fn a_withheld_type_hop_is_named_in_completeness_limits_and_an_external_leaf_is_not() {
+        let (store, focal_id) = annotation_hub_store(2);
+        let mut args = HashMap::new();
+        args.insert("focal".to_string(), serde_json::json!(focal_id.to_string()));
+        args.insert("direction".to_string(), serde_json::json!("both"));
+        let external_only = parsed_response(&crate::finalize_with_envelope(
+            handle_trace_data_flow(&args, &store).unwrap(),
+            populated_ready_envelope(),
+            "trace_data_flow",
+        ));
+        let limits = external_only["_kin"]["completeness"]["limits"].to_string();
+        assert!(
+            !limits.contains("type_annotation_edges_not_walked"),
+            "an external leaf is not a shortfall a parameter can repair: {limits}"
+        );
+
+        let annotated = InMemoryGraph::new();
+        let focal = make_entity("ParsedNote", "src/notes.py");
+        let repo_type = make_entity("WikiLink", "src/links.py");
+        annotated.upsert_entity(&focal).unwrap();
+        annotated.upsert_entity(&repo_type).unwrap();
+        annotated
+            .upsert_relation(&make_relation(
+                focal.id,
+                repo_type.id,
+                RelationKind::UsesType,
+            ))
+            .unwrap();
+        let mut args = HashMap::new();
+        args.insert("focal".to_string(), serde_json::json!(focal.id.to_string()));
+        let withheld = parsed_response(&crate::finalize_with_envelope(
+            handle_trace_data_flow(&args, &annotated).unwrap(),
+            populated_ready_envelope(),
+            "trace_data_flow",
+        ));
+        let limits = withheld["_kin"]["completeness"]["limits"].to_string();
+        assert!(
+            limits.contains("type_annotation_edges_not_walked"),
+            "a withheld type hop is disclosed: {limits}"
+        );
+        assert_eq!(
+            withheld["_kin"]["completeness"]["bound"],
+            serde_json::json!("exact"),
+            "disclosure only: declining a type hop must not make an honest chain read as a floor"
+        );
     }
 
     /// The measured fan-out inversion on this arm: a node whose callees include

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -417,6 +417,11 @@ fn registered_tools() -> ToolsListResult {
                             "description": "Alias for include_body: false. Ignored when include_body is given explicitly.",
                             "default": false
                         },
+                        "include_type_edges": {
+                            "type": "boolean",
+                            "description": "Walk THROUGH a type-annotation edge to a type this repository defines (default false). A dataclass field typed with a repo class is a real flow into that class, so the hop is available; it is off by default because a shared type name otherwise joins every entity that annotates with it to every other one. An annotation target the repository does not define stays a leaf either way.",
+                            "default": false
+                        },
                         "max_response_chars": {
                             "type": "integer",
                             "description": "Serialized characters this response may occupy (default 30000, the same default every retrieval tool answers under). The tool enforces it itself, dropping bodies before edges and reporting the cut in degradations, so a result is never refused for size. `max_chars` is the same parameter under the name the other retrieval tools use.",

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -247,14 +247,79 @@ pub fn owner_graph_mass<G: GraphStore>(
 
 /// Rank relation kinds for trace operations.
 ///
-/// Higher values indicate more significant relations: Calls > Imports > References.
+/// Higher values indicate more significant relations:
+/// Calls > Imports > References > UsesType. An annotation edge sits last on
+/// purpose: naming a type in a signature moves no value, so when a scarce
+/// fan-out slot is contested a bare value reference wins it.
 pub fn trace_relation_rank(kind: RelationKind) -> usize {
     match kind {
-        RelationKind::Calls => 2,
-        RelationKind::Imports => 1,
-        RelationKind::References => 0,
+        RelationKind::Calls => 3,
+        RelationKind::Imports => 2,
+        RelationKind::References => 1,
+        RelationKind::UsesType => 0,
         _ => 0,
     }
+}
+
+/// Whether an edge of this kind states a TYPE dependency rather than a flow of
+/// values.
+///
+/// [`RelationKind::UsesType`] is the model's own name for "type dependency in
+/// signature/body", so it is what this reads. The distinction matters to a walk
+/// rather than to a reference count: `find_references` on a class should list
+/// the signature that names it, while a data-flow chain that hops through the
+/// annotation has left the flow it was asked about.
+pub fn trace_relation_is_annotation(kind: RelationKind) -> bool {
+    matches!(kind, RelationKind::UsesType)
+}
+
+/// Why a trace walk reported a node as a leaf instead of expanding it.
+///
+/// A terminal is not a truncation. Both of these are boundaries of what a
+/// data-flow answer means, so neither says the caller received less of the
+/// chain than exists; they say the chain ends there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceTerminal {
+    /// The repository defines nothing for this symbol, so there is no next hop
+    /// to take. Measured on a converted `psf/requests`: `typing.Any` arrived as
+    /// a file-less node with 44 referrers past the step budget, and walking it
+    /// put `Response.json`, `create_cookie` and `super_len` in the data-flow
+    /// chain of a TLS configuration function.
+    ExternalReference,
+    /// The edge into this node states a type, and the caller did not ask for
+    /// type edges. Two entities that both annotate a parameter with the same
+    /// class share nothing, so traversing the annotation makes every widely
+    /// used type name a hub joining everything to everything.
+    TypeAnnotation,
+}
+
+impl TraceTerminal {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TraceTerminal::ExternalReference => "external_reference",
+            TraceTerminal::TypeAnnotation => "type_annotation",
+        }
+    }
+}
+
+/// Whether a trace step is a leaf, and which boundary made it one.
+///
+/// `None` means the node may be expanded. External wins over annotation when
+/// both apply, and it is unconditional: `include_type_edges` opens same-repo
+/// type edges, and no parameter makes a symbol this repository does not define
+/// walkable, because there is nothing on the other side of it to walk.
+pub fn trace_step_terminal(
+    entity: &Entity,
+    relation_kind: RelationKind,
+    include_type_edges: bool,
+) -> Option<TraceTerminal> {
+    if trace_entity_is_external(entity) {
+        return Some(TraceTerminal::ExternalReference);
+    }
+    if trace_relation_is_annotation(relation_kind) && !include_type_edges {
+        return Some(TraceTerminal::TypeAnnotation);
+    }
+    None
 }
 
 /// Extract the directory component of an entity's file origin.
@@ -447,6 +512,65 @@ mod tests {
         assert!(
             trace_relation_rank(RelationKind::Imports)
                 > trace_relation_rank(RelationKind::References)
+        );
+        assert!(
+            trace_relation_rank(RelationKind::References)
+                > trace_relation_rank(RelationKind::UsesType),
+            "naming a type in a signature moves no value, so a real reference wins a scarce slot"
+        );
+    }
+
+    #[test]
+    fn only_a_type_edge_is_an_annotation_edge() {
+        assert!(trace_relation_is_annotation(RelationKind::UsesType));
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::Imports,
+            RelationKind::References,
+            RelationKind::Instantiates,
+        ] {
+            assert!(
+                !trace_relation_is_annotation(kind),
+                "{kind:?} moves a value and must stay walkable"
+            );
+        }
+    }
+
+    #[test]
+    fn an_external_target_is_terminal_whatever_edge_reached_it() {
+        let external = fanout_entity("Any", None);
+        for kind in [
+            RelationKind::Calls,
+            RelationKind::References,
+            RelationKind::UsesType,
+        ] {
+            for include_type_edges in [false, true] {
+                assert_eq!(
+                    trace_step_terminal(&external, kind, include_type_edges),
+                    Some(TraceTerminal::ExternalReference),
+                    "no parameter makes a symbol this repository does not define walkable \
+                     ({kind:?}, include_type_edges={include_type_edges})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_repo_type_is_terminal_only_until_the_caller_asks_for_type_edges() {
+        let located = fanout_entity("WikiLink", Some("src/links.py"));
+        assert_eq!(
+            trace_step_terminal(&located, RelationKind::UsesType, false),
+            Some(TraceTerminal::TypeAnnotation)
+        );
+        assert_eq!(
+            trace_step_terminal(&located, RelationKind::UsesType, true),
+            None,
+            "a field typed with a repo class is a real flow into that class"
+        );
+        assert_eq!(
+            trace_step_terminal(&located, RelationKind::Calls, false),
+            None,
+            "an ordinary call is untouched by either boundary"
         );
     }
 


### PR DESCRIPTION
`trace_data_flow` walked THROUGH a symbol this repository defines nothing for, so a shared stdlib type name became a hub joining unrelated code into a data-flow chain. On a converted `psf/requests`, `trace_data_flow(cert_verify, direction: "both", depth: 2, limit_per_step: 8)` returned 27 steps and roughly a third of them arrived through one node: `typing.Any`, a file-less `Module` carrying `fanout_dropped: 44`. `requests.help.info`, `Response.json`, `create_cookie`, `super_len` and `dispatch_hook` reached the chain of a TLS configuration function through a type annotation, and the per-step budget the response otherwise discloses honestly was spent on the fan-in of a type name.

## Mechanism

The frontier push was gated on depth alone. `crates/kin-cli/src/commands/trace_data_flow.rs:966` pushed any admitted candidate onto the next frontier, so a file-less reference target was expanded exactly like a located one, and `crates/kin-mcp/src/handlers/entities.rs:3296` did the same on the generic-store arm. Nothing in the walk asked whether there was anything behind the node it was about to expand.

## The fix

`trace_step_terminal` at `crates/kin-ranking/src/entity_ranking.rs:322` is the one classifier both arms read, so the two cannot drift.

An entity the repository owns no file for is terminal unconditionally. There is no next hop behind it and no parameter would produce one, which is why `include_type_edges` does not override it.

An edge of kind `UsesType` is terminal unless the caller passes `include_type_edges`, which opens the hop when the target is a type this repository defines. A dataclass field or a return typed with a repo class is a real flow into that class. External wins when both apply.

`UsesType` joins the walked kinds so an annotation target is a NAMED leaf rather than a symbol the walk never mentions, and so the parameter has an edge to open. It stays out of the coverage observation at `crates/kin-mcp/src/handlers/entities.rs:3066`, because a graph holding no annotation edges says nothing about whether a data-flow answer was whole. It ranks below `References` in `trace_relation_rank`, so a value reference wins a contested fan-out slot.

Every step carries `terminal`, null on an ordinary one. That key is not optional: the first version used `skip_serializing_if` and `every_step_carries_the_same_keys_admitted_or_external` caught it, for the right reason, since one array holding two key sets is the shape that broke a consumer's parser twice.

`terminal_external_steps` and `terminal_annotation_steps` are counted from the chain the caller receives, after the response budget has cut what it cuts, and are kept apart because only the second is recoverable by a parameter. Neither sets `truncated`. A cap that dropped neighbors means the caller received less of a chain that exists; a boundary means the chain ends there, and marking it as a shortfall would report every honest trace as a floor, which is the regression kin#921 bars by test. The completeness envelope names `type_annotation_edges_not_walked` in `limits` when a type hop was withheld, and names nothing for an external leaf; `limits` is disclosure that does not decide `status` and does not move `bound`, which is asserted directly.

`kin trace-data-flow --include-type-edges` gives the CLI the same switch, threaded through `run_seeded`, so a CLI caller reading a `type_annotation` terminal is not told to change a parameter the command does not accept.

## Before and after

On a fixture built to the ticket's own parameters (`depth: 2`, `limit_per_step: 8`, `direction: "both"`, a file-less `Any` with 44 further referrers), the default trace returns **9 steps before the gate and 1 after**. The 8 referrers that filled the step budget are gone and `Any` is a leaf with `fanout_dropped: 0`, `clipped_steps` empty, and `truncated` false.

## What this does not fix

Python type annotations reach the graph as `RelationKind::References` (`crates/kin-parser/src/languages/python.rs:1048`, from kin#904), indistinguishable at the trace layer from a value reference. So what stops the reported `typing.Any` hub is the external rule. The annotation rule is what stops a same-repo annotation hub, and no parser emits `UsesType` today, so that half is proven on a fixture rather than on a converted repository. Making the Python parser emit `UsesType` would change what `find_references` returns for a class, which is the behavior FIR-2399 was filed to add, so it belongs in its own change.

## Falsification

Each case was run to completion and its exit code read raw, never through a pipe, then reverted and the suite re-run green.

Removing the kin-cli frontier gate: rc=101. `an_external_annotation_hub_is_a_leaf_and_its_referrers_never_enter_the_chain` failed with `left: ["Any", "unrelated_0" through "unrelated_7"] right: ["Any"]`, which is the before number. `a_repo_defined_annotation_target_is_a_named_leaf_by_default` failed with `left: ["WikiLink", "normalize_target"] right: ["WikiLink"]`. `the_same_hub_without_the_gate_fills_the_chain_with_unrelated_entities` failed `left: 9 right: 1`.

Making `include_type_edges` a no-op: rc=101 on both arms. kin-cli `a_repo_defined_annotation_target_is_walkable_on_request` failed `left: ["WikiLink"] right: ["WikiLink", "normalize_target"]`; kin-mcp `trace_data_flow_offline_type_edges_open_a_repo_type_and_never_an_external_one` failed `left: ["Any", "WikiLink"] right: ["Any", "WikiLink", "normalize_target"]`.

Removing the kin-mcp frontier gate: rc=101, two failures. The hub test failed with the same 9-name chain, and the type-edge test failed `left: ["Any", "WikiLink", "normalize_target", "unrelated"]`, showing the external hub rejoining unrelated code.

Removing the completeness label: rc=101. `a_withheld_type_hop_is_named_in_completeness_limits_and_an_external_leaf_is_not` failed with the limits it did see, `["edge_coverage:calls_absent","edge_coverage:imports_absent","edge_coverage:references_absent"]`.

## Gate

`bin/kin-lane run tracehub kin -- bin/kin-dev local-test kin` at `b66f0e69` on
`/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/tracehub-kin (chore/lane-tracehub-kin)`:
`Summary [ 353.434s] 6305 tests run: 6305 passed (3 slow, 2 leaky), 12 skipped`, exit 0.
`cargo fmt --all -- --check` exit 0. Clippy under the ci.yml allowlist with `RUSTFLAGS=-D warnings` exit 0.
`scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`,
`scripts/check_runtime_boundaries.sh` and `scripts/check_private_repo_coupling.sh` all exit 0.
`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and
`git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

An earlier run of the same gate caught the one defect in this branch: a test of mine asserted a
`bound` literal the fixture never produced, and the filtered runs that came before had matched on
`trace`, which that test's name does not contain.

Closes FIR-2432
