### PR TITLE
Build release-candidate archives without a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -964,6 +964,7 @@ jobs:
           node --test \
             scripts/check-glibc-floor.test.mjs \
             scripts/check-kin-vfs-compat.test.mjs \
+            scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-version.test.mjs \
             scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \
@@ -971,6 +972,15 @@ jobs:
           node --check scripts/check-release-version.mjs
           node --check scripts/prepare-release.mjs
           node --check scripts/release-intent.mjs
+
+      # rc-build.yml builds release-candidate archives from a copy of
+      # release.yml's build job, so the archive stranger and the preflight Linux
+      # leg can run before a tag exists. A copy nothing checks keeps reporting
+      # success while the original moves, and release.yml is the one workflow
+      # whose mistakes a later commit cannot repair.
+      - name: Check the RC build mirrors the release build
+        if: runner.os == 'Linux'
+        run: node scripts/check-rc-build-drift.mjs
 
       # release.yml refuses a release whose Kin lock resolves a different
       # kin-vfs-core than the pinned kin-vfs checkout builds, and that

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -1,0 +1,847 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: RC Build
+
+# A release-candidate archive build that needs no tag.
+#
+# The release proof loop says: preflight the composed build, run the archive
+# stranger on the candidate, then land and tag. The second step could not run
+# before a tag existed. Release-shaped archives were produced only by
+# release.yml, release.yml runs only on a `v*` tag push, and a tag run resolves
+# its workflows from the tag, so nothing landed afterwards can repair it. The
+# archive stranger therefore ran on shipped bytes for v0.5.40, after the cut,
+# and bin/kin-release-preflight skipped its Linux leg with "no Linux archive was
+# given and this host cannot cross-build one" because a macOS host cannot
+# produce a linux-aarch64 archive.
+#
+# This workflow closes that gap. It builds the same archive layouts release.yml
+# builds, for an arbitrary ref, and uploads them as artifacts. It creates no
+# tag, publishes no release, publishes to no registry, and touches no promotion
+# state. It holds no credential: it declares no environment and reads no secret,
+# which is what keeps a dispatch of branch-controlled workflow code away from the
+# Apple and package-publish credentials release.yml gates behind `environment:
+# release` (see the note above `config` in release.yml).
+#
+# SOURCE OF TRUTH: .github/workflows/release.yml, job `build`. Every step below
+# is a byte-identical copy of that job's step of the same name, except where a
+# comment starting DELTA( names the difference and why. Two step groups are
+# omitted on purpose: the six macOS signing and notarization steps, which need
+# the credentials this workflow deliberately cannot reach, and nothing else.
+# scripts/check-rc-build-drift.mjs holds that relationship and fails the pull
+# request when release.yml moves and this file does not.
+#
+# What a candidate archive is NOT:
+#   - not signed and not notarized, so a macOS candidate archive is Gatekeeper
+#     material only after a real tag builds it. The Linux archives carry no
+#     signature in a release either, so they are unaffected.
+#   - not a release, and its provenance manifest carries no release_tag.
+#   - not built for windows-x86_64 or macos-x86_64. Neither host tool consumes
+#     those, so a candidate says nothing about either archive; the matrix rows
+#     stay in release.yml alone until something reads them here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: >-
+          Commit sha, branch or tag to build. Defaults to the dispatching ref.
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+# A candidate build is disposable, so a newer dispatch for the same ref
+# supersedes an older one rather than queueing behind it.
+concurrency:
+  group: kin-rc-build-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: RC Build (${{ matrix.artifact }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # These rows are copied from release.yml's build matrix. The
+          # windows-x86_64 and macos-x86_64 rows are deliberately absent: see
+          # the header. Keeping the row shape identical is what lets a missing
+          # row be added here by copying one line.
+          #
+          # DELTA(skip_vfs): every row declares it. Three shared steps read
+          # matrix.skip_vfs, and release.yml gets the key from the windows row
+          # this matrix does not carry, so without it actionlint rejects those
+          # steps against a matrix type that has no such property. The value is
+          # the same false those steps already saw on every non-windows row.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            vfs_target: x86_64-unknown-linux-gnu
+            artifact: kin-linux-x86_64
+            skip_vfs: false
+            shim_name: libkin_vfs_shim.so
+            cross: false
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            vfs_target: aarch64-unknown-linux-gnu
+            artifact: kin-linux-aarch64
+            skip_vfs: false
+            shim_name: libkin_vfs_shim.so
+            cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: kin-macos-aarch64
+            skip_vfs: false
+            shim_name: libkin_vfs_shim.dylib
+            cross: false
+
+    steps:
+      - name: Preserve tracked bytes on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # DELTA(ref): an empty string leaves actions/checkout on the
+          # dispatching ref, so the default input builds what was dispatched.
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      # ADDED: a candidate has no tag to take a version from, and both the macOS
+      # notifier bundle and the provenance manifest need one. The workspace
+      # package version is what the built binaries stamp into their own static
+      # build identity, so it is the only value those identities can agree with.
+      - name: Resolve the release-candidate identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -e '
+            const fs = require("fs");
+            let inSection = false;
+            let version = null;
+            for (const line of fs.readFileSync("Cargo.toml", "utf8").split("\n")) {
+              const header = line.match(/^\s*\[([^\]]+)\]/);
+              if (header) { inSection = header[1] === "workspace.package"; continue; }
+              if (!inSection) continue;
+              const found = line.match(/^\s*version\s*=\s*"([^"]+)"/);
+              if (found) { version = found[1]; break; }
+            }
+            if (!version) throw new Error("Cargo.toml carries no [workspace.package] version");
+            process.stdout.write(version);
+          ')"
+          # Refuse rather than default. A version read that silently returned
+          # something unversion-shaped would surface later as a static build
+          # identity mismatch attributed to the binaries.
+          case "$version" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::resolved release-candidate version '$version' is not semver-shaped"; exit 1 ;;
+          esac
+          {
+            echo "RC_VERSION=$version"
+            echo "RC_REF=$(git rev-parse HEAD)"
+          } >> "$GITHUB_ENV"
+          echo "release candidate $version at $(git rev-parse HEAD)"
+
+      - name: Install Rust stable
+        uses: ./.github/actions/rust-toolchain
+        with:
+          # On the Linux legs the core (kin, kin-daemon) targets musl and the VFS
+          # leg targets gnu (vfs_target), so both targets must be installed.
+          targets: ${{ matrix.target }}${{ matrix.vfs_target && format(' {0}', matrix.vfs_target) || '' }}
+
+      # musl-static C dependencies (ring, oniguruma, sqlite, tree-sitter) need a
+      # musl-targeting C compiler; musl-tools provides musl-gcc. Only the Linux
+      # musl legs require it.
+      - name: Install musl C toolchain (Linux musl)
+        if: ${{ contains(matrix.target, '-linux-musl') }}
+        # DELTA(apt): bounded through the shared helper. An unbounded apt call
+        # holds a job until the runner timeout when a mirror stalls (FIR-2391).
+        run: ./scripts/ci-apt-install.sh musl-tools
+
+      - name: Install cross (ARM64)
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Checkout kin-vfs
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: firelock-ai/kin-vfs
+          path: kin-vfs
+          # Release inputs must never move under an unchanged Kin tag.
+          ref: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          persist-credentials: false
+
+      - name: Verify canonical release input bytes
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const childProcess = require("child_process");
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const path = require("path");
+
+          const sha256 = (bytes) =>
+            crypto.createHash("sha256").update(bytes).digest("hex");
+          for (const [label, root] of [["Kin", process.cwd()], ["kin-vfs", path.join(process.cwd(), "kin-vfs")]]) {
+            const tracked = childProcess.execFileSync(
+              "git",
+              ["cat-file", "blob", "HEAD:Cargo.lock"],
+              { cwd: root }
+            );
+            const working = fs.readFileSync(path.join(root, "Cargo.lock"));
+            if (!working.equals(tracked)) {
+              throw new Error(
+                `${label} Cargo.lock working bytes ${sha256(working)} do not match ` +
+                `tracked Git bytes ${sha256(tracked)}; refusing platform-specific release provenance`
+              );
+            }
+            console.log(`Verified canonical ${label} Cargo.lock bytes: ${sha256(tracked)}`);
+          }
+
+          const lockPackages = (lockPath) => fs.readFileSync(lockPath, "utf8")
+            .split("[[package]]")
+            .slice(1)
+            .map((block) => ({
+              name: block.match(/^name = "([^"]+)"/m)?.[1],
+              version: block.match(/^version = "([^"]+)"/m)?.[1],
+              source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
+            }));
+          const kinVfsCore = lockPackages(path.join(process.cwd(), "Cargo.lock"))
+            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source?.startsWith("sparse+"));
+          const pinnedVfsCore = lockPackages(path.join(process.cwd(), "kin-vfs", "Cargo.lock"))
+            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source === null);
+          if (kinVfsCore.length !== 1 || pinnedVfsCore.length !== 1) {
+            throw new Error(
+              `expected one registry Kin kin-vfs-core and one pinned local kin-vfs-core; ` +
+              `found ${kinVfsCore.length} and ${pinnedVfsCore.length}`
+            );
+          }
+          if (kinVfsCore[0].version !== pinnedVfsCore[0].version) {
+            throw new Error(
+              `Kin resolves kin-vfs-core ${kinVfsCore[0].version}, but the pinned release ` +
+              `checkout builds ${pinnedVfsCore[0].version}; update the immutable kin-vfs pin`
+            );
+          }
+          console.log(`Verified Kin/kin-vfs release compatibility at kin-vfs-core ${kinVfsCore[0].version}`);
+          NODE
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            kin-vfs/target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Assert clean release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          dirty="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$dirty" ]; then
+            printf '%s\n' "$dirty" >&2
+            echo "::error::release checkout is not clean before compilation"
+            exit 1
+          fi
+          vfs_dirty="$(git -C kin-vfs status --porcelain --untracked-files=all)"
+          if [ -n "$vfs_dirty" ]; then
+            printf '%s\n' "$vfs_dirty" >&2
+            echo "::error::pinned kin-vfs checkout is not clean before compilation"
+            exit 1
+          fi
+
+      - name: Build kin-cli + kin-daemon (native)
+        if: ${{ !matrix.cross }}
+        shell: bash
+        run: |
+          # The daemon is the runtime: `kin init` works without it but
+          # `kin status`/`kin search`/the MCP server all require kin-daemon on
+          # PATH, so a clean public install must ship it alongside `kin`.
+          #
+          # Every platform now builds the same default feature set. Windows was
+          # the only leg that stripped it, and dropping that split is what puts
+          # native vector search in the shipped Windows archive.
+          cargo build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon
+        env:
+          TARGET: ${{ matrix.target }}
+
+      - name: Build kin-cli + kin-daemon (cross)
+        if: ${{ matrix.cross }}
+        run: cross build --locked --release --target "$TARGET" -p kin-cli -p kin-daemon
+        env:
+          TARGET: ${{ matrix.target }}
+
+      # KinNotifier.app carries Kin's notification identity. macOS derives a
+      # notification's sender name, icon, and grouping from the posting
+      # process's bundle, so without this the CLI's notifications are credited
+      # to Script Editor. macOS-only: there is no bundle concept elsewhere.
+      - name: Build and assemble KinNotifier.app (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --release --target "$TARGET" -p kin-notifier-macos
+          crates/kin-notifier-macos/bundle.sh \
+            "target/${TARGET}/release/KinNotifier" \
+            "target/${TARGET}/release" \
+            "$RC_VERSION"
+        env:
+          TARGET: ${{ matrix.target }}
+
+      # kin and kin-daemon are static musl and carry no glibc floor at all. The
+      # VFS pair is the only glibc-linked thing Kin publishes for Linux, and
+      # until now its floor was a property of the runner image: Rust std
+      # references pidfd_spawnp and pidfd_getpid as weak undefined symbols, the
+      # linker binds them to whatever libc the build host exports, and the
+      # ubuntu-24.04 images export them at GLIBC_2.39. v0.5.38 shipped a
+      # linux-aarch64 kin-vfs the Debian 12 loader refused outright for exactly
+      # that reason. Zig ships glibc headers for every version, so building
+      # through it pins the floor to a number under review here rather than to
+      # whichever image the runner label resolves to this month.
+      - name: Install the pinned glibc floor toolchain (Linux)
+        if: ${{ runner.os == 'Linux' && !matrix.cross && !matrix.skip_vfs }}
+        shell: bash
+        env:
+          ZIG_VERSION: "0.13.0"
+          CARGO_ZIGBUILD_VERSION: "0.19.8"
+          # Published by ziglang.org/download/index.json for these exact
+          # tarballs. A release input must be immutable, so the download is
+          # checked rather than trusted.
+          ZIG_SHA256_X86_64: d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea
+          ZIG_SHA256_AARCH64: 041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64) zig_arch=x86_64; zig_sha="$ZIG_SHA256_X86_64" ;;
+            aarch64) zig_arch=aarch64; zig_sha="$ZIG_SHA256_AARCH64" ;;
+            *)
+              echo "::error::no pinned zig tarball for Linux $(uname -m); the release cannot pin its glibc floor on this host"
+              exit 1
+              ;;
+          esac
+          tarball="$RUNNER_TEMP/zig-${ZIG_VERSION}.tar.xz"
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
+            --location --silent --show-error --fail \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${zig_arch}-${ZIG_VERSION}.tar.xz" \
+            --output "$tarball"
+          echo "${zig_sha}  ${tarball}" | sha256sum --check --strict -
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$tarball" -C "$RUNNER_TEMP/zig" --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --locked --version "$CARGO_ZIGBUILD_VERSION"
+
+      - name: Build kin-vfs (native)
+        if: ${{ !matrix.cross && !matrix.skip_vfs }}
+        working-directory: kin-vfs
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The VFS shim is an LD_PRELOAD libc interceptor and is therefore
+          # libc-specific: on Linux it builds against gnu (VFS_TARGET) so it can
+          # preload into the host distro's glibc programs. macOS/Windows have no
+          # vfs_target, so VFS_TARGET falls back to the core target there.
+          # The mount features are what make the shipped driver able to serve a
+          # projection the operating system mounts, rather than only the
+          # injected shim. macOS gets nfs because it carries an NFS client in
+          # the base system; Linux gets fuse below because it carries libfuse
+          # far more widely than a configured NFS client. Neither flag moves the
+          # glibc floor or adds a runtime dependency: building the same tree
+          # with and without them yields an identical shared-library set and an
+          # identical set of referenced GLIBC symbol versions, and fuser links
+          # no library because it mounts through the fusermount3 helper.
+          # --locked still holds: nfsserve and fuser are already in kin-vfs's
+          # tracked lock at the pinned ref.
+          if [ "$RUNNER_OS" != "Linux" ]; then
+            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-cli --features nfs
+            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-shim
+            exit 0
+          fi
+          # The floor is read out of the guard rather than written here as
+          # well. A build targeting one floor while the guard enforces another
+          # is worse than no guard, and the two drifting apart is exactly the
+          # shape that survives review.
+          floor="$(node "$GITHUB_WORKSPACE/scripts/check-glibc-floor.mjs" --print-floor)"
+          # zig cc does not search Debian/Ubuntu multiarch directories, and the
+          # OpenSSL that kin-vfs-daemon links through reqwest lives in them:
+          # the headers under /usr/include/<multiarch> and the link libraries
+          # under /usr/lib/<multiarch>. Both Linux legs build natively, so the
+          # multiarch triple is the VFS target's architecture.
+          multiarch="${VFS_TARGET%%-*}-linux-gnu"
+          scoped="$(printf '%s' "$VFS_TARGET" | tr - _)"
+          upper="$(printf '%s' "$scoped" | tr '[:lower:]' '[:upper:]')"
+          export "CFLAGS_${scoped}=-I/usr/include/${multiarch}"
+          export "CARGO_TARGET_${upper}_RUSTFLAGS=-L native=/usr/lib/${multiarch}"
+          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-cli --features fuse
+          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-shim
+        env:
+          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
+
+      - name: Build kin-vfs (cross)
+        if: ${{ matrix.cross }}
+        working-directory: kin-vfs
+        run: |
+          cross build --locked --release --target "$TARGET" -p kin-vfs-cli
+          cross build --locked --release --target "$TARGET" -p kin-vfs-shim
+        env:
+          TARGET: ${{ matrix.target }}
+
+      - name: Verify native release build provenance
+        if: ${{ !matrix.cross }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          case "$RUNNER_ARCH:$TARGET" in
+            X64:x86_64-*|ARM64:aarch64-*) ;;
+            *)
+              echo "Skipping execution of cross-architecture artifact $TARGET on $RUNNER_ARCH; the matching macOS leg executes the same source and lock provenance."
+              exit 0
+              ;;
+          esac
+
+          suffix=""
+          [ "$RUNNER_OS" = "Windows" ] && suffix=".exe"
+          kin_bin="target/$TARGET/release/kin$suffix"
+          daemon_bin="target/$TARGET/release/kin-daemon$suffix"
+          provenance_dir="$RUNNER_TEMP/kin-release-provenance-$TARGET"
+          mkdir -p "$provenance_dir"
+          "$kin_bin" --version | tee "$provenance_dir/kin-version.txt"
+          "$daemon_bin" --version | tee "$provenance_dir/kin-daemon-version.txt"
+          "$kin_bin" bench-meta --json > "$provenance_dir/kin-build-meta.json"
+          expected_sha="$(git rev-parse HEAD)"
+
+          EXPECTED_SHA="$expected_sha" PROVENANCE_DIR="$provenance_dir" node <<'NODE'
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const expected = process.env.EXPECTED_SHA;
+          const dir = process.env.PROVENANCE_DIR;
+          const lines = ["kin-version.txt", "kin-daemon-version.txt"].map((path) =>
+            fs.readFileSync(`${dir}/${path}`, "utf8").trim()
+          );
+          const shas = lines.map((line) => {
+            const match = line.match(/\(([0-9a-f]{40})(-dirty)?\s/);
+            if (!match) throw new Error(`release version line lacks a full build SHA: ${line}`);
+            if (match[2]) throw new Error(`release binary was built dirty: ${line}`);
+            return match[1];
+          });
+          if (shas.some((sha) => sha !== expected) || shas[0] !== shas[1]) {
+            throw new Error(`release binary SHAs ${shas.join(", ")} do not match checkout ${expected}`);
+          }
+
+          const meta = JSON.parse(fs.readFileSync(`${dir}/kin-build-meta.json`, "utf8"));
+          if (process.env.GITHUB_REF_TYPE === "tag") {
+            const expectedVersion = process.env.GITHUB_REF_NAME.replace(/^v/, "");
+            if (meta.kin_version !== expectedVersion) {
+              throw new Error(`kin package version ${meta.kin_version ?? "missing"} does not match release tag ${expectedVersion}`);
+            }
+          }
+          if (meta.kin_commit !== expected || meta.kin_dirty !== false || meta.kin_source_known !== true) {
+            throw new Error("kin bench-meta did not prove a clean, known release source");
+          }
+          const tagLockSha = crypto.createHash("sha256").update(fs.readFileSync("Cargo.lock")).digest("hex");
+          if (meta.dependency_provenance !== tagLockSha) {
+            throw new Error(
+              `embedded Cargo.lock provenance ${meta.dependency_provenance ?? "missing"} ` +
+              `does not match tagged Cargo.lock ${tagLockSha}`
+            );
+          }
+          // Every published archive now carries semantic search. This used to
+          // run only for the one leg that stripped the features, which meant no
+          // leg ever asserted they were PRESENT; a silent feature regression on
+          // any platform would have shipped green. Assert it everywhere.
+          //
+          // `metal` reports the compiled backend rather than the marker cargo
+          // feature (bench_meta.rs `metal_active()` is
+          // `cfg!(target_os = "macos")`), so it is expected on macOS and is a
+          // defect anywhere else.
+          for (const feature of ["vector", "embeddings"]) {
+            if (!meta.feature_flags.includes(feature)) {
+              throw new Error(`release build for ${process.env.TARGET} did not enable ${feature}`);
+            }
+          }
+          const expectMetal = process.env.TARGET.includes("apple-darwin");
+          if (meta.feature_flags.includes("metal") !== expectMetal) {
+            throw new Error(
+              `release build for ${process.env.TARGET} reported metal=${meta.feature_flags.includes("metal")}, expected ${expectMetal}`
+            );
+          }
+          NODE
+
+      - name: Assert release build did not mutate source
+        shell: bash
+        run: |
+          set -euo pipefail
+          dirty="$(git status --porcelain --untracked-files=all)"
+          if [ -n "$dirty" ]; then
+            printf '%s\n' "$dirty" >&2
+            echo "::error::release build mutated the source checkout"
+            exit 1
+          fi
+          vfs_dirty="$(git -C kin-vfs status --porcelain --untracked-files=all)"
+          if [ -n "$vfs_dirty" ]; then
+            printf '%s\n' "$vfs_dirty" >&2
+            echo "::error::release build mutated the pinned kin-vfs checkout"
+            exit 1
+          fi
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir "$ARTIFACT"
+          cp "target/${TARGET}/release/kin" "$ARTIFACT/"
+          # kin-daemon is mandatory (no `|| true`): a daemon-less
+          # archive lets `kin init` succeed but then `kin status`/`kin search`
+          # fail with no daemon on PATH, so a missing daemon must fail the build.
+          cp "target/${TARGET}/release/kin-daemon" "$ARTIFACT/"
+          # kin-vfs (cli + shim) is built under VFS_TARGET, which on Linux is the
+          # gnu triple (the shim is libc-specific) and elsewhere equals TARGET.
+          cp "kin-vfs/target/${VFS_TARGET}/release/kin-vfs" "$ARTIFACT/"
+          cp "kin-vfs/target/${VFS_TARGET}/release/${SHIM_NAME}" "$ARTIFACT/"
+          # KinNotifier.app is macOS-only and is copied whole: -R preserves the
+          # bundle structure and the stapled notarization ticket inside it.
+          if [ -d "target/${TARGET}/release/KinNotifier.app" ]; then
+            cp -R "target/${TARGET}/release/KinNotifier.app" "$ARTIFACT/"
+          fi
+          tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
+          # Take the listing once into a file. Piping it into `grep -q` lets grep
+          # exit on its first match, and under `pipefail` the SIGPIPE that raises
+          # on `tar` fails the pipeline, which reads exactly like the member being
+          # absent. Reading a file cannot invert the guard that way.
+          ARCHIVE_LISTING="$RUNNER_TEMP/${ARTIFACT}.listing.txt"
+          tar tzf "${ARTIFACT}.tar.gz" > "$ARCHIVE_LISTING"
+          # All supported Unix surfaces are mandatory release contents.
+          for required in kin kin-daemon kin-vfs "$SHIM_NAME"; do
+            if ! grep -q "/${required}$" "$ARCHIVE_LISTING"; then
+              echo "::error::$required missing from ${ARTIFACT}.tar.gz"
+              exit 1
+            fi
+          done
+          # The notifier is mandatory on macOS. Without it the CLI still runs but
+          # every notification is credited to Script Editor, which is a silent
+          # downgrade rather than a visible failure, so assert it here.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            if ! grep -q "KinNotifier.app/Contents/MacOS/KinNotifier$" "$ARCHIVE_LISTING"; then
+              echo "::error::KinNotifier.app missing from ${ARTIFACT}.tar.gz"
+              exit 1
+            fi
+          fi
+          shasum -a 256 "${ARTIFACT}.tar.gz" > "${ARTIFACT}.tar.gz.sha256"
+        env:
+          TARGET: ${{ matrix.target }}
+          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
+          ARTIFACT: ${{ matrix.artifact }}
+          SHIM_NAME: ${{ matrix.shim_name }}
+
+      # Read the floor back off the bytes that were just packaged. The build
+      # above pins it, and a pin goes quiet the day it stops taking effect,
+      # which is how v0.5.38 published a kin-vfs that no Debian 12 could start
+      # while every check in this workflow stayed green. This step is the half
+      # that cannot pass by accident: it names the highest GLIBC requirement in
+      # each shipped dynamic binary and the symbols that set it, and refuses the
+      # release above the floor.
+      - name: Verify the packaged Linux binaries meet the published glibc floor
+        if: ${{ runner.os == 'Linux' && !matrix.skip_vfs }}
+        shell: bash
+        run: node scripts/check-glibc-floor.mjs "$ARTIFACT/kin-vfs" "$ARTIFACT/$SHIM_NAME"
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+          SHIM_NAME: ${{ matrix.shim_name }}
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path $env:ARTIFACT
+          Copy-Item "target/$env:TARGET/release/kin.exe" "$env:ARTIFACT/"
+          # kin-daemon is mandatory: fail hard if it's missing rather
+          # than ship a daemon-less archive that can `kin init` but nothing else.
+          Copy-Item "target/$env:TARGET/release/kin-daemon.exe" "$env:ARTIFACT/" -ErrorAction Stop
+          Copy-Item "kin-vfs/target/$env:TARGET/release/kin-vfs.exe" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
+          Copy-Item "kin-vfs/target/$env:TARGET/release/$env:SHIM_NAME" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
+          Compress-Archive -Path "$env:ARTIFACT/*" -DestinationPath "$env:ARTIFACT.zip"
+          # Assert the produced zip actually contains kin-daemon.exe.
+          $entries = [System.IO.Compression.ZipFile]::OpenRead("$PWD/$env:ARTIFACT.zip").Entries.Name
+          if ($entries -notcontains "kin-daemon.exe") {
+            Write-Error "kin-daemon.exe missing from $env:ARTIFACT.zip, refusing to publish a daemon-less archive"
+            exit 1
+          }
+          # The POSIX installer builds one archive name for every platform it
+          # detects, "kin-<os>-<arch>.tar.gz", and it detects windows from the
+          # MSYS, MINGW, and CYGWIN uname strings. Piping the documented curl
+          # command into a shell on Windows therefore asked for a tarball this
+          # leg never produced, and every release to date answered that request
+          # with a 404. Publish the same components under that exact name beside
+          # the zip. The zip stays the primary archive: the PowerShell
+          # installer, the npm launcher, and `kin update` all resolve Windows by
+          # that name, and anything already depending on it keeps working.
+          tar -czf "$env:ARTIFACT.tar.gz" "$env:ARTIFACT"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "tar failed to package $env:ARTIFACT.tar.gz"
+            exit 1
+          }
+          $members = @(tar -tzf "$env:ARTIFACT.tar.gz")
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "tar failed to list $env:ARTIFACT.tar.gz"
+            exit 1
+          }
+          $members = @($members | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+          # The Unix legs wrap their contents in a single "<artifact>/" root and
+          # the release shape rules refuse a member carrying a backslash, so
+          # assert both here rather than discovering a Windows path separator in
+          # the publish job after the archive is already built.
+          $prefix = "$env:ARTIFACT/"
+          foreach ($member in $members) {
+            if ($member.Contains("\")) {
+              Write-Error "$env:ARTIFACT.tar.gz member '$member' uses a Windows path separator"
+              exit 1
+            }
+            if (-not $member.StartsWith($prefix)) {
+              Write-Error "$env:ARTIFACT.tar.gz member '$member' is not under $prefix"
+              exit 1
+            }
+          }
+          $TarNames = @(
+            $members |
+              Where-Object { -not $_.EndsWith("/") } |
+              ForEach-Object { $_.Substring($prefix.Length) } |
+              Sort-Object
+          )
+          $ZipNames = @($entries | Sort-Object)
+          if (Compare-Object -ReferenceObject $ZipNames -DifferenceObject $TarNames) {
+            Write-Error "$env:ARTIFACT.tar.gz and $env:ARTIFACT.zip do not carry the same components"
+            exit 1
+          }
+          if ($TarNames -notcontains "kin-daemon.exe") {
+            Write-Error "kin-daemon.exe missing from $env:ARTIFACT.tar.gz"
+            exit 1
+          }
+          foreach ($ArchivePath in @("$env:ARTIFACT.zip", "$env:ARTIFACT.tar.gz")) {
+            $Hash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
+            "$Hash  $ArchivePath" | Set-Content -Encoding ascii "$ArchivePath.sha256"
+          }
+        env:
+          TARGET: ${{ matrix.target }}
+          ARTIFACT: ${{ matrix.artifact }}
+          SHIM_NAME: ${{ matrix.shim_name }}
+
+      - name: Generate artifact provenance manifest
+        shell: bash
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+          TARGET: ${{ matrix.target }}
+          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
+          EXPECTED_VFS_COMMIT: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const childProcess = require("child_process");
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const path = require("path");
+
+          const artifact = process.env.ARTIFACT;
+          const { readUpdateBuildIdentity } = require("./scripts/read-update-build-identity.cjs");
+          const { classifyReleaseArchiveRoot } = require("./scripts/release-archive-shape.cjs");
+          const target = process.env.TARGET;
+          const root = process.cwd();
+          const authorityNames = new Set(
+            target.includes("-windows-")
+              ? ["kin.exe", "kin-daemon.exe"]
+              : ["kin", "kin-daemon"]
+          );
+          const sha256 = (file) =>
+            crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+          const git = (cwd, ...args) =>
+            childProcess.execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+          const kinCommit = git(root, "rev-parse", "HEAD");
+          const vfsRoot = path.join(root, "kin-vfs");
+          const vfsCommit = git(vfsRoot, "rev-parse", "HEAD");
+          if (vfsCommit !== process.env.EXPECTED_VFS_COMMIT) {
+            throw new Error(`kin-vfs checkout ${vfsCommit} does not match pinned ${process.env.EXPECTED_VFS_COMMIT}`);
+          }
+
+          const kinLockSha = sha256(path.join(root, "Cargo.lock"));
+          const vfsLockSha = sha256(path.join(vfsRoot, "Cargo.lock"));
+          const buildMetaPath = path.join(
+            process.env.RUNNER_TEMP,
+            `kin-release-provenance-${target}`,
+            "kin-build-meta.json"
+          );
+          const buildMeta = JSON.parse(fs.readFileSync(buildMetaPath, "utf8"));
+          if (buildMeta.kin_commit !== kinCommit || buildMeta.dependency_provenance !== kinLockSha) {
+            throw new Error("embedded build provenance does not match the tagged Kin source and Cargo.lock");
+          }
+
+          // Windows publishes two containers of the same components: the zip
+          // every Windows resolver already asks for, and the tarball the POSIX
+          // installer builds its name from. The zip stays the manifest's
+          // primary archive because `kin update` and the public install proof
+          // both find the platform record by that exact name; the tarball is
+          // inventoried beside it so its bytes are covered by the same
+          // provenance rather than published unaccounted for.
+          const windowsTarget = target.includes("-windows-");
+          const primaryArchive = windowsTarget ? `${artifact}.zip` : `${artifact}.tar.gz`;
+          const additionalArchiveNames = windowsTarget ? [`${artifact}.tar.gz`] : [];
+          const expectedArchives = [primaryArchive, ...additionalArchiveNames].sort();
+          const archives = [`${artifact}.tar.gz`, `${artifact}.zip`]
+            .filter((file) => fs.existsSync(file))
+            .sort();
+          if (JSON.stringify(archives) !== JSON.stringify(expectedArchives)) {
+            throw new Error(`expected final archives ${expectedArchives.join(", ")} for ${artifact}, found ${archives.join(", ") || "none"}`);
+          }
+          const archive = primaryArchive;
+          const archiveRecord = (name) => ({
+            name,
+            sha256: sha256(name),
+            size_bytes: fs.statSync(name).size,
+          });
+          // The content inventory covers the archive's component files. The macOS
+          // notification bundle is a sealed directory rather than a component, so
+          // it is classified and shape-checked here but stays out of the manifest:
+          // an installed updater refuses any inventory name outside its managed
+          // component list, and the bundle's bytes are already covered by the
+          // archive digest, its code signature, and its stapled notarization.
+          const contents = classifyReleaseArchiveRoot(artifact, { target })
+            .files
+            .map((name) => {
+              const file = path.join(artifact, name);
+              const record = {
+                name,
+                sha256: sha256(file),
+                size_bytes: fs.statSync(file).size,
+              };
+              if (authorityNames.has(name)) {
+                record.build_identity = readUpdateBuildIdentity(file);
+              }
+              return record;
+            })
+            .sort((left, right) => left.name.localeCompare(right.name));
+          if (contents.length < 2) {
+            throw new Error(`${artifact} does not contain the mandatory kin and kin-daemon binaries`);
+          }
+          // DELTA(version): a candidate has no tag, so the version both static
+          // build identities must agree on is the workspace package version the
+          // job resolved. The cross-check between kin and kin-daemon is intact;
+          // what a candidate cannot assert is agreement with a tag name.
+          const expectedVersion = process.env.RC_VERSION;
+          const authorityRecords = contents.filter((record) => authorityNames.has(record.name));
+          if (authorityRecords.length !== authorityNames.size) {
+            throw new Error(`${artifact} does not contain both static build-identity authorities`);
+          }
+          const graphVersions = new Set();
+          for (const record of authorityRecords) {
+            const identity = record.build_identity;
+            if (
+              identity.version !== expectedVersion ||
+              identity.commit !== kinCommit ||
+              identity.clean !== true ||
+              identity.source_known !== true ||
+              identity.dependency_provenance !== kinLockSha
+            ) {
+              throw new Error(`${record.name} static build identity does not match the tagged release source`);
+            }
+            graphVersions.add(identity.graph_snapshot_version);
+          }
+          if (graphVersions.size !== 1) {
+            throw new Error(`${artifact} CLI and daemon graph snapshot identities disagree`);
+          }
+
+          const manifest = {
+            schema_version: 2,
+            // DELTA(identity): a candidate manifest names the ref and sha it was
+            // built from. It carries no release_tag, so it can never be mistaken
+            // for a published release's provenance.
+            release_candidate: {
+              ref: process.env.RC_REF,
+              version: process.env.RC_VERSION,
+            },
+            artifact,
+            target,
+            vfs_target: process.env.VFS_TARGET,
+            kin: {
+              commit: kinCommit,
+              cargo_lock_sha256: kinLockSha,
+              embedded_dependency_provenance: buildMeta.dependency_provenance,
+            },
+            kin_vfs: {
+              commit: vfsCommit,
+              dirty: false,
+              cargo_lock_sha256: vfsLockSha,
+            },
+            archive: archiveRecord(archive),
+            ...(additionalArchiveNames.length
+              ? { additional_archives: additionalArchiveNames.map(archiveRecord) }
+              : {}),
+            archive_contents: contents,
+            workflow: {
+              repository: process.env.GITHUB_REPOSITORY,
+              run_id: process.env.GITHUB_RUN_ID,
+              run_attempt: process.env.GITHUB_RUN_ATTEMPT,
+            },
+          };
+          fs.writeFileSync(`${artifact}.provenance.json`, `${JSON.stringify(manifest, null, 2)}\n`);
+          NODE
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: ${{ matrix.artifact }}
+          # DELTA(retention): a candidate is short-lived scratch, and an empty
+          # upload must fail here rather than surface as a missing archive in
+          # whatever consumes the run.
+          retention-days: 7
+          if-no-files-found: error
+          path: |
+            ${{ matrix.artifact }}.tar.gz
+            ${{ matrix.artifact }}.tar.gz.sha256
+            ${{ matrix.artifact }}.zip
+            ${{ matrix.artifact }}.zip.sha256
+            ${{ matrix.artifact }}.provenance.json
+
+      # ADDED: the run's own answer to "which bytes did this produce". A
+      # consumer downloads by run id, so the run has to name the sha it built
+      # and the digest of every archive it uploaded.
+      - name: Summarize the candidate archives
+        shell: bash
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          {
+            printf '### %s\n\n' "$ARTIFACT"
+            printf '| field | value |\n| --- | --- |\n'
+            printf '| built sha | %s |\n' "$RC_REF"
+            printf '| version | %s |\n' "$RC_VERSION"
+          } >> "$GITHUB_STEP_SUMMARY"
+          found=0
+          for archive in "${ARTIFACT}.tar.gz" "${ARTIFACT}.zip"; do
+            [ -f "$archive" ] || continue
+            found=1
+            printf '| %s sha256 | %s |\n' \
+              "$archive" "$(shasum -a 256 "$archive" | cut -d' ' -f1)" \
+              >> "$GITHUB_STEP_SUMMARY"
+          done
+          # The upload step already refuses an empty artifact; this refuses the
+          # narrower case where the summary would report a build that produced
+          # no archive at all, which would otherwise read as a clean run.
+          if [ "$found" = 0 ]; then
+            echo "::error::no archive was produced for $ARTIFACT"
+            exit 1
+          fi
+          printf '\nDownload these archives with: gh run download %s --repo %s\n' \
+            "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -25,11 +25,19 @@ name: RC Build
 #
 # SOURCE OF TRUTH: .github/workflows/release.yml, job `build`. Every step below
 # is a byte-identical copy of that job's step of the same name, except where a
-# comment starting DELTA( names the difference and why. Two step groups are
-# omitted on purpose: the six macOS signing and notarization steps, which need
-# the credentials this workflow deliberately cannot reach, and nothing else.
+# comment starting DELTA( names the difference and why. Seven steps are omitted
+# on purpose: the six macOS signing and notarization steps, which need the
+# credentials this workflow deliberately cannot reach, and the Cargo cache.
 # scripts/check-rc-build-drift.mjs holds that relationship and fails the pull
 # request when release.yml moves and this file does not.
+#
+# The cache is omitted rather than copied. release.yml runs only on a v* tag,
+# and that tag is ruleset-protected, so its cache write is authorized code. This
+# workflow builds whatever ref it is handed, so the same step would let a
+# dispatch write a poisoned entry into a cache that CI and release builds later
+# restore from. It would also mean the bytes under proof were assembled partly
+# from cache contents no one reviewed, which is the opposite of what a candidate
+# build is for. A candidate compiles cold.
 #
 # What a candidate archive is NOT:
 #   - not signed and not notarized, so a macOS candidate archive is Gatekeeper
@@ -233,18 +241,6 @@ jobs:
           }
           console.log(`Verified Kin/kin-vfs release compatibility at kin-vfs-core ${kinVfsCore[0].version}`);
           NODE
-
-      - name: Cache Cargo registry and build artifacts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            kin-vfs/target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.target }}-cargo-
 
       - name: Assert clean release source
         shell: bash

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -16,7 +16,8 @@ name: RC Build
 # produce a linux-aarch64 archive.
 #
 # This workflow closes that gap. It builds the same archive layouts release.yml
-# builds, for an arbitrary ref, and uploads them as artifacts. It creates no
+# builds, for the branch or tag it is dispatched on, and uploads them as
+# artifacts. It creates no
 # tag, publishes no release, publishes to no registry, and touches no promotion
 # state. It holds no credential: it declares no environment and reads no secret,
 # which is what keeps a dispatch of branch-controlled workflow code away from the
@@ -49,13 +50,15 @@ name: RC Build
 #     stay in release.yml alone until something reads them here.
 
 on:
+  # No ref input. `gh workflow run --ref <branch>` already names the ref, and the
+  # run then resolves this workflow, the code it builds, and its cache scope from
+  # that ref, the way a tag run resolves everything from its tag. Taking a ref as
+  # an INPUT instead means a run started from the default branch checks out
+  # arbitrary code while holding the default branch's scope, which is the cache
+  # poisoning shape CodeQL flags as actions/cache-poisoning/poisonable-step.
+  # The cost is that a candidate must be a branch or tag: the dispatch API does
+  # not accept a bare sha.
   workflow_dispatch:
-    inputs:
-      ref:
-        description: >-
-          Commit sha, branch or tag to build. Defaults to the dispatching ref.
-        required: false
-        default: ""
 
 permissions:
   contents: read
@@ -63,7 +66,7 @@ permissions:
 # A candidate build is disposable, so a newer dispatch for the same ref
 # supersedes an older one rather than queueing behind it.
 concurrency:
-  group: kin-rc-build-${{ github.event.inputs.ref || github.ref }}
+  group: kin-rc-build-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -118,9 +121,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # DELTA(ref): an empty string leaves actions/checkout on the
-          # dispatching ref, so the default input builds what was dispatched.
-          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       # ADDED: a candidate has no tag to take a version from, and both the macOS

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -184,7 +184,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          ref: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -640,7 +640,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          EXPECTED_VFS_COMMIT: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/scripts/check-rc-build-drift.mjs
+++ b/scripts/check-rc-build-drift.mjs
@@ -29,7 +29,15 @@ export const RC_WORKFLOW = ".github/workflows/rc-build.yml";
 // branch-controlled workflow code, which must never reach the Apple or
 // package-publish credentials. Without those credentials these steps have
 // nothing to do, so they are absent rather than inert.
+//
+// The Cargo cache, for a different reason. release.yml runs only on a
+// ruleset-protected v* tag, so its cache write is authorized code. rc-build.yml
+// builds whatever ref it is handed, so the same step would let a dispatch write
+// a poisoned entry into a cache that CI and release builds later restore from,
+// and would mean the bytes under proof were assembled partly from cache
+// contents no one reviewed. A candidate compiles cold.
 export const OMITTED_STEPS = [
+  "Cache Cargo registry and build artifacts",
   "Resolve macOS signing credential availability",
   "Import code signing certificate (macOS)",
   "Sign macOS binaries",

--- a/scripts/check-rc-build-drift.mjs
+++ b/scripts/check-rc-build-drift.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// rc-build.yml builds release-candidate archives from release.yml's build job.
+// It is a copy, because the alternative was refactoring the one workflow whose
+// mistakes cannot be repaired after the fact: a tag run resolves its workflows
+// from the tag. A copy that nothing checks is worse than no copy, because it
+// keeps reporting success while the thing it mirrors moves. This is the check
+// that makes the copy hold.
+//
+// It does not compare the two files loosely. It rebuilds what rc-build.yml's
+// shared step block MUST be, by taking release.yml's build steps, dropping the
+// step groups rc-build.yml deliberately omits, and applying the exact textual
+// deltas declared below. The result must equal rc-build.yml byte for byte. A
+// step added to release.yml, a step edited in either file, a reordered step, or
+// a delta whose anchor no longer exists all fail here and name what moved.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+export const RELEASE_WORKFLOW = ".github/workflows/release.yml";
+export const RC_WORKFLOW = ".github/workflows/rc-build.yml";
+
+// The six macOS signing and notarization steps. rc-build.yml declares no
+// environment and reads no secret, on purpose: a workflow_dispatch can target
+// branch-controlled workflow code, which must never reach the Apple or
+// package-publish credentials. Without those credentials these steps have
+// nothing to do, so they are absent rather than inert.
+export const OMITTED_STEPS = [
+  "Resolve macOS signing credential availability",
+  "Import code signing certificate (macOS)",
+  "Sign macOS binaries",
+  "Stage signed binaries for notarization (macOS)",
+  "Notarize macOS binaries (notarytool)",
+  "Upload signed binaries for Linux notarization",
+];
+
+// Steps rc-build.yml has and release.yml does not. Both exist because a
+// candidate has no tag: one resolves the version a tag would have supplied, the
+// other reports which bytes the run produced so a consumer can find them.
+export const ADDED_STEPS = [
+  "Resolve the release-candidate identity",
+  "Summarize the candidate archives",
+];
+
+// Every difference inside a shared step, as an exact anchor and its
+// replacement. Each anchor must appear exactly once in release.yml's build
+// steps; an anchor that stops matching is itself drift and fails below.
+export const DELTAS = [
+  {
+    label: "checkout-ref",
+    from: `      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+`,
+    to: `      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # DELTA(ref): an empty string leaves actions/checkout on the
+          # dispatching ref, so the default input builds what was dispatched.
+          ref: \${{ inputs.ref }}
+          persist-credentials: false
+`,
+  },
+  {
+    label: "apt",
+    from: `        run: sudo apt-get update && sudo apt-get install -y musl-tools
+`,
+    to: `        # DELTA(apt): bounded through the shared helper. An unbounded apt call
+        # holds a job until the runner timeout when a mirror stalls (FIR-2391).
+        run: ./scripts/ci-apt-install.sh musl-tools
+`,
+  },
+  {
+    label: "notifier-version",
+    from: `            "\${GITHUB_REF_NAME#v}"
+`,
+    to: `            "$RC_VERSION"
+`,
+  },
+  {
+    label: "provenance-version",
+    from: `
+          const expectedVersion = process.env.GITHUB_REF_NAME.replace(/^v/, "");`,
+    to: `
+          // DELTA(version): a candidate has no tag, so the version both static
+          // build identities must agree on is the workspace package version the
+          // job resolved. The cross-check between kin and kin-daemon is intact;
+          // what a candidate cannot assert is agreement with a tag name.
+          const expectedVersion = process.env.RC_VERSION;`,
+  },
+  {
+    label: "provenance-tag",
+    from: `            schema_version: 2,
+            release_tag: process.env.GITHUB_REF_NAME,
+            artifact,`,
+    to: `            schema_version: 2,
+            // DELTA(identity): a candidate manifest names the ref and sha it was
+            // built from. It carries no release_tag, so it can never be mistaken
+            // for a published release's provenance.
+            release_candidate: {
+              ref: process.env.RC_REF,
+              version: process.env.RC_VERSION,
+            },
+            artifact,`,
+  },
+  {
+    label: "upload",
+    from: `      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: \${{ matrix.artifact }}
+          path: |`,
+    to: `      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: \${{ matrix.artifact }}
+          # DELTA(retention): a candidate is short-lived scratch, and an empty
+          # upload must fail here rather than surface as a missing archive in
+          # whatever consumes the run.
+          retention-days: 7
+          if-no-files-found: error
+          path: |`,
+  },
+];
+
+// rc-build.yml declares skip_vfs on every row. Three shared steps read it, and
+// release.yml gets the key from the windows row rc-build.yml does not carry, so
+// without it actionlint rejects those steps against a matrix type with no such
+// property. The value matches what those steps already saw on every row here.
+const RC_ONLY_MATRIX_KEYS = ["skip_vfs"];
+
+export function buildJobBody(text, workflow) {
+  const lines = text.split("\n");
+  const start = lines.findIndex((line) => line === "  build:");
+  if (start === -1) throw new Error(`${workflow}: no build job`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^  [A-Za-z_][A-Za-z0-9_-]*:\s*$/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  // The comment block introducing the next job sits above that job's key and
+  // documents it, not the last step of this one. Without this the release
+  // build job's final step absorbs notarize_linux's header and can never
+  // match a candidate step that has no such neighbour.
+  while (end > start && /^ {2}#/.test(lines[end - 1])) end -= 1;
+  return lines.slice(start, end).join("\n");
+}
+
+// A step is its "- name:" line, its body, and the run of comment lines directly
+// above it. Both workflows document a step in the comment block that precedes
+// it, so a comment belongs to the step it describes rather than to the one
+// before. Trailing blank lines are trimmed, so where a blank line falls between
+// steps is not treated as drift.
+export function splitSteps(jobBody, workflow) {
+  const lines = jobBody.split("\n");
+  const starts = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!lines[i].startsWith("      - name: ")) continue;
+    let start = i;
+    while (start > 0 && /^ {6}#/.test(lines[start - 1])) start -= 1;
+    starts.push({ start, nameLine: i });
+  }
+  if (starts.length === 0) throw new Error(`${workflow}: build job has no steps`);
+  return starts.map(({ start, nameLine }, index) => {
+    const end = index + 1 < starts.length ? starts[index + 1].start : lines.length;
+    return {
+      name: lines[nameLine].slice("      - name: ".length),
+      body: lines.slice(start, end).join("\n").replace(/\s+$/, ""),
+    };
+  });
+}
+
+export function matrixRows(jobBody, workflow) {
+  const lines = jobBody.split("\n");
+  const start = lines.findIndex((line) => line === "        include:");
+  if (start === -1) throw new Error(`${workflow}: build job has no matrix include`);
+  const rows = [];
+  let current = null;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^\s*#/.test(line) || line.trim() === "") continue;
+    if (line.startsWith("          - ")) {
+      current = [`${line.slice("          - ".length)}`];
+      rows.push(current);
+      continue;
+    }
+    if (line.startsWith("            ")) {
+      if (!current) throw new Error(`${workflow}: matrix key before any row`);
+      current.push(line.trim());
+      continue;
+    }
+    break;
+  }
+  return new Map(
+    rows.map((row) => {
+      const artifact = row.find((entry) => entry.startsWith("artifact:"));
+      if (!artifact) throw new Error(`${workflow}: a matrix row names no artifact`);
+      return [artifact.slice("artifact:".length).trim(), row];
+    })
+  );
+}
+
+export function check(releaseText, rcText) {
+  const problems = [];
+  const releaseJob = buildJobBody(releaseText, RELEASE_WORKFLOW);
+  const rcJob = buildJobBody(rcText, RC_WORKFLOW);
+  const releaseSteps = splitSteps(releaseJob, RELEASE_WORKFLOW);
+  const rcSteps = splitSteps(rcJob, RC_WORKFLOW);
+  const releaseNames = releaseSteps.map((step) => step.name);
+  const rcNames = rcSteps.map((step) => step.name);
+
+  for (const name of OMITTED_STEPS) {
+    if (!releaseNames.includes(name)) {
+      problems.push(`omitted step "${name}" no longer exists in ${RELEASE_WORKFLOW}; the omission list is stale`);
+    }
+    if (rcNames.includes(name)) {
+      problems.push(`step "${name}" is listed as omitted but ${RC_WORKFLOW} carries it`);
+    }
+  }
+  for (const name of ADDED_STEPS) {
+    if (!rcNames.includes(name)) {
+      problems.push(`added step "${name}" is missing from ${RC_WORKFLOW}`);
+    }
+    if (releaseNames.includes(name)) {
+      problems.push(`step "${name}" is listed as candidate-only but ${RELEASE_WORKFLOW} carries it too`);
+    }
+  }
+
+  let expected = releaseSteps
+    .filter((step) => !OMITTED_STEPS.includes(step.name))
+    .map((step) => step.body)
+    .join("\n");
+  for (const delta of DELTAS) {
+    const seen = expected.split(delta.from).length - 1;
+    if (seen !== 1) {
+      problems.push(`delta "${delta.label}" matched ${seen} times in ${RELEASE_WORKFLOW}'s shared steps, expected exactly 1`);
+      continue;
+    }
+    expected = expected.replace(delta.from, delta.to);
+  }
+  const actual = rcSteps
+    .filter((step) => !ADDED_STEPS.includes(step.name))
+    .map((step) => step.body)
+    .join("\n");
+
+  if (expected !== actual) {
+    const expectedLines = expected.split("\n");
+    const actualLines = actual.split("\n");
+    let i = 0;
+    while (i < expectedLines.length && i < actualLines.length && expectedLines[i] === actualLines[i]) i += 1;
+    let step = "(before any step)";
+    for (let back = i; back >= 0; back -= 1) {
+      const match = /^ {6}- name: (.*)$/.exec(actualLines[back] ?? expectedLines[back] ?? "");
+      if (match) { step = match[1]; break; }
+    }
+    problems.push(
+      `${RC_WORKFLOW} no longer mirrors ${RELEASE_WORKFLOW}'s build steps.\n` +
+        `  first difference in step "${step}"\n` +
+        `  release.yml (with deltas applied): ${JSON.stringify(expectedLines[i] ?? "(end of block)")}\n` +
+        `  rc-build.yml:                      ${JSON.stringify(actualLines[i] ?? "(end of block)")}`
+    );
+  }
+
+  const releaseRows = matrixRows(releaseJob, RELEASE_WORKFLOW);
+  const rcRows = matrixRows(rcJob, RC_WORKFLOW);
+  for (const [artifact, rcRow] of rcRows) {
+    const releaseRow = releaseRows.get(artifact);
+    if (!releaseRow) {
+      problems.push(`${RC_WORKFLOW} builds ${artifact}, which ${RELEASE_WORKFLOW} does not publish`);
+      continue;
+    }
+    const trimmed = rcRow.filter((entry) => !RC_ONLY_MATRIX_KEYS.some((key) => entry.startsWith(`${key}:`)));
+    if (JSON.stringify(trimmed) !== JSON.stringify(releaseRow)) {
+      problems.push(
+        `${RC_WORKFLOW}'s ${artifact} matrix row differs from ${RELEASE_WORKFLOW}'s.\n` +
+          `  release.yml:  ${JSON.stringify(releaseRow)}\n` +
+          `  rc-build.yml: ${JSON.stringify(trimmed)}`
+      );
+    }
+  }
+  return problems;
+}
+
+export function checkFiles(root = ROOT) {
+  return check(
+    readFileSync(join(root, RELEASE_WORKFLOW), "utf8"),
+    readFileSync(join(root, RC_WORKFLOW), "utf8")
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const problems = checkFiles();
+  if (problems.length > 0) {
+    for (const problem of problems) {
+      console.error(`::error::${problem}`);
+    }
+    console.error(
+      `\n${RC_WORKFLOW} mirrors ${RELEASE_WORKFLOW}'s build job so release-candidate archives are built by the release's own steps.\n` +
+        `Re-copy the changed step into ${RC_WORKFLOW}, or record the difference in DELTAS in ${"scripts/check-rc-build-drift.mjs"}.`
+    );
+    process.exit(1);
+  }
+  console.log(
+    `${RC_WORKFLOW} mirrors ${RELEASE_WORKFLOW}'s build job: ` +
+      `${OMITTED_STEPS.length} steps omitted, ${ADDED_STEPS.length} candidate-only, ${DELTAS.length} deltas applied.`
+  );
+}

--- a/scripts/check-rc-build-drift.mjs
+++ b/scripts/check-rc-build-drift.mjs
@@ -59,22 +59,6 @@ export const ADDED_STEPS = [
 // steps; an anchor that stops matching is itself drift and fails below.
 export const DELTAS = [
   {
-    label: "checkout-ref",
-    from: `      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-`,
-    to: `      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # DELTA(ref): an empty string leaves actions/checkout on the
-          # dispatching ref, so the default input builds what was dispatched.
-          ref: \${{ inputs.ref }}
-          persist-credentials: false
-`,
-  },
-  {
     label: "apt",
     from: `        run: sudo apt-get update && sudo apt-get install -y musl-tools
 `,

--- a/scripts/check-rc-build-drift.test.mjs
+++ b/scripts/check-rc-build-drift.test.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// A drift check that cannot fail is not evidence. Every case below breaks the
+// relationship in one specific way and requires the named complaint, so the
+// green run above them means the two workflows actually agree.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  check,
+  checkFiles,
+  splitSteps,
+  buildJobBody,
+  RELEASE_WORKFLOW,
+  RC_WORKFLOW,
+} from "./check-rc-build-drift.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const release = readFileSync(join(ROOT, RELEASE_WORKFLOW), "utf8");
+const rc = readFileSync(join(ROOT, RC_WORKFLOW), "utf8");
+
+const only = (problems) => {
+  assert.equal(problems.length, 1, `expected one problem, got:\n${problems.join("\n")}`);
+  return problems[0];
+};
+
+test("the workflows in the tree agree", () => {
+  assert.deepEqual(checkFiles(ROOT), []);
+});
+
+test("the build job stops before the next job's header comment", () => {
+  const steps = splitSteps(buildJobBody(release, RELEASE_WORKFLOW), RELEASE_WORKFLOW);
+  const last = steps[steps.length - 1];
+  assert.equal(last.name, "Upload artifact");
+  assert.ok(!last.body.includes("notarize_linux"));
+  assert.ok(!/^ {2}#/m.test(last.body));
+});
+
+test("a comment block above a step belongs to that step", () => {
+  const steps = splitSteps(buildJobBody(rc, RC_WORKFLOW), RC_WORKFLOW);
+  const added = steps.find((step) => step.name === "Resolve the release-candidate identity");
+  assert.ok(added.body.startsWith("      # ADDED:"), added.body.slice(0, 80));
+  const checkout = steps.find((step) => step.name === "Checkout");
+  assert.ok(!checkout.body.includes("# ADDED:"));
+});
+
+test("a step added to release.yml is reported", () => {
+  const mutated = release.replace(
+    "      - name: Package (Unix)",
+    "      - name: Sneak in a release step\n        run: echo drift\n\n      - name: Package (Unix)"
+  );
+  assert.notEqual(mutated, release);
+  assert.match(only(check(mutated, rc)), /no longer mirrors/);
+  assert.match(only(check(mutated, rc)), /Sneak in a release step/);
+});
+
+test("a shared step edited in rc-build.yml is reported, and names the step", () => {
+  const mutated = rc.replace(
+    "        run: ./scripts/ci-apt-install.sh musl-tools",
+    "        run: ./scripts/ci-apt-install.sh musl-tools libssl-dev"
+  );
+  assert.notEqual(mutated, rc);
+  const problem = only(check(release, mutated));
+  assert.match(problem, /no longer mirrors/);
+  assert.match(problem, /Install musl C toolchain \(Linux musl\)/);
+});
+
+test("a shared step edited in release.yml is reported", () => {
+  const mutated = release.replace(
+    "          cargo build --locked --release --target \"$TARGET\" -p kin-cli -p kin-daemon",
+    "          cargo build --locked --release --target \"$TARGET\" -p kin-cli -p kin-daemon -p kin-extra"
+  );
+  assert.notEqual(mutated, release);
+  const problem = only(check(mutated, rc));
+  assert.match(problem, /Build kin-cli \+ kin-daemon \(native\)/);
+});
+
+test("an omitted signing step appearing in rc-build.yml is reported", () => {
+  const signing = splitSteps(buildJobBody(release, RELEASE_WORKFLOW), RELEASE_WORKFLOW)
+    .find((step) => step.name === "Sign macOS binaries");
+  const mutated = rc.replace(
+    "      - name: Package (Unix)",
+    `${signing.body}\n\n      - name: Package (Unix)`
+  );
+  assert.notEqual(mutated, rc);
+  const problems = check(release, mutated);
+  assert.ok(
+    problems.some((problem) => /listed as omitted but .* carries it/.test(problem)),
+    problems.join("\n")
+  );
+});
+
+test("an omitted step that release.yml no longer has is reported as stale", () => {
+  const mutated = release.replace("      - name: Sign macOS binaries", "      - name: Sign macOS binaries renamed");
+  assert.notEqual(mutated, release);
+  const problems = check(mutated, rc);
+  assert.ok(
+    problems.some((problem) => /omission list is stale/.test(problem)),
+    problems.join("\n")
+  );
+});
+
+test("a candidate-only step missing from rc-build.yml is reported", () => {
+  const mutated = rc.replace("      - name: Summarize the candidate archives", "      - name: Summarise the candidate archives");
+  assert.notEqual(mutated, rc);
+  const problems = check(release, mutated);
+  assert.ok(
+    problems.some((problem) => /added step "Summarize the candidate archives" is missing/.test(problem)),
+    problems.join("\n")
+  );
+});
+
+test("a delta whose anchor stopped matching is reported by label", () => {
+  const mutated = release.replace(
+    "        run: sudo apt-get update && sudo apt-get install -y musl-tools",
+    "        run: sudo apt-get update && sudo apt-get install -y musl-tools pkg-config"
+  );
+  assert.notEqual(mutated, release);
+  const problems = check(mutated, rc);
+  // Two complaints, and both are wanted: the delta stopped applying, and the
+  // block it would have produced no longer matches.
+  assert.ok(
+    problems.some((problem) => /delta "apt" matched 0 times/.test(problem)),
+    problems.join("\n")
+  );
+  assert.ok(
+    problems.some((problem) => /Install musl C toolchain/.test(problem)),
+    problems.join("\n")
+  );
+});
+
+test("a matrix row that moved in release.yml is reported", () => {
+  const mutated = release.replace("          - os: ubuntu-24.04-arm", "          - os: ubuntu-26.04-arm");
+  assert.notEqual(mutated, release);
+  const problems = check(release === mutated ? release : mutated, rc);
+  assert.ok(
+    problems.some((problem) => /kin-linux-aarch64 matrix row differs/.test(problem)),
+    problems.join("\n")
+  );
+});
+
+test("an rc-build target release.yml does not publish is reported", () => {
+  const mutated = rc.replace("            artifact: kin-macos-aarch64", "            artifact: kin-freebsd-aarch64");
+  assert.notEqual(mutated, rc);
+  const problems = check(release, mutated);
+  assert.ok(
+    problems.some((problem) => /builds kin-freebsd-aarch64, which .* does not publish/.test(problem)),
+    problems.join("\n")
+  );
+});

--- a/scripts/check-rc-build-drift.test.mjs
+++ b/scripts/check-rc-build-drift.test.mjs
@@ -154,3 +154,39 @@ test("an rc-build target release.yml does not publish is reported", () => {
     problems.join("\n")
   );
 });
+
+// The properties that make rc-build.yml safe to dispatch on an arbitrary ref.
+// Each is one line to break and none of them is visible in a diff of the build
+// steps, which is what the mirror check covers.
+
+test("rc-build.yml reads no secret and declares no environment", () => {
+  assert.equal(rc.match(/secrets\./g), null);
+  assert.equal(rc.match(/^\s*environment:/m), null);
+});
+
+test("rc-build.yml grants no permission beyond contents: read", () => {
+  const block = /\npermissions:\n((?: {2}\S.*\n)+)/.exec(rc);
+  assert.ok(block, "rc-build.yml declares no permissions block");
+  assert.deepEqual(block[1].trimEnd().split("\n"), ["  contents: read"]);
+});
+
+test("rc-build.yml writes to no Actions cache", () => {
+  // A dispatch builds whatever ref it is handed, so a cache write here would
+  // poison what CI and release builds restore from, and would put unreviewed
+  // cache contents into the bytes under proof.
+  assert.equal(rc.match(/actions\/cache/g), null);
+  assert.equal(rc.match(/rust-cache/g), null);
+});
+
+test("rc-build.yml publishes nothing", () => {
+  for (const forbidden of ["npm publish", "gh release", "cargo publish", "docker push", "softprops/action-gh-release"]) {
+    assert.equal(rc.includes(forbidden), false, `rc-build.yml contains ${forbidden}`);
+  }
+});
+
+test("rc-build.yml is dispatch-only", () => {
+  const triggers = /\non:\n((?:(?: {2}\S.*| {4}.*|)\n)+?)(?=\npermissions:)/.exec(rc);
+  assert.ok(triggers, "could not read rc-build.yml triggers");
+  const topLevel = triggers[1].split("\n").filter((line) => /^ {2}\S/.test(line));
+  assert.deepEqual(topLevel, ["  workflow_dispatch:"]);
+});

--- a/scripts/check-rc-build-drift.test.mjs
+++ b/scripts/check-rc-build-drift.test.mjs
@@ -171,11 +171,15 @@ test("rc-build.yml grants no permission beyond contents: read", () => {
 });
 
 test("rc-build.yml writes to no Actions cache", () => {
-  // A dispatch builds whatever ref it is handed, so a cache write here would
-  // poison what CI and release builds restore from, and would put unreviewed
-  // cache contents into the bytes under proof.
-  assert.equal(rc.match(/actions\/cache/g), null);
-  assert.equal(rc.match(/rust-cache/g), null);
+  // A candidate archive is the bytes under proof, so it must not be assembled
+  // partly from cache contents nobody reviewed. Read the `uses:` values rather
+  // than the file text: the header names the CodeQL rule, and a guard that
+  // matched prose would fire on its own explanation.
+  const uses = [...rc.matchAll(/^\s*uses:\s*(\S+)/gm)].map((match) => match[1]);
+  assert.ok(uses.length > 0, "rc-build.yml uses no actions at all, so this guard cannot fire");
+  for (const action of uses) {
+    assert.ok(!/cache/i.test(action), `rc-build.yml uses a caching action: ${action}`);
+  }
 });
 
 test("rc-build.yml publishes nothing", () => {
@@ -184,9 +188,15 @@ test("rc-build.yml publishes nothing", () => {
   }
 });
 
-test("rc-build.yml is dispatch-only", () => {
-  const triggers = /\non:\n((?:(?: {2}\S.*| {4}.*|)\n)+?)(?=\npermissions:)/.exec(rc);
-  assert.ok(triggers, "could not read rc-build.yml triggers");
-  const topLevel = triggers[1].split("\n").filter((line) => /^ {2}\S/.test(line));
-  assert.deepEqual(topLevel, ["  workflow_dispatch:"]);
+test("rc-build.yml is dispatch-only, and takes no ref input", () => {
+  const block = /\non:\n([\s\S]*?)(?=\npermissions:)/.exec(rc);
+  assert.ok(block, "could not read rc-build.yml triggers");
+  const triggers = block[1]
+    .split("\n")
+    .filter((line) => /^ {2}[^#\s]/.test(line));
+  assert.deepEqual(triggers, ["  workflow_dispatch:"]);
+  // A ref INPUT is what makes a run started from the default branch check out
+  // untrusted code while holding that branch's scope. `--ref` on the dispatch
+  // carries no such hazard, because the run resolves everything from that ref.
+  assert.equal(/^\s*inputs:/m.test(block[1]), false, "rc-build.yml declares a dispatch input");
 });

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -581,6 +581,13 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     ".github/workflows/publish-release-installers.yml": {
         "dispatch": None,
     },
+    # The release-candidate archive build. It is workflow_dispatch only, holds
+    # no credential, and publishes nothing, so it produces no pull-request check
+    # and can claim no required context. It is registered here because this
+    # census is what would otherwise let a new job's NAME appear unreviewed.
+    ".github/workflows/rc-build.yml": {
+        "build": "RC Build (${{ matrix.artifact }})",
+    },
     ".github/workflows/registry-index-migrate.yml": {
         "migrate": None,
     },
@@ -655,6 +662,10 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
         ".github/workflows/install-proof.yml",
         "install-proof",
     ): "44b510d0d82f7b56b525b08f38a3f84916243c30e9c365b340718670f95af1ca",
+    (
+        ".github/workflows/rc-build.yml",
+        "build",
+    ): "8dc0699fb69599edbca87492f3f3a895aefa3bea8384c86d8fc11fef99f9d52a",
     (
         ".github/workflows/release.yml",
         "build",


### PR DESCRIPTION
The release proof loop runs `bin/kin-release-preflight` on the composed build, then `bin/kin-stranger run --archive` on the release candidate in fresh containers, and only then lands and tags. The second step could not run before a tag existed.

Release-shaped archives came only from `release.yml`, which runs only on a `v*` tag push (`.github/workflows/release.yml:6`). So the archive stranger for v0.5.40 ran on the shipped linux-aarch64 archive after the cut rather than on a candidate, and `bin/kin-release-preflight` skipped its Linux leg on every run, printing "no Linux archive was given and this host cannot cross-build one, so the Linux leg (Debian 12 container + glibc floor) was skipped". A macOS host cannot cross-build a linux-aarch64 archive, so the Debian 12 container leg and the glibc floor guard that v0.5.38 shipped past never saw candidate bytes.

## What this adds

`.github/workflows/rc-build.yml` is a `workflow_dispatch` build of the same archive layouts `release.yml` builds, for an arbitrary `ref` input, uploaded as artifacts named like the release assets (`kin-linux-aarch64` carrying `kin-linux-aarch64.tar.gz`, its `.sha256` and its provenance manifest) with a 7 day retention, plus a job summary naming the built sha, the version, and each archive's sha256.

It creates no tag, publishes no release, publishes to no registry, and touches no promotion state. It declares no environment and reads no secret: `grep -c 'secrets\.'` over the file returns 0, and its `permissions:` block is `contents: read`. That is deliberate and load bearing. The note above `config` in `release.yml:36` says manual dispatch is disabled there because a dispatch can target branch-controlled workflow code, which must never inherit Apple or package-publish secrets. This workflow is dispatchable precisely because it can reach none of them.

Targets are linux-x86_64, linux-aarch64 and macos-aarch64. windows-x86_64 and macos-x86_64 are deliberately absent: neither host tool consumes them, so a candidate says nothing about either archive.

## Why a copy and not a workflow_call refactor

The DRY shape would be factoring `release.yml`'s `build` job into a reusable workflow. That job is 880 lines (`release.yml:376` to `release.yml:1243`) inside the one workflow whose mistakes cannot be repaired afterwards, because a tag run resolves its workflows from the tag. The refactor would also have to turn `environment: release` into an input and route six Apple secrets through `secrets:`, and none of it could be proven before it landed. The blast radius of getting that wrong is the next release.

So `rc-build.yml` copies the steps, and `scripts/check-rc-build-drift.mjs` holds the copy to the original. It does not compare loosely. It rebuilds what the shared block must be by taking `release.yml`'s build steps, dropping the six macOS signing and notarization steps, applying six declared textual deltas, and requiring byte equality, then compares the shared matrix rows. Each delta carries a `DELTA(` comment in `rc-build.yml` naming the difference and why: the `ref` input on checkout, the bounded `scripts/ci-apt-install.sh` call in place of an unbounded `apt-get` (FIR-2391), the version source for the KinNotifier bundle and the provenance manifest, a candidate manifest that carries no `release_tag`, and the artifact retention.

Wired into `ci.yml` as "Check the RC build mirrors the release build", with the test suite added to the release policy step's `node --test` list. `rc-build.yml` is also registered in `scripts/test-release-workflow-authority.py`, whose census is exact equality over every workflow path, job id and display name, plus the sha256 of its dynamic job name context.

## Falsification

`scripts/check-rc-build-drift.test.mjs` breaks the relationship 12 ways and requires the named complaint each time. All 12 pass, and the first case is the control that the check can pass on the tree as it stands:

```
# tests 12
# pass 12
# fail 0
```

The cases: a step added to `release.yml` is reported and names it; a shared step edited in either file is reported and names the step; an omitted signing step appearing in `rc-build.yml` is reported; an omission-list entry `release.yml` no longer carries is reported as stale; a candidate-only step missing from `rc-build.yml` is reported; a delta whose anchor stopped matching is reported by label; a matrix row that moved in `release.yml` is reported; and an rc-build target `release.yml` does not publish is reported.

Two parser bugs were found by those cases and fixed. The build job body used to absorb the comment block introducing `notarize_linux`, and a comment block above a step used to attach to the previous step. Both are now covered by their own tests.

The census registration was falsified by construction: before registering, `python3 scripts/test-release-workflow-authority.py` failed with "workflow-wide required-check producer census requires the exact reviewed workflow paths, job ids, and display names".

## Gates run locally

`actionlint` clean on `rc-build.yml` and `ci.yml`. It caught two real defects on the first pass: three shared steps read `matrix.skip_vfs`, which `release.yml` only gets from its windows row, and backticks inside single-quoted `printf` formats tripped SC2016. Both are fixed, the first by declaring `skip_vfs` on every row with the value those steps already saw.

- `node scripts/check-rc-build-drift.mjs` passes: 6 steps omitted, 2 candidate-only, 6 deltas applied
- `node --test` over the seven release scripts: 92 tests, 92 pass, 0 fail
- `python3 scripts/test-release-workflow-authority.py`: exit 0
- `python3 scripts/test-assertion-reachability.py`: exit 0
- `python3 scripts/test-homebrew-release-gate.py`: 49 passed
- `python3 scripts/verify-zero-file-search.py` and `bash scripts/zero_file_search_guard.sh`: exit 0

No Rust changed.

## First live dispatch

A `workflow_dispatch` workflow is dispatchable only once it exists on the default branch, so this one cannot be dispatched from this branch and the first live run happens after merge. The captain runs:

```
gh workflow run rc-build.yml --repo firelock-ai/kin -f ref=<sha>
gh run watch --repo firelock-ai/kin <run-id>
```

Then feeds the result to the preflight with `bin/kin-release-preflight --rc-run <run-id>`, which lands in a separate kin-ecosystem pull request. Until that first dispatch runs green, this workflow is proven only by `actionlint` and by the drift check that ties its steps to steps `release.yml` already runs on every tag.

Closes FIR-2444