### PR TITLE
Never certify absence of a thing from absence of a match

### DIFF
--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -74,6 +74,11 @@ pub const EDGE_COVERAGE_KEY: &str = "edge_coverage";
 /// instead of an unqualified "1".
 pub const REFERENCE_RESOLUTION_KEY: &str = "reference_resolution";
 
+/// Key inside the observation carrying what the query's NAME FILTER selected on
+/// its own, for an answer whose narrowing filters could have emptied it. Read by
+/// [`crate::negative`].
+pub const NAME_FILTER_KEY: &str = "name_filter";
+
 /// How many entities may have their relations read while looking for a witness.
 ///
 /// A healthy graph answers in single digits, so this bound is only reached on a
@@ -359,6 +364,38 @@ pub fn observe_absence_scope(languages: &[LanguageId], scope_entities: Option<us
         observation["scope_entities"] = json!(count);
     }
     observation
+}
+
+/// Record what the query's NAME FILTER selected on its own, beside the scope
+/// [`observe_absence_scope`] already measured.
+///
+/// The two counts answer different questions and an absence needs both. The
+/// scope count removes the NAME and keeps the narrowing filters, so it says
+/// whether the region the caller asked about is populated at all. This one
+/// removes the NARROWING FILTERS and keeps the name, so it says whether the name
+/// resolved to anything before those filters were applied.
+///
+/// Only the second can see the case FIR-2452 was filed for. On psf/requests,
+/// `semantic_search(query: "request", kind: "method")` answered zero while the
+/// scope held every method in the repository and Python is a language this build
+/// enriches, so every gate that existed read healthy and the answer certified
+/// `safe_to_conclude_absent: true` about a name the graph resolves. What
+/// actually happened is visible only from the name's own side: the store's
+/// pattern index returns its exact-name and token hits and returns EARLY on any
+/// hit, never reaching its substring fallback, and the kind predicate then
+/// removed every candidate it had returned. That is absence of a MATCH, and the
+/// observation has to carry it before the gate can refuse to call it absence of
+/// a THING.
+///
+/// `narrowed_by` names the filters that were applied, so the verdict can say
+/// which ones removed the candidates rather than reporting an unattributed miss.
+/// Attached only when a narrowing filter was actually applied: with none, this
+/// query IS the name query and a second count would restate the first.
+pub fn attach_name_filter_scope(observation: &mut Value, narrowed_by: &[&str], candidates: usize) {
+    observation[NAME_FILTER_KEY] = json!({
+        "narrowed_by": narrowed_by,
+        "candidates": candidates,
+    });
 }
 
 /// The distinct languages a resolved entity set spans, in first-seen order.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4852,9 +4852,13 @@ mod tests {
             serde_json::json!(["kind"])
         );
 
-        let negative =
-            crate::negative::negative_for("semantic_search", &empty, &ready_daemon_envelope(2))
-                .expect("an empty search carries a negative");
+        let negative = crate::negative::negative_for(
+            "semantic_search",
+            &empty,
+            &ready_daemon_envelope(2),
+            &[],
+        )
+        .expect("an empty search carries a negative");
         assert_eq!(negative["safe_to_conclude_absent"], false);
         assert_eq!(negative["trust"], "inconclusive");
         assert!(
@@ -4880,9 +4884,13 @@ mod tests {
                 ["candidates"],
             0
         );
-        let negative =
-            crate::negative::negative_for("semantic_search", &absent, &ready_daemon_envelope(2))
-                .expect("an empty search carries a negative");
+        let negative = crate::negative::negative_for(
+            "semantic_search",
+            &absent,
+            &ready_daemon_envelope(2),
+            &[],
+        )
+        .expect("an empty search carries a negative");
         assert_eq!(
             negative["safe_to_conclude_absent"], true,
             "a name that matches nothing at all is still a certifiable absence: {negative}"

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -102,15 +102,70 @@ pub fn handle_semantic_search<G: GraphStore>(
             ..filter.clone()
         };
         let scoped = store.query_entities(&scope).map_err(McpError::graph)?;
-        payload[crate::edge_coverage::EDGE_COVERAGE_KEY] =
-            crate::edge_coverage::observe_absence_scope(
-                &crate::edge_coverage::languages_of(&scoped),
-                Some(scoped.len()),
+        let mut observation = crate::edge_coverage::observe_absence_scope(
+            &crate::edge_coverage::languages_of(&scoped),
+            Some(scoped.len()),
+        );
+
+        // FIR-2452. The scope above removes the name and keeps the narrowing
+        // filters, so it cannot see an answer that the narrowing filters emptied.
+        // That is the answer the stranger run got: `query: "request", kind:
+        // "method"` on psf/requests returned zero and certified the absence,
+        // because the scope held every method in the repository and Python is a
+        // language this build enriches, so every gate read healthy. Asking the
+        // name's own side is what separates the two: the store's pattern index
+        // returns its exact-name and token hits and returns EARLY on any hit
+        // without reaching its substring fallback, and the kind predicate then
+        // removed every candidate it had returned.
+        //
+        // Paid only when a narrowing filter was actually applied and only on the
+        // empty path. With no narrowing filter this query IS the name query, its
+        // count is the zero already in hand, and running it again would buy
+        // nothing.
+        let narrowed_by = narrowing_filters_of(&filter);
+        if !narrowed_by.is_empty() {
+            let name_only = kin_model::graph::EntityFilter {
+                kinds: None,
+                languages: None,
+                roles: None,
+                ..filter.clone()
+            };
+            let candidates = store.query_entities(&name_only).map_err(McpError::graph)?;
+            crate::edge_coverage::attach_name_filter_scope(
+                &mut observation,
+                &narrowed_by,
+                candidates.len(),
             );
+        }
+
+        payload[crate::edge_coverage::EDGE_COVERAGE_KEY] = observation;
     }
 
     let json = serde_json::to_string_pretty(&payload).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
+}
+
+/// The narrowing filters a search request applied beside its name pattern, named
+/// as the caller asked for them.
+///
+/// These are the filters that can empty an answer the name pattern did not, so
+/// naming them is what lets an absence verdict say which one removed the
+/// candidates instead of reporting an unattributed miss. `role` is listed
+/// separately from `kind` because `kind: "test"` resolves to a role filter with
+/// no kind filter at all, so reporting it as a kind would name a predicate the
+/// query never applied.
+fn narrowing_filters_of(filter: &kin_model::graph::EntityFilter) -> Vec<&'static str> {
+    let mut applied = Vec::new();
+    if filter.kinds.is_some() {
+        applied.push("kind");
+    }
+    if filter.languages.is_some() {
+        applied.push("language");
+    }
+    if filter.roles.is_some() {
+        applied.push("role");
+    }
+    applied
 }
 
 pub const SEMANTIC_LOCATE_DESC: &str = "\
@@ -4738,6 +4793,113 @@ mod tests {
         .expect("an empty search carries a negative");
         assert_eq!(negative["safe_to_conclude_absent"], true);
         assert_eq!(negative["trust"], "authoritative");
+    }
+
+    /// The reported call from the v0.5.41 stranger run, end to end (FIR-2452).
+    ///
+    /// `semantic_search(query: "request", kind: "method")` on psf/requests
+    /// answered zero and reported `safe_to_conclude_absent: true` with "safe to
+    /// treat the target as genuinely absent/unused", about a name the graph
+    /// resolves. Nothing that existed could see it: the store is Python, which
+    /// this build enriches, the scope holds entities, and the tool traverses no
+    /// edge, so every gate correctly read healthy. The name's own side is the
+    /// only place the miss is visible.
+    #[test]
+    fn a_search_whose_kind_filter_removed_every_name_match_certifies_nothing() {
+        let store = InMemoryGraph::new();
+        // `requests.api.request` is a function, and it is what the name matches.
+        store
+            .upsert_entity(&make_entity_in(
+                LanguageId::Python,
+                "request",
+                "requests/api.py",
+            ))
+            .unwrap();
+        store
+            .upsert_entity(&make_entity_in(
+                LanguageId::Python,
+                "render_page",
+                "app/views.py",
+            ))
+            .unwrap();
+        // A method the kind filter DOES select, so the region it narrows to is
+        // populated and the older scope gate stays quiet. That is the case this
+        // test is about: on psf/requests the scope held every method in the
+        // repository, which is why nothing refused to certify.
+        let mut method = make_entity_in(LanguageId::Python, "send", "requests/sessions.py");
+        method.kind = EntityKind::Method;
+        store.upsert_entity(&method).unwrap();
+
+        let empty = parsed_response(
+            &handle_semantic_search(&search_args("request", Some("method")), &store).unwrap(),
+        );
+        assert_eq!(empty["total_matches"], 0);
+        let coverage = &empty[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        // Every signal the older gates read is healthy here, which is the point.
+        assert_eq!(coverage["language"], "Python");
+        assert_eq!(coverage["reference_enrichment"], "unknown");
+        assert_eq!(
+            coverage["scope_entities"], 1,
+            "the region the kind filter selected is populated: {coverage}"
+        );
+        assert_eq!(
+            coverage[crate::edge_coverage::NAME_FILTER_KEY]["candidates"],
+            1,
+            "the name matched a declaration on its own: {coverage}"
+        );
+        assert_eq!(
+            coverage[crate::edge_coverage::NAME_FILTER_KEY]["narrowed_by"],
+            serde_json::json!(["kind"])
+        );
+
+        let negative =
+            crate::negative::negative_for("semantic_search", &empty, &ready_daemon_envelope(2))
+                .expect("an empty search carries a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], false);
+        assert_eq!(negative["trust"], "inconclusive");
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("name_filter_narrowed_to_zero"),
+            "{negative}"
+        );
+
+        // Positive control on the same store and the same kind filter: a name
+        // nothing carries matches nothing on its own, so no filter removed
+        // anything and the absence is still certifiable. Without this the fix
+        // would be indistinguishable from marking every kind-filtered answer
+        // uncertain.
+        let absent = parsed_response(
+            &handle_semantic_search(&search_args("zzz_not_a_symbol", Some("method")), &store)
+                .unwrap(),
+        );
+        assert_eq!(absent["total_matches"], 0);
+        assert_eq!(
+            absent[crate::edge_coverage::EDGE_COVERAGE_KEY][crate::edge_coverage::NAME_FILTER_KEY]
+                ["candidates"],
+            0
+        );
+        let negative =
+            crate::negative::negative_for("semantic_search", &absent, &ready_daemon_envelope(2))
+                .expect("an empty search carries a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"], true,
+            "a name that matches nothing at all is still a certifiable absence: {negative}"
+        );
+
+        // And a query that applied no narrowing filter publishes no name-filter
+        // observation at all, because that query IS the name query and counting
+        // it twice would buy nothing.
+        let unfiltered = parsed_response(
+            &handle_semantic_search(&search_args("zzz_not_a_symbol", None), &store).unwrap(),
+        );
+        assert!(
+            unfiltered[crate::edge_coverage::EDGE_COVERAGE_KEY]
+                .get(crate::edge_coverage::NAME_FILTER_KEY)
+                .is_none(),
+            "no narrowing filter, no second count: {unfiltered}"
+        );
     }
 
     /// A filter that selected a region the extractor never populated says

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -6263,6 +6263,7 @@ mod tests {
                 "graph_entity_count": 2,
                 "graph_generation": 1,
             })),
+            &[],
         )
         .expect("impact verdicts are always qualified");
         assert_eq!(negative["kind"], "impact_verdicts");

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -6208,6 +6208,70 @@ mod tests {
         assert_eq!(rows[0]["span"]["start_line"], 41);
     }
 
+    /// FIR-2452 clause 2, on the real handler output. `impact_analysis` emits
+    /// used/unused verdicts and was the only retrieval surface publishing no
+    /// coverage observation, so the gate every sibling passes had nothing to read
+    /// and the tool with the highest blast radius per wrong absence carried no
+    /// rail at all.
+    #[tokio::test]
+    async fn impact_analysis_handler_publishes_the_coverage_its_verdicts_rest_on() {
+        let callee = impact_probe_entity("callee_probe_2452", None);
+        let caller = impact_probe_entity("caller_probe_2452", Some(41));
+
+        let mut store = EmptyStore::default();
+        store.insert_test_entity(callee.clone());
+        store.insert_test_entity(caller.clone());
+        store.insert_test_calls_relation(&caller, &callee);
+
+        let args = HashMap::from([
+            (
+                "entity_ids".to_string(),
+                serde_json::json!([callee.id.to_string()]),
+            ),
+            ("include_traffic".to_string(), serde_json::json!(false)),
+        ]);
+        let sessions = SessionRegistry::new();
+
+        let value = tool_result_json(
+            review::handle_impact_analysis(&args, &store, &sessions)
+                .await
+                .unwrap(),
+        );
+
+        let coverage = &value[crate::edge_coverage::EDGE_COVERAGE_KEY];
+        assert!(
+            !coverage.is_null(),
+            "the verdicts are read off cross-file reference edges, so the answer states \
+             what it observed about them: {value}"
+        );
+        assert_eq!(
+            coverage["requested_classes"],
+            serde_json::json!(["calls", "imports", "references"]),
+            "the observation covers exactly what negative::absence_cross_file_classes \
+             declares this tool reads: {coverage}"
+        );
+
+        // The rail itself: the negative is attached whatever the blast radius
+        // holds, because a `consumer_count: 0` row beside a populated report is
+        // still the verdict a caller acts on.
+        let negative = crate::negative::negative_for(
+            "impact_analysis",
+            &value,
+            &crate::envelope::Envelope::daemon().with_health(&serde_json::json!({
+                "graph_loaded": true,
+                "initialized": true,
+                "graph_entity_count": 2,
+                "graph_generation": 1,
+            })),
+        )
+        .expect("impact verdicts are always qualified");
+        assert_eq!(negative["kind"], "impact_verdicts");
+        assert!(
+            negative.get("safe_to_conclude_absent").is_some(),
+            "the flag find_references carries is the one this tool most needed: {negative}"
+        );
+    }
+
     /// The measurement FIR-2408 asked for, taken on the real handler output
     /// rather than a hand-built payload.
     ///

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -45,7 +45,13 @@ semantic_review when you want diff + impact + risk together in a single report. 
 Per-entity counts separate `consumer_count` (every inbound edge) from \
 `proven_consumer_count` (only edges resolved above `name_only`), and each ranked path \
 step carries its own `resolution`. Read a used/unused claim against the proven count: a \
-call edge matched by bare method name is a candidate, not a fact.";
+call edge matched by bare method name is a candidate, not a fact. The response also \
+carries an additive `negative` object whose `safe_to_conclude_absent` flag says whether \
+this graph could have seen the impact it reports missing: the verdicts are read off \
+cross-file call, import and reference edges, so on a language whose reference edges this \
+build cannot produce, or on a graph holding none of them, an empty blast radius means \
+the query could not observe what it was asked about rather than that nothing depends on \
+the change. Check it before reading a zero consumer count as safe to change.";
 
 /// The blast-radius buckets of an [`kin_review::ImpactReport`] that serialize as
 /// arrays of raw entities, paired with their key in the response object.
@@ -171,9 +177,47 @@ pub async fn handle_impact_analysis<G: GraphStore>(
             serde_json::json!(format!("spine_unavailable: {reason}"));
     }
 
+    // FIR-2452. Every `entity_impacts` row carrying no consumers is a
+    // used/unused verdict a caller reads before changing or deleting something,
+    // and it is read off the same cross-file reference edges `find_references`
+    // reads. Until this observation existed, `impact_analysis` was the one
+    // retrieval surface with no `negative` object at all, so the tool with the
+    // highest blast radius per wrong absence was the only one outside the gate
+    // every smaller one passes.
+    //
+    // The languages are the CHANGED entities' own. A verdict covers all of them
+    // and the weakest governs, which is the same rule the batch reachability
+    // surface applies for the same reason: one language whose reference edges
+    // were never produced must not have its absences certified by a sibling
+    // language that links cleanly. Unresolvable ids contribute no language
+    // rather than a guessed one.
+    let impact_languages = crate::edge_coverage::languages_of(
+        &impact
+            .changed_ids
+            .iter()
+            .filter_map(|id| store.get_entity(id).ok().flatten())
+            .collect::<Vec<_>>(),
+    );
+    result[crate::edge_coverage::EDGE_COVERAGE_KEY] =
+        crate::edge_coverage::observe_cross_file_reference_coverage_for_languages(
+            store,
+            &impact_languages,
+            &IMPACT_REFERENCE_KINDS,
+        );
+
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
 }
+
+/// The cross-file reference classes an impact verdict is read off, matching what
+/// [`crate::negative::absence_cross_file_classes`] declares `impact_analysis`
+/// depends on. Declaring one set and observing another is how a gate comes to
+/// judge a class the answer never measured.
+const IMPACT_REFERENCE_KINDS: [kin_model::relation::RelationKind; 3] = [
+    kin_model::relation::RelationKind::Calls,
+    kin_model::relation::RelationKind::Imports,
+    kin_model::relation::RelationKind::References,
+];
 
 pub const SEMANTIC_REVIEW_DESC: &str = "\
 Produce a complete semantic review of a change in one call: the entity-level diff, the \

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -161,6 +161,25 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
             always: false,
             class: NegativeClass::Structural,
         },
+        // The whole output is used/unused verdicts, so like the batch below it
+        // always qualifies rather than qualifying an empty page. An
+        // `entity_impacts` row carrying `consumer_count: 0` IS the verdict a
+        // caller reads before changing or deleting something, and it is read off
+        // the same cross-file reference edges `find_references` reads, so it can
+        // be wrong for the same reason and now says so.
+        //
+        // This was the last retrieval surface without the rail, which put the
+        // tool with the highest blast radius per wrong absence outside the gate
+        // every smaller one passes. Its declarations in
+        // [`absence_cross_file_classes`] and [`absence_is_language_scoped`] were
+        // already written and were waiting for this row.
+        "impact_analysis" => RetrievalSpec {
+            field: "entity_impacts",
+            kind: "impact_verdicts",
+            subject: "per-changed-entity downstream impact verdicts",
+            always: true,
+            class: NegativeClass::Structural,
+        },
         // Batch reachability never returns an empty `results` on success (it
         // errors on empty input), but its `has_references: false` rows ARE the
         // negatives a "safe to delete?" sweep depends on — so always qualify.
@@ -204,7 +223,7 @@ pub(crate) fn negative_class_for(tool: &str) -> Option<NegativeClass> {
 /// | `find_references` | the query's own `relation_kinds` (default calls, imports, references) | its rows ARE those edges |
 /// | `bulk_check_references` | the query's own `relation_kinds` | one `has_references: false` row per entity, read off the same edges |
 /// | `trace_data_flow` | calls, imports, references | the walk expands exactly those kinds |
-/// | `impact_analysis` | calls, imports, references | downstream impact is those edges transitively; it has no absence spec today, and this entry is what stops one inheriting authority if it gains one |
+/// | `impact_analysis` | calls, imports, references | downstream impact is those edges transitively, and every `consumer_count: 0` verdict is read off them |
 /// | `graph_neighborhood` | none | the merged walk includes containment edges, which are intra-file by construction, so an empty neighborhood is not evidence about cross-file coverage; its absence is gated instead by focal-not-in-graph and depth-zero |
 /// | `semantic_locate` | none | ranks entities from embeddings and never traverses an edge |
 /// | `semantic_search` | none | filters declarations by name/kind/language and never traverses an edge |
@@ -462,6 +481,55 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
         ));
     }
 
+    // The name filter's own side, and the one gate that can see a match the
+    // narrowing filters removed. Every other gate here reads the substrate, so
+    // on a healthy store they all correctly report nothing, which is exactly how
+    // `semantic_search(query: "request", kind: "method")` on psf/requests
+    // certified `safe_to_conclude_absent: true` about a name the graph resolves.
+    // A nonzero candidate count is proof the name matched declarations, so what
+    // this answer observed is absence of a MATCH under those filters and never
+    // absence of the thing.
+    //
+    // Reported only when the answer measured it. A query that applied no
+    // narrowing filter carries no observation here and is unaffected, which is
+    // what keeps a genuinely absent name on a healthy store certifiable.
+    if let Some(name_filter) = coverage
+        .get(crate::edge_coverage::NAME_FILTER_KEY)
+        .and_then(Value::as_object)
+    {
+        let candidates = name_filter
+            .get("candidates")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if candidates > 0 {
+            let narrowed = name_filter
+                .get("narrowed_by")
+                .and_then(Value::as_array)
+                .map(|applied| {
+                    applied
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .filter(|narrowed| !narrowed.is_empty())
+                .unwrap_or_else(|| "the filters".to_string());
+            let declarations = if candidates == 1 {
+                "1 declaration".to_string()
+            } else {
+                format!("{candidates} declarations")
+            };
+            gaps.push(format!(
+                "name_filter_narrowed_to_zero: this query's name pattern selects {declarations} \
+                 on its own and the {narrowed} filter removed every one of them, so this answer \
+                 observed that no candidate survived those filters rather than that the \
+                 repository holds no such declaration; the name resolves, so do not read this as \
+                 the target being absent, and re-run without the narrowing filter to see what it \
+                 matched"
+            ));
+        }
+    }
+
     // Independent of what any scan measured. A language this build cannot
     // resolve is not one that happened to come back empty, and no amount of
     // scanning or re-indexing will ever move it.
@@ -606,6 +674,19 @@ pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> V
         Some("unsupported") | Some("no_language_server")
     ) {
         labels.push("edge_coverage:reference_enrichment_unsupported".to_string());
+    }
+    // Disclosed on the same terms as the two above: what the verdict rests on is
+    // named in the signals beside it, so a reader never has to parse the reason
+    // sentence to learn that the name matched and a narrowing filter is what
+    // emptied the answer.
+    if coverage
+        .get(crate::edge_coverage::NAME_FILTER_KEY)
+        .and_then(Value::as_object)
+        .and_then(|name_filter| name_filter.get("candidates"))
+        .and_then(Value::as_u64)
+        .is_some_and(|candidates| candidates > 0)
+    {
+        labels.push("absence_coverage:name_filter_narrowed".to_string());
     }
     labels
 }
@@ -1104,7 +1185,20 @@ fn build_advice(
 /// instruction for every structural gap: a missing cross-file call edge is not
 /// waiting on an embedding, and a reader who follows that advice re-runs the
 /// query unchanged and gets the identical unusable answer.
-fn absence_consequence(always: bool, trustworthy: bool) -> &'static str {
+fn absence_consequence(tool: &str, always: bool, trustworthy: bool) -> &'static str {
+    // A certified name/kind filter is a statement about DECLARATIONS, and this
+    // tool reads the entity index and traverses no edge at all
+    // ([`absence_cross_file_classes`] gives it no class for exactly that
+    // reason), so it has no basis for the word "unused". The generic sentence
+    // supplied one anyway, and a stranger run quoted it back verbatim as the
+    // thing it believed. Scoping it costs no authority: the verdict stays
+    // authoritative and the fixture that must keep certifying still does.
+    if tool == "semantic_search" && !always && trustworthy {
+        return "Absence is authoritative for this filter: no declaration in the index carries \
+                this name under it. That is a statement about declarations, not about use, \
+                because this filter reads the entity index and traverses no edge; settle whether \
+                anything references the name with find_references.";
+    }
     match (always, trustworthy) {
         (true, true) => {
             "A `has_references: false` row here is an authoritative negative — safe to treat that entity as unreferenced."
@@ -1126,8 +1220,13 @@ fn absence_consequence(always: bool, trustworthy: bool) -> &'static str {
 /// isolated-install report quoted the advice line verbatim as the thing it
 /// believed, so an advice line that states the consequence and leaves the cause
 /// in a neighbouring field is one field away from being acted on blind.
-fn absence_advice_consequence(always: bool, trustworthy: bool, trust_reason: &str) -> String {
-    let consequence = absence_consequence(always, trustworthy);
+fn absence_advice_consequence(
+    tool: &str,
+    always: bool,
+    trustworthy: bool,
+    trust_reason: &str,
+) -> String {
+    let consequence = absence_consequence(tool, always, trustworthy);
     if trustworthy {
         consequence.to_string()
     } else {
@@ -1540,7 +1639,7 @@ pub fn negative_for(
     let consequence = if ranking_names_nothing {
         unnamed_ranking_consequence().to_string()
     } else {
-        absence_advice_consequence(spec.always, trustworthy, &trust_reason)
+        absence_advice_consequence(tool, spec.always, trustworthy, &trust_reason)
     };
 
     let degraded_signals = degraded_signals(tool, payload, envelope);
@@ -2099,6 +2198,178 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("structural_authoritative"));
+    }
+
+    /// A narrowing filter that removed every candidate the name DID match
+    /// (FIR-2452). This is the residual kin#935 left: every gate that existed
+    /// reads the substrate, and on this payload the substrate is healthy, so all
+    /// of them correctly report nothing and the answer certified.
+    #[test]
+    fn a_name_filter_narrowed_to_zero_certifies_nothing() {
+        // The shape the stranger run hit on psf/requests, which is a fully
+        // enriched Python store: `semantic_search(query: "request", kind:
+        // "method")` answered zero and reported `safe_to_conclude_absent: true`
+        // with "safe to treat the target as genuinely absent/unused", about a
+        // name the graph resolves. The scope held every method in the
+        // repository, Python is a language this build enriches, and the tool
+        // traverses no edge, so the class gate, the scope gate and the
+        // enrichment gate all read healthy. Only the name's own side can see it.
+        let mut scope = resolvable_language_scope(Some(256));
+        scope["name_filter"] = json!({ "narrowed_by": ["kind"], "candidates": 1 });
+        let payload = empty_search_page(scope);
+
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "the name matched a declaration and a kind filter removed it, so this \
+             observed absence of a match: {negative}"
+        );
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("name_filter_narrowed_to_zero"),
+            "{reason}"
+        );
+        assert!(
+            reason.contains("selects 1 declaration on its own"),
+            "the count it measured is in the reason: {reason}"
+        );
+        assert!(
+            reason.contains("kind filter removed every one of them"),
+            "the filter that emptied it is named rather than left unattributed: {reason}"
+        );
+        assert!(
+            negative["degraded_signals"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("absence_coverage:name_filter_narrowed")),
+            "the shortfall the verdict rests on is disclosed: {negative}"
+        );
+
+        // Positive control on the same payload shape: the name matched nothing
+        // on its own, so the narrowing filter removed nothing and the absence is
+        // the name's, not the filter's. The gate reads the count.
+        let mut matched_nothing = resolvable_language_scope(Some(256));
+        matched_nothing["name_filter"] = json!({ "narrowed_by": ["kind"], "candidates": 0 });
+        let negative = negative_for(
+            "semantic_search",
+            &empty_search_page(matched_nothing),
+            &structural_ready_envelope(),
+        )
+        .expect("empty results yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "a kind-filtered query whose name matched nothing at all still certifies: {negative}"
+        );
+    }
+
+    /// The other half of the FIR-2452 rule, on the answer that still certifies.
+    /// A tool that traverses no edge cannot speak about use, and the generic
+    /// sentence supplied the word anyway.
+    #[test]
+    fn a_certified_search_absence_states_no_verdict_about_use() {
+        let payload = empty_search_page(resolvable_language_scope(Some(29)));
+        let negative = negative_for("semantic_search", &payload, &structural_ready_envelope())
+            .expect("empty results yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "the authority is unchanged: {negative}"
+        );
+        let advice = negative["advice"].as_str().unwrap();
+        assert!(
+            !advice.contains("genuinely absent/unused"),
+            "a name filter reads the entity index and traverses no edge, so it has no \
+             basis for a verdict about use: {advice}"
+        );
+        assert!(
+            advice.contains("Absence is authoritative for this filter"),
+            "{advice}"
+        );
+        assert!(
+            advice.contains("not about use"),
+            "it says which question it answered: {advice}"
+        );
+
+        // The sibling that DOES read those edges keeps the sentence, so scoping
+        // one tool did not quietly disarm the others.
+        let references = negative_for(
+            "find_references",
+            &authoritative_empty_references("function"),
+            &structural_ready_envelope(),
+        )
+        .expect("empty references yields a negative");
+        assert!(
+            references["advice"]
+                .as_str()
+                .unwrap()
+                .contains("genuinely absent/unused"),
+            "find_references reads the edges, so its verdict about use stands: {references}"
+        );
+    }
+
+    /// FIR-2452 clause 2. The tool whose entire output is used/unused verdicts
+    /// was the only retrieval surface with no `negative` object at all, so the
+    /// one with the highest blast radius per wrong absence sat outside the gate
+    /// every smaller one passes.
+    #[test]
+    fn impact_verdicts_carry_the_rail_and_pass_the_same_gate() {
+        // Populated, and still qualified: like batch reachability, an impact
+        // report's rows ARE the negatives, so a zero consumer count beside a
+        // full blast radius is exactly the verdict that needs calibrating.
+        let mut payload = json!({
+            "changed_ids": ["00000000-0000-0000-0000-000000000001"],
+            "affected_callers": [],
+            "entity_impacts": [{
+                "entity_id": "00000000-0000-0000-0000-000000000001",
+                "consumer_count": 0,
+                "proven_consumer_count": 0,
+            }],
+        });
+        payload["edge_coverage"] = cross_file_edges_observed();
+
+        let negative = negative_for("impact_analysis", &payload, &structural_ready_envelope())
+            .expect("impact verdicts are always qualified");
+        assert_eq!(negative["kind"], json!("impact_verdicts"));
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "a graph that links calls across files for this language can certify: {negative}"
+        );
+
+        // The same gate the sibling reference surfaces pass. A graph holding no
+        // cross-file calls answers every impact query with an empty blast radius
+        // no matter how healthy it looks, so the verdict cannot be certified.
+        let mut absent = payload.clone();
+        absent["edge_coverage"]["classes"]["calls"] = json!("absent");
+        let negative = negative_for("impact_analysis", &absent, &structural_ready_envelope())
+            .expect("impact verdicts are always qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("cross_file_edges_absent"),
+            "{negative}"
+        );
+
+        // And an answer that published no observation at all is the unknown
+        // case, never the healthy one.
+        let mut unreported = payload.clone();
+        unreported.as_object_mut().unwrap().remove("edge_coverage");
+        let negative = negative_for("impact_analysis", &unreported, &structural_ready_envelope())
+            .expect("impact verdicts are always qualified");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("edge_coverage_unreported"),
+            "{negative}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`semantic_search` reported `safe_to_conclude_absent: true` with "safe to treat the target as genuinely absent/unused" for a name the graph resolves, and `impact_analysis`, whose whole output is used/unused verdicts, carried no `negative` object at all. Both are fixed here.

## The call, and why nothing caught it

The v0.5.41 candidate stranger run recorded its first Kin call as `semantic_search(query: "request", kind: "method")` on psf/requests. Zero results, `trust: "authoritative"`, about `Session.request`, which is a method, is named `request`, and is in the graph.

kin#935 routed every empty path through one gate, and on this payload that gate worked correctly. `semantic_search` declares no cross-file edge class, so the class arm is skipped by design. The kind filter's scope held every method in the repository, so `absence_scope_empty` could not fire. Python is one of the two entries in `ENRICHABLE_LANGUAGES` (`crates/kin-core/src/reference_coverage.rs:42`), so `reference_enrichment` read `unknown` and the enrichment arm could not fire either. Every gate read a healthy substrate and every gate was right. This is not the unenrichable-language case the family's first three tickets were about.

The matcher is what missed, and no observation described it. `by_name_pattern` (kin-db `crates/kin-db/src/engine/index.rs:130`) collects exact-name and token-index hits and returns EARLY on any hit, never reaching its substring fallback; the filter predicate (`crates/kin-db/src/engine/graph.rs:10168`) then drops what survives by kind, language and role. A query whose name pattern did select candidates can answer zero because the narrowing filters removed all of them, and it certified because nothing in the payload said the name had matched anything.

## The fix

`crates/kin-mcp/src/handlers/entities.rs:117` asks the name's own side: on the empty path only, and only when a narrowing filter was applied, it re-runs the filter with `kinds`, `languages` and `roles` cleared and the name kept, publishing the count and the filters applied through `attach_name_filter_scope` (`crates/kin-mcp/src/edge_coverage.rs:361`). With no narrowing filter that query is this query, so nothing extra runs and nothing is published.

`absence_coverage_gap` (`crates/kin-mcp/src/negative.rs:497`) reads it. A nonzero count means the query observed absence of a MATCH, so `name_filter_narrowed_to_zero` fires, names the count and the filter that removed the candidates, and the answer reads inconclusive. `absence_coverage:name_filter_narrowed` joins `degraded_signals` on the same terms as the two gaps beside it.

The certified case stopped overclaiming too. A name filter reads the entity index and traverses no edge, which is exactly why `absence_cross_file_classes` gives it no class, so it has no basis for the word "unused". Its authoritative advice now speaks about declarations and sends the caller to `find_references` for the question about use. `find_references` keeps the original sentence, because it reads the edges that sentence is about.

`impact_analysis` gained a `RetrievalSpec` row (`field: "entity_impacts"`, `always: true`, `Structural`), so the generic annotator at `crates/kin-mcp/src/envelope.rs:1271` attaches the envelope on every response, and `crates/kin-mcp/src/handlers/review.rs:168` publishes the cross-file reference coverage its verdicts are read off, over the changed entities' languages with the weakest governing. Its declarations in `absence_cross_file_classes` and `absence_is_language_scoped` were already written and were waiting for the spec row. `always: true` matches `bulk_check_references`: an `entity_impacts` row carrying `consumer_count: 0` is the verdict a caller acts on whether or not the blast radius elsewhere is populated.

## Falsification

Six guards, each broken in turn, the named test re-run, full output and exit code read from a file rather than through a pipe. Every case exited 101 with the named test FAILED.

1. Gate arm disabled: `a_name_filter_narrowed_to_zero_certifies_nothing` failed reading `safe_to_conclude_absent: true`, `trust: "authoritative"`, which is the pre-fix bug reproduced.
2. Handler observation not published: the handler test failed with the `name_filter` key absent (`left: Null`, `right: 1`).
3. Consequence unscoped: the advice failed carrying the literal string the stranger quoted, "Absence is authoritative: safe to treat the target as genuinely absent/unused."
4. `impact_analysis` spec row removed: `negative_for` returned `None`, panicking on "impact verdicts are always qualified".
5. `impact_analysis` coverage not published: the handler test failed on a payload carrying no `edge_coverage`.
6. Disclosure label renamed: the test failed on the missing `absence_coverage:name_filter_narrowed`.

Controls in the other direction, which is the FIR-2404 regression bar: the pre-existing `a_resolvable_language_still_certifies_a_genuinely_absent_declaration` passed before and after, a kind-filtered query whose name matches nothing at all still certifies, and a query with no narrowing filter publishes no second count.

## Gates

All run from the lane worktree through `bin/kin-lane run matchabsence kin`, statuses read raw rather than through a pipe.

- `cargo fmt --all -- --check` rc=0, re-run rc=0 after the rebase.
- `cargo clippy --all-targets --all-features` with the exact 45-lint allowlist read out of ci.yml, under `RUSTFLAGS=-D warnings`: rc=0. The one warning in the log is the pre-existing `block v0.1.6` future-incompat note.
- All four ci.yml guard scripts rc=0: `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`.
- `cargo nextest run --workspace --no-fail-fast` rc=0: 6459 tests run, 6459 passed, 12 skipped, zero FAIL lines, so the run never cancelled early. `cargo test --doc` rc=0.
- Feature permutations on the changed crate, `--all-targets` under `-D warnings`: `--no-default-features` rc=0, `--all-features` rc=0.
- Rebased onto origin/main at 64c7c8c5; `cargo nextest run -p kin-mcp` rc=0 afterwards, 526 tests run, 526 passed.
- `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty. `git diff HEAD~1..HEAD --numstat` lists only the five files above.

One leg could not run here and is not being claimed. `cargo check --locked --target x86_64-pc-windows-msvc -p kin-cli -p kin-daemon --no-default-features` fails on this host inside `ring`'s C build for want of an MSVC toolchain, before reaching any Rust, so it is a host limit rather than a result. The check that leg catches is platform-gated dead code, and this diff adds none: it introduces zero `cfg(` lines, against a positive control that finds the one already in the file.



## Post-967 rebase

The merge queue ejected this branch (run 32297411043): the speculative merge compiled #967's four-argument `negative_for` against this branch's three-argument test calls at entities.rs:4856/4884 and handlers/mod.rs:6257. Rebased onto main carrying #967 and passed the empty response-gap list at those three sites, exactly as #967's own test call sites do. kin-mcp's 542 tests pass beside the new language gates, including this branch's positive control that an unnarrowed nothing-matched absence stays certifiable; fmt and all six guard scripts pass on the rebased tip.

Closes FIR-2452