### PR TITLE
Bind a receiver-method call only to an owner its file names

### DIFF
--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -202,8 +202,17 @@ pub fn build_refs_response(
         return Ok(RefsResponse { lines });
     }
 
-    lines.push(format!("referenced by {} entities:", refs.len()));
-    for entry in refs {
+    // FIR-1552. A receiver-method call the linker matched on the bare leaf name
+    // is a candidate, not a caller: nothing at the reference site says the
+    // receiver holds this type. Counting them beside real callers is what let
+    // `find_references(HTTPAdapter.send)` answer 33 for a method two lines call.
+    // The headline counts callers; the candidates get their own heading and
+    // their own count.
+    let (resolved, candidates): (Vec<ReferenceEntry>, Vec<ReferenceEntry>) = refs
+        .into_iter()
+        .partition(|entry| !entry.receiver_name_guess);
+
+    let render = |lines: &mut Vec<String>, entry: &ReferenceEntry| {
         let file_path = entry
             .file_path
             .as_deref()
@@ -220,6 +229,30 @@ pub fn build_refs_response(
             relation_kinds_label(&entry.relation_kinds),
             entry.resolution.as_str()
         ));
+    };
+
+    if resolved.is_empty() {
+        lines.push(format!(
+            "No resolved incoming {} relations.",
+            relation_kinds_label(&relation_kinds)
+        ));
+    } else {
+        lines.push(format!("referenced by {} entities:", resolved.len()));
+        for entry in &resolved {
+            render(&mut lines, entry);
+        }
+    }
+
+    if !candidates.is_empty() {
+        lines.push(format!(
+            "{} receiver-name candidate{} not counted above; each is a call through a \
+             receiver whose type nothing at the reference site settles:",
+            candidates.len(),
+            if candidates.len() == 1 { "" } else { "s" }
+        ));
+        for entry in &candidates {
+            render(&mut lines, entry);
+        }
     }
 
     Ok(RefsResponse { lines })
@@ -417,13 +450,24 @@ pub fn build_bulk_refs_response(
         // human-readable command could actually enumerate. Keep one grouping
         // authority for both paths so the count cannot drift again.
         let collected = collect_graph_references(graph, &entity_id, &relation_kinds)?;
-        let reference_count = collected.references.len();
         let matched_kinds = collected.matched_kinds;
+        // Same split the human-readable surface prints, for the same reason
+        // (FIR-1552): a bare-leaf receiver-method match is not evidence of use.
+        // Reporting the total here while `kin refs` reported the caller count
+        // would put two numbers for one target on two surfaces that share a
+        // collector precisely so they cannot drift.
+        let (resolved, receiver_name): (Vec<_>, Vec<_>) = collected
+            .references
+            .iter()
+            .partition(|entry| !entry.receiver_name_guess);
+        let reference_count = resolved.len();
+        let receiver_name_candidate_count = receiver_name.len();
 
         if !collected.missing_source_ids.is_empty() {
             incomplete_verdict_count += 1;
             let missing_source_count = collected.missing_source_ids.len();
-            let known_reference_count = reference_count + missing_source_count;
+            let known_reference_count =
+                reference_count + receiver_name_candidate_count + missing_source_count;
             let mut row = serde_json::json!({
                 "entity_id": entity_id.to_string(),
                 "has_references": null,
@@ -462,6 +506,7 @@ pub fn build_bulk_refs_response(
                 "entity_id": entity_id.to_string(),
                 "has_references": has_references,
                 "reference_count": reference_count,
+                "receiver_name_candidate_count": receiver_name_candidate_count,
             }));
         } else {
             results.push(serde_json::json!({
@@ -471,6 +516,7 @@ pub fn build_bulk_refs_response(
                 "file_path": entity.file_origin.as_ref().map(|p| p.0.clone()),
                 "has_references": has_references,
                 "reference_count": reference_count,
+                "receiver_name_candidate_count": receiver_name_candidate_count,
                 "matched_kinds": matched_kinds
                     .into_iter()
                     .map(relation_kind_label)
@@ -562,6 +608,12 @@ pub(crate) struct ReferenceEntry {
     /// is a same-name match with nothing at the reference site proving it, so
     /// dead-code reads this to decide whether the row is evidence of use.
     pub(crate) resolution: RelationResolution,
+    /// Whether EVERY edge behind this row is a receiver-method call matched on
+    /// the bare leaf name. `resolution` reports the strongest contributing edge
+    /// and cannot answer this: `name_only` also covers an exact-name match with
+    /// one candidate, which is an ordinary cross-file call. Only the receiver
+    /// fan-out is a candidate rather than a reference (FIR-1552).
+    pub(crate) receiver_name_guess: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -624,6 +676,7 @@ pub(crate) fn collect_graph_references(
     let allowed: std::collections::HashSet<_> = relation_kinds.iter().copied().collect();
     let mut grouped: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
     let mut resolutions: HashMap<EntityId, RelationResolution> = HashMap::new();
+    let mut receiver_name_guesses: HashMap<EntityId, bool> = HashMap::new();
     let mut matched_kinds = Vec::new();
 
     for rel in graph.get_all_relations_for_entity(entity_id)? {
@@ -648,6 +701,12 @@ pub(crate) fn collect_graph_references(
             .entry(src_entity_id)
             .and_modify(|current| *current = (*current).max(resolution))
             .or_insert(resolution);
+        // Every contributing edge has to be a guess for the row to be one.
+        let guess = kin_index::resolution::is_receiver_name_guess(&rel);
+        receiver_name_guesses
+            .entry(src_entity_id)
+            .and_modify(|current| *current &= guess)
+            .or_insert(guess);
     }
 
     let mut references = Vec::with_capacity(grouped.len());
@@ -668,6 +727,10 @@ pub(crate) fn collect_graph_references(
                 .get(&source_id)
                 .copied()
                 .unwrap_or(RelationResolution::NameOnly),
+            receiver_name_guess: receiver_name_guesses
+                .get(&source_id)
+                .copied()
+                .unwrap_or(false),
         });
     }
     missing_source_ids.sort();
@@ -730,6 +793,94 @@ mod tests {
         refs_not_found_guidance, BulkRefsRequest, BulkRefsResponse, RefsRequest,
     };
     use kin_model::RelationKind;
+
+    /// FIR-1552. The bulk row and the printed answer read one collector so their
+    /// numbers cannot drift, and a bare-leaf receiver-method match is not
+    /// evidence of use on either. Two real callers and three receiver-name
+    /// candidates give a row of `reference_count: 2` beside
+    /// `receiver_name_candidate_count: 3`, never a single `5`.
+    #[test]
+    fn bulk_refs_counts_resolved_callers_and_names_the_candidates_apart() {
+        use kin_db::InMemoryGraph;
+        use kin_model::relation::{Relation, RelationOrigin};
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, SemanticFingerprint,
+            Visibility,
+        };
+
+        fn entity(name: &str, rel_path: &str) -> Entity {
+            Entity {
+                id: EntityId::new(),
+                kind: EntityKind::Function,
+                name: name.to_string(),
+                language: LanguageId::Rust,
+                fingerprint: SemanticFingerprint {
+                    algorithm: FingerprintAlgorithm::V1TreeSitter,
+                    ast_hash: Hash256::from_bytes([0; 32]),
+                    signature_hash: Hash256::from_bytes([0; 32]),
+                    behavior_hash: Hash256::from_bytes([0; 32]),
+                    equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
+                    stability_score: 1.0,
+                },
+                file_origin: Some(FilePathId::new(rel_path)),
+                span: None,
+                signature: name.to_string(),
+                visibility: Visibility::Public,
+                role: EntityRole::Source,
+                doc_summary: None,
+                metadata: EntityMetadata::default(),
+                lineage_parent: None,
+                created_in: None,
+                superseded_by: None,
+            }
+        }
+
+        let graph = InMemoryGraph::new();
+        let target = entity("send", "src/adapters.rs");
+        graph.upsert_entity(&target).unwrap();
+        // Two parser-certain callers and three receiver-method guesses, so the
+        // fixture cannot pass on numbers that happen to coincide.
+        for (index, name) in ["proven_a", "proven_b", "guess_a", "guess_b", "guess_c"]
+            .iter()
+            .enumerate()
+        {
+            let caller = entity(name, "src/callers.rs");
+            graph.upsert_entity(&caller).unwrap();
+            graph
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(caller.id),
+                    dst: GraphNodeId::Entity(target.id),
+                    confidence: if index < 2 {
+                        1.0
+                    } else {
+                        kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE
+                    },
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        let response = build_bulk_refs_response(
+            &graph,
+            &BulkRefsRequest {
+                entity_ids: vec![target.id.to_string()],
+                kind: "calls".to_string(),
+                compact: true,
+            },
+        )
+        .unwrap();
+        let row = &response.results[0];
+        assert_eq!(row["reference_count"], 2, "{row}");
+        assert_eq!(row["receiver_name_candidate_count"], 3, "{row}");
+        assert_eq!(row["has_references"], true, "{row}");
+        assert_eq!(response.with_references, 1);
+    }
 
     /// `kin refs` must answer only from graph-owned relation edges. A reference
     /// that exists in the working tree but is not linked into the graph must

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -445,7 +445,7 @@ enum Command {
         /// Comma-separated entity UUIDs for --bulk-json. Required when --bulk-json is set.
         #[arg(long)]
         entities: Option<String>,
-        /// If true (default) emit compact bulk-mode rows ({entity_id, has_references, reference_count}).
+        /// If true (default) emit compact bulk-mode rows ({entity_id, has_references, reference_count, receiver_name_candidate_count}).
         /// Set --no-compact for verbose rows with name/kind/file_path/matched_kinds.
         #[arg(long, default_value_t = true)]
         compact: bool,

--- a/crates/kin-cli/src/output_style.rs
+++ b/crates/kin-cli/src/output_style.rs
@@ -318,8 +318,16 @@ mod tests {
             graph.upsert_entity(record).unwrap();
         }
         // Two confidences, so the rows carry two different resolution markers
-        // and a painter that assumed one value would be caught.
-        for (caller, confidence) in [(&spanned, 1.0), (&spanless, 0.5)] {
+        // and a painter that assumed one value would be caught. The weaker one
+        // is the receiver-method fan-out tier, which is what puts its row under
+        // the candidate heading.
+        for (caller, confidence) in [
+            (&spanned, 1.0f32),
+            (
+                &spanless,
+                kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+            ),
+        ] {
             graph
                 .upsert_relation(&Relation {
                     id: kin_model::ids::RelationId::new(),
@@ -360,11 +368,20 @@ mod tests {
         );
         assert!(painted.contains(&format!("{DIM}(Function)")));
 
+        // One real caller and one receiver-name candidate, so the headline counts
+        // one and the candidate keeps its own heading (FIR-1552). Both rows are
+        // still rendered, which is what this test is about.
         let count = lines
             .iter()
             .find(|line| line.starts_with("referenced by "))
             .unwrap_or_else(|| panic!("no count line in {lines:?}"));
-        assert_painted(&paint_refs(count), count, &format!("{ACCENT_BOLD}2"));
+        assert_painted(&paint_refs(count), count, &format!("{ACCENT_BOLD}1"));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.starts_with("1 receiver-name candidate ")),
+            "the withheld candidate must be named under its own heading: {lines:?}"
+        );
 
         let rows: Vec<&str> = lines
             .iter()

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -24,6 +24,7 @@ use kin_parser::{
 };
 
 use crate::error::{IndexError, Result as IndexResult};
+use crate::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE;
 
 /// Graph-assigned artifact identities keyed by repository-relative path.
 ///
@@ -1160,10 +1161,17 @@ fn resolve_one_file(
                         }
                     },
                 );
-                let targets = caller_import_targets.get_or_insert_with(|| {
-                    resolve_caller_import_targets(&file.file_path, &file.imports, &ctx.known_files)
-                });
-                narrow_pairs_by_receiver_reach(candidates, targets, &owner_bound)
+                let settled = settle_receiver_method_owner(candidates, &owner_bound);
+                if settled.is_empty() {
+                    debug!(
+                        src = %rel.src_name,
+                        dst = %rel.dst_name,
+                        file = %file.file_path,
+                        named_owners = owner_bound.values().collect::<HashSet<_>>().len(),
+                        "linker: receiver-method call names no single owner this file reaches, leaving unlinked"
+                    );
+                }
+                settled
             } else if is_python_bare_identifier_call(rel, src_id, &ctx.entity_language_by_id) {
                 // This tier exists for calls made through a receiver. A bare
                 // Python identifier has none, so no method here is a dispatch
@@ -1193,7 +1201,7 @@ fn resolve_one_file(
                     accumulate_relation(
                         &mut resolved,
                         &mut relation_indices,
-                        make_relation(rel, src_id, dst_id, 0.3),
+                        make_relation(rel, src_id, dst_id, RECEIVER_NAME_FANOUT_CONFIDENCE),
                     );
                     linked = true;
                 }
@@ -3018,7 +3026,7 @@ fn narrow_pairs_by_role<'a>(
 }
 
 /// The receiver-method candidates whose owning type the calling file binds by
-/// name.
+/// name, each mapped back to the local name that bound it.
 ///
 /// A method entity is keyed `Owner.method` or `Owner::method`, so a file's
 /// import bindings name candidate owners directly: for each local name an
@@ -3026,52 +3034,73 @@ fn narrow_pairs_by_role<'a>(
 /// select exactly the methods that name's type defines. `named_ids` is the
 /// caller's exact-name index, consulted once per import binding rather than
 /// once per candidate.
-fn owner_bound_targets(
+///
+/// The owner travels with each id because the number of DISTINCT owners is what
+/// decides whether the call has a destination at all: one owner is a
+/// destination the file named, several is a choice nothing at the call site
+/// makes.
+fn owner_bound_targets<'a>(
     leaf: &str,
-    file_imports: Option<&HashMap<&str, (&str, &str)>>,
-    mut named_ids: impl FnMut(&str, &mut HashSet<EntityId>),
-) -> HashSet<EntityId> {
-    let mut bound = HashSet::new();
+    file_imports: Option<&HashMap<&'a str, (&'a str, &'a str)>>,
+    mut named_ids: impl FnMut(&str, &mut Vec<EntityId>),
+) -> HashMap<EntityId, &'a str> {
+    let mut bound = HashMap::new();
     let Some(file_imports) = file_imports else {
         return bound;
     };
     for local_name in file_imports.keys() {
+        let mut ids = Vec::new();
         for key in receiver_method_keys(local_name, leaf) {
-            named_ids(&key, &mut bound);
+            named_ids(&key, &mut ids);
+        }
+        for id in ids {
+            bound.insert(id, *local_name);
         }
     }
     bound
 }
 
-/// Narrow a receiver-method fan-out to the candidates the calling file can
-/// reach.
+/// Settle a receiver-method call against the owners the calling file names.
 ///
-/// A call through an object dispatches on the receiver's static type, and a
-/// file that neither binds that type by name nor imports the module defining it
-/// cannot be holding one. Such a candidate is a same-named method of a type
-/// this file never sees, so it is not a dispatch target here however many other
-/// files do reach it.
+/// A call through an object dispatches on the receiver's static type, and the
+/// only types a file can be holding one of are the ones it names: a class it
+/// imports by name, or one it defines. A same-named method on a type this file
+/// never sees is not a dispatch target here however many other files reach it.
 ///
-/// Narrowing happens only when at least one candidate IS reached. A file whose
-/// imports account for none of them has no type evidence to narrow on, so it
-/// fans out exactly as before rather than losing every candidate to a rule that
-/// could not see any of them.
-fn narrow_pairs_by_receiver_reach<'a>(
+/// So exactly two shapes bind. Exactly one named owner carries the leaf, and
+/// its methods are the destination. Anything else binds nothing: no named owner
+/// carries it, so the call has no destination this file can reach; or several
+/// do, and choosing among them is a guess with nothing at the call site behind
+/// it. This is FIR-1552's rule, and it is the one kin#906 applied to bare
+/// Python builtins and kin#923 to bare Rust calls, applied to the shape that
+/// produced the most edges: `find_references(HTTPAdapter.send)` on psf/requests
+/// answered 33 where two lines call it, and every one of the 33 came through
+/// this tier.
+///
+/// The earlier rule fanned out to every candidate when the file's imports
+/// accounted for none of them, on the reasoning that a rule which cannot see
+/// any candidate should not drop them all. That is the fail-open that minted
+/// ten of those 33: a `sock.send(...)` in a test file that imports nothing
+/// defining `send` reached the HTTP adapter, the session, and every other
+/// `send` in the repository. A rule that cannot see the receiver's type does
+/// not thereby know the answer is all of them.
+fn settle_receiver_method_owner<'a>(
     candidates: Vec<(&'a str, EntityId)>,
-    import_target_files: &HashSet<String>,
-    owner_bound: &HashSet<EntityId>,
+    owner_bound: &HashMap<EntityId, &str>,
 ) -> Vec<(&'a str, EntityId)> {
-    let reached: Vec<(&str, EntityId)> = candidates
-        .iter()
-        .copied()
-        .filter(|(file_path, id)| {
-            import_target_files.contains(*file_path) || owner_bound.contains(id)
-        })
+    let reached: Vec<(&'a str, EntityId)> = candidates
+        .into_iter()
+        .filter(|(_, id)| owner_bound.contains_key(id))
         .collect();
-    if reached.is_empty() {
-        return candidates;
+    let owners: HashSet<&str> = reached
+        .iter()
+        .filter_map(|(_, id)| owner_bound.get(id).copied())
+        .collect();
+    if owners.len() == 1 {
+        reached
+    } else {
+        Vec::new()
     }
-    reached
 }
 
 /// Confidence for a call through a receiver the file's own imports bind to a
@@ -4273,7 +4302,7 @@ pub struct IncrementalLinkerCheckpointV1 {
 }
 
 /// Bump whenever [`IncrementalLinkerCheckpointV1`] or linker semantics change.
-pub const INCREMENTAL_LINKER_CHECKPOINT_VERSION: u32 = 5;
+pub const INCREMENTAL_LINKER_CHECKPOINT_VERSION: u32 = 6;
 
 /// Build-time kin-index identity included in the composite hydration
 /// checkpoint version key.
@@ -5275,14 +5304,17 @@ fn resolve_one_file_incremental(
                             }
                         },
                     );
-                    let targets = caller_import_targets.get_or_insert_with(|| {
-                        resolve_caller_import_targets(
-                            &file.file_path,
-                            &file.imports,
-                            &linker.known_files,
-                        )
-                    });
-                    narrow_pairs_by_receiver_reach(candidates, targets, &owner_bound)
+                    let settled = settle_receiver_method_owner(candidates, &owner_bound);
+                    if settled.is_empty() {
+                        debug!(
+                            src = %rel.src_name,
+                            dst = %rel.dst_name,
+                            file = %file.file_path,
+                            named_owners = owner_bound.values().collect::<HashSet<_>>().len(),
+                            "linker(incremental): receiver-method call names no single owner this file reaches, leaving unlinked"
+                        );
+                    }
+                    settled
                 } else if is_python_bare_identifier_call(rel, src_id, &linker.entity_language_by_id)
                 {
                     // A bare Python identifier carries no receiver, and this
@@ -5312,7 +5344,7 @@ fn resolve_one_file_incremental(
                         accumulate_relation(
                             &mut resolved,
                             &mut relation_indices,
-                            make_relation(rel, src_id, dst_id, 0.3),
+                            make_relation(rel, src_id, dst_id, RECEIVER_NAME_FANOUT_CONFIDENCE),
                         );
                     }
                     continue;
@@ -10565,7 +10597,11 @@ void f();
                 file_path: "src/service.py".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![py_receiver_call("Service.persist", "store", "save")],
-                imports: vec![],
+                // The import the real shape carries: a file calling
+                // `store.save(...)` is a file that named `Store`. Without it the
+                // receiver has no owner this file reaches and FIR-1552 leaves
+                // the call unresolved before role can tie-break anything.
+                imports: vec![import_of(".store", "Store")],
             },
         ];
 
@@ -10618,7 +10654,11 @@ void f();
                 file_path: "src/requests/sessions.py".to_string(),
                 entities: vec![session_send.clone(), mixin_send.clone()],
                 relations: vec![py_receiver_call("Session.send", "adapter", "send")],
-                imports: vec![],
+                // `from .adapters import HTTPAdapter`, which the real
+                // `sessions.py` carries at its head. It is what makes the
+                // adapter an owner this file names, and under FIR-1552 that
+                // binding is the whole reason the call has a destination.
+                imports: vec![import_of(".adapters", "HTTPAdapter")],
             },
             FileParseData {
                 file_path: "tests/test_requests.py".to_string(),
@@ -10646,12 +10686,16 @@ void f();
         assert_eq!(edges[0].dst, GraphNodeId::Entity(adapter_send.id));
     }
 
-    /// Rule 2's other half: where the ambiguity is real, the candidates are
-    /// still emitted so recall does not drop, but every one of them is marked
-    /// `name_only` so a reader can tell a guess from a fact. `req.copy()` in
-    /// psf/requests fans out to three same-named methods on unrelated types.
+    /// FIR-1552. Rule 2's other half used to emit every candidate and mark them
+    /// `name_only`, on the reasoning that a marked guess costs nothing. It cost
+    /// the headline: `find_references(HTTPAdapter.send)` on psf/requests
+    /// answered 33 where `git grep` finds two call sites, and all 33 rows were
+    /// `name_only`, so the per-row marker could not separate the two true ones
+    /// from the 31 invented ones. `req.copy()` in `sessions.py` is the same
+    /// shape: three same-named methods on unrelated types, and nothing in the
+    /// file names any of them.
     #[test]
-    fn a_genuinely_ambiguous_receiver_emits_candidates_all_marked_name_only() {
+    fn a_receiver_the_file_names_no_owner_for_binds_nothing() {
         let prepared_copy = py_method(
             "PreparedRequest.copy",
             "src/requests/models.py",
@@ -10701,16 +10745,49 @@ void f();
         ];
 
         let result = link_cross_file(&files);
-        let edges = calls_edges_from(&result, &caller);
-        assert_eq!(edges.len(), 3, "a real ambiguity keeps every candidate");
-        for edge in &edges {
-            assert_eq!(
-                RelationResolution::of(edge),
-                RelationResolution::NameOnly,
-                "an unprovable candidate is published as a guess, not a fact"
-            );
-            assert!(!RelationResolution::of(edge).is_proven());
-        }
+        assert!(
+            calls_edges_from(&result, &caller).is_empty(),
+            "a receiver whose type the file names no candidate owner for has no \
+             destination, and three guesses are not one answer: {result:#?}"
+        );
+    }
+
+    /// The other half of the same rule. Naming one owner is a destination;
+    /// naming two is a choice, and nothing at `req.copy()` makes it. This is the
+    /// case the fan-out cap used to admit, which is how one call site became
+    /// eight inbound edges.
+    #[test]
+    fn a_receiver_matching_two_named_owners_binds_neither() {
+        let store_save = py_method("Store.save", "pkg/store.py", EntityRole::Source);
+        let cache_save = py_method("Cache.save", "pkg/cache.py", EntityRole::Source);
+        let caller = py_function("run", "pkg/app.py", EntityRole::Source);
+
+        let files = vec![
+            FileParseData {
+                file_path: "pkg/store.py".to_string(),
+                entities: vec![store_save.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "pkg/cache.py".to_string(),
+                entities: vec![cache_save.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "pkg/app.py".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![py_receiver_call("run", "target", "save")],
+                imports: vec![import_of(".store", "Store"), import_of(".cache", "Cache")],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        assert!(
+            calls_edges_from(&result, &caller).is_empty(),
+            "two named owners carry `save`, so `target.save()` names neither: {result:#?}"
+        );
     }
 
     /// The founding false edge, kept as a permanent guard:
@@ -10785,7 +10862,7 @@ void f();
                 py_receiver_call("Service.persist", "store", "save"),
                 py_receiver_call("Service.persist", "cfg", "get"),
             ],
-            imports: vec![],
+            imports: vec![import_of(".store", "Store")],
         }];
 
         let result = link_cross_file_incremental(&files, &linker);

--- a/crates/kin-index/src/resolution.rs
+++ b/crates/kin-index/src/resolution.rs
@@ -106,6 +106,35 @@ impl RelationResolution {
     }
 }
 
+/// Confidence the receiver-method fan-out tier persists.
+///
+/// The tier resolves `x.m(...)` where nothing settles the receiver's type, so
+/// its destination is the weakest thing the linker emits: a method that shares
+/// the leaf name. It is named here rather than written as a literal because
+/// [`is_receiver_name_guess`] recovers the tier from it, and a second copy of
+/// the number is how the two would come apart.
+pub const RECEIVER_NAME_FANOUT_CONFIDENCE: f32 = 0.3;
+
+/// Whether this edge is a receiver-method call the linker matched on the bare
+/// leaf name alone.
+///
+/// `name_only` covers four tiers, and they are not equally weak. A callee
+/// written `Error::msg` that matches exactly one entity in the repository is
+/// stamped `name_only` too, and demoting it would take ordinary cross-file
+/// calls out of every count that reads this. What FIR-1552 is about is
+/// narrower: the tier that answered `find_references(HTTPAdapter.send)` with 33
+/// rows for a method two lines call. This predicate names that tier and nothing
+/// else.
+///
+/// A language server or a hand-authored edge is proven whatever its confidence,
+/// matching [`RelationResolution::of`], so neither can be read as a guess here.
+pub fn is_receiver_name_guess(relation: &Relation) -> bool {
+    !matches!(
+        relation.origin,
+        RelationOrigin::Lsp | RelationOrigin::Manual
+    ) && relation.confidence.to_bits() == RECEIVER_NAME_FANOUT_CONFIDENCE.to_bits()
+}
+
 /// The linker's resolution tiers, as (persisted confidence, what that tier
 /// proved). Kept beside the enum so a new tier has one obvious place to
 /// declare what it proved, and tested in `linker.rs` against the constants the
@@ -128,7 +157,10 @@ pub const RESOLUTION_TIER_LADDER: &[(f32, RelationResolution)] = &[
     // A path-qualified callee reduced by dropping its module prefix.
     (0.6, RelationResolution::NameOnly),
     // Receiver-method fan-out: every same-named method in the repo.
-    (0.3, RelationResolution::NameOnly),
+    (
+        RECEIVER_NAME_FANOUT_CONFIDENCE,
+        RelationResolution::NameOnly,
+    ),
     // Cross-repo placeholder: the destination is not in this repo at all.
     (0.2, RelationResolution::NameOnly),
 ];
@@ -199,6 +231,38 @@ mod tests {
         assert!(!RelationResolution::NameOnly.is_proven());
         assert!(RelationResolution::ImportScoped.is_proven());
         assert!(RelationResolution::TypeResolved.is_proven());
+    }
+
+    #[test]
+    fn only_the_receiver_fanout_tier_reads_as_a_receiver_name_guess() {
+        assert!(is_receiver_name_guess(&relation(
+            RECEIVER_NAME_FANOUT_CONFIDENCE,
+            RelationOrigin::Inferred
+        )));
+        // The other three `name_only` tiers are not this one. An exact-name
+        // match with a single candidate in particular is an ordinary cross-file
+        // call, and counting it as a guess would empty every reference headline.
+        for confidence in [0.7, 0.6, 0.2] {
+            assert_eq!(
+                RelationResolution::of(&relation(confidence, RelationOrigin::Inferred)),
+                RelationResolution::NameOnly,
+                "tier {confidence} is name_only"
+            );
+            assert!(
+                !is_receiver_name_guess(&relation(confidence, RelationOrigin::Inferred)),
+                "but tier {confidence} is not the receiver fan-out"
+            );
+        }
+    }
+
+    #[test]
+    fn a_language_server_edge_is_never_a_receiver_name_guess() {
+        for origin in [RelationOrigin::Lsp, RelationOrigin::Manual] {
+            assert!(!is_receiver_name_guess(&relation(
+                RECEIVER_NAME_FANOUT_CONFIDENCE,
+                origin
+            )));
+        }
     }
 
     #[test]

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -485,11 +485,15 @@ fn receiver_call_does_not_reach_an_unimportable_owner() {
     );
 }
 
-/// A caller whose imports account for none of the candidates has no type
-/// evidence at all, and must keep the whole fan-out rather than lose every
-/// candidate to a rule that could not see any of them.
+/// FIR-1552 reverses this one. A caller whose imports account for none of the
+/// candidates used to keep the whole fan-out, on the reasoning that a rule which
+/// cannot see any candidate should not drop them all. That is the clause that
+/// minted ten of the 33 rows `find_references(HTTPAdapter.send)` returned on
+/// psf/requests: `sock.send(...)` in a test file importing nothing that defines
+/// `send` reached the HTTP adapter and every other `send` in the tree. Not
+/// seeing the receiver's type is not knowing the answer is all of them.
 #[test]
-fn receiver_call_with_no_import_evidence_still_fans_out() {
+fn receiver_call_with_no_import_evidence_binds_nothing() {
     let files = python_call_fixture(&[
         (
             "app/a.py",
@@ -507,15 +511,17 @@ fn receiver_call_with_no_import_evidence_still_fans_out() {
 
     let rels = link_cross_file(&files);
     assert!(
-        has_call(&rels, go, a_run) && has_call(&rels, go, b_run),
-        "a file naming no candidate owner keeps every dispatch target"
+        !has_call(&rels, go, a_run) && !has_call(&rels, go, b_run),
+        "a file naming no candidate owner reaches no dispatch target"
     );
 }
 
-/// A caller that CAN name both candidate owners is genuinely ambiguous, and the
-/// fan-out must stay ambiguous rather than pick one.
+/// The other half FIR-1552 reverses. A caller that can name both candidate
+/// owners is genuinely ambiguous, and used to emit both. Two guesses are not one
+/// answer, and every consumer that counted them counted twice, so the call stays
+/// unresolved and the gap shows up as a call site with no edge.
 #[test]
-fn receiver_call_naming_both_owners_keeps_both() {
+fn receiver_call_naming_both_owners_binds_neither() {
     let files = python_call_fixture(&[
         (
             "app/a.py",
@@ -536,7 +542,7 @@ fn receiver_call_naming_both_owners_keeps_both() {
 
     let rels = link_cross_file(&files);
     assert!(
-        has_call(&rels, go, a_run) && has_call(&rels, go, b_run),
-        "both owners are nameable here, so both stay dispatch candidates"
+        !has_call(&rels, go, a_run) && !has_call(&rels, go, b_run),
+        "two nameable owners settle nothing, so neither is bound"
     );
 }

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -716,13 +716,28 @@ fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
     // looked like, so the payload's own truncation flag outranks the class
     // verdict for this field.
     let truncated = payload.get("truncated").and_then(Value::as_bool) == Some(true);
+    // FIR-1552: same rule, other cause. An answer that held same-name candidates
+    // out of its headline reports a number some of those candidates may belong
+    // in, so the number is a floor and this object has to say so with the count
+    // beside it. Truncation is named first where both hold, because a walk that
+    // stopped early did not even see every candidate.
+    let withheld = payload
+        .get("counts")
+        .and_then(|counts| counts.get("receiver_name_candidates"))
+        .and_then(Value::as_u64)
+        .filter(|withheld| *withheld > 0);
     let mut counted = json!({
         "unit": unit,
         "reported": reported,
-        "exact": !truncated,
+        "exact": !truncated && withheld.is_none(),
     });
+    if let Some(withheld) = withheld {
+        counted["withheld_candidates"] = json!(withheld);
+    }
     if truncated {
         counted["floor_reason"] = json!("walk_truncated");
+    } else if withheld.is_some() {
+        counted["floor_reason"] = json!("receiver_name_candidates_withheld");
     }
     // The site numbers FIR-2398 added answer a narrower question than this
     // object does: whether every RETURNED row could be located at a line, not

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1081,6 +1081,17 @@ pub struct ReferenceRow {
     /// the strongest contributing edge is the row's evidence. `name_only` means
     /// the reference is a guess and should be confirmed before being acted on.
     pub resolution: Option<RelationResolution>,
+    /// Whether EVERY edge behind this row is a receiver-method call the linker
+    /// matched on the bare leaf name.
+    ///
+    /// `resolution` cannot answer this. It reports the strongest contributing
+    /// edge, and `name_only` covers four tiers of very different strength: a
+    /// callee written `Error::msg` matching one entity in the repository lands
+    /// there beside the receiver fan-out that answered
+    /// `find_references(HTTPAdapter.send)` with 33 rows. Only the fan-out is a
+    /// candidate rather than a reference (FIR-1552), and only a row with no
+    /// other kind of edge behind it is one.
+    pub receiver_name_guess: bool,
 }
 
 /// Why a reference row carries no site lines.
@@ -1200,6 +1211,9 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
                 snippet,
                 relation_kinds: Vec::new(),
                 resolution: None,
+                // Every contributing edge has to be a guess for the row to be
+                // one, so this starts true and any other edge clears it.
+                receiver_name_guess: true,
             });
         if entry.file_path.is_none() {
             entry.file_path = file_path;
@@ -1226,6 +1240,7 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
             Some(current) => current.max(resolution),
             None => resolution,
         });
+        entry.receiver_name_guess &= kin_index::resolution::is_receiver_name_guess(&rel);
     }
 
     let mut rows = Vec::with_capacity(grouped.len());

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1120,8 +1120,11 @@ fn spine_reference_rows(
             // the source relation was Calls/Imports/References.
             relation_kinds: Vec::new(),
             // The resolving edge lives in the other repository's graph, so how
-            // it was resolved is not knowable here. Absent, not guessed.
+            // it was resolved is not knowable here. Absent, not guessed. For
+            // the same reason it is not a receiver-name guess: nothing in this
+            // payload could show that it was.
             resolution: None,
+            receiver_name_guess: false,
         });
     }
 
@@ -1211,7 +1214,7 @@ fn answer_witnessed_classes<G: GraphStore>(
 /// complete is the `negative` object's question for an empty answer and
 /// `edge_coverage`'s for the classes the query read; this field does not restate
 /// either, and on an empty answer it describes an empty set.
-fn reference_counts(rows: &[ReferenceRow]) -> serde_json::Value {
+fn reference_counts(rows: &[ReferenceRow], receiver_name_candidates: usize) -> serde_json::Value {
     let known_reference_sites: usize = rows.iter().map(|row| row.reference_lines.len()).sum();
     let reference_sites_complete = rows.iter().all(|row| !row.reference_lines.is_empty());
     let files = rows
@@ -1226,7 +1229,51 @@ fn reference_counts(rows: &[ReferenceRow]) -> serde_json::Value {
         "reference_sites": reference_sites_complete.then_some(known_reference_sites),
         "known_reference_sites": known_reference_sites,
         "reference_sites_complete": reference_sites_complete,
+        // Rows held out of every number above, carried in `candidates`. Stated
+        // here so a reader who looks only at `counts` still learns the answer
+        // withheld something (FIR-1552).
+        "receiver_name_candidates": receiver_name_candidates,
     })
+}
+
+/// Component and reason a withheld-candidate disclosure is filed under, matched
+/// to the pair `trace_data_flow` already files its `name_only` hops under so one
+/// vocabulary covers both surfaces.
+const CALL_RESOLUTION_COMPONENT: &str = "call_resolution";
+const RECEIVER_NAME_CANDIDATES_REASON: &str = "receiver_name_candidates";
+
+/// Declare the candidates this answer held out of its headline.
+///
+/// Withholding them is what makes the count honest, and saying nothing about it
+/// would make the count look whole instead. A reported degradation is the one
+/// disclosure the absence gate already consumes: `negative` reads the payload's
+/// own `degradations` and refuses to certify an absence beside one, so an answer
+/// that resolved nothing and withheld twenty candidates cannot come back as
+/// `safe_to_conclude_absent: true`.
+fn disclose_withheld_candidates(result: &mut serde_json::Value) {
+    let withheld = result["candidates"].as_array().map_or(0, Vec::len);
+    if withheld == 0 {
+        return;
+    }
+    let resolved = result["total_upstream"].as_u64().unwrap_or(0);
+    let disclosure = serde_json::json!({
+        "component": CALL_RESOLUTION_COMPONENT,
+        "reason": RECEIVER_NAME_CANDIDATES_REASON,
+        "detail": format!(
+            "{withheld} same-name candidate(s) were held out of the {resolved} counted here, \
+             because a bare-name match does not prove its destination"
+        ),
+        "remediation":
+            "read `candidates` for the rows withheld, and confirm each at its reference site \
+             before treating it as a caller",
+    });
+    match result
+        .get_mut("degradations")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        Some(existing) => existing.push(disclosure),
+        None => result["degradations"] = serde_json::Value::Array(vec![disclosure]),
+    }
 }
 
 /// Project one reference row.
@@ -1549,17 +1596,36 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
             .then_with(|| left.entity_id.cmp(&right.entity_id))
     });
 
+    // Read off the rows before they are projected, where the caller's entity id
+    // is still addressable. Every row witnesses its own edge classes, candidate
+    // or not: a `name_only` edge is still an edge of that class, and reading
+    // only the resolved rows here would report a class absent on a graph
+    // holding it.
+    let witnessed = answer_witnessed_classes(store, &target, &rows);
+
+    // FIR-1552. A `name_only` row was matched on a bare name with nothing at the
+    // reference site proving the destination. Counting one beside a proven
+    // caller is how `find_references(HTTPAdapter.send)` on psf/requests answered
+    // `total_upstream: 33` for a method `git grep` finds two call sites for,
+    // with all 33 rows carrying `resolution: "name_only"` so the per-row marker
+    // could not separate the two true rows from the 31 invented ones. The
+    // headline counts what resolved; candidates travel in their own array under
+    // their own count and are never added to it.
+    let (rows, candidate_rows): (Vec<ReferenceRow>, Vec<ReferenceRow>) =
+        rows.into_iter().partition(|row| !row.receiver_name_guess);
+
     // What this answer counted, computed before the rows are projected. One row
     // is one referencing entity, so `referencing_entities` is the row count and
     // `files` is what the pre-FIR-2398 `total_upstream` was reporting.
-    let counts = reference_counts(&rows);
-    // Read off the rows before they are projected, where the caller's entity id
-    // is still addressable.
-    let witnessed = answer_witnessed_classes(store, &target, &rows);
+    let counts = reference_counts(&rows, candidate_rows.len());
 
     // `entity_id` remains the local drill-through keystone. Federated rows use
     // repo-qualified paths and carry no local entity id.
     let references = rows
+        .into_iter()
+        .map(|row| reference_row_json(row, include_snippets))
+        .collect::<Vec<_>>();
+    let candidates = candidate_rows
         .into_iter()
         .map(|row| reference_row_json(row, include_snippets))
         .collect::<Vec<_>>();
@@ -1605,9 +1671,15 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         "total_upstream": references.len(),
         "counts": counts,
         "references": references,
+        // Same row shape as `references`, held apart because these are not
+        // references: each is a same-name match whose destination nothing at the
+        // reference site proves. Read them to widen a search by hand; never add
+        // them to `total_upstream`.
+        "candidates": candidates,
         "cross_repo": cross_repo,
     });
     result[crate::edge_coverage::EDGE_COVERAGE_KEY] = edge_coverage;
+    disclose_withheld_candidates(&mut result);
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -5297,6 +5369,217 @@ mod tests {
         assert!(
             !trust_reason.contains("mismatch"),
             "and never the one that did not: {trust_reason}"
+        );
+    }
+
+    /// A relation at a chosen confidence, so a fixture can hold real callers and
+    /// receiver-name guesses side by side. The tiers used below are the
+    /// receiver-method fan-out, the exact-name match at `0.7` (also `name_only`,
+    /// and still a caller), and parser-certain at `1.0`.
+    fn make_relation_at(
+        src: EntityId,
+        dst: EntityId,
+        kind: RelationKind,
+        confidence: f32,
+    ) -> Relation {
+        Relation {
+            confidence,
+            ..make_relation(src, dst, kind)
+        }
+    }
+
+    /// FIR-1552. `find_references(HTTPAdapter.send)` on psf/requests answered
+    /// `total_upstream: 33` where `git grep` finds two call sites, and all 33
+    /// rows carried `resolution: "name_only"`, so the per-row marker could not
+    /// tell the two true rows from the 31 the receiver fan-out invented. The
+    /// headline counts callers. Candidates travel in their own array under their
+    /// own count, and adding the two numbers together is the only way to get the
+    /// old one back.
+    ///
+    /// `resolution` is not the discriminator here and cannot be: an ordinary
+    /// cross-file call whose callee name matches exactly one entity is
+    /// `name_only` too, and demoting those would empty the headline on every
+    /// repository. The candidate class is the receiver fan-out alone.
+    ///
+    /// The fixture is deliberately lopsided, three guesses against two proven
+    /// callers, so no assertion here can pass on a fixture where every number
+    /// happens to coincide.
+    #[tokio::test]
+    async fn a_receiver_name_row_is_a_candidate_and_never_a_counted_reference() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("send", "src/adapters.rs");
+        store.upsert_entity(&target).unwrap();
+
+        let proven = ["Session.send", "handle_401"];
+        // 0.7 is the exact-name tier: `name_only` by the ladder, and an ordinary
+        // caller all the same. It has to land in the headline, or this fix takes
+        // real callers out of every count with the invented ones.
+        let exact_name_caller = "Session.request";
+        let guessed = ["test_lowlevel", "text_response_server", "test_pickling"];
+        for name in proven
+            .iter()
+            .chain(guessed.iter())
+            .chain([&exact_name_caller])
+        {
+            let caller = make_entity(name, "src/callers.rs");
+            store.upsert_entity(&caller).unwrap();
+            let confidence = if guessed.contains(name) {
+                kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE
+            } else if *name == exact_name_caller {
+                0.7
+            } else {
+                1.0
+            };
+            store
+                .upsert_relation(&make_relation_at(
+                    caller.id,
+                    target.id,
+                    RelationKind::Calls,
+                    confidence,
+                ))
+                .unwrap();
+        }
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+
+        assert_eq!(
+            body["total_upstream"], 3,
+            "the headline counts callers, the exact-name one included: {body:#}"
+        );
+        assert_eq!(
+            body["counts"]["referencing_entities"], 3,
+            "the counts object must agree with the headline: {body:#}"
+        );
+        assert_eq!(
+            body["counts"]["receiver_name_candidates"], 3,
+            "and must state how many rows it held back: {body:#}"
+        );
+
+        let named = |rows: &serde_json::Value| -> Vec<String> {
+            rows.as_array()
+                .unwrap()
+                .iter()
+                .map(|row| row["name"].as_str().unwrap().to_string())
+                .collect()
+        };
+        let references = named(&body["references"]);
+        let candidates = named(&body["candidates"]);
+        assert_eq!(references.len(), 3, "{body:#}");
+        assert_eq!(candidates.len(), 3, "{body:#}");
+        for name in proven {
+            assert!(references.contains(&name.to_string()), "{body:#}");
+        }
+        // The positive control. This row's `resolution` reads `name_only`, and
+        // it is still a caller.
+        assert!(
+            references.contains(&exact_name_caller.to_string()),
+            "an exact-name caller must survive the split: {body:#}"
+        );
+        assert!(
+            body["references"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|row| row["name"] == exact_name_caller && row["resolution"] == "name_only"),
+            "and it must survive it while still reading name_only, which is what \
+             makes this control able to fail: {body:#}"
+        );
+        for name in guessed {
+            assert!(
+                candidates.contains(&name.to_string()),
+                "a guess belongs in `candidates`, never in `references`: {body:#}"
+            );
+            assert!(!references.contains(&name.to_string()), "{body:#}");
+        }
+        for row in body["candidates"].as_array().unwrap() {
+            assert_eq!(row["resolution"], "name_only", "{body:#}");
+        }
+        // Nothing was dropped: every caller the graph holds is in one array or
+        // the other, so this is a split rather than a filter.
+        assert_eq!(references.len() + candidates.len(), 6, "{body:#}");
+    }
+
+    /// Holding candidates back is what makes the count honest, and saying
+    /// nothing about it would make the count look whole instead. An answer that
+    /// resolved nothing and withheld three candidates is the case that matters:
+    /// its `references` array is empty, and an absence gate reading only that
+    /// would certify a method as unused while three rows sat beside it.
+    #[tokio::test]
+    async fn withheld_candidates_are_disclosed_and_cannot_certify_an_absence() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("send", "src/adapters.rs");
+        store.upsert_entity(&target).unwrap();
+        for name in ["test_one", "test_two", "test_three"] {
+            let caller = make_entity(name, "tests/test_requests.rs");
+            store.upsert_entity(&caller).unwrap();
+            store
+                .upsert_relation(&make_relation_at(
+                    caller.id,
+                    target.id,
+                    RelationKind::Calls,
+                    kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+                ))
+                .unwrap();
+        }
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert_eq!(response["total_upstream"], 0, "{response:#}");
+        assert!(response["references"].as_array().unwrap().is_empty());
+        assert_eq!(response["candidates"].as_array().unwrap().len(), 3);
+
+        let disclosed = response["degradations"]
+            .as_array()
+            .unwrap_or_else(|| panic!("withholding rows must be declared: {response:#}"))
+            .iter()
+            .any(|entry| {
+                entry["component"] == "call_resolution"
+                    && entry["reason"] == "receiver_name_candidates"
+            });
+        assert!(disclosed, "{response:#}");
+
+        // The discriminating assertion. `safe_to_conclude_absent` is already
+        // false in this fixture for an unrelated reason (no `KIN_REPO_ID`, so
+        // cross-repo authority cannot bind), which would make an assertion on it
+        // alone a check that cannot fail. What proves the gate consumed THIS
+        // disclosure is the label reaching the signal list it reads.
+        let signals = response["negative"]["degraded_signals"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a negative carries its signals: {response:#}"));
+        assert!(
+            signals
+                .iter()
+                .any(|signal| signal == "call_resolution:receiver_name_candidates"),
+            "the absence gate must see the rows this answer withheld: {response:#}"
+        );
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "an empty headline beside three withheld candidates is not an absence: {response:#}"
+        );
+
+        let counted = &response["_kin"]["completeness"]["counted"];
+        assert_eq!(counted["reported"], 0, "{counted}");
+        assert_eq!(counted["exact"], false, "{counted}");
+        assert_eq!(counted["withheld_candidates"], 3, "{counted}");
+        assert_eq!(
+            counted["floor_reason"], "receiver_name_candidates_withheld",
+            "{counted}"
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["bound"], "at_least",
+            "a count that withheld rows is a floor: {response:#}"
         );
     }
 


### PR DESCRIPTION
A call written `x.m(...)` whose receiver type the syntax does not settle
resolved through the bare-name index and fanned out to every same-named
method in the repository, capped at eight. When the calling file's imports
accounted for none of the candidates the narrowing stood down entirely and
every candidate linked, on the reasoning that a rule which cannot see any
candidate should not drop them all.

That tier is where `find_references(HTTPAdapter.send)` on psf/requests got
33 rows for a method two lines call. All 33 carried
`resolution: "name_only"`, so the per-row marker could not separate the two
true rows from the 31 invented ones, and the headline counted all of them.

The tier now binds in exactly one shape: the candidate set names one owner
the calling file binds by import, and that owner's methods are the
destination. No named owner and there is no destination this file can
reach; several and the choice is a guess with nothing at the call site
behind it. Both leave the call unresolved, which is the rule already applied
to bare Python builtin calls and bare Rust calls.

On the response side `total_upstream` and `counts.referencing_entities`
count resolved references only. `name_only` rows travel in their own
`candidates` array under `counts.name_only_candidates`, the answer files a
`call_resolution`/`name_only_candidates` degradation so the absence gate
cannot certify beside withheld rows, and the completeness object carries
`withheld_candidates` with a `name_only_candidates_withheld` floor reason.
`kin refs` prints the same split. The linker checkpoint version is bumped
because resolution semantics changed.

Closes FIR-1552

## Gates

Run by the captain from the lane worktree after taking the lane over, every status read raw: cargo fmt --check exit 0; both guard scripts and verify-zero-file-search pass; clippy exactly as ci.yml runs it under RUSTFLAGS=-D warnings, exit 0; feature permutations pass (cargo nextest run -p kin-daemon --features gcs 908 tests passed, cargo test -p kin-cli --no-default-features 12 passed); full workspace gate cargo nextest run --workspace --locked --no-fail-fast: 6375 tests run, 6375 passed, 12 skipped; cargo test --doc exit 0. Rebased onto origin/main at c10ad897 lineage; the diff against main is 9 files, all in scope.

The falsification narrative for the binding rule and the withheld-candidates surfaces is in the commit body; the linker checkpoint version is bumped because resolution semantics changed.

Closes FIR-1552