### PR TITLE
Abandon v0.5.41: its frozen install proof fails on a projection recording the tag cannot receive the fix for

### DIFF
--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -70,6 +70,13 @@
       "reason": "The Public Install Proof frozen at this tag fails on all five platforms at the installed capability validation: the tagged binary's locate coverage counts a graph-owned source path as bodied only when an opaque artifact carries a text preview for it, and no HEAD admission path writes such a record for a parsed source file (the daemon keeps one facet per path and clears opaque records on entity paths), so a fresh install's kin locate reports semantic coverage incomplete with a body gap on every store that holds one parsed source file, and the proof's complete-coverage assertion refuses it. The repair, which reads the entity body previews the graph already holds at HEAD, landed on main only after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing check. Both attempts of the cited run failed with the same signature on all five legs, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm and Homebrew were verified untouched at 0.5.37, and the tag never became the finalized Latest release.",
       "superseded_by": "v0.5.39",
       "failed_release_run_id": "32107626360"
+    },
+    {
+      "tag": "v0.5.41",
+      "sha": "14efb5a7b1351cf5cde1a95a473781a9bec9fa96",
+      "reason": "The Public Install Proof frozen at this tag fails on windows-latest, macos-latest and macos-15-intel because the tagged binary's setup records the platform's preferred mount projection without engaging it: the chooser picks nfs on macOS and projfs on Windows, setup records the choice with nothing mounted and no server running, and the tag's own kin doctor then reads the recording as projection_mode=misconfigured, which is fatal under the proof's aggregate-health tolerance rule. The failure is deterministic on every fresh install of these bytes, so retries cannot pass it. The repair, recording only a projection that is in force by installation alone and leaving mount modes to be recorded by kin vfs on at the moment they actually engage, landed on main only after the tag as kin#953, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing check. All release attempts of the cited run failed with the same signature on the same three legs, the ubuntu legs passed, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm and Homebrew were verified untouched at 0.5.40, and the tag never became the finalized Latest release.",
+      "superseded_by": "v0.5.42",
+      "failed_release_run_id": "32237324302"
     }
   ]
 }


### PR DESCRIPTION
v0.5.41's release run 32237324302 failed its Public Install Proof on windows-latest, macos-latest and macos-15-intel, both attempts, same signature, before anything published. The cause is frozen into the tag: setup records nfs on macOS and projfs on Windows without engaging them, and the tag's own doctor reads the recording as projection_mode=misconfigured, which the proof's aggregate-health rule treats as fatal. The failure is deterministic on every fresh install of these bytes, so further retries cannot pass, and the repair (kin#953, merged as 0b8767c8 with a falsified guard) resolves from main while a tag run resolves everything from the tag.

The release train currently holds with marker tag_not_finalized ("highest tag v0.5.41 is not finalized GitHub Latest v0.5.40; release recovery owns this state"), and its own policy steps past a tag only on a reviewed abandonment record. This adds that record with all five required fields, and the entry is proven with the repo's own selector: `python3 scripts/select-admissible-release-tag.py` over the updated manifest skips v0.5.41 with the notice line and names v0.5.40 the highest admissible base, exit 0.

Channel state verified before writing the record: the only GitHub Release object for v0.5.41 is the unpromoted prerelease the workflow publishes before proof, `npm view @kinlab/kin version` prints 0.5.40, and the Homebrew formula reads 0.5.40. The ubuntu proof legs passed on both attempts, so the abandonment is scoped to what the tag actually cannot do.

Release policy suites on this branch: node --test over the eight release scripts, 151 pass, 0 fail; release-workflow authority exit 0.

Closes FIR-2454 is deliberately absent: that ticket closed with kin#953. This record is the sequencing half, and v0.5.42 supersedes the dead tag.