### PR TITLE
Report only what the capability tier actually gates

### DIFF
--- a/crates/kin-cli/src/capability.rs
+++ b/crates/kin-cli/src/capability.rs
@@ -4,11 +4,18 @@
 //! Machine capability detection for adaptive locate behavior.
 //!
 //! Determines the [`LocateProfile`] tier from effective CPU cores + available
-//! RAM. Lower tiers trade recall for latency on constrained hardware (shallower
-//! multihop, no reranker / PRF / LTR), so the tier changes retrieval quality —
-//! that downgrade is surfaced, never silent (see [`LocateProfile::name`] /
+//! RAM. Lower tiers narrow the graph multihop budget (shallower depth, a
+//! smaller frontier, a shorter timeout), which trades recall for latency on
+//! constrained hardware, so the tier changes retrieval quality and that
+//! downgrade is surfaced, never silent (see [`LocateProfile::name`] /
 //! [`LocateProfile::disabled_signals`], reported as a `capability_tier`
 //! degradation on every `kin locate` result).
+//!
+//! The multihop budget is the whole of it. The tier does not select between a
+//! fused and a lexical retrieval arm, and it does not gate the cross-encoder,
+//! which [`crate::retrieval_profile::RetrievalProfile`] owns. Entity-granularity
+//! fusion, the lexical parity floor and the calibrated embedding seed floor are
+//! `accuracy-v2` defaults and run on every tier.
 //!
 //! Detection is container-aware: cores and RAM are capped by the active cgroup
 //! v2 (`cpu.max` / `memory.max`) or v1 (CFS quota / `memory.limit_in_bytes`)
@@ -91,18 +98,6 @@ impl LocateProfile {
         }
     }
 
-    pub fn prf_enabled(&self) -> bool {
-        matches!(self, Self::Standard | Self::Performance)
-    }
-
-    pub fn ltr_enabled(&self) -> bool {
-        matches!(self, Self::Performance)
-    }
-
-    pub fn reranker_enabled(&self) -> bool {
-        matches!(self, Self::Standard | Self::Performance)
-    }
-
     /// Stable lowercase tier name. Also the exact token accepted by the
     /// `KIN_LOCATE_PROFILE` override, so surfaced output names the lever a user
     /// would set to change it.
@@ -121,19 +116,29 @@ impl LocateProfile {
     /// smaller machine really does return lower-recall results, and the caller
     /// can see exactly which signals were dropped rather than inferring it from
     /// differing results across machines.
+    ///
+    /// It names the graph multihop budget and nothing else, because that budget
+    /// is the only thing the tier actually gates. This list used to also claim
+    /// `reranker`, `prf` and `ltr`. None of the three was ever read from the
+    /// tier: `prf` has no implementation anywhere in the tree, and `reranker`
+    /// and `ltr` are the same cross-encoder, owned by
+    /// [`crate::retrieval_profile::RetrievalProfile`] and off unconditionally
+    /// under the default `accuracy-v2` on every tier, the proof machine
+    /// included. So the entry told a below-tier operator that three signals had
+    /// been withdrawn when two were running exactly as they run everywhere and
+    /// the third does not exist, and then advised buying hardware that would
+    /// not have changed any of them. A disclosure that overstates the downgrade
+    /// is the same defect as one that hides it.
     pub fn disabled_signals(&self) -> Vec<&'static str> {
         let mut off = Vec::new();
-        if !self.reranker_enabled() {
-            off.push("reranker");
-        }
-        if !self.prf_enabled() {
-            off.push("prf");
-        }
-        if !self.ltr_enabled() {
-            off.push("ltr");
-        }
         if self.multihop_max_depth() < Self::Performance.multihop_max_depth() {
             off.push("multihop_depth");
+        }
+        if self.multihop_frontier_limit() < Self::Performance.multihop_frontier_limit() {
+            off.push("multihop_frontier");
+        }
+        if self.multihop_timeout_ms() < Self::Performance.multihop_timeout_ms() {
+            off.push("multihop_timeout");
         }
         off
     }
@@ -558,15 +563,43 @@ mod tests {
     #[test]
     fn performance_disables_nothing_lower_tiers_do() {
         assert!(LocateProfile::Performance.disabled_signals().is_empty());
-        // Standard keeps reranker + PRF but loses LTR and full multihop depth.
-        let standard = LocateProfile::Standard.disabled_signals();
-        assert!(standard.contains(&"ltr"));
-        assert!(standard.contains(&"multihop_depth"));
-        assert!(!standard.contains(&"reranker"));
-        // Minimal loses every learned signal.
-        let minimal = LocateProfile::Minimal.disabled_signals();
-        for sig in ["reranker", "prf", "ltr", "multihop_depth"] {
-            assert!(minimal.contains(&sig), "minimal should disable {sig}");
+        // Every sub-Performance tier narrows all three multihop bounds.
+        for tier in [LocateProfile::Standard, LocateProfile::Minimal] {
+            let off = tier.disabled_signals();
+            for sig in ["multihop_depth", "multihop_frontier", "multihop_timeout"] {
+                assert!(off.contains(&sig), "{} should narrow {sig}", tier.name());
+            }
+        }
+    }
+
+    /// The tier may only claim what it actually gates.
+    ///
+    /// `reranker`, `prf` and `ltr` were reported here for tiers that never
+    /// gated them, which told a below-tier operator that three signals had been
+    /// withdrawn when two run identically on every tier and the third is not
+    /// implemented at all. Nothing in the tree reads a tier to decide any of
+    /// them, so a disclosure naming them cannot be true.
+    #[test]
+    fn the_tier_claims_no_signal_it_does_not_gate() {
+        for tier in [
+            LocateProfile::Minimal,
+            LocateProfile::Standard,
+            LocateProfile::Performance,
+        ] {
+            for phantom in ["reranker", "prf", "ltr"] {
+                assert!(
+                    !tier.disabled_signals().contains(&phantom),
+                    "{} must not claim to disable {phantom}, which no tier gates",
+                    tier.name()
+                );
+            }
+            for signal in tier.disabled_signals() {
+                assert!(
+                    signal.starts_with("multihop_"),
+                    "{} reports {signal}, which is not a multihop bound",
+                    tier.name()
+                );
+            }
         }
     }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1838,11 +1838,16 @@ fn record_vector_index_degradation(
 }
 
 /// Record the active hardware capability tier as a structured degradation when
-/// it runs below the full pipeline. `LocateProfile` silently scales retrieval
-/// quality with the machine's effective cores/RAM (shallower multihop, reranker
-/// / PRF / LTR off on smaller tiers); without this entry the same query returns
-/// different-quality results on different hardware with no in-band signal. On
-/// the `Performance` tier nothing is disabled and no entry is added.
+/// it runs below the full pipeline. `LocateProfile` silently scales the graph
+/// multihop budget with the machine's effective cores/RAM (shallower depth, a
+/// smaller frontier, a shorter timeout); without this entry the same query
+/// returns different-quality results on different hardware with no in-band
+/// signal. On the `Performance` tier nothing is narrowed and no entry is added.
+///
+/// The entry describes the multihop budget and stops there, because that is the
+/// entire reach of the tier. It is not an arm selector: the fused pipeline
+/// answers on every tier, and a `text_fallback` row means the query found no
+/// better evidence, never that the hardware withdrew a stage.
 ///
 /// A tier chosen after a failed host probe is reported as its own thing. The
 /// ordinary entry's remediation tells the reader to run on a bigger host, which
@@ -1886,27 +1891,35 @@ fn record_capability_tier_degradation(
                 describe_disabled_signals(profile),
             ),
             remediation:
-                "set KIN_LOCATE_PROFILE=performance to force the full pipeline, or run on a host \
-                 with >=8 cores and >=16GB RAM"
+                "set KIN_LOCATE_PROFILE=performance to widen the multihop budget on this host, \
+                 or run on a host with >=8 cores and >=16GB RAM"
                     .to_string(),
         },
     );
 }
 
-/// The signals a tier turns off and the depths it narrows, as a clause both
-/// capability entries append to their own opening.
+/// What a tier narrows, as a clause both capability entries append to their own
+/// opening.
+///
+/// It reports the graph multihop budget and says outright that the rest of the
+/// pipeline is untouched, because the entry's job is to let a reader size the
+/// downgrade rather than guess at it. The clause used to say three named
+/// signals were "disabled"; see [`LocateProfile::disabled_signals`] for why
+/// that was false. "Narrowed" is also the accurate verb: these are bounds the
+/// tier lowers, not features it removes.
 fn describe_disabled_signals(profile: LocateProfile) -> String {
-    let disabled = profile.disabled_signals();
-    if disabled.is_empty() {
+    if profile.disabled_signals().is_empty() {
         return ": full pipeline".to_string();
     }
     format!(
-        ": {} disabled; multihop depth {}/{}, frontier {}/{}",
-        disabled.join(", "),
+        ": graph multihop budget narrowed (depth {}/{}, frontier {}/{}, timeout {}ms/{}ms); \
+         retrieval is otherwise unchanged, since the tier gates no other stage",
         profile.multihop_max_depth(),
         LocateProfile::Performance.multihop_max_depth(),
         profile.multihop_frontier_limit(),
         LocateProfile::Performance.multihop_frontier_limit(),
+        profile.multihop_timeout_ms(),
+        LocateProfile::Performance.multihop_timeout_ms(),
     )
 }
 
@@ -17630,8 +17643,17 @@ mod tests {
         );
         let entry = capability_entry(&small);
         assert_eq!(entry.reason, "minimal");
-        assert!(entry.detail.contains("reranker"));
+        assert!(entry.detail.contains("multihop"));
         assert!(entry.remediation.contains(">=8 cores"));
+        // The entry may only name what the tier gates. It used to assert
+        // "reranker" here, which was the false claim itself under test.
+        for phantom in ["reranker", "prf", "ltr"] {
+            assert!(
+                !entry.detail.contains(phantom),
+                "the capability entry must not claim {phantom}, which no tier gates: {}",
+                entry.detail
+            );
+        }
     }
 
     /// The full pipeline on a host that was actually read stays silent, which


### PR DESCRIPTION
The capability tier told every below-tier operator that retrieval signals had been withdrawn that no tier has ever gated. This makes the disclosure describe what the tier actually does. No threshold moves and no tier's retrieval changes.

## The threshold, and its real reach

`crates/kin-cli/src/capability.rs:48` (`LocateProfile::score`) is the whole threshold: 8 cores and 16 GB for `performance`, 4 and 8 for `standard`, otherwise `minimal`. `CapabilityDetection::detect` reads it once per query at `crates/kin-cli/src/commands/locate.rs:2355`.

What the tier gates is exactly three numbers, all bounds on one graph walk, read at `crates/kin-cli/src/commands/locate.rs:9009-9021`: multihop `max_depth` (4 / 3 / 2), `frontier_limit` (200 / 100 / 50) and `timeout_ms` (1000 / 500 / 200). That call site is the profile's single production read.

## What the message claimed, and why it was false

The entry named `reranker`, `prf` and `ltr`. `ltr_enabled`, `prf_enabled` and `reranker_enabled` had exactly one caller each, `disabled_signals` in the same file, which used them to compose the message text. Nothing else in the tree read a tier to decide any of them. That the three predicates delete without breaking the build is the same fact from the compiler.

- `prf` has no implementation anywhere in the tree.
- `reranker` and `ltr` are the same cross-encoder. `crates/kin-cli/src/retrieval_profile.rs` owns it, and the default `accuracy-v2` profile turns it off unconditionally on every tier, the proof machine included.

So the entry named one signal that does not exist and two that run identically everywhere, then advised buying an 8-core, 16 GB host that would not have changed any of them. The shipped 0.5.40 binary in a `--cpus=5 --memory=12g` container emits this verbatim:

```
"reason": "standard",
"detail": "hardware capability tier 'standard': ltr, multihop_depth disabled; multihop depth 3/4, frontier 100/200",
"remediation": "set KIN_LOCATE_PROFILE=performance to force the full pipeline, or run on a host with >=8 cores and >=16GB RAM"
```

On `minimal` the same binary says `reranker, prf, ltr, mult...`.

## The fix

`disabled_signals` now reports the three multihop bounds and nothing else. The clause says outright that retrieval is otherwise unchanged, and uses "narrowed" rather than "disabled", because these are bounds the tier lowers and not features it removes. The remediation now promises what forcing `performance` actually does, which is widen the multihop budget on this host.

A degradation entry that overstates the downgrade is the same class of defect as one that hides it, because both leave the reader unable to size what they lost.

## Why the threshold does not move

Measured rather than argued. One store, one machine, three tiers: `psf/requests` at 8f8b212 with full history (6491 commits), ingested by kin 0.5.40 inside `docker run --cpus=5 --memory=12g`, which auto-detects `standard`. The store holds 777 entities and 1237 cross-file entity relations. Ten queries, five bare symbol names and five descriptive, each run at auto (`standard`), forced `performance` and forced `minimal`, with a fresh daemon per arm, in two passes; the second pinned `KIN_LOCATE_MULTIHOP_TIMEOUT_MS=60000` on every arm so a ranking difference could not be an artifact of one arm running out of wall clock on a loaded box.

The ranking was identical across all three tiers on 10 of 10 queries in both passes. The entire run was then repeated after embeddings completed (1765/1765 indexed), and the ranking was again identical across all three tiers on 10 of 10 queries in both passes.

That is a real null result rather than a vacuous one, because the budget was demonstrably binding and moved a lot between arms. On one query the `--explain` prune ledger reports `multihop_depth` dropping 8827 walk nodes at limit 4 on `performance`, 6091 at limit 3 on `standard`, and 3370 at limit 2 on `minimal`, with `minimal` additionally hitting `multihop_frontier` (limit 50, 261 relations dropped) which neither higher tier reached. The walk really did go further at higher tiers, the `raw_multihop_signal` stage returned identical top files with identical scores at all three, and the final ranking did not move. The extra reach changed which nodes were visited and changed no ranked answer.

Lowering the threshold would therefore be a change with no measured benefit. Being below the tier also cost nothing measurable on this corpus. I am not claiming the threshold is optimal: this is one corpus, one language, 777 entities, ten queries, and a larger graph could plausibly show the depth-4 walk earning its cost.

One further measurement worth recording here, because it is what FIR-2355 originally reported: `text_fallback` is not caused by the capability tier. It appeared in the same proportion at forced `performance` as at `standard` and `minimal`, and the code that computes `all_fallback` takes no tier input. The whole run was then repeated after embeddings completed, and that is worth stating precisely because it refuted the simpler explanation I expected: going from 0 to 1674 indexed cleared the `vector_index` degradation and moved `semantic_coverage` to `complete: true`, yet the ranked `match_kind` mix barely moved, from 147 `text_fallback` of 180 rows to 144. So embedding coverage does not explain the fallback rows either, and I am not claiming it does. What the measurement does establish is the tier's non-involvement, in both embedding states. Below the tier the fused pipeline still answers; what narrows is the multihop budget, not the arm.

Container end state, read inside the container at the end of the run: `memory.max=12884901888` unchanged from creation so the workload did not raise its own cap, `memory.peak=12467023872`, `oom 0 / oom_kill 0`, `OOMKilled=false`.

## Falsification

Reintroducing the phantom `ltr` claim into `disabled_signals` fails the new test by name:

```
test capability::tests::the_tier_claims_no_signal_it_does_not_gate ... FAILED
panicked at crates/kin-cli/src/capability.rs:591:17:
minimal must not claim to disable ltr, which no tier gates
test result: FAILED. 19 passed; 1 failed
```

The mutation exited 101 and the tree was restored clean afterward. The existing test that asserted the entry contains "reranker" was the false claim under test, and now asserts the opposite for all three phantom names.

## Gate

`cargo fmt --all -- --check` clean. `python3 scripts/verify-zero-file-search.py`, `bash scripts/zero_file_search_guard.sh`, `python3 scripts/verify-hydration-semantics.py` and `bash scripts/check_runtime_boundaries.sh` all pass locally.

Closes FIR-2355
