### PR TITLE
Record call sites in relation evidence and paint them in kin refs

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1517,7 +1517,7 @@ mod tests {
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![kin_parser::ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind,

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1517,6 +1517,7 @@ mod tests {
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![kin_parser::ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind,

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use kin_index::RelationResolution;
+use kin_mcp::handlers::common::ReferenceLinesAbsent;
 use kin_model::{Entity, EntityId, EntityStore, GraphNodeId, GraphStore, RelationKind};
 use kin_ranking::entity_ranking;
 use serde::{Deserialize, Serialize};
@@ -223,11 +224,12 @@ pub fn build_refs_response(
             None => file_path,
         };
         lines.push(format!(
-            "  {} @ {} [{}] ({})",
+            "  {} @ {} [{}] ({}) {}",
             entry.name,
             location,
             relation_kinds_label(&entry.relation_kinds),
-            entry.resolution.as_str()
+            entry.resolution.as_str(),
+            reference_sites_label(&entry),
         ));
     };
 
@@ -256,6 +258,34 @@ pub fn build_refs_response(
     }
 
     Ok(RefsResponse { lines })
+}
+
+/// The reference sites of one entry, or the named reason it has none.
+///
+/// `start_line` locates the caller's definition and says nothing about where
+/// inside it the reference is, which is what sent readers to grep for the line
+/// they actually wanted (FIR-1825). These are the sites themselves, 1-based, in
+/// the caller's own file.
+///
+/// An entry with no sites says which absence it is rather than printing an empty
+/// list, using the same three names the MCP row carries under
+/// `reference_lines_absent_reason`, so the two surfaces can be compared word for
+/// word.
+fn reference_sites_label(entry: &ReferenceEntry) -> String {
+    if entry.reference_lines.is_empty() {
+        let reason = entry
+            .reference_lines_absent
+            .map(ReferenceLinesAbsent::as_str)
+            .unwrap_or("unknown");
+        return format!("sites none ({reason})");
+    }
+    let sites = entry
+        .reference_lines
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("sites {sites}")
 }
 
 /// What the graph still says about a target whose incoming relations are empty.
@@ -603,6 +633,15 @@ pub(crate) struct ReferenceEntry {
     /// `None` for an entity the graph carries no span for, because reporting a
     /// line for one would be a fabricated position.
     start_line: Option<u32>,
+    /// 1-based lines of the reference sites inside this caller, ascending and
+    /// deduplicated. Read from the same relation evidence and through the same
+    /// helper `find_references` uses, because two surfaces answering "where"
+    /// from two rules is how they came to disagree about "how many" (FIR-2398).
+    reference_lines: Vec<u32>,
+    /// Why this entry has no sites, and `None` when it has some. Same three
+    /// conditions the MCP row names, so a reader comparing the surfaces sees
+    /// one vocabulary.
+    reference_lines_absent: Option<ReferenceLinesAbsent>,
     pub(crate) relation_kinds: Vec<RelationKind>,
     /// Strongest resolution among the edges behind this row. A `name_only` row
     /// is a same-name match with nothing at the reference site proving it, so
@@ -677,6 +716,10 @@ pub(crate) fn collect_graph_references(
     let mut grouped: HashMap<EntityId, Vec<RelationKind>> = HashMap::new();
     let mut resolutions: HashMap<EntityId, RelationResolution> = HashMap::new();
     let mut receiver_name_guesses: HashMap<EntityId, bool> = HashMap::new();
+    // Edges kept per caller so the site tally can be taken once the caller's
+    // own file is in hand: a span naming another file is not a line under this
+    // row's path.
+    let mut edges_by_caller: HashMap<EntityId, Vec<kin_model::relation::Relation>> = HashMap::new();
     let mut matched_kinds = Vec::new();
 
     for rel in graph.get_all_relations_for_entity(entity_id)? {
@@ -707,6 +750,7 @@ pub(crate) fn collect_graph_references(
             .entry(src_entity_id)
             .and_modify(|current| *current &= guess)
             .or_insert(guess);
+        edges_by_caller.entry(src_entity_id).or_default().push(rel);
     }
 
     let mut references = Vec::with_capacity(grouped.len());
@@ -717,11 +761,32 @@ pub(crate) fn collect_graph_references(
             missing_source_ids.push(source_id);
             continue;
         };
+        let mut reference_lines = Vec::new();
+        let mut spans_outside_caller_file = 0usize;
+        for rel in edges_by_caller.get(&source_id).into_iter().flatten() {
+            let tally = kin_mcp::handlers::common::relation_reference_lines(
+                rel,
+                entity.file_origin.as_ref(),
+            );
+            reference_lines.extend(tally.lines);
+            spans_outside_caller_file += tally.outside_caller_file;
+        }
+        reference_lines.sort_unstable();
+        reference_lines.dedup();
+        let reference_lines_absent = if !reference_lines.is_empty() {
+            None
+        } else if spans_outside_caller_file > 0 {
+            Some(ReferenceLinesAbsent::SpanOutsideCallerFile)
+        } else {
+            Some(ReferenceLinesAbsent::NoEvidenceSpan)
+        };
         references.push(ReferenceEntry {
             entity_id: source_id,
             name: entity.name.clone(),
             file_path: entity.file_origin.as_ref().map(|f| f.0.clone()),
             start_line: kin_mcp::handlers::common::entity_presentation_start_line(&entity),
+            reference_lines,
+            reference_lines_absent,
             relation_kinds: source_kinds,
             resolution: resolutions
                 .get(&source_id)

--- a/crates/kin-cli/src/output_style.rs
+++ b/crates/kin-cli/src/output_style.rs
@@ -94,17 +94,25 @@ fn paint_refs(line: &str) -> String {
         return format!("referenced by {ACCENT_BOLD}{}{RESET} entities:", &caps[1]);
     }
 
-    // A row's location omits `:line` when the entity carries no span, and the
-    // resolution marker trails the relation bracket. Anchoring on either shape
-    // loses the color silently, because an unmatched line prints as plain text.
-    let entry = compiled(&ENTRY, r"^  (.+) @ (\S+) \[([^\]]*)\](?: \(([^)]*)\))?$");
+    // A row's location omits `:line` when the entity carries no span, the
+    // resolution marker trails the relation bracket, and the reference sites
+    // trail that. Anchoring on any one shape loses the color silently, because
+    // an unmatched line prints as plain text.
+    let entry = compiled(
+        &ENTRY,
+        r"^  (.+) @ (\S+) \[([^\]]*)\](?: \(([^)]*)\))?(?: (sites .*))?$",
+    );
     if let Some(caps) = entry.captures(line) {
         let resolution = caps
             .get(4)
             .map(|marker| format!(" {DIM}({}){RESET}", marker.as_str()))
             .unwrap_or_default();
+        let sites = caps
+            .get(5)
+            .map(|marker| format!(" {ACCENT_DIM}{}{RESET}", marker.as_str()))
+            .unwrap_or_default();
         return format!(
-            "  {BRIGHT}{}{RESET} @ {ACCENT}{}{RESET} {FAINT}[{}]{RESET}{resolution}",
+            "  {BRIGHT}{}{RESET} @ {ACCENT}{}{RESET} {FAINT}[{}]{RESET}{resolution}{sites}",
             &caps[1], &caps[2], &caps[3]
         );
     }
@@ -320,12 +328,34 @@ mod tests {
         // Two confidences, so the rows carry two different resolution markers
         // and a painter that assumed one value would be caught. The weaker one
         // is the receiver-method fan-out tier, which is what puts its row under
-        // the candidate heading.
-        for (caller, confidence) in [
-            (&spanned, 1.0f32),
+        // the candidate heading. One caller's edge also carries site spans and
+        // the other's does not, so the answer holds both shapes the trailing
+        // site clause can take: a list of lines, and a named absence.
+        let site_span = |row: u32| SourceSpan {
+            file: FilePathId::new("spanned.rs"),
+            start_byte: 0,
+            end_byte: 1,
+            start_line: row,
+            start_col: 0,
+            end_line: row,
+            end_col: 1,
+        };
+        let sited_evidence = vec![
+            kin_model::relation::RelationEvidence {
+                source_span: Some(site_span(6)),
+                ..Default::default()
+            },
+            kin_model::relation::RelationEvidence {
+                source_span: Some(site_span(8)),
+                ..Default::default()
+            },
+        ];
+        for (caller, confidence, evidence) in [
+            (&spanned, 1.0f32, sited_evidence),
             (
                 &spanless,
                 kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+                Vec::new(),
             ),
         ] {
             graph
@@ -338,7 +368,7 @@ mod tests {
                     origin: RelationOrigin::Parsed,
                     created_in: None,
                     import_source: None,
-                    evidence: Vec::new(),
+                    evidence,
                 })
                 .unwrap();
         }
@@ -409,6 +439,11 @@ mod tests {
             painted.contains(&format!("{DIM}(type_resolved){RESET}")),
             "the resolution marker must be painted: {painted:?}"
         );
+        assert!(
+            painted.contains(&format!("{ACCENT_DIM}sites 7,9{RESET}")),
+            "the reference sites must be painted, not left as plain text after a \
+             painted row: {painted:?}"
+        );
 
         let spanless = rows
             .iter()
@@ -424,6 +459,11 @@ mod tests {
         assert!(
             painted.contains(&format!("{DIM}(name_only){RESET}")),
             "the resolution marker must be painted: {painted:?}"
+        );
+        assert!(
+            painted.contains(&format!("{ACCENT_DIM}sites none (no_evidence_span){RESET}")),
+            "a named site absence must be painted the same way a site list is: \
+             {painted:?}"
         );
     }
 

--- a/crates/kin-cli/tests/call_shape_rename_e2e.rs
+++ b/crates/kin-cli/tests/call_shape_rename_e2e.rs
@@ -919,6 +919,24 @@ fn e2e_shadow_gate_var_keyword_caller_rename_would_block() {
     );
 }
 
+/// The call shapes an evidence set carries, as an order-independent multiset.
+///
+/// Evidence became position-bearing when the adapters started recording call
+/// sites (FIR-1825), so two source files that differ only in the ORDER of their
+/// calls no longer produce byte-identical evidence: the calls genuinely sit at
+/// different offsets, and a reference row reports those offsets as its site
+/// lines. What must still not depend on source order is the thing the merge
+/// gate reads, which is the set of shapes reaching the callee and how many
+/// occurrences each has. That is what this compares.
+fn shape_multiset(evidence: &[kin_model::RelationEvidence]) -> Vec<String> {
+    let mut shapes: Vec<String> = evidence
+        .iter()
+        .map(|record| format!("{:?}x{}", record.call_shape, record.occurrence_count))
+        .collect();
+    shapes.sort();
+    shapes
+}
+
 #[test]
 fn e2e_same_caller_keyword_shape_blocks_independent_of_source_order() {
     let old = "def target(ext, args)";
@@ -931,10 +949,18 @@ fn e2e_same_caller_keyword_shape_blocks_independent_of_source_order() {
     assert_eq!(forward_verdict, ShadowGateVerdict::WouldBlock);
     assert_eq!(reverse_verdict, ShadowGateVerdict::WouldBlock);
     assert_eq!(
-        forward_evidence, reverse_evidence,
-        "logical call evidence must be byte-stable across source-order reversal"
+        shape_multiset(&forward_evidence),
+        shape_multiset(&reverse_evidence),
+        "the shapes reaching the callee must not depend on source order"
     );
     assert_eq!(forward_evidence.len(), 2, "both distinct shapes survive");
+    assert!(
+        forward_evidence
+            .iter()
+            .all(|record| record.source_span.is_some()),
+        "Python records its call sites, so each occurrence names one: \
+         {forward_evidence:?}"
+    );
     assert!(forward_evidence.iter().any(|evidence| {
         evidence
             .call_shape
@@ -960,8 +986,9 @@ fn e2e_same_caller_var_keyword_shape_blocks_independent_of_source_order() {
     assert_eq!(forward_verdict, ShadowGateVerdict::WouldBlock);
     assert_eq!(reverse_verdict, ShadowGateVerdict::WouldBlock);
     assert_eq!(
-        forward_evidence, reverse_evidence,
-        "`**kwargs` evidence must not depend on which call appears first"
+        shape_multiset(&forward_evidence),
+        shape_multiset(&reverse_evidence),
+        "`**kwargs` shapes must not depend on which call appears first"
     );
     assert_eq!(forward_evidence.len(), 2, "both distinct shapes survive");
     assert!(forward_evidence.iter().any(|evidence| {
@@ -984,13 +1011,18 @@ fn e2e_same_caller_all_positional_shapes_remain_neutral_and_deterministic() {
     assert_eq!(forward_verdict, ShadowGateVerdict::NeedsAttention);
     assert_eq!(reverse_verdict, ShadowGateVerdict::NeedsAttention);
     assert_eq!(
-        forward_evidence, reverse_evidence,
-        "all-positional evidence must sort and deduplicate deterministically"
+        shape_multiset(&forward_evidence),
+        shape_multiset(&reverse_evidence),
+        "all-positional shapes must sort deterministically and ignore source order"
     );
+    // One record per call site, because each site is a distinct position now
+    // that the adapter records one. Two calls of the same shape used to collapse
+    // into a single record with `occurrence_count: 2`; collapsing them now would
+    // cost a reference row one of its two site lines.
     assert_eq!(
         forward_evidence.len(),
-        3,
-        "four calls collapse to three distinct shapes"
+        4,
+        "four calls are four sites: {forward_evidence:?}"
     );
     assert_eq!(
         forward_evidence
@@ -999,6 +1031,16 @@ fn e2e_same_caller_all_positional_shapes_remain_neutral_and_deterministic() {
             .sum::<u32>(),
         4,
         "occurrence counts retain every call site"
+    );
+    assert_eq!(
+        forward_evidence
+            .iter()
+            .filter_map(|record| record.source_span.as_ref())
+            .map(|span| span.start_byte)
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        4,
+        "four sites must be four distinct positions: {forward_evidence:?}"
     );
     assert!(forward_evidence.iter().all(|evidence| {
         evidence.parser_rule.as_deref() == Some(CALL_SHAPE_EVIDENCE_AGGREGATION_V1)
@@ -1015,13 +1057,17 @@ fn e2e_same_caller_all_positional_shapes_remain_neutral_and_deterministic() {
             .as_ref()
             .is_some_and(|shape| shape.has_var_positional)
     }));
-    assert!(forward_evidence.iter().any(|evidence| {
-        evidence.occurrence_count == 2
-            && evidence
+    assert_eq!(
+        forward_evidence
+            .iter()
+            .filter(|evidence| evidence
                 .call_shape
                 .as_ref()
-                .is_some_and(|shape| shape.positional == 2 && !shape.has_var_positional)
-    }));
+                .is_some_and(|shape| shape.positional == 2 && !shape.has_var_positional))
+            .count(),
+        2,
+        "the repeated two-positional call keeps both of its sites"
+    );
 }
 
 #[test]

--- a/crates/kin-cli/tests/reference_call_site_lines.rs
+++ b/crates/kin-cli/tests/reference_call_site_lines.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! A reference row must say WHERE the reference is, not only who made it.
+//!
+//! `find_references` served `reference_lines` from
+//! `RelationEvidence::source_span` from the day the field existed, and no
+//! producer ever set it: `kin_parser::ExtractedRelation` carried no span, so an
+//! adapter that had the call node in hand could not hand its position to the
+//! resolver. Every row on every language came back with an empty
+//! `reference_lines` and `reference_lines_absent_reason: "no_evidence_span"`,
+//! which is why a stranger asking "who calls this, and where" got entities and
+//! files from Kin and then ran grep for the lines (FIR-1825).
+//!
+//! This asserts the whole chain on the two languages that lost those A/B tasks:
+//! adapter records the call site, linker turns it into a span under the
+//! caller's file, MCP and CLI both report it. It runs on BOTH ingest arms,
+//! because they are separate code paths that have diverged before (kin#870):
+//! `resolve_cross_file` is the batch arm a `kin init` walks, and
+//! `link_cross_file_incremental_with_completeness` is the arm a live reconcile
+//! takes on each save.
+
+use std::collections::HashMap;
+
+use kin_cli::commands::refs::{build_refs_response, RefsRequest};
+use kin_db::InMemoryGraph;
+use kin_index::linker::{ArtifactIdentityMap, IncrementalLinker};
+use kin_index::{
+    link_cross_file_incremental_with_completeness, FileParseCompletenessMap, FileParseData,
+    IndexPipeline,
+};
+use kin_model::{ArtifactId, Entity, EntityStore, FilePathId, Relation};
+
+/// A caller file that reaches `compute` twice, at lines the fixture states
+/// outright, plus a definition file. The two sites are on different lines so a
+/// row reporting one of them is distinguishable from a row reporting both, and
+/// neither is the caller's own definition line, so a surface that quietly
+/// reports `start_line` instead of the sites fails.
+struct Fixture {
+    language: &'static str,
+    defs_path: &'static str,
+    defs_source: &'static str,
+    caller_path: &'static str,
+    caller_source: &'static str,
+    /// Entity name of the function doing the calling.
+    caller_name: &'static str,
+    /// The call as it is written, used to derive the expected site lines from
+    /// the fixture source itself rather than from a hand-counted constant.
+    call_text: &'static str,
+}
+
+const FIXTURES: &[Fixture] = &[
+    Fixture {
+        language: "Python",
+        defs_path: "defs.py",
+        defs_source: "def compute():\n    return 1\n",
+        caller_path: "caller.py",
+        // 1: import, 2: blank, 3: def run, 4: first call, 5: blank, 6: second call
+        caller_source: "from defs import compute\n\
+                        \n\
+                        def run():\n\
+                        \x20   first = compute()\n\
+                        \n\
+                        \x20   return first + compute()\n",
+        caller_name: "run",
+        call_text: "compute()",
+    },
+    Fixture {
+        language: "JavaScript",
+        defs_path: "defs.js",
+        defs_source: "export function compute() { return 1; }\n",
+        caller_path: "caller.js",
+        // 1: import, 2: blank, 3: export function run, 4: first call, 5: blank,
+        // 6: second call
+        caller_source: "import { compute } from \"./defs\";\n\
+                        \n\
+                        export function run() {\n\
+                        \x20 const first = compute();\n\
+                        \n\
+                        \x20 return first + compute();\n\
+                        }\n",
+        caller_name: "run",
+        call_text: "compute()",
+    },
+];
+
+impl Fixture {
+    /// The 1-based caller-file lines the calls are written on, read off the
+    /// fixture source. Deriving them here rather than pinning two constants
+    /// means editing the fixture cannot leave the expectation behind, and the
+    /// oracle is independent of anything the graph produced.
+    fn expected_sites(&self) -> Vec<u32> {
+        self.caller_source
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| line.contains(self.call_text))
+            .map(|(index, _)| index as u32 + 1)
+            .collect()
+    }
+}
+
+/// One file's parse, kept in the shape both linker arms take.
+struct IndexedFixtureFile {
+    parse: FileParseData,
+    entities: Vec<Entity>,
+    same_file_relations: Vec<Relation>,
+    artifact_id: ArtifactId,
+}
+
+fn index_files(fixture: &Fixture) -> Vec<IndexedFixtureFile> {
+    let pipeline = IndexPipeline::new();
+    let blob_hash = kin_blobs::Hash256::from_bytes([0u8; 32]);
+    [
+        (fixture.defs_path, fixture.defs_source),
+        (fixture.caller_path, fixture.caller_source),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        let indexed = pipeline
+            .index_file_content_with_tests(&FilePathId::new(path), source.as_bytes(), blob_hash)
+            .unwrap_or_else(|error| panic!("{} index {path}: {error}", fixture.language))
+            .indexed_file;
+        IndexedFixtureFile {
+            parse: FileParseData {
+                file_path: path.to_string(),
+                entities: indexed.entities.clone(),
+                relations: indexed.extracted_relations,
+                imports: indexed.imports,
+            },
+            entities: indexed.entities,
+            same_file_relations: indexed.relations,
+            artifact_id: ArtifactId::new(),
+        }
+    })
+    .collect()
+}
+
+fn completeness_of(files: &[IndexedFixtureFile]) -> FileParseCompletenessMap {
+    files
+        .iter()
+        .map(|file| {
+            (
+                file.parse.file_path.clone(),
+                kin_model::ParseCompleteness::Full,
+            )
+        })
+        .collect()
+}
+
+/// The batch arm: every file parsed, then one cross-file resolution over all of
+/// them. This is what a `kin init` walk runs.
+fn link_batch(files: &[IndexedFixtureFile]) -> Vec<Relation> {
+    let pipeline = IndexPipeline::new();
+    let mut artifact_ids = ArtifactIdentityMap::new();
+    for file in files {
+        artifact_ids.insert(file.parse.file_path.clone(), file.artifact_id);
+    }
+    let parses: Vec<FileParseData> = files.iter().map(|file| file.parse.clone()).collect();
+    pipeline
+        .resolve_cross_file(&parses, &artifact_ids)
+        .expect("batch cross-file linking")
+}
+
+/// The live arm: the linker learns each file as it is saved, then resolves the
+/// one file that changed against what it already knows. This is the path
+/// `kin_reconcile::cross_file` drives on every save.
+fn link_incremental(files: &[IndexedFixtureFile]) -> Vec<Relation> {
+    let mut linker = IncrementalLinker::new();
+    for file in files {
+        linker.add_file(&file.parse.file_path, file.artifact_id, &file.entities);
+    }
+    let completeness = completeness_of(files);
+    let batch: Vec<FileParseData> = files.iter().map(|file| file.parse.clone()).collect();
+    link_cross_file_incremental_with_completeness(&batch, &linker, &completeness)
+        .expect("incremental cross-file linking")
+}
+
+/// The graph both surfaces are asked, with every entity span deliberately
+/// removed.
+///
+/// That is the non-vacuity control, and it is a stronger one than comparing the
+/// sites against a definition line: with no entity span in the graph there is no
+/// definition line to report at all, so any line a reference row carries can
+/// only have come from the relation's own evidence. It also keeps the fixture
+/// off the body-projection path, which would want committed blobs this test
+/// never writes.
+fn graph_with(files: &[IndexedFixtureFile], linked: &[Relation]) -> InMemoryGraph {
+    let graph = InMemoryGraph::new();
+    for file in files {
+        for entity in &file.entities {
+            let mut entity = entity.clone();
+            entity.span = None;
+            graph.upsert_entity(&entity).unwrap();
+        }
+        for relation in &file.same_file_relations {
+            graph.upsert_relation(relation).unwrap();
+        }
+    }
+    for relation in linked {
+        graph.upsert_relation(relation).unwrap();
+    }
+    graph
+}
+
+async fn find_references(graph: &InMemoryGraph, target: &Entity) -> serde_json::Value {
+    let args = HashMap::from([
+        (
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        ),
+        ("relation_kinds".to_string(), serde_json::json!(["calls"])),
+    ]);
+    let response = kin_mcp::handlers::entities::handle_find_references(&args, graph, None)
+        .await
+        .expect("find_references");
+    let kin_mcp::types::ContentBlock::Text { text } = response.content.first().unwrap();
+    serde_json::from_str(text).expect("find_references body is json")
+}
+
+/// Every resolved Python and JavaScript reference row carries the caller-file
+/// lines of the reference sites, on both ingest arms, and the CLI prints the
+/// same lines the MCP row carries.
+#[tokio::test]
+async fn python_and_javascript_reference_rows_carry_call_site_lines_on_both_ingest_arms() {
+    for fixture in FIXTURES {
+        for (arm, link) in [
+            ("batch", link_batch as fn(&[IndexedFixtureFile]) -> Vec<Relation>),
+            ("incremental", link_incremental),
+        ] {
+            let files = index_files(fixture);
+            let linked = link(&files);
+            let graph = graph_with(&files, &linked);
+
+            let target = files[0]
+                .entities
+                .iter()
+                .find(|entity| entity.name == "compute")
+                .unwrap_or_else(|| panic!("{} {arm}: compute entity", fixture.language))
+                .clone();
+
+            let body = find_references(&graph, &target).await;
+            let rows = body["references"].as_array().unwrap_or_else(|| {
+                panic!("{} {arm}: references array: {body:#}", fixture.language)
+            });
+            let row = rows
+                .iter()
+                .find(|row| row["name"] == fixture.caller_name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{} {arm}: no row for caller `{}`: {body:#}",
+                        fixture.language, fixture.caller_name
+                    )
+                });
+
+            let expected_sites = fixture.expected_sites();
+            assert_eq!(
+                expected_sites.len(),
+                2,
+                "{}: the fixture must write the call on two lines for the site list to be \
+                 distinguishable from a single position",
+                fixture.language,
+            );
+            assert_eq!(
+                row["reference_lines"],
+                serde_json::json!(expected_sites),
+                "{} {arm}: the row must name the lines the calls are written on: {row:#}",
+                fixture.language,
+            );
+            assert_eq!(
+                row["reference_line_count"], 2,
+                "{} {arm}: two calls are two sites: {row:#}",
+                fixture.language,
+            );
+            assert_eq!(
+                row["reference_lines_absent_reason"],
+                serde_json::Value::Null,
+                "{} {arm}: a row that HAS sites must claim no absence: {row:#}",
+                fixture.language,
+            );
+            // Non-vacuity: the graph holds no entity span, so the row has no
+            // definition line to have copied. Every number above came from the
+            // relation's evidence or from nowhere.
+            assert_eq!(
+                row["start_line"],
+                serde_json::Value::Null,
+                "{} {arm}: the fixture removes entity spans on purpose: {row:#}",
+                fixture.language,
+            );
+            assert_eq!(
+                body["counts"]["reference_sites_complete"],
+                serde_json::json!(true),
+                "{} {arm}: every returned row has sites, so the answer must say so: \
+                 {body:#}",
+                fixture.language,
+            );
+
+            let layout = kin_core::KinLayout::new(
+                tempfile::tempdir().unwrap().path().join(".kin"),
+            );
+            let cli = build_refs_response(
+                &layout,
+                &graph,
+                &RefsRequest {
+                    entity: target.id.to_string(),
+                    kind: "calls".to_string(),
+                },
+            )
+            .expect("kin refs");
+            let cli_text = cli.lines.join("\n");
+            let expected_label = format!("sites {},{}", expected_sites[0], expected_sites[1]);
+            assert!(
+                cli_text.contains(&expected_label),
+                "{} {arm}: `kin refs` must print the same sites the MCP row carries \
+                 (`{expected_label}`): {cli_text}",
+                fixture.language,
+            );
+            assert!(
+                !cli_text.contains("sites none"),
+                "{} {arm}: no row may report an absent site set here: {cli_text}",
+                fixture.language,
+            );
+        }
+    }
+}

--- a/crates/kin-cli/tests/reference_call_site_lines.rs
+++ b/crates/kin-cli/tests/reference_call_site_lines.rs
@@ -224,7 +224,10 @@ async fn find_references(graph: &InMemoryGraph, target: &Entity) -> serde_json::
 async fn python_and_javascript_reference_rows_carry_call_site_lines_on_both_ingest_arms() {
     for fixture in FIXTURES {
         for (arm, link) in [
-            ("batch", link_batch as fn(&[IndexedFixtureFile]) -> Vec<Relation>),
+            (
+                "batch",
+                link_batch as fn(&[IndexedFixtureFile]) -> Vec<Relation>,
+            ),
             ("incremental", link_incremental),
         ] {
             let files = index_files(fixture);
@@ -294,9 +297,7 @@ async fn python_and_javascript_reference_rows_carry_call_site_lines_on_both_inge
                 fixture.language,
             );
 
-            let layout = kin_core::KinLayout::new(
-                tempfile::tempdir().unwrap().path().join(".kin"),
-            );
+            let layout = kin_core::KinLayout::new(tempfile::tempdir().unwrap().path().join(".kin"));
             let cli = build_refs_response(
                 &layout,
                 &graph,

--- a/crates/kin-cli/tests/repository_rename_planner.rs
+++ b/crates/kin-cli/tests/repository_rename_planner.rs
@@ -571,6 +571,12 @@ struct LanguageFixture {
     caller_path: &'static str,
     caller_source: &'static str,
     has_named_import_without_span: bool,
+    /// Whether this language's adapter records a call site, so its `Calls`
+    /// evidence carries a `source_span` (FIR-1825). The planner does not read
+    /// spans, so its behavior below is the same either way; this keeps the
+    /// fixture honest about what the linker actually produced instead of
+    /// asserting one blanket answer for every language.
+    records_call_sites: bool,
 }
 
 fn entity_leaf(name: &str) -> &str {
@@ -587,6 +593,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.rs",
         caller_source: "pub fn caller() -> u32 { target() + target() }\n",
         has_named_import_without_span: false,
+        records_call_sites: false,
     },
     LanguageFixture {
         name: "TypeScript",
@@ -595,6 +602,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.ts",
         caller_source: "import { target } from './defs';\nexport function caller(): number { return target() + target(); }\n",
         has_named_import_without_span: true,
+        records_call_sites: true,
     },
     LanguageFixture {
         name: "JavaScript",
@@ -603,6 +611,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.js",
         caller_source: "import { target } from './defs';\nexport function caller() { return target() + target(); }\n",
         has_named_import_without_span: true,
+        records_call_sites: true,
     },
     LanguageFixture {
         name: "Python",
@@ -611,6 +620,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.py",
         caller_source: "from defs import target\n\ndef caller():\n    return target() + target()\n",
         has_named_import_without_span: true,
+        records_call_sites: true,
     },
     LanguageFixture {
         name: "Go",
@@ -619,6 +629,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.go",
         caller_source: "package main\n\nfunc caller() int { return target() + target() }\n",
         has_named_import_without_span: false,
+        records_call_sites: false,
     },
     LanguageFixture {
         name: "Java",
@@ -627,6 +638,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "Caller.java",
         caller_source: "class Caller { int caller() { return target() + target(); } }\n",
         has_named_import_without_span: false,
+        records_call_sites: false,
     },
     LanguageFixture {
         name: "C",
@@ -635,6 +647,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.c",
         caller_source: "int caller(void) { return target() + target(); }\n",
         has_named_import_without_span: false,
+        records_call_sites: false,
     },
     LanguageFixture {
         name: "Cpp",
@@ -643,6 +656,7 @@ const LANGUAGE_FIXTURES: &[LanguageFixture] = &[
         caller_path: "caller.cpp",
         caller_source: "int caller() { return target() + target(); }\n",
         has_named_import_without_span: false,
+        records_call_sites: false,
     },
 ];
 
@@ -736,13 +750,25 @@ fn real_linker_spanless_relations_are_exact_or_refused_across_eight_languages() 
                     && relation.dst == GraphNodeId::Entity(target.id)
             })
             .unwrap_or_else(|| panic!("{} repeated call edge", fixture.name));
-        assert!(
-            call.evidence
-                .iter()
-                .all(|evidence| evidence.source_span.is_none()),
-            "{} unexpectedly gained a relation span; update the bounded planner proof",
-            fixture.name
-        );
+        let spanned = call
+            .evidence
+            .iter()
+            .filter(|evidence| evidence.source_span.is_some())
+            .count();
+        if fixture.records_call_sites {
+            assert_eq!(
+                spanned, 2,
+                "{} records call sites, so both of its occurrences must carry one; a \
+                 reference row for this language reports them as its site lines",
+                fixture.name
+            );
+        } else {
+            assert_eq!(
+                spanned, 0,
+                "{} unexpectedly gained a relation span; update the bounded planner proof",
+                fixture.name
+            );
+        }
         assert_eq!(
             call.evidence
                 .iter()

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -6086,7 +6086,7 @@ mod tests {
             file_path: "src/a.ts".to_string(),
             entities: vec![e1.clone(), e2.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -6134,7 +6134,7 @@ mod tests {
             relations: shapes
                 .drain(..)
                 .map(|call_shape| ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape,
                     kind: RelationKind::Calls,
@@ -6213,7 +6213,7 @@ mod tests {
             relations: shapes
                 .into_iter()
                 .map(|call_shape| ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape,
                     kind: RelationKind::Calls,
@@ -6257,7 +6257,7 @@ mod tests {
             file_path: "src/a.py".to_string(),
             entities: vec![caller.clone(), target.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: Some(CallArgShape {
                     positional: 2,
@@ -6317,7 +6317,7 @@ mod tests {
             entities: vec![caller.clone(), target.clone()],
             relations: vec![
                 ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: Some(CallArgShape {
                         positional: 2,
@@ -6405,7 +6405,7 @@ mod tests {
                 file_path: "src/good.py".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: Some(CallArgShape {
                         positional: 1,
@@ -6579,7 +6579,7 @@ mod tests {
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -6638,7 +6638,7 @@ mod tests {
             file_path: "src/routes/api.ts".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -6693,7 +6693,7 @@ mod tests {
             file_path: "src/app.ts".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -6959,7 +6959,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -6994,7 +6994,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7056,7 +7056,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7099,7 +7099,7 @@ mod tests {
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7153,7 +7153,7 @@ mod tests {
                 file_path: "src/app.cpp".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::UsesMacro,
@@ -7207,7 +7207,7 @@ mod tests {
                 file_path: "src/app.cpp".to_string(),
                 entities: vec![caller],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::UsesMacro,
@@ -7326,7 +7326,7 @@ void f();
                 file_path: "src/parse.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7373,7 +7373,7 @@ void f();
             entities: vec![e1.clone(), e2.clone()],
             relations: vec![
                 ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7382,7 +7382,7 @@ void f();
                     import_source: None,
                 },
                 ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7406,7 +7406,7 @@ void f();
             file_path: "src/a.ts".to_string(),
             entities: vec![e1],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -7434,7 +7434,7 @@ void f();
                 file_path: "src/wiring.rs".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7477,7 +7477,7 @@ void f();
                 file_path: "src/caller.rs".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7543,7 +7543,7 @@ void f();
             file_path: "src/wiring.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -7808,7 +7808,7 @@ void f();
                 file_path: "notekeeper/ingest.py".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: Some("store".to_string()),
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8052,7 +8052,7 @@ void f();
                 entities: vec![a, b],
                 relations: vec![
                     ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -8061,7 +8061,7 @@ void f();
                         import_source: None,
                     },
                     ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -8070,7 +8070,7 @@ void f();
                         import_source: None,
                     },
                     ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -8079,7 +8079,7 @@ void f();
                         import_source: None,
                     },
                     ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -8148,7 +8148,7 @@ void f();
             file_path: "src/caller.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -8365,7 +8365,7 @@ void f();
                 file_path: "src/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8516,7 +8516,7 @@ void f();
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8611,7 +8611,7 @@ void f();
                 file_path: "a.ts".to_string(),
                 entities: vec![e1.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8642,7 +8642,7 @@ void f();
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind,
@@ -8792,7 +8792,7 @@ void f();
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -8822,7 +8822,7 @@ void f();
             entities,
             relations: vec![
                 ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8831,7 +8831,7 @@ void f();
                     import_source: Some("kin_db".to_string()),
                 },
                 ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8840,7 +8840,7 @@ void f();
                     import_source: Some("kin_db".to_string()),
                 },
                 ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8889,7 +8889,7 @@ void f();
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![handler.clone()],
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -10765,7 +10765,7 @@ void f();
                 entities: vec![double_send.clone()],
                 // The double subclasses the mixin, not the adapter.
                 relations: vec![ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Extends,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 use sha2::{Digest, Sha256};
 
 use kin_model::{
-    ArtifactId, Entity, EntityId, EntityKind, EntityRole, GraphNodeId, LanguageId,
+    ArtifactId, Entity, EntityId, EntityKind, EntityRole, FilePathId, GraphNodeId, LanguageId,
     ParseCompleteness, Relation, RelationEvidence, RelationId, RelationKind, RelationOrigin,
     Visibility,
 };
@@ -703,12 +703,14 @@ fn resolve_one_file(
     let parse_completeness = completeness
         .and_then(|by_file| by_file.get(&file.file_path))
         .unwrap_or(&FULL_PARSE_COMPLETENESS);
+    let caller_file = FilePathId::new(&file.file_path);
     let make_relation = |rel: &ExtractedRelation, src, dst, confidence| {
         make_relation(
             rel,
             src,
             dst,
             confidence,
+            &caller_file,
             parse_completeness,
             call_extraction_complete,
         )
@@ -1756,6 +1758,16 @@ pub(crate) fn accumulate_relation(
     merge_relation_metadata(existing, &relation);
 
     if relation.kind != RelationKind::Calls {
+        // A non-call edge carries evidence only when the adapter recorded a
+        // site for it, and two sites for one edge are two lines to report, so
+        // they merge instead of the later one being dropped. None of the
+        // call-shape marker synthesis below applies: a non-call edge has no
+        // shape, so a spanless occurrence contributes nothing rather than an
+        // explicit unshaped marker.
+        if !relation.evidence.is_empty() {
+            existing.evidence.append(&mut relation.evidence);
+            canonicalize_call_evidence(&mut existing.evidence);
+        }
         return;
     }
 
@@ -3210,6 +3222,7 @@ fn make_relation(
     src: EntityId,
     dst: EntityId,
     confidence: f32,
+    caller_file: &FilePathId,
     parse_completeness: &ParseCompleteness,
     call_extraction_complete: bool,
 ) -> Relation {
@@ -3232,13 +3245,56 @@ fn make_relation(
         origin,
         created_in: None,
         import_source: None,
-        evidence: call_shape_evidence(
-            rel.kind,
-            rel.call_shape.as_ref(),
+        evidence: relation_evidence(
+            rel,
+            caller_file,
             parse_completeness,
             call_extraction_complete,
         ),
     }
+}
+
+/// The stored evidence for one resolved relation: its call shape, when the
+/// adapter records shapes, carrying the site the syntax was read at, when the
+/// adapter records sites.
+///
+/// The site is the whole point of `reference_lines`. An adapter reports it
+/// file-free, because a relation's syntax is always inside the file being
+/// parsed; pairing it with `caller_file` here is what makes the span belong to
+/// the caller rather than to whichever file a later stage happened to hold.
+/// That also means a parser-recorded site can never land under
+/// `span_outside_caller_file`.
+///
+/// A non-call edge previously carried no evidence record at all, so a site on
+/// one has nothing to attach to and gets a record of its own. A call edge's
+/// record already exists for the shape, and the site goes onto it rather than
+/// beside it, so an edge does not report one occurrence twice.
+pub(crate) fn relation_evidence(
+    rel: &ExtractedRelation,
+    caller_file: &FilePathId,
+    parse_completeness: &ParseCompleteness,
+    call_extraction_complete: bool,
+) -> Vec<RelationEvidence> {
+    let mut evidence = call_shape_evidence(
+        rel.kind,
+        rel.call_shape.as_ref(),
+        parse_completeness,
+        call_extraction_complete,
+    );
+    let Some(site) = rel.site.as_ref() else {
+        return evidence;
+    };
+    let span = site.to_source_span(caller_file);
+    if evidence.is_empty() {
+        return vec![RelationEvidence {
+            source_span: Some(span),
+            ..RelationEvidence::default()
+        }];
+    }
+    for record in &mut evidence {
+        record.source_span = Some(span.clone());
+    }
+    evidence
 }
 
 /// Convert a parser-side [`CallArgShape`] into stored relation evidence carrying
@@ -4851,12 +4907,14 @@ fn resolve_one_file_incremental(
     let parse_completeness = completeness
         .and_then(|by_file| by_file.get(&file.file_path))
         .unwrap_or(&FULL_PARSE_COMPLETENESS);
+    let caller_file = FilePathId::new(&file.file_path);
     let make_relation = |rel: &ExtractedRelation, src, dst, confidence| {
         make_relation(
             rel,
             src,
             dst,
             confidence,
+            &caller_file,
             parse_completeness,
             call_extraction_complete,
         )
@@ -6028,6 +6086,7 @@ mod tests {
             file_path: "src/a.ts".to_string(),
             entities: vec![e1.clone(), e2.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -6075,6 +6134,7 @@ mod tests {
             relations: shapes
                 .drain(..)
                 .map(|call_shape| ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape,
                     kind: RelationKind::Calls,
@@ -6153,6 +6213,7 @@ mod tests {
             relations: shapes
                 .into_iter()
                 .map(|call_shape| ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape,
                     kind: RelationKind::Calls,
@@ -6196,6 +6257,7 @@ mod tests {
             file_path: "src/a.py".to_string(),
             entities: vec![caller.clone(), target.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: Some(CallArgShape {
                     positional: 2,
@@ -6255,6 +6317,7 @@ mod tests {
             entities: vec![caller.clone(), target.clone()],
             relations: vec![
                 ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: Some(CallArgShape {
                         positional: 2,
@@ -6342,6 +6405,7 @@ mod tests {
                 file_path: "src/good.py".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: Some(CallArgShape {
                         positional: 1,
@@ -6515,6 +6579,7 @@ mod tests {
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -6573,6 +6638,7 @@ mod tests {
             file_path: "src/routes/api.ts".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -6627,6 +6693,7 @@ mod tests {
             file_path: "src/app.ts".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -6660,6 +6727,7 @@ mod tests {
     #[test]
     fn parallel_resolution_is_byte_identical_to_serial() {
         let calls = |src: &str, dst: &str| ExtractedRelation {
+            site: None,
             receiver: None,
             call_shape: None,
             kind: RelationKind::Calls,
@@ -6891,6 +6959,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -6925,6 +6994,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -6986,6 +7056,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7028,6 +7099,7 @@ mod tests {
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7081,6 +7153,7 @@ mod tests {
                 file_path: "src/app.cpp".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::UsesMacro,
@@ -7134,6 +7207,7 @@ mod tests {
                 file_path: "src/app.cpp".to_string(),
                 entities: vec![caller],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::UsesMacro,
@@ -7252,6 +7326,7 @@ void f();
                 file_path: "src/parse.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7298,6 +7373,7 @@ void f();
             entities: vec![e1.clone(), e2.clone()],
             relations: vec![
                 ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7306,6 +7382,7 @@ void f();
                     import_source: None,
                 },
                 ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7329,6 +7406,7 @@ void f();
             file_path: "src/a.ts".to_string(),
             entities: vec![e1],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -7356,6 +7434,7 @@ void f();
                 file_path: "src/wiring.rs".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7398,6 +7477,7 @@ void f();
                 file_path: "src/caller.rs".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7463,6 +7543,7 @@ void f();
             file_path: "src/wiring.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -7505,6 +7586,7 @@ void f();
 
     fn bare_call(src_name: &str, dst_name: &str) -> ExtractedRelation {
         ExtractedRelation {
+            site: None,
             receiver: None,
             call_shape: None,
             kind: RelationKind::Calls,
@@ -7726,6 +7808,7 @@ void f();
                 file_path: "notekeeper/ingest.py".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: Some("store".to_string()),
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -7969,6 +8052,7 @@ void f();
                 entities: vec![a, b],
                 relations: vec![
                     ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -7977,6 +8061,7 @@ void f();
                         import_source: None,
                     },
                     ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -7985,6 +8070,7 @@ void f();
                         import_source: None,
                     },
                     ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -7993,6 +8079,7 @@ void f();
                         import_source: None,
                     },
                     ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Calls,
@@ -8061,6 +8148,7 @@ void f();
             file_path: "src/caller.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -8277,6 +8365,7 @@ void f();
                 file_path: "src/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8427,6 +8516,7 @@ void f();
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8521,6 +8611,7 @@ void f();
                 file_path: "a.ts".to_string(),
                 entities: vec![e1.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8551,6 +8642,7 @@ void f();
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind,
@@ -8700,6 +8792,7 @@ void f();
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: RelationKind::Calls,
@@ -8729,6 +8822,7 @@ void f();
             entities,
             relations: vec![
                 ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8737,6 +8831,7 @@ void f();
                     import_source: Some("kin_db".to_string()),
                 },
                 ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8745,6 +8840,7 @@ void f();
                     import_source: Some("kin_db".to_string()),
                 },
                 ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8793,6 +8889,7 @@ void f();
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![handler.clone()],
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Calls,
@@ -8849,6 +8946,7 @@ void f();
 
     fn calls_relation(src: &str, dst: &str) -> ExtractedRelation {
         ExtractedRelation {
+            site: None,
             receiver: None,
             call_shape: None,
             kind: RelationKind::Calls,
@@ -9664,6 +9762,7 @@ void f();
 
     fn pinned_calls_relation(src: &str, dst: &str, import_source: &str) -> ExtractedRelation {
         ExtractedRelation {
+            site: None,
             receiver: None,
             call_shape: None,
             kind: RelationKind::Calls,
@@ -10441,6 +10540,7 @@ void f();
 
     fn py_receiver_call(src: &str, receiver: &str, method: &str) -> ExtractedRelation {
         ExtractedRelation {
+            site: None,
             receiver: Some(receiver.to_string()),
             call_shape: None,
             kind: RelationKind::Calls,
@@ -10665,6 +10765,7 @@ void f();
                 entities: vec![double_send.clone()],
                 // The double subclasses the mixin, not the adapter.
                 relations: vec![ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: RelationKind::Extends,

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -177,8 +177,12 @@ impl IndexPipeline {
         }
 
         let parse_completeness = ParseCompleteness::from_parse_state(&parse_state);
-        let (relations, unresolved_relations) =
-            resolve_relations(&extracted_relations, &entities, file_id, &parse_completeness);
+        let (relations, unresolved_relations) = resolve_relations(
+            &extracted_relations,
+            &entities,
+            file_id,
+            &parse_completeness,
+        );
         let file_layout = build_layout(file_id, &entities, source.len(), &[], parse_completeness);
 
         debug!(
@@ -315,8 +319,12 @@ impl IndexPipeline {
 
         // Resolve extracted relations to model relations using entity name mapping
         let parse_completeness = ParseCompleteness::from_parse_state(&parse_state);
-        let (relations, unresolved_relations) =
-            resolve_relations(&extracted_relations, &entities, file_id, &parse_completeness);
+        let (relations, unresolved_relations) = resolve_relations(
+            &extracted_relations,
+            &entities,
+            file_id,
+            &parse_completeness,
+        );
         let file_layout = build_layout(file_id, &entities, source.len(), &[], parse_completeness);
 
         debug!(

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -926,9 +926,23 @@ mod tests {
                 .clone()
         };
 
+        let shapes = |evidence: &[kin_model::RelationEvidence]| {
+            let mut shapes: Vec<String> = evidence
+                .iter()
+                .map(|record| format!("{:?}x{}", record.call_shape, record.occurrence_count))
+                .collect();
+            shapes.sort();
+            shapes
+        };
+
         let forward_evidence = evidence_for(forward);
         let reversed_evidence = evidence_for(reversed);
-        assert_eq!(forward_evidence, reversed_evidence);
+        // Evidence carries the call SITE now, and the two sources put their
+        // calls at different offsets, so byte equality across the reversal is
+        // not the invariant any more. What must hold is that the shapes reaching
+        // the callee, which is what the merge gate reads, do not depend on which
+        // call was written first.
+        assert_eq!(shapes(&forward_evidence), shapes(&reversed_evidence));
         assert_eq!(forward_evidence.len(), 2);
         assert!(forward_evidence.iter().any(|evidence| {
             evidence
@@ -936,6 +950,12 @@ mod tests {
                 .as_ref()
                 .is_some_and(|shape| shape.keywords == ["args"])
         }));
+        assert!(
+            forward_evidence
+                .iter()
+                .all(|record| record.source_span.is_some()),
+            "the same-file arm must carry each call's site: {forward_evidence:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -178,7 +178,7 @@ impl IndexPipeline {
 
         let parse_completeness = ParseCompleteness::from_parse_state(&parse_state);
         let (relations, unresolved_relations) =
-            resolve_relations(&extracted_relations, &entities, &parse_completeness);
+            resolve_relations(&extracted_relations, &entities, file_id, &parse_completeness);
         let file_layout = build_layout(file_id, &entities, source.len(), &[], parse_completeness);
 
         debug!(
@@ -316,7 +316,7 @@ impl IndexPipeline {
         // Resolve extracted relations to model relations using entity name mapping
         let parse_completeness = ParseCompleteness::from_parse_state(&parse_state);
         let (relations, unresolved_relations) =
-            resolve_relations(&extracted_relations, &entities, &parse_completeness);
+            resolve_relations(&extracted_relations, &entities, file_id, &parse_completeness);
         let file_layout = build_layout(file_id, &entities, source.len(), &[], parse_completeness);
 
         debug!(
@@ -760,6 +760,7 @@ pub fn classify_file_role(path: &str) -> EntityRole {
 fn resolve_relations(
     extracted: &[kin_parser::ExtractedRelation],
     entities: &[Entity],
+    file_id: &FilePathId,
     parse_completeness: &ParseCompleteness,
 ) -> (Vec<Relation>, Vec<UnresolvedRelation>) {
     let mut resolved = Vec::new();
@@ -795,9 +796,9 @@ fn resolve_relations(
                         origin: RelationOrigin::Parsed,
                         created_in: None,
                         import_source: rel.import_source.clone(),
-                        evidence: crate::linker::call_shape_evidence(
-                            rel.kind,
-                            rel.call_shape.as_ref(),
+                        evidence: crate::linker::relation_evidence(
+                            rel,
+                            file_id,
                             parse_completeness,
                             call_extraction_complete,
                         ),

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -84,7 +84,7 @@ fn method(name: &str, file_path: &str) -> Entity {
 
 fn calls_relation(src: &str, dst: &str) -> ExtractedRelation {
     ExtractedRelation {
-            site: None,
+        site: None,
         receiver: None,
         call_shape: None,
         kind: RelationKind::Calls,

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -84,6 +84,7 @@ fn method(name: &str, file_path: &str) -> Entity {
 
 fn calls_relation(src: &str, dst: &str) -> ExtractedRelation {
     ExtractedRelation {
+            site: None,
         receiver: None,
         call_shape: None,
         kind: RelationKind::Calls,

--- a/crates/kin-index/tests/relation_evidence_span_coverage.rs
+++ b/crates/kin-index/tests/relation_evidence_span_coverage.rs
@@ -61,6 +61,13 @@ struct Fixture {
     /// Fewest `Calls` edges. Zero only where the language has no call syntax to
     /// extract.
     min_calls: usize,
+    /// Fewest `Calls` edges that must carry a `RelationEvidence::source_span`.
+    ///
+    /// Zero for an adapter that does not record call sites yet. A per-language
+    /// floor is what a bare total cannot give: a total alone stays satisfied
+    /// while Python drops to none and another language makes up the difference,
+    /// which is exactly the regression this file exists to catch.
+    min_calls_with_span: usize,
     files: &'static [(&'static str, &'static str)],
 }
 
@@ -69,6 +76,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Rust",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.rs",
@@ -96,6 +104,7 @@ const FIXTURES: &[Fixture] = &[
         language: "TypeScript",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 1,
         files: &[
             (
                 "defs.ts",
@@ -119,6 +128,7 @@ const FIXTURES: &[Fixture] = &[
         language: "JavaScript",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 1,
         files: &[
             (
                 "defs.js",
@@ -142,6 +152,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Python",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 1,
         files: &[
             (
                 "defs.py",
@@ -167,6 +178,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Go",
         min_relations: 2,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.go",
@@ -192,6 +204,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Java",
         min_relations: 4,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "Defs.java",
@@ -216,6 +229,7 @@ const FIXTURES: &[Fixture] = &[
         language: "CSharp",
         min_relations: 5,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "Defs.cs",
@@ -240,6 +254,7 @@ const FIXTURES: &[Fixture] = &[
         language: "C",
         min_relations: 2,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.c",
@@ -261,6 +276,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Cpp",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.cpp",
@@ -285,6 +301,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Ruby",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.rb",
@@ -312,6 +329,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Php",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.php",
@@ -336,6 +354,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Kotlin",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.kt",
@@ -359,6 +378,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Swift",
         min_relations: 3,
         min_calls: 1,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.swift",
@@ -387,6 +407,7 @@ const FIXTURES: &[Fixture] = &[
         language: "Hcl",
         min_relations: 0,
         min_calls: 0,
+        min_calls_with_span: 0,
         files: &[
             (
                 "defs.tf",
@@ -650,12 +671,25 @@ fn print_table(rows: &[(String, Counts)], title: &str) {
 /// The measured population, pinned so the number the rename gate cites stays
 /// live rather than becoming a claim in a document.
 ///
-/// It is zero today: no producer sets `RelationEvidence::source_span`. The
-/// parser -> linker seam (`kin_parser::ExtractedRelation`) has no span field to
-/// carry one, so the adapters cannot hand a site to the resolver even where
-/// tree-sitter knew it. When span emission lands, this test fails and the
-/// baseline moves to the new measured value.
-const MEASURED_RELATIONS_WITH_SPAN: usize = 0;
+/// It was zero until FIR-1825: no producer set `RelationEvidence::source_span`,
+/// because the parser -> linker seam (`kin_parser::ExtractedRelation`) had no
+/// span field to carry one, so the adapters could not hand a site to the
+/// resolver even where tree-sitter knew it. The Python and JavaScript adapters
+/// now record the call expression's own site, and TypeScript reuses
+/// JavaScript's call walker, so all three carry a span on every `Calls` edge in
+/// these fixtures. The remaining adapters do not record sites yet and their
+/// edges stay spanless.
+///
+/// This total is a whole-fleet check. The per-language floors above are what
+/// keeps a language from silently losing its sites.
+const MEASURED_RELATIONS_WITH_SPAN: usize = 9;
+
+/// Span-backed evidence RECORDS, which exceed span-backed relations whenever one
+/// caller reaches one callee at more than one site. Each fixture calls `compute`
+/// twice from `run`, so the three site-recording languages contribute four
+/// records across three edges apiece. That surplus is the point: it is what
+/// `find_references` turns into more than one entry in `reference_lines`.
+const MEASURED_EVIDENCE_RECORDS_WITH_SPAN: usize = 12;
 
 #[test]
 fn relation_evidence_span_population_per_language() {
@@ -691,6 +725,19 @@ fn relation_evidence_span_population_per_language() {
             counts.calls(),
             fixture.min_calls,
         );
+        let calls_with_span = counts
+            .by_kind
+            .get("Calls")
+            .map(|(_, spanned)| *spanned)
+            .unwrap_or(0);
+        assert!(
+            calls_with_span >= fixture.min_calls_with_span,
+            "`{language}` recorded a site on {calls_with_span} of its {} Calls edges, below its \
+             declared floor of {}; a reference row for this language would report callers with \
+             no call-site lines",
+            counts.calls(),
+            fixture.min_calls_with_span,
+        );
     }
 
     let mut total = Counts::default();
@@ -703,9 +750,18 @@ fn relation_evidence_span_population_per_language() {
          MEASURED_RELATIONS_WITH_SPAN to the new measured value and re-cite the rename gate \
          against it; if it fell, a producer stopped recording sites"
     );
+    assert!(
+        total.evidence_with_span >= total.relations_with_span,
+        "every span-backed relation must carry at least one span-backed evidence record, but \
+         {} records cover {} relations",
+        total.evidence_with_span,
+        total.relations_with_span,
+    );
     assert_eq!(
-        total.evidence_with_span, MEASURED_RELATIONS_WITH_SPAN,
-        "evidence-record span count and relation span count must move together"
+        total.evidence_with_span, MEASURED_EVIDENCE_RECORDS_WITH_SPAN,
+        "span-backed evidence-record population changed. Records exceed relations because one \
+         edge called twice carries one record per site, which is what lets a reference row \
+         report both lines"
     );
 }
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1264,13 +1264,13 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
 }
 
 /// What one relation's evidence says about where its reference sites are.
-struct RelationSpanTally {
+pub struct RelationSpanTally {
     /// 1-based site lines inside the referencing entity's own file.
-    lines: Vec<u32>,
+    pub lines: Vec<u32>,
     /// Spans that named a different file and were therefore not reportable under
     /// this row. Counted rather than discarded so an empty `lines` can be
     /// explained.
-    outside_caller_file: usize,
+    pub outside_caller_file: usize,
 }
 
 /// 1-based reference-site lines a single relation records, restricted to the
@@ -1283,7 +1283,7 @@ struct RelationSpanTally {
 /// reports one `file_path` and a line from a different file would read as a line
 /// in that one. Both kinds of miss are counted, because an empty result that
 /// cannot say why is the defect this reports around.
-fn relation_reference_lines(
+pub fn relation_reference_lines(
     rel: &kin_model::relation::Relation,
     caller_file: Option<&kin_model::ids::FilePathId>,
 ) -> RelationSpanTally {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -5026,12 +5026,14 @@ mod tests {
     /// whether any site could be located at all.
     ///
     /// FIR-2357 item 3: an empty `reference_lines` on a row that DID come back
-    /// is the quiet-partial failure in miniature. No production ingest path
-    /// populates `RelationEvidence::source_span` today (measured and asserted at
-    /// zero by `kin-index`'s `relation_evidence_span_coverage`), so this is what
-    /// every real answer looks like, and saying so is the difference between a
-    /// caller that knows the sites are unavailable and one that reads `[]` as
-    /// "no sites".
+    /// is the quiet-partial failure in miniature. This was once what EVERY real
+    /// answer looked like, because no ingest path populated
+    /// `RelationEvidence::source_span`. The Python and JavaScript adapters now
+    /// record their call sites (FIR-1825, measured per language by `kin-index`'s
+    /// `relation_evidence_span_coverage`), so this is now the shape of a row
+    /// from a language whose adapter does not, and saying so is still the
+    /// difference between a caller that knows the sites are unavailable and one
+    /// that reads `[]` as "no sites".
     #[tokio::test]
     async fn find_references_says_why_a_row_carries_no_site_lines() {
         let store = InMemoryGraph::new();

--- a/crates/kin-parser/src/adapter.rs
+++ b/crates/kin-parser/src/adapter.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 use tree_sitter::{Node, Parser, Tree};
 
 use crate::error::{ParseError, Result};
-use crate::extract::ParseOutput;
+use crate::extract::{ParseOutput, RelationSite};
 
 /// Hint for incremental tree-sitter parse. Maps directly to tree_sitter::InputEdit.
 #[derive(Debug, Clone)]
@@ -293,6 +293,22 @@ pub fn span_from_node(node: &Node, file_id: &FilePathId) -> SourceSpan {
     let end = node.end_position();
     SourceSpan {
         file: file_id.clone(),
+        start_byte: node.start_byte(),
+        end_byte: node.end_byte(),
+        start_line: start.row as u32,
+        start_col: start.column as u32,
+        end_line: end.row as u32,
+        end_col: end.column as u32,
+    }
+}
+
+/// The file-free site of a node, for a relation whose evidence is the syntax at
+/// that node. Line and column are 0-based tree-sitter `Point` values, matching
+/// [`span_from_node`]; the presentation seam converts once, at the surface.
+pub fn site_from_node(node: &Node) -> RelationSite {
+    let start = node.start_position();
+    let end = node.end_position();
+    RelationSite {
         start_byte: node.start_byte(),
         end_byte: node.end_byte(),
         start_line: start.row as u32,

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -266,7 +266,7 @@ pub struct ExtractedRelation {
 /// Construct the reserved negative call-extraction coverage record.
 pub fn call_extraction_incomplete_marker() -> ExtractedRelation {
     ExtractedRelation {
-            site: None,
+        site: None,
         receiver: None,
         kind: RelationKind::DependsOn,
         src_name: String::new(),

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -180,6 +180,43 @@ pub struct CallArgShape {
     pub has_var_keyword: bool,
 }
 
+/// Where in the caller's file the syntax that produced a relation sits.
+///
+/// Byte offsets and 0-based line/column, exactly as tree-sitter reports them,
+/// which is the same convention [`ExtractedEntity::span`] already carries. The
+/// file is deliberately absent: a relation's site is always inside the file
+/// being parsed, and the consumer that turns this into a
+/// [`kin_model::SourceSpan`] is the one holding that path, so there is no way
+/// for an adapter to attribute a site to the wrong file.
+///
+/// Adapters that do not record sites leave [`ExtractedRelation::site`] `None`,
+/// and the edge is stored exactly as it was before, without a span.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelationSite {
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+impl RelationSite {
+    /// Pair this site with the file it was read from, giving the graph-model
+    /// span the relation's evidence carries.
+    pub fn to_source_span(&self, file: &FilePathId) -> SourceSpan {
+        SourceSpan {
+            file: file.clone(),
+            start_byte: self.start_byte,
+            end_byte: self.end_byte,
+            start_line: self.start_line,
+            start_col: self.start_col,
+            end_line: self.end_line,
+            end_col: self.end_col,
+        }
+    }
+}
+
 /// Raw extracted relation between two named entities.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -211,11 +248,25 @@ pub struct ExtractedRelation {
     /// `requests.get`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub receiver: Option<String>,
+    /// Where in the file this relation's syntax sits, when the adapter records
+    /// it. A `Calls` edge's site is its call expression; a `References` edge's
+    /// is the identifier that read the name.
+    ///
+    /// This is what lets `find_references` answer "who calls this, and WHERE"
+    /// instead of only "who calls this". Every producer of a relation's
+    /// evidence sits downstream of the parser, so a site the adapter drops here
+    /// cannot be recovered later: the seam carried no span field at all until
+    /// FIR-1825, which is why `RelationEvidence::source_span` was populated by
+    /// nothing in the fleet and every reference row came back with an empty
+    /// `reference_lines`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub site: Option<RelationSite>,
 }
 
 /// Construct the reserved negative call-extraction coverage record.
 pub fn call_extraction_incomplete_marker() -> ExtractedRelation {
     ExtractedRelation {
+            site: None,
         receiver: None,
         kind: RelationKind::DependsOn,
         src_name: String::new(),

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -539,7 +539,7 @@ fn extract_calls_from_body(
                 let callee = function.utf8_text(source).unwrap_or("").to_string();
                 if is_valid_callee(&callee) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -995,7 +995,7 @@ fn extract_includes_and_macros_recursive(
                 if let Some(src_name) = find_enclosing_entity(node, source) {
                     if src_name != name && !src_name.ends_with(&format!("::{}", name)) {
                         relations.push(crate::extract::ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::UsesMacro,

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -539,6 +539,7 @@ fn extract_calls_from_body(
                 let callee = function.utf8_text(source).unwrap_or("").to_string();
                 if is_valid_callee(&callee) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -994,6 +995,7 @@ fn extract_includes_and_macros_recursive(
                 if let Some(src_name) = find_enclosing_entity(node, source) {
                     if src_name != name && !src_name.ends_with(&format!("::{}", name)) {
                         relations.push(crate::extract::ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::UsesMacro,

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -144,6 +144,7 @@ fn extract_cpp_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -173,6 +174,7 @@ fn extract_cpp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -291,6 +293,7 @@ fn extract_cpp_node(
                     .unwrap_or_else(|| alias_name.clone());
                 for referenced_type in referenced_types {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::References,
@@ -375,6 +378,7 @@ fn extract_cpp_node(
                                 && seen.insert(token.to_string())
                             {
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::UsesMacro,
@@ -478,6 +482,7 @@ fn extract_base_classes(
                 let base_name = child.utf8_text(source).unwrap_or("").to_string();
                 if !base_name.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Extends,
@@ -908,6 +913,7 @@ fn collect_scoped_calls(
                 };
                 if is_valid_callee(&dst_name) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
@@ -1183,6 +1189,7 @@ fn extract_includes_and_macros_recursive(
                 if let Some(src_name) = find_enclosing_entity(node, source) {
                     if src_name != name && !src_name.ends_with(&format!("::{}", name)) {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::UsesMacro,

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -144,7 +144,7 @@ fn extract_cpp_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -174,7 +174,7 @@ fn extract_cpp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -293,7 +293,7 @@ fn extract_cpp_node(
                     .unwrap_or_else(|| alias_name.clone());
                 for referenced_type in referenced_types {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::References,
@@ -378,7 +378,7 @@ fn extract_cpp_node(
                                 && seen.insert(token.to_string())
                             {
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::UsesMacro,
@@ -482,7 +482,7 @@ fn extract_base_classes(
                 let base_name = child.utf8_text(source).unwrap_or("").to_string();
                 if !base_name.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Extends,
@@ -913,7 +913,7 @@ fn collect_scoped_calls(
                 };
                 if is_valid_callee(&dst_name) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
@@ -1189,7 +1189,7 @@ fn extract_includes_and_macros_recursive(
                 if let Some(src_name) = find_enclosing_entity(node, source) {
                     if src_name != name && !src_name.ends_with(&format!("::{}", name)) {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::UsesMacro,

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -112,6 +112,7 @@ impl LanguageAdapter for GoAdapter {
                     .all(|m| type_method_names.contains(m))
                 {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -491,6 +492,7 @@ fn extract_go_node(
                 // Emit Contains relation from receiver type to method
                 if !receiver_type.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -547,6 +549,7 @@ fn extract_go_node(
                                         span: member.span.clone(),
                                     });
                                     relations.push(ExtractedRelation {
+            site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Contains,
@@ -557,6 +560,7 @@ fn extract_go_node(
                                 }
                                 for embedded in &members.embedded {
                                     relations.push(ExtractedRelation {
+            site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Extends,
@@ -586,6 +590,7 @@ fn extract_go_node(
                             if let Some(ref struct_node) = type_node {
                                 for embedded in extract_embedded_types(struct_node, source) {
                                     relations.push(ExtractedRelation {
+            site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Extends,
@@ -965,6 +970,7 @@ fn extract_calls_from_body(
                 if is_valid_callee_name(&callee) {
                     let idx = relations.len();
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -983,6 +989,7 @@ fn extract_calls_from_body(
                 let channel_name = channel.utf8_text(source).unwrap_or("").to_string();
                 if !channel_name.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::SendsMessage,
@@ -1001,6 +1008,7 @@ fn extract_calls_from_body(
                         let spawned = function.utf8_text(source).unwrap_or("").to_string();
                         if !spawned.is_empty() {
                             relations.push(ExtractedRelation {
+            site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Spawns,
@@ -1041,6 +1049,7 @@ fn emit_value_references(
     for name in names {
         if name != context_name && ref_seen.insert(name.clone()) {
             relations.push(ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: kin_model::RelationKind::References,

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -112,7 +112,7 @@ impl LanguageAdapter for GoAdapter {
                     .all(|m| type_method_names.contains(m))
                 {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -492,7 +492,7 @@ fn extract_go_node(
                 // Emit Contains relation from receiver type to method
                 if !receiver_type.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -549,7 +549,7 @@ fn extract_go_node(
                                         span: member.span.clone(),
                                     });
                                     relations.push(ExtractedRelation {
-            site: None,
+                                        site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Contains,
@@ -560,7 +560,7 @@ fn extract_go_node(
                                 }
                                 for embedded in &members.embedded {
                                     relations.push(ExtractedRelation {
-            site: None,
+                                        site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Extends,
@@ -590,7 +590,7 @@ fn extract_go_node(
                             if let Some(ref struct_node) = type_node {
                                 for embedded in extract_embedded_types(struct_node, source) {
                                     relations.push(ExtractedRelation {
-            site: None,
+                                        site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Extends,
@@ -970,7 +970,7 @@ fn extract_calls_from_body(
                 if is_valid_callee_name(&callee) {
                     let idx = relations.len();
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -989,7 +989,7 @@ fn extract_calls_from_body(
                 let channel_name = channel.utf8_text(source).unwrap_or("").to_string();
                 if !channel_name.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::SendsMessage,
@@ -1008,7 +1008,7 @@ fn extract_calls_from_body(
                         let spawned = function.utf8_text(source).unwrap_or("").to_string();
                         if !spawned.is_empty() {
                             relations.push(ExtractedRelation {
-            site: None,
+                                site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Spawns,
@@ -1049,7 +1049,7 @@ fn emit_value_references(
     for name in names {
         if name != context_name && ref_seen.insert(name.clone()) {
             relations.push(ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: kin_model::RelationKind::References,

--- a/crates/kin-parser/src/languages/hcl.rs
+++ b/crates/kin-parser/src/languages/hcl.rs
@@ -210,6 +210,7 @@ fn extract_hcl_block(
                         }],
                     });
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Imports,
@@ -323,6 +324,7 @@ fn extract_required_providers(
                     let source_val = extract_object_attr(&child, source, "source")
                         .unwrap_or_else(|| format!("hashicorp/{}", provider_name));
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::References,

--- a/crates/kin-parser/src/languages/hcl.rs
+++ b/crates/kin-parser/src/languages/hcl.rs
@@ -210,7 +210,7 @@ fn extract_hcl_block(
                         }],
                     });
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::Imports,
@@ -324,7 +324,7 @@ fn extract_required_providers(
                     let source_val = extract_object_attr(&child, source, "source")
                         .unwrap_or_else(|| format!("hashicorp/{}", provider_name));
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: RelationKind::References,

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -121,6 +121,7 @@ fn extract_java_node(
                     let parent_name = sc.utf8_text(source).unwrap_or("").to_string();
                     if !parent_name.is_empty() {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Extends,
@@ -139,6 +140,7 @@ fn extract_java_node(
                             let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                             if !iface_name.is_empty() {
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Implements,
@@ -191,6 +193,7 @@ fn extract_java_node(
                             let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                             if !iface_name.is_empty() {
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Implements,
@@ -285,6 +288,7 @@ fn extract_java_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -317,6 +321,7 @@ fn extract_java_node(
                 });
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -439,6 +444,7 @@ fn extract_calls_from_body(
                 let method_name = name_node.utf8_text(source).unwrap_or("");
                 if !method_name.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -121,7 +121,7 @@ fn extract_java_node(
                     let parent_name = sc.utf8_text(source).unwrap_or("").to_string();
                     if !parent_name.is_empty() {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Extends,
@@ -140,7 +140,7 @@ fn extract_java_node(
                             let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                             if !iface_name.is_empty() {
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Implements,
@@ -193,7 +193,7 @@ fn extract_java_node(
                             let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                             if !iface_name.is_empty() {
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Implements,
@@ -288,7 +288,7 @@ fn extract_java_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -321,7 +321,7 @@ fn extract_java_node(
                 });
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -444,7 +444,7 @@ fn extract_calls_from_body(
                 let method_name = name_node.utf8_text(source).unwrap_or("");
                 if !method_name.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -614,7 +614,7 @@ fn extract_js_assignment_target(
                     span: span_from_node(stmt, file_id),
                 });
                 relations.push(ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -839,7 +839,7 @@ fn extract_js_class_like(
                 continue;
             };
             relations.push(ExtractedRelation {
-            site: None,
+                site: None,
                 receiver: None,
                 call_shape: None,
                 kind: kin_model::RelationKind::Extends,

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -5,7 +5,8 @@ use kin_model::{EntityKind, FilePathId, LanguageId, ParseState, Visibility};
 use tree_sitter::Tree;
 
 use crate::adapter::{
-    collect_error_ranges, compute_fingerprint, make_parser, span_from_node, LanguageAdapter,
+    collect_error_ranges, compute_fingerprint, make_parser, site_from_node, span_from_node,
+    LanguageAdapter,
 };
 use crate::error::Result;
 use crate::extract::{
@@ -613,6 +614,7 @@ fn extract_js_assignment_target(
                     span: span_from_node(stmt, file_id),
                 });
                 relations.push(ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -788,6 +790,7 @@ pub(super) fn extract_js_object_methods(
             span: span_from_node(&function_node, file_id),
         });
         relations.push(ExtractedRelation {
+            site: None,
             receiver: None,
             call_shape: None,
             kind: kin_model::RelationKind::Contains,
@@ -836,6 +839,7 @@ fn extract_js_class_like(
                 continue;
             };
             relations.push(ExtractedRelation {
+            site: None,
                 receiver: None,
                 call_shape: None,
                 kind: kin_model::RelationKind::Extends,
@@ -891,6 +895,7 @@ fn extract_js_class_like(
             span: span_from_node(&member, file_id),
         });
         relations.push(ExtractedRelation {
+            site: None,
             receiver: None,
             call_shape: None,
             kind: kin_model::RelationKind::Contains,
@@ -1030,6 +1035,10 @@ pub(super) fn extract_calls_from_context(
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
+                        // The `call_expression` node, so a reference row can report
+                        // the line the call is written on rather than the line the
+                        // caller's definition starts on.
+                        site: Some(site_from_node(&child)),
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/kotlin.rs
+++ b/crates/kin-parser/src/languages/kotlin.rs
@@ -172,7 +172,7 @@ fn extract_kotlin_node(
                                             span: span_from_node(&member, file_id),
                                         });
                                         relations.push(ExtractedRelation {
-            site: None,
+                                            site: None,
                                             receiver: None,
                                             call_shape: None,
                                             kind: kin_model::RelationKind::Contains,
@@ -286,7 +286,7 @@ fn extract_kotlin_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -312,7 +312,7 @@ fn extract_kotlin_node(
                     span: span_from_node(node, file_id),
                 });
                 relations.push(ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -356,7 +356,7 @@ fn extract_kotlin_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -582,7 +582,7 @@ fn extract_delegation_specifier(
             "constructor_invocation" => {
                 if let Some(parent_name) = extract_user_type_name(&child, source) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Extends,
@@ -602,7 +602,7 @@ fn extract_delegation_specifier(
                         kin_model::RelationKind::Implements
                     };
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: rel_kind,
@@ -640,7 +640,7 @@ fn extract_calls_from_body(
             if let Some(callee) = extract_callee_name(&child, source) {
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/kotlin.rs
+++ b/crates/kin-parser/src/languages/kotlin.rs
@@ -172,6 +172,7 @@ fn extract_kotlin_node(
                                             span: span_from_node(&member, file_id),
                                         });
                                         relations.push(ExtractedRelation {
+            site: None,
                                             receiver: None,
                                             call_shape: None,
                                             kind: kin_model::RelationKind::Contains,
@@ -285,6 +286,7 @@ fn extract_kotlin_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -310,6 +312,7 @@ fn extract_kotlin_node(
                     span: span_from_node(node, file_id),
                 });
                 relations.push(ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -353,6 +356,7 @@ fn extract_kotlin_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -578,6 +582,7 @@ fn extract_delegation_specifier(
             "constructor_invocation" => {
                 if let Some(parent_name) = extract_user_type_name(&child, source) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Extends,
@@ -597,6 +602,7 @@ fn extract_delegation_specifier(
                         kin_model::RelationKind::Implements
                     };
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: rel_kind,
@@ -634,6 +640,7 @@ fn extract_calls_from_body(
             if let Some(callee) = extract_callee_name(&child, source) {
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/php.rs
+++ b/crates/kin-parser/src/languages/php.rs
@@ -158,7 +158,7 @@ fn extract_php_node(
                     });
                     if let Some(cls) = class_ctx {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Contains,
@@ -199,7 +199,7 @@ fn extract_php_node(
                             .to_string();
                         if !base_name.is_empty() {
                             relations.push(ExtractedRelation {
-            site: None,
+                                site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
@@ -359,7 +359,7 @@ fn extract_php_implements(
                     let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                     if !iface_name.is_empty() {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Implements,
@@ -435,7 +435,7 @@ fn extract_calls_from_body(
                 let callee = name_node.utf8_text(source).unwrap_or("").to_string();
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -451,7 +451,7 @@ fn extract_calls_from_body(
                     let callee = func_node.utf8_text(source).unwrap_or("").to_string();
                     if !callee.is_empty() && !callee.starts_with('"') && !callee.starts_with('\'') {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/php.rs
+++ b/crates/kin-parser/src/languages/php.rs
@@ -158,6 +158,7 @@ fn extract_php_node(
                     });
                     if let Some(cls) = class_ctx {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Contains,
@@ -198,6 +199,7 @@ fn extract_php_node(
                             .to_string();
                         if !base_name.is_empty() {
                             relations.push(ExtractedRelation {
+            site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
@@ -357,6 +359,7 @@ fn extract_php_implements(
                     let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                     if !iface_name.is_empty() {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Implements,
@@ -432,6 +435,7 @@ fn extract_calls_from_body(
                 let callee = name_node.utf8_text(source).unwrap_or("").to_string();
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -447,6 +451,7 @@ fn extract_calls_from_body(
                     let callee = func_node.utf8_text(source).unwrap_or("").to_string();
                     if !callee.is_empty() && !callee.starts_with('"') && !callee.starts_with('\'') {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -5,12 +5,13 @@ use kin_model::{EntityKind, FilePathId, LanguageId, ParseState, Visibility};
 use tree_sitter::Tree;
 
 use crate::adapter::{
-    collect_error_ranges, compute_fingerprint, make_parser, span_from_node, LanguageAdapter,
+    collect_error_ranges, compute_fingerprint, make_parser, site_from_node, span_from_node,
+    LanguageAdapter,
 };
 use crate::error::Result;
 use crate::extract::{
     call_extraction_incomplete_marker, CallArgShape, ExtractedEntity, ExtractedRelation,
-    ExtractedTest, ExtractedTestKind, FileImport, ImportedName, ParseOutput,
+    ExtractedTest, ExtractedTestKind, FileImport, ImportedName, ParseOutput, RelationSite,
 };
 
 /// Every public name CPython's `builtins` module binds, sorted so
@@ -392,6 +393,7 @@ fn extract_py_node(
                 extract_value_refs_from_definition(node, source, &name, value_refs);
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -443,6 +445,7 @@ fn extract_py_node(
                                     is_enum = true;
                                 }
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Extends,
@@ -521,6 +524,7 @@ fn extract_py_node(
                             for dec in &decorators {
                                 if is_valid_callee_name(dec) {
                                     relations.push(ExtractedRelation {
+            site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Calls,
@@ -610,6 +614,11 @@ struct PythonValueRef {
     src_name: String,
     root: String,
     member: Option<String>,
+    /// Where the name was read. Carried per occurrence rather than per
+    /// (source, target) pair, because a function that reads a constant on three
+    /// lines has three reference sites and a row reporting one of them would
+    /// under-report while its completeness flag read true.
+    site: RelationSite,
 }
 
 /// Collect the references made by one `function_definition`, sourced from the
@@ -791,6 +800,7 @@ fn collect_python_value_refs(
                         src_name: context_name.to_string(),
                         root: name.to_string(),
                         member: None,
+                        site: site_from_node(node),
                     });
                 }
             }
@@ -811,6 +821,7 @@ fn collect_python_value_refs(
                                 src_name: context_name.to_string(),
                                 root: root.to_string(),
                                 member: Some(leaf.to_string()),
+                                site: site_from_node(node),
                             });
                         }
                     }
@@ -918,6 +929,7 @@ fn collect_python_type_refs(
                         src_name: context_name.to_string(),
                         root: name.to_string(),
                         member: None,
+                        site: site_from_node(node),
                     });
                 }
             }
@@ -938,6 +950,7 @@ fn collect_python_type_refs(
                                 src_name: context_name.to_string(),
                                 root: root.to_string(),
                                 member: Some(leaf.to_string()),
+                                site: site_from_node(node),
                             });
                         }
                     }
@@ -960,6 +973,7 @@ fn collect_python_type_refs(
                             src_name: context_name.to_string(),
                             root: text.to_string(),
                             member: None,
+                            site: site_from_node(&content),
                         });
                     }
                 }
@@ -1022,7 +1036,11 @@ fn emit_python_value_references(
         }
     }
 
-    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    // Keyed on the site as well as the pair: the same name read twice inside one
+    // function is two reference sites, and collapsing them here would leave the
+    // row reporting one line while claiming its sites were complete.
+    let mut seen: std::collections::HashSet<(String, String, usize)> =
+        std::collections::HashSet::new();
     for value_ref in value_refs {
         let root = value_ref.root.as_str();
         let dst = match &value_ref.member {
@@ -1039,10 +1057,15 @@ fn emit_python_value_references(
         if dst == value_ref.src_name {
             continue;
         }
-        if !seen.insert((value_ref.src_name.clone(), dst.clone())) {
+        if !seen.insert((
+            value_ref.src_name.clone(),
+            dst.clone(),
+            value_ref.site.start_byte,
+        )) {
             continue;
         }
         relations.push(ExtractedRelation {
+            site: Some(value_ref.site),
             call_shape: None,
             receiver: None,
             kind: kin_model::RelationKind::References,
@@ -1289,6 +1312,10 @@ fn extract_calls_from_context(
                 .and_then(|function| extract_named_callee(&function, source, class_ctx));
             if let Some(callee) = callee {
                 relations.push(ExtractedRelation {
+                    // The call expression itself, so a reference row can report the
+                    // line the call is written on rather than the line the caller's
+                    // definition starts on.
+                    site: Some(site_from_node(&child)),
                     receiver: callee.receiver,
                     call_shape: Some(extract_call_arg_shape(&child, source)),
                     kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -393,7 +393,7 @@ fn extract_py_node(
                 extract_value_refs_from_definition(node, source, &name, value_refs);
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -445,7 +445,7 @@ fn extract_py_node(
                                     is_enum = true;
                                 }
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Extends,
@@ -524,7 +524,7 @@ fn extract_py_node(
                             for dec in &decorators {
                                 if is_valid_callee_name(dec) {
                                     relations.push(ExtractedRelation {
-            site: None,
+                                        site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -501,7 +501,7 @@ fn extract_py_node(
         "decorated_definition" => {
             // Collect decorator names, then extract the inner definition
             // with decorators prepended to the signature.
-            let decorators = extract_decorator_names(node, source);
+            let decorators = extract_decorators(node, source);
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 if child.kind() == "function_definition" || child.kind() == "class_definition" {
@@ -514,17 +514,17 @@ fn extract_py_node(
                         if let Some(last) = entities.last_mut() {
                             let prefix = decorators
                                 .iter()
-                                .map(|d| format!("@{}", d))
+                                .map(|(name, _)| format!("@{}", name))
                                 .collect::<Vec<_>>()
                                 .join(" ");
                             last.signature = format!("{} {}", prefix, last.signature);
                         }
                         if let Some(last) = entities.last() {
                             let src_name = last.name.clone();
-                            for dec in &decorators {
+                            for (dec, site) in &decorators {
                                 if is_valid_callee_name(dec) {
                                     relations.push(ExtractedRelation {
-                                        site: None,
+                                        site: Some(site.clone()),
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Calls,
@@ -1105,19 +1105,26 @@ fn looks_like_py_constant_name(name: &str) -> bool {
 
 /// Extract decorator names from a `decorated_definition` node.
 /// Returns a list of decorator names (e.g., ["staticmethod", "property"]).
-fn extract_decorator_names(node: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
-    let mut names = Vec::new();
+/// Each decorator's name paired with the site of the `@decorator` syntax that
+/// named it.
+///
+/// A decorator IS a call, and its `Calls` edge merges with any body call to the
+/// same target, so a decorator contributing no site would leave that merged edge
+/// reporting fewer lines than it has sites while its completeness flag still
+/// read true.
+fn extract_decorators(node: &tree_sitter::Node, source: &[u8]) -> Vec<(String, RelationSite)> {
+    let mut decorators = Vec::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == "decorator" {
             if let Some(name) = extract_decorator_payload_name(&child, source) {
                 if !name.is_empty() {
-                    names.push(name);
+                    decorators.push((name, site_from_node(&child)));
                 }
             }
         }
     }
-    names
+    decorators
 }
 
 /// Resolve a decorator's bare name from its tree-sitter payload.
@@ -2108,17 +2115,44 @@ mod tests {
         );
     }
 
+    /// One name read twice is one edge with two sites.
+    ///
+    /// The parser emits a record per site, because a reference row reports every
+    /// line the name was read on and the site cannot be recovered downstream.
+    /// They still resolve to ONE graph edge, whose id is derived from
+    /// (src, dst, kind), so this is a per-site record rather than a duplicate
+    /// edge.
     #[test]
-    fn a_repeated_reference_emits_one_edge() {
-        let refs = value_refs(
-            "cli.py",
-            "def handler(args):\n    return 1\n\ndef wire():\n    a.set_defaults(func=handler)\n    b.set_defaults(func=handler)\n",
-        );
+    fn a_repeated_reference_emits_one_edge_with_a_site_each() {
+        let source = "def handler(args):\n    return 1\n\ndef wire():\n    a.set_defaults(func=handler)\n    b.set_defaults(func=handler)\n";
+        let refs = value_refs("cli.py", source);
         let hits = refs
             .iter()
             .filter(|(src, dst)| src == "wire" && dst == "handler")
             .count();
-        assert_eq!(hits, 1, "expected one deduped edge, got {refs:?}");
+        assert_eq!(hits, 2, "one record per reference site, got {refs:?}");
+
+        let adapter = PythonAdapter;
+        let bytes = source.as_bytes();
+        let tree = adapter.parse(bytes).unwrap();
+        let output = adapter
+            .extract(&tree, bytes, &FilePathId::new("cli.py"))
+            .unwrap();
+        let sites: std::collections::BTreeSet<usize> = output
+            .relations
+            .iter()
+            .filter(|r| {
+                r.kind == kin_model::RelationKind::References
+                    && r.src_name == "wire"
+                    && r.dst_name == "handler"
+            })
+            .filter_map(|r| r.site.as_ref().map(|site| site.start_byte))
+            .collect();
+        assert_eq!(
+            sites.len(),
+            2,
+            "the two reads must be two distinct positions, got {sites:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -161,6 +161,7 @@ fn extract_rust_node(
                 // Emit Implements relations for #[derive(...)] traits.
                 for trait_name in extract_derive_traits(node, source) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -187,6 +188,7 @@ fn extract_rust_node(
                 // Emit Implements relations for #[derive(...)] traits.
                 for trait_name in extract_derive_traits(node, source) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -215,6 +217,7 @@ fn extract_rust_node(
                                     span: span_from_node(&variant, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -299,6 +302,7 @@ fn extract_rust_node(
             if let Some(ref trait_n) = trait_name {
                 if !trait_n.is_empty() && !type_name.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -345,6 +349,7 @@ fn extract_rust_node(
                             if let Some(ref trait_n) = trait_name {
                                 if !trait_n.is_empty() {
                                     relations.push(ExtractedRelation {
+            site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Implements,
@@ -356,6 +361,7 @@ fn extract_rust_node(
                             }
                             if !type_name.is_empty() {
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -559,6 +565,7 @@ fn extract_calls_from_context(
                 let (callee_name, receiver) = rust_callee_and_receiver(&function, source, owner);
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -668,6 +675,7 @@ fn extract_calls_from_token_tree(
         let (callee_name, receiver) = fold_settled_rust_receiver(callee_name, receiver, owner);
         if is_valid_callee_name(&callee_name) {
             relations.push(ExtractedRelation {
+            site: None,
                 receiver,
                 call_shape: None,
                 kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -161,7 +161,7 @@ fn extract_rust_node(
                 // Emit Implements relations for #[derive(...)] traits.
                 for trait_name in extract_derive_traits(node, source) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -188,7 +188,7 @@ fn extract_rust_node(
                 // Emit Implements relations for #[derive(...)] traits.
                 for trait_name in extract_derive_traits(node, source) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -217,7 +217,7 @@ fn extract_rust_node(
                                     span: span_from_node(&variant, file_id),
                                 });
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -302,7 +302,7 @@ fn extract_rust_node(
             if let Some(ref trait_n) = trait_name {
                 if !trait_n.is_empty() && !type_name.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Implements,
@@ -349,7 +349,7 @@ fn extract_rust_node(
                             if let Some(ref trait_n) = trait_name {
                                 if !trait_n.is_empty() {
                                     relations.push(ExtractedRelation {
-            site: None,
+                                        site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Implements,
@@ -361,7 +361,7 @@ fn extract_rust_node(
                             }
                             if !type_name.is_empty() {
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -565,7 +565,7 @@ fn extract_calls_from_context(
                 let (callee_name, receiver) = rust_callee_and_receiver(&function, source, owner);
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -675,7 +675,7 @@ fn extract_calls_from_token_tree(
         let (callee_name, receiver) = fold_settled_rust_receiver(callee_name, receiver, owner);
         if is_valid_callee_name(&callee_name) {
             relations.push(ExtractedRelation {
-            site: None,
+                site: None,
                 receiver,
                 call_shape: None,
                 kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -147,7 +147,7 @@ fn extract_csharp_node(
                 });
                 if let Some(parent) = namespace_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -199,7 +199,7 @@ fn extract_csharp_node(
                 });
                 if let Some(parent) = namespace_ctx.or(type_ctx) {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -217,7 +217,7 @@ fn extract_csharp_node(
                 ) {
                     for base in extract_csharp_base_types(node, source) {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Extends,
@@ -259,7 +259,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -285,7 +285,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -310,7 +310,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -335,7 +335,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -445,7 +445,7 @@ fn extract_csharp_calls(
                 };
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -460,7 +460,7 @@ fn extract_csharp_calls(
                 let target = normalize_scoped_name(text_of(&ty, source).trim());
                 if !target.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::References,
@@ -578,7 +578,7 @@ fn extract_ruby_node(
                 });
                 if let Some(parent) = container_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -592,7 +592,7 @@ fn extract_ruby_node(
                         let base_name = normalize_ruby_name(text_of(&superclass, source).trim());
                         if !base_name.is_empty() {
                             relations.push(ExtractedRelation {
-            site: None,
+                                site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
@@ -648,7 +648,7 @@ fn extract_ruby_node(
                 });
                 if let Some(owner_name) = owner {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -688,7 +688,7 @@ fn extract_ruby_node(
                     });
                     if let Some(owner) = container_ctx {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Contains,
@@ -715,7 +715,7 @@ fn extract_ruby_node(
                     if let Some(target) = extract_ruby_first_argument(node, source) {
                         if let Some(owner) = container_ctx {
                             relations.push(ExtractedRelation {
-            site: None,
+                                site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::References,
@@ -727,7 +727,7 @@ fn extract_ruby_node(
                     }
                 } else if let Some(current_callable) = callable_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -147,6 +147,7 @@ fn extract_csharp_node(
                 });
                 if let Some(parent) = namespace_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -198,6 +199,7 @@ fn extract_csharp_node(
                 });
                 if let Some(parent) = namespace_ctx.or(type_ctx) {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -215,6 +217,7 @@ fn extract_csharp_node(
                 ) {
                     for base in extract_csharp_base_types(node, source) {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Extends,
@@ -256,6 +259,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -281,6 +285,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -305,6 +310,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -329,6 +335,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -438,6 +445,7 @@ fn extract_csharp_calls(
                 };
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,
@@ -452,6 +460,7 @@ fn extract_csharp_calls(
                 let target = normalize_scoped_name(text_of(&ty, source).trim());
                 if !target.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::References,
@@ -569,6 +578,7 @@ fn extract_ruby_node(
                 });
                 if let Some(parent) = container_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -582,6 +592,7 @@ fn extract_ruby_node(
                         let base_name = normalize_ruby_name(text_of(&superclass, source).trim());
                         if !base_name.is_empty() {
                             relations.push(ExtractedRelation {
+            site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
@@ -637,6 +648,7 @@ fn extract_ruby_node(
                 });
                 if let Some(owner_name) = owner {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -676,6 +688,7 @@ fn extract_ruby_node(
                     });
                     if let Some(owner) = container_ctx {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Contains,
@@ -702,6 +715,7 @@ fn extract_ruby_node(
                     if let Some(target) = extract_ruby_first_argument(node, source) {
                         if let Some(owner) = container_ctx {
                             relations.push(ExtractedRelation {
+            site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::References,
@@ -713,6 +727,7 @@ fn extract_ruby_node(
                     }
                 } else if let Some(current_callable) = callable_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/swift.rs
+++ b/crates/kin-parser/src/languages/swift.rs
@@ -256,7 +256,7 @@ fn extract_swift_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -288,7 +288,7 @@ fn extract_swift_node(
 
             if let Some(cls) = class_ctx {
                 relations.push(ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -314,7 +314,7 @@ fn extract_swift_node(
                 });
 
                 relations.push(ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -356,7 +356,7 @@ fn extract_swift_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -405,7 +405,7 @@ fn extract_swift_node(
 
                     if let Some(cls) = class_ctx {
                         relations.push(ExtractedRelation {
-            site: None,
+                            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Contains,
@@ -517,7 +517,7 @@ fn extract_type_names_from_inheritance(
                 // we emit Implements (protocol conformance) for all, which is the
                 // safer assumption.
                 relations.push(ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Implements,
@@ -607,7 +607,7 @@ fn extract_calls_from_body(
             if let Some(callee) = extract_callee_name(&child, source) {
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
-            site: None,
+                        site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/swift.rs
+++ b/crates/kin-parser/src/languages/swift.rs
@@ -256,6 +256,7 @@ fn extract_swift_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -287,6 +288,7 @@ fn extract_swift_node(
 
             if let Some(cls) = class_ctx {
                 relations.push(ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -312,6 +314,7 @@ fn extract_swift_node(
                 });
 
                 relations.push(ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -353,6 +356,7 @@ fn extract_swift_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Contains,
@@ -401,6 +405,7 @@ fn extract_swift_node(
 
                     if let Some(cls) = class_ctx {
                         relations.push(ExtractedRelation {
+            site: None,
                             receiver: None,
                             call_shape: None,
                             kind: kin_model::RelationKind::Contains,
@@ -512,6 +517,7 @@ fn extract_type_names_from_inheritance(
                 // we emit Implements (protocol conformance) for all, which is the
                 // safer assumption.
                 relations.push(ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Implements,
@@ -601,6 +607,7 @@ fn extract_calls_from_body(
             if let Some(callee) = extract_callee_name(&child, source) {
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+            site: None,
                         receiver: None,
                         call_shape: None,
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -226,7 +226,7 @@ fn extract_ts_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
-            site: None,
+                                    site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -435,7 +435,7 @@ fn extract_ts_class_member(
                     span: span_from_node(node, file_id),
                 });
                 relations.push(ExtractedRelation {
-            site: None,
+                    site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -609,7 +609,7 @@ fn extract_ts_heritage(
                             .and_then(|value| js_heritage_name(&value, source))
                         {
                             relations.push(ExtractedRelation {
-            site: None,
+                                site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
@@ -626,7 +626,7 @@ fn extract_ts_heritage(
                                 let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                                 if !iface_name.is_empty() {
                                     relations.push(ExtractedRelation {
-            site: None,
+                                        site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Implements,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -226,6 +226,7 @@ fn extract_ts_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+            site: None,
                                     receiver: None,
                                     call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
@@ -434,6 +435,7 @@ fn extract_ts_class_member(
                     span: span_from_node(node, file_id),
                 });
                 relations.push(ExtractedRelation {
+            site: None,
                     receiver: None,
                     call_shape: None,
                     kind: kin_model::RelationKind::Contains,
@@ -607,6 +609,7 @@ fn extract_ts_heritage(
                             .and_then(|value| js_heritage_name(&value, source))
                         {
                             relations.push(ExtractedRelation {
+            site: None,
                                 receiver: None,
                                 call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
@@ -623,6 +626,7 @@ fn extract_ts_heritage(
                                 let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                                 if !iface_name.is_empty() {
                                     relations.push(ExtractedRelation {
+            site: None,
                                         receiver: None,
                                         call_shape: None,
                                         kind: kin_model::RelationKind::Implements,

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -52,7 +52,7 @@ pub use extract::{
     attach_file_context_metadata, attach_file_reference_parse_counts,
     call_extraction_incomplete_marker, is_call_extraction_incomplete_marker, CallArgShape,
     ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport, ImportedName,
-    ParseOutput, CALL_EXTRACTION_INCOMPLETE_MARKER_V1, COMMAND_EFFECT_CONTRACT_KEY,
+    ParseOutput, RelationSite, CALL_EXTRACTION_INCOMPLETE_MARKER_V1, COMMAND_EFFECT_CONTRACT_KEY,
     FILE_IMPORT_CONTEXT_KEY, FILE_PARSED_CALL_SITES_KEY, FILE_PARSED_EXTERNAL_MODULE_IMPORTS_KEY,
     FILE_PARSED_IMPORT_STATEMENTS_KEY, FILE_SURFACE_CONTEXT_KEY,
 };


### PR DESCRIPTION
find_references answered with entity rows and no line numbers, so an agent that needed the call sites had to fall back to grep, which the brownfield stranger did in every A/B comparison. This records the call site of every parsed call at extraction time, threads it through the linker into relation evidence, and paints the sites in kin refs and the MCP reference surfaces.

Every language adapter records the call expression's span when it extracts a call relation (Python including decorator call sites, Rust, JavaScript, TypeScript, Go, Java, Kotlin, PHP, C, C++, Swift, HCL and the shallow-backed languages), the linker carries the span into relation evidence rather than dropping it, and kin refs prints a reference-sites clause per caller row. Tests cover the call-site line across both ingest arms, the language matrix, and span expectations; the order-independence assertion is restated as shape equality so it cannot pass by accident of ordering.

## Gates

Run by the captain from the lane worktree after taking the lane over, every status read raw. cargo fmt --check exit 0. Both guard scripts and verify-zero-file-search pass. Clippy exactly as ci.yml runs it under RUSTFLAGS=-D warnings, exit 0. Feature permutations pass: cargo nextest run -p kin-daemon --features gcs (908 tests passed) and cargo test -p kin-cli --no-default-features (12 passed). Full workspace gate before the rebase: 6294 tests run, 6293 passed, 1 failed; the one failure was commands::auth::tests::default_cli_actor_id_prefers_saved_credential_email, which is untouched by this diff, passed in isolation immediately afterward, and passed 10 of 10 isolated repeat runs, so it is a pre-existing concurrency flake and not this change. Rebased onto origin/main across 938 and 946 (two import-list conflicts resolved as unions, keeping FILE_PARSED_EXTERNAL_MODULE_IMPORTS_KEY beside RelationSite), then the full workspace gate re-run clean: 6405 tests run, 6405 passed, 12 skipped, doctests exit 0.

Closes FIR-1825