### PR TITLE
Bring the README, the agent-distribution manifests, and the MCP tool copy back to canon

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "kin",
-      "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+      "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
       "source": {
         "source": "local",
         "path": "./plugins/kin-codex"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "kin",
-  "description": "Firelock's marketplace for Kin, the semantic system of record for software work. Ships the Kin plugin: the bundled MCP server plus skills for graph-backed retrieval and blast-radius review.",
+  "description": "Firelock's marketplace for Kin, the system of record for AI-written software. Ships the Kin plugin: the bundled MCP server plus skills for graph-backed retrieval and blast-radius review.",
   "owner": {
     "name": "Firelock",
     "url": "https://kinlab.ai"
@@ -9,7 +9,7 @@
     {
       "name": "kin",
       "source": "./plugins/kin-claude",
-      "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+      "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
       "category": "development",
       "homepage": "https://kinlab.ai"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://kinlab.ai"
   },
   "metadata": {
-    "description": "Firelock's marketplace for Kin, the semantic system of record for software work.",
+    "description": "Firelock's marketplace for Kin, the system of record for AI-written software.",
     "version": "0.1.0"
   },
   "plugins": [
     {
       "name": "kin",
       "source": "./plugins/kin-cursor",
-      "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search."
+      "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ reaches. The callers of the changed signature come first, then everything
 those callers pull in behind them.
 
 <p align="center">
-  <img src="docs/assets/kin-impact-ripgrep.png" alt="kin impact on ripgrep listing 13 impacted entities within 3 hops of a one-line signature change" width="100%" />
+  <img src="docs/assets/kin-impact-ripgrep.png" alt="kin impact on ripgrep: a one-line signature edit, and Kin surfaces the entities it affects before a compiler runs" width="100%" />
 </p>
 
 Recorded against a prepared graph at ripgrep commit
-`e89fff89ac9af12e8d4ce9d5fd07beb408ca730f`. 13 impacted entities within 3 hops,
-including 3 direct callers of the changed signature. The graph was built
+`e89fff89ac9af12e8d4ce9d5fd07beb408ca730f`. A one-line signature edit, and Kin
+surfaces the entities it affects before a compiler runs. The graph was built
 beforehand. No compiler ran. Exact commands:
 [kinlab.ai/proof](https://kinlab.ai/proof). The raw run directory is not
 public yet, so this is a recipe you can re-run, not a trace you can audit.

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -160,7 +160,7 @@ fn daemon_url_from_env() -> Result<String> {
 /// Query the daemon for federated impact analysis, returning the typed struct.
 ///
 /// Returns a [`SpineQuery`] so callers can distinguish a spine that is simply
-/// not configured (local-only — quiet) from one that is configured but
+/// not configured (local-only: quiet) from one that is configured but
 /// unavailable (surface it) and a healthy, possibly-empty answer.
 pub async fn fetch_spine_impact_typed(
     repo_id: &str,
@@ -1033,7 +1033,7 @@ pub struct ReferenceRow {
     /// Graph entity id of the referencing (caller) entity, when it is a
     /// graph-owned local entity. Lets an agent drill a reference straight to the
     /// caller's body (`get_entity_source`/`get_context_pack`) without re-resolving
-    /// the caller by name — the keystone of the no-filesystem reference→body
+    /// the caller by name. That is the keystone of the no-filesystem reference→body
     /// chain. `None` for federated spine xrefs (no local entity).
     pub entity_id: Option<String>,
     pub name: String,
@@ -2248,7 +2248,7 @@ pub fn entity_body_gap_reason(entity: &Entity) -> String {
 
 /// Caps for the inline snippet surfaced on a retrieval hit (`kin locate --json`
 /// symbols, `semantic_locate` entity results): a signature plus the first
-/// several body lines — dense enough for an agent to act on without a follow-up
+/// several body lines, dense enough for an agent to act on without a follow-up
 /// read, but far tighter than the full-body excerpt
 /// ([`MCP_SOURCE_MAX_LINES`]/[`MCP_SOURCE_MAX_CHARS`]) `get_entity_source` and
 /// `get_context_pack` serve. One bound shared by every agent surface so the

--- a/crates/kin-mcp/src/handlers/provenance.rs
+++ b/crates/kin-mcp/src/handlers/provenance.rs
@@ -185,8 +185,8 @@ pub fn handle_provenance_query<G: GraphStore>(
     // An id that resolves to nothing and has nothing recorded against it is a
     // resolution miss, not an empty provenance record.
     //
-    // Both cases used to answer identically — change_count 0, latest_change
-    // null, empty approvals and audit events, no error — so an agent that
+    // Both cases used to answer identically (change_count 0, latest_change
+    // null, empty approvals and audit events, no error), so an agent that
     // fat-fingered an id, or passed an artifact_id, read "nothing is recorded
     // about this code" and moved on. `get_entity_source` fails loudly on the
     // same id; this tool succeeded.

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -24,7 +24,7 @@ fn daemon_required_unavailable(operation: &str) -> ToolCallResult {
 
 pub const REGISTER_SESSION_DESC: &str = "\
 Register a lightweight assistant session with Kin so its activity can be tracked. This \
-is the legacy, minimal entry point — it records an assistant name and session ID and \
+is the legacy, minimal entry point: it records an assistant name and session ID and \
 nothing more. Prefer kin_session_start for new integrations, which captures \
 capabilities, transport, and working directory and unlocks intent registration and \
 collision detection. Use this only for simple or backward-compatible setups.";
@@ -58,7 +58,7 @@ client name, transport, working directory, optional PID, and a capability set \
 (read/write/execute/branch/commit, max concurrent intents). Reach for it at the \
 beginning of an agent's work so Kin can attribute activity, surface your presence to \
 other agents, and gate collaboration features. It returns a session ID that the rest of \
-the session lifecycle uses — keep it alive with kin_session_heartbeat, declare what \
+the session lifecycle uses: keep it alive with kin_session_heartbeat, declare what \
 you'll touch via kin_register_intent (enabling collision detection against other \
 agents), and close out with kin_session_end. Prefer this over the legacy \
 register_session, which captures none of this context. When the session is daemon-backed \
@@ -215,7 +215,7 @@ pub async fn handle_session_heartbeat(
 }
 
 pub const SESSION_END_DESC: &str = "\
-End an agent session and release everything it held — all of its registered intents are \
+End an agent session and release everything it held. All of its registered intents are \
 freed so other agents are no longer blocked or warned off the scopes it was working. \
 Reach for it when an agent finishes its work or shuts down, so the collaboration graph \
 reflects reality and doesn't leave stale locks behind. The complement to \
@@ -269,7 +269,7 @@ pub async fn handle_session_end(
 pub const REGISTER_INTENT_DESC: &str = "\
 Declare, ahead of acting, which scopes (entities, contracts, or artifacts) an agent \
 intends to modify and why. This is how Kin does collision detection: by publishing your \
-intent — with a soft or hard lock — other agents can see you're working a region and \
+intent (with a soft or hard lock), other agents can see you're working a region and \
 avoid clobbering it, and you can see if someone is already there. Reach for it before \
 making changes in a multi-agent setting so concurrent work coordinates through graph \
 truth instead of racing. Optionally set an expiry; release it early with \
@@ -412,7 +412,7 @@ pub async fn handle_register_intent(
 pub const RELEASE_INTENT_DESC: &str = "\
 Release a single previously registered intent by ID, freeing the scopes it held so \
 other agents can proceed. Reach for it as soon as you finish the specific piece of work \
-an intent covered, rather than holding the lock until session end — it keeps the \
+an intent covered, rather than holding the lock until session end. Doing so keeps the \
 collaboration graph tight and unblocks teammates promptly. Ending the whole session \
 with kin_session_end releases all remaining intents at once.";
 
@@ -465,7 +465,7 @@ pub async fn handle_release_intent(
 pub const CHECK_TRAFFIC_DESC: &str = "\
 Check whether other agents are actively working on or near a set of scopes (entities, \
 contracts, or artifacts), and what they're doing. Reach for it before you start \
-changing something in a multi-agent setting — it surfaces in-flight intents and locks \
+changing something in a multi-agent setting. It surfaces in-flight intents and locks \
 so you can avoid collisions, coordinate, or pick different work. It's the read-side \
 companion to kin_register_intent (the write side): one declares what you'll touch, the \
 other tells you what others are touching.";
@@ -1043,7 +1043,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
 
     // Fail loud on operations the commit path cannot turn into a delta (relation
     // update/modify, blob payloads) instead of silently dropping them while
-    // still reporting "committed". Reject the whole commit atomically — nothing
+    // still reporting "committed". Reject the whole commit atomically: nothing
     // is applied and the transaction stays active so the agent can fix it.
     let uncommittable = crate::session::uncommittable_operations(&tx.staged_operations);
     if !uncommittable.is_empty() {

--- a/crates/kin-mcp/src/handlers/verification.rs
+++ b/crates/kin-mcp/src/handlers/verification.rs
@@ -16,7 +16,7 @@ Inspect the test coverage recorded for a single entity: which tests are linked t
 how many, and whether it is covered at all, alongside the repo-wide coverage figures for \
 context. Filter by runner (e.g. cargo, jest, pytest) when you only care about one test \
 system. Reach for it to answer \"is this function tested, and by what?\" before changing \
-or relying on it. Note this reports linked tests and recorded coverage from the graph — \
+or relying on it. Note this reports linked tests and recorded coverage from the graph; \
 it does not execute tests. For the whole-repo picture use kin_coverage_summary; for \
 contracts use kin_contract_check.";
 
@@ -68,7 +68,7 @@ Read `coverage_trust` BEFORE treating a low or zero number as a fact about the \
 repository: this tool counts RECORDED VERIFICATION RUNS, never the repository's test \
 files, so a graph with no runs reports zero coverage while the code may be thoroughly \
 tested. `safe_to_conclude_uncovered` is false in exactly that case, which is the normal \
-state of a freshly-initialised repo. `population` names what `total_entities` counts — \
+state of a freshly-initialised repo. `population` names what `total_entities` counts: \
 the current-generation entity map, which is NOT the set retrieval ranks over, so it is \
 the wrong denominator for a completeness claim about everything semantic_locate can \
 return.";

--- a/crates/kin-mcp/src/handlers/work.rs
+++ b/crates/kin-mcp/src/handlers/work.rs
@@ -12,8 +12,8 @@ use crate::types::ToolCallResult;
 use super::common::*;
 
 pub const WORK_CREATE_DESC: &str = "\
-Create a work item in Kin's work graph — a feature, task, issue, debt, todo, or \
-investigation — with a title and optional description, acceptance criteria, and linked \
+Create a work item in Kin's work graph (a feature, task, issue, debt, todo, or \
+investigation) with a title and optional description, acceptance criteria, and linked \
 scopes. Reach for it to capture a unit of work as first-class graph truth so it can be \
 linked to the actual entities it concerns, decomposed into children, blocked by other \
 work, and tracked through status changes. Returns the new work item's ID, which the \
@@ -86,7 +86,7 @@ pub fn handle_work_create<G: GraphStore>(
 pub const WORK_LIST_DESC: &str = "\
 List work items, optionally filtered by status (proposed, planned, in_progress, \
 blocked, done, verified, archived), kind, or scope. Reach for it to survey the backlog \
-or current work — what's in progress, what's blocked, what touches a given scope. \
+or current work: what's in progress, what's blocked, what touches a given scope. \
 Returns compact rows; use kin_work_show to pull the full detail (relationships, \
 annotations) of a specific item.";
 
@@ -138,8 +138,8 @@ pub fn handle_work_list<G: GraphStore>(
 }
 
 pub const WORK_SHOW_DESC: &str = "\
-Show one work item in full: its details plus its graph relationships — parents, \
-children, blockers, the scopes/entities implementing it — and any attached annotations. \
+Show one work item in full: its details plus its graph relationships (parents, \
+children, blockers, the scopes/entities implementing it) and any attached annotations. \
 Reach for it to understand a single piece of work in context: what it depends on, what \
 breaks it down into, and what code realizes it. It assembles the whole picture in one \
 call rather than chasing each relationship separately. Find work IDs with kin_work_list.";
@@ -201,7 +201,7 @@ pub fn handle_work_show<G: GraphStore>(
 }
 
 pub const WORK_LINK_DESC: &str = "\
-Link a work item to semantic scopes — the entities, contracts, or artifacts it concerns. \
+Link a work item to semantic scopes: the entities, contracts, or artifacts it concerns. \
 Reach for it to connect planning to code so the work item shows up in context when \
 someone looks at those scopes, and so impact/coverage reasoning can relate work to the \
 declarations it touches. This expresses what the work is *about*; use kin_work_implement \
@@ -249,8 +249,8 @@ pub fn handle_work_link<G: GraphStore>(
 
 pub const WORK_DECOMPOSE_DESC: &str = "\
 Establish a parent/child relationship between two work items, breaking a larger item \
-down into a smaller one. Reach for it to build a work hierarchy — an epic into tasks, a \
-feature into subtasks — so progress and structure roll up through the graph. Both items \
+down into a smaller one. Reach for it to build a work hierarchy (an epic into tasks, a \
+feature into subtasks) so progress and structure roll up through the graph. Both items \
 must already exist (create them with kin_work_create first).";
 
 pub fn handle_work_decompose<G: GraphStore>(
@@ -277,7 +277,7 @@ pub fn handle_work_decompose<G: GraphStore>(
 pub const WORK_BLOCK_DESC: &str = "\
 Record that one work item is blocked by another. Reach for it to capture real \
 dependencies between pieces of work so the graph reflects what can't start until \
-something else lands — useful for sequencing and for surfacing what's holding a task up \
+something else lands. This is useful for sequencing and for surfacing what's holding a task up \
 (visible via kin_work_show). Both items must already exist.";
 
 pub fn handle_work_block<G: GraphStore>(
@@ -303,7 +303,7 @@ pub fn handle_work_block<G: GraphStore>(
 
 pub const WORK_IMPLEMENT_DESC: &str = "\
 Record the semantic scopes (entities, contracts, artifacts) that actually implement a \
-work item — the code that fulfills it. Reach for it once you've written or identified \
+work item: the code that fulfills it. Reach for it once you've written or identified \
 the implementation, so the graph ties the work to its realization: this powers \
 traceability (\"what code delivered this feature?\") and lets coverage/verification \
 relate tests back to the work. Distinct from kin_work_link, which marks what the work \
@@ -337,7 +337,7 @@ pub fn handle_work_implement<G: GraphStore>(
 }
 
 pub const WORK_STATUS_DESC: &str = "\
-Update a work item's status — proposed, planned, in_progress, blocked, done, verified, \
+Update a work item's status: proposed, planned, in_progress, blocked, done, verified, \
 or archived. Reach for it to move work through its lifecycle so the graph reflects \
 current reality and kin_work_list filters stay meaningful. The item must already exist.";
 
@@ -364,7 +364,7 @@ pub fn handle_work_status<G: GraphStore>(
 }
 
 pub const ANNOTATION_ADD_DESC: &str = "\
-Attach a semantic annotation — a comment, warning, instruction, or piece of reasoning — \
+Attach a semantic annotation (a comment, warning, instruction, or piece of reasoning) \
 to one or more targets (entities, contracts, artifacts, changes, or work items). Reach \
 for it to leave durable, scope-anchored knowledge in the graph: a warning on a fragile \
 function, an instruction for whoever touches a module, the reasoning behind a decision. \
@@ -447,7 +447,7 @@ List the annotations attached to given targets (entities, contracts, artifacts, 
 changes, or work items), or across the graph when no targets are given. Set \
 include_stale to control whether annotations whose anchor has drifted are included. \
 Reach for it to surface the warnings, instructions, comments, and reasoning recorded \
-about the code you're about to touch — the read side of kin_annotation_add. Resolve \
+about the code you're about to touch. This is the read side of kin_annotation_add. Resolve \
 ones that no longer apply with kin_annotation_mark_resolved.";
 
 pub fn handle_annotation_list<G: GraphStore>(
@@ -536,7 +536,7 @@ pub fn handle_annotation_mark_resolved<G: GraphStore>(
 pub const TODO_IMPORT_DESC: &str = "\
 Scan source files for inline TODO/FIXME/HACK markers and import each as a work item in \
 the graph. Point it at a root directory (defaults to the working directory). Reach for \
-it to promote scattered in-code reminders into tracked, linkable work — so they can be \
+it to promote scattered in-code reminders into tracked, linkable work, so they can be \
 prioritized, decomposed, and tracked like any other work item rather than being lost in \
 comments. A one-shot way to bootstrap a backlog from an existing codebase.";
 

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -392,7 +392,7 @@ fn registered_tools() -> ToolsListResult {
                         "query": { "type": "string", "description": "Exact entity name to resolve to a focal entity. Required if `entity_id` is not given." },
                         "depth": { "type": "integer", "description": "Dependency traversal depth across the trace neighborhood", "default": 3 },
                         "token_budget": { "type": "integer", "description": "Token budget for the assembled trace response", "default": 8000 },
-                        "compact": { "type": "boolean", "description": "If true, return signature-only entries for everyone (smaller). If false (default), focal gets FullBody, deps get SignatureOnly — better for trace-style reasoning.", "default": false }
+                        "compact": { "type": "boolean", "description": "If true, return signature-only entries for everyone (smaller). If false (default), focal gets FullBody and deps get SignatureOnly, which is better for trace-style reasoning.", "default": false }
                     }
                 }),
             },
@@ -414,7 +414,7 @@ fn registered_tools() -> ToolsListResult {
                         "limit_per_step": { "type": "integer", "description": "Max relations expanded per step (default 5, capped at 25). Kept by relevance, not by relation order; a step whose fan-out was cut says so with the count it dropped.", "default": 5, "minimum": 1, "maximum": 25 },
                         "include_body": {
                             "type": "boolean",
-                            "description": "Inline each step's source body (default true). Pass false to ask for the SHAPE of the chain — names, kinds, roles, spans, edges — which is a fraction of the size and is what you want unless you intend to read the code.",
+                            "description": "Inline each step's source body (default true). Pass false to ask for the SHAPE of the chain (names, kinds, roles, spans, edges), which is a fraction of the size and is what you want unless you intend to read the code.",
                             "default": true
                         },
                         "compact": {
@@ -511,7 +511,7 @@ fn registered_tools() -> ToolsListResult {
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to analyze impact for" },
-                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths — resolves to entities, then analyzes impact" },
+                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths: resolves to entities, then analyzes impact" },
                         "change_ids": { "type": "array", "items": { "type": "string" }, "description": "Change ID hexes to combine and analyze impact" },
                         "include_traffic": { "type": "boolean", "description": "Include active traffic on impacted entities", "default": true }
                     }
@@ -527,7 +527,7 @@ fn registered_tools() -> ToolsListResult {
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to diff (current state vs history)" },
-                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths — resolves to entities, then diffs" },
+                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths: resolves to entities, then diffs" },
                         "change_ids": { "type": "array", "items": { "type": "string" }, "description": "Change ID hexes to combine into one diff" }
                     }
                 }),
@@ -542,7 +542,7 @@ fn registered_tools() -> ToolsListResult {
                         "base": { "type": "string", "description": "Base semantic change ID (hex)" },
                         "head": { "type": "string", "description": "Head semantic change ID (hex)" },
                         "entity_ids": { "type": "array", "items": { "type": "string" }, "description": "Entity UUIDs to review (current state vs history)" },
-                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths — resolves to entities, then reviews" },
+                        "files": { "type": "array", "items": { "type": "string" }, "description": "File paths: resolves to entities, then reviews" },
                         "change_ids": { "type": "array", "items": { "type": "string" }, "description": "Change ID hexes to combine into one review" },
                         "format": { "type": "string", "enum": ["text", "json"], "description": "Response format. Use json for editor integrations.", "default": "text" },
                         "include_traffic": { "type": "boolean", "description": "Include active traffic on reviewed entities", "default": true }
@@ -593,7 +593,7 @@ fn registered_tools() -> ToolsListResult {
                         "compact": { "type": "boolean", "description": "If true (default), omit ranking explanation and per-signal breakdowns and return one shape per hit. Pass false (or explain: true) to get the breakdowns back.", "default": true },
                         "query": {
                             "type": "string",
-                            "description": "Search query — concept or partial name to seed candidates"
+                            "description": "Search query: concept or partial name to seed candidates"
                         },
                         "limit": {
                             "type": "integer",
@@ -1328,11 +1328,11 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
 /// This is the belt the graph-native benchmark agent arm drives: purely
 /// graph-native retrieval/read tools and NO write-side session/transaction tools
 /// (which `agent_default_tool_names` carries) and NO filesystem tools (there are
-/// none to expose — the entire MCP surface is graph-backed). It includes
+/// none to expose, because the entire MCP surface is graph-backed). It includes
 /// `semantic_locate` (entity-centric + paged), which `benchmark_tool_names`
 /// omits, so the agent can do natural-language entity retrieval, drill via
 /// `find_references`/`trace_data_flow`/`graph_neighborhood`, and read bodies via
-/// `get_entity_source`/`get_context_pack` — all without ever touching a file.
+/// `get_entity_source`/`get_context_pack`, all without ever touching a file.
 pub fn context_bench_tool_names() -> &'static [&'static str] {
     &[
         "kin_artifact_list",
@@ -2028,7 +2028,7 @@ The Kin MCP server exposes 2 semantic tools to AI assistants.
         }
 
         // GRAPH-NATIVE: not a single filesystem tool name in the belt (there are
-        // none to expose — the whole MCP surface is graph-backed).
+        // none to expose, because the whole MCP surface is graph-backed).
         for fs in ["cat", "ls", "grep", "find", "read_file", "open_file"] {
             assert!(
                 !profile.contains(&fs),

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "kin",
   "version": "0.5.27",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "kin": {

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "kin",
-      "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+      "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
       "source": {
         "source": "local",
         "path": "./plugins/kin-codex"

--- a/plugins/kin-claude/.claude-plugin/plugin.json
+++ b/plugins/kin-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kin",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
   "version": "0.1.0",
   "author": {
     "name": "Firelock",

--- a/plugins/kin-claude/README.md
+++ b/plugins/kin-claude/README.md
@@ -1,8 +1,8 @@
 # Kin for Claude Code
 
-Semantic code retrieval over a graph of entities, relationships, changes, and provenance.
-Locate, search, context packs, data-flow tracing, and impact analysis without raw file
-search.
+Kin keeps a living map of the software itself so humans and agents can understand what
+every change touches. Locate, search, context packs, data-flow tracing, and impact
+analysis without raw file search.
 
 ## Install
 

--- a/plugins/kin-codex/.codex-plugin/plugin.json
+++ b/plugins/kin-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kin",
   "version": "0.1.0",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
   "author": {
     "name": "Firelock",
     "url": "https://kinlab.ai"

--- a/plugins/kin-codex/README.md
+++ b/plugins/kin-codex/README.md
@@ -1,8 +1,8 @@
 # Kin for Codex
 
-Semantic code retrieval over a graph of entities, relationships, changes, and provenance.
-Locate, search, context packs, data-flow tracing, and impact analysis without raw file
-search.
+Kin keeps a living map of the software itself so humans and agents can understand what
+every change touches. Locate, search, context packs, data-flow tracing, and impact
+analysis without raw file search.
 
 ## Install
 

--- a/plugins/kin-cursor/.cursor-plugin/plugin.json
+++ b/plugins/kin-cursor/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "kin",
   "displayName": "Kin",
   "version": "0.1.0",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
   "author": {
     "name": "Firelock"
   },

--- a/plugins/kin-cursor/README.md
+++ b/plugins/kin-cursor/README.md
@@ -1,8 +1,8 @@
 # Kin for Cursor
 
-Semantic code retrieval over a graph of entities, relationships, changes, and provenance.
-Locate, search, context packs, data-flow tracing, and impact analysis without raw file
-search.
+Kin keeps a living map of the software itself so humans and agents can understand what
+every change touches. Locate, search, context packs, data-flow tracing, and impact
+analysis without raw file search.
 
 ## Install
 

--- a/scripts/mcpb/manifest.json
+++ b/scripts/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "name": "kin",
   "display_name": "Kin",
   "version": "0.5.27",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
+  "description": "Kin keeps a living map of the software itself so humans and agents can understand what every change touches. Locate, search, context packs, data-flow tracing, and impact analysis without raw file search.",
   "author": {
     "name": "Firelock, LLC",
     "url": "https://kinlab.ai"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.kinlab/kin",
   "title": "Kin",
-  "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance.",
+  "description": "The system of record for AI-written software.",
   "repository": {
     "url": "https://github.com/firelock-ai/kin",
     "source": "github"


### PR DESCRIPTION
Canon violations on public kin surfaces, from the 2026-08-18 brand audit. Partial by design,
and the gaps are named at the bottom so the captain can decide whether to land it as is.

## What changed

**The README ships the ripgrep demonstration without a count.** Binding ruling 5 of 2026-08-04
holds the entity and hop figures pending recapture and forbids inventing a replacement. The
body text and the banner image alt text both carried them. Canon's replacement sentence is used
verbatim.

**Thirteen agent-distribution manifests move onto the locked category noun.** `server.json`, the
Claude, Codex and Cursor plugin manifests and their READMEs, the marketplace files, the Gemini
extension manifest, and the mcpb manifest all described Kin as code retrieval rather than the
system of record. The audit named seven files. A repo-wide search found six more carrying the
identical defect, one of them a worse drift than any in the original list. The MCP registry
entry is minted from `server.json` at release time, so that surface updates on the next publish
rather than immediately.

**Em dashes leave the agent-facing MCP tool copy, part one of two.** `tools.rs` plus five
handler description files. Agent-facing copy is public copy: it lands verbatim in transcripts
and screenshots. Every one was removed by restructuring the sentence. Where a dash was serving
as a list bullet or a label separator, it became a hyphen bullet or a colon, which is what it
always meant.

## Verified

`README.md` now matches zero of the held figures, against three on `main`. `tools.rs` matches
zero em dashes, against nine on `main`. Both checks were run with a control proving the pattern
can fire.

## What this PR does not do

Two files still carry em dashes in the same family, `handlers/entities.rs` and
`handlers/review.rs`, which is why the commit says part one of two. Both were already clean on
`main` when this was rebased, so the remaining work may be smaller than it looks.

`AGENTS.md` still carries internal framing on a public file, and the `kin commit` conflict
mapper still returns 500 where 409 belongs. Neither is in this branch.

**The local gate has not run on this tip.** The lane stopped on a usage limit before reaching
it, and this branch was rebased onto `origin/main` afterward. CI, which builds the PR merged
into main, is the first real test. The change is copy and manifests only, with no Rust logic
touched beyond string literals.

Opened as a draft and handed to the `kin` merge captain. No merge-authority lock was taken and
nothing was enqueued.
