### PR TITLE
Report a commit whose daemon died in memory terms, and free the graph copies it held at its peak

### DIFF
--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -170,7 +170,21 @@ enum LostReply {
     /// The commit is running; it has not failed.
     StillRunning(String),
     /// No receipt, and nothing proves any work is still in flight.
-    Gone,
+    Gone {
+        /// The marker the daemon left behind, when one is there.
+        ///
+        /// A daemon that is killed never retires its own marker, so this is
+        /// the last thing it managed to say about the work it was doing: the
+        /// phase it was in, how long it had been there, and how much memory it
+        /// was holding. It is carried out of the classification rather than
+        /// dropped because it is the entire evidence base for the sentence the
+        /// caller gets.
+        abandoned: Option<Box<kin_daemon_spawn::OpenTransaction>>,
+        /// Whether the pid that published `abandoned` is still running. A dead
+        /// pid is a process that stopped; a live one whose beat went quiet is a
+        /// daemon that is wedged, and the two need different sentences.
+        daemon_alive: bool,
+    },
 }
 
 /// Decide what a lost reply means from the facts on disk.
@@ -192,11 +206,15 @@ fn classify_lost_reply(
     if let Some(result) = landed {
         return LostReply::Landed(Box::new(result));
     }
+    let daemon_alive = open.as_ref().is_some_and(|open| is_alive(open.pid));
     match open {
-        Some(open) if open.is_beating(now_unix) && is_alive(open.pid) => {
+        Some(open) if open.is_beating(now_unix) && daemon_alive => {
             LostReply::StillRunning(open.summary())
         }
-        _ => LostReply::Gone,
+        abandoned => LostReply::Gone {
+            abandoned: abandoned.map(Box::new),
+            daemon_alive,
+        },
     }
 }
 
@@ -246,11 +264,29 @@ fn resolve_commit_after_lost_reply(
              Operation {operation_id} appears in `kin log` when it lands; a `kin commit` \
              run before then waits for it and is refused rather than recorded."
         ),
-        LostReply::Gone => {
+        LostReply::Gone {
+            abandoned,
+            daemon_alive,
+        } => {
             // A transport error names a socket. When the daemon was killed with
             // this request in flight, the socket is the symptom and the killer
             // left the cause in the repository.
-            let error = match daemon_death_explanation(kin_root) {
+            //
+            // Two killers leave two different traces. A reaper writes a death
+            // note, so that is read first and quoted as the killer's own words.
+            // The kernel's OOM killer writes nothing at all, which is why the
+            // reported failure named only HTTP: the daemon's own abandoned
+            // marker and this host's memory accounting are the only evidence
+            // that death leaves, and they are what the second reading uses.
+            let cause = daemon_death_explanation(kin_root).or_else(|| {
+                super::commit_progress::daemon_loss_explanation(
+                    abandoned.as_deref(),
+                    daemon_alive,
+                    unix_now(),
+                    &crate::capability::memory_evidence(),
+                )
+            });
+            let error = match cause {
                 Some(cause) => anyhow::Error::new(error).context(cause),
                 None => {
                     anyhow::Error::new(error).context("send daemon-owned native commit request")
@@ -470,6 +506,46 @@ mod tests {
             elapsed_secs: 213,
             phase_elapsed_secs: 60,
             beat_unix,
+            rss_bytes: None,
+            peak_rss_bytes: None,
+        }
+    }
+
+    /// The marker a dead daemon leaves is the only evidence of what it was
+    /// doing, so the classification must carry it out rather than drop it.
+    ///
+    /// Falsify by returning `abandoned: None` from the `Gone` arm of
+    /// [`classify_lost_reply`]: this fails, and with it every memory sentence
+    /// the caller can produce, because there is then nothing left to read.
+    #[test]
+    fn a_dead_daemons_marker_is_carried_out_of_the_classification() {
+        match classify_lost_reply(None, Some(open_commit(1_000)), 1_030, |_| false) {
+            LostReply::Gone {
+                abandoned,
+                daemon_alive,
+            } => {
+                assert!(!daemon_alive, "the pid probe said this daemon is gone");
+                let marker = abandoned.expect("the marker the daemon left must survive");
+                assert_eq!(
+                    marker.phase.as_deref(),
+                    Some("reconcile_workspace_and_commit_authority")
+                );
+                assert_eq!(marker.elapsed_secs, 213);
+            }
+            other => panic!("a dead daemon's commit is gone, not {other:?}"),
+        }
+        match classify_lost_reply(None, None, 1_030, |_| true) {
+            LostReply::Gone {
+                abandoned,
+                daemon_alive,
+            } => {
+                assert!(abandoned.is_none(), "no marker means no evidence to carry");
+                assert!(
+                    !daemon_alive,
+                    "with no marker there is no pid to have found alive"
+                );
+            }
+            other => panic!("no receipt and no marker is gone, not {other:?}"),
         }
     }
 
@@ -599,7 +675,7 @@ mod tests {
         assert!(
             matches!(
                 classify_lost_reply(None, Some(open_commit(1_000)), quiet, |_| true),
-                LostReply::Gone
+                LostReply::Gone { .. }
             ),
             "a marker that stopped beating proves nothing is in flight"
         );
@@ -609,14 +685,14 @@ mod tests {
         assert!(
             matches!(
                 classify_lost_reply(None, Some(open_commit(1_000)), 1_030, |_| false),
-                LostReply::Gone
+                LostReply::Gone { .. }
             ),
             "a marker belonging to a dead daemon is a leftover, not work in flight"
         );
         assert!(
             matches!(
                 classify_lost_reply(None, None, 1_030, |_| true),
-                LostReply::Gone
+                LostReply::Gone { .. }
             ),
             "no receipt and no marker is a commit that failed, and must still report failure"
         );

--- a/crates/kin-cli/src/commands/commit_progress.rs
+++ b/crates/kin-cli/src/commands/commit_progress.rs
@@ -185,6 +185,150 @@ pub fn daemon_death_explanation(kin_root: &Path) -> Option<String> {
     ))
 }
 
+/// How close to the ceiling a resident set has to get before a lost daemon is
+/// reported as having most likely run out of memory.
+///
+/// The measured case cleared a 12288 MiB ceiling by five megabytes, so a bar
+/// anywhere near the top would have called it. The bar sits well below that
+/// because the cost of being wrong is asymmetric: a daemon that died at 92% of
+/// its ceiling for some other reason is told memory was the likely cause and
+/// loses a little time, while one that really was killed at 92% and is told
+/// nothing sends its user back to reading a socket error.
+const NEAR_CEILING_FRACTION: f64 = 0.90;
+
+fn human_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else {
+        format!("{} MiB", bytes / MIB)
+    }
+}
+
+/// What the daemon's own abandoned marker says about how the commit ended.
+///
+/// The failure this exists for reaches the caller as `connection closed before
+/// message completed`, which describes a socket. The daemon had been
+/// OOM-killed: `memory.events` recorded two kills, the successful retry of the
+/// same one-file commit peaked at 12283 MiB against a 12288 MiB ceiling, and
+/// nothing in the reported error named memory, the phase, or even a process
+/// that had stopped. A person reading it concludes the tool is flaky.
+///
+/// [`daemon_death_explanation`] already covers the killer that writes a note.
+/// The kernel writes none, so everything here is reconstructed from two things
+/// that survive a SIGKILL: the transaction marker the daemon published on its
+/// own beat, and this host's memory accounting read after the fact.
+///
+/// Memory is attributed in two grades and they are labelled differently on
+/// purpose, the same way [`super::embed`] grades an embed that lost its daemon.
+/// A cgroup that recorded a kill is the kernel's own statement and is reported
+/// as observed. A resident set that had climbed to within
+/// [`NEAR_CEILING_FRACTION`] of the ceiling is a strong prior and nothing more,
+/// so it is reported as likely. With neither, the phase and the process death
+/// are still reported and memory is not mentioned at all: a daemon that died
+/// for another reason must not be handed a diagnosis nobody measured.
+pub fn daemon_loss_explanation(
+    abandoned: Option<&kin_daemon_spawn::OpenTransaction>,
+    daemon_alive: bool,
+    now_unix: u64,
+    evidence: &crate::capability::MemoryEvidence,
+) -> Option<String> {
+    // No marker is no evidence. The daemon may never have opened a transaction
+    // at all, and inventing a phase for it would be worse than the socket error
+    // this replaces.
+    let open = abandoned?;
+    let beat_age = open.beat_age_secs(now_unix);
+    let doing = match &open.phase {
+        Some(phase) => format!(
+            "{} in phase {} for {}s",
+            open.operation, phase, open.elapsed_secs
+        ),
+        None => format!("{} for {}s", open.operation, open.elapsed_secs),
+    };
+    let state = if daemon_alive {
+        format!(
+            "the daemon serving this repository (pid {}) is still running but stopped beating \
+             {}s ago, with {} open",
+            open.pid, beat_age, doing
+        )
+    } else {
+        format!(
+            "the daemon serving this repository (pid {}) is gone; it was {}, and its last beat \
+             {}s before it stopped",
+            open.pid, doing, beat_age
+        )
+    };
+    let mut sentence = match observed_rss(open) {
+        Some(rss) => format!(
+            "{state} reported a resident set of {}",
+            render_rss(open, rss)
+        ),
+        None => format!("{state} published no memory reading"),
+    };
+    sentence.push('.');
+    if let Some(memory) = memory_attribution(open, evidence) {
+        sentence.push(' ');
+        sentence.push_str(&memory);
+    }
+    Some(sentence)
+}
+
+/// The resident set to reason about: the high-water mark when the beat saw one,
+/// otherwise the last sample.
+///
+/// The peak is the better answer to "how close did this get to the ceiling",
+/// and it is a floor under the true peak rather than the true peak itself: the
+/// beat samples every five seconds and a climb can outrun it.
+fn observed_rss(open: &kin_daemon_spawn::OpenTransaction) -> Option<u64> {
+    open.peak_rss_bytes.max(open.rss_bytes)
+}
+
+fn render_rss(open: &kin_daemon_spawn::OpenTransaction, observed: u64) -> String {
+    match (open.rss_bytes, open.peak_rss_bytes) {
+        (Some(last), Some(peak)) if peak > last => format!(
+            "{} (at least {} at its highest sampled beat)",
+            human_bytes(last),
+            human_bytes(peak)
+        ),
+        _ => human_bytes(observed),
+    }
+}
+
+/// The memory sentence, when this host can support one.
+fn memory_attribution(
+    open: &kin_daemon_spawn::OpenTransaction,
+    evidence: &crate::capability::MemoryEvidence,
+) -> Option<String> {
+    let observed_kills = evidence.cgroup_oom_kills.filter(|count| *count > 0);
+    let near_ceiling = observed_rss(open)
+        .is_some_and(|rss| rss as f64 >= evidence.limit_bytes as f64 * NEAR_CEILING_FRACTION);
+    let cause = match (observed_kills, near_ceiling) {
+        (Some(count), _) => format!(
+            "This machine's kernel recorded {count} out-of-memory kill(s) against the {} \
+             available here, so the commit ran out of memory.",
+            human_bytes(evidence.limit_bytes)
+        ),
+        (None, true) => format!(
+            "That is within {}% of the {} available here, so it most likely ran out of memory.",
+            (100.0 - NEAR_CEILING_FRACTION * 100.0).round(),
+            human_bytes(evidence.limit_bytes)
+        ),
+        (None, false) => return None,
+    };
+    Some(format!("{cause} {COMMIT_MEMORY_REMEDY}"))
+}
+
+/// What a caller can do about a commit that ran out of memory.
+///
+/// Stated once and shared with the `kin doctor` check that reports the same
+/// headroom before a commit is attempted, so the two surfaces cannot drift into
+/// describing the same cost differently.
+pub const COMMIT_MEMORY_REMEDY: &str =
+    "A commit prepares the whole repository successor in memory, so its peak follows the size of \
+     the store rather than the size of the edit. Re-run it with more memory available; \
+     `kin doctor` reports this headroom before a commit is attempted.";
+
 /// The line a `kin commit` prints after recording a change.
 ///
 /// `kin commit` is not a git commit, and until now nothing said so: the working
@@ -198,6 +342,177 @@ pub const AUTHORITY_NOT_GIT_NOTE: &str = "Recorded in Kin authority, not in git 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    fn evidence(limit_bytes: u64, oom_kills: Option<u64>) -> crate::capability::MemoryEvidence {
+        crate::capability::MemoryEvidence {
+            limit_bytes,
+            cgroup_oom_kills: oom_kills,
+        }
+    }
+
+    /// A marker shaped like the one the OOM-killed daemon left behind.
+    ///
+    /// Written through `kin_daemon_spawn` and read back through it rather than
+    /// constructed inline, so the round trip a real diagnosis depends on is the
+    /// thing under test. A field the daemon writes and the CLI cannot read
+    /// makes every sentence below silently lose its evidence, and an inline
+    /// struct would never notice.
+    fn abandoned_marker(
+        rss_bytes: Option<u64>,
+        peak_rss_bytes: Option<u64>,
+    ) -> Option<Box<kin_daemon_spawn::OpenTransaction>> {
+        let dir = tempfile::tempdir().unwrap();
+        kin_daemon_spawn::write_open_transaction(
+            dir.path(),
+            &kin_daemon_spawn::OpenTransaction {
+                pid: 412,
+                operation: "commit".to_string(),
+                phase: Some("reconcile_workspace_and_commit_authority".to_string()),
+                elapsed_secs: 178,
+                phase_elapsed_secs: 26,
+                beat_unix: 1_000,
+                rss_bytes,
+                peak_rss_bytes,
+            },
+        );
+        kin_daemon_spawn::read_open_transaction(dir.path()).map(Box::new)
+    }
+
+    /// The reported failure, and the sentence that replaces it.
+    ///
+    /// A stranger adding 17 lines of docstring to one file was told
+    /// `connection closed before message completed` and lost 207 seconds to a
+    /// message that names HTTP. The kernel had killed the daemon: `oom_kill 2`
+    /// in the cgroup, and the successful retry of the same commit peaked at
+    /// 12283 MiB against a 12288 MiB ceiling. Nothing in the reported error
+    /// named memory, the phase, or a process that had stopped.
+    ///
+    /// Falsify by returning `None` from `memory_attribution` for the observed
+    /// grade: the phase still reports and the memory assertions fail, which is
+    /// exactly the half of the defect that got the tool called flaky.
+    #[test]
+    fn a_daemon_the_kernel_killed_is_reported_in_memory_terms_and_names_its_phase() {
+        let marker = abandoned_marker(Some(11 * GIB), Some(11 * GIB + GIB / 2));
+        let explained = daemon_loss_explanation(
+            marker.as_deref(),
+            false,
+            1_006,
+            &evidence(12 * GIB, Some(2)),
+        )
+        .expect("a dead daemon holding a marker must be explained");
+
+        assert!(
+            explained.contains("reconcile_workspace_and_commit_authority"),
+            "the phase the commit died in must be named: {explained}"
+        );
+        assert!(
+            explained.contains("pid 412") && explained.contains("is gone"),
+            "the process death must be stated, not implied: {explained}"
+        );
+        assert!(
+            explained.contains("out-of-memory kill"),
+            "the kernel's own accounting must be quoted: {explained}"
+        );
+        assert!(
+            explained.contains("11.0 GiB") && explained.contains("11.5 GiB"),
+            "the last reading and the high-water mark must both appear: {explained}"
+        );
+        assert!(
+            explained.contains("12.0 GiB"),
+            "the ceiling it ran against must be named: {explained}"
+        );
+        assert!(
+            explained.contains("`kin doctor`"),
+            "the reader must be told where the headroom is reported before a commit: {explained}"
+        );
+    }
+
+    /// A resident set at the ceiling with no kernel accounting is reported as
+    /// likely, never as observed. The two are different claims and a reader
+    /// acts on them differently.
+    #[test]
+    fn a_resident_set_at_the_ceiling_without_kernel_accounting_is_only_likely() {
+        let marker = abandoned_marker(Some(11 * GIB + GIB / 2), None);
+        let explained =
+            daemon_loss_explanation(marker.as_deref(), false, 1_006, &evidence(12 * GIB, None))
+                .expect("a dead daemon holding a marker must be explained");
+        assert!(
+            explained.contains("most likely ran out of memory"),
+            "an unaccounted death at the ceiling is a prior, not a kernel statement: {explained}"
+        );
+        assert!(
+            !explained.contains("out-of-memory kill"),
+            "nothing may quote accounting this host never produced: {explained}"
+        );
+    }
+
+    /// A daemon that died with room to spare keeps its own cause.
+    ///
+    /// Telling a user their commit ran out of memory when it did not is the
+    /// same defect as telling them nothing, pointed the other way: both send
+    /// them to fix something that is not broken.
+    #[test]
+    fn a_death_with_headroom_reports_the_phase_and_claims_nothing_about_memory() {
+        let marker = abandoned_marker(Some(2 * GIB), Some(2 * GIB));
+        let explained = daemon_loss_explanation(
+            marker.as_deref(),
+            false,
+            1_006,
+            &evidence(64 * GIB, Some(0)),
+        )
+        .expect("a dead daemon holding a marker must still be explained");
+        assert!(
+            explained.contains("reconcile_workspace_and_commit_authority"),
+            "the phase is worth reporting whatever killed it: {explained}"
+        );
+        assert!(
+            !explained.contains("ran out of memory"),
+            "no measurement supports a memory diagnosis here: {explained}"
+        );
+    }
+
+    /// No marker is no evidence, and the caller keeps the message it had.
+    #[test]
+    fn a_lost_reply_with_no_marker_at_all_invents_no_diagnosis() {
+        assert!(
+            daemon_loss_explanation(None, false, 1_006, &evidence(GIB, Some(9))).is_none(),
+            "a kill count alone says nothing about a commit that published no transaction"
+        );
+    }
+
+    /// A daemon that is still running but stopped beating is wedged, not dead,
+    /// and is described as what it is.
+    #[test]
+    fn a_live_daemon_whose_beat_went_quiet_is_reported_as_wedged_rather_than_gone() {
+        let marker = abandoned_marker(Some(3 * GIB), Some(3 * GIB));
+        let explained =
+            daemon_loss_explanation(marker.as_deref(), true, 1_400, &evidence(64 * GIB, None))
+                .expect("a marker with a live pid still explains itself");
+        assert!(
+            explained.contains("still running but stopped beating 400s ago"),
+            "a wedged daemon must not be reported as a dead one: {explained}"
+        );
+    }
+
+    /// A daemon that could not sample its own memory says so, and is never
+    /// reported as having used nothing.
+    #[test]
+    fn an_unsampled_resident_set_reads_as_absent_and_never_as_zero() {
+        let marker = abandoned_marker(None, None);
+        let explained =
+            daemon_loss_explanation(marker.as_deref(), false, 1_006, &evidence(12 * GIB, None))
+                .expect("a dead daemon holding a marker must be explained");
+        assert!(
+            explained.contains("published no memory reading"),
+            "an unsampled reading must be stated as absent: {explained}"
+        );
+        assert!(
+            !explained.contains("0 MiB") && !explained.contains("ran out of memory"),
+            "an absent sample must never become a measurement: {explained}"
+        );
+    }
 
     #[test]
     fn a_phase_survives_the_ansi_escapes_the_daemon_writes_between_name_and_value() {

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2935,7 +2935,12 @@ const MIB: u64 = 1024 * 1024;
 /// The two rows are why a curve would be wrong: a store less than half the size
 /// of the other peaked within 12% of it, because a commit prepares the whole
 /// repository successor in memory and the fixed part of that dominates. Both
-/// were measured in the same 5 CPU / 12 GiB container on `kin 0.5.40`.
+/// were measured in the same 5 CPU / 12 GiB container on `kin 0.5.40`, before
+/// the workspace-graph scoping in `plan_native_commit_inner` cut what a commit
+/// holds at its peak. A build that peaks lower than a row makes this check
+/// conservative rather than wrong, which is the safe direction for a warning:
+/// it can advise headroom nobody needs, and it cannot stay quiet about a
+/// ceiling somebody does.
 const MEASURED_COMMIT_PEAKS: &[MeasuredCommitPeak] = &[
     MeasuredCommitPeak {
         repository: "expressjs/express",

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -174,6 +174,7 @@ pub async fn run_health_checks() -> HealthReport {
     checks.push(check_reference_edge_coverage().await);
     checks.push(check_background_work().await);
     checks.push(check_embedding_model().await);
+    checks.push(check_commit_memory_headroom());
     checks.push(check_retrieval_profile());
     checks.push(check_update_policy());
     checks.push(check_binary_assessment_load());
@@ -2914,6 +2915,144 @@ const LANGUAGE_SERVER_FIX: &str =
 /// Report the active retrieval quality profile and the effective lever set,
 /// so an operator can see at a glance whether they are getting full
 /// retrieval capability — and why not, when a lever is off.
+/// One commit peak measured on a real converted repository.
+struct MeasuredCommitPeak {
+    repository: &'static str,
+    store_bytes: u64,
+    peak_bytes: u64,
+}
+
+const MIB: u64 = 1024 * 1024;
+
+/// Commit peaks measured on converted repositories, smallest store first.
+///
+/// Every row is one observation, not a fitted curve, and the check below never
+/// interpolates or extrapolates between them. It quotes the largest row whose
+/// store is no larger than the store in front of it, so what a reader is told
+/// is always a repository that has actually been measured rather than a
+/// prediction about theirs. Below the smallest row nothing is claimed at all.
+///
+/// The two rows are why a curve would be wrong: a store less than half the size
+/// of the other peaked within 12% of it, because a commit prepares the whole
+/// repository successor in memory and the fixed part of that dominates. Both
+/// were measured in the same 5 CPU / 12 GiB container on `kin 0.5.40`.
+const MEASURED_COMMIT_PEAKS: &[MeasuredCommitPeak] = &[
+    MeasuredCommitPeak {
+        repository: "expressjs/express",
+        store_bytes: 437 * MIB,
+        peak_bytes: 10809 * MIB,
+    },
+    MeasuredCommitPeak {
+        repository: "psf/requests",
+        store_bytes: 922 * MIB,
+        peak_bytes: 12283 * MIB,
+    },
+];
+
+/// Report whether this machine has the memory a commit on this store has been
+/// measured to need.
+///
+/// A commit that runs out of memory is reported to the person running it as a
+/// closed socket, and the store size that decides it is knowable before any
+/// commit is attempted. This is that reading, published where a user looks
+/// before they are surprised rather than after.
+///
+/// It is advisory by construction and can only ever be `Stale`, never a
+/// failure. A ceiling below a measured peak is a fact about a machine, not a
+/// broken install, and a check that failed readiness on it would fail every
+/// correct install on a small host.
+fn check_commit_memory_headroom() -> HealthCheck {
+    let cwd = env::current_dir().unwrap_or_default();
+    let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
+        return HealthCheck::new(
+            "commit_memory_headroom",
+            "Commit memory headroom",
+            HealthStatus::Unsupported,
+            "not in a Kin repository, so there is no store to measure a commit against",
+        );
+    };
+    let footprint = crate::commands::store_footprint::StoreFootprint::measure(&layout);
+    commit_memory_headroom_check_for(&footprint, &crate::capability::memory_evidence())
+}
+
+/// Core of [`check_commit_memory_headroom`] with both readings as inputs, so
+/// every branch is testable on any host.
+fn commit_memory_headroom_check_for(
+    footprint: &crate::commands::store_footprint::StoreFootprint,
+    evidence: &crate::capability::MemoryEvidence,
+) -> HealthCheck {
+    const ID: &str = "commit_memory_headroom";
+    const LABEL: &str = "Commit memory headroom";
+    let Some(store) = footprint.store.as_ref() else {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Unsupported,
+            "the store could not be measured, so nothing here can be compared against it",
+        );
+    };
+    let available = format_health_bytes(evidence.limit_bytes);
+    let measured = MEASURED_COMMIT_PEAKS
+        .iter()
+        .rev()
+        .find(|point| store.bytes >= point.store_bytes);
+    let Some(measured) = measured else {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Healthy,
+            format!(
+                "{} of memory available; this {} store is smaller than any store a commit peak \
+                 has been measured on, so no headroom claim is made about it",
+                available,
+                format_health_bytes(store.bytes)
+            ),
+        );
+    };
+    let needed = format_health_bytes(measured.peak_bytes);
+    if evidence.limit_bytes >= measured.peak_bytes {
+        return HealthCheck::new(
+            ID,
+            LABEL,
+            HealthStatus::Healthy,
+            format!(
+                "{available} of memory available; a commit on {} ({} store) was measured peaking \
+                 at {needed}, and this {} store is at least that size",
+                measured.repository,
+                format_health_bytes(measured.store_bytes),
+                format_health_bytes(store.bytes)
+            ),
+        );
+    }
+    HealthCheck::new(
+        ID,
+        LABEL,
+        HealthStatus::Stale,
+        format!(
+            "only {available} of memory is available here, and a commit on {} ({} store) was \
+             measured peaking at {needed}; this store is {}, so a commit can be killed \
+             mid-transaction and report a closed connection. {}",
+            measured.repository,
+            format_health_bytes(measured.store_bytes),
+            format_health_bytes(store.bytes),
+            crate::commands::commit_progress::COMMIT_MEMORY_REMEDY,
+        ),
+    )
+    .with_manual_fix(
+        "Run the commit on a machine or container with more memory, or raise this container's \
+         memory limit.",
+    )
+}
+
+fn format_health_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else {
+        format!("{} MiB", bytes / MIB)
+    }
+}
+
 fn check_retrieval_profile() -> HealthCheck {
     let profile = crate::retrieval_profile::RetrievalProfile::from_env();
     let ce_model = env::var("KIN_LOCATE_CROSS_ENCODER_MODEL")
@@ -3015,6 +3154,120 @@ mod tests {
     use super::*;
     use kin_core::test_env::EnvVarGuard;
     use serial_test::serial;
+
+    fn footprint(store_bytes: u64) -> crate::commands::store_footprint::StoreFootprint {
+        crate::commands::store_footprint::StoreFootprint {
+            store: Some(crate::commands::store_footprint::TreeBytes {
+                bytes: store_bytes,
+                unreadable_entries: 0,
+            }),
+            git_objects: None,
+            unmeasured_reason: None,
+        }
+    }
+
+    fn memory(limit_bytes: u64) -> crate::capability::MemoryEvidence {
+        crate::capability::MemoryEvidence {
+            limit_bytes,
+            cgroup_oom_kills: None,
+        }
+    }
+
+    /// The reading a user needed BEFORE the commit that killed their daemon.
+    ///
+    /// A one-file commit on a 922 MiB store peaked at 12283 MiB against a
+    /// 12288 MiB ceiling, and the only warning anyone got was a closed socket
+    /// afterward. The store size that decides it is knowable the whole time.
+    ///
+    /// Falsify by comparing against `store.bytes` instead of the measured peak,
+    /// or by returning `Healthy` unconditionally: the constrained arm then
+    /// passes silently, which is the state this check exists to end.
+    #[test]
+    fn doctor_warns_when_this_machines_ceiling_is_below_a_measured_commit_peak() {
+        let check =
+            commit_memory_headroom_check_for(&footprint(922 * MIB), &memory(8 * 1024 * MIB));
+        assert!(
+            matches!(check.status, HealthStatus::Stale),
+            "a ceiling under a measured peak needs attention: {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("psf/requests") && check.detail.contains("12.0 GiB"),
+            "the warning must quote the repository and peak it was measured on: {}",
+            check.detail
+        );
+        assert!(
+            check.manual_fix.is_some(),
+            "a warning a reader cannot act on is noise"
+        );
+    }
+
+    /// A machine with the headroom is told so, quoting the same measurement.
+    #[test]
+    fn doctor_reports_headroom_as_healthy_against_the_same_measured_peak() {
+        let check =
+            commit_memory_headroom_check_for(&footprint(922 * MIB), &memory(64 * 1024 * MIB));
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "64 GiB clears every measured peak: {:?}",
+            check.status
+        );
+        assert!(check.detail.contains("psf/requests"), "{}", check.detail);
+    }
+
+    /// Below the smallest measured store nothing is claimed at all.
+    ///
+    /// The two measured points do not scale with each other, so there is no
+    /// curve to run down. A check that invented one would warn every small
+    /// repository on a small machine about a cost nobody has measured there.
+    #[test]
+    fn doctor_makes_no_headroom_claim_about_a_store_smaller_than_any_measurement() {
+        let check = commit_memory_headroom_check_for(&footprint(64 * MIB), &memory(2 * 1024 * MIB));
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "an unmeasured size is not a warning: {:?}",
+            check.status
+        );
+        assert!(
+            check.detail.contains("no headroom claim is made"),
+            "silence must be stated rather than implied: {}",
+            check.detail
+        );
+        assert!(
+            !check.detail.contains("psf/requests"),
+            "a measurement that does not apply must not be quoted: {}",
+            check.detail
+        );
+    }
+
+    /// The middle band quotes the smaller measurement, not the larger one.
+    #[test]
+    fn doctor_quotes_the_largest_measurement_the_store_actually_reaches() {
+        let check =
+            commit_memory_headroom_check_for(&footprint(500 * MIB), &memory(8 * 1024 * MIB));
+        assert!(
+            check.detail.contains("expressjs/express"),
+            "a 500 MiB store has passed the express point and not the requests one: {}",
+            check.detail
+        );
+        assert!(!check.detail.contains("psf/requests"), "{}", check.detail);
+    }
+
+    /// A store that could not be measured produces no verdict about it.
+    #[test]
+    fn doctor_reports_an_unmeasurable_store_as_unsupported_rather_than_as_healthy() {
+        let unmeasured = crate::commands::store_footprint::StoreFootprint {
+            store: None,
+            git_objects: None,
+            unmeasured_reason: Some("permission denied".to_string()),
+        };
+        let check = commit_memory_headroom_check_for(&unmeasured, &memory(1024 * MIB));
+        assert!(
+            matches!(check.status, HealthStatus::Unsupported),
+            "an unread store is not a passed check: {:?}",
+            check.status
+        );
+    }
 
     /// A host with no language server must be told which language lost which
     /// edge class, and told it in words rather than as a low relation count.

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -198,6 +198,25 @@ pub struct OpenTransaction {
     pub phase_elapsed_secs: u64,
     /// Unix seconds at the last beat. Freshness is decided against this.
     pub beat_unix: u64,
+    /// Resident set of the publishing daemon at the last beat, in bytes.
+    ///
+    /// Published here rather than asked for later because the reader that needs
+    /// it most is reading after the process is gone: a daemon the kernel
+    /// OOM-kills answers no request and leaves no note, so the only memory
+    /// figure that survives it is one it wrote down while it was still running.
+    /// `None` means the beat could not sample it, never that the daemon was
+    /// using nothing.
+    #[serde(default)]
+    pub rss_bytes: Option<u64>,
+    /// The largest resident set any beat saw while this transaction was open.
+    ///
+    /// Kept beside the last sample because the two answer different questions.
+    /// The last sample says where the daemon was when it stopped beating; the
+    /// high-water mark says how close it ever came to the ceiling. A beat every
+    /// five seconds can miss the top of a fast climb, so this is a floor under
+    /// the real peak and is reported as one.
+    #[serde(default)]
+    pub peak_rss_bytes: Option<u64>,
 }
 
 impl OpenTransaction {

--- a/crates/kin-daemon/src/commit_liveness.rs
+++ b/crates/kin-daemon/src/commit_liveness.rs
@@ -133,10 +133,12 @@ struct ActiveTransaction {
     opened: std::time::Instant,
     phase: Option<&'static str>,
     phase_entered: std::time::Instant,
+    /// Largest resident set any beat has seen since this transaction opened.
+    peak_rss_bytes: Option<u64>,
 }
 
 impl ActiveTransaction {
-    fn record(&self) -> OpenTransaction {
+    fn record(&self, rss_bytes: Option<u64>) -> OpenTransaction {
         OpenTransaction {
             pid: std::process::id(),
             operation: self.operation.to_string(),
@@ -144,8 +146,32 @@ impl ActiveTransaction {
             elapsed_secs: self.opened.elapsed().as_secs(),
             phase_elapsed_secs: self.phase_entered.elapsed().as_secs(),
             beat_unix: unix_now(),
+            rss_bytes,
+            peak_rss_bytes: self.peak_rss_bytes,
         }
     }
+}
+
+/// This process's resident set right now, or `None` when it cannot be sampled.
+///
+/// Absent rather than zero on every failure. A commit that reports "the daemon
+/// was using 0 bytes" is worse than one that reports nothing, because the first
+/// is a measurement a reader will act on and it is wrong.
+///
+/// The pid comes from `sysinfo::get_current_pid` for the same reason
+/// `sample_process_cpu` uses it: the zero-file-search guard reads a
+/// `process::`-prefixed path as a subprocess launch, and the crate's own
+/// accessor states the intent without arguing with a guard that is right to be
+/// blunt.
+fn sample_own_rss_bytes() -> Option<u64> {
+    let pid = sysinfo::get_current_pid().ok()?;
+    let mut system = sysinfo::System::new();
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing().with_memory(),
+    );
+    Some(system.process(pid)?.memory())
 }
 
 fn active() -> &'static Mutex<Option<ActiveTransaction>> {
@@ -155,13 +181,19 @@ fn active() -> &'static Mutex<Option<ActiveTransaction>> {
 
 /// Publish the marker for whatever is currently open. A no-op when nothing is.
 fn publish_beat() {
-    let Ok(guard) = active().lock() else {
+    // Sampled before the lock is taken. The refresh walks the OS process table
+    // and `enter_phase` waits on this same mutex from the commit path, so
+    // holding it across the sample would put a process-table read between every
+    // phase and the next.
+    let rss_bytes = sample_own_rss_bytes();
+    let Ok(mut guard) = active().lock() else {
         return;
     };
-    let Some(transaction) = guard.as_ref() else {
+    let Some(transaction) = guard.as_mut() else {
         return;
     };
-    let record = transaction.record();
+    transaction.peak_rss_bytes = transaction.peak_rss_bytes.max(rss_bytes);
+    let record = transaction.record(rss_bytes);
     let kin_root = transaction.kin_root.clone();
     let phase = transaction.phase;
     let phase_elapsed_ms = transaction.phase_entered.elapsed().as_millis();
@@ -226,6 +258,7 @@ impl TransactionGuard {
                 opened: now,
                 phase: None,
                 phase_entered: now,
+                peak_rss_bytes: None,
             });
         }
         ensure_beat_thread();
@@ -361,6 +394,8 @@ mod tests {
             elapsed_secs: 400,
             phase_elapsed_secs: 300,
             beat_unix: unix_now().saturating_sub(BEAT_STALE_AFTER.as_secs() + 5),
+            rss_bytes: None,
+            peak_rss_bytes: None,
         };
         write_marker(&kin_root, &record);
 

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -766,17 +766,28 @@ fn plan_native_commit_inner(
         None => None,
     };
 
-    let authority_workspace_graph =
-        lease
-            .workspace_graph_snapshot(&workspace_id)?
-            .ok_or_else(|| {
-                invalid(format!(
-                    "repository authority has no graph snapshot for workspace {workspace_id}"
-                ))
-            })?;
-    let desired_workspace_graph =
-        crate::mcp_commit::timed_commit_phase("plan_snapshot_clone", || graph.to_snapshot());
-    let workspace_semantic_delta =
+    // Both sides of the semantic diff are whole copies of the graph and neither
+    // is read again once the delta exists, so both are scoped to the diff and
+    // freed before the phase that follows.
+    //
+    // `InMemoryGraph::to_snapshot` deep-clones every sub-store, the change DAG
+    // included, so on a converted repository it is a copy of the store rather
+    // than a copy of the workspace. Left at function scope it stayed resident
+    // through `plan_compute_deltas`, which is where a one-file commit on a
+    // 1.0 GB psf/requests store reaches its resident-set peak, and through the
+    // whole authority publication after it. It has nothing to contribute to
+    // either.
+    let workspace_semantic_delta = {
+        let authority_workspace_graph =
+            lease
+                .workspace_graph_snapshot(&workspace_id)?
+                .ok_or_else(|| {
+                    invalid(format!(
+                        "repository authority has no graph snapshot for workspace {workspace_id}"
+                    ))
+                })?;
+        let desired_workspace_graph =
+            crate::mcp_commit::timed_commit_phase("plan_snapshot_clone", || graph.to_snapshot());
         crate::mcp_commit::timed_commit_phase("plan_diff_semantics", || {
             kin_core::diff_workspace_semantics(
                 &authority_workspace_graph.entities,
@@ -784,7 +795,8 @@ fn plan_native_commit_inner(
                 &desired_workspace_graph.entities,
                 &desired_workspace_graph.relations,
             )
-        })?;
+        })?
+    };
     let deltas = crate::mcp_commit::timed_commit_phase("plan_compute_deltas", || {
         compute_deltas_vs_repository_authority(graph, lease.snapshot(), parent.as_ref())
     })?;


### PR DESCRIPTION
A stranger adding 17 lines of docstring to one file on a converted psf/requests
store was told `connection closed before message completed` and lost 207 seconds
to a message that names HTTP. The kernel had OOM-killed the daemon: the cgroup
recorded `oom_kill 2`, and the successful retry of the same commit peaked at
12283 MiB against a 12288 MiB ceiling. Nothing in the reported error named
memory, the phase the commit died in, or even a process that had stopped, so the
only conclusion available to a reader was that the tool is flaky.

## The diagnosis

A reaper that kills a daemon writes a death note, and
`commit_progress::daemon_death_explanation` already reports it. The kernel writes
nothing, so this had to be rebuilt from what survives a SIGKILL.

`kin-daemon-spawn/src/lib.rs:187` gives `OpenTransaction` an `rss_bytes` and a
`peak_rss_bytes`, both `#[serde(default)]`, and
`kin-daemon/src/commit_liveness.rs:166` samples the daemon's own resident set on
the transaction beat and publishes both. That beat is a plain OS thread on a five
second interval, which is the whole reason the marker exists: it keeps writing
while the runtime has no worker free to answer anything.

`kin-cli/src/commands/commit.rs:200` carries the abandoned marker and the
liveness of the pid that wrote it out of `classify_lost_reply` instead of
dropping both, and `commit_progress.rs:231` turns them into a sentence. Memory is
graded the way `kin embed` grades it after FIR-1479. A cgroup that recorded a
kill is the kernel's own statement and reads as observed. A resident set within
10% of the ceiling is a prior and reads as likely. A death with headroom reports
the phase and claims nothing about memory, because telling somebody their commit
ran out of memory when it did not sends them to fix something that is not broken.
An unsampled reading stays absent and never becomes zero.

`kin-cli/src/commands/health.rs:2969` adds the same reading before a commit is
attempted. `kin doctor` measures the store and quotes the largest commit peak
measured on a real converted repository whose store is no larger than this one.
Below the smallest measured store it makes no claim at all: the two measured
points do not scale with each other, a store less than half the size peaked
within 12% of the larger one, so there is no curve to run down and a check that
invented one would warn every small repository about a cost nobody measured
there. The check can only ever be advisory; a ceiling below a measured peak is a
fact about a machine, not a broken install.

## The cost, in the part of it that lives here

`plan_native_commit_inner` built two complete copies of the graph to diff the
workspace and then kept both alive for the rest of the commit, though neither is
read again once the delta exists. `InMemoryGraph::to_snapshot` deep-clones every
sub-store under its own read lock, the change DAG included, so on a converted
repository it is a copy of the store rather than a copy of the workspace. On a
1.0 GB psf/requests store built from 6491 commits, the daemon's resident set goes
from 4112 MiB to 7295 MiB across that one call, and the sampled peak of 8692 MiB
lands two seconds later inside `plan_compute_deltas`. `vmmap` on the same daemon
read `Physical footprint (peak): 12.9G`, which is the kernel's own high-water
mark rather than a sample and is in the same place as the ticket's 12283 MiB.

`repository_commit.rs:769` scopes both copies to the diff that reads them, so
3183 MiB of measured allocation is freed before the phase that peaks rather than
at the end of the function. Nothing else reads either binding and the delta they
produce is owned, so the change is a block and nothing more.

The authority publication after the plan is still O(store) on its own account and
its own timing line says so, `workspace_ms=49020 storage_admission_ms=42805
replay_decode_ms=13816` for one docstring edit. That is FIR-2291 and FIR-2347, in
kin-db, and is not touched here.

What the process peak does, measured on `Physical footprint (peak)` with the
daemon lock held, three paired rounds, same fixture, same host:

| round | before | after | load at start |
|---|---|---|---|
| 1 | 14.0G | 12.8G | 41.54 / 41.71 |
| 2 | 12.8G | 12.8G | 33.80 / 38.69 |
| 3 | 14.1G | 13.1G | 38.31 / 47.48 |

The after arm never reads higher than the before arm in a paired round, the
before arm's two highest readings have no counterpart in the after arm, and the
worst case falls from 14.1G to 13.1G. Mean 13.63G against 12.90G. The drop is
smaller than the 3183 MiB freed, which is what should happen: a process peak is
the maximum of several overlapping live sets, and removing one contributor lowers
it only by what that contributor held at the peak instant. `vmmap` prints tenths
of a gigabyte, so round 2's tie is inside one display unit.

A first attempt is worth recording because it was wrong in a way that reads
right. Seven paired runs on a 1 Hz `ps` sampler gave overlapping ranges, mean
7117 MiB before against 6507 MiB after with three of five rounds inverting, and
both arms fell together as the box load rose from 45 to 98. That sampler had read
8692 MiB on a process the kernel says peaked at 12.9G, so it was missing the peak
and more of its samples would not have been more evidence. A sampler that
competes for the CPU it is measuring reports the box's load, not the workload's
memory.

## Falsification

Each guard was broken, the named test was confirmed to fail, and the tree was
restored clean. Exit codes were read raw rather than through a pipe.

Returning `abandoned: None` from the `Gone` arm of `classify_lost_reply` fails
`a_dead_daemons_marker_is_carried_out_of_the_classification` with "the marker the
daemon left must survive", rc=101.

Returning `None` from `memory_attribution` before the observed grade fails both
`a_daemon_the_kernel_killed_is_reported_in_memory_terms_and_names_its_phase` and
`a_resident_set_at_the_ceiling_without_kernel_accounting_is_only_likely`, rc=101,
with "the kernel's own accounting must be quoted: the daemon serving this
repository (pid 412) is gone; it was commit in phase
reconcile_workspace_and_commit_authority for 178s, and its last beat 6s before it
stopped reported a resident set of 11.0 GiB (at least 11.5 GiB at its highest
sampled beat)." The phase half still reports under that break, which is correct,
and only the memory half is lost.

Making `commit_memory_headroom_check_for` always take the healthy branch fails
`doctor_warns_when_this_machines_ceiling_is_below_a_measured_commit_peak`,
rc=101.

The daemon half is also verified outside the tests. During a real commit on the
fixture the published marker read `{"pid":84064,"operation":"commit",
"phase":"reconcile_workspace_and_commit_authority","elapsed_secs":115,
"beat_unix":1787099847,"rss_bytes":4843192320,"peak_rss_bytes":4843192320}`, and
later beats held `peak_rss_bytes` at 4936990720 while `rss_bytes` fell to
1212334080. A daemon killed at any of those points leaves that file behind, which
is exactly what the CLI now reads.

## Gate

`bin/kin-lane run commitmem kin -- bin/kin-dev local-test kin` on
`/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/commitmem-kin @
6d95310b (chore/lane-commitmem-kin)`: `6293 tests run: 6293 passed (9 slow, 2
leaky), 12 skipped`, no tracked lock contamination, and `git diff --quiet HEAD --
Cargo.lock` clean after the pass. `cargo fmt --all -- --check` clean. Clippy
exactly as ci.yml runs it under `RUSTFLAGS=-Dwarnings` with the 45-lint
allowlist: 0 errors. All six ci.yml guard scripts rc=0
(`verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`verify-hydration-semantics.py`, `check_runtime_boundaries.sh`,
`check_private_repo_coupling.sh`, `test-private-repo-coupling.py`).

Closes FIR-2431
Part of FIR-2291
