### PR TITLE
Abandon v0.5.41: its frozen install proof fails on a recorded-but-unengaged projection the tag cannot receive the fix for

### DIFF
--- a/scripts/abandoned-release-tags.json
+++ b/scripts/abandoned-release-tags.json
@@ -70,6 +70,13 @@
       "reason": "The Public Install Proof frozen at this tag fails on all five platforms at the installed capability validation: the tagged binary's locate coverage counts a graph-owned source path as bodied only when an opaque artifact carries a text preview for it, and no HEAD admission path writes such a record for a parsed source file (the daemon keeps one facet per path and clears opaque records on entity paths), so a fresh install's kin locate reports semantic coverage incomplete with a body gap on every store that holds one parsed source file, and the proof's complete-coverage assertion refuses it. The repair, which reads the entity body previews the graph already holds at HEAD, landed on main only after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing check. Both attempts of the cited run failed with the same signature on all five legs, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm and Homebrew were verified untouched at 0.5.37, and the tag never became the finalized Latest release.",
       "superseded_by": "v0.5.39",
       "failed_release_run_id": "32107626360"
+    },
+    {
+      "tag": "v0.5.41",
+      "sha": "14efb5a7b1351cf5cde1a95a473781a9bec9fa96",
+      "reason": "The Public Install Proof frozen at this tag fails on its three non-Linux legs: the tagged binary's setup records the platform-preferred mount projection (nfs on macOS, projfs on Windows) without engaging it, so on every fresh install kin doctor reads the recorded mode against the running state and reports projection_mode=misconfigured, which is fatal under the proof's aggregate-health rule; the macOS legs' own capture reads nfs is recorded but is not what is running; mode=nfs mounted=no readable=no writable=no degraded=yes, and the Windows leg reads identically with projfs. The repair, which records only a projection that installation alone puts in force and prints the preferred mount mode as the engage-to-record upgrade path, landed on main only after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing check. Both attempts of the cited run failed with the same signature on windows-latest, macos-latest and macos-15-intel while the Linux legs passed, the only GitHub Release object for this tag is the unpromoted prerelease the workflow publishes before proof, npm and Homebrew were verified untouched at 0.5.40, and the tag never became the finalized Latest release.",
+      "superseded_by": "v0.5.42",
+      "failed_release_run_id": "32237324302"
     }
   ]
 }


### PR DESCRIPTION
Adds the eleventh record to `scripts/abandoned-release-tags.json`, retiring tag v0.5.41 (14efb5a7b1351cf5cde1a95a473781a9bec9fa96) in favour of v0.5.42.

Release run 32237324302 failed its Public Install Proof on the three non-Linux legs at the doctor health gate. The tagged binary's setup records the platform-preferred mount projection (nfs on macOS, projfs on Windows) without engaging it, so on every fresh install `kin doctor` reads the recorded mode against the running state and reports `projection_mode=misconfigured`, which is fatal under the proof's aggregate-health rule. The macOS legs' own capture reads "nfs is recorded but is not what is running; mode=nfs mounted=no readable=no writable=no degraded=yes", and the Windows leg reads identically with projfs. The repair is kin#953 (squash 0b8767c83c7beb5117565d97f9f12aa82fbb95eb), which records only a projection that installation alone puts in force and prints the preferred mount mode as the engage-to-record upgrade path; it landed on main after the tag, and both the proof workflow and the binary resolve from the tag, so no later change to main can reach the failing check.

Both attempts of the run failed with the same signature on windows-latest, macos-latest and macos-15-intel while the Linux legs passed (attempt 1 at 09:23:07Z, the recovery-dispatched attempt 2 at 10:07:10Z). The only GitHub Release object for the tag is the unpromoted prerelease the workflow publishes before proof (20 assets, prerelease true). npm serves 0.5.40 and the Homebrew formula reads 0.5.40, verified at 12:25Z. The tag never became the finalized Latest release.

The release-workflow authority test and the release-order, hold-alarm and release-notes node tests pass with the record in place. kin#953 is already on main, so the train's next cut carries the repair.

Refs FIR-2454
