### PR TITLE
Give the MCP belt calls that retire and relocate source, and pin what a retirement takes with it

### DIFF
--- a/crates/kin-cli/tests/entity_file_retirement.rs
+++ b/crates/kin-cli/tests/entity_file_retirement.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Retiring a committed entity-owning file, through the real binaries.
+//!
+//! A stranger in an isolated container deleted a probe file and kept being
+//! steered by it: 35 minutes later the graph still reported it as the single
+//! file it held and `kin locate` still returned it as the top hit (FIR-2419).
+//! A second container found the other half of the same seam: `rm` of a plain
+//! file reconciled, `rm` of an entity-owning file did not, and `kin commit`
+//! named the constraint outright with "absent from the staged tree"
+//! (FIR-2429).
+//!
+//! A unit test on the planner cannot cover this, because the defect is in what
+//! survives one whole commit and reaches the next query. These drive `kin`
+//! itself and read `kin locate`, which is the surface the stale hit was found
+//! on.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+fn run_git(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(repo)
+        .output()
+        .expect("run git")
+}
+
+fn require_git(repo: &Path, args: &[&str]) {
+    let output = run_git(repo, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    runtime
+        .kin_command()
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .env("KIN_DAEMON_BIN", runtime.daemon_bin())
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_AUTO_EMBED", "0")
+        .current_dir(repo)
+        .output()
+        .expect("run kin")
+}
+
+fn require_kin(
+    runtime: &common::IsolatedDaemonRuntime,
+    repo: &Path,
+    args: &[&str],
+) -> std::process::Output {
+    let output = run_kin(runtime, repo, args);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn initialize(runtime: &common::IsolatedDaemonRuntime, repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    require_git(repo, &["config", "user.name", "Ada Lovelace"]);
+    require_git(repo, &["config", "user.email", "ada@example.com"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), b"pub fn shipped() -> u8 { 1 }\n").expect("write source");
+    fs::write(
+        repo.join("notes.txt"),
+        b"a plain file that owns no entity\n",
+    )
+    .expect("write notes");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "first commit"]);
+
+    require_kin(runtime, repo, &["init", ".", "--json"]);
+}
+
+/// Every file path `kin locate` attributes a ranked hit to.
+fn located_paths(runtime: &common::IsolatedDaemonRuntime, repo: &Path, query: &str) -> Vec<String> {
+    let output = require_kin(runtime, repo, &["locate", "--json", query]);
+    let report: Value =
+        serde_json::from_slice(&output.stdout).expect("kin locate --json should emit JSON");
+    let mut paths = report["files"]
+        .as_array()
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(|file| file["path"].as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    paths.extend(
+        report["entities"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|entity| entity["path"].as_str().map(str::to_string)),
+    );
+    paths
+}
+
+/// Deleting a committed entity-owning file and committing that deletion.
+///
+/// Falsify by removing `record_retired_source_path`'s call site from
+/// `plan_exact_transaction`, or by dropping the removal branch out of
+/// `evict_enrichment_for_removed_paths`: the commit then fails with "absent
+/// from the staged tree" and `kin locate` keeps returning `src/retired.rs`.
+#[test]
+fn deleting_a_committed_entity_owning_file_retires_it_from_every_query_surface() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    fs::write(
+        repo.join("src/retired.rs"),
+        b"pub fn soon_to_be_retired() -> u8 { 7 }\n",
+    )
+    .expect("add source");
+    require_kin(&runtime, &repo, &["commit", "-m", "publish retired source"]);
+
+    let before = located_paths(&runtime, &repo, "soon_to_be_retired");
+    assert!(
+        before.iter().any(|path| path == "src/retired.rs"),
+        "the fixture never made the file findable, so nothing below proves a retirement: {before:?}"
+    );
+
+    fs::remove_file(repo.join("src/retired.rs")).expect("delete the committed source");
+    let retired = run_kin(&runtime, &repo, &["commit", "-m", "retire the source"]);
+    assert!(
+        retired.status.success(),
+        "committing a tree with a committed entity-owning file removed must succeed: \
+         stdout={} stderr={}",
+        String::from_utf8_lossy(&retired.stdout),
+        String::from_utf8_lossy(&retired.stderr)
+    );
+
+    let after = located_paths(&runtime, &repo, "soon_to_be_retired");
+    assert!(
+        !after.iter().any(|path| path == "src/retired.rs"),
+        "a retired file is still ranked by kin locate: {after:?}"
+    );
+}
+
+/// The plain-file arm, which already worked and must keep working.
+#[test]
+fn deleting_a_file_that_owns_no_entity_still_commits() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    initialize(&runtime, &repo);
+
+    fs::remove_file(repo.join("notes.txt")).expect("delete the plain file");
+    let retired = run_kin(&runtime, &repo, &["commit", "-m", "retire the plain file"]);
+    assert!(
+        retired.status.success(),
+        "deleting a non-entity file must still commit: stdout={} stderr={}",
+        String::from_utf8_lossy(&retired.stdout),
+        String::from_utf8_lossy(&retired.stderr)
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -21988,6 +21988,7 @@ mod tests {
                 payload: None,
                 body: Some("pub fn greet() {}".into()),
                 description: "restart-durability".into(),
+                destination: None,
             };
             registry.stage_transaction(&tx_id, vec![op]).unwrap();
             persist_mcp_transactions(&state, &registry);

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -137,7 +137,7 @@ impl AdmittedFileEvent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EnrichmentFacet {
+pub(crate) enum EnrichmentFacet {
     EntitySource,
     ShallowSyntax,
     StructuredArtifact,
@@ -146,8 +146,8 @@ enum EnrichmentFacet {
 }
 
 #[derive(Debug, Default)]
-struct FacetCleanup {
-    removed_entities: Vec<EntityId>,
+pub(crate) struct FacetCleanup {
+    pub(crate) removed_entities: Vec<EntityId>,
     changed: bool,
 }
 
@@ -1147,38 +1147,51 @@ fn clear_incompatible_facets(
     file_id: &FilePathId,
     keep: EnrichmentFacet,
 ) -> Result<FacetCleanup> {
+    clear_incompatible_facets_in(state.graph.as_ref(), file_id, keep)
+}
+
+/// The same cleanup against a graph named outright rather than reached through
+/// the daemon's live state.
+///
+/// The MCP transaction planner needs it against the PROSPECTIVE graph it is
+/// building, which is not the live one and must not be, because a transaction
+/// that fails to plan may not have touched anything a query can see. Naming the
+/// graph is what lets one definition of "retire this file's enrichment" serve
+/// both the watcher seam and the planner, so the two cannot drift into
+/// disagreeing about what a retirement takes with it.
+pub(crate) fn clear_incompatible_facets_in(
+    graph: &kin_db::InMemoryGraph,
+    file_id: &FilePathId,
+    keep: EnrichmentFacet,
+) -> Result<FacetCleanup> {
     let mut cleanup = FacetCleanup::default();
 
     if keep != EnrichmentFacet::EntitySource {
-        let entities = state.graph.query_entities(&EntityFilter {
+        let entities = graph.query_entities(&EntityFilter {
             file_path: Some(file_id.clone()),
             ..Default::default()
         })?;
         cleanup.removed_entities = entities.into_iter().map(|entity| entity.id).collect();
-        state
-            .graph
-            .remove_entities_batch(&cleanup.removed_entities)?;
+        graph.remove_entities_batch(&cleanup.removed_entities)?;
         cleanup.changed |= !cleanup.removed_entities.is_empty();
-        if state.graph.get_file_layout(file_id)?.is_some() {
-            state.graph.delete_file_layout(file_id)?;
+        if graph.get_file_layout(file_id)?.is_some() {
+            graph.delete_file_layout(file_id)?;
             cleanup.changed = true;
         }
     }
 
-    if keep != EnrichmentFacet::ShallowSyntax && state.graph.get_shallow_file(file_id)?.is_some() {
-        state.graph.delete_shallow_file(file_id)?;
+    if keep != EnrichmentFacet::ShallowSyntax && graph.get_shallow_file(file_id)?.is_some() {
+        graph.delete_shallow_file(file_id)?;
         cleanup.changed = true;
     }
     if keep != EnrichmentFacet::StructuredArtifact
-        && state.graph.get_structured_artifact(file_id)?.is_some()
+        && graph.get_structured_artifact(file_id)?.is_some()
     {
-        state.graph.delete_structured_artifact(file_id)?;
+        graph.delete_structured_artifact(file_id)?;
         cleanup.changed = true;
     }
-    if keep != EnrichmentFacet::OpaqueArtifact
-        && state.graph.get_opaque_artifact(file_id)?.is_some()
-    {
-        state.graph.delete_opaque_artifact(file_id)?;
+    if keep != EnrichmentFacet::OpaqueArtifact && graph.get_opaque_artifact(file_id)?.is_some() {
+        graph.delete_opaque_artifact(file_id)?;
         cleanup.changed = true;
     }
 

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1130,6 +1130,7 @@ fn plan_exact_transaction(
     let mut layouts = Vec::new();
     let pipeline = kin_index::IndexPipeline::new();
 
+    refuse_overlapping_file_operations(&creations, &retirements, &relocations, &edits)?;
     // Retirements and relocations run before the creations and the edits. A
     // transaction that retires one path and creates another has to see the
     // retirement first, or the create plans against a tree that still carries
@@ -1444,6 +1445,74 @@ fn record_new_source_file(
             "{target} is created more than once in one transaction; overlapping source authority \
              is ambiguous"
         ));
+    }
+    Ok(())
+}
+
+/// Refuse a transaction whose file-level operations act on the same path twice.
+///
+/// The three file-level shapes are planned in a fixed order (retire, relocate,
+/// create), and each one is checked against the base tree when it is recorded,
+/// so an overlap is invisible at record time and only surfaces as whichever
+/// error the second operation happens to hit against a tree the first one
+/// already moved. That error names an internal planning step rather than the
+/// pair of operations the caller wrote. Two operations on one path also have no
+/// unambiguous meaning: retiring and renaming the same file is a question about
+/// intent, not an ordering problem, and answering it by ordering would publish
+/// a guess.
+///
+/// An edit inside a file this transaction retires is the same class. The edit
+/// would be planned against a path the retirement has already taken out, and
+/// there is no reading of "change this function and delete the file it lives
+/// in" that both halves survive.
+fn refuse_overlapping_file_operations(
+    creations: &BTreeMap<String, (FilePathId, Vec<u8>)>,
+    retirements: &BTreeMap<String, FilePathId>,
+    relocations: &BTreeMap<String, (FilePathId, FilePathId)>,
+    edits: &BTreeMap<String, (FilePathId, Vec<(Entity, Vec<u8>)>)>,
+) -> Result<(), String> {
+    for path in retirements.keys() {
+        if relocations.contains_key(path) {
+            return Err(format!(
+                "{path} is both retired and renamed in one transaction; a file either leaves the \
+                 repository or moves within it, and which one was meant cannot be inferred"
+            ));
+        }
+        if creations.contains_key(path) {
+            return Err(format!(
+                "{path} is both retired and created in one transaction; retire it in one change \
+                 and admit the new file in the next, so each is reviewable on its own"
+            ));
+        }
+        if edits.contains_key(path) {
+            return Err(format!(
+                "{path} is retired and also carries an entity edit in one transaction; the edit \
+                 would be planned against a path this transaction has already taken out"
+            ));
+        }
+    }
+    let mut destinations = BTreeSet::new();
+    for (from, (_, to)) in relocations {
+        if !destinations.insert(to.0.clone()) {
+            return Err(format!(
+                "two files are renamed onto {} in one transaction; a destination holds one file",
+                to.0
+            ));
+        }
+        if creations.contains_key(&to.0) {
+            return Err(format!(
+                "{} is both a rename destination (from {from}) and a created path in one \
+                 transaction; a rename may not overwrite a file",
+                to.0
+            ));
+        }
+        if relocations.contains_key(&to.0) {
+            return Err(format!(
+                "{} is renamed away and is also the destination of {from} in one transaction; \
+                 chained renames are ambiguous, so stage them as separate transactions",
+                to.0
+            ));
+        }
     }
     Ok(())
 }
@@ -3302,6 +3371,97 @@ mod tests {
             .tree
             .artifact_at_path(&test_path("src/lib.rs"))
             .is_some());
+    }
+
+    /// Two file-level operations on one path are refused by name, before
+    /// anything is planned.
+    ///
+    /// The three shapes are planned in a fixed order and each is checked
+    /// against the base tree when it is recorded, so an overlap is invisible
+    /// until the second operation meets a tree the first one already moved.
+    /// What comes back then names an internal planning step, not the pair the
+    /// caller wrote. Two operations on one path also have no unambiguous
+    /// meaning, so ordering them would publish a guess.
+    #[test]
+    fn overlapping_file_level_operations_on_one_path_are_refused_by_name() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 2 }\n",
+            "other",
+        );
+        let sessions = test_sessions();
+
+        let commit_with = |operations: Vec<kin_mcp::McpMutationOperation>| {
+            let transaction = sessions
+                .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+                .unwrap();
+            sessions
+                .stage_transaction(&transaction.transaction_id, operations)
+                .unwrap();
+            commit_exact_transaction(
+                &state,
+                &sessions,
+                &HashMap::from([(
+                    "transaction_id".to_string(),
+                    serde_json::json!(transaction.transaction_id),
+                )]),
+                None,
+            )
+        };
+
+        let both = commit_with(vec![
+            retired_source_file("src/lib.rs"),
+            renamed_source_file("src/lib.rs", "src/moved.rs"),
+        ]);
+        assert_eq!(both.is_error, Some(true));
+        assert!(
+            result_text(&both).contains("is both retired and renamed in one transaction"),
+            "{}",
+            result_text(&both)
+        );
+
+        let collide = commit_with(vec![
+            renamed_source_file("src/lib.rs", "src/dest.rs"),
+            renamed_source_file("src/other.rs", "src/dest.rs"),
+        ]);
+        assert_eq!(collide.is_error, Some(true));
+        assert!(
+            result_text(&collide).contains("two files are renamed onto src/dest.rs"),
+            "{}",
+            result_text(&collide)
+        );
+
+        // The control: the same two renames onto distinct destinations are not
+        // an overlap, so this refusal is about collisions rather than about
+        // refusing every multi-operation transaction.
+        let fine = commit_with(vec![
+            renamed_source_file("src/lib.rs", "src/one.rs"),
+            renamed_source_file("src/other.rs", "src/two.rs"),
+        ]);
+        assert_ne!(fine.is_error, Some(true), "{}", result_text(&fine));
+
+        // Neither end of the refused pairs moved.
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert!(after
+            .tree
+            .artifact_at_path(&test_path("src/one.rs"))
+            .is_some());
+        assert!(after
+            .tree
+            .artifact_at_path(&test_path("src/two.rs"))
+            .is_some());
+        assert!(after
+            .tree
+            .artifact_at_path(&test_path("src/dest.rs"))
+            .is_none());
     }
 
     /// A rename moves the file and everything keeps its identity.

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1649,21 +1649,22 @@ fn plan_retired_source_files(
     // retirement to be atomic. Without them the transition is refused outright
     // with "unadmitted destination endpoint", which is the shape a two-file
     // Python fixture reaches on its first import.
-    let retired: HashSet<kin_model::ArtifactId> = artifacts
-        .iter()
-        .map(|artifact| artifact.artifact_id)
-        .collect();
-    let touches_retired = |node: GraphNodeId| match node {
-        GraphNodeId::Artifact(id) => retired.contains(&id),
-        _ => false,
-    };
-    let relation_deltas = prospective
-        .to_snapshot()
-        .relations
-        .into_values()
-        .filter(|relation| touches_retired(relation.src) || touches_retired(relation.dst))
-        .map(|old| RelationDelta::Removed { old })
-        .collect::<Vec<_>>();
+    let mut seen = HashSet::new();
+    let mut relation_deltas = Vec::new();
+    for artifact in &artifacts {
+        let node = GraphNodeId::Artifact(artifact.artifact_id);
+        for relation in prospective
+            .get_all_relations_for_node(&node)
+            .map_err(|error| format!("load edges incident to {}: {error}", artifact.path))?
+        {
+            // An edge between two retired artifacts is reachable from both, and
+            // removing it twice in one delta is not the same statement as
+            // removing it once.
+            if seen.insert(relation.id) {
+                relation_deltas.push(RelationDelta::Removed { old: relation });
+            }
+        }
+    }
 
     let tree_deltas = artifacts
         .iter()

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -103,8 +103,22 @@ fn authored_files_from_staged(
                 // collapses to `None`, and a resumed commit would then declare
                 // every file it published as carried when the original declared
                 // none of them.
-                if kin_mcp::session::is_new_source_file(operation) {
+                if kin_mcp::session::is_new_source_file(operation)
+                    || kin_mcp::session::is_retired_source_file(operation)
+                {
                     authored.insert(RepoPath::from_utf8(operation.target.trim().to_string()).ok()?);
+                    continue;
+                }
+                // A rename writes at both ends. Claiming only the destination
+                // would leave the origin looking like a file the workspace
+                // happened to be carrying, which is the distinction this set
+                // exists to keep.
+                if kin_mcp::session::is_renamed_source_file(operation) {
+                    authored.insert(RepoPath::from_utf8(operation.target.trim().to_string()).ok()?);
+                    authored.insert(
+                        RepoPath::from_utf8(operation.destination.as_deref()?.trim().to_string())
+                            .ok()?,
+                    );
                     continue;
                 }
                 kin_mcp::handlers::sessions::resolve_target_entity(graph, &operation.target).ok()?
@@ -927,6 +941,8 @@ fn plan_exact_transaction(
         .map_err(|error| format!("create prospective exact graph: {error}"))?;
     let mut edits: BTreeMap<String, (FilePathId, Vec<(Entity, Vec<u8>)>)> = BTreeMap::new();
     let mut creations: BTreeMap<String, (FilePathId, Vec<u8>)> = BTreeMap::new();
+    let mut retirements: BTreeMap<String, FilePathId> = BTreeMap::new();
+    let mut relocations: BTreeMap<String, (FilePathId, FilePathId)> = BTreeMap::new();
     let mut relation_operations = Vec::new();
     let mut edited_entities = HashSet::new();
 
@@ -942,6 +958,22 @@ fn plan_exact_transaction(
         // edit another and publish both or neither.
         if operation.payload.is_none() && kin_mcp::session::is_new_source_file(operation) {
             record_new_source_file(&mut creations, base, operation)?;
+            continue;
+        }
+        // A payload-less `delete` carrying a repository path retires source the
+        // graph already holds, and a payload-less `rename` carrying two paths
+        // relocates it. They are the mirror image of `create`: an entity
+        // payload names one entity, which can neither retire the artifact it
+        // sits on nor move it, so a file-level transition has to name the file.
+        // Recorded here and planned below, beside the creations and the edits,
+        // so one transaction can retire one file and write another and publish
+        // both or neither.
+        if operation.payload.is_none() && kin_mcp::session::is_retired_source_file(operation) {
+            record_retired_source_path(&mut retirements, base, operation)?;
+            continue;
+        }
+        if operation.payload.is_none() && kin_mcp::session::is_renamed_source_file(operation) {
+            record_renamed_source_path(&mut relocations, base, operation)?;
             continue;
         }
         // A payload-less `update` carrying a target and a body is the minimal
@@ -1087,6 +1119,8 @@ fn plan_exact_transaction(
         .values()
         .map(|(file_id, _)| file_id)
         .chain(creations.values().map(|(file_id, _)| file_id))
+        .chain(retirements.values())
+        .chain(relocations.values().flat_map(|(from, to)| [from, to]))
         .map(|file_id| {
             RepoPath::from_utf8(file_id.0.clone())
                 .map_err(|error| format!("invalid exact source path {file_id}: {error}"))
@@ -1096,6 +1130,15 @@ fn plan_exact_transaction(
     let mut layouts = Vec::new();
     let pipeline = kin_index::IndexPipeline::new();
 
+    // Retirements and relocations run before the creations and the edits. A
+    // transaction that retires one path and creates another has to see the
+    // retirement first, or the create plans against a tree that still carries
+    // what this transaction is about to take out of it. Ordering them here also
+    // means a relocation's destination is occupied by the time a later create
+    // is planned against the same tree, so the collision is caught rather than
+    // published.
+    plan_retired_source_files(&prospective, retirements)?;
+    plan_renamed_source_files(&prospective, relocations, &mut layouts)?;
     plan_new_source_files(state, &prospective, &pipeline, creations, &mut layouts)?;
     for (_, (file_id, file_edits)) in edits {
         let path = RepoPath::from_utf8(file_id.0.clone())
@@ -1401,6 +1444,297 @@ fn record_new_source_file(
             "{target} is created more than once in one transaction; overlapping source authority \
              is ambiguous"
         ));
+    }
+    Ok(())
+}
+
+/// Record one retirement: the file at `target` leaves the repository.
+///
+/// The path must be one repository authority already tracks. A retirement of a
+/// path nothing holds is refused rather than treated as satisfied, because the
+/// caller believes a file left the graph and would have no way to learn it
+/// never did; a silent success there is the same failure class as an admission
+/// that quietly overwrote somebody else's file.
+fn record_retired_source_path(
+    retirements: &mut BTreeMap<String, FilePathId>,
+    base: &NativeCommitBase,
+    operation: &kin_mcp::McpMutationOperation,
+) -> Result<(), String> {
+    let target = operation.target.trim();
+    let path = RepoPath::from_utf8(target.to_string())
+        .map_err(|error| format!("retired source path {target:?} is unusable: {error}"))?;
+    if base.tree.artifact_at_path(&path).is_none() {
+        return Err(format!(
+            "{target} is not tracked by repository authority, so there is nothing to retire; \
+             'delete' retires only a path the graph already holds. Name a path kin_graph_status \
+             or semantic_locate reports, or drop this operation"
+        ));
+    }
+    let file_id = FilePathId::new(target.to_string());
+    if retirements.insert(file_id.0.clone(), file_id).is_some() {
+        return Err(format!(
+            "{target} is retired more than once in one transaction; retiring a path that is \
+             already gone is ambiguous"
+        ));
+    }
+    Ok(())
+}
+
+/// Record one relocation: the file at `target` moves to `destination`.
+///
+/// Both ends are checked against the base tree here rather than only at the
+/// transition, so a caller learns which end was wrong. A destination that is
+/// already tracked is refused instead of overwritten, for the same reason
+/// `create` refuses a tracked path: a move that silently replaces another file
+/// destroys truth the caller never named.
+fn record_renamed_source_path(
+    relocations: &mut BTreeMap<String, (FilePathId, FilePathId)>,
+    base: &NativeCommitBase,
+    operation: &kin_mcp::McpMutationOperation,
+) -> Result<(), String> {
+    let target = operation.target.trim();
+    let destination = operation
+        .destination
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default();
+    let from = RepoPath::from_utf8(target.to_string())
+        .map_err(|error| format!("renamed source path {target:?} is unusable: {error}"))?;
+    let to = RepoPath::from_utf8(destination.to_string())
+        .map_err(|error| format!("rename destination {destination:?} is unusable: {error}"))?;
+    kin_core::validate_source_paths([&to]).map_err(|error| {
+        format!("rename destination {destination:?} is not an admissible repository path: {error}")
+    })?;
+    if base.tree.artifact_at_path(&from).is_none() {
+        return Err(format!(
+            "{target} is not tracked by repository authority, so there is nothing to rename; \
+             'rename' moves only a path the graph already holds"
+        ));
+    }
+    if base.tree.artifact_at_path(&to).is_some() {
+        return Err(format!(
+            "{destination} is already tracked by repository authority, so {target} cannot move \
+             onto it; a rename may not overwrite a file. Retire {destination} first, or pick a \
+             path that does not exist yet"
+        ));
+    }
+    let from_id = FilePathId::new(target.to_string());
+    let to_id = FilePathId::new(destination.to_string());
+    if relocations
+        .insert(from_id.0.clone(), (from_id, to_id))
+        .is_some()
+    {
+        return Err(format!(
+            "{target} is renamed more than once in one transaction; a file has one destination"
+        ));
+    }
+    Ok(())
+}
+
+/// Take every recorded retirement out of prospective graph truth: entities,
+/// their incident edges, the file layout, every non-entity enrichment facet,
+/// and the tree entry itself.
+///
+/// The enrichment goes before the tree entry and through the same function the
+/// watcher seam uses ([`crate::loop_runner::clear_incompatible_facets_in`]),
+/// which is what keeps the two definitions of "retire this file" from drifting
+/// apart. The order is not a preference: repository authority refuses a
+/// transition that leaves an entity on a path the staged tree no longer
+/// carries, and it is right to, because an artifact that stops existing while
+/// its entities keep ranking is exactly the stale top hit this exists to
+/// prevent. Removing the entities first is what makes the tree transition
+/// admissible.
+fn plan_retired_source_files(
+    prospective: &kin_db::InMemoryGraph,
+    retirements: BTreeMap<String, FilePathId>,
+) -> Result<(), String> {
+    if retirements.is_empty() {
+        return Ok(());
+    }
+    let mut artifacts = Vec::new();
+    for (_, file_id) in retirements {
+        let path = RepoPath::from_utf8(file_id.0.clone())
+            .map_err(|error| format!("invalid retired source path {file_id}: {error}"))?;
+        let artifact = prospective
+            .resolved_tree()
+            .artifact_at_path(&path)
+            .cloned()
+            .ok_or_else(|| {
+                format!("retired source artifact disappeared during planning: {file_id}")
+            })?;
+        crate::loop_runner::clear_incompatible_facets_in(
+            prospective,
+            &file_id,
+            crate::loop_runner::EnrichmentFacet::None,
+        )
+        .map_err(|error| format!("retire enrichment for {file_id}: {error}"))?;
+        artifacts.push(artifact);
+    }
+
+    // Edges that address the ARTIFACT rather than an entity inside it. Removing
+    // the entities took every edge incident to them, and this is what is left:
+    // an import that resolved to the file, a dependency drawn on the file. They
+    // are collected after the enrichment pass so an edge already gone is not
+    // removed twice, and carried in the same delta as the tree removal because
+    // repository authority requires artifact retirement and incident-edge
+    // retirement to be atomic. Without them the transition is refused outright
+    // with "unadmitted destination endpoint", which is the shape a two-file
+    // Python fixture reaches on its first import.
+    let retired: HashSet<kin_model::ArtifactId> = artifacts
+        .iter()
+        .map(|artifact| artifact.artifact_id)
+        .collect();
+    let touches_retired = |node: GraphNodeId| match node {
+        GraphNodeId::Artifact(id) => retired.contains(&id),
+        _ => false,
+    };
+    let relation_deltas = prospective
+        .to_snapshot()
+        .relations
+        .into_values()
+        .filter(|relation| touches_retired(relation.src) || touches_retired(relation.dst))
+        .map(|old| RelationDelta::Removed { old })
+        .collect::<Vec<_>>();
+
+    let tree_deltas = artifacts
+        .iter()
+        .map(|artifact| TreeDelta::Removed {
+            artifact_id: artifact.artifact_id,
+            old: artifact.located_entry(),
+        })
+        .collect::<Vec<_>>();
+    prospective
+        .apply_transaction_delta(&TransactionDelta {
+            relation_deltas,
+            tree_deltas,
+            ..TransactionDelta::default()
+        })
+        .map_err(|error| {
+            let paths = artifacts
+                .iter()
+                .map(|artifact| artifact.path.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("retire {paths} from the exact tree: {error}")
+        })?;
+    Ok(())
+}
+
+/// Move every recorded relocation in prospective graph truth, keeping the
+/// identity of everything it moves.
+///
+/// The artifact keeps its id, every entity keeps its id, span, lineage, and
+/// documentation, and every relation keeps both endpoints, because relations
+/// address entities rather than paths. Only the path changes, which is the
+/// whole difference between a rename and a retirement followed by an admission:
+/// the second mints new identity and orphans every incoming edge.
+///
+/// The entity relocation and the tree transition travel in ONE delta. Split
+/// across two, the first half would be exactly the state repository authority
+/// refuses (entities on a path the staged tree no longer carries), so a rename
+/// planned in two steps cannot reach the second. This is the "or relocation"
+/// half of what that refusal asks a caller to carry.
+///
+/// The layout and the non-entity facets carry the path in their key rather than
+/// in their body, so they are re-keyed rather than rebuilt: the bytes did not
+/// move, so every byte range in them is still correct.
+fn plan_renamed_source_files(
+    prospective: &kin_db::InMemoryGraph,
+    relocations: BTreeMap<String, (FilePathId, FilePathId)>,
+    layouts: &mut Vec<FileLayout>,
+) -> Result<(), String> {
+    for (_, (from_id, to_id)) in relocations {
+        let from = RepoPath::from_utf8(from_id.0.clone())
+            .map_err(|error| format!("invalid rename origin {from_id}: {error}"))?;
+        let to = RepoPath::from_utf8(to_id.0.clone())
+            .map_err(|error| format!("invalid rename destination {to_id}: {error}"))?;
+        let artifact = prospective
+            .resolved_tree()
+            .artifact_at_path(&from)
+            .cloned()
+            .ok_or_else(|| {
+                format!("renamed source artifact disappeared during planning: {from_id}")
+            })?;
+
+        let entity_deltas = prospective
+            .query_entities(&kin_model::EntityFilter {
+                file_path: Some(from_id.clone()),
+                ..Default::default()
+            })
+            .map_err(|error| format!("load entities on {from_id}: {error}"))?
+            .into_iter()
+            .map(|old| {
+                let mut new = old.clone();
+                new.file_origin = Some(to_id.clone());
+                EntityDelta::Modified { old, new }
+            })
+            .collect::<Vec<_>>();
+
+        prospective
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas,
+                tree_deltas: vec![TreeDelta::Updated {
+                    artifact_id: artifact.artifact_id,
+                    old: artifact.located_entry(),
+                    new: LocatedEntry::new(to.clone(), artifact.entry),
+                }],
+                ..TransactionDelta::default()
+            })
+            .map_err(|error| format!("relocate {from_id} to {to_id}: {error}"))?;
+
+        if let Some(layout) = prospective
+            .get_file_layout(&from_id)
+            .map_err(|error| format!("load layout for {from_id}: {error}"))?
+        {
+            let mut moved = layout;
+            moved.file_id = to_id.clone();
+            prospective
+                .delete_file_layout(&from_id)
+                .map_err(|error| format!("drop layout at {from_id}: {error}"))?;
+            prospective
+                .upsert_file_layout(&moved)
+                .map_err(|error| format!("install layout at {to_id}: {error}"))?;
+            layouts.push(moved);
+        }
+        if let Some(shallow) = prospective
+            .get_shallow_file(&from_id)
+            .map_err(|error| format!("load shallow record for {from_id}: {error}"))?
+        {
+            let mut moved = shallow;
+            moved.file_id = to_id.clone();
+            prospective
+                .delete_shallow_file(&from_id)
+                .map_err(|error| format!("drop shallow record at {from_id}: {error}"))?;
+            prospective
+                .upsert_shallow_file(&moved)
+                .map_err(|error| format!("install shallow record at {to_id}: {error}"))?;
+        }
+        if let Some(structured) = prospective
+            .get_structured_artifact(&from_id)
+            .map_err(|error| format!("load structured record for {from_id}: {error}"))?
+        {
+            let mut moved = structured;
+            moved.file_id = to_id.clone();
+            prospective
+                .delete_structured_artifact(&from_id)
+                .map_err(|error| format!("drop structured record at {from_id}: {error}"))?;
+            prospective
+                .upsert_structured_artifact(&moved)
+                .map_err(|error| format!("install structured record at {to_id}: {error}"))?;
+        }
+        if let Some(opaque) = prospective
+            .get_opaque_artifact(&from_id)
+            .map_err(|error| format!("load opaque record for {from_id}: {error}"))?
+        {
+            let mut moved = opaque;
+            moved.file_id = to_id.clone();
+            prospective
+                .delete_opaque_artifact(&from_id)
+                .map_err(|error| format!("drop opaque record at {from_id}: {error}"))?;
+            prospective
+                .upsert_opaque_artifact(&moved)
+                .map_err(|error| format!("install opaque record at {to_id}: {error}"))?;
+        }
     }
     Ok(())
 }
@@ -2274,6 +2608,7 @@ mod tests {
                     payload: Some(kin_mcp::McpMutationPayload::Entity(entity.clone())),
                     body: Some(body.to_string()),
                     description: "replace exact entity body".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -2373,6 +2708,7 @@ mod tests {
             target: path.to_string(),
             payload: None,
             body: Some(body.to_string()),
+            destination: None,
             description: format!("admit new source {path}"),
         }
     }
@@ -2599,6 +2935,590 @@ mod tests {
             .expect("an ordinary repository-relative path must stage");
     }
 
+    /// One repository path, for the assertions that read the exact tree.
+    fn test_path(path: &str) -> RepoPath {
+        RepoPath::from_utf8(path.to_string()).expect("test repository path must be usable")
+    }
+
+    /// Build the delete-file operation an agent stages to retire source.
+    fn retired_source_file(path: &str) -> kin_mcp::McpMutationOperation {
+        kin_mcp::McpMutationOperation {
+            verb: "delete".to_string(),
+            target: path.to_string(),
+            payload: None,
+            body: None,
+            destination: None,
+            description: format!("retire {path}"),
+        }
+    }
+
+    /// Build the rename operation an agent stages to relocate source.
+    fn renamed_source_file(from: &str, to: &str) -> kin_mcp::McpMutationOperation {
+        kin_mcp::McpMutationOperation {
+            verb: "rename".to_string(),
+            target: from.to_string(),
+            payload: None,
+            body: None,
+            destination: Some(to.to_string()),
+            description: format!("move {from} to {to}"),
+        }
+    }
+
+    /// An agent holding only the MCP belt retires a file, and the graph stops
+    /// holding it.
+    ///
+    /// This is the defect FIR-2419 records, from the query side. A probe file
+    /// deleted 35 minutes earlier was still the top `semantic_locate` hit and
+    /// still the single file the graph counted, because retirement never
+    /// reached the retrieval index. It could not: the belt had no call that
+    /// retires anything. `create` admits a file and `update` edits an entity
+    /// inside one, and an entity payload carrying verb `delete` names one
+    /// entity, which cannot take the artifact it sits on out of the tree.
+    ///
+    /// Every surface a stale hit can come through is asserted, not just the
+    /// tree: the entity ids stop resolving, the file stops being an
+    /// entity-bearing path, the layout goes, and the working file goes with
+    /// them. `semantic_locate`, `find_references` and `get_context_pack` all
+    /// read those, so a retirement that left any of them standing would keep
+    /// steering an agent toward a file that no longer exists.
+    #[test]
+    fn retiring_a_tracked_file_over_mcp_takes_its_entities_and_its_tree_entry() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/retired.rs",
+            b"pub fn retired_value() -> u8 { 1 }\n",
+            "retired_value",
+        );
+        let (kept, _) = install_exact_source(
+            &state,
+            "src/kept.rs",
+            b"pub fn kept_value() -> u8 { 2 }\n",
+            "kept_value",
+        );
+        let file_id = FilePathId::new("src/retired.rs");
+        let before = load_native_commit_base(&state.layout).unwrap();
+        assert!(
+            before
+                .tree
+                .artifact_at_path(&test_path("src/retired.rs"))
+                .is_some(),
+            "the fixture never tracked the file, so nothing below proves a retirement"
+        );
+
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/retired.rs")
+            .unwrap();
+        let operations = vec![retired_source_file("src/retired.rs")];
+        kin_mcp::session::validate_staged_operations(&operations)
+            .expect("staging must accept the retirement form");
+        sessions
+            .stage_transaction(&transaction.transaction_id, operations)
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "retiring a tracked file over MCP failed: {}",
+            result_text(&result)
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert!(
+            after
+                .tree
+                .artifact_at_path(&test_path("src/retired.rs"))
+                .is_none(),
+            "a retired file is still tracked by repository authority"
+        );
+        assert!(
+            after.graph.get_entity(&entity.id).unwrap().is_none(),
+            "a retired file's entity id still resolves: {}",
+            entity.id
+        );
+        assert!(
+            after
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(file_id.clone()),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .is_empty(),
+            "a retired path still owns entities"
+        );
+        assert!(
+            !after
+                .graph
+                .entity_bearing_file_paths()
+                .contains(&"src/retired.rs".to_string()),
+            "a retired path is still counted as an entity-bearing file"
+        );
+        // Enrichment lives on the live query graph rather than in the published
+        // change, and the live graph is what `semantic_locate`,
+        // `find_references` and `get_context_pack` read, so it is where a stale
+        // hit would actually come from. Asserted with the sibling beside it, so
+        // an assertion that could only ever pass would fail here too.
+        assert!(
+            state.graph.get_file_layout(&file_id).unwrap().is_none(),
+            "a retired file kept its layout on the live query graph"
+        );
+        assert!(
+            state
+                .graph
+                .get_file_layout(&FilePathId::new("src/kept.rs"))
+                .unwrap()
+                .is_some(),
+            "the control layout is absent, so the retired-layout assertion proves nothing"
+        );
+        assert!(
+            state
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(file_id.clone()),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .is_empty(),
+            "a retired path still owns entities on the live query graph"
+        );
+        assert!(
+            state.graph.get_entity(&kept.id).unwrap().is_some(),
+            "the control entity is absent from the live graph, so the retirement proves nothing"
+        );
+        assert!(
+            !state.layout.working_dir().join("src/retired.rs").exists(),
+            "the commit projects the tree it published, so the working file must go with it"
+        );
+
+        // The two-sided arm: the sibling this transaction never named keeps its
+        // artifact and the exact entity id it had, so a retirement retired one
+        // path rather than emptying the graph.
+        assert!(
+            after
+                .tree
+                .artifact_at_path(&test_path("src/kept.rs"))
+                .is_some(),
+            "an unnamed sibling lost its artifact"
+        );
+        assert!(
+            after.graph.get_entity(&kept.id).unwrap().is_some(),
+            "an unnamed sibling lost its entity"
+        );
+
+        let reply: serde_json::Value = serde_json::from_str(result_text(&result)).unwrap();
+        assert!(
+            reply["change_id"].as_str().is_some_and(|id| !id.is_empty()),
+            "a retirement must publish a change an agent can review: {reply}"
+        );
+    }
+
+    /// A retired file leaves every row a retrieval surface reads.
+    ///
+    /// FIR-2419 is a query defect, not a bookkeeping one: the deleted file was
+    /// still the top `semantic_locate` hit and still the single file the graph
+    /// counted. Those surfaces do not read the tree. `semantic_locate` and
+    /// `get_context_pack` rank entities and read their layouts,
+    /// `find_references` reads relation rows, the file count reads
+    /// entity-bearing paths, and the embedding queue holds a retrieval key per
+    /// entity. A retirement that moved the tree and left any of those standing
+    /// would keep steering an agent toward a file that no longer exists, which
+    /// is exactly what 35 minutes of that container looked like.
+    ///
+    /// The cross-file edge is what makes this more than a restatement of the
+    /// previous test. `run` lives in a file this transaction never names, so
+    /// its edge to `helper` can only go if retiring a file takes the edges
+    /// incident to its entities with it.
+    #[test]
+    fn retiring_a_file_evicts_it_from_the_rows_every_retrieval_surface_reads() {
+        let (_dir, state) = test_state();
+        let sessions = test_sessions();
+
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:pkg/app.py")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![
+                    new_source_file("pkg/util.py", NEW_UTIL_PY),
+                    new_source_file("pkg/app.py", NEW_APP_PY),
+                ],
+            )
+            .unwrap();
+        let created = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(created.is_error, Some(true), "{}", result_text(&created));
+
+        let entity_in = |file: &str, name: &str| {
+            state
+                .graph
+                .query_entities(&EntityFilter {
+                    file_path: Some(FilePathId::new(file)),
+                    ..EntityFilter::default()
+                })
+                .unwrap()
+                .into_iter()
+                .find(|entity| entity.name == name)
+                .unwrap_or_else(|| panic!("{name} must be a graph entity derived from {file}"))
+        };
+        let helper = entity_in("pkg/util.py", "helper");
+        let run = entity_in("pkg/app.py", "run");
+        let crossing = |graph: &kin_db::InMemoryGraph| {
+            graph
+                .get_all_relations_for_entity(&run.id)
+                .unwrap()
+                .into_iter()
+                .any(|relation| relation.dst == GraphNodeId::Entity(helper.id))
+        };
+        assert!(
+            crossing(state.graph.as_ref()),
+            "the fixture produced no cross-file edge, so nothing below proves one was evicted"
+        );
+        let queued_before = state.graph.pending_embeddings();
+        assert!(
+            queued_before > 0,
+            "the fixture queued no embeddings, so the queue assertion below proves nothing"
+        );
+
+        let retire = sessions
+            .begin_transaction(TEST_SESSION, "file:pkg/util.py")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &retire.transaction_id,
+                vec![retired_source_file("pkg/util.py")],
+            )
+            .unwrap();
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(retire.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+
+        // What `semantic_locate` and `get_context_pack` rank.
+        assert!(
+            state.graph.get_entity(&helper.id).unwrap().is_none(),
+            "a retired file's entity still resolves, so it can still be ranked"
+        );
+        // What `find_references` reads, from the surviving side of the edge.
+        assert!(
+            !crossing(state.graph.as_ref()),
+            "an entity in an untouched file still holds an edge into the retired file"
+        );
+        // What the file count reads.
+        let bearing = state.graph.entity_bearing_file_paths();
+        assert!(
+            !bearing.contains(&"pkg/util.py".to_string()),
+            "a retired path is still counted as an entity-bearing file: {bearing:?}"
+        );
+        assert!(
+            bearing.contains(&"pkg/app.py".to_string()),
+            "the untouched file left the count too, so this proves nothing: {bearing:?}"
+        );
+        // What the vector index is fed from. kin-db drops the retrieval key for
+        // every removed entity in the same call that removes it, so a store
+        // that never built an index still shows the eviction here.
+        assert!(
+            state.graph.pending_embeddings() < queued_before,
+            "the retired entities are still queued for embedding: {} of {queued_before}",
+            state.graph.pending_embeddings()
+        );
+        // The survivor keeps its own entity, so the eviction was scoped.
+        assert!(
+            state.graph.get_entity(&run.id).unwrap().is_some(),
+            "retiring one file took an entity out of another"
+        );
+    }
+
+    /// A `delete` naming a path the graph does not track is refused by name.
+    ///
+    /// Answering "already gone, nothing to do" would be the worse failure. A
+    /// caller that mistyped a path would be told its file left the graph while
+    /// the real one kept ranking, which is the FIR-2419 symptom arriving by a
+    /// second route.
+    #[test]
+    fn retiring_a_path_the_graph_does_not_track_is_refused_by_name() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![retired_source_file("src/never_existed.rs")],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_eq!(result.is_error, Some(true));
+        let text = result_text(&result);
+        assert!(
+            text.contains("src/never_existed.rs is not tracked by repository authority"),
+            "refusal must name the path it could not retire: {text}"
+        );
+
+        // The refusal is not merely a message: the file it did not name is
+        // untouched.
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert!(after
+            .tree
+            .artifact_at_path(&test_path("src/lib.rs"))
+            .is_some());
+    }
+
+    /// A rename moves the file and everything keeps its identity.
+    ///
+    /// This is the half of FIR-2429 that a retirement cannot cover. A rename is
+    /// a removal at one path and an arrival at another, and doing it as that
+    /// pair mints new entity ids and orphans every incoming reference, so the
+    /// history of the code that moved is lost and every caller of it stops
+    /// resolving. Repository authority says as much from its own side: it
+    /// refuses a transition that leaves an entity on a path the staged tree no
+    /// longer carries unless the same delta carries its removal OR RELOCATION.
+    /// This is the relocation.
+    ///
+    /// The incoming edge is asserted because it is what `find_references` reads.
+    /// A move that kept the entity but dropped its callers would still report a
+    /// renamed function as referenced by nothing.
+    #[test]
+    fn renaming_a_tracked_file_over_mcp_keeps_entity_identity_and_incoming_edges() {
+        let (_dir, state) = test_state();
+        let sessions = test_sessions();
+
+        // Two files created in one transaction so the second really references
+        // the first; the planner seeds its cross-file linker for exactly this.
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:pkg/app.py")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![
+                    new_source_file("pkg/util.py", NEW_UTIL_PY),
+                    new_source_file("pkg/app.py", NEW_APP_PY),
+                ],
+            )
+            .unwrap();
+        let created = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(created.is_error, Some(true), "{}", result_text(&created));
+
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let helper = before
+            .graph
+            .query_entities(&EntityFilter {
+                file_path: Some(FilePathId::new("pkg/util.py")),
+                ..EntityFilter::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == "helper")
+            .expect("the fixture must hold helper");
+        let referencing_before = before
+            .graph
+            .get_all_relations_for_entity(&helper.id)
+            .unwrap()
+            .len();
+        assert!(
+            referencing_before > 0,
+            "the fixture produced no edges on helper, so nothing below proves they survived"
+        );
+
+        let moved = sessions
+            .begin_transaction(TEST_SESSION, "file:pkg/util.py")
+            .unwrap();
+        let operations = vec![renamed_source_file("pkg/util.py", "pkg/core/util.py")];
+        kin_mcp::session::validate_staged_operations(&operations)
+            .expect("staging must accept the rename form");
+        sessions
+            .stage_transaction(&moved.transaction_id, operations)
+            .unwrap();
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(moved.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "renaming a tracked file over MCP failed: {}",
+            result_text(&result)
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert!(
+            after
+                .tree
+                .artifact_at_path(&test_path("pkg/util.py"))
+                .is_none(),
+            "the origin path is still tracked after a rename"
+        );
+        let destination = after
+            .tree
+            .artifact_at_path(&test_path("pkg/core/util.py"))
+            .expect("the destination path must be tracked after a rename");
+        assert_eq!(
+            destination.artifact_id,
+            before
+                .tree
+                .artifact_at_path(&test_path("pkg/util.py"))
+                .unwrap()
+                .artifact_id,
+            "a rename must keep artifact identity; a new id is a delete plus a create"
+        );
+
+        let relocated = after
+            .graph
+            .get_entity(&helper.id)
+            .unwrap()
+            .expect("a rename must keep the entity id it moved");
+        assert_eq!(
+            relocated.file_origin,
+            Some(FilePathId::new("pkg/core/util.py")),
+            "the relocated entity still claims its old path"
+        );
+        assert_eq!(
+            after
+                .graph
+                .get_all_relations_for_entity(&helper.id)
+                .unwrap()
+                .len(),
+            referencing_before,
+            "a rename dropped edges incident to the entity it moved"
+        );
+        assert!(
+            state
+                .graph
+                .get_file_layout(&FilePathId::new("pkg/core/util.py"))
+                .unwrap()
+                .is_some(),
+            "the layout must move with the file on the live query graph"
+        );
+        assert!(
+            state
+                .graph
+                .get_file_layout(&FilePathId::new("pkg/util.py"))
+                .unwrap()
+                .is_none(),
+            "the layout must not stay behind at the old path"
+        );
+
+        // The bytes travelled unchanged, and the working copy is the projection
+        // of what committed rather than anything the agent wrote.
+        assert_eq!(
+            std::fs::read_to_string(state.layout.working_dir().join("pkg/core/util.py")).unwrap(),
+            NEW_UTIL_PY
+        );
+        assert!(
+            !state.layout.working_dir().join("pkg/util.py").exists(),
+            "the origin file must go with the rename"
+        );
+    }
+
+    /// A rename onto a path the graph already tracks is refused by name.
+    #[test]
+    fn renaming_onto_a_tracked_path_is_refused_by_name() {
+        let (_dir, state) = test_state();
+        install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        install_exact_source(
+            &state,
+            "src/other.rs",
+            b"pub fn other() -> u8 { 2 }\n",
+            "other",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![renamed_source_file("src/lib.rs", "src/other.rs")],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_eq!(result.is_error, Some(true));
+        let text = result_text(&result);
+        assert!(
+            text.contains("src/other.rs is already tracked by repository authority"),
+            "refusal must name the destination it would have overwritten: {text}"
+        );
+
+        // Neither end moved.
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert!(after
+            .tree
+            .artifact_at_path(&test_path("src/lib.rs"))
+            .is_some());
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/other.rs")).unwrap(),
+            b"pub fn other() -> u8 { 2 }\n"
+        );
+    }
+
     #[test]
     fn payload_less_target_body_update_commits_like_an_entity_payload() {
         // Staging accepts verb `update` with a `target` (entity name or id) and a
@@ -2625,6 +3545,7 @@ mod tests {
             payload: None,
             body: Some("pub fn value() -> u8 { 2 }".to_string()),
             description: "payload-less body update".to_string(),
+            destination: None,
         };
         kin_mcp::session::validate_staged_operations(std::slice::from_ref(&operation))
             .expect("staging must accept the payload-less target body form");
@@ -3023,6 +3944,7 @@ mod tests {
                     payload: None,
                     body: Some(body.to_string()),
                     description: "attributed body update".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -3626,6 +4548,7 @@ mod tests {
                     payload: None,
                     body: Some("pub fn value() -> u8 { 2 }".to_string()),
                     description: "attributed body update".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -3704,6 +4627,7 @@ mod tests {
                     }),
                     body: None,
                     description: "link the call".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -3912,6 +4836,7 @@ mod tests {
                     payload: None,
                     body: Some("pub fn no_such_entity() {}".to_string()),
                     description: String::new(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -3981,6 +4906,7 @@ mod tests {
                         payload: None,
                         body: Some("pub fn value() -> u8 { 3 }".to_string()),
                         description: "correct work staged alongside the failure".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -3988,6 +4914,7 @@ mod tests {
                         payload: None,
                         body: Some("pub fn no_such_entity() {}".to_string()),
                         description: String::new(),
+                        destination: None,
                     },
                 ],
             )
@@ -4035,6 +4962,7 @@ mod tests {
                     payload: None,
                     body: Some("pub fn value() -> u8 { 2 }".to_string()),
                     description: "corrected retry".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4099,6 +5027,7 @@ mod tests {
                     payload: None,
                     body: Some("pub fn shared() -> u8 { 2 }".to_string()),
                     description: "bare name an agent would reach for first".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4138,6 +5067,7 @@ mod tests {
                     payload: None,
                     body: Some("pub fn shared() -> u8 { 2 }".to_string()),
                     description: "corrected id retry".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4204,6 +5134,7 @@ mod tests {
                             "    pub fn set(&mut self) -> u8 {\n        2\n    }".to_string(),
                         ),
                         description: "impl-nested method".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4211,6 +5142,7 @@ mod tests {
                         payload: None,
                         body: Some("    pub fn nested() -> u8 {\n        2\n    }".to_string()),
                         description: "module-nested function".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4218,6 +5150,7 @@ mod tests {
                         payload: None,
                         body: Some("pub fn plain() -> u8 {\n    2\n}".to_string()),
                         description: "top-level function".to_string(),
+                        destination: None,
                     },
                 ],
             )
@@ -4292,6 +5225,7 @@ mod tests {
                     // No leading indentation: the span slice, verbatim.
                     body: Some("pub fn set(&mut self) -> u8 {\n        2\n    }".to_string()),
                     description: "span-slice body".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4379,6 +5313,7 @@ mod tests {
                         payload: None,
                         body: Some(NEW_RESOLVE_BINARY.to_string()),
                         description: "add the search_dirs parameter".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4386,6 +5321,7 @@ mod tests {
                         payload: None,
                         body: Some(NEW_PREPROCESSOR.to_string()),
                         description: "pass None".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4393,6 +5329,7 @@ mod tests {
                         payload: None,
                         body: Some(NEW_COMMANDS.to_string()),
                         description: "pass None, targeted by bare name".to_string(),
+                        destination: None,
                     },
                 ],
             )
@@ -4437,6 +5374,7 @@ mod tests {
                         payload: None,
                         body: Some(NEW_RESOLVE_BINARY.to_string()),
                         description: "add the search_dirs parameter".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4444,6 +5382,7 @@ mod tests {
                         payload: None,
                         body: Some(NEW_PREPROCESSOR.to_string()),
                         description: "pass None".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4451,6 +5390,7 @@ mod tests {
                         payload: None,
                         body: Some(NEW_COMMANDS.to_string()),
                         description: "pass None".to_string(),
+                        destination: None,
                     },
                 ],
             )
@@ -4588,6 +5528,7 @@ mod tests {
                         payload: None,
                         body: Some("pub fn value() -> u8 { 2 }".to_string()),
                         description: "correct work staged alongside the failure".to_string(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4595,6 +5536,7 @@ mod tests {
                         payload: None,
                         body: Some("pub fn no_such_entity() {}".to_string()),
                         description: String::new(),
+                        destination: None,
                     },
                 ],
             )
@@ -4630,6 +5572,7 @@ mod tests {
                         payload: None,
                         body: Some("pub fn value() -> u8 { 3 }".to_string()),
                         description: "after the abort".to_string(),
+                        destination: None,
                     }],
                 )
                 .is_err(),
@@ -4721,6 +5664,7 @@ mod tests {
                 payload: Some(kin_mcp::McpMutationPayload::Entity(payload)),
                 body: Some("pub fn value() -> u8 { 2 }".to_string()),
                 description: String::new(),
+                destination: None,
             }],
             commit_payload_hash: None,
         };
@@ -4856,6 +5800,7 @@ mod tests {
                     payload: Some(kin_mcp::McpMutationPayload::Entity(inserted)),
                     body: Some("pub fn inserted() {}".to_string()),
                     description: String::new(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4891,6 +5836,7 @@ mod tests {
                     payload: Some(kin_mcp::McpMutationPayload::Entity(entity)),
                     body: None,
                     description: String::new(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4950,6 +5896,7 @@ mod tests {
                         payload: Some(kin_mcp::McpMutationPayload::Entity(entity.clone())),
                         body: Some("pub fn value() -> u8 { 2 }".to_string()),
                         description: String::new(),
+                        destination: None,
                     },
                     kin_mcp::McpMutationOperation {
                         verb: "update".to_string(),
@@ -4957,6 +5904,7 @@ mod tests {
                         payload: Some(kin_mcp::McpMutationPayload::Entity(shadow.clone())),
                         body: Some("pub fn shadow() -> u8 { 3 }".to_string()),
                         description: String::new(),
+                        destination: None,
                     },
                 ],
             )

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -3262,11 +3262,22 @@ mod tests {
             crossing(state.graph.as_ref()),
             "the fixture produced no cross-file edge, so nothing below proves one was evicted"
         );
-        let queued_before = state.graph.pending_embeddings();
-        assert!(
-            queued_before > 0,
-            "the fixture queued no embeddings, so the queue assertion below proves nothing"
-        );
+        // The embedding queue only exists in a build that carries the vector
+        // feature, and `pending_embeddings` is a constant zero without it, so
+        // the fixture guard below would refuse a build that simply has no queue
+        // to evict from. Gated rather than softened: a zero that means "no
+        // queue" and a zero that means "the eviction did not happen" are
+        // different answers, and a guard that cannot tell them apart is not a
+        // guard.
+        #[cfg(feature = "vector")]
+        let queued_before = {
+            let queued = state.graph.pending_embeddings();
+            assert!(
+                queued > 0,
+                "the fixture queued no embeddings, so the queue assertion below proves nothing"
+            );
+            queued
+        };
 
         let retire = sessions
             .begin_transaction(TEST_SESSION, "file:pkg/util.py")
@@ -3311,6 +3322,7 @@ mod tests {
         // What the vector index is fed from. kin-db drops the retrieval key for
         // every removed entity in the same call that removes it, so a store
         // that never built an index still shows the eviction here.
+        #[cfg(feature = "vector")]
         assert!(
             state.graph.pending_embeddings() < queued_before,
             "the retired entities are still queued for embedding: {} of {queued_before}",

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -3163,6 +3163,7 @@ mod tests {
             target: String::new(),
             payload,
             body: None,
+            destination: None,
             description: String::new(),
         }
     }
@@ -3197,7 +3198,8 @@ mod tests {
             "`description` (string, REQUIRED)",
             "`body` (string, optional)",
             "`payload` (object, optional)",
-            "create/add/upsert/insert, update/modify, or delete/remove",
+            "`destination` (string, optional)",
+            "create/add/upsert/insert, update/modify, delete/remove, or rename/move",
         ] {
             assert!(err.contains(expected), "refusal omits {expected:?}: {err}");
         }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -4324,6 +4324,7 @@ mod tests {
             payload: Some(McpMutationPayload::Entity(entity.clone())),
             body: None,
             description: "add test function".into(),
+            destination: None,
         };
 
         let mut stage_args = HashMap::new();
@@ -4469,6 +4470,7 @@ mod tests {
             payload: None::<McpMutationPayload>,
             body: Some("pub fn value() -> u8 { 2 }".into()),
             description: "payload-less body update".into(),
+            destination: None,
         };
         let mut stage_args = HashMap::new();
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
@@ -4534,6 +4536,7 @@ mod tests {
             payload: Some(McpMutationPayload::Entity(updated)),
             body: None,
             description: "entity payload update".into(),
+            destination: None,
         };
         let mut stage_args = HashMap::new();
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
@@ -4602,6 +4605,7 @@ mod tests {
             payload: Some(McpMutationPayload::Entity(updated)),
             body: Some("pub fn value() -> u8 { 2 }".into()),
             description: "entity payload plus source body".into(),
+            destination: None,
         };
         let mut stage_args = HashMap::new();
         stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
@@ -4675,6 +4679,7 @@ mod tests {
             payload: Some(McpMutationPayload::Entity(updated)),
             body: Some("pub fn value() -> u8 { 2 }".into()),
             description: "inline entity payload plus source body".into(),
+            destination: None,
         };
         let mut commit_args = HashMap::new();
         commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
@@ -4718,6 +4723,7 @@ mod tests {
             payload: None::<McpMutationPayload>,
             body: Some("pub fn value() -> u8 { 2 }".into()),
             description: "payload-less body update".into(),
+            destination: None,
         };
         let mut commit_args = HashMap::new();
         commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
@@ -4842,6 +4848,7 @@ mod tests {
                     .then_some(McpMutationPayload::Entity(updated)),
                 body: shape.body.map(str::to_string),
                 description: shape.label.into(),
+                destination: None,
             };
             let mut commit_args = HashMap::new();
             commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
@@ -4926,6 +4933,7 @@ mod tests {
                     payload: None::<McpMutationPayload>,
                     body: Some("pub fn value() -> u8 { 2 }".into()),
                     description: "body update".into(),
+                    destination: None,
                 }],
             )
             .unwrap();
@@ -4974,6 +4982,7 @@ mod tests {
             payload: None::<McpMutationPayload>,
             body: None,
             description: "add dummy".into(),
+            destination: None,
         };
         let mut stage_args = HashMap::new();
         stage_args.insert("transaction_id".into(), serde_json::json!("no-such-tx"));
@@ -5022,6 +5031,7 @@ mod tests {
             payload: None,
             body: Some("value = 1\n".into()),
             description: "admit new source src/tracked.py".into(),
+            destination: None,
         };
         let mut stage_args = HashMap::new();
         stage_args.insert("transaction_id".into(), serde_json::json!("no-such-tx"));
@@ -5036,6 +5046,101 @@ mod tests {
             err.to_string().contains("already tracked"),
             "actionable stage-time message expected, got: {err}"
         );
+    }
+
+    /// A retirement or a rename naming a path the graph does NOT track is
+    /// refused at stage time, and so is a rename onto a path it does.
+    ///
+    /// The mirror image of the create check, and it matters for the same
+    /// reason in the opposite direction: a retirement that answered "already
+    /// gone, nothing to do" would tell a caller its file left the graph while
+    /// the real one kept ranking, which is the FIR-2419 symptom arriving by a
+    /// second route.
+    #[tokio::test]
+    async fn handle_transaction_stage_rejects_file_level_operations_on_the_wrong_paths() {
+        use crate::session::McpMutationOperation;
+
+        let store = InMemoryGraph::default();
+        for path in ["src/tracked.py", "src/occupied.py"] {
+            let path = kin_model::RepoPath::from_utf8(path.to_string()).unwrap();
+            store
+                .apply_transaction_delta(&kin_model::TransactionDelta {
+                    tree_deltas: vec![kin_model::TreeDelta::Added {
+                        artifact_id: kin_model::ArtifactId::new(),
+                        new: kin_model::LocatedEntry::new(
+                            path,
+                            kin_model::TreeEntry::blob(Hash256::from_bytes([1; 32]), false),
+                        ),
+                    }],
+                    ..kin_model::TransactionDelta::default()
+                })
+                .unwrap();
+        }
+        let sessions = SessionRegistry::new();
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+
+        let file_op = |verb: &str, target: &str, destination: Option<&str>| {
+            let op = McpMutationOperation {
+                verb: verb.into(),
+                target: target.into(),
+                payload: None,
+                body: None,
+                destination: destination.map(str::to_string),
+                description: format!("{verb} {target}"),
+            };
+            let mut args = HashMap::new();
+            args.insert("transaction_id".into(), serde_json::json!("no-such-tx"));
+            args.insert("operations".into(), serde_json::json!(vec![op]));
+            args
+        };
+
+        let err = sessions::handle_transaction_stage(
+            &file_op("delete", "src/never_tracked.py", None),
+            &store,
+            &sessions,
+            session_authority,
+        )
+        .await
+        .expect_err("a retirement of an untracked path must be rejected at stage time");
+        assert!(matches!(err, McpError::InvalidParams(_)));
+        assert!(
+            err.to_string()
+                .contains("is not tracked by repository authority"),
+            "actionable stage-time message expected, got: {err}"
+        );
+
+        let err = sessions::handle_transaction_stage(
+            &file_op("rename", "src/tracked.py", Some("src/occupied.py")),
+            &store,
+            &sessions,
+            session_authority,
+        )
+        .await
+        .expect_err("a rename onto a tracked path must be rejected at stage time");
+        assert!(
+            err.to_string()
+                .contains("is already tracked by repository authority"),
+            "actionable stage-time message expected, got: {err}"
+        );
+
+        // The control: the same two shapes on the right paths get past these
+        // checks and fail only on the bogus transaction id, which is what
+        // proves the refusals above came from the path checks rather than from
+        // staging refusing everything.
+        for args in [
+            file_op("delete", "src/tracked.py", None),
+            file_op("rename", "src/tracked.py", Some("src/moved.py")),
+        ] {
+            let result =
+                sessions::handle_transaction_stage(&args, &store, &sessions, session_authority)
+                    .await
+                    .expect("a well-formed file-level operation must reach transaction lookup");
+            let text = tool_result_text(&result);
+            assert!(
+                text.contains("Transaction not found"),
+                "expected the bogus transaction id to be what refuses, got: {text}"
+            );
+        }
     }
 
     use std::sync::{Mutex, OnceLock};

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -672,8 +672,11 @@ Use verb 'delete' (or 'remove') with `target` set to a repository-relative path 
 tracked file: {verb: \"delete\", target: \"<repository-relative path>\", description: \"...\"}. \
 It takes the file, every entity derived from it, and every edge incident to those entities \
 out of the graph in one change, and the commit removes the working file. Send no body; a \
-delete carrying text is refused rather than guessed at. Deleting the file with some other \
-tool does NOT retire it, for the same reason writing one does not admit it. \
+delete carrying text is refused rather than guessed at. Removing the file with some other \
+tool is not the same thing: the daemon retires a delete it observes, but whether it \
+observes one depends on the working copy delivering a notification, and a mount or a \
+projection may deliver none. Only this operation publishes the retirement as a change you \
+can review. \
 Use verb 'rename' (or 'move') with `target` and `destination` to relocate a tracked file: \
 {verb: \"rename\", target: \"<current path>\", destination: \"<new path>\", description: \"...\"}. \
 Entity ids, history, and every incoming reference survive the move, which is what you lose \

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -664,8 +664,20 @@ pub async fn handle_transaction_begin(
 }
 
 pub const TRANSACTION_STAGE_DESC: &str = "\
-Stage one or more mutation operations onto an active transaction. Two verbs admit source, \
-and which one you want depends on whether the graph has seen the file before. \
+Stage one or more mutation operations onto an active transaction. Four verbs move source, \
+and which one you want depends on what is happening to the file. Use 'create' to admit one \
+the graph has never seen, 'update' to change an entity inside one it holds, 'delete' to \
+retire one outright, and 'rename' to move one. \
+Use verb 'delete' (or 'remove') with `target` set to a repository-relative path to retire a \
+tracked file: {verb: \"delete\", target: \"<repository-relative path>\", description: \"...\"}. \
+It takes the file, every entity derived from it, and every edge incident to those entities \
+out of the graph in one change, and the commit removes the working file. Send no body; a \
+delete carrying text is refused rather than guessed at. Deleting the file with some other \
+tool does NOT retire it, for the same reason writing one does not admit it. \
+Use verb 'rename' (or 'move') with `target` and `destination` to relocate a tracked file: \
+{verb: \"rename\", target: \"<current path>\", destination: \"<new path>\", description: \"...\"}. \
+Entity ids, history, and every incoming reference survive the move, which is what you lose \
+if you delete and re-create instead. The destination must not be tracked already. \
 Use verb 'create' (or 'add'/'insert') to admit a file the graph has never seen: \
 {verb: \"create\", target: \"<repository-relative path, e.g. src/parser.py>\", \
 body: \"<the file's complete source text>\", description: \"...\"}. This is the ONLY \
@@ -740,20 +752,56 @@ pub async fn handle_transaction_stage<G: GraphStore>(
     // conflicting create between stage and commit, and commit remains the
     // authority that catches that race.
     for (idx, operation) in operations.iter().enumerate() {
-        if !crate::session::is_new_source_file(operation) {
+        if crate::session::is_new_source_file(operation) {
+            let target = operation.target.trim();
+            let Ok(path) = kin_model::RepoPath::from_utf8(target.to_string()) else {
+                continue;
+            };
+            if store.artifact_id_at_path(&path).is_some() {
+                return Err(crate::error::McpError::InvalidParams(format!(
+                    "operation #{idx} ('create'): {target:?} is already tracked by repository \
+                     authority, so it cannot be created; 'create' admits only source the graph \
+                     has never seen. Edit it with verb 'update' naming an entity inside it, or \
+                     create a path that does not exist yet"
+                )));
+            }
             continue;
         }
-        let target = operation.target.trim();
-        let Ok(path) = kin_model::RepoPath::from_utf8(target.to_string()) else {
-            continue;
-        };
-        if store.artifact_id_at_path(&path).is_some() {
-            return Err(crate::error::McpError::InvalidParams(format!(
-                "operation #{idx} ('create'): {target:?} is already tracked by repository \
-                 authority, so it cannot be created; 'create' admits only source the graph has \
-                 never seen. Edit it with verb 'update' naming an entity inside it, or create a \
-                 path that does not exist yet"
-            )));
+        // A retirement and a rename are the mirror image: they name a path the
+        // graph must already hold, and the same snapshot answers both. A
+        // retirement of a path nothing tracks is not a harmless no-op, because
+        // the caller believes a file left the graph and it never did.
+        if crate::session::is_retired_source_file(operation)
+            || crate::session::is_renamed_source_file(operation)
+        {
+            let verb = operation.verb.trim().to_lowercase();
+            let target = operation.target.trim();
+            let Ok(path) = kin_model::RepoPath::from_utf8(target.to_string()) else {
+                continue;
+            };
+            if store.artifact_id_at_path(&path).is_none() {
+                return Err(crate::error::McpError::InvalidParams(format!(
+                    "operation #{idx} ('{verb}'): {target:?} is not tracked by repository \
+                     authority, so there is nothing to {verb}. Name a repository-relative path \
+                     the graph already holds; kin_graph_status and semantic_locate report what \
+                     it holds"
+                )));
+            }
+            let Some(destination) = operation.destination.as_deref().map(str::trim) else {
+                continue;
+            };
+            let Ok(destination_path) = kin_model::RepoPath::from_utf8(destination.to_string())
+            else {
+                continue;
+            };
+            if store.artifact_id_at_path(&destination_path).is_some() {
+                return Err(crate::error::McpError::InvalidParams(format!(
+                    "operation #{idx} ('{verb}'): {destination:?} is already tracked by \
+                     repository authority, so {target:?} cannot move onto it; a rename may not \
+                     overwrite a file. Retire the destination first, or pick a path that does \
+                     not exist yet"
+                )));
+            }
         }
     }
 
@@ -955,9 +1003,25 @@ fn offline_only_uncommittable_operations(operations: &[McpMutationOperation]) ->
     operations
         .iter()
         .enumerate()
-        .filter(|(_, op)| crate::session::carries_source_body(op))
+        .filter(|(_, op)| {
+            crate::session::carries_source_body(op)
+                || crate::session::is_retired_source_file(op)
+                || crate::session::is_renamed_source_file(op)
+        })
         .map(|(idx, op)| {
-            let shape = if op.payload.is_some() {
+            // A retirement and a rename carry no body, so the body-shaped
+            // refusal above cannot see them, and the in-process delta builder
+            // has no arm for either: both would land as `ops_applied: 0`,
+            // `empty: true`, which is a refusal wearing the costume of a
+            // no-op transaction. They need the daemon for the same reason a
+            // body edit does. A tree transition has to reach repository
+            // authority and the working copy has to be projected to match, and
+            // this path can do neither.
+            let shape = if crate::session::is_retired_source_file(op) {
+                "a payload-less retirement (target naming a tracked path)"
+            } else if crate::session::is_renamed_source_file(op) {
+                "a payload-less rename (target plus destination)"
+            } else if op.payload.is_some() {
                 "an entity payload plus a source body"
             } else {
                 "a payload-less source update (target plus body)"
@@ -970,9 +1034,9 @@ fn offline_only_uncommittable_operations(operations: &[McpMutationOperation]) ->
             };
             format!(
                 "operation #{idx} ('{}'): {shape} for target '{target}' requires the daemon \
-                 commit path, which plans the exact span edit and projects the new source into \
-                 the working file; the in-process commit path has no projection and would report \
-                 success while discarding the body",
+                 commit path, which carries the tree transition into repository authority and \
+                 projects the working copy to match; the in-process commit path has no \
+                 projection and would report success while discarding it",
                 op.verb,
             )
         })

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -47,6 +47,11 @@ pub struct McpMutationOperation {
     /// closed because they cannot produce exact source truth.
     #[serde(default)]
     pub body: Option<String>,
+    /// Where a relocation puts the file `target` names, as a
+    /// repository-relative path. Present only on a rename, which is the one
+    /// operation that needs two paths; every other shape leaves it absent.
+    #[serde(default)]
+    pub destination: Option<String>,
     pub description: String,
 }
 
@@ -104,6 +109,59 @@ pub fn is_new_source_file(op: &McpMutationOperation) -> bool {
             .body
             .as_deref()
             .is_some_and(|body| !body.trim().is_empty())
+}
+
+/// A payload-less operation that expresses "the repository no longer holds the
+/// file at `target`": verb delete/remove, `target` naming a repository-relative
+/// path, and no body.
+///
+/// This is the retirement counterpart of [`is_new_source_file`], and it is the
+/// only shape that can retire a file. An entity payload carrying verb `delete`
+/// names one entity, which cannot retire the artifact the entity lives on, and
+/// leaves the file tracked with a hole in it. Naming the path instead retires
+/// the artifact, every entity derived from it, and every edge incident to
+/// those entities, in one delta, which is what repository authority requires
+/// of any transition that drops a path an entity sits on.
+///
+/// A body is refused rather than ignored. `create` and `update` both mean "the
+/// new text is `body`", so an operation that carries text and asks for a
+/// deletion is two intentions in one call, and guessing which one the caller
+/// meant is how a retirement silently becomes an edit.
+pub fn is_retired_source_file(op: &McpMutationOperation) -> bool {
+    op.payload.is_none()
+        && matches!(op.verb.trim().to_lowercase().as_str(), "delete" | "remove")
+        && !op.target.trim().is_empty()
+        && op.body.as_deref().is_none_or(|body| body.trim().is_empty())
+        && op
+            .destination
+            .as_deref()
+            .is_none_or(|to| to.trim().is_empty())
+}
+
+/// A payload-less operation that expresses "the file at `target` now lives at
+/// `destination`": verb rename/move, both paths repository-relative.
+///
+/// A rename is a removal at one path and an arrival at another, and staging it
+/// as that pair would lose the one fact that makes it a rename: that the
+/// entities on the old path are the entities on the new one. Repository
+/// authority already distinguishes the two, refusing a transition that leaves
+/// an entity on a path the staged tree no longer carries unless the same delta
+/// carries "its exact entity removal OR RELOCATION". This shape is how a caller
+/// says relocation, so entity identity, history, and every incoming edge
+/// survive the move.
+///
+/// The bytes are not resent. A rename that also rewrote the file would be a
+/// move and an edit at once, and the two have different failure modes: a move
+/// that cannot resolve its destination should refuse before anything is
+/// reparsed. Stage a rename and an `update` in the same transaction to do both.
+pub fn is_renamed_source_file(op: &McpMutationOperation) -> bool {
+    op.payload.is_none()
+        && matches!(op.verb.trim().to_lowercase().as_str(), "rename" | "move")
+        && !op.target.trim().is_empty()
+        && op
+            .destination
+            .as_deref()
+            .is_some_and(|to| !to.trim().is_empty())
 }
 
 /// An operation that carries new source text for a file.
@@ -333,12 +391,22 @@ pub struct CoordinationWritePreflight {
 
 /// The mutation verbs the transaction commit path understands, listed for
 /// actionable error messages.
-const KNOWN_MUTATION_VERBS: &str = "create/add/upsert/insert, update/modify, or delete/remove";
+const KNOWN_MUTATION_VERBS: &str =
+    "create/add/upsert/insert, update/modify, delete/remove, or rename/move";
 
 fn is_known_mutation_verb(verb: &str) -> bool {
     matches!(
         verb,
-        "create" | "add" | "upsert" | "insert" | "update" | "modify" | "delete" | "remove"
+        "create"
+            | "add"
+            | "upsert"
+            | "insert"
+            | "update"
+            | "modify"
+            | "delete"
+            | "remove"
+            | "rename"
+            | "move"
     )
 }
 
@@ -376,15 +444,39 @@ pub fn validate_staged_operations(
                 continue;
             }
             if is_new_source_file(op) {
-                validate_new_source_path(idx, op)?;
+                validate_source_operation_path(idx, op, op.target.trim(), "target")?;
+                continue;
+            }
+            if is_retired_source_file(op) {
+                validate_source_operation_path(idx, op, op.target.trim(), "target")?;
+                continue;
+            }
+            if is_renamed_source_file(op) {
+                let destination = op
+                    .destination
+                    .as_deref()
+                    .expect("a rename always carries a destination")
+                    .trim();
+                validate_source_operation_path(idx, op, op.target.trim(), "target")?;
+                validate_source_operation_path(idx, op, destination, "destination")?;
+                if op.target.trim() == destination {
+                    return Err(format!(
+                        "operation #{idx} ('{}'): `target` and `destination` are both {:?}; a \
+                         rename must move the file somewhere else",
+                        op.verb, destination
+                    ));
+                }
                 continue;
             }
             return Err(format!(
                 "operation #{idx} ('{}'): missing payload; provide an entity, relation, or blob \
                  payload, express an edit to an existing entity as verb 'update' with `target` \
-                 (entity name or id) and `body` (the entity's full new source text), or admit a \
+                 (entity name or id) and `body` (the entity's full new source text), admit a \
                  source file the graph has never seen as verb 'create' with `target` (its \
-                 repository-relative path) and `body` (the file's complete text)",
+                 repository-relative path) and `body` (the file's complete text), retire a \
+                 tracked file as verb 'delete' with `target` (its repository-relative path) and \
+                 no body, or relocate one as verb 'rename' with `target` and `destination` (both \
+                 repository-relative paths)",
                 op.verb
             ));
         };
@@ -406,7 +498,7 @@ pub fn validate_staged_operations(
     Ok(())
 }
 
-/// Validate the repository-relative path a new-source-file operation names.
+/// Validate one repository-relative path a path-shaped operation names.
 ///
 /// Runs the same path rule the projection applies
 /// ([`kin_core::validate_source_paths`]), so a path that stages clean is a path
@@ -419,19 +511,23 @@ pub fn validate_staged_operations(
 /// Intrinsic to the payload and free of graph access, like every other check in
 /// [`validate_staged_operations`], so it behaves identically in-process and
 /// through the daemon.
-fn validate_new_source_path(idx: usize, op: &McpMutationOperation) -> Result<(), String> {
-    let target = op.target.trim();
-    let path = kin_model::RepoPath::from_utf8(target.to_string()).map_err(|error| {
+fn validate_source_operation_path(
+    idx: usize,
+    op: &McpMutationOperation,
+    value: &str,
+    field: &str,
+) -> Result<(), String> {
+    let path = kin_model::RepoPath::from_utf8(value.to_string()).map_err(|error| {
         format!(
-            "operation #{idx} ('{}'): {target:?} is not a usable repository path: {error}",
+            "operation #{idx} ('{}'): `{field}` {value:?} is not a usable repository path: {error}",
             op.verb
         )
     })?;
     kin_core::validate_source_paths([&path]).map_err(|error| {
         format!(
-            "operation #{idx} ('{}'): {target:?} is not an admissible repository source path: \
-             {error}. Name a repository-relative path such as \"src/parser.py\", with no leading \
-             slash, no \"..\", and no Kin or Git control component",
+            "operation #{idx} ('{}'): `{field}` {value:?} is not an admissible repository source \
+             path: {error}. Name a repository-relative path such as \"src/parser.py\", with no \
+             leading slash, no \"..\", and no Kin or Git control component",
             op.verb
         )
     })
@@ -468,16 +564,37 @@ pub fn uncommittable_reason(op: &McpMutationOperation) -> Option<String> {
         ));
     }
     let Some(payload) = op.payload.as_ref() else {
-        if is_target_body_update(op) || is_new_source_file(op) {
+        if is_target_body_update(op)
+            || is_new_source_file(op)
+            || is_retired_source_file(op)
+            || is_renamed_source_file(op)
+        {
             return None;
         }
         return Some("missing payload".to_string());
     };
     match payload {
-        // Every known verb maps to an entity delta (add/modify/remove).
-        McpMutationPayload::Entity(_) => None,
+        // Every entity verb but relocation maps to an entity delta
+        // (add/modify/remove). A relocation is a statement about a file, and an
+        // entity payload cannot carry one: moving a single entity out of the
+        // file it was extracted from would leave the artifact tracked with a
+        // hole in it and the entity placed on a path no artifact holds. Refused
+        // here rather than at commit, where the payload branch has no arm for
+        // these verbs and would drop the operation without a word.
+        McpMutationPayload::Entity(_) => {
+            if matches!(verb.as_str(), "rename" | "move") {
+                Some(format!(
+                    "verb '{}' is not committable for entity payloads; a rename moves a file, so \
+                     stage it with no payload, `target` set to the file's current \
+                     repository-relative path, and `destination` set to its new one",
+                    op.verb
+                ))
+            } else {
+                None
+            }
+        }
         McpMutationPayload::Relation { .. } => {
-            if matches!(verb.as_str(), "update" | "modify") {
+            if matches!(verb.as_str(), "update" | "modify" | "rename" | "move") {
                 Some(format!(
                     "verb '{}' is not committable for relation payloads; relations support only \
                      create/add/upsert/insert or delete/remove",
@@ -509,19 +626,30 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
      \"description\": \"<why>\"}\n  \
      - a relation edit: {\"verb\": \"create\"|\"delete\", \"target\": \"\", \
      \"payload\": {\"Relation\": {\"from\": \"<uuid>\", \"to\": \"<uuid>\", \"kind\": \"<relation kind>\"}}, \
-     \"description\": \"<why>\"}\n\
-     Prefer the first shape: it needs only a target and the new source text.\n\
+     \"description\": \"<why>\"}\n  \
+     - a new source file: {\"verb\": \"create\", \"target\": \"<repository-relative path>\", \
+     \"body\": \"<the file's complete source text>\", \"description\": \"<why>\"}\n  \
+     - a retired source file: {\"verb\": \"delete\", \"target\": \"<repository-relative path>\", \
+     \"description\": \"<why>\"}\n  \
+     - a renamed source file: {\"verb\": \"rename\", \"target\": \"<current path>\", \
+     \"destination\": \"<new path>\", \"description\": \"<why>\"}\n\
+     Prefer the first shape for changing code that exists: it needs only a target and the new \
+     source text.\n\
      Every field of an operation, and nothing else is accepted:\n  \
-     - `verb` (string, REQUIRED): one of create/add/upsert/insert, update/modify, or \
-     delete/remove. Compared case-insensitively after trimming.\n  \
+     - `verb` (string, REQUIRED): one of create/add/upsert/insert, update/modify, \
+     delete/remove, or rename/move. Compared case-insensitively after trimming.\n  \
      - `target` (string, REQUIRED): the entity this operation acts on, as either its uuid or \
-     its exact name. Empty string for relation payloads, which identify themselves by their \
-     endpoints and kind.\n  \
+     its exact name. A repository-relative path instead for the three file-level shapes \
+     (create, delete, rename). Empty string for relation payloads, which identify themselves \
+     by their endpoints and kind.\n  \
      - `description` (string, REQUIRED): why this operation is being made.\n  \
+     - `destination` (string, optional): where a rename puts the file, as a \
+     repository-relative path. Required by rename/move and accepted by nothing else.\n  \
      - `body` (string, optional): the entity's complete new source text, never a fragment or a \
      diff. New source text is carried by this field and no other; a key like `content`, \
      `source`, or `new_body` is refused rather than accepted with the source dropped.\n  \
-     - `payload` (object, optional): omit it for a source edit. Otherwise exactly one of \
+     - `payload` (object, optional): omit it for a source edit and for every file-level shape. \
+     Otherwise exactly one of \
      {\"Entity\": {<entity object>}}, {\"Relation\": {\"from\": \"<uuid>\", \"to\": \"<uuid>\", \
      \"kind\": \"<relation kind>\"}}, or {\"Blob\": [<bytes>]}. Relation payloads accept only \
      create/add/upsert/insert or delete/remove, and blob payloads are not committable through \
@@ -533,7 +661,14 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
 /// anything other than `body` decodes cleanly with `body: None` and is planned
 /// as if no source had been sent. Checking the key set first is what turns that
 /// into a refusal the caller can act on.
-const OPERATION_FIELDS: [&str; 5] = ["verb", "target", "payload", "body", "description"];
+const OPERATION_FIELDS: [&str; 6] = [
+    "verb",
+    "target",
+    "payload",
+    "body",
+    "destination",
+    "description",
+];
 
 /// Decode an `operations` argument into staged operations.
 ///
@@ -2058,6 +2193,7 @@ mod tests {
             payload: None,
             body: None,
             description: "add dummy function".to_string(),
+            destination: None,
         };
         let tx_staged = registry
             .stage_transaction(&tx.transaction_id, vec![op])
@@ -2087,6 +2223,7 @@ mod tests {
                     payload: None,
                     body: Some("pub fn value() -> u8 { 2 }".to_string()),
                     description: "replace the body".to_string(),
+                    destination: None,
                 }],
             )
             .unwrap()
@@ -2211,7 +2348,7 @@ mod tests {
 
     // ── Stage-time validation (D.7 Track A) ──────────────────────────────────
 
-    fn entity_named(name: &str) -> kin_model::Entity {
+    pub(super) fn entity_named(name: &str) -> kin_model::Entity {
         use kin_model::entity::{
             EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
             Visibility,
@@ -2249,6 +2386,7 @@ mod tests {
             target: "function".to_string(),
             payload,
             body: None,
+            destination: None,
             description: "d".to_string(),
         }
     }
@@ -2515,6 +2653,7 @@ mod target_body_update_tests {
             target: target.to_string(),
             payload: None,
             body: body.map(str::to_string),
+            destination: None,
             description: "test".to_string(),
         }
     }
@@ -2525,6 +2664,161 @@ mod target_body_update_tests {
         assert!(is_target_body_update(&op));
         assert!(uncommittable_reason(&op).is_none());
         assert!(validate_staged_operations(std::slice::from_ref(&op)).is_ok());
+    }
+
+    /// Build a file-level operation: a verb, a path, and optionally a
+    /// destination.
+    fn path_op(verb: &str, target: &str, destination: Option<&str>) -> McpMutationOperation {
+        McpMutationOperation {
+            verb: verb.to_string(),
+            target: target.to_string(),
+            payload: None,
+            body: None,
+            destination: destination.map(str::to_string),
+            description: "test".to_string(),
+        }
+    }
+
+    /// The two file-level shapes an agent can stage without a payload, and the
+    /// near misses that must not be mistaken for them.
+    ///
+    /// The near misses are the point. `delete` and `remove` were already known
+    /// verbs before they meant anything at the file level, so a payload-less
+    /// `delete` used to fail with "missing payload" and now succeeds; every
+    /// shape that still has to fail is listed here so the widening is bounded
+    /// to what was intended.
+    #[test]
+    fn file_level_shapes_are_recognized_and_their_near_misses_are_not() {
+        let retire = path_op("delete", "src/gone.rs", None);
+        assert!(is_retired_source_file(&retire));
+        assert!(!is_renamed_source_file(&retire));
+        assert!(!is_new_source_file(&retire));
+        assert!(uncommittable_reason(&retire).is_none());
+        validate_staged_operations(std::slice::from_ref(&retire))
+            .expect("a payload-less delete naming a path must stage");
+
+        let rename = path_op("rename", "src/old.rs", Some("src/new.rs"));
+        assert!(is_renamed_source_file(&rename));
+        assert!(!is_retired_source_file(&rename));
+        assert!(uncommittable_reason(&rename).is_none());
+        validate_staged_operations(std::slice::from_ref(&rename))
+            .expect("a payload-less rename naming both paths must stage");
+
+        // A retirement carrying text is two intentions in one call. Guessing
+        // which one was meant is how a delete silently becomes an edit.
+        let mut bodied = path_op("delete", "src/gone.rs", None);
+        bodied.body = Some("pub fn resurrect() {}\n".to_string());
+        assert!(!is_retired_source_file(&bodied));
+        assert!(validate_staged_operations(std::slice::from_ref(&bodied)).is_err());
+
+        // A rename is not a rename without somewhere to go.
+        let no_destination = path_op("rename", "src/old.rs", None);
+        assert!(!is_renamed_source_file(&no_destination));
+        assert!(validate_staged_operations(std::slice::from_ref(&no_destination)).is_err());
+
+        let empty_destination = path_op("rename", "src/old.rs", Some("   "));
+        assert!(!is_renamed_source_file(&empty_destination));
+        assert!(validate_staged_operations(std::slice::from_ref(&empty_destination)).is_err());
+
+        // A move to where it already is moves nothing, and would publish a
+        // change carrying no transition.
+        let in_place = path_op("rename", "src/same.rs", Some("src/same.rs"));
+        let error = validate_staged_operations(std::slice::from_ref(&in_place))
+            .expect_err("a rename onto its own path must not stage");
+        assert!(
+            error.contains("must move the file somewhere else"),
+            "{error}"
+        );
+
+        // A retirement with nothing to name.
+        let unnamed = path_op("delete", "  ", None);
+        assert!(!is_retired_source_file(&unnamed));
+        assert!(validate_staged_operations(std::slice::from_ref(&unnamed)).is_err());
+    }
+
+    /// Both ends of a file-level operation take the projection's path rule.
+    ///
+    /// Stage time, not commit time, and quoting the field so a caller with two
+    /// paths in one operation learns which of them is wrong.
+    #[test]
+    fn an_inadmissible_file_level_path_is_refused_at_stage_time_on_either_end() {
+        // Positive controls first, so a loop that refused everything would fail
+        // here rather than read as a working guard.
+        let ordinary_retirement = path_op("delete", "src/old.py", None);
+        validate_staged_operations(std::slice::from_ref(&ordinary_retirement))
+            .expect("an ordinary repository-relative path must stage as a retirement");
+        let ordinary = path_op("rename", "src/old.py", Some("src/new.py"));
+        validate_staged_operations(std::slice::from_ref(&ordinary))
+            .expect("two ordinary repository-relative paths must stage");
+
+        for path in [
+            "/etc/passwd",
+            "../outside.py",
+            ".kin/objects/sneak.py",
+            ".git/hooks/pre-commit",
+        ] {
+            let retire = path_op("delete", path, None);
+            let error = validate_staged_operations(std::slice::from_ref(&retire))
+                .expect_err("an inadmissible path must not stage as a retirement");
+            assert!(error.contains(path), "{error}");
+        }
+
+        for path in ["/etc/passwd", "../outside.py", ".git/config"] {
+            let bad_origin = path_op("rename", path, Some("src/new.py"));
+            let error = validate_staged_operations(std::slice::from_ref(&bad_origin))
+                .expect_err("an inadmissible origin must not stage");
+            assert!(error.contains("`target`"), "{error}");
+            assert!(error.contains(path), "{error}");
+
+            let bad_destination = path_op("rename", "src/old.py", Some(path));
+            let error = validate_staged_operations(std::slice::from_ref(&bad_destination))
+                .expect_err("an inadmissible destination must not stage");
+            assert!(error.contains("`destination`"), "{error}");
+            assert!(error.contains(path), "{error}");
+        }
+    }
+
+    /// A rename carrying a payload is refused rather than dropped.
+    ///
+    /// The in-process commit path builds its deltas from a `match` on the
+    /// payload and the verb, and it has no arm for rename/move. Without this
+    /// refusal such an operation stages clean, commits clean, and does nothing,
+    /// which is the silent-drop failure stage-time validation exists to be a
+    /// superset of.
+    #[test]
+    fn a_payload_cannot_carry_a_rename() {
+        let mut entity_rename = path_op("rename", "src/old.rs", Some("src/new.rs"));
+        entity_rename.payload = Some(McpMutationPayload::Entity(super::tests::entity_named(
+            "moved",
+        )));
+        let reason = uncommittable_reason(&entity_rename)
+            .expect("an entity payload must not be committable with a rename verb");
+        assert!(
+            reason.contains("is not committable for entity payloads"),
+            "{reason}"
+        );
+        assert!(validate_staged_operations(std::slice::from_ref(&entity_rename)).is_err());
+
+        let mut relation_rename = path_op("move", "", None);
+        relation_rename.payload = Some(McpMutationPayload::Relation {
+            from: kin_model::ids::EntityId::new(),
+            to: kin_model::ids::EntityId::new(),
+            kind: kin_model::relation::RelationKind::Calls,
+        });
+        let reason = uncommittable_reason(&relation_rename)
+            .expect("a relation payload must not be committable with a move verb");
+        assert!(
+            reason.contains("is not committable for relation payloads"),
+            "{reason}"
+        );
+
+        // Positive control: the same payloads stay committable under the verbs
+        // they were always committable under.
+        let mut entity_update = path_op("update", "src/old.rs", None);
+        entity_update.payload = Some(McpMutationPayload::Entity(super::tests::entity_named(
+            "moved",
+        )));
+        assert!(uncommittable_reason(&entity_update).is_none());
     }
 
     #[test]

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -55,18 +55,67 @@ fn destructive_idempotent(title: &str) -> ToolAnnotations {
 
 /// Honest JSON Schema for one transaction operation.
 ///
-/// The product daemon accepts three materially different shapes. A source-body
-/// edit and a new source file are both intentionally payload-less; structured
-/// entity/relation mutations require `payload`. Keeping these as disjoint
-/// `oneOf` branches prevents MCP clients from being told that the preferred
-/// source-edit form is invalid.
+/// The product daemon accepts five materially different shapes. A source-body
+/// edit, a new source file, a retirement, and a rename are all intentionally
+/// payload-less; structured entity/relation mutations require `payload`.
+/// Keeping these as disjoint `oneOf` branches prevents MCP clients from being
+/// told that the preferred source-edit form is invalid.
 ///
-/// The branches cannot both match one operation: the two payload-less branches
+/// No two branches can match one operation: the four payload-less branches
 /// carry disjoint verb enums, and the structured branch requires `payload`,
-/// which neither of the others accepts.
+/// which none of the others accepts.
 fn transaction_operation_schema() -> serde_json::Value {
     serde_json::json!({
         "oneOf": [
+            {
+                "title": "Retired source file",
+                "type": "object",
+                "properties": {
+                    "verb": {
+                        "type": "string",
+                        "enum": ["delete", "remove"],
+                        "description": "Retire a tracked file. This is the only operation that removes a file, along with every entity derived from it and every edge incident to those entities."
+                    },
+                    "target": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative path of the file to retire, such as \"src/parser.py\". It must be a path repository authority already tracks; a path the graph has never seen is refused."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable explanation of this change."
+                    }
+                },
+                "required": ["verb", "target", "description"],
+                "additionalProperties": false
+            },
+            {
+                "title": "Renamed source file",
+                "type": "object",
+                "properties": {
+                    "verb": {
+                        "type": "string",
+                        "enum": ["rename", "move"],
+                        "description": "Relocate a tracked file. Entity identity, history, and incoming edges survive the move, which is what separates this from a delete followed by a create."
+                    },
+                    "target": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative path the file lives at now. It must be a path repository authority already tracks."
+                    },
+                    "destination": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative path the file moves to. It must not be tracked already, and it follows the same path rules as `target`: no leading slash, no \"..\", and no Kin or Git control component."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable explanation of this change."
+                    }
+                },
+                "required": ["verb", "target", "destination", "description"],
+                "additionalProperties": false
+            },
             {
                 "title": "New source file",
                 "type": "object",
@@ -1623,7 +1672,43 @@ mod tests {
             let variants = tool["inputSchema"]["properties"]["operations"]["items"]["oneOf"]
                 .as_array()
                 .expect("transaction operations must be disjoint oneOf variants");
-            assert_eq!(variants.len(), 3, "{tool_name}");
+            assert_eq!(variants.len(), 5, "{tool_name}");
+
+            let retirement = variants
+                .iter()
+                .find(|variant| variant["title"] == "Retired source file")
+                .expect("payload-less retirement branch");
+            assert_eq!(
+                required_set(retirement),
+                ["description", "target", "verb"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            );
+            assert!(
+                retirement["properties"].get("payload").is_none(),
+                "payload-less retirement branch must reject payload"
+            );
+            assert!(
+                retirement["properties"].get("body").is_none(),
+                "a retirement carries no body; accepting one would let a delete read as an edit"
+            );
+
+            let rename = variants
+                .iter()
+                .find(|variant| variant["title"] == "Renamed source file")
+                .expect("payload-less rename branch");
+            assert_eq!(
+                required_set(rename),
+                ["description", "destination", "target", "verb"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            );
+            assert!(
+                rename["properties"].get("payload").is_none(),
+                "payload-less rename branch must reject payload"
+            );
 
             let new_source_file = variants
                 .iter()


### PR DESCRIPTION
An agent holding only Kin's MCP tools could admit a file into the graph and edit an entity inside one, and had no call that took a file back out or moved it. kin#931 built the admission half. This is its mirror image, plus the regression tests that pin what a retirement is supposed to take with it.

## The mechanism, established before anything was changed

**The deletion in FIR-2419 was never observed. Nothing refused it.** A delete of a tracked file is observed and retired wherever the watcher delivers the event, and the refusal at `crates/kin-daemon/src/loop_runner.rs:2237` is about untracked host content only, so a tracked delete never reaches it.

The container's own report says so. `.kin-coord/reports/kinagent-stranger-20260818.md:224` records 11 Python files on disk against `Entities: 2 ... Files: 1`, and line 223 concludes "There is no watcher." The agent's 14 creates were missed too, not just the delete of `probe_widget.py`, which had reached the graph only because `kin init`'s own initial scan caught it while the probe was racing that command. No file event of any kind arrived for that working copy, which was a mount.

The watcher path already retires. `admit_file_event_with_exact_tree` returns `AdmittedFileEvent::Removed` for a vanished tracked path (`crates/kin-daemon/src/loop_runner.rs:1012`), the loop calls `finalize_tree_removal` (`:2419`), and `exact_tree_admission` calls `evict_enrichment_for_removed_paths` before the tree transition (`:869`) precisely because kin-db refuses a transition that leaves an entity on a path the staged tree no longer carries. That eviction runs `clear_incompatible_facets`, which calls `remove_entities_batch`, which is where kin-db drops the text index entries, the vector index entries, and the embedding-queue keys.

FIR-2429's `kin commit` half does not reproduce on today's `main`. I wrote the ticket's shape as an end-to-end test through the real binaries and ran it against `origin/main` at `40bc69e5` with this branch's source changes stashed. It passed:

```
test deleting_a_file_that_owns_no_entity_still_commits ... ok
test deleting_a_committed_entity_owning_file_retires_it_from_every_query_surface ... ok
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 122.88s
```

Nothing in the tree pinned that, which is why the test ships here.

## What this adds

`kin_transaction_stage` takes two more payload-less operation shapes.

A `delete`/`remove` naming a repository-relative `target` retires that path: its entities, the edges incident to them, its layout, its non-entity enrichment facets, and its tree entry, all in one change, with the working file removed by the projection the commit publishes.

A `rename`/`move` naming a `target` and a new `destination` relocates it, keeping the artifact id, every entity id, span and lineage, and every incoming reference. That is the whole difference between a rename and a delete followed by a create, and repository authority already named what it owes: it refuses a transition that leaves an entity on a path the staged tree no longer carries unless the same delta carries "its exact entity removal or relocation". The rename carries both halves in one delta for that reason.

`clear_incompatible_facets_in` (`crates/kin-daemon/src/loop_runner.rs:1162`) is the watcher seam's own eviction, now taking the graph outright so the planner can run it against its prospective graph rather than the live one. One definition of "retire this file's enrichment" serves both seams, so they cannot drift into disagreeing.

Retiring an artifact also has to carry the edges that address the **artifact** rather than an entity inside it. An import that resolved to the file survives removing the file's entities, and authority refuses the whole transition with "unadmitted destination endpoint". The two-file Python fixture reaches that on its first import, which is how the retrieval-eviction test found it.

Both shapes are refused at stage time when they name the wrong path: a retirement or rename of a path authority does not track, and a rename onto a path it does. A retirement carrying a body is refused rather than guessed at, because `create` and `update` both mean "the new text is `body`", so a delete with text in it is two intentions in one call. An entity or relation payload cannot carry `rename`/`move`: the in-process delta builder has no arm for those verbs, so without the refusal such an operation stages clean, commits clean, and does nothing. The offline commit path refuses both new shapes for the reason it already refuses a source body, since it has no projection to write the transition with. Two file-level operations on one path are refused before anything is planned, because ordering them would publish a guess about intent.

## Falsification

Each canary was installed on top of the committed change, run, then reverted with `git checkout --`; `git status --short` was empty afterwards and `grep -c 'FALSIFICATION CANARY'` printed 0.

Removing the enrichment eviction from `plan_retired_source_files` fails both retirement tests with the exact error FIR-2429 quotes:

```
retire pkg/util.py from the exact tree: storage error: transaction leaves entity
6a35382a-12fe-5c58-b4aa-2359a7c9aac1 on repository path pkg/util.py absent from the staged
tree; carry its exact entity removal or relocation in the same delta
test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 870 filtered out
```

Removing the artifact-incident edge retirement is caught only by the two-file fixture, which is why that test exists:

```
test mcp_commit::tests::retiring_a_file_evicts_it_from_the_rows_every_retrieval_surface_reads ... FAILED
test mcp_commit::tests::retiring_a_tracked_file_over_mcp_takes_its_entities_and_its_tree_entry ... ok
retire pkg/util.py from the exact tree: storage error: transaction relation
7def5b3f-b302-3f92-5a86-a1bfaa406451 has unadmitted destination endpoint
artifact:5b777bf3-e813-4543-bd40-fb01e610c2c2
```

Splitting the rename's entity relocation and tree move into two deltas fails with the "or relocation" clause verbatim:

```
relocate pkg/util.py to pkg/core/util.py: storage error: transaction leaves entity
78c61ef0-aad5-5c99-b989-302347ad5325 on repository path pkg/util.py absent from the staged
tree; carry its exact entity removal or relocation in the same delta
```

The other direction holds: `deleting_a_file_that_owns_no_entity_still_commits` removes a plain `notes.txt` and commits, and passes both before and after this change.

## What is deliberately not here

The retrieval payload does not say that a hit's file is absent from the working tree. Adding it would put a per-result filesystem stat on the runtime query authority path, which the Zero File-Search Authority Rule bars without exception, and the drift answer already lives on a seam that owns it: `kin doctor --drift --json` names a tracked path whose file was deleted, proven by `crates/kin-cli/tests/repository_drift.rs:236` ("A removed tracked member is drift the report also must not repair"). That is a founder call rather than mine, which is why both tickets are `Part of`.

FIR-2429's mount repro is also not fixed here. `rm` through the FUSE mount returned rc=1 in that container; the daemon seam it blames already retires, and there is no `ContentWriter` in this repository, so what remains is the mount's own unlink path in kin-vfs.

Part of FIR-2419
Part of FIR-2429
