### PR TITLE
Place watcher events by repository containment, not by path spelling

### DIFF
--- a/crates/kin-cli/tests/symlinked_repository_root_admission.rs
+++ b/crates/kin-cli/tests/symlinked_repository_root_admission.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Ambient admission through a repository root reached by a symbolic link.
+//!
+//! A repository is reached through symlinked paths far more often than it looks.
+//! On macOS `/tmp` and `/var` are themselves symbolic links, so a repository
+//! under either is already in this case before anyone chooses it, and people
+//! routinely keep work directories behind links of their own.
+//!
+//! The daemon binds one spelling of that root and its watcher backend reports
+//! another. When the two were compared lexically the events lost, silently: the
+//! repository below took nothing from ambient admission for as long as the
+//! daemon ran, while every surface still reported a healthy daemon (FIR-2442).
+
+use std::fs;
+use std::net::{SocketAddr, TcpStream};
+use std::path::Path;
+use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// How long ambient admission has to take the write.
+///
+/// Generous against a loaded machine and still far short of the failure it
+/// guards: the defect admitted nothing at all, for the whole life of the
+/// daemon, so no bound distinguishes it from a slow one.
+const ADMISSION_BOUND: Duration = Duration::from_secs(60);
+
+struct IsolatedDaemon {
+    child: Option<common::RuntimeOwnedChild>,
+}
+
+impl IsolatedDaemon {
+    fn spawn(repo: &Path, runtime: &common::IsolatedDaemonRuntime) -> Self {
+        let mut command = runtime.daemon_command();
+        let child = command
+            .arg("--repo")
+            .arg(repo)
+            .arg("--port")
+            .arg("0")
+            .env("KIN_DAEMON_DISABLE_LSP", "1")
+            .env("KIN_DAEMON_AUTO_EMBED", "0")
+            .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn_owned()
+            .expect("spawn isolated kin-daemon");
+        Self { child: Some(child) }
+    }
+
+    fn wait_until_serving(&mut self, kin_root: &Path) -> u16 {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let child = self.child.as_mut().expect("daemon child exists");
+            if let Some(status) = child.try_wait().expect("inspect daemon child") {
+                panic!("isolated daemon exited before readiness: {status}");
+            }
+            if let Some(port) = fs::read_to_string(kin_root.join("daemon.port"))
+                .ok()
+                .and_then(|value| value.trim().parse::<u16>().ok())
+            {
+                let address = SocketAddr::from(([127, 0, 0, 1], port));
+                if TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok() {
+                    return port;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "isolated daemon did not become ready"
+            );
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn stop(mut self) {
+        let mut child = self.child.take().expect("daemon child exists");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for IsolatedDaemon {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", kin_git::empty_global_git_config())
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn seed_repository(repo: &Path) {
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    run_git(repo, &["init", "--initial-branch=main"]);
+    run_git(repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(repo, &["config", "user.name", "Kin"]);
+    fs::write(
+        repo.join("src/lib.rs"),
+        b"pub fn helper() -> u32 {\n    7\n}\n",
+    )
+    .expect("write entity source");
+    run_git(repo, &["add", "--all"]);
+    run_git(repo, &["commit", "-m", "seed"]);
+}
+
+/// Entities the live query graph reports, read through the production route.
+fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
+    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["graph", "status"])
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("KIN_DAEMON_URL", format!("http://127.0.0.1:{port}"))
+        .current_dir(repo)
+        .output()
+        .expect("run production kin graph status route");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "graph status stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    stdout
+        .lines()
+        .find(|line| line.starts_with("Entities: "))
+        .and_then(|line| {
+            line.trim_start_matches("Entities: ")
+                .split_whitespace()
+                .next()
+        })
+        .and_then(|count| count.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("graph status names an entity count: {stdout}"))
+}
+
+/// FIR-2442. A repository reached through a symbolic link admits host writes
+/// ambiently, exactly as the same repository reached directly does.
+#[cfg(unix)]
+#[test]
+fn a_repository_bound_through_a_symlinked_root_admits_a_host_write() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let real = root.path().join("real-repo");
+    let linked = root.path().join("linked-repo");
+    fs::create_dir_all(&home).expect("create home");
+    fs::create_dir_all(&real).expect("create repo");
+    std::os::unix::fs::symlink(&real, &linked).expect("link the repository root");
+
+    // Every path from here on is the symlinked spelling, which is what a person
+    // with a linked work directory types and what their editor and agent
+    // inherit. Nothing in the test resolves it, because nothing they run would.
+    seed_repository(&linked);
+
+    let init = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(["init", ".", "--json"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .current_dir(&linked)
+        .output()
+        .expect("run production kin init route");
+    assert!(
+        init.status.success(),
+        "init stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let runtime = common::IsolatedDaemonRuntime::new(&linked);
+    let mut daemon = IsolatedDaemon::spawn(&linked, &runtime);
+    let port = daemon.wait_until_serving(&linked.join(".kin"));
+
+    let before = live_entity_count(&linked, &home, port);
+
+    // The write a person makes: a new file, through the linked root, with no
+    // command run afterwards. Ambient admission is what makes it queryable.
+    fs::write(
+        linked.join("src/added.rs"),
+        b"pub fn ambiently_admitted() -> u32 {\n    41\n}\n",
+    )
+    .expect("write a new source file through the symlinked root");
+
+    let deadline = Instant::now() + ADMISSION_BOUND;
+    let mut latest = before;
+    while Instant::now() < deadline {
+        latest = live_entity_count(&linked, &home, port);
+        if latest > before {
+            break;
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    daemon.stop();
+
+    assert!(
+        latest > before,
+        "a file written through the symlinked repository root {} was never admitted: the live \
+         query graph held {before} entities before the write and {latest} after {}s. The \
+         repository resolves to {}, and a watcher that cannot place its own events reports \
+         nothing at all",
+        linked.display(),
+        ADMISSION_BOUND.as_secs(),
+        real.canonicalize()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|_| real.display().to_string()),
+    );
+}

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -216,59 +216,37 @@ enum TreePublication {
     DeferredToCaller,
 }
 
-fn canonicalize_host_parent_preserving_leaf(path: &Path) -> std::io::Result<PathBuf> {
-    let leaf = path.file_name().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!(
-                "filesystem event has no repository entry name: {}",
-                path.display()
-            ),
-        )
-    })?;
-    let mut unresolved = vec![leaf.to_os_string()];
-    let mut ancestor = path.parent().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!(
-                "filesystem event has no parent directory: {}",
-                path.display()
-            ),
-        )
-    })?;
-
-    loop {
-        match ancestor.canonicalize() {
-            Ok(mut canonical) => {
-                for component in unresolved.iter().rev() {
-                    canonical.push(component);
-                }
-                return Ok(canonical);
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let component = ancestor.file_name().ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        format!(
-                            "filesystem event has no existing ancestor to establish repository containment: {}",
-                            path.display()
-                        ),
-                    )
-                })?;
-                unresolved.push(component.to_os_string());
-                ancestor = ancestor.parent().ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        format!(
-                            "filesystem event has no existing ancestor to establish repository containment: {}",
-                            path.display()
-                        ),
-                    )
-                })?;
-            }
-            Err(error) => return Err(error),
-        }
+/// State what a watcher could not place inside this repository, or nothing when
+/// it has already been stated.
+///
+/// Once per rise rather than once per tick. The count is a running total, so a
+/// loop that re-read it every tick would re-record one unchanged fault forever
+/// and bury whatever failed next behind it. A rise is new evidence; a steady
+/// count is the same evidence.
+///
+/// The message names both spellings on purpose. The whole failure is that two
+/// correct names for one directory did not compare equal, and a report that
+/// gave only one of them would leave a reader unable to see why.
+fn events_outside_root_disclosure(
+    events: &kin_index::EventsOutsideRoot,
+    disclosed: u64,
+    working_dir: &Path,
+) -> Option<String> {
+    if events.count <= disclosed {
+        return None;
     }
+    let last_path = events
+        .last_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "an unrecorded path".to_string());
+    Some(format!(
+        "{} host event(s) named paths the watcher could not place inside the repository root \
+         {}; most recently {last_path}. Nothing those paths changed is admitted from the act of \
+         writing it",
+        events.count,
+        working_dir.display(),
+    ))
 }
 
 fn repo_path(path: &Path, working_dir: &Path) -> Result<Option<RepoPath>> {
@@ -279,7 +257,8 @@ fn repo_path(path: &Path, working_dir: &Path) -> Result<Option<RepoPath>> {
     // events that appear lexically beneath the repository but traverse a
     // directory symlink out of it.
     let canonical_root = working_dir.canonicalize().map_err(DaemonError::Io)?;
-    let canonical_path = canonicalize_host_parent_preserving_leaf(path).map_err(DaemonError::Io)?;
+    let canonical_path =
+        kin_index::canonicalize_host_parent_preserving_leaf(path).map_err(DaemonError::Io)?;
     let relative = canonical_path
         .strip_prefix(&canonical_root)
         .map_err(|error| {
@@ -1825,6 +1804,10 @@ pub async fn run_loop(
 
     let watcher = FileWatcher::new(working_dir).map_err(DaemonError::from)?;
     let enrichment_pipeline = IndexPipeline::new();
+    // The watcher's running total of host events it could not place inside this
+    // repository, as this loop last disclosed it. Held so a standing count is
+    // reported once per rise rather than once per tick.
+    let mut disclosed_events_outside_root = 0_u64;
 
     info!(
         poll_ms = config.poll_interval_ms,
@@ -1948,6 +1931,25 @@ pub async fn run_loop(
             incoming_events.extend(due_retries.into_iter().map(FileEvent::Changed));
         }
         incoming_events.extend(watcher.drain());
+        // An event the watcher could not place inside this repository never
+        // reaches anything below, so this loop is the only place that can say it
+        // happened. Silence here is the whole defect: a repository reached
+        // through a symlink took nothing from ambient admission and every
+        // surface still reported a healthy daemon (FIR-2442). Reported through
+        // the skipped-event probe, which is what turns a working daemon that is
+        // seeing nothing into `attention` on `/health` and on `kin graph status`.
+        let events_outside_root = watcher.events_outside_root();
+        if let Some(disclosure) = events_outside_root_disclosure(
+            &events_outside_root,
+            disclosed_events_outside_root,
+            working_dir,
+        ) {
+            disclosed_events_outside_root = events_outside_root.count;
+            state
+                .background_work
+                .reconcile()
+                .record_event_skipped(disclosure, tick_started);
+        }
         // A graph-only repository member owns its own host subtree. Admission
         // already refuses to traverse one, so an event beneath it carries no
         // observation of this repository's source projection. Waking the tick
@@ -2783,6 +2785,80 @@ mod tests {
     fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
         let init = kin_core::init(repo.path()).unwrap();
         Arc::new(DaemonState::open(init.layout).unwrap())
+    }
+
+    /// FIR-2442. A dropped host event is disclosed through the reconcile health
+    /// surface, naming the root it could not be placed in and the path itself.
+    #[test]
+    fn an_event_outside_the_bound_root_is_disclosed_with_both_paths() {
+        let events = kin_index::EventsOutsideRoot {
+            count: 2,
+            last_path: Some(PathBuf::from("/private/var/repo/main.rs")),
+        };
+
+        let disclosure = events_outside_root_disclosure(&events, 0, Path::new("/var/repo"))
+            .expect("a risen count is disclosed");
+
+        assert!(
+            disclosure.contains("/var/repo"),
+            "the disclosure names the bound root: {disclosure}"
+        );
+        assert!(
+            disclosure.contains("/private/var/repo/main.rs"),
+            "the disclosure names the dropped path: {disclosure}"
+        );
+        assert!(
+            disclosure.contains('2'),
+            "the disclosure carries the count: {disclosure}"
+        );
+    }
+
+    /// The same standing count is stated once. A running total re-read every
+    /// tick would otherwise re-record one unchanged fault forever.
+    #[test]
+    fn an_already_disclosed_outside_root_count_is_not_restated() {
+        let events = kin_index::EventsOutsideRoot {
+            count: 2,
+            last_path: Some(PathBuf::from("/private/var/repo/main.rs")),
+        };
+
+        assert_eq!(
+            events_outside_root_disclosure(&events, 2, Path::new("/var/repo")),
+            None,
+            "a count that has not risen is not new evidence"
+        );
+        assert!(
+            events_outside_root_disclosure(&events, 1, Path::new("/var/repo")).is_some(),
+            "a count that rose by one is"
+        );
+    }
+
+    /// FIR-2442. What the disclosure is for: the reconcile surface stops
+    /// reporting a healthy loop once a host event has been dropped unplaced.
+    #[test]
+    fn a_disclosed_outside_root_event_degrades_the_reconcile_surface() {
+        let probes = crate::background_work::ReconcileProbes::default();
+        let now = Instant::now();
+        assert!(
+            !probes.report(now).degraded(),
+            "a loop that has dropped nothing is not degraded"
+        );
+
+        let events = kin_index::EventsOutsideRoot {
+            count: 1,
+            last_path: Some(PathBuf::from("/private/var/repo/main.rs")),
+        };
+        let disclosure = events_outside_root_disclosure(&events, 0, Path::new("/var/repo"))
+            .expect("a risen count is disclosed");
+        probes.record_event_skipped(disclosure, now);
+
+        let report = probes.report(now);
+        assert!(report.degraded(), "a dropped host event is a degraded loop");
+        let reasons = report.degraded_reasons().join(" ");
+        assert!(
+            reasons.contains("/private/var/repo/main.rs"),
+            "the degraded reason names the dropped path: {reasons}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -68,16 +68,17 @@ pub use pipeline::{
     COMMAND_EFFECT_CONTRACT_KEY,
 };
 pub use repository::{
-    host_path_from_repo_path, is_repository_control_path, read_verified_scanned_entry,
-    repo_path_from_host_relative, scan_repository, scan_repository_preserving_graph_only,
-    should_track_host_relative_path, tracked_paths_covered_by_ignore,
-    tracked_paths_retracted_by_ignore, CompleteRepositoryScan, CompleteScanToken,
-    IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore, RepositoryScanDiagnostics,
-    ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES, PYTHON_VIRTUALENV_MARKER,
+    canonicalize_host_parent_preserving_leaf, host_path_from_repo_path, is_repository_control_path,
+    read_verified_scanned_entry, repo_path_from_host_relative, scan_repository,
+    scan_repository_preserving_graph_only, should_track_host_relative_path,
+    tracked_paths_covered_by_ignore, tracked_paths_retracted_by_ignore, CompleteRepositoryScan,
+    CompleteScanToken, IgnoredTrackedPaths, IncompleteRepositoryScan, RepositoryIgnore,
+    RepositoryScanDiagnostics, ScannedEntryKind, ScannedRepositoryEntry, DEFAULT_IGNORED_NAMES,
+    PYTHON_VIRTUALENV_MARKER,
 };
 pub use resolution::{RelationResolution, RESOLUTION_FIELD, RESOLUTION_TIER_LADDER};
 pub use support::{compute_coverage_report, CoverageReport};
-pub use watcher::{FileEvent, FileWatcher};
+pub use watcher::{EventsOutsideRoot, FileEvent, FileWatcher};
 
 use std::path::Path;
 

--- a/crates/kin-index/src/repository.rs
+++ b/crates/kin-index/src/repository.rs
@@ -650,6 +650,73 @@ pub fn tracked_paths_retracted_by_ignore<'a>(
     covered
 }
 
+/// Resolve every symbolic link above a host path while leaving its final
+/// component exactly as it was named.
+///
+/// Repository containment is decided by comparing a host path against a
+/// repository root, and the two rarely arrive in the same form. A watcher
+/// backend, a shell, a config file, and `--repo` each name the same directory
+/// differently the moment a symbolic link stands anywhere above it, and a
+/// lexical comparison of two such names disagrees while both are correct.
+/// Resolving the parent puts them in one form.
+///
+/// The leaf is deliberately left alone. It may be a symbolic link whose own
+/// identity the repository tracks, it may dangle, and after a removal it may
+/// not exist at all, so dereferencing it would either answer about the wrong
+/// entry or fail on exactly the events that matter most. Resolving the parent
+/// also rejects a path that reads as being beneath the root but leaves it
+/// through a directory symlink, which a purely lexical test admits.
+pub fn canonicalize_host_parent_preserving_leaf(path: &Path) -> io::Result<PathBuf> {
+    let leaf = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("host path has no repository entry name: {}", path.display()),
+        )
+    })?;
+    let mut unresolved = vec![leaf.to_os_string()];
+    let mut ancestor = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("host path has no parent directory: {}", path.display()),
+        )
+    })?;
+
+    loop {
+        match ancestor.canonicalize() {
+            Ok(mut canonical) => {
+                for component in unresolved.iter().rev() {
+                    canonical.push(component);
+                }
+                return Ok(canonical);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let component = ancestor.file_name().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!(
+                            "host path has no existing ancestor to establish repository \
+                             containment: {}",
+                            path.display()
+                        ),
+                    )
+                })?;
+                unresolved.push(component.to_os_string());
+                ancestor = ancestor.parent().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!(
+                            "host path has no existing ancestor to establish repository \
+                             containment: {}",
+                            path.display()
+                        ),
+                    )
+                })?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 /// Convert a host-relative path to Kin's byte-exact repository path.
 pub fn repo_path_from_host_relative(path: &Path) -> io::Result<RepoPath> {
     let mut bytes = Vec::new();

--- a/crates/kin-index/src/watcher.rs
+++ b/crates/kin-index/src/watcher.rs
@@ -2,10 +2,10 @@
 // Copyright 2026 Firelock, LLC
 
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex, PoisonError};
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::error::{IndexError, Result};
 
@@ -18,10 +18,116 @@ pub enum FileEvent {
     Removed(PathBuf),
 }
 
+/// Host events a watcher declined to place inside the repository it watches.
+///
+/// Reported rather than merely counted, because nothing downstream ever sees
+/// these paths. An event dropped here never reaches the reconciliation loop, so
+/// the loop cannot notice its own blindness and every surface that asks the
+/// loop how it is doing gets a healthy answer.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EventsOutsideRoot {
+    /// How many host events this watcher could not place.
+    pub count: u64,
+    /// The most recently dropped path, so a report names one.
+    pub last_path: Option<PathBuf>,
+}
+
+/// Every form of the repository root a host event may legitimately arrive under.
+///
+/// The backends do not agree on which form they report, and none of them is
+/// wrong. macOS FSEvents resolves every symbolic link above the watched
+/// directory before it reports anything, so a watch registered on
+/// `/var/repo` is told about `/private/var/repo/main.rs`. Linux inotify
+/// instead echoes the path it was handed, so the same watch registered through
+/// a symlink keeps reporting the symlinked form. On Windows canonicalization
+/// adds a `\\?\` verbatim prefix that no event carries at all.
+///
+/// So neither form alone can be the root: binding the resolved one breaks the
+/// backends that echo, and binding the given one breaks the backends that
+/// resolve. Both are held, and a path that matches neither lexically is
+/// resolved once and asked again.
+struct RepositoryRoots {
+    bound: PathBuf,
+    canonical: Option<PathBuf>,
+}
+
+impl RepositoryRoots {
+    fn bind(root: &Path) -> Self {
+        let bound = root.to_path_buf();
+        let canonical = root
+            .canonicalize()
+            .ok()
+            .filter(|resolved| *resolved != bound);
+        Self { bound, canonical }
+    }
+
+    /// Place one host path inside this repository, or report that it is not
+    /// inside it at all.
+    fn relative(&self, path: &Path) -> Option<PathBuf> {
+        if let Some(relative) = self.strip(path) {
+            return Some(relative);
+        }
+        // Disagreeing lexically is the ordinary case rather than a miss, so the
+        // path is resolved the way admission resolves it and asked again. The
+        // leaf is preserved: a removal names a path that no longer exists, and
+        // an event about a symbolic link is about the link and not its target.
+        let resolved = crate::canonicalize_host_parent_preserving_leaf(path).ok()?;
+        self.strip(&resolved)
+    }
+
+    fn strip(&self, path: &Path) -> Option<PathBuf> {
+        if let Ok(relative) = path.strip_prefix(&self.bound) {
+            return Some(relative.to_path_buf());
+        }
+        self.canonical
+            .as_deref()
+            .and_then(|canonical| path.strip_prefix(canonical).ok())
+            .map(Path::to_path_buf)
+    }
+
+    /// The resolved root, or the bound one when it could not be resolved.
+    fn resolved(&self) -> &Path {
+        self.canonical.as_deref().unwrap_or(&self.bound)
+    }
+}
+
+/// Record one host event that named a path outside the bound repository.
+///
+/// Loud once and counted always. The first is warned because a repository whose
+/// events all land outside it admits nothing ambiently and used to say so
+/// nowhere; the rest are counted because a genuinely foreign path can churn,
+/// and a warning per event would bury the one that explains the daemon.
+fn record_outside_root(
+    outside_root: &Mutex<EventsOutsideRoot>,
+    roots: &RepositoryRoots,
+    path: &Path,
+) {
+    let mut recorded = outside_root.lock().unwrap_or_else(PoisonError::into_inner);
+    recorded.count = recorded.count.saturating_add(1);
+    recorded.last_path = Some(path.to_path_buf());
+    if recorded.count == 1 {
+        warn!(
+            path = %path.display(),
+            bound_root = %roots.bound.display(),
+            resolved_root = %roots.resolved().display(),
+            "a host event names a path this watcher cannot place inside the repository it \
+             watches; it was dropped, so nothing that path changed will be admitted from the \
+             act of writing it"
+        );
+    } else {
+        debug!(
+            count = recorded.count,
+            path = %path.display(),
+            "another host event fell outside the bound repository root"
+        );
+    }
+}
+
 /// File watcher that monitors a directory for source file changes.
 pub struct FileWatcher {
     _watcher: RecommendedWatcher,
     receiver: mpsc::Receiver<FileEvent>,
+    outside_root: Arc<Mutex<EventsOutsideRoot>>,
 }
 
 impl FileWatcher {
@@ -33,13 +139,19 @@ impl FileWatcher {
     pub fn new(root: &Path) -> Result<Self> {
         let (tx, rx) = mpsc::channel();
         let root = root.to_path_buf();
-        let event_root = root.clone();
+        // Resolved once here rather than per event. The root does not move
+        // under a running daemon, and resolving it on every notification would
+        // put a filesystem call on the path a churning working copy walks
+        // thousands of times.
+        let event_roots = RepositoryRoots::bind(&root);
+        let outside_root = Arc::new(Mutex::new(EventsOutsideRoot::default()));
+        let event_outside_root = Arc::clone(&outside_root);
 
         let mut watcher =
             notify::recommended_watcher(move |res: std::result::Result<Event, notify::Error>| {
                 match res {
                     Ok(event) => {
-                        let events = classify_event(&event, &event_root);
+                        let events = classify_event(&event, &event_roots, &event_outside_root);
                         for fe in events {
                             if tx.send(fe).is_err() {
                                 return;
@@ -53,6 +165,8 @@ impl FileWatcher {
             })
             .map_err(|e| IndexError::Watcher(e.to_string()))?;
 
+        // Registered on the root as it was given. The backend resolves it or
+        // does not, and either way both forms are already held.
         watcher
             .watch(&root, RecursiveMode::Recursive)
             .map_err(|e| IndexError::Watcher(e.to_string()))?;
@@ -62,7 +176,17 @@ impl FileWatcher {
         Ok(Self {
             _watcher: watcher,
             receiver: rx,
+            outside_root,
         })
+    }
+
+    /// Host events this watcher could not place inside the repository it
+    /// watches, so a caller can disclose its own blind spot.
+    pub fn events_outside_root(&self) -> EventsOutsideRoot {
+        self.outside_root
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
     }
 
     /// Receive the next file event (blocking).
@@ -85,17 +209,22 @@ impl FileWatcher {
     }
 }
 
-fn classify_event(event: &Event, root: &Path) -> Vec<FileEvent> {
+fn classify_event(
+    event: &Event,
+    roots: &RepositoryRoots,
+    outside_root: &Mutex<EventsOutsideRoot>,
+) -> Vec<FileEvent> {
     let mut file_events = Vec::new();
 
     let relevant_paths: Vec<&PathBuf> = event
         .paths
         .iter()
         .filter(|p| {
-            let Ok(rel_path) = p.strip_prefix(root) else {
+            let Some(rel_path) = roots.relative(p) else {
+                record_outside_root(outside_root, roots, p);
                 return false;
             };
-            if !crate::should_index_repo_relative_path(rel_path) {
+            if !crate::should_index_repo_relative_path(&rel_path) {
                 return false;
             }
             // A removed path no longer has metadata to inspect. Notify emits
@@ -135,6 +264,30 @@ fn classify_event(event: &Event, root: &Path) -> Vec<FileEvent> {
 mod tests {
     use super::*;
 
+    /// Classify one event against a root, discarding the outside-root record.
+    fn classify(event: &Event, root: &Path) -> Vec<FileEvent> {
+        classify_against(event, root).0
+    }
+
+    /// Classify one event against a root and keep what it declined to place.
+    fn classify_against(event: &Event, root: &Path) -> (Vec<FileEvent>, EventsOutsideRoot) {
+        let roots = RepositoryRoots::bind(root);
+        let outside_root = Mutex::new(EventsOutsideRoot::default());
+        let events = classify_event(event, &roots, &outside_root);
+        let recorded = outside_root.into_inner().unwrap();
+        (events, recorded)
+    }
+
+    fn content_change(paths: Vec<PathBuf>) -> Event {
+        Event {
+            kind: EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+            paths,
+            attrs: Default::default(),
+        }
+    }
+
     #[test]
     fn classify_detects_unsupported_and_extensionless_files() {
         let root = tempfile::tempdir().unwrap();
@@ -151,7 +304,7 @@ mod tests {
             paths: vec![readme, compose, lockfile],
             attrs: Default::default(),
         };
-        let result = classify_event(&event, root.path());
+        let result = classify(&event, root.path());
         assert_eq!(result.len(), 3);
         assert!(result
             .iter()
@@ -170,7 +323,7 @@ mod tests {
             paths: vec![path],
             attrs: Default::default(),
         };
-        let result = classify_event(&event, root.path());
+        let result = classify(&event, root.path());
         assert_eq!(result.len(), 1);
         assert!(matches!(result[0], FileEvent::Changed(_)));
     }
@@ -182,7 +335,7 @@ mod tests {
             paths: vec![PathBuf::from("/tmp/old.py")],
             attrs: Default::default(),
         };
-        let result = classify_event(&event, Path::new("/tmp"));
+        let result = classify(&event, Path::new("/tmp"));
         assert_eq!(result.len(), 1);
         assert!(matches!(result[0], FileEvent::Removed(_)));
     }
@@ -200,8 +353,125 @@ mod tests {
             paths: vec![generated],
             attrs: Default::default(),
         };
-        let result = classify_event(&event, root.path());
+        let result = classify(&event, root.path());
         assert_eq!(result.len(), 1);
         assert!(matches!(result[0], FileEvent::Changed(_)));
+    }
+
+    /// FIR-2442. A watcher bound through a symlinked root must still place the
+    /// events its backend reports, whichever form the backend chose.
+    ///
+    /// This is the shape macOS produces on every run: FSEvents resolves the
+    /// watched path before reporting, so a daemon bound to `/var/repo` is told
+    /// about `/private/var/repo/main.rs`. The lexical comparison this replaced
+    /// dropped every one of those, silently.
+    #[cfg(unix)]
+    #[test]
+    fn classify_places_an_event_the_backend_reported_under_the_resolved_root() {
+        let base = tempfile::tempdir().unwrap();
+        let real = base.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let written = link.join("main.rs");
+        std::fs::write(&written, "fn main() {}").unwrap();
+
+        let reported = real.canonicalize().unwrap().join("main.rs");
+        assert_ne!(
+            reported, written,
+            "the fixture must exercise two different spellings of one file"
+        );
+
+        let (result, outside) = classify_against(&content_change(vec![reported]), &link);
+
+        assert_eq!(result.len(), 1, "the resolved form names a repository file");
+        assert!(matches!(result[0], FileEvent::Changed(_)));
+        assert_eq!(outside, EventsOutsideRoot::default());
+    }
+
+    /// The mirror case, which is what Linux inotify and Windows canonicalization
+    /// produce: the root is held resolved and the event arrives unresolved.
+    #[cfg(unix)]
+    #[test]
+    fn classify_places_an_event_reported_under_a_symlinked_spelling_of_the_root() {
+        let base = tempfile::tempdir().unwrap();
+        let real = base.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let written = link.join("main.rs");
+        std::fs::write(&written, "fn main() {}").unwrap();
+
+        let resolved_root = real.canonicalize().unwrap();
+        let (result, outside) = classify_against(&content_change(vec![written]), &resolved_root);
+
+        assert_eq!(result.len(), 1, "the symlinked form names the same file");
+        assert!(matches!(result[0], FileEvent::Changed(_)));
+        assert_eq!(outside, EventsOutsideRoot::default());
+    }
+
+    /// FIR-2442. A path that really is outside the repository is still dropped,
+    /// but it is counted and named rather than discarded in silence.
+    #[test]
+    fn classify_reports_an_event_that_falls_outside_the_bound_root() {
+        let base = tempfile::tempdir().unwrap();
+        let root = base.path().join("repo");
+        let foreign = base.path().join("elsewhere");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&foreign).unwrap();
+        let outside_path = foreign.join("stranger.rs");
+        std::fs::write(&outside_path, "pub fn stranger() {}").unwrap();
+
+        let (result, outside) =
+            classify_against(&content_change(vec![outside_path.clone()]), &root);
+
+        assert!(result.is_empty(), "a foreign path is not admitted");
+        assert_eq!(outside.count, 1, "the drop is counted");
+        assert_eq!(
+            outside.last_path,
+            Some(outside_path),
+            "the drop names the path it dropped"
+        );
+    }
+
+    /// FIR-2442, end to end through a real backend. A repository reached through
+    /// a symlink must report the writes made through it.
+    #[cfg(unix)]
+    #[test]
+    fn a_watcher_bound_through_a_symlinked_root_reports_writes_through_it() {
+        let base = tempfile::tempdir().unwrap();
+        let real = base.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let watcher = FileWatcher::new(&link).unwrap();
+        // The backend registers its watch asynchronously, so a write racing
+        // registration would prove nothing either way.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        std::fs::write(link.join("added.rs"), "pub fn added() {}").unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut seen = Vec::new();
+        while std::time::Instant::now() < deadline && seen.is_empty() {
+            if let Some(event) = watcher.try_recv() {
+                seen.push(event);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        assert!(
+            !seen.is_empty(),
+            "a write through the symlinked root {} produced no event in 30s; the watcher \
+             placed {} event(s) outside the root it is bound to (most recent {:?})",
+            link.display(),
+            watcher.events_outside_root().count,
+            watcher.events_outside_root().last_path,
+        );
+        assert_eq!(
+            watcher.events_outside_root().count,
+            0,
+            "no event from inside the repository may be dropped as foreign"
+        );
     }
 }

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -388,12 +388,11 @@
     },
     {
       "file": "crates/kin-daemon/src/loop_runner.rs",
-      "reason": "Host event ingestion boundary. The excused bodies are the file watcher's admission path: reading a host file or symlink target and its mode so the change can be admitted into the graph as exact tree state, and comparing a host entry against what the graph already holds so an unchanged file is not re-admitted. Reading the working tree is the entire job of an ingestion boundary, and the result is written into graph truth rather than returned as an answer. The remaining three are repository binding, which precedes any graph consult: recognizing a bare git layout, canonicalizing a host parent while preserving the leaf, and resolving a path relative to the bound root. The cfg-gated executable-bit helper is the pair that carries a count of two. Function-scoped so the rest of the runner stays scanned.",
+      "reason": "Host event ingestion boundary. The excused bodies are the file watcher's admission path: reading a host file or symlink target and its mode so the change can be admitted into the graph as exact tree state, and comparing a host entry against what the graph already holds so an unchanged file is not re-admitted. Reading the working tree is the entire job of an ingestion boundary, and the result is written into graph truth rather than returned as an answer. The remaining two are repository binding, which precedes any graph consult: recognizing a bare git layout, and resolving a path relative to the bound root. The helper that canonicalized a host parent while preserving its leaf moved to kin-index, which is a declared ingestion boundary, so the watcher and this runner decide repository containment by one rule instead of two. The cfg-gated executable-bit helper is the pair that carries a count of two. Function-scoped so the rest of the runner stays scanned.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_fn": [
         "is_bare_repository",
-        "canonicalize_host_parent_preserving_leaf",
         "repo_path",
         {
           "fn": "regular_file_is_executable",


### PR DESCRIPTION
A repository reached through a symbolic link took nothing from ambient admission, and nothing anywhere said so. A daemon bound to such a root ran, reported itself healthy, and never noticed a single edit.

## Mechanism

The ticket's hypothesis named `observation_covers_path` and the exact-tree scan's untracked report. Neither is ever reached. The event is dropped one layer earlier, in the watcher itself.

`crates/kin-index/src/watcher.rs:95` relativized every host event with one lexical comparison against the root as bound:

```rust
let Ok(rel_path) = p.strip_prefix(root) else {
    return false;
};
```

A failure returned `false`, filtering the path out with no log, no counter and no error. macOS FSEvents resolves every symbolic link above a watched directory before it reports, so the comparison could never succeed for a root bound through one.

The daemon's own conversion would have placed the path correctly. `repo_path` at `crates/kin-daemon/src/loop_runner.rs:274` already canonicalized both sides through `canonicalize_host_parent_preserving_leaf` and already rejected a directory-symlink escape. It simply never ran, because the event ended in the watcher.

Evidence from a raw `notify` capture: a watch registered on `/var/folders/.../link` reported `/private/var/folders/.../real/raw_probe.rs`. Both hops resolved. A `FileWatcher` bound to that root produced zero events in ten seconds.

## Fix

`RepositoryRoots` holds the root as bound and its resolved form, tries each lexically, then resolves the event path once and asks again. Both forms are needed: binding only the resolved one loses every event on Linux inotify, which echoes the path it was handed, and binding only the given one loses every event on macOS. Windows canonicalization adds a `\\?\` verbatim prefix that no event carries, which is the same problem a third time. `canonical_path` in `crates/kin-cli/src/commands/mcp.rs:673` and `canonical_health_repo` in `crates/kin-cli/src/commands/health.rs:1590` already exist for this hazard; the watcher was the surface that never got it.

An event genuinely outside the root is now counted and named rather than discarded. The first warns with both spellings, the rest are counted, and the reconcile loop reports a rise through `ReconcileProbes::record_event_skipped`. Because `skipped_events > 0` already produces a degraded reason in `ReconcileHealth::degraded_reasons`, a daemon that is seeing nothing stops reporting itself healthy on `/health` and on `kin graph status`.

`canonicalize_host_parent_preserving_leaf` moves from kin-daemon to `crates/kin-index/src/repository.rs`, so the watcher and the admission path decide containment by one rule. kin-index is already a declared ingestion boundary, so the kin-daemon allowlist entry retires.

## What this deliberately does not do

The ticket asked for bind-time canonicalization at every bind site. I implemented it in the daemon entrypoint, proved it redundant, and removed it. It is not sufficient alone, since the two backends disagree about which form they report, so containment has to accept both regardless. And it is not necessary once containment accepts both: with the bind-time change reverted and the daemon's watcher root logged as the unresolved `/var/folders/.../linked-repo`, the end-to-end fixture passed in 4.70s. Keeping it would have required a new exemption in `scripts/verify-zero-file-search.py`, which flagged the line. `crates/kin-daemon/src/bin/kin-daemon.rs` is unmodified.

The `repo.canonicalize()` workaround in `crates/kin-cli/tests/live_graph_durability_disclosure.rs` stays. Removing it failed that fixture three times out of three; restoring it passed two of two. The failure is not the symlink path: the fixture gets past its ambient-admission assertion, so the write is admitted through the unresolved root, and then fails on a transient `selected-graph embedding coverage is changing` response. That fixture does not disable background embedding, while the new fixture here binds an equally unresolved root with `KIN_DAEMON_AUTO_EMBED=0` and is reliably green. This change moves that fixture's failure from "never admits" to "admits, then races", which is a different defect and is not claimed as fixed.

## Falsification

Reverting the containment change, exit code 101:

```
test classify_places_an_event_reported_under_a_symlinked_spelling_of_the_root ... FAILED
test classify_places_an_event_the_backend_reported_under_the_resolved_root ... FAILED
test a_watcher_bound_through_a_symlinked_root_reports_writes_through_it ... FAILED

assertion `left == right` failed: the resolved form names a repository file
  left: 0
 right: 1

a write through the symlinked root /var/folders/.../.tmpyxCoh7/link produced no event in 30s;
the watcher placed 2 event(s) outside the root it is bound to
(most recent Some("/private/var/folders/.../.tmpyxCoh7/real/added.rs"))

test result: FAILED. 5 passed; 3 failed
```

Removing only the recording so the drop is silent again, exit code 101:

```
assertion `left == right` failed: the drop is counted
  left: 0
 right: 1
```

End-to-end fixture with the fix reverted, exit code 101:

```
a file written through the symlinked repository root /var/folders/.../.tmpwW30hL/linked-repo
was never admitted: the live query graph held 1 entities before the write and 1 after 60s.
The repository resolves to /private/var/folders/.../.tmpwW30hL/real-repo, and a watcher that
cannot place its own events reports nothing at all
```

The first attempt at that last falsification was invalid and read as a pass. `fresh_daemon_bin` reuses the existing `kin-daemon` binary while its build stamp matches, and `cargo test -p kin-cli` never rebuilds another package's binary, so the reverted run exercised a daemon built from the fixed source. The daemon's own log gave it away, reporting `started file watcher root=/private/var/.../real-repo` under source that no longer resolved anything. Every falsification after that rebuilt the daemon binary first.

## Gates

`cargo fmt --all -- --check` clean. `cargo clippy --all-targets --all-features` with the ci.yml allowlist under `RUSTFLAGS=-D warnings` exit 0. `scripts/verify-zero-file-search.py` PASSED over 176 files, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh` and `scripts/verify-hydration-semantics.py` all passed.

Local gate on the lane worktree, `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/symlinkroot-kin @ 1d948a19 (chore/lane-symlinkroot-kin)`:

```
Summary [ 406.197s] 6386 tests run: 6386 passed (3 slow, 3 leaky), 12 skipped
```

An earlier run of the same gate reported one failure, `live_graph_durability_disclosure` timing out at its 60 second ambient-admission bound while other lanes saturated the box. It passes in isolation on this branch and passed in the full green run above; this change is inert on its path, since it binds an already-canonical root where the first lexical comparison matches exactly as before and adds no filesystem call.

Not claiming: no Linux or Windows execution. Both are covered by the containment rule and by tests that run on this host, and neither was run.

Closes FIR-2442
