### PR TITLE
Hold the Git capture lease before the name a reap tests exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,16 @@ jobs:
             "init::tests" \
             --locked --target x86_64-pc-windows-msvc \
             -p kin-core --lib
+          # The capture lease is the only thing that stops one init's reap from
+          # deleting a sibling init's capture directory, and every clause of it
+          # is a Windows sharing rule rather than Kin's code: that a locked file
+          # can be renamed at all, that the lock follows it, and that a second
+          # opener is then refused. None of that is observable from a Unix run,
+          # and until this leg existed no Windows run touched the module.
+          run_required_filter "kin-core Git capture lease" \
+            "init_staging::tests" \
+            --locked --target x86_64-pc-windows-msvc \
+            -p kin-core --lib
           run_required_filter "managed-install spawn fence" \
             "managed_spawn_fence" \
             --locked --target x86_64-pc-windows-msvc \

--- a/crates/kin-core/src/init_staging.rs
+++ b/crates/kin-core/src/init_staging.rs
@@ -46,6 +46,22 @@ pub const GIT_CAPTURE_PREFIX: &str = ".kin-git-capture-";
 /// published authority.
 const CAPTURE_LEASE_NAME: &str = "capture.lease";
 
+/// Name the lease is created and locked under before it is published.
+///
+/// A lease is proof only while it is held, so the name a reader tests must
+/// never exist unheld. Creating the file and locking it are two calls, and a
+/// reap landing between them takes the lock the claim is about to take, reads a
+/// live directory as abandoned, and deletes the capture out from under an init
+/// that carries on believing it owns one. Locking under this name and renaming
+/// it into place closes that window rather than narrowing it: the rename is
+/// atomic, the lock follows the inode through it, and `CAPTURE_LEASE_NAME`
+/// therefore never exists unheld.
+///
+/// The reap deliberately does not know this name. A directory carrying no
+/// published lease is retained and disclosed whatever else is inside it, which
+/// is what makes a claim in flight safe from a concurrent reap.
+const CAPTURE_LEASE_PENDING_NAME: &str = "capture.lease.pending";
+
 /// One init's isolated Git capture directory.
 ///
 /// Dropping this removes the directory. Holding it holds the lease that tells
@@ -73,22 +89,7 @@ impl GitCaptureStaging {
         register_staging_path(&path);
         let mut staging = Self { path, lease: None };
         create_private_directory(&staging.path)?;
-        let lease_path = staging.path.join(CAPTURE_LEASE_NAME);
-        let mut options = OpenOptions::new();
-        options.read(true).write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-
-            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
-        }
-        let lease = options
-            .open(&lease_path)
-            .map_err(|error| KinError::io(&lease_path, error))?;
-        lease
-            .try_lock_exclusive()
-            .map_err(|error| KinError::io(&lease_path, error))?;
-        staging.lease = Some(lease);
+        staging.lease = Some(hold_capture_lease(&staging.path)?);
         Ok(staging)
     }
 
@@ -103,6 +104,34 @@ impl Drop for GitCaptureStaging {
         unregister_staging_path(&self.path);
         remove_staging_tree(&self.path);
     }
+}
+
+/// Take this init's lease on one capture directory, held on return.
+///
+/// The lease is created and locked under [`CAPTURE_LEASE_PENDING_NAME`] and
+/// only then renamed to the name every reader tests, so no reader can ever
+/// observe [`CAPTURE_LEASE_NAME`] unheld. See that constant for why the order
+/// is the guarantee.
+fn hold_capture_lease(directory: &Path) -> Result<std::fs::File> {
+    let pending_path = directory.join(CAPTURE_LEASE_PENDING_NAME);
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let lease = options
+        .open(&pending_path)
+        .map_err(|error| KinError::io(&pending_path, error))?;
+    lease
+        .try_lock_exclusive()
+        .map_err(|error| KinError::io(&pending_path, error))?;
+    let lease_path = directory.join(CAPTURE_LEASE_NAME);
+    std::fs::rename(&pending_path, &lease_path)
+        .map_err(|error| KinError::io(&lease_path, error))?;
+    Ok(lease)
 }
 
 /// Create one directory readable only by its owner.
@@ -155,7 +184,8 @@ const STAGING_REMOVAL_ATTEMPTS: usize = 8;
 /// init, which is ordinary when sibling repositories under one parent are
 /// admitted at the same time. A directory carrying no readable lease is
 /// disclosed rather than removed, because an older Kin wrote it and this call
-/// cannot prove nothing is using it.
+/// cannot prove nothing is using it, and because a claim that has created its
+/// directory but not yet published its lease looks exactly the same from here.
 ///
 /// Answers how many were removed.
 pub(crate) fn reap_abandoned_git_captures(parent: &Path) -> Result<usize> {
@@ -427,6 +457,10 @@ mod tests {
         let path = staged.path().to_path_buf();
         assert!(path.is_dir());
         assert!(path.join(CAPTURE_LEASE_NAME).is_file());
+        assert!(
+            !path.join(CAPTURE_LEASE_PENDING_NAME).exists(),
+            "the lease is published by rename, so its pending name must be gone"
+        );
         drop(staged);
         assert!(!path.exists(), "{} survived its owner", path.display());
     }
@@ -582,6 +616,67 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_secs(1));
         }
     }
+
+    /// A reap never removes a capture directory whose claim is still in flight.
+    ///
+    /// Two inits admitting sibling repositories under one parent share this
+    /// directory, which the module treats as ordinary, so one init's reap runs
+    /// while another init's claim is partway through. A claim becomes visible
+    /// to that reap the instant its directory exists, and stays reapable until
+    /// its lease is held, so the reaper hammers here for the whole of many
+    /// claims rather than sampling one.
+    #[test]
+    fn a_claim_in_flight_survives_a_concurrent_reap() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let parent = tempfile::tempdir().expect("tempdir");
+        let root = parent.path().to_path_buf();
+        let stop = Arc::new(AtomicBool::new(false));
+        let reaper = {
+            let root = root.clone();
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    let _ = reap_abandoned_git_captures(&root);
+                }
+            })
+        };
+
+        // The reaper is stopped before anything is asserted: a panic here would
+        // otherwise leave it spinning on a core for the rest of the run. Both
+        // ways a claim can lose are recorded, because an unpublished lease
+        // fails in two directions: the reap takes the lock the claim was about
+        // to take, or it removes the directory the claim already believes it
+        // owns.
+        let mut lost = None;
+        for attempt in 0..CONCURRENT_REAP_ATTEMPTS {
+            match GitCaptureStaging::claim(&root) {
+                Err(error) => {
+                    lost = Some(format!("attempt {attempt} could not claim at all: {error}"));
+                    break;
+                }
+                Ok(staged) => {
+                    let held =
+                        staged.path().is_dir() && staged.path().join(CAPTURE_LEASE_NAME).is_file();
+                    drop(staged);
+                    if !held {
+                        lost = Some(format!("attempt {attempt} lost the directory it claimed"));
+                        break;
+                    }
+                }
+            }
+        }
+        stop.store(true, Ordering::Relaxed);
+        reaper.join().expect("reaper thread");
+
+        if let Some(detail) = lost {
+            panic!("a concurrent reap defeated a claim still in flight: {detail}");
+        }
+    }
+
+    /// How many claims the concurrent reap above races.
+    const CONCURRENT_REAP_ATTEMPTS: usize = 200;
 
     /// A path wearing the prefix that is not a directory is left alone.
     #[test]


### PR DESCRIPTION
`GitCaptureStaging::claim` created `capture.lease` and locked it as two separate calls (`crates/kin-core/src/init_staging.rs:76..91` before this change). Between them the lease file exists and nobody holds it, which is byte for byte the state `abandoned_capture_lease` (`crates/kin-core/src/init_staging.rs:223`) is built to answer "abandoned" for. A concurrent init's reap landing in that window takes the lock the claim was about to take and deletes a live init's capture directory.

Two inits admitting sibling repositories under one parent share that directory, because `claim` is called with `source.parent()` (`crates/kin-core/src/git_init.rs:213-219`), and the module's own contract already calls that ordinary: "A directory whose lease is contended belongs to a concurrent init, which is ordinary when sibling repositories under one parent are admitted at the same time."

It fails two ways and neither is safe. The reap removes the directory and `claim` still returns `Ok`, so init writes the entire source object closure into a directory that no longer exists. Or the reap holds the lock at the instant the claimer tries, and init refuses on its own brand-new lease file with `Resource temporarily unavailable (os error 35)`.

## The fix

The lease is created and locked under `capture.lease.pending` and then renamed into place, so `capture.lease` never exists unheld. The rename is atomic and the lock follows the inode through it.

The reap deliberately does not learn the pending name. A directory carrying no published lease is already retained and disclosed rather than removed, and that is what makes a claim in flight safe from a concurrent reap. Teaching the reap the pending name would only move the window, since creating that file and locking it are still two calls.

One bound stays. A claim killed between creating its directory and publishing its lease is disclosed rather than reaped, so it is retained forever. That is unchanged in kind from before this change, one open and one lock wider, and it loses nothing.

## Falsification

The new guard is `a_claim_in_flight_survives_a_concurrent_reap`. A reaper thread hammers `reap_abandoned_git_captures` while 200 claims run under the same parent, and it records both ways a claim can lose.

Reverting only the production side, leaving the test text untouched, it failed 20 of 20 runs at raw exit 101, catching within the first few attempts each time. 17 runs lost the directory they had claimed and 3 could not claim at all:

```
RESULT: 20 failures out of 20 runs
a concurrent reap defeated a claim still in flight: attempt 33 could not claim at all:
IO error: .../.kin-git-capture-d64c55fc-f2d2-4049-b3bb-cdb2716af9c2/capture.lease:
Resource temporarily unavailable (os error 35)
```

With the fix restored it passed 50 of 50 runs.

Before the guard existed I reproduced the hazard on `40bc69e5` a second way, by widening the gap inside `claim` between creating the lease and locking it and reaping from another thread while a claim was in flight:

```
PROBE reaped=1 claim_ok=true dir_exists=false
```

That is the whole bug in one line: the reap took the directory, and the claim reported success anyway.

## Windows

No Windows CI run has ever touched `init_staging`. The Windows authority job runs `-p kin-core --lib` under the filters `registry::tests`, `config::capability_owned_config_replacement_tests`, `config::windows::capability_exclusion_tests` and `init::tests`, and `init.rs` carries no reference to `git_init`, so `init::tests` never reaches `claim`. The lease mechanism as a whole is therefore unproven on Windows, not just this change.

Every clause of the fix is a Windows sharing rule rather than Kin's code: that a locked file can be renamed at all, that the lock follows it, and that a second opener is then refused. So `init_staging::tests` joins that job, which is where this repo settles platform properties. If that leg goes red, the publish step needs a different shape and this PR should not merge on the strength of its Unix runs.

## On FIR-2418

This PR does not close FIR-2418. That ticket asked for the test's waiter to wait on the lease, and kin#925 (`d45598ca`) already did it under a heading its own body calls "Third fix, no ticket". I verified it rather than trusting it: 50 raw runs of `a_terminating_signal_removes_the_capture_directory` against `origin/main` under six cores of synthetic load, 0 failures. FIR-2418 is closed in Linear with that evidence. This is its production twin, which the ticket did not cover.

## Gate

`bin/kin-lane run leasewait kin -- bin/kin-dev local-test kin`, exit 0:

```
kin-dev: local-test: kin  /Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/leasewait-kin @ e29e9900 (chore/lane-leasewait-kin)
Summary [ 375.453s] 6294 tests run: 6294 passed (3 slow, 2 leaky), 12 skipped
```

All 6294 of 6294 ran, so nextest never cut the run short on a first failure and nothing past one is hidden. The new guard is in it at 2756 of 6294, at 3.318s.

Also green: `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the ci.yml allowlist parsed out of the workflow file itself, exit 0 (its one warning is the pre-existing future-incompat notice for the third-party `block v0.1.6` crate); `scripts/verify-zero-file-search.py`; `scripts/zero_file_search_guard.sh`; `scripts/check_runtime_boundaries.sh`; `scripts/verify-hydration-semantics.py`; `scripts/check_private_repo_coupling.sh`.

The gate ran at `e29e9900`, whose base was `40bc69e5`. The branch was then rebased onto `af784178` with no conflicts, and `git log HEAD..origin/main` over both files listed nothing, so the commit carries a byte-identical diff.

Closes FIR-2443
