### PR TITLE
Pin kin-vfs-core 0.4.6 so the release ships the ProjFS write path

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -184,7 +184,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+          ref: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -640,7 +640,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+          EXPECTED_VFS_COMMIT: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,7 +468,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+          ref: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -1088,7 +1088,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+          EXPECTED_VFS_COMMIT: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1376,7 +1376,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+          ref: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1444,7 +1444,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+          EXPECTED_VFS_COMMIT: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1806,7 +1806,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
+      expected_vfs_commit: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
     permissions:
       contents: read
       attestations: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.4.5"
+version = "0.4.6"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9850523f9705b3399768158261e58e22e7c3ff5f88bb7e648ceec4b17b962689"
+checksum = "7f82f2985f00428a2ec1c115cd74cade89785e70565e56407388755e4b104cdf"
 dependencies = [
  "lru",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ kin-lsp = { version = "0.6.5", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "=0.7.35", registry = "kin", default-features = false }
-kin-vfs-core = { version = "=0.4.5", registry = "kin" }
+kin-vfs-core = { version = "=0.4.6", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -12586,7 +12586,7 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 3df11fcbbb541e4b0ee98d6da50ccae1063abe66",
+        "expected_vfs_commit: 2596a4477cfb0b389d9c52026cf9da8f7ff40138",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 


### PR DESCRIPTION
## What moved and why

kin#932 shipped the Windows ProjFS projection and kin#942 pinned the release to kin-vfs `3df11fcb`, which carries `kin-vfs-core` 0.4.5. On that commit the ProjFS write path posts to a daemon route that no longer exists, so a release cut from that pin would ship a projection whose writes cannot reach graph truth. That is the defect FIR-2440 names, and it is why this is release-gating for the Windows half.

kin-vfs#112 fixed it and landed as squash `2596a4477cfb0b389d9c52026cf9da8f7ff40138`, "Carry a ProjFS write across the VFS protocol into graph truth". Its workspace version is 0.4.6 and Registry Publish shipped `kin-vfs-core` 0.4.6 to the kin sparse registry.

This moves the exact pin and the release checkout together, so the release builds the shipped kin-vfs from the same commit its lock resolves.

## Both version reads, and how each was read

Both read 0.4.6.

Kin's side, parsed out of this branch's `Cargo.lock`:

```
version = 0.4.6
source  = sparse+https://kinlab.ai/registry/cargo/
checksum= 7f82f2985f00428a2ec1c115cd74cade89785e70565e56407388755e4b104cdf
```

The pinned kin-vfs checkout, read with `git show 2596a4477cfb0b389d9c52026cf9da8f7ff40138:Cargo.lock`, carries `kin-vfs-core` at `version = 0.4.6` with no source, which is the local workspace member release.yml actually compares against. Its workspace `Cargo.toml:23`, read with `git show 2596a447:Cargo.toml`, also reads `version = "0.4.6"`. `2596a447` was confirmed an ancestor of kin-vfs `origin/main` with `git merge-base --is-ancestor` after a fetch.

The lock checksum is the one the registry index serves: `curl -s https://kinlab.ai/registry/cargo/ki/n-/kin-vfs-core` returns `"vers":"0.4.6"`, `"cksum":"7f82f2985f00428a2ec1c115cd74cade89785e70565e56407388755e4b104cdf"`, `"yanked":false`.

## All five pin sites move, plus the test literal

`scripts/check-kin-vfs-compat.mjs` reads the kin-vfs pin out of every site in release.yml and refuses when they disagree, because a half-updated pin builds one commit and proves another:

- `.github/workflows/release.yml:471`, build-matrix checkout ref
- `.github/workflows/release.yml:1091`, per-artifact provenance manifest expected commit
- `.github/workflows/release.yml:1379`, publish job provenance-source checkout ref
- `.github/workflows/release.yml:1447`, aggregate provenance check
- `.github/workflows/release.yml:1809`, install-proof reusable workflow input
- `scripts/test-release-workflow-authority.py:12578`, asserts the install-proof input by literal text

Sweeping the tree for the old sha `3df11fcb` returns nothing, with the positive control on `2596a447` returning all six sites. A sweep for `0.4.5` was also read rather than blanket-replaced: every remaining hit is kin's own historical release version in `CHANGELOG.md`, the Homebrew Cellar fixtures in `crates/kin-notify/src/lib.rs`, `scripts/abandoned-release-tags.json` and the release-notes tests. None is the kin-vfs-core pin.

## The lock diff is one entry

`git diff origin/main...HEAD -- Cargo.lock` is 2 insertions and 2 deletions, the version and the checksum. The entry keeps its `sparse+` source and a checksum, so nothing is path-patched. `git ls-tree -r HEAD --name-only` shows exactly one tracked `.cargo/` file.

As on the 0.4.5 move, `cargo update -p kin-vfs-core` also tried to drag `winapi-util 0.1.11` from `windows-sys 0.61.2` down to `0.48.0`. That is the pre-existing invalid edge in main, since `winapi-util 0.1.11` requires `windows-sys` at `>=0.48.0, <=0.61` and `0.61.2` does not satisfy it, so cargo repairs it on every re-resolve. It is excluded here too, and the minimal lock is accepted by `cargo metadata --locked`.

## Source impact

0.4.6 is additive over 0.4.5 and touches only `crates/kin-vfs-core/src/protocol.rs`. `Write`, `Remove` and `Rename` are appended at the end of the request enum so a v4 peer still decodes every frame a v4 peer sends, `VFS_PROTOCOL_VERSION` moves from 4 to 5, and `MAX_FRAME_BYTES` plus `MAX_PROJECTION_WRITE` are added. There are no changes to `lib.rs` exports.

Nothing in kin needed adapting, and this was verified rather than assumed: a full `cargo check --all-targets --locked` against 0.4.6 exits 0 with zero errors. kin declares the crate at `crates/kin-cli/Cargo.toml:52` but no kin source imports it, the only `use kin_vfs_core` in the tree being inside a string literal in a test fixture at `crates/kin-core/src/dependencies.rs:1319`. No source file is touched by this PR.

## Gates

Run from the lane worktree through `bin/kin-lane run`, which uses the tracked `[registries.kin]` config and applies no patches, so the registry resolution this PR changes is the one under test. The build log carries `Checking kin-vfs-core v0.4.6 (registry \`kin\`)`.

- `cargo nextest run --workspace --locked --no-fail-fast`: `Summary [440.570s] 6369 tests run: 6369 passed (4 slow, 2 leaky), 12 skipped`, exit 0, no FAIL lines.
- `cargo test --doc --locked`: exit 0.
- `cargo check --all-targets --locked` under `RUSTFLAGS=-D warnings`: exit 0, zero errors.
- Clippy exactly as ci.yml runs it, all 95 arguments, under `RUSTFLAGS=-D warnings`: exit 0, zero errors.
- `cargo fmt --all -- --check` and `cargo fmt -- --check`: both exit 0.
- `python3 scripts/verify-zero-file-search.py`: PASSED, 176 source files scanned.
- `bash scripts/zero_file_search_guard.sh`: passed.
- `bash scripts/check_runtime_boundaries.sh`: passed.
- `bash scripts/check_private_repo_coupling.sh` and `python3 scripts/test-private-repo-coupling.py`: passed, 4 guard tests.
- `python3 scripts/test-release-workflow-authority.py`: exit 0.
- `node --test` over the six release policy suites: 80 pass, 0 fail.

`bin/kin-dev local-test` was deliberately not used. It generates `kin-vfs-core = { path = ... }`, so it resolves the crate by path and would pass whatever version this PR wrote.

## Replicating the release assertion locally

```
Verified Kin/kin-vfs compatibility at kin-vfs-core 0.4.6 (pinned kin-vfs 2596a4477cfb0b389d9c52026cf9da8f7ff40138)
```

Falsified once to prove it fires. Leaving line 1809 on the old sha gives exit 1:

```
::error::release.yml records disagreeing firelock-ai/kin-vfs pins: 2596a4477cfb0b389d9c52026cf9da8f7ff40138
(expected_vfs_commit, firelock-ai/kin-vfs checkout ref) and 3df11fcbbb541e4b0ee98d6da50ccae1063abe66
(expected_vfs_commit); the release would build one commit and prove another
```

Restored, exit 0.

## Why 0.4.6 and not 0.4.7

The registry already serves `kin-vfs-core` 0.4.7, not yanked. It is deliberately not pinned here, because it currently cannot be proven. Sweeping every kin-vfs ref for workspace version 0.4.7 returns exactly one, `origin/automation/kin-registry-dependency-wave`, an unmerged automation branch. kin-vfs main's tip reads 0.4.6, every other branch reads 0.4.6, and tags stop at v0.4.6. Since the release assertion requires a release.yml ref whose checkout's workspace version equals what Kin resolves, and no commit on kin-vfs main carries 0.4.7, pinning it today would fail the gate. 0.4.6 at `2596a447` is the version that is both published and reachable on main.

## Tickets

Referenced, not closed. FIR-2440 records that ProjFS write-through posts to a daemon route that no longer exists; this PR carries the fix into kin's release inputs, but the ticket's acceptance includes the shipped chain, so it stays open here.

## Not claiming

The release workflow was not run. The compatibility assertion was replicated locally against the real pinned kin-vfs `Cargo.lock`; it was not observed in a release run. No Windows hardware was exercised, no ProjFS mount was mounted, and no write was carried end to end on Windows. The `winapi-util` lock edge is reported, not fixed.
