### PR TITLE
Name the context pack's two directions and disclose small-corpus ranking

### DIFF
--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -81,8 +81,15 @@ pub struct ContextTarget {
 pub struct ContextDependencySelection {
     /// `dependency_edges` or `same_file_fallback`.
     pub source: String,
-    /// Rows in `pack.dependency_signatures`.
+    /// Rows in `pack.dependency_signatures` the focal depends on, plus any
+    /// same-file fallback rows. This is the count the `Dependencies` line
+    /// reports.
     pub returned: usize,
+    /// Rows in `pack.dependency_signatures` that depend on the focal instead.
+    /// They ride real edges and stay in the pack; they are simply not
+    /// dependencies, and counting them as such reported callers as callees.
+    #[serde(default)]
+    pub dependents_returned: usize,
     /// Same-file neighbours the fallback had to choose from. Zero when the
     /// fallback did not run.
     pub same_file_candidates: usize,
@@ -200,6 +207,8 @@ pub fn build_context_response(
 
     let (pack, selection) =
         kin_context::build_context_pack_with_provenance(graph, &target.id, &opts)?;
+    let dependents_returned = count_dependents(&pack, &selection);
+    let dependencies_returned = pack.dependency_signatures.len() - dependents_returned;
 
     let mut lines = vec![
         format!("Context pack for '{}' ({:?}):", target.name, target.kind),
@@ -211,9 +220,10 @@ pub fn build_context_response(
         format!("  Focal: {} entries", pack.focal_entities.len()),
         format!(
             "  Dependencies: {} entries{}",
-            pack.dependency_signatures.len(),
-            dependency_selection_note(&selection, pack.dependency_signatures.len())
+            dependencies_returned,
+            dependency_selection_note(&selection, dependencies_returned)
         ),
+        format!("  Dependents: {} entries", dependents_returned),
         format!("  Transitive: {} entries", pack.transitive_deps.len()),
         format!("  Contracts: {} entries", pack.contracts.len()),
         format!("  Tests: {} entries", pack.tests.len()),
@@ -242,12 +252,31 @@ pub fn build_context_response(
         }),
         dependency_selection: Some(ContextDependencySelection {
             source: selection.source().as_str().to_string(),
-            returned: pack.dependency_signatures.len(),
+            returned: dependencies_returned,
+            dependents_returned,
             same_file_candidates: selection.same_file_candidates(),
             same_file_dropped: selection.same_file_dropped(),
         }),
         pack: Some(pack),
     })
+}
+
+/// Rows in the pack's dependency section that depend on the focal.
+///
+/// Counted off the rows themselves rather than tracked as a separate total, so
+/// the number cannot drift from the list it describes when the token budget
+/// drops a row.
+fn count_dependents(
+    pack: &kin_model::context::ContextPack,
+    selection: &kin_context::DependencySelection,
+) -> usize {
+    pack.dependency_signatures
+        .iter()
+        .filter(|entry| {
+            selection.relation_for(&entry.entity_id)
+                == kin_context::DependencyRelation::DependentEdge
+        })
+        .count()
 }
 
 /// The parenthetical after the dependency count in the human rendering.

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1837,6 +1837,54 @@ fn record_vector_index_degradation(
     );
 }
 
+/// Disclose that this store is too small for a description query to rank well.
+///
+/// The threshold is the ranker's own fusion constant, not a number picked to fit
+/// the symptom. A ranked list contributes `1 / (k + rank + 1)` to a fused score,
+/// so across `n` entities the best and worst rows differ by a factor of
+/// `(k + n) / (k + 1)`. While `n` stays under `k` that whole span is under two:
+/// the corpus sits inside the flat part of the curve, rank position carries less
+/// than the constant does, and a description query, whose evidence is diffuse to
+/// begin with, has nothing left to separate candidates with. Tuning
+/// `KIN_LOCATE_RRF_K` therefore moves this disclosure with the behaviour it
+/// describes.
+///
+/// Exact names are unaffected and are what the remediation points at: a named
+/// hit sorts by its name tier ABOVE the fused score rather than through it, so
+/// it cannot be outbid by the flat band this entry is about.
+///
+/// This is a fact about the store, not a report that the query ran degraded.
+/// Every signal ran and nothing was cut, which is why
+/// [`kin_mcp::negative`] excludes this pair from the absence gate: a small graph
+/// makes an absence more trustworthy, not less, and gating on it would refuse to
+/// certify absences on exactly the stores where they are most reliable.
+///
+/// Ranking behaviour is deliberately unchanged here. Blending the signals
+/// differently at this scale is a measured project; saying so is not.
+fn record_small_corpus_degradation(entity_count: usize, sink: &mut Vec<RetrievalDegradation>) {
+    let threshold = locate_rrf_k() as usize;
+    if entity_count >= threshold {
+        return;
+    }
+    record_degradation(
+        sink,
+        RetrievalDegradation {
+            component: kin_mcp::negative::CORPUS_SCALE_COMPONENT.to_string(),
+            reason: kin_mcp::negative::SMALL_CORPUS_REASON.to_string(),
+            detail: format!(
+                "this graph holds {entity_count} entities, under the {threshold}-entity rank \
+                 fusion constant this ranker scores with, so a query phrased as a description \
+                 has too little signal to separate candidates and can rank the obvious target \
+                 low or miss it"
+            ),
+            remediation: "at this size ask by exact entity or file name, or by a literal \
+                 string you expect in the code; description queries earn their accuracy as the \
+                 graph grows"
+                .to_string(),
+        },
+    );
+}
+
 /// Record the active hardware capability tier as a structured degradation when
 /// it runs below the full pipeline. `LocateProfile` silently scales the graph
 /// multihop budget with the machine's effective cores/RAM (shallower depth, a
@@ -2495,6 +2543,9 @@ fn run_with_graph_capture_budgeted(
     // tier some retrieval signals are off, and that must never be silent — nor
     // must a tier that a failed host probe, rather than the host, chose.
     record_capability_tier_degradation(&detection, &mut degradations);
+    // Say when the graph is too small for a description query to rank well,
+    // rather than serving a weak answer that looks like a confident one.
+    record_small_corpus_degradation(graph.entity_count(), &mut degradations);
     // A caller that asked for tests outranks the keyword heuristic. Folding the
     // ask into `test_query` is what makes every stage that already respects the
     // heuristic respect the ask too, rather than adding a second, differently
@@ -17598,6 +17649,58 @@ mod tests {
         sink.iter()
             .find(|entry| entry.component == "capability_tier")
             .expect("a sub-Performance tier must record a capability_tier degradation")
+    }
+
+    /// The greenfield stranger stopped trusting description queries on a
+    /// five-module project and fell back to grep, which was the right call and
+    /// one the tool never made for them. Below the fusion constant the whole
+    /// corpus sits in the flat part of the curve, so the honest move is to say
+    /// so rather than serve a weak answer that looks like a confident one.
+    #[test]
+    fn a_graph_under_the_fusion_constant_discloses_that_descriptions_rank_weakly() {
+        let threshold = locate_rrf_k() as usize;
+        let small = threshold.saturating_sub(1);
+
+        let mut sink = Vec::new();
+        record_small_corpus_degradation(small, &mut sink);
+        let entry = sink
+            .iter()
+            .find(|entry| entry.component == kin_mcp::negative::CORPUS_SCALE_COMPONENT)
+            .unwrap_or_else(|| {
+                panic!(
+                    "a graph of {small} entities is under the {threshold}-entity fusion \
+                        constant and must disclose it, got {sink:?}"
+                )
+            });
+        assert_eq!(entry.reason, kin_mcp::negative::SMALL_CORPUS_REASON);
+        assert!(
+            entry.detail.contains(&format!("{small} entities")),
+            "the entry must name the count it is about: {}",
+            entry.detail
+        );
+        assert!(
+            entry.detail.contains(&threshold.to_string()),
+            "and the threshold it is measured against: {}",
+            entry.detail
+        );
+        assert!(
+            entry.remediation.contains("exact entity or file name"),
+            "the remediation must name the form that does work at this size: {}",
+            entry.remediation
+        );
+
+        // The control that makes the threshold mean something: a graph at the
+        // constant discloses nothing, so this cannot be an entry every store
+        // carries.
+        let mut large = Vec::new();
+        record_small_corpus_degradation(threshold, &mut large);
+        assert!(
+            large.is_empty(),
+            "a graph of {threshold} entities is not a small corpus, got {large:?}"
+        );
+        let mut much_larger = Vec::new();
+        record_small_corpus_degradation(threshold * 100, &mut much_larger);
+        assert!(much_larger.is_empty(), "{much_larger:?}");
     }
 
     /// The misread host in the surface a caller actually reads. A tier the host

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -236,19 +236,31 @@ impl Default for ContextOptions {
 /// the candidate total beside the kept count.
 pub const SAME_FILE_FALLBACK_MAX: usize = 6;
 
-/// Why a row is in a pack's dependency section.
+/// Why a row is in a pack's dependency section, and which way it points.
 ///
-/// The two are not interchangeable. An edge row is a dependency the graph
-/// asserts; a same-file row is a neighbour the builder reached for because the
-/// focal had no dependency edge at all. A class whose only edges are `Contains`
-/// produces same-file rows, and without this distinction a caller reads them as
-/// the class's dependencies.
+/// The three are not interchangeable. A dependency rides an edge LEAVING the
+/// focal, so the focal needs it. A dependent rides an edge ARRIVING at the
+/// focal, so it needs the focal; changing the focal is what breaks it. A
+/// same-file row is a neighbour the builder reached for because the focal had
+/// no dependency edge in either direction. A class whose only edges are
+/// `Contains` produces same-file rows, and without this distinction a caller
+/// reads them as the class's dependencies.
+///
+/// Direction is not decoration. Every relation kind [`is_dependency_edge`]
+/// accepts runs src-depends-on-dst, so the endpoint alone cannot say which
+/// question a row answers: "what does this need to run" and "what breaks if I
+/// change this" are opposite queries served by opposite edges. Collapsing them
+/// reported a caller as a callee.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DependencyRelation {
-    /// The entity reaches the focal over a real dependency edge.
+    /// The focal reaches this entity over a real dependency edge. The focal
+    /// depends on it.
     DependencyEdge,
-    /// The focal carried no dependency edge, so this row is an entity that
-    /// shares the focal's file. Not a dependency.
+    /// This entity reaches the focal over a real dependency edge. It depends on
+    /// the focal. Not a dependency of the focal.
+    DependentEdge,
+    /// The focal carried no dependency edge in either direction, so this row is
+    /// an entity that shares the focal's file. Not a dependency.
     SameFileNeighbor,
 }
 
@@ -258,7 +270,23 @@ impl DependencyRelation {
     pub fn as_str(self) -> &'static str {
         match self {
             DependencyRelation::DependencyEdge => "dependency_edge",
+            DependencyRelation::DependentEdge => "dependent_edge",
             DependencyRelation::SameFileNeighbor => "same_file_neighbor",
+        }
+    }
+
+    /// Sort bucket for the pack's dependency section: what the focal needs
+    /// first, then what needs the focal, then the fallback neighbours.
+    ///
+    /// A pack whose focal had one callee and nine callers listed the callee
+    /// tenth, because the section was ordered on relation weight alone and
+    /// weight does not know direction. The one row that answers "what does this
+    /// need" must not sit below nine rows that answer a different question.
+    pub fn sort_rank(self) -> u8 {
+        match self {
+            DependencyRelation::DependencyEdge => 0,
+            DependencyRelation::DependentEdge => 1,
+            DependencyRelation::SameFileNeighbor => 2,
         }
     }
 }
@@ -296,6 +324,7 @@ pub struct DependencySelection {
     fallback: bool,
     same_file_candidates: usize,
     same_file_neighbors: Vec<EntityId>,
+    dependents: Vec<EntityId>,
 }
 
 impl DependencySelection {
@@ -308,10 +337,17 @@ impl DependencySelection {
         }
     }
 
-    /// Why one dependency row is in the pack.
+    /// Why one dependency-section row is in the pack, and which way it points.
+    ///
+    /// An entity joined to the focal by edges in BOTH directions is reported as
+    /// a dependency. It is genuinely one, and the stronger claim is the one a
+    /// reader acts on: dropping it would break the focal, which the weaker
+    /// label does not say.
     pub fn relation_for(&self, entity_id: &EntityId) -> DependencyRelation {
         if self.same_file_neighbors.contains(entity_id) {
             DependencyRelation::SameFileNeighbor
+        } else if self.dependents.contains(entity_id) {
+            DependencyRelation::DependentEdge
         } else {
             DependencyRelation::DependencyEdge
         }
@@ -520,15 +556,43 @@ where
 
     // A direct *dependency* must ride a real dependency edge (Calls, Imports,
     // UsesType, …), not git co-change or structural plumbing. Without this gate
-    // the "dependencies" section is dominated by `CoChanges` neighbours and
-    // same-file containment noise rather than the entity's actual callees
-    // An entity counts as a dependency if *any* of its edges to the
-    // focal is a dependency edge.
-    let direct_dep_ids: Vec<EntityId> = direct_relations
-        .iter()
-        .filter(|r| is_dependency_edge(&r.kind))
-        .filter_map(direct_neighbor)
+    // the dependency section is dominated by `CoChanges` neighbours and
+    // same-file containment noise rather than the entity's actual callees.
+    //
+    // Every kind `is_dependency_edge` accepts runs src-depends-on-dst, so the
+    // edge's direction is the whole of the answer: an edge leaving the focal
+    // names something the focal needs, and an edge arriving names something
+    // that needs the focal. Reading the non-focal endpoint without the
+    // direction is how nine callers reached a caller as nine "dependencies".
+    let dependency_edge_relations = || {
+        direct_relations
+            .iter()
+            .filter(|r| is_dependency_edge(&r.kind))
+    };
+    let focal_node = GraphNodeId::Entity(*focal_id);
+    // focal --dep--> X: the focal needs X.
+    let dependency_ids: Vec<EntityId> = dependency_edge_relations()
+        .filter(|r| r.src == focal_node)
+        .filter_map(|r| r.dst.as_entity())
         .collect();
+    // Y --dep--> focal: Y needs the focal. Both directions stay in the section,
+    // because dropping the arriving edges would hide real graph truth behind
+    // the same-file fallback on exactly the entities that have callers and no
+    // callees. They are labelled, not withheld.
+    let dependent_ids: Vec<EntityId> = dependency_edge_relations()
+        .filter(|r| r.dst == focal_node)
+        .filter_map(|r| r.src.as_entity())
+        .filter(|id| !dependency_ids.contains(id))
+        .collect();
+    // The union keeps the section's membership, the fallback trigger, and the
+    // work/annotation scope exactly as they were; only the labels and the order
+    // within the section change.
+    let direct_dep_ids: Vec<EntityId> = dependency_ids
+        .iter()
+        .copied()
+        .chain(dependent_ids.iter().copied())
+        .collect();
+    selection.dependents = dependent_ids;
 
     // BFS only follows outgoing edges, so entities with only incoming edges to
     // the focal (e.g. test entities with a Tests relation pointing at the focal)
@@ -727,6 +791,15 @@ where
             }
         }
     }
+
+    // Order the section by what each row answers, not by relation weight alone.
+    //
+    // Weight ranks a `Calls` edge above a `References` edge whichever way it
+    // points, so a focal with one callee and nine callers listed the callee
+    // last. `sort_by_key` is stable, so weight order survives inside each
+    // bucket and this only lifts the rows that answer "what does this need"
+    // above the rows that answer "what needs this".
+    dep_entries.sort_by_key(|entry| selection.relation_for(&entry.entity_id).sort_rank());
 
     // 4. Gather active work items scoped to focal and direct dependencies.
     let mut work_entries = Vec::new();
@@ -1871,6 +1944,146 @@ mod tests {
                 .iter()
                 .all(|entry| entry.entity_id != sibling.id),
             "a same-file sibling must not join a pack that has real edges"
+        );
+    }
+
+    /// The greenfield stranger's pack listed nine callers under "dependencies"
+    /// and put the one real callee tenth. Direction is the whole of the answer:
+    /// every kind `is_dependency_edge` accepts runs src-depends-on-dst, so an
+    /// edge leaving the focal names what the focal needs and an edge arriving
+    /// names what needs the focal. Reading only the non-focal endpoint reported
+    /// callers as callees, and ordering on relation weight alone buried the one
+    /// row that answered the question asked.
+    #[test]
+    fn one_dependency_leads_the_section_and_nine_dependents_are_labelled_as_such() {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+
+        let store = kin_db::InMemoryGraph::new();
+        let calls = |src: EntityId, dst: EntityId| {
+            store
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(src),
+                    dst: GraphNodeId::Entity(dst),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        };
+
+        let focal = make_file_entity("save_note", EntityKind::Function, "src/store.py");
+        // The one entity the focal needs.
+        let dependency = make_file_entity("serialize", EntityKind::Function, "src/codec.py");
+        store.upsert_entity(&focal).unwrap();
+        store.upsert_entity(&dependency).unwrap();
+        calls(focal.id, dependency.id);
+
+        // Nine entities that need the focal.
+        let mut dependents = Vec::new();
+        for index in 0..9 {
+            let caller = make_file_entity(
+                &format!("handle_request_{index}"),
+                EntityKind::Function,
+                &format!("src/api_{index}.py"),
+            );
+            store.upsert_entity(&caller).unwrap();
+            calls(caller.id, focal.id);
+            dependents.push(caller);
+        }
+
+        let (pack, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &ContextOptions::default())
+                .unwrap();
+
+        assert_eq!(selection.source(), DependencySource::DependencyEdges);
+        assert_eq!(
+            pack.dependency_signatures.len(),
+            10,
+            "both directions stay in the pack; only the labels and the order change"
+        );
+
+        // Labels first, then order. The order is DERIVED from the labels, so
+        // asserting it first would report a mislabelling as a sort bug and hide
+        // which of the two actually broke.
+        assert_eq!(
+            selection.relation_for(&dependency.id),
+            DependencyRelation::DependencyEdge,
+            "an edge leaving the focal is a dependency"
+        );
+        for caller in &dependents {
+            assert_eq!(
+                selection.relation_for(&caller.id),
+                DependencyRelation::DependentEdge,
+                "'{}' calls the focal, so it depends on the focal; reporting it as a \
+                 dependency inverts the claim a caller acts on",
+                caller.name
+            );
+        }
+        let labelled_dependencies = pack
+            .dependency_signatures
+            .iter()
+            .filter(|entry| {
+                selection.relation_for(&entry.entity_id) == DependencyRelation::DependencyEdge
+            })
+            .count();
+        assert_eq!(
+            labelled_dependencies, 1,
+            "exactly one row rides an edge that leaves the focal"
+        );
+
+        assert_eq!(
+            pack.dependency_signatures[0].entity_id, dependency.id,
+            "the one entity the focal depends on must lead the section, not trail nine callers"
+        );
+    }
+
+    /// An entity joined to the focal in both directions is a dependency: the
+    /// focal really does need it, and that is the claim a reader acts on when
+    /// deciding what may be removed.
+    #[test]
+    fn a_mutual_edge_is_reported_as_a_dependency_not_a_dependent() {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+
+        let store = kin_db::InMemoryGraph::new();
+        let calls = |src: EntityId, dst: EntityId| {
+            store
+                .upsert_relation(&Relation {
+                    id: kin_model::ids::RelationId::new(),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(src),
+                    dst: GraphNodeId::Entity(dst),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        };
+
+        let focal = make_file_entity("ping", EntityKind::Function, "src/a.py");
+        let peer = make_file_entity("pong", EntityKind::Function, "src/b.py");
+        store.upsert_entity(&focal).unwrap();
+        store.upsert_entity(&peer).unwrap();
+        calls(focal.id, peer.id);
+        calls(peer.id, focal.id);
+
+        let (pack, selection) =
+            build_context_pack_with_provenance(&store, &focal.id, &ContextOptions::default())
+                .unwrap();
+
+        assert_eq!(
+            pack.dependency_signatures.len(),
+            1,
+            "one entity produces one row however many edges join it to the focal"
+        );
+        assert_eq!(
+            selection.relation_for(&peer.id),
+            DependencyRelation::DependencyEdge
         );
     }
 

--- a/crates/kin-mcp/src/budget.rs
+++ b/crates/kin-mcp/src/budget.rs
@@ -272,7 +272,16 @@ fn shape_for(tool: &str) -> Option<ResponseShape> {
             narrow_param: "depth",
         },
         "get_context_pack" | "trace_computation" => ResponseShape {
-            collections: &["dependencies", "transitive_deps", "tests", "contracts"],
+            // `dependents` sheds beside `dependencies`: it is the same section
+            // split by direction, and a group the budget cannot trim is a group
+            // that can push a response past its cap on its own.
+            collections: &[
+                "dependencies",
+                "dependents",
+                "transitive_deps",
+                "tests",
+                "contracts",
+            ],
             body_keys: &["body"],
             explain_keys: &["projection"],
             top_explain_keys: &[],

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -652,13 +652,16 @@ which measures the serialized response this call returns, as what the call costs
 `focal_entity.body` in the response IS the focal entity's exact source text, so this one \
 call already answers \"show me the code\": no follow-up read is needed, and it is the body \
 to edit and stage back, in compact mode too, which drops the dependency bodies and \
-projection levels but never the focal body. Every dependency row says why it is there: \
-`relation: \"dependency_edge\"` is an edge the graph asserts, and \
-`relation: \"same_file_neighbor\"` means the focal had no dependency edge at all, so the \
-row is a neighbour sharing the focal's file rather than anything the focal depends on. \
-That is the usual shape for a class whose only edges are containment. \
-`dependency_selection` names which of the two filled the list and, for the fallback, how \
-many same-file candidates there were and how many were dropped to fit. \
+projection levels but never the focal body. The two directions are separate groups, because they answer opposite questions: \
+`dependencies` is what the focal needs to run, and `dependents` is what breaks if you \
+change it. Every row also says why it is there: `relation: \"dependency_edge\"` is an \
+edge leaving the focal, `relation: \"dependent_edge\"` is an edge arriving at it, and \
+`relation: \"same_file_neighbor\"` means the focal had no dependency edge in either \
+direction, so the row is a neighbour sharing the focal's file rather than anything the \
+focal depends on. That last one is the usual shape for a class whose only edges are \
+containment, and those rows sort after the real edges. `dependency_selection` names \
+which of the two filled the list, how many rows each group returned, and, for the \
+fallback, how many same-file candidates there were and how many were dropped to fit. \
 If get_entity_source is available to you it is cheaper for a raw \
 body alone; if you need to follow an actual call chain step by step, use trace_data_flow.";
 
@@ -803,11 +806,25 @@ pub fn handle_get_context_pack<G: GraphStore>(
         }
     };
 
-    let dependencies: Vec<_> = pack
-        .dependency_signatures
-        .iter()
-        .map(|entry| project_dep(entry, Some(selection.relation_for(&entry.entity_id))))
-        .collect::<Result<Vec<_>>>()?;
+    // The dependency section carries both directions, so it is served as two
+    // groups named for what they are. Serving it as one list called
+    // `dependencies` reported a focal's callers as things the focal depends on,
+    // which is the opposite claim and the one an agent acts on when it decides
+    // what it may safely change. The builder has already ordered the section so
+    // real dependencies precede dependents and fallback neighbours, and that
+    // order survives the partition.
+    let mut dependencies: Vec<serde_json::Value> = Vec::new();
+    let mut dependents: Vec<serde_json::Value> = Vec::new();
+    for entry in &pack.dependency_signatures {
+        let relation = selection.relation_for(&entry.entity_id);
+        let row = project_dep(entry, Some(relation))?;
+        match relation {
+            DependencyRelation::DependentEdge => dependents.push(row),
+            DependencyRelation::DependencyEdge | DependencyRelation::SameFileNeighbor => {
+                dependencies.push(row)
+            }
+        }
+    }
     let transitive: Vec<_> = pack
         .transitive_deps
         .iter()
@@ -820,12 +837,18 @@ pub fn handle_get_context_pack<G: GraphStore>(
     // caller deciding whether to ask again needs it most when the answer is
     // small.
     let returned = dependencies.len();
+    let dependents_returned = dependents.len();
     let mut result = serde_json::json!({
         "focal_entity": focal_json,
         "dependencies": dependencies,
+        // Always present, empty included. "no dependents" and "this build does
+        // not report dependents" are different answers, and a group that
+        // appears only when populated cannot tell them apart.
+        "dependents": dependents,
         "dependency_selection": {
             "source": selection.source().as_str(),
             "returned": returned,
+            "dependents_returned": dependents_returned,
             "same_file_candidates": selection.same_file_candidates(),
             "same_file_dropped": selection.same_file_dropped(),
         },

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -2968,11 +2968,14 @@ mod tests {
         );
     }
 
-    /// A pack fixture with both dependency shapes: a class whose only edges are
+    /// A pack fixture with every dependency shape: a class whose only edges are
     /// containment, so its dependency section can only be filled from the
     /// neighbours in its file, and a function that really does call two
-    /// entities. One store, so the two answers are told apart by what the
-    /// payload says rather than by which fixture produced it.
+    /// entities and is itself called by a third. One store, so the answers are
+    /// told apart by what the payload says rather than by which fixture
+    /// produced it. `renderer` calls `reader`, which makes `reader` a focal
+    /// with both directions on it: two things it needs, one thing that needs
+    /// it.
     struct PackProvenanceFixture {
         _dir: tempfile::TempDir,
         _env: EnvVarGuard,
@@ -2980,6 +2983,7 @@ mod tests {
         authority: RequestRepositoryAuthority,
         note_store: Entity,
         reader: Entity,
+        renderer: Entity,
     }
 
     const NOTES_SOURCE: &str = "export class NoteStore {\n  open(): void {}\n  close(): void {}\n  stats(): number { return 0; }\n}\n";
@@ -3072,6 +3076,13 @@ mod tests {
             EntityKind::Class,
             1,
         );
+        let renderer = file_entity(
+            "render.ts",
+            "export function renderNotes(): string {\n  return \"\";\n}\n",
+            "renderNotes",
+            EntityKind::Function,
+            0,
+        );
 
         // The class's only edges are containment, which is the shape that sends
         // the builder to its same-file fallback: edges exist, none of them is a
@@ -3101,6 +3112,9 @@ mod tests {
         }
         store.insert_test_calls_relation(&reader, &link_record);
         store.insert_test_calls_relation(&reader, &note_record);
+        // The arriving edge. `reader` does not depend on `renderNotes`; changing
+        // `reader` is what breaks it.
+        store.insert_test_calls_relation(&renderer, &reader);
 
         install_empty_store_exact_tree(&mut store, dir.path());
         let authority = test_repository_authority(dir.path());
@@ -3112,6 +3126,7 @@ mod tests {
             authority,
             note_store,
             reader,
+            renderer,
         }
     }
 
@@ -3217,6 +3232,88 @@ mod tests {
             );
             assert_eq!(value["dependency_selection"]["same_file_candidates"], 0);
         }
+    }
+
+    /// The greenfield stranger's pack called its focal's callers "dependencies"
+    /// and sorted the one real callee last of ten. Both directions ride the same
+    /// relation kinds, so the endpoint alone cannot say which question a row
+    /// answers, and one list named for half of what it carried made the wrong
+    /// answer the readable one.
+    #[test]
+    fn a_context_pack_serves_dependencies_and_dependents_as_separate_named_groups() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        for compact in [false, true] {
+            let value = context_pack_json(&fixture, &fixture.reader, compact);
+
+            let dependents = value["dependents"].as_array().unwrap_or_else(|| {
+                panic!("the pack must name the group holding what depends on the focal: {value}")
+            });
+            assert_eq!(
+                dependents.len(),
+                1,
+                "one entity calls the focal (compact={compact}): {value}"
+            );
+            assert_eq!(
+                dependents[0]["id"],
+                serde_json::json!(fixture.renderer.id.to_string()),
+                "the caller belongs in `dependents` (compact={compact}): {value}"
+            );
+            assert_eq!(
+                dependents[0]["relation"],
+                serde_json::json!("dependent_edge"),
+                "an arriving edge must say which way it points (compact={compact}): {value}"
+            );
+
+            let dependencies = value["dependencies"]
+                .as_array()
+                .unwrap_or_else(|| panic!("the pack must carry dependency rows: {value}"));
+            assert!(
+                dependencies
+                    .iter()
+                    .all(|row| row["id"] != serde_json::json!(fixture.renderer.id.to_string())),
+                "a caller must not be served as something the focal depends on \
+                 (compact={compact}): {value}"
+            );
+            assert_eq!(
+                value["dependency_selection"]["returned"],
+                serde_json::json!(2),
+                "`returned` counts the group it describes (compact={compact}): {value}"
+            );
+            assert_eq!(
+                value["dependency_selection"]["dependents_returned"],
+                serde_json::json!(1),
+                "the selection must count both groups (compact={compact}): {value}"
+            );
+        }
+    }
+
+    /// A focal with no callers still names the group, because "nothing depends
+    /// on this" and "this build does not report dependents" are different
+    /// answers and a caller deciding whether a change is safe acts on the first.
+    #[test]
+    fn a_context_pack_names_the_dependents_group_even_when_it_is_empty() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        let value = context_pack_json(&fixture, &fixture.note_store, false);
+        assert_eq!(
+            value["dependents"],
+            serde_json::json!([]),
+            "an empty group is still an answer: {value}"
+        );
+        assert_eq!(
+            value["dependency_selection"]["dependents_returned"],
+            serde_json::json!(0),
+            "{value}"
+        );
     }
 
     /// `compact: true` dropped the focal body while still paying for the read

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -851,8 +851,41 @@ fn trace_flow_gaps(payload: &Value) -> Vec<String> {
     gaps
 }
 
+/// The component and reason a retrieval payload files its corpus-scale
+/// disclosure under.
+///
+/// The names live here rather than at the surface that writes them because the
+/// exemption below is what makes them meaningful, and a name that moved without
+/// its exemption would silently start blocking absence claims. `kin-cli`'s
+/// locate path writes entries under this pair; nothing else may.
+pub const CORPUS_SCALE_COMPONENT: &str = "corpus_scale";
+/// See [`CORPUS_SCALE_COMPONENT`].
+pub const SMALL_CORPUS_REASON: &str = "small_corpus";
+
+/// Whether a `component:reason` label describes the STORE rather than the run.
+///
+/// A corpus-scale disclosure says a graph is too small for a description query
+/// to rank well. Every signal still ran, nothing was cut, and the pipeline
+/// answered at full capability: the corpus simply has little to say. Treating
+/// it as a run degradation would be wrong in the one direction that matters
+/// here, because a small graph makes an absence MORE trustworthy, not less,
+/// and there is less in it to have been missed. Folding it into the gate would
+/// have made every absence claim on a small store uncertifiable on the grounds
+/// that the store was small.
+///
+/// It stays in the payload's own `degradations[]`, where a caller reads it. This
+/// only keeps it out of the run-quality verdicts below.
+fn describes_the_store_not_the_run(label: &str) -> bool {
+    label.split_once(':').is_some_and(|(component, reason)| {
+        component == CORPUS_SCALE_COMPONENT && reason == SMALL_CORPUS_REASON
+    })
+}
+
 /// The degradations a retrieval payload reported about its OWN run, as stable
 /// `component:reason` labels.
+///
+/// Corpus-scale disclosures are excluded: they describe the store, not the run.
+/// See [`describes_the_store_not_the_run`].
 ///
 /// The envelope's [`Degraded`] flags describe the daemon; this array describes
 /// the query that just ran, and the two are not the same fact. A locate page
@@ -878,6 +911,7 @@ fn payload_degradation_labels(payload: &Value) -> Vec<String> {
             let reason = entry.get("reason").and_then(Value::as_str)?;
             Some(format!("{component}:{reason}"))
         })
+        .filter(|label| !describes_the_store_not_the_run(label))
         .collect()
 }
 
@@ -2172,6 +2206,84 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("no degraded signals"));
+    }
+
+    /// A small store is a fact about the corpus, not a report that the query
+    /// ran degraded, and an absence found in a small graph is MORE trustworthy
+    /// rather than less: there is less in it to have been missed. Folding the
+    /// disclosure into the run-quality gate would have refused to certify
+    /// absences on exactly the stores where they are most reliable.
+    #[test]
+    fn a_corpus_scale_disclosure_does_not_make_an_absence_inconclusive() {
+        let small = json!({
+            "query": "where do notes get written to disk",
+            "results": [],
+            "total_ranked": 0,
+            "degradations": [{
+                "component": CORPUS_SCALE_COMPONENT,
+                "reason": SMALL_CORPUS_REASON,
+                "detail": "this graph holds 41 entities, under the 60-entity rank fusion \
+                           constant this ranker scores with",
+                "remediation": "ask by exact entity or file name",
+            }],
+        });
+        let negative = negative_for(
+            "semantic_locate",
+            &small,
+            &semantic_authoritative_envelope(),
+        )
+        .expect("empty results yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "a small corpus is not a degraded run: {negative}"
+        );
+        assert_eq!(
+            negative["degraded_signals"],
+            json!([]),
+            "no signal degraded; every one of them ran: {negative}"
+        );
+        assert!(
+            !negative["trust_reason"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("retrieval_degraded"),
+            "the store's size is not a reason to distrust this run: {negative}"
+        );
+
+        // The control that keeps the exemption from swallowing real
+        // degradations: one genuine run degradation beside it still blocks.
+        let mut mixed = small.clone();
+        mixed["degradations"] = json!([
+            {
+                "component": CORPUS_SCALE_COMPONENT,
+                "reason": SMALL_CORPUS_REASON,
+                "detail": "small",
+                "remediation": "name it",
+            },
+            {
+                "component": "vector_sidecar",
+                "reason": "retired_entity_keys",
+                "detail": "40 ranked vector key(s) resolved to entities the graph no longer holds",
+                "remediation": "run 'kin embed'",
+            },
+        ]);
+        let negative = negative_for(
+            "semantic_locate",
+            &mixed,
+            &semantic_authoritative_envelope(),
+        )
+        .unwrap();
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a real degradation must still block, exemption or not: {negative}"
+        );
+        assert_eq!(
+            negative["degraded_signals"],
+            json!(["vector_sidecar:retired_entity_keys"]),
+            "the exempt label is the only one dropped: {negative}"
+        );
     }
 
     #[test]

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -128,9 +128,17 @@ boundary you can rely on.
 - **`get_entity`**: Fetch metadata about a specific entity (kind, language, path, line range, signature) without its source body.
 - **`get_entity_source` / `get_entity_body`**: Retrieve the implementation source of an entity, served from the graph.
 - **`get_entity_sources`**: The batch form of `get_entity_source`. Hand it up to 50 entity IDs in priority order and it returns each entity's metadata plus its body in one budgeted call, which replaces the N separate round-trips and N response envelopes those reads would otherwise cost. Bodies fill in the order you list the IDs until the shared `token_budget` is reached, and entities past that point come back signature-only with `omitted=true`.
-- **`get_context_pack`**: Package a target entity alongside its caller/import neighborhood into a single prompt-friendly bundle.
+- **`get_context_pack`**: Package a target entity alongside its caller/import neighborhood into a single prompt-friendly bundle. The two directions come back as separate named groups: `dependencies` is what the focal needs to run, `dependents` is what breaks if you change it, and every row carries a `relation` saying which way its edge points.
 - **`explore_codebase`**: Get a one-shot map of the codebase via a selectable strategy (e.g. `overview`: entity counts by kind and language, plus the top public declarations).
 - **`graph_neighborhood`**: Return the dependency neighborhood of an entity, traversed to a given depth. The neighborhood covers what it depends on and what depends on it. `direction` selects which side to walk: `out` for dependencies, `in` for dependents (blast radius), `both` (default) for the merged neighborhood; every returned edge is tagged with the direction it was traversed in.
+
+**On a new or very small repository, expect the value curve to start later.** Kin ranks on
+cross-file structure, and a project of a few files has little of it yet. `kin commit`,
+`kin graph status`, `trace_data_flow`, and `get_entity_source` earn their keep from the
+first checkpoint. `semantic_locate` by description does not, until the graph is bigger, so
+ask by exact name at that size. Below the ranker's fusion constant `semantic_locate`
+discloses the limit itself, as a `corpus_scale` entry in `degradations`, so the weakness is
+reported rather than served as a confident answer.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -430,6 +430,17 @@ processes that do not inherit your `PATH`.)
 > on by default, so these tools have a live graph to query. `semantic_locate` returns an
 > explicit error in offline / no-daemon mode.
 
+### What to ask for on a brand new project
+
+Adjust the ask when the repository is one you just started. Kin ranks on cross-file
+structure, and a five-file project has the least of it. The tools that pay off from the
+first checkpoint are `kin commit`, `kin graph status` to watch the graph fill in,
+`trace_data_flow` for how the pieces wire together, and `get_entity_source` for reading
+code back. Description-shaped `semantic_locate` queries need more entities than a new
+project has, so ask by exact name at that size and let ranked retrieval earn your trust as
+the graph grows. When the graph is small enough for this to bite, `semantic_locate` says so
+in its `degradations` array rather than leaving you to find out from a weak answer.
+
 For the full tool surface, see the [MCP Tools Reference](mcp-tools.md). To wire up a
 client by hand (or use the npm wrapper), see
 [Advanced configuration](#9-advanced-configuration).


### PR DESCRIPTION
The greenfield stranger run on the v0.5.41 candidate reported that `get_context_pack` called a focal's dependents "dependencies" and sorted the one real dependency last of ten. Both halves were the same bug.

## The mechanism

`crates/kin-context/src/builder.rs:527` built `direct_dep_ids` by mapping every dependency edge through `direct_neighbor`, which returns the non-focal endpoint of an edge in either direction. Every relation kind `is_dependency_edge` accepts (`Calls`, `Imports`, `UsesType`, and the rest) runs src-depends-on-dst, so the endpoint alone cannot say which question a row answers. A focal's callers and its callees both landed in one list served as `dependencies`, and the section was ordered on relation weight, which does not know direction. Ten rows, one real dependency, and weight put it last.

## The fix

`DependencyRelation` gains `DependentEdge` beside the existing `DependencyEdge` and `SameFileNeighbor`, so FIR-2401's same-file markers are untouched. The builder splits the two directions at the source and records the dependents on `DependencySelection`, and `get_context_pack` serves `dependencies` and `dependents` as separate named groups with every row carrying the `relation` that put it there. `dependents` is always present, empty included, because "nothing depends on this" and "this build does not report dependents" are different answers.

Two deliberate restraints. The union still fills the dependency section, so the same-file fallback trigger and the work and annotation scope behave exactly as before; withholding the arriving edges would have hidden real graph truth behind fallback neighbours on precisely the entities that have callers and no callees. And `dep_entries` is stable-sorted on direction AFTER budget admission rather than inside the weight sort, so which entities survive a tight budget does not move.

`kin context`, the response budget's shedding list, and the tool description follow the same split.

## The small-corpus disclosure

`record_small_corpus_degradation` files a `corpus_scale:small_corpus` entry when the store holds fewer entities than the ranker's own fusion constant (`locate_rrf_k()`, default 60). The threshold is derived rather than chosen to fit the symptom: a ranked list contributes `1/(k+rank+1)`, so across `n` entities the best and worst rows differ by `(k+n)/(k+1)`, which stays under two while `n < k`. The whole corpus sits in the flat part of the curve, rank position carries less than the constant does, and a description query has nothing left to separate candidates with. Tuning `KIN_LOCATE_RRF_K` moves the disclosure with the behaviour it describes. Exact names are unaffected, because a named hit sorts by its name tier above the fused score rather than through it, which is what the remediation points at.

Ranking behaviour is deliberately unchanged. Blending the signals differently at this scale is a measured project; saying so is not.

`kin_mcp::negative` exempts that one label from the absence gate. A small corpus is a fact about the store, not a report that the query ran degraded: every signal ran and nothing was cut. Folding it into the gate would have made every absence claim on a small store uncertifiable on the grounds that the store was small, which is backwards, since a small graph has less in it to have been missed.

## Docs

`docs/quickstart.md` section 7 and `docs/mcp-tools.md` section 1 gain the greenfield value curve: on a project of a few files the workhorses are `kin commit`, `kin graph status`, `trace_data_flow` and `get_entity_source`, and ranked retrieval earns trust as the graph grows. The `get_context_pack` entry now names both groups.

## Falsification

Six breaks, each reverted after the run, each rc 100 with its own named message.

- Direction sort removed: `the one entity the focal depends on must lead the section, not trail nine callers`.
- Direction discarded in the builder: `'handle_request_0' calls the focal, so it depends on the focal; reporting it as a dependency inverts the claim a caller acts on`, left `DependencyEdge`, right `DependentEdge`.
- Handler partition collapsed back to one list: the dumped payload reproduced the reported bug verbatim, a row reading `"relation":"dependent_edge"` inside `dependencies` with `"dependents":[]` and `"returned":3`.
- Disclosure suppressed: `a graph of 59 entities is under the 60-entity fusion constant and must disclose it, got []`.
- Threshold removed so it always fires: `a graph of 60 entities is not a small corpus`, with the entry printed.
- Absence exemption removed: `safe_to_conclude_absent: false` with `retrieval_degraded: this query reported degradations [corpus_scale:small_corpus], so it did not run at full capability`, which is the false claim the exemption exists to prevent.

The assertions are ordered labels-first because the order is derived from the labels, so asserting order first would report a mislabelling as a sort bug.

## Gates

Run through `bin/kin-lane run packlabels kin --` against the lane worktree at `.kin-coord/worktrees/packlabels-kin`, statuses read raw.

- `cargo nextest run --workspace --no-fail-fast`: 6460 tests run, 6460 passed, 12 skipped.
- `bin/kin-dev local-test kin`: `All repos green under 'cargo nextest run --workspace (+ cargo test --doc)', no tracked lock contamination`, 6460/6460 plus doctests.
- `cargo fmt --all -- --check`: rc 0.
- Clippy with the exact `ci.yml` allowlist under `RUSTFLAGS=-D warnings`, `--all-targets --all-features`: rc 0. The same allowlist under `--no-default-features`: rc 0.
- `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/check_runtime_boundaries.sh`, `scripts/check_private_repo_coupling.sh`, `scripts/test-private-repo-coupling.py`: all rc 0.
- The four FIR-2404/FIR-2430 absence fixtures pass by name, untouched.
- `git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`, and `git diff origin/main --stat -- Cargo.lock .cargo/` is empty.

The Windows cross-compile leg could not run on this host: `ring`'s C build fails for `x86_64-pc-windows-msvc` before reaching any Kin crate. That leg is left to CI. The diff adds no `cfg`-gated code, which is the dead-code trap that leg catches.

Closes FIR-2453
