### PR TITLE
Pin kin-vfs-core 0.4.5 and the kin-vfs release checkout to the composed mount landing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,7 +468,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          ref: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1088,7 +1088,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          EXPECTED_VFS_COMMIT: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1376,7 +1376,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          ref: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1444,7 +1444,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+          EXPECTED_VFS_COMMIT: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1806,7 +1806,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: a1ba0a3a2556011c508aeb108ff9e2e21addd615
+      expected_vfs_commit: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.2"
+version = "0.4.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5032cf253334f030b958f36417f84978eafcdbf12708e777cf4e1f395ba49cd5"
+checksum = "9850523f9705b3399768158261e58e22e7c3ff5f88bb7e648ceec4b17b962689"
 dependencies = [
  "lru",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.35", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.2", registry = "kin" }
+kin-vfs-core = { version = "=0.4.5", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -12575,7 +12575,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: a1ba0a3a2556011c508aeb108ff9e2e21addd615",
+        "expected_vfs_commit: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
## What moved and why

kin-vfs#111 composed the NFS, FUSE and Windows ProjFS write-through work and landed on kin-vfs main as squash `3df11fcbbb541e4b0ee98d6da50ccae1063abe66`, whose workspace version is 0.4.5. Registry Publish shipped `kin-vfs-core` 0.4.5 to the kin sparse registry. kin#932 already shipped the per-OS mount feature flags on this side, but they were compiled against `kin-vfs-core` 0.4.2 while the release still checked out kin-vfs at `a1ba0a3a2556011c508aeb108ff9e2e21addd615`. So the release would have built a kin-vfs predating the write-through mounts kin now ships features for.

This moves both halves in one commit, so the release builds the shipped kin-vfs from the same commit its lock resolves.

## The pin has five homes in release.yml, not one

`scripts/check-kin-vfs-compat.mjs` reads the kin-vfs pin out of every site in release.yml and refuses when they disagree, because a half-updated pin builds one commit and proves another. All five moved, plus a literal assertion in the workflow authority test:

- `.github/workflows/release.yml:471`, build-matrix checkout ref
- `.github/workflows/release.yml:1091`, per-artifact provenance manifest expected commit
- `.github/workflows/release.yml:1379`, publish job provenance-source checkout ref
- `.github/workflows/release.yml:1447`, aggregate provenance check
- `.github/workflows/release.yml:1809`, install-proof reusable workflow input
- `scripts/test-release-workflow-authority.py:12578`, asserts the install-proof input by literal text

A tree sweep for `a1ba0a3a` returns nothing after the change. The remaining `0.4.2` strings in `CHANGELOG.md:589`, `scripts/check-kin-vfs-compat.test.mjs:121,128` and `scripts/test-release-workflow-authority.py:3985` are historical fixtures describing the kin#788 incident, not the live pin, and were left alone.

## Both version reads, and how each was read

The release assertion compares the `kin-vfs-core` Kin resolves from the registry against the one the pinned kin-vfs checkout builds. Both read 0.4.5.

Kin's side, parsed out of this branch's `Cargo.lock`:

```
version = 0.4.5
source  = sparse+https://kinlab.ai/registry/cargo/
checksum= 9850523f9705b3399768158261e58e22e7c3ff5f88bb7e648ceec4b17b962689
```

The pinned kin-vfs checkout, read with `git show 3df11fcbbb541e4b0ee98d6da50ccae1063abe66:Cargo.lock`, carries `kin-vfs-core` at `version = 0.4.5` with no source, which is the local workspace member release.yml actually compares against. Its workspace `Cargo.toml:23`, read with `git show 3df11fcb:Cargo.toml`, also reads `version = "0.4.5"`. The old pin `a1ba0a3a` read 0.4.2 by the same two commands.

The lock checksum is the one the registry index serves. `curl -s https://kinlab.ai/registry/cargo/ki/n-/kin-vfs-core | tail -1` returns `"vers":"0.4.5"`, `"cksum":"9850523f9705b3399768158261e58e22e7c3ff5f88bb7e648ceec4b17b962689"` and `"yanked":false`.

`3df11fcb` was confirmed an ancestor of kin-vfs `origin/main` with `git merge-base --is-ancestor` after a fetch.

## The lock diff is one entry

`git diff origin/main...HEAD -- Cargo.lock` is 2 insertions and 2 deletions: the `kin-vfs-core` version and checksum. The entry keeps its `sparse+` source and a checksum, so nothing is path-patched. `git ls-tree -r HEAD --name-only` shows exactly one tracked `.cargo/` file, `.cargo/config.toml`, which carries `[registries.kin]` and no patch stanza.

One note for whoever bumps this next. `cargo update -p kin-vfs-core` also rewrote an unrelated edge, moving `winapi-util 0.1.11` from `windows-sys 0.61.2` down to `0.48.0`, and `--precise` produced the same. That is pre-existing drift in main rather than a consequence of this change: `winapi-util 0.1.11` requires `windows-sys` at `>=0.48.0, <=0.61`, which `0.61.2` does not satisfy, so cargo repairs it whenever it re-resolves. Read from `https://index.crates.io/wi/na/winapi-util`. A control run proved the direction, since `cargo metadata` on main's untouched tree exited 0 and left the lock byte-identical. This PR therefore ships the minimal one-entry lock, and `cargo metadata --locked` accepts it and leaves it byte-identical, the same `--locked` contract CI enforces at `ci.yml:1108` and `ci.yml:1173`. The invalid edge deserves its own ticket and was not widened into this one.

## Source impact

0.4.5 is additive over 0.4.2: a new `writer` module, six new exports (`Admission`, `ContentWriter`, `NoWrites`, `Staged`, `WriteHealth`, `WriteThroughProvider`), and `PartialEq` plus `Eq` derives on `VirtualStat` and `DirEntry`. Read from `git diff a1ba0a3a..3df11fcb -- crates/kin-vfs-core`.

Nothing in kin's mount code needed adapting to the 0.4.5 writer surface. Kin declares the crate at `crates/kin-cli/Cargo.toml:52` but no kin source imports it: the only `use kin_vfs_core` in the tree is inside a string literal in a test fixture at `crates/kin-core/src/dependencies.rs:1319`, and the other references are a name-to-repo mapping and assertions. No source file was touched by this PR.

## Gates

Run from the lane worktree through `bin/kin-lane run`, which uses the tracked `[registries.kin]` config and applies no patches. The build log carries `Compiling kin-vfs-core v0.4.5 (registry \`kin\`)`, so the gate exercised the registry resolution this PR changes.

- `cargo nextest run --workspace --locked --no-fail-fast`: 6313 tests run, 6312 passed, 1 failed, 12 skipped. See below.
- `cargo test --doc --locked`: exit 0.
- `cargo check --all-targets --locked`: exit 0, zero errors.
- `cargo fmt --all -- --check` and `cargo fmt -- --check`: both exit 0.
- Clippy exactly as ci.yml runs it, all 95 arguments extracted from the workflow, under `RUSTFLAGS=-D warnings`: exit 0, zero errors.
- `python3 scripts/verify-zero-file-search.py`: PASSED, 176 source files scanned.
- `bash scripts/zero_file_search_guard.sh`: passed.
- `bash scripts/check_runtime_boundaries.sh`: passed.
- `bash scripts/check_private_repo_coupling.sh`: passed, and `python3 scripts/test-private-repo-coupling.py`: 4 guard tests passed.
- `python3 scripts/test-release-workflow-authority.py`: exit 0.
- `node --test` over the six release policy suites: 80 pass, 0 fail.

### The one failing test is non-deterministic and has no causal path to this change

`kin-cli::live_graph_durability_disclosure mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit_records_them` failed once:

```
panicked at crates/kin-cli/tests/live_graph_durability_disclosure.rs:349:28:
envelope carries no durability object: {"_kin":{"degraded":{},"envelope_version":1,
"runtime":"repo-daemon"},"message":"selected-graph embedding coverage is changing;
retry kin_graph_status"}
```

The daemon answered with a transient retry message instead of a durability envelope. Re-run twice against the identical binaries, it failed once and passed once, at 17.252s with exit 0, so it is not deterministic. It also has no causal path to this change: kin imports no symbol from `kin-vfs-core` anywhere, so a purely additive version bump cannot alter an MCP durability envelope. The test arrived with kin#933, which landed on main independently of this branch. The machine was under a concurrent full workspace test run at the time.

## Replicating the release assertion locally

The comparison only runs during a release, so it was run directly. `node scripts/check-kin-vfs-compat.mjs` fetches the real kin-vfs `Cargo.lock` at the pinned commit over the GitHub API:

```
Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.5 (pinned kin-vfs 3df11fcbbb541e4b0ee98d6da50ccae1063abe66)
```

That gate was falsified in both directions to prove it fires, then restored to green.

Leaving one of the five sites on the old sha, exit 1:

```
::error::release.yml records disagreeing firelock-ai/kin-vfs pins: 3df11fcb... (expected_vfs_commit,
firelock-ai/kin-vfs checkout ref) and a1ba0a3a... (expected_vfs_commit); the release would build one
commit and prove another
```

Moving the lock while leaving all five sites behind, which is the shape this PR would have had without its release.yml half, exit 1:

```
::error::Kin resolves kin-vfs-core 0.4.5, but the pinned kin-vfs checkout builds 0.4.2; advance the
immutable kin-vfs pin in .github/workflows/release.yml, or hold this lock change until kin-vfs ships
a matching commit. Landing them apart reds the release after the tag exists.
```

Restored, exit 0. The second case independently confirms the gate reads the real kin-vfs lock at `a1ba0a3a` as 0.4.2.

## A note on which gate can validate a registry pin

`bin/kin-dev local-test` cannot validate this class of change. `bin/kin-dev:603` generates `kin-vfs-core = { path = "$WS/kin-vfs/crates/kin-vfs-core" }`, so the DEV-LOCAL lane resolves the crate by path and never consults the registry. It would have passed whatever version this PR wrote. For a registry pin on a patched crate, `cargo nextest run --workspace --locked` against the registry resolution is the gate that can actually fail, which is what was run here and what ci.yml runs at `ci.yml:1173`.

## Tickets

No ticket is closed by this PR, so it carries no Closes line. FIR-2422, projection setup across shim, NFS and FUSE, is already Done and was closed by kin#930 and kin#932. FIR-2428 and FIR-2423 track the macOS NFS and Linux FUSE mounts that 0.4.5 carries and are Done. FIR-1970, native Windows filesystem projection, is In Review and its acceptance requires a shipped release proven on real Windows hardware, which this PR does not provide.

## Not claiming

The release workflow was not run. The compatibility assertion was replicated locally against the real pinned kin-vfs `Cargo.lock`; it was not observed in a release run. No Windows hardware was exercised and no mount was mounted. The `winapi-util` lock edge is reported as a finding, not fixed.
