### PR TITLE
Report commit-memory parity as a warning and state the cost in INSTALL.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
             ./scripts/prepare-release.test.mjs \
             ./scripts/read-update-build-identity.test.cjs \
             ./scripts/release-archive-shape.test.cjs \
+            ./scripts/write-release-archive-docs.test.mjs \
             ./scripts/release-order.test.mjs \
             ./scripts/release-hold-alarm.test.mjs \
             ./scripts/advisory-sweep.test.mjs \
@@ -968,7 +969,8 @@ jobs:
             scripts/check-release-version.test.mjs \
             scripts/extract-release-notes.test.mjs \
             scripts/prepare-release.test.mjs \
-            scripts/release-archive-shape.test.cjs
+            scripts/release-archive-shape.test.cjs \
+            scripts/write-release-archive-docs.test.mjs
           node --check scripts/check-release-version.mjs
           node --check scripts/prepare-release.mjs
           node --check scripts/release-intent.mjs

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -32,6 +32,13 @@ pub enum HealthStatus {
     /// needing attention, because the surface is not answering at full strength
     /// yet, but it never blocks readiness: nothing is wrong and nothing is lost.
     Pending,
+    /// A real shortfall in the machine or container Kin was asked to run on,
+    /// rather than in the install. It reads red because ignoring it costs the
+    /// reader work, and it never blocks readiness because nothing about the
+    /// install is wrong: a host below a measured cost is a fact about the host,
+    /// and a gate that failed on one would fail every correct install on a
+    /// small machine.
+    Degraded,
     Unsupported,
 }
 
@@ -99,6 +106,10 @@ fn is_failing(status: &HealthStatus) -> bool {
 /// install is expected to be doing on its way to ready, not ground a ready
 /// install lost, and a gate that cannot tell those apart fails every fresh
 /// install for succeeding.
+///
+/// `Degraded` sits outside it too, for the opposite reason. It names ground the
+/// host never had rather than ground a correct install lost, and a gate that
+/// failed on one would fail every correct install on a small machine.
 fn blocks_readiness(check: &HealthCheck) -> bool {
     is_failing(&check.status)
         || (check.id == "semantic_query_readiness" && matches!(check.status, HealthStatus::Stale))
@@ -140,7 +151,8 @@ impl HealthReport {
                 HealthStatus::Missing
                 | HealthStatus::Misconfigured
                 | HealthStatus::Stale
-                | HealthStatus::Pending => summary.attention += 1,
+                | HealthStatus::Pending
+                | HealthStatus::Degraded => summary.attention += 1,
             }
         }
         summary
@@ -2985,6 +2997,25 @@ const MEASURED_COMMIT_PEAKS: &[MeasuredCommitPeak] = &[
     },
 ];
 
+/// How far above the quoted peak a ceiling has to sit, as a percentage of that
+/// peak, before this check calls it ok.
+///
+/// The quoted row is a floor rather than a bound. The store in front of the
+/// check is at least as large as the row's store, and a larger store peaks
+/// higher: `psf/requests` holds barely more than twice `expressjs/express`'s
+/// store and peaks 13.6% above it, because a commit prepares the whole
+/// repository successor in memory and the fixed part of that dominates. So a
+/// ceiling merely level with the quoted peak is the edge rather than headroom,
+/// and calling that ok is what told an isolated stranger run its 12288 MiB
+/// container was fine six hours before a commit was killed at 12283 MiB.
+///
+/// The number rounds the observed spread up, because the safe direction for a
+/// warning is to advise headroom nobody needs rather than to stay quiet about a
+/// ceiling somebody does. `the_comfort_margin_covers_the_spread_the_table_shows`
+/// holds it to the table, so a row measured later that spreads wider fails a
+/// test instead of quietly narrowing the band this exists to open.
+const COMMIT_PEAK_COMFORT_MARGIN_PERCENT: u64 = 14;
+
 /// Report whether this machine has the memory a commit on this store has been
 /// measured to need.
 ///
@@ -2993,8 +3024,13 @@ const MEASURED_COMMIT_PEAKS: &[MeasuredCommitPeak] = &[
 /// commit is attempted. This is that reading, published where a user looks
 /// before they are surprised rather than after.
 ///
-/// It is advisory by construction and can only ever be `Stale`, never a
-/// failure. A ceiling below a measured peak is a fact about a machine, not a
+/// It reports three bands. A ceiling clear of the quoted peak is healthy, one
+/// merely level with it is `Stale`, and one below it is `Degraded`. The middle
+/// band exists because the quoted peak is a floor for a store at least the
+/// quoted size, so parity with it is the edge rather than headroom.
+///
+/// It is advisory by construction and never blocks readiness, whichever band it
+/// lands in. A ceiling below a measured peak is a fact about a machine, not a
 /// broken install, and a check that failed readiness on it would fail every
 /// correct install on a small host.
 fn check_commit_memory_headroom() -> HealthCheck {
@@ -3046,38 +3082,82 @@ fn commit_memory_headroom_check_for(
         );
     };
     let needed = format_health_bytes(measured.peak_bytes);
-    if evidence.limit_bytes >= measured.peak_bytes {
+    let measured_store = format_health_bytes(measured.store_bytes);
+    let store_size = format_health_bytes(store.bytes);
+    let ratio = format_store_ratio(store.bytes, measured.store_bytes);
+    let comfortable = measured.peak_bytes.saturating_add(
+        measured
+            .peak_bytes
+            .saturating_mul(COMMIT_PEAK_COMFORT_MARGIN_PERCENT)
+            / 100,
+    );
+    if evidence.limit_bytes >= comfortable {
         return HealthCheck::new(
             ID,
             LABEL,
             HealthStatus::Healthy,
             format!(
-                "{available} of memory available; a commit on {} ({} store) was measured peaking \
-                 at {needed}, and this {} store is at least that size",
-                measured.repository,
-                format_health_bytes(measured.store_bytes),
-                format_health_bytes(store.bytes)
+                "{available} of memory available; a commit on {} ({measured_store} store) was \
+                 measured peaking at {needed}, and this ceiling clears that peak by at least \
+                 {}%. This {store_size} store is {ratio} the measured one",
+                measured.repository, COMMIT_PEAK_COMFORT_MARGIN_PERCENT
             ),
         );
     }
+    let (status, opening) = if evidence.limit_bytes >= measured.peak_bytes {
+        (
+            HealthStatus::Stale,
+            format!(
+                "{available} of memory available is parity with the {needed} peak a commit on {} \
+                 ({measured_store} store) was measured at, not headroom over it",
+                measured.repository
+            ),
+        )
+    } else {
+        (
+            HealthStatus::Degraded,
+            format!(
+                "only {available} of memory is available here, below the {needed} peak a commit \
+                 on {} ({measured_store} store) was already measured at",
+                measured.repository
+            ),
+        )
+    };
+    // The floor clause is claimed only where it is true. On a store no larger
+    // than the measured one the row is the measurement for that size, and
+    // saying it understates would be inventing a margin the table never showed.
+    let floor_note = if store.bytes > measured.store_bytes {
+        ", and a larger store peaks higher, so that measurement is a floor here rather than a bound"
+    } else {
+        ""
+    };
     HealthCheck::new(
         ID,
         LABEL,
-        HealthStatus::Stale,
+        status,
         format!(
-            "only {available} of memory is available here, and a commit on {} ({} store) was \
-             measured peaking at {needed}; this store is {}, so a commit can be killed \
-             mid-transaction and report a closed connection. {}",
-            measured.repository,
-            format_health_bytes(measured.store_bytes),
-            format_health_bytes(store.bytes),
+            "{opening}. This {store_size} store is {ratio} the measured one{floor_note}, so a \
+             commit here can be killed mid-transaction and report a closed connection. Do this \
+             write on a smaller repository or a larger machine. {}",
             crate::commands::commit_progress::COMMIT_MEMORY_REMEDY,
         ),
     )
     .with_manual_fix(
-        "Run the commit on a machine or container with more memory, or raise this container's \
-         memory limit.",
+        "Run the commit on a machine or container with more memory, raise this container's memory \
+         limit, or do this write on a smaller repository.",
     )
+}
+
+/// How many times the measured store this store is.
+///
+/// The ratio is what turns a quoted peak into a floor: a reader whose store is
+/// twice the measured one is being told the least their commit can cost, not
+/// the most.
+fn format_store_ratio(store_bytes: u64, measured_bytes: u64) -> String {
+    if measured_bytes == 0 {
+        return "an unknown multiple of".to_string();
+    }
+    format!("{:.1}x", store_bytes as f64 / measured_bytes as f64)
 }
 
 fn format_health_bytes(bytes: u64) -> String {
@@ -3211,20 +3291,20 @@ mod tests {
 
     /// The reading a user needed BEFORE the commit that killed their daemon.
     ///
-    /// A one-file commit on a 922 MiB store peaked at 12283 MiB against a
-    /// 12288 MiB ceiling, and the only warning anyone got was a closed socket
-    /// afterward. The store size that decides it is knowable the whole time.
+    /// A ceiling under a peak already measured for a store no larger than this
+    /// one is the band that reads red: nothing about the install is wrong, and
+    /// the write is still going to die.
     ///
     /// Falsify by comparing against `store.bytes` instead of the measured peak,
     /// or by returning `Healthy` unconditionally: the constrained arm then
     /// passes silently, which is the state this check exists to end.
     #[test]
-    fn doctor_warns_when_this_machines_ceiling_is_below_a_measured_commit_peak() {
+    fn doctor_reads_a_ceiling_below_a_measured_commit_peak_as_degraded() {
         let check =
-            commit_memory_headroom_check_for(&footprint(922 * MIB), &memory(8 * 1024 * MIB));
+            commit_memory_headroom_check_for(&footprint(1844 * MIB), &memory(8 * 1024 * MIB));
         assert!(
-            matches!(check.status, HealthStatus::Stale),
-            "a ceiling under a measured peak needs attention: {:?}",
+            matches!(check.status, HealthStatus::Degraded),
+            "a ceiling under a measured peak is over parity, not at it: {:?}",
             check.status
         );
         assert!(
@@ -3233,9 +3313,106 @@ mod tests {
             check.detail
         );
         assert!(
+            check.detail.contains("2.0x the measured one"),
+            "the reader cannot judge a floor without the store ratio: {}",
+            check.detail
+        );
+        assert!(
             check.manual_fix.is_some(),
             "a warning a reader cannot act on is noise"
         );
+    }
+
+    /// Parity with a measured peak is the edge, and it used to round up to ok.
+    ///
+    /// A one-file commit on a 922 MiB store peaked at 12283 MiB against a
+    /// 12288 MiB ceiling. `kin doctor` had both numbers and called it ok six
+    /// hours before the commit was killed, because it compared with `>=` and
+    /// 12288 clears 12283. Amber is the whole finding: it costs a reader
+    /// nothing to move the write to a smaller repository, and it costs them the
+    /// write not to.
+    ///
+    /// Falsify by restoring the `>=` comparison against the bare peak: both
+    /// arms below go `Healthy` again and the assertions name the status.
+    #[test]
+    fn doctor_reads_a_ceiling_at_a_measured_commit_peak_as_parity_rather_than_ok() {
+        let exactly_at = commit_memory_headroom_check_for(
+            &footprint(1844 * MIB),
+            &memory(MEASURED_COMMIT_PEAKS[1].peak_bytes),
+        );
+        assert!(
+            matches!(exactly_at.status, HealthStatus::Stale),
+            "a ceiling exactly at the measured peak is parity, not headroom: {:?}",
+            exactly_at.status
+        );
+
+        // The container the isolated stranger run actually had: 5 MiB of margin
+        // on a 12 GiB budget, which is arithmetic rather than headroom.
+        let stranger =
+            commit_memory_headroom_check_for(&footprint(1844 * MIB), &memory(12288 * MIB));
+        assert!(
+            matches!(stranger.status, HealthStatus::Stale),
+            "12288 MiB over a 12283 MiB peak is parity: {:?}",
+            stranger.status
+        );
+        assert!(
+            stranger.detail.contains("parity"),
+            "the row has to say what band it is in: {}",
+            stranger.detail
+        );
+        assert!(
+            stranger.detail.contains("psf/requests") && stranger.detail.contains("12.0 GiB"),
+            "parity must quote the peak it is at parity with: {}",
+            stranger.detail
+        );
+        assert!(
+            stranger.detail.contains("2.0x the measured one")
+                && stranger.detail.contains("floor here rather than a bound"),
+            "a bigger store makes the quoted peak a floor, and the reader is owed that: {}",
+            stranger.detail
+        );
+        assert!(
+            stranger.detail.contains("smaller repository"),
+            "the row exists to redirect the write before the kill: {}",
+            stranger.detail
+        );
+        assert!(
+            stranger.manual_fix.is_some(),
+            "a warning a reader cannot act on is noise"
+        );
+    }
+
+    /// Neither warning band may fail an install.
+    ///
+    /// The install proof computes its own aggregate from the check statuses and
+    /// fails a fresh install whose report disagrees with it, so a headroom band
+    /// that blocked readiness would fence a release at tag time, where no fix on
+    /// `main` can reach it. Both bands are asserted here rather than trusted to
+    /// the enum, because `blocks_readiness` is where that would go wrong.
+    #[test]
+    fn no_commit_headroom_band_blocks_aggregate_readiness() {
+        for limit in [
+            MEASURED_COMMIT_PEAKS[1].peak_bytes,
+            12288 * MIB,
+            8 * 1024 * MIB,
+        ] {
+            let check = commit_memory_headroom_check_for(&footprint(1844 * MIB), &memory(limit));
+            assert!(
+                !matches!(check.status, HealthStatus::Healthy),
+                "the fixture must exercise a warning band: {:?}",
+                check.status
+            );
+            assert!(
+                !blocks_readiness(&check),
+                "a small machine is not a broken install: {:?}",
+                check.status
+            );
+            let report = assemble_health_report("test".to_string(), vec![check]);
+            assert!(
+                report.healthy,
+                "commit headroom must never flip the aggregate the install proof reads"
+            );
+        }
     }
 
     /// A machine with the headroom is told so, quoting the same measurement.
@@ -3249,6 +3426,68 @@ mod tests {
             check.status
         );
         assert!(check.detail.contains("psf/requests"), "{}", check.detail);
+        assert!(
+            check.detail.contains("clears that peak by at least"),
+            "ok has to say what it cleared, or it is the rounding again: {}",
+            check.detail
+        );
+        assert!(
+            check.detail.contains("1.0x the measured one"),
+            "the store ratio belongs in every band: {}",
+            check.detail
+        );
+    }
+
+    /// The comfort margin is read off the table, so it cannot fall behind it.
+    ///
+    /// The margin exists because a larger store peaks higher than the row the
+    /// check quotes. The table itself measures how much higher, and a row added
+    /// later that spreads wider than the constant would silently shrink the
+    /// amber band back toward the rounding this replaced.
+    #[test]
+    fn the_comfort_margin_covers_the_spread_the_table_shows() {
+        let widest = MEASURED_COMMIT_PEAKS
+            .windows(2)
+            .map(|pair| {
+                let (lower, higher) = (pair[0].peak_bytes, pair[1].peak_bytes);
+                if higher <= lower {
+                    0
+                } else {
+                    ((higher - lower) * 100).div_ceil(lower)
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        assert!(
+            COMMIT_PEAK_COMFORT_MARGIN_PERCENT >= widest,
+            "the table measures a {widest}% spread between adjacent peaks and the comfort margin \
+             is {COMMIT_PEAK_COMFORT_MARGIN_PERCENT}%, so a store past the quoted row can peak \
+             above a ceiling this check calls ok"
+        );
+    }
+
+    /// The table has to be ordered and real for the lookup to mean anything.
+    ///
+    /// The check walks it in reverse to find the largest row a store reaches. A
+    /// row inserted out of order would quote the wrong measurement without
+    /// failing anything, and a zero store would divide the ratio by nothing.
+    #[test]
+    fn the_measured_table_is_ordered_and_carries_no_empty_rows() {
+        for point in MEASURED_COMMIT_PEAKS {
+            assert!(
+                point.store_bytes > 0 && point.peak_bytes > 0,
+                "{} carries an empty measurement",
+                point.repository
+            );
+        }
+        for pair in MEASURED_COMMIT_PEAKS.windows(2) {
+            assert!(
+                pair[1].store_bytes > pair[0].store_bytes,
+                "the table must be smallest store first: {} is not above {}",
+                pair[1].repository,
+                pair[0].repository
+            );
+        }
     }
 
     /// Below the smallest measured store nothing is claimed at all.

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12593,6 +12593,7 @@ fn status_label(status: &crate::commands::health::HealthStatus) -> &'static str 
         HealthStatus::Stale => "STALE",
         HealthStatus::Misconfigured => "MISCONFIGURED",
         HealthStatus::Pending => "PENDING",
+        HealthStatus::Degraded => "DEGRADED",
         HealthStatus::Unsupported => "n/a",
     }
 }
@@ -12606,7 +12607,9 @@ fn print_human_report(report: &crate::commands::health::HealthReport) {
     for check in &report.checks {
         let mark = match check.status {
             HealthStatus::Healthy => style("✓").green(),
-            HealthStatus::Missing | HealthStatus::Misconfigured => style("✗").red(),
+            HealthStatus::Missing | HealthStatus::Misconfigured | HealthStatus::Degraded => {
+                style("✗").red()
+            }
             HealthStatus::Stale => style("!").yellow(),
             HealthStatus::Pending => style("…").yellow(),
             HealthStatus::Unsupported => style("→").cyan(),

--- a/scripts/verify-capability-proof.mjs
+++ b/scripts/verify-capability-proof.mjs
@@ -116,6 +116,7 @@ export const HEALTH_STATUSES = [
   "stale",
   "misconfigured",
   "pending",
+  "degraded",
   "unsupported",
 ];
 

--- a/scripts/write-release-archive-docs.mjs
+++ b/scripts/write-release-archive-docs.mjs
@@ -83,7 +83,19 @@ it. The \`.sha256\` file published next to the archive covers the archive itself
 
 const install = `# Installing Kin ${version} (${target})
 
-Two decisions, both answered here.
+Two decisions, both answered here, and one number to plan around first.
+
+## Requirements
+
+A commit prepares the whole repository successor in memory, so its peak follows
+the size of the repository rather than the size of the edit, and on a converted
+repository it can reach 16 GB per repository per write. Give the machine or
+container that much free memory before you commit, because a commit that runs
+out of it is killed mid-transaction.
+
+Run \`kin doctor\` inside the repository to see where you stand. It measures your
+store against the commit peaks Kin has recorded and tells you which side of that
+line you are on, before you spend a write finding out.
 
 ## 1. The executables
 

--- a/scripts/write-release-archive-docs.test.mjs
+++ b/scripts/write-release-archive-docs.test.mjs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const GENERATOR = path.join(HERE, 'write-release-archive-docs.mjs');
+
+// The three archive layouts release.yml builds. The docs differ across them
+// (extensions, shim name, home directory), so every assertion below runs
+// against all three rather than against whichever one is convenient.
+const TARGETS = [
+  'aarch64-apple-darwin',
+  'x86_64-unknown-linux-gnu',
+  'x86_64-pc-windows-msvc',
+];
+
+const PAYLOAD = {
+  'aarch64-apple-darwin': ['kin', 'kin-daemon', 'kin-vfs', 'libkin_vfs_shim.dylib'],
+  'x86_64-unknown-linux-gnu': ['kin', 'kin-daemon', 'kin-vfs', 'libkin_vfs_shim.so'],
+  'x86_64-pc-windows-msvc': ['kin.exe', 'kin-daemon.exe', 'kin-vfs.exe', 'kin_vfs_shim.dll'],
+};
+
+function generate(target) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-archive-docs-'));
+  for (const name of PAYLOAD[target]) {
+    fs.writeFileSync(path.join(dir, name), `stand-in bytes for ${name}\n`);
+  }
+  execFileSync(process.execPath, [GENERATOR, dir, target, '9.9.9'], { stdio: 'pipe' });
+  return {
+    dir,
+    readme: fs.readFileSync(path.join(dir, 'README.md'), 'utf8'),
+    install: fs.readFileSync(path.join(dir, 'INSTALL.md'), 'utf8'),
+    checksums: fs.readFileSync(path.join(dir, 'checksums-sha256.txt'), 'utf8'),
+  };
+}
+
+// An isolated stranger run lost a task to this number. Its container had 12 GiB,
+// `kin doctor` had the measurement the whole time, and the only place the cost
+// was written down was a health check the reader had to think to run. A commit
+// peak that big is a requirement, and a requirement belongs where someone reads
+// before they choose the machine.
+test('every archive states the memory a commit needs before a reader picks a machine', () => {
+  for (const target of TARGETS) {
+    const { install } = generate(target);
+    assert.match(
+      install,
+      /16 GB per repository per write/,
+      `${target}: INSTALL.md does not state the per-write memory requirement, so the only ` +
+        'place it is written down is a health check the reader has to think to run',
+    );
+    assert.match(
+      install,
+      /## Requirements/,
+      `${target}: the memory figure is not in a requirements section`,
+    );
+    assert.match(
+      install,
+      /kin doctor/,
+      `${target}: the requirement names no way to check it against this machine`,
+    );
+  }
+});
+
+// Requirements that arrive after the install steps are requirements nobody
+// used. The reader has already chosen the machine by then.
+test('the requirement is stated before the install steps', () => {
+  for (const target of TARGETS) {
+    const { install } = generate(target);
+    const requirements = install.indexOf('## Requirements');
+    const executables = install.indexOf('## 1. The executables');
+    assert.ok(requirements > 0, `${target}: no requirements section`);
+    assert.ok(
+      requirements < executables,
+      `${target}: the requirements section sits after the install steps`,
+    );
+  }
+});
+
+// A stranger who has extracted the archive can still check what is inside it,
+// which is the whole reason this manifest exists beside the per-archive sidecar.
+test('the checksum manifest covers every file beside it and no others', () => {
+  for (const target of TARGETS) {
+    const { dir, checksums } = generate(target);
+    const listed = new Map(
+      checksums
+        .trimEnd()
+        .split('\n')
+        .map((line) => {
+          const [digest, name] = line.split('  ');
+          return [name, digest];
+        }),
+    );
+    const present = fs
+      .readdirSync(dir)
+      .filter((name) => name !== 'checksums-sha256.txt')
+      .sort();
+    assert.deepEqual(
+      [...listed.keys()].sort(),
+      present,
+      `${target}: the manifest and the archive root disagree about what is in the archive`,
+    );
+    for (const [name, digest] of listed) {
+      const actual = createHash('sha256')
+        .update(fs.readFileSync(path.join(dir, name)))
+        .digest('hex');
+      assert.equal(digest, actual, `${target}: ${name} is listed with the wrong digest`);
+    }
+  }
+});
+
+// House rule, on the one prose surface that ships inside the product and is
+// generated rather than reviewed line by line.
+test('the shipped archive prose carries no em dash', () => {
+  for (const target of TARGETS) {
+    const { readme, install } = generate(target);
+    assert.ok(!readme.includes('—'), `${target}: README.md carries an em dash`);
+    assert.ok(!install.includes('—'), `${target}: INSTALL.md carries an em dash`);
+  }
+});


### PR DESCRIPTION
`kin doctor`'s commit headroom check compared this machine's ceiling against the
quoted commit peak with `>=` (`crates/kin-cli/src/commands/health.rs:3085`), so a
ceiling merely level with that peak reported ok. The quoted row is a floor rather
than a bound: the check picks the largest measured row whose store is no larger
than the store in front of it, and a larger store peaks higher, so parity with the
row is the edge rather than headroom. An isolated stranger run read ok on a 12288
MiB container against the 12283 MiB `psf/requests` peak and lost a task to an
out-of-memory kill six hours after the setup phase had flagged the line.

The check now reports three bands. A ceiling that clears the quoted peak by the
spread the measurement table itself shows stays healthy, one level with it is
`Stale`, and one below it is the new `Degraded` status. Every band names the
measured peak, the ceiling and the store-size ratio, and both warning bands say to
do the write on a smaller repository. `COMMIT_PEAK_COMFORT_MARGIN_PERCENT` is 14,
which rounds up the 13.6% spread the two measured rows actually show, and a test
holds it to the table so a row measured later that spreads wider fails rather than
quietly narrowing the band.

`Degraded` renders red in the doctor table and is deliberately absent from
`is_failing` and `blocks_readiness`, so neither warning band can flip the aggregate
the public install proof recomputes from the check statuses. That property is
asserted against the assembled report rather than trusted to the enum. It was
checked against the proof's own rule too: `validateHealthReport` from
`scripts/verify-capability-proof.mjs` accepts a report carrying
`commit_memory_headroom=degraded` with `healthy=true`, and still rejects the same
report carrying `misconfigured`, which is the control proving the rule can fail.
The Windows install-proof leg is stricter still, admitting only `repo_init`,
`healthy` and `unsupported`, and it is unreachable here: that leg has no
repository, so the check returns `Unsupported` from the branch above the store
measurement, which this change does not touch. `HEALTH_STATUSES` in the capability
proof gains `degraded`, because that list documents itself as the whole vocabulary
the Rust enum serializes.

INSTALL.md, written into every release archive by
`scripts/write-release-archive-docs.mjs`, gains a requirements section stating that
a commit on a converted repository can reach 16 GB per repository per write, and
pointing at `kin doctor` to check a given machine against it. The generator carried
no test at all; it has one now covering all three archive layouts, wired into both
`node --test` lists in `ci.yml`.

Falsification, each reverting one behavior and reading the full output and exit
code rather than a pipe:

- Comfort margin 14 to 0, which restores the `>=` rounding: the parity test fails
  rc=101 with "a ceiling exactly at the measured peak is parity, not headroom:
  Healthy".
- Over-parity `Degraded` back to `Stale`, which restores the two-band check: the
  degraded test fails rc=101 with "a ceiling under a measured peak is over parity,
  not at it: Stale".
- `Degraded` added to `is_failing`, which is how this would fence a release at tag
  time: the readiness test fails rc=101 with "a small machine is not a broken
  install: Degraded".
- Requirements section removed from the generator: the doc test fails rc=1 with
  "INSTALL.md does not state the per-write memory requirement, so the only place it
  is written down is a health check the reader has to think to run".

Gates, all run on this branch at 32768cd3 in the lane worktree the run printed
(`worktree=/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/worktrees/headroom-kin`):
`cargo fmt --all -- --check` rc=0; `cargo clippy --all-targets --all-features` with
`ci.yml`'s exact allowlist under `RUSTFLAGS=-D warnings` rc=0 and zero error lines;
`bin/kin-dev local-test kin` rc=0 with "6458 tests run: 6458 passed, 12 skipped"
against "Starting 6458 tests", so the run reached its own end rather than stopping
early; an independent `cargo nextest run --workspace --no-fail-fast` rc=0 with the
same 6458 of 6458; `cargo check -p kin-cli --no-default-features --lib` rc=0;
`verify-zero-file-search.py`, `zero_file_search_guard.sh`,
`check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`,
`test-private-repo-coupling.py` and `verify-hydration-semantics.py` all rc=0;
`test-release-workflow-authority.py` rc=0; `node --test` over
`verify-capability-proof.test.mjs`, `write-release-archive-docs.test.mjs` and
`release-archive-shape.test.cjs` rc=0 with 40 of 40 passing. The tracked
`Cargo.lock` and `.cargo/` are unchanged against `origin/main` and the tree is
clean.

The Windows `-p kin-cli --no-default-features --lib` leg could not run locally:
cross-compiling to `x86_64-pc-windows-msvc` from this host fails in `ring`'s build
script for want of an MSVC C toolchain. The trap that leg usually catches does not
apply here, since this change introduces no `#[cfg]` gate at all against 27 already
in the file, and every symbol it adds has an unconditional caller.

Closes FIR-2451
