### PR TITLE
Cut the release build's dead cache and its 40-minute Intel leg, and probe a candidate's first install

### DIFF
--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -860,3 +860,296 @@ jobs:
           fi
           printf '\nDownload these archives with: gh run download %s --repo %s\n' \
             "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" >> "$GITHUB_STEP_SUMMARY"
+
+  # What a candidate build could not say before this job existed: whether the
+  # bytes it produced survive a first install. v0.5.41 built cleanly on all five
+  # platforms and then died at the tag's own doctor health gate, because setup
+  # recorded a mount projection it never engaged and `kin doctor` read the
+  # recorded mode against the running state. That defect is visible the moment
+  # anything installs the archive and asks, and nothing pre-tag ever asked on a
+  # non-Linux platform.
+  #
+  # This job asks, on the archives this run actually built, and it stays inside
+  # the properties that make rc-build.yml safe to dispatch on any ref: it reads
+  # no secret, declares no environment, takes no permission beyond the
+  # workflow's `contents: read`, writes to no cache, and touches no release
+  # asset. It installs through the same scripts/install.sh a stranger runs, over
+  # a file:// base URL, which is that installer's own documented offline path.
+  #
+  # It is deliberately NOT a fourth copy of the capability contract.
+  # install-proof.yml holds that contract and remains the authority; the three
+  # copies that already exist are a known maintenance hazard and this does not
+  # add another. What is asserted here is a named subset that a candidate
+  # install with no agent clients present can legitimately satisfy, plus the
+  # rollup-consistency invariant over the whole report. Every other check is
+  # printed to the job summary and explicitly not asserted, so the summary can
+  # never be read as coverage this job did not provide.
+  capability:
+    name: RC Capability (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # `covered` is this row's claim about whether the build matrix above
+          # produces an archive it can install. The first step reads that matrix
+          # and refuses a row whose claim is wrong in either direction, so
+          # adding a build row without enabling its probe fails here rather than
+          # leaving the platform silently unproven, and a probe claiming an
+          # archive that is not built fails instead of reporting a vacuous pass.
+          - os: macos-latest
+            artifact: kin-macos-aarch64
+            covered: true
+            setup-shell: zsh
+          # release.yml publishes kin-windows-x86_64; this workflow deliberately
+          # does not build it (see the header). A Windows candidate therefore
+          # has nothing to install, and this row exists to say so out loud in
+          # the run that would otherwise look like it covered every platform.
+          - os: windows-latest
+            artifact: kin-windows-x86_64
+            covered: false
+            setup-shell: powershell
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Reconcile this row's coverage claim against the build matrix
+        shell: bash
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+          COVERED: ${{ matrix.covered }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("fs");
+          const lines = fs.readFileSync(".github/workflows/rc-build.yml", "utf8").split("\n");
+          const start = lines.indexOf("  build:");
+          if (start === -1) throw new Error("rc-build.yml has no build job to read a matrix from");
+          let end = lines.length;
+          for (let i = start + 1; i < lines.length; i += 1) {
+            if (/^  [A-Za-z_][A-Za-z0-9_-]*:\s*$/.test(lines[i])) { end = i; break; }
+          }
+          const built = lines
+            .slice(start, end)
+            .filter((line) => /^\s+artifact:\s/.test(line))
+            .map((line) => line.trim().slice("artifact:".length).trim());
+          // A parse that silently returned nothing would make every claim below
+          // read as "not built", which is the answer this job is here to stop
+          // anyone from faking. Refuse an empty or implausible read first.
+          if (built.length < 2 || !built.includes("kin-linux-x86_64")) {
+            throw new Error(`read ${built.length} artifact rows out of the build matrix (${built.join(", ") || "none"}); the parse, not the matrix, is what failed`);
+          }
+          const artifact = process.env.ARTIFACT;
+          const covered = process.env.COVERED === "true";
+          const isBuilt = built.includes(artifact);
+          if (covered && !isBuilt) {
+            throw new Error(`this row claims to probe ${artifact}, but the build matrix builds only ${built.join(", ")}`);
+          }
+          if (!covered && isBuilt) {
+            throw new Error(`the build matrix now builds ${artifact}, so this row must set covered: true and probe it rather than reporting the platform unproven`);
+          }
+          console.log(`build matrix produces: ${built.join(", ")}`);
+          console.log(`${artifact}: covered=${covered}, built=${isBuilt}`);
+          NODE
+
+      - name: Record a platform this run builds no archive for
+        if: ${{ !matrix.covered }}
+        shell: bash
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+          PROBE_OS: ${{ matrix.os }}
+        run: |
+          set -euo pipefail
+          {
+            printf '### %s: NOT COVERED\n\n' "$PROBE_OS"
+            printf 'This run built no %s archive, so nothing here installed or probed a\n' "$ARTIFACT"
+            printf 'candidate on %s. The row is present so the absence is stated rather than\n' "$PROBE_OS"
+            printf 'inferred from a job list.\n\n'
+            printf 'What stays unproven until the tag: whether a first install on %s reaches\n' "$PROBE_OS"
+            printf 'a healthy doctor report. That is proved only by release.yml, whose install\n'
+            printf 'proof runs after the archives are published, which is the last gate before\n'
+            printf 'promotion and the one v0.5.41 died on.\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::warning::$PROBE_OS candidate capability is not covered pre-tag: this workflow builds no $ARTIFACT archive"
+
+      - name: Download the candidate archive
+        if: ${{ matrix.covered }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}/kin-candidate
+
+      - name: Install the candidate through the public installer
+        if: ${{ matrix.covered }}
+        shell: bash
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          staged="$RUNNER_TEMP/kin-candidate"
+          # The sidecar is checked before anything runs the bytes. A candidate
+          # travels through an artifact store, and an archive whose digest no
+          # longer matches its sidecar must refuse rather than be probed.
+          want="$(cut -d' ' -f1 < "$staged/${ARTIFACT}.tar.gz.sha256")"
+          have="$(shasum -a 256 "$staged/${ARTIFACT}.tar.gz" | cut -d' ' -f1)"
+          if [ "$want" != "$have" ]; then
+            echo "::error::${ARTIFACT}.tar.gz sidecar says $want, bytes are $have"
+            exit 1
+          fi
+          # The version the candidate stamped into its own binaries. Reading it
+          # from the manifest the build wrote keeps this job from re-deriving a
+          # version the archive might disagree with.
+          version="$(node -e '
+            const fs = require("fs");
+            const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const version = manifest.release_candidate?.version;
+            if (!version) throw new Error("candidate manifest carries no release_candidate.version");
+            process.stdout.write(version);
+          ' "$staged/${ARTIFACT}.provenance.json")"
+          served="$RUNNER_TEMP/kin-candidate-served"
+          mkdir -p "$served/download/v$version"
+          cp "$staged/${ARTIFACT}.tar.gz" "$staged/${ARTIFACT}.tar.gz.sha256" \
+            "$served/download/v$version/"
+          # KIN_BASE_URL is the installer's own offline path, so the archive is
+          # resolved, verified and unpacked by the same code a stranger runs.
+          # KIN_NO_SETUP defers setup to the probe below, which needs to run it
+          # explicitly to capture what it recorded.
+          KIN_NO_SETUP=1 KIN_VERSION="$version" KIN_BASE_URL="file://$served" \
+            sh ./scripts/install.sh
+          echo "$HOME/.kin/bin" >> "$GITHUB_PATH"
+          # The installer resolves the archive name from the host, so a name
+          # this matrix row and the installer disagree about would otherwise
+          # surface as a confusing later failure.
+          test -x "$HOME/.kin/bin/kin"
+          test -x "$HOME/.kin/bin/kin-daemon"
+          echo "installed candidate $version from $ARTIFACT"
+
+      - name: Capture the first-install doctor and setup health surface
+        if: ${{ matrix.covered }}
+        shell: bash
+        env:
+          PROBE_SHELL: ${{ matrix.setup-shell }}
+        run: |
+          set -euo pipefail
+          export SHELL="/bin/$PROBE_SHELL"
+          # A fresh repository so the daemon has something to initialize
+          # against, outside the workspace so the checkout this job made for the
+          # installer never becomes corpus, and captures written outside the
+          # probe repo too: the daemon admits observed new files as they are
+          # written, so a report written into the admitted tree becomes corpus
+          # and the store grows while it is measured.
+          captures="$RUNNER_TEMP/kin-candidate-captures"
+          probe="$RUNNER_TEMP/kin-candidate-probe"
+          mkdir -p "$captures" "$probe"
+          cd "$probe"
+          git init -q && git config user.email ci@firelock.ai && git config user.name ci
+          printf 'def hello():\n    return 42\n' > probe.py
+          git add -A && git commit -qm "probe"
+          kin init > "$captures/kin-init.txt" 2>&1
+          cat "$captures/kin-init.txt"
+          # setup is what records the projection mode, so the doctor reports
+          # below are only meaningful after it has run.
+          kin setup --no-interactive --intent agent --shell "$PROBE_SHELL" \
+            2>&1 | tee "$captures/kin-setup.txt"
+          # An unhealthy report is the finding, not a reason to stop before
+          # anything can read it. Capture the exit status and let the next step
+          # name the failing checks; a doctor that writes no JSON at all still
+          # fails there, and says so.
+          health_status=0
+          kin setup status --json > "$captures/kin-health.json" || health_status=$?
+          doctor_status=0
+          kin doctor --json > "$captures/kin-doctor.json" || doctor_status=$?
+          printf 'kin setup status exit %s, kin doctor exit %s\n' "$health_status" "$doctor_status"
+
+      - name: Judge the candidate health surface
+        if: ${{ matrix.covered }}
+        shell: bash
+        env:
+          PROBE_OS: ${{ matrix.os }}
+          ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("fs");
+          const captures = `${process.env.RUNNER_TEMP}/kin-candidate-captures`;
+          // The named subset a candidate install with no agent clients present
+          // can legitimately satisfy. projection_mode is the check v0.5.41's
+          // tag reported misconfigured on every fresh macOS and Windows
+          // install; it is in this list for that reason and not by accident.
+          const asserted = [
+            "kin_binary",
+            "kin_daemon_binary",
+            "daemon_running",
+            "repo_init",
+            "shell_path",
+            "setup_ledger",
+            "vfs_projection",
+            "projection_mode",
+          ];
+          const summary = [];
+          const problems = [];
+          for (const name of ["kin-health.json", "kin-doctor.json"]) {
+            const report = JSON.parse(fs.readFileSync(`${captures}/${name}`, "utf8"));
+            if (!Array.isArray(report.checks)) {
+              problems.push(`${name}: checks is missing or malformed`);
+              continue;
+            }
+            const byId = new Map(report.checks.map((check) => [check.id, check]));
+            if (byId.size !== report.checks.length) {
+              problems.push(`${name}: duplicate health-check ids are not authoritative`);
+            }
+            // The rollup has to agree with the checks it summarizes. A release
+            // has already been abandoned over an aggregate that disagreed with
+            // its own list, and that defect is invisible to any check that only
+            // reads `healthy`.
+            const expectedHealthy = !report.checks.some(
+              (check) =>
+                check.status === "missing" ||
+                check.status === "misconfigured" ||
+                (check.id === "semantic_query_readiness" && check.status === "stale")
+            );
+            if (report.healthy !== expectedHealthy) {
+              problems.push(
+                `${name}: aggregate healthy=${report.healthy} disagrees with its checks; expected ${expectedHealthy}`
+              );
+            }
+            for (const id of asserted) {
+              const status = byId.get(id)?.status;
+              if (status === undefined) {
+                problems.push(`${name}: ${id} is missing from the report entirely`);
+              } else if (status === "missing" || status === "misconfigured") {
+                problems.push(`${name}: ${id}=${status}`);
+              }
+            }
+            const rows = report.checks
+              .map((check) => {
+                const judged = asserted.includes(check.id) ? "asserted" : "reported only";
+                return `| ${check.id} | ${check.status} | ${judged} |`;
+              })
+              .join("\n");
+            summary.push(
+              `### ${process.env.PROBE_OS}: ${name}\n\n` +
+                `Candidate archive \`${process.env.ARTIFACT}\`, aggregate healthy=${report.healthy}.\n\n` +
+                `| check | status | this job |\n| --- | --- | --- |\n${rows}\n`
+            );
+          }
+          summary.push(
+            "Checks marked `reported only` are printed rather than judged. " +
+              "install-proof.yml holds the full capability contract and remains the authority; " +
+              "this probe asserts a named subset plus the rollup-consistency invariant, so nothing " +
+              "above should be read as coverage of the whole contract.\n"
+          );
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary.join("\n")}\n`);
+          if (problems.length > 0) {
+            for (const problem of problems) console.error(`::error::${problem}`);
+            throw new Error(
+              `the candidate's first-install health surface failed ${problems.length} assertion(s) on ${process.env.PROBE_OS}`
+            );
+          }
+          console.log(`candidate health surface holds on ${process.env.PROBE_OS}`);
+          NODE

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -913,6 +913,18 @@ jobs:
             setup-shell: powershell
 
     steps:
+      # Before the checkout, or it has nothing to act on. Windows otherwise
+      # checks out CRLF, and rc-build run 32275955235 is what that costs: every
+      # line of the workflow carried a trailing \r, the reconciler's exact match
+      # on "  build:" found nothing, and it reported "rc-build.yml has no build
+      # job to read a matrix from". That reads as a verdict about the workflow
+      # and was a fact about the probe. The parser below strips \r as well, so
+      # neither half of the fix depends on the other.
+      - name: Preserve tracked bytes on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -924,12 +936,37 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           COVERED: ${{ matrix.covered }}
         run: |
-          set -euo pipefail
-          node <<'NODE'
+          set -uo pipefail
+          # `-e` is on by default in this shell and must be off across the
+          # reconciler, because a nonzero exit is one of its answers rather than
+          # an accident. Every path below exits explicitly.
+          set +e
+          verdict=kin-coverage-verdict.txt
+          rm -f "$verdict"
+          # Three outcomes that must never be confusable. RECONCILED and
+          # MISMATCH are verdicts about the build matrix. Anything else is
+          # UNREADABLE, which is a fact about this probe and says nothing about
+          # coverage. The verdict is a FILE rather than an exit code alone, so a
+          # reconciler that died before answering cannot be read as one that
+          # answered: run 32275955235 threw exit 1 for a CRLF parse failure,
+          # which is the same exit a real mismatch would have used.
+          VERDICT_FILE="$verdict" node <<'NODE'
           const fs = require("fs");
-          const lines = fs.readFileSync(".github/workflows/rc-build.yml", "utf8").split("\n");
+          const write = (line) => fs.writeFileSync(process.env.VERDICT_FILE, `${line}\n`);
+          const unreadable = (why) => { write(`UNREADABLE ${why}`); process.exit(30); };
+          const mismatch = (why) => { write(`MISMATCH ${why}`); process.exit(20); };
+          let lines;
+          try {
+            // Split on either line ending. A CRLF checkout otherwise leaves a
+            // trailing \r on every line and no exact match can land.
+            lines = fs.readFileSync(".github/workflows/rc-build.yml", "utf8").split(/\r?\n/);
+          } catch (error) {
+            unreadable(`this probe could not read .github/workflows/rc-build.yml: ${error.message}`);
+          }
           const start = lines.indexOf("  build:");
-          if (start === -1) throw new Error("rc-build.yml has no build job to read a matrix from");
+          if (start === -1) {
+            unreadable("this probe found no '  build:' line in rc-build.yml, so it read no matrix at all");
+          }
           let end = lines.length;
           for (let i = start + 1; i < lines.length; i += 1) {
             if (/^  [A-Za-z_][A-Za-z0-9_-]*:\s*$/.test(lines[i])) { end = i; break; }
@@ -939,23 +976,48 @@ jobs:
             .filter((line) => /^\s+artifact:\s/.test(line))
             .map((line) => line.trim().slice("artifact:".length).trim());
           // A parse that silently returned nothing would make every claim below
-          // read as "not built", which is the answer this job is here to stop
-          // anyone from faking. Refuse an empty or implausible read first.
+          // read as "not built", which is the answer this job exists to stop
+          // anyone from faking. That is a broken probe, not an uncovered
+          // platform, so it reports UNREADABLE rather than a verdict.
           if (built.length < 2 || !built.includes("kin-linux-x86_64")) {
-            throw new Error(`read ${built.length} artifact rows out of the build matrix (${built.join(", ") || "none"}); the parse, not the matrix, is what failed`);
+            unreadable(`this probe read ${built.length} artifact rows out of the build matrix (${built.join(", ") || "none"})`);
           }
           const artifact = process.env.ARTIFACT;
           const covered = process.env.COVERED === "true";
           const isBuilt = built.includes(artifact);
           if (covered && !isBuilt) {
-            throw new Error(`this row claims to probe ${artifact}, but the build matrix builds only ${built.join(", ")}`);
+            mismatch(`this row claims to probe ${artifact}, but the build matrix builds ${built.join(", ")}`);
           }
           if (!covered && isBuilt) {
-            throw new Error(`the build matrix now builds ${artifact}, so this row must set covered: true and probe it rather than reporting the platform unproven`);
+            mismatch(`the build matrix now builds ${artifact}, so this row must set covered: true and probe it rather than reporting the platform unproven`);
           }
-          console.log(`build matrix produces: ${built.join(", ")}`);
-          console.log(`${artifact}: covered=${covered}, built=${isBuilt}`);
+          write(`RECONCILED ${artifact} covered=${covered} built=${isBuilt}; the build matrix produces ${built.join(", ")}`);
           NODE
+          rc=$?
+          if [ ! -f "$verdict" ]; then
+            echo "::error::UNREADABLE: the coverage reconciler exited $rc without writing a verdict. That is a fact about this probe, not a coverage verdict: nothing here says whether $ARTIFACT is built or not."
+            exit 1
+          fi
+          line="$(cat "$verdict")"
+          rm -f "$verdict"
+          case "$line" in
+            RECONCILED*)
+              printf '%s\n' "$line"
+              exit 0
+              ;;
+            MISMATCH*)
+              echo "::error::COVERAGE MISMATCH: ${line#MISMATCH }"
+              exit 1
+              ;;
+            UNREADABLE*)
+              echo "::error::UNREADABLE: ${line#UNREADABLE } (reconciler exit $rc). That is a fact about this probe, not a coverage verdict: nothing here says whether $ARTIFACT is built or not."
+              exit 1
+              ;;
+            *)
+              echo "::error::UNREADABLE: the coverage reconciler wrote a verdict this step does not recognize: $line"
+              exit 1
+              ;;
+          esac
 
       - name: Record a platform this run builds no archive for
         if: ${{ !matrix.covered }}

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -169,10 +169,16 @@ jobs:
       # musl-static C dependencies (ring, oniguruma, sqlite, tree-sitter) need a
       # musl-targeting C compiler; musl-tools provides musl-gcc. Only the Linux
       # musl legs require it.
+      #
+      # Bounded through the shared helper rather than called directly. A bare
+      # `apt-get update && apt-get install` has no ceiling below the job
+      # timeout: the hosted mirrorlist puts azure.archive.ubuntu.com first and a
+      # stall there trickles bytes slowly enough that no per-fetch timeout
+      # fires. The helper bounds each call, retries three times, and fails over
+      # to archive.ubuntu.com from the second attempt, so a stalled mirror ends
+      # the step with its own error line instead of holding a release build.
       - name: Install musl C toolchain (Linux musl)
         if: ${{ contains(matrix.target, '-linux-musl') }}
-        # DELTA(apt): bounded through the shared helper. An unbounded apt call
-        # holds a job until the runner timeout when a mirror stalls (FIR-2391).
         run: ./scripts/ci-apt-install.sh musl-tools
 
       - name: Install cross (ARM64)

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -26,19 +26,20 @@ name: RC Build
 #
 # SOURCE OF TRUTH: .github/workflows/release.yml, job `build`. Every step below
 # is a byte-identical copy of that job's step of the same name, except where a
-# comment starting DELTA( names the difference and why. Seven steps are omitted
-# on purpose: the six macOS signing and notarization steps, which need the
-# credentials this workflow deliberately cannot reach, and the Cargo cache.
+# comment starting DELTA( names the difference and why. Six steps are omitted on
+# purpose: the macOS signing and notarization steps, which need the credentials
+# this workflow deliberately cannot reach.
 # scripts/check-rc-build-drift.mjs holds that relationship and fails the pull
 # request when release.yml moves and this file does not.
 #
-# The cache is omitted rather than copied. release.yml runs only on a v* tag,
-# and that tag is ruleset-protected, so its cache write is authorized code. This
-# workflow builds whatever ref it is handed, so the same step would let a
-# dispatch write a poisoned entry into a cache that CI and release builds later
-# restore from. It would also mean the bytes under proof were assembled partly
-# from cache contents no one reviewed, which is the opposite of what a candidate
-# build is for. A candidate compiles cold.
+# Neither workflow caches Cargo. This one never did, because it builds whatever
+# ref it is handed and the same step would let a dispatch write a poisoned entry
+# into a cache that CI and release builds later restore from, and would mean the
+# bytes under proof were assembled partly from cache contents no one reviewed.
+# release.yml has now dropped its own for a related reason: its entry was
+# tag-scoped and unreadable from the next tag, so it never restored, and a
+# restore that worked would have put unreviewed objects into published bytes.
+# A candidate compiles cold, and so does a release.
 #
 # What a candidate archive is NOT:
 #   - not signed and not notarized, so a macOS candidate archive is Gatekeeper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,14 @@ jobs:
     name: Build (${{ matrix.artifact }})
     needs: config
     runs-on: ${{ matrix.os }}
+    # rc-build.yml bounds the identical compile at 90, and this job had no bound
+    # at all, so it inherited the 360-minute default while holding
+    # `kin-release-promotion` with cancel-in-progress: false. A hung leg could
+    # block every release-channel mutation for six hours. The slowest leg ever
+    # measured is 40m03s, so 90 leaves better than twice that headroom. This
+    # bounds execution rather than queue time, so it is not a runner-label
+    # safety net; it is the ceiling on a build that stops making progress.
+    timeout-minutes: 90
     environment: release
     # Every advertised platform is release-blocking. A public release must not
     # be created without one of the archives consumed by the installers.
@@ -498,9 +506,17 @@ jobs:
       # musl-static C dependencies (ring, oniguruma, sqlite, tree-sitter) need a
       # musl-targeting C compiler; musl-tools provides musl-gcc. Only the Linux
       # musl legs require it.
+      #
+      # Bounded through the shared helper rather than called directly. A bare
+      # `apt-get update && apt-get install` has no ceiling below the job
+      # timeout: the hosted mirrorlist puts azure.archive.ubuntu.com first and a
+      # stall there trickles bytes slowly enough that no per-fetch timeout
+      # fires. The helper bounds each call, retries three times, and fails over
+      # to archive.ubuntu.com from the second attempt, so a stalled mirror ends
+      # the step with its own error line instead of holding a release build.
       - name: Install musl C toolchain (Linux musl)
         if: ${{ contains(matrix.target, '-linux-musl') }}
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        run: ./scripts/ci-apt-install.sh musl-tools
 
       - name: Install cross (ARM64)
         if: matrix.cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,7 +429,33 @@ jobs:
             cross: false
           # Use an Intel host so this archive is executed before packaging;
           # building x86_64 on an arm64 runner would leave it unproven.
-          - os: macos-15-intel
+          #
+          # The host is Intel, and larger. This row was the release's critical
+          # path: 40m03s on v0.5.40 against 24m46s for the aarch64 row, and
+          # 34m15s of it was the one `cargo build --release` step, which is
+          # 9m20s on linux-aarch64. The workflow treats both macOS rows
+          # identically, so the gap was the runner. macos-15-intel is 4 vCPU and
+          # 14 GB; macos-15-large is the same macOS 15 on Intel with 12 vCPU and
+          # 30 GB, at $0.077 a minute against $0.062, so it is three times the
+          # cores for 1.24 times the rate and a shorter job costs less than the
+          # one it replaces.
+          #
+          # Cross-compiling x86_64 from the faster Apple Silicon host was the
+          # other candidate and is refused, on provenance rather than on
+          # signing. codesign and notarytool never execute the binary, so both
+          # work fine on a cross-built artifact. "Verify native release build
+          # provenance" does execute it, and its `case "$RUNNER_ARCH:$TARGET"`
+          # declines a cross-architecture artifact and returns before writing
+          # kin-build-meta.json, which "Generate artifact provenance manifest"
+          # then reads unconditionally. Making that path work means either
+          # running the x86_64 binary under Rosetta on the arm64 host, which the
+          # macos-15-arm64 runner image does not list among its software, or
+          # dropping the execution proof for a shipped archive: the version-line
+          # commit match, the dirty refusal, the embedded Cargo.lock provenance,
+          # and the vector/embeddings/metal feature assertions all stop running.
+          # Staying on Intel keeps RUNNER_ARCH X64, so that guard's X64:x86_64-*
+          # arm still matches and nothing else in the job moves.
+          - os: macos-15-large
             target: x86_64-apple-darwin
             artifact: kin-macos-x86_64
             shim_name: libkin_vfs_shim.dylib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,6 +382,24 @@ jobs:
     # Signing credentials are deliberately step-scoped below. The untrusted
     # Cargo build matrix never receives Apple secrets or a write-scoped token.
     # Tagged releases fail closed when any required credential is absent.
+    #
+    # There is no Cargo cache step, and adding one back is a change to what the
+    # shipped bytes are made of rather than a speed tweak. The step that used to
+    # sit before "Assert clean release source" cached ~/.cargo and both target
+    # directories and never restored once. GitHub scopes a cache entry to the
+    # ref that wrote it, this workflow runs only on a v* tag, so every tag wrote
+    # into a scope no later tag could read. Measured on v0.5.41: the exact key
+    # and the prefix restore-key both missed and the step saved anyway, roughly
+    # 1.4 GB per release out of the repository's 10 GB budget, evicting the CI
+    # entries that do restore.
+    #
+    # A cache that did restore would be worse than the dead one. target/ holds
+    # linked objects that go straight into the published binary, "Assert clean
+    # release source" cannot see them because target/ is gitignored, and
+    # "Verify native release build provenance" runs the binary and matches an
+    # embedded commit sha, which a poisoned object still reports correctly. So
+    # a working restore would put unreviewed bytes in a released artifact for
+    # the first time, with no guard able to fail. A release compiles cold.
     env:
       # When true, the macOS leg codesigns and uploads the signed-but-unnotarized
       # zip, and the separate notarize_linux job submits it to Apple Notary via
@@ -525,18 +543,6 @@ jobs:
           }
           console.log(`Verified Kin/kin-vfs release compatibility at kin-vfs-core ${kinVfsCore[0].version}`);
           NODE
-
-      - name: Cache Cargo registry and build artifacts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            kin-vfs/target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.target }}-cargo-
 
       - name: Assert clean release source
         shell: bash

--- a/scripts/check-rc-build-drift.mjs
+++ b/scripts/check-rc-build-drift.mjs
@@ -72,15 +72,12 @@ export const DELTAS = [
     to: `          node scripts/write-release-archive-docs.mjs "$ARTIFACT" "$TARGET" "$RC_VERSION"
 `,
   },
-  {
-    label: "apt",
-    from: `        run: sudo apt-get update && sudo apt-get install -y musl-tools
-`,
-    to: `        # DELTA(apt): bounded through the shared helper. An unbounded apt call
-        # holds a job until the runner timeout when a mirror stalls (FIR-2391).
-        run: ./scripts/ci-apt-install.sh musl-tools
-`,
-  },
+  // An "apt" delta used to sit here. rc-build.yml bounded its musl-tools
+  // install through scripts/ci-apt-install.sh while release.yml still called
+  // apt directly, so the candidate was protected from a mirror stall and the
+  // release was not. release.yml now calls the same helper, the two steps are
+  // byte-identical again, and a delta describing a difference that no longer
+  // exists would fail here as an anchor that matches nothing.
   {
     label: "notifier-version",
     from: `            "\${GITHUB_REF_NAME#v}"

--- a/scripts/check-rc-build-drift.mjs
+++ b/scripts/check-rc-build-drift.mjs
@@ -30,14 +30,14 @@ export const RC_WORKFLOW = ".github/workflows/rc-build.yml";
 // package-publish credentials. Without those credentials these steps have
 // nothing to do, so they are absent rather than inert.
 //
-// The Cargo cache, for a different reason. release.yml runs only on a
-// ruleset-protected v* tag, so its cache write is authorized code. rc-build.yml
-// builds whatever ref it is handed, so the same step would let a dispatch write
-// a poisoned entry into a cache that CI and release builds later restore from,
-// and would mean the bytes under proof were assembled partly from cache
-// contents no one reviewed. A candidate compiles cold.
+// A seventh entry, "Cache Cargo registry and build artifacts", used to sit at
+// the head of this list. release.yml no longer carries that step: it never
+// restored, because a tag-scoped cache entry is unreadable from the next tag,
+// and a restore that did work would assemble published bytes partly from cache
+// contents nobody reviewed. Both workflows now compile cold, so the difference
+// this entry described no longer exists and listing it here would report the
+// omission list as stale.
 export const OMITTED_STEPS = [
-  "Cache Cargo registry and build artifacts",
   "Resolve macOS signing credential availability",
   "Import code signing certificate (macOS)",
   "Sign macOS binaries",

--- a/scripts/check-rc-build-drift.test.mjs
+++ b/scripts/check-rc-build-drift.test.mjs
@@ -118,19 +118,19 @@ test("a candidate-only step missing from rc-build.yml is reported", () => {
 
 test("a delta whose anchor stopped matching is reported by label", () => {
   const mutated = release.replace(
-    "        run: sudo apt-get update && sudo apt-get install -y musl-tools",
-    "        run: sudo apt-get update && sudo apt-get install -y musl-tools pkg-config"
+    '          node scripts/write-release-archive-docs.mjs "$ARTIFACT" "$TARGET" "${GITHUB_REF_NAME#v}"',
+    '          node scripts/write-release-archive-docs.mjs "$ARTIFACT" "$TARGET" "${GITHUB_REF_NAME#v}" --extra'
   );
   assert.notEqual(mutated, release);
   const problems = check(mutated, rc);
   // Two complaints, and both are wanted: the delta stopped applying, and the
   // block it would have produced no longer matches.
   assert.ok(
-    problems.some((problem) => /delta "apt" matched 0 times/.test(problem)),
+    problems.some((problem) => /delta "archive-docs-version" matched 0 times/.test(problem)),
     problems.join("\n")
   );
   assert.ok(
-    problems.some((problem) => /Install musl C toolchain/.test(problem)),
+    problems.some((problem) => /Package \(Unix\)/.test(problem)),
     problems.join("\n")
   );
 });

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -674,7 +674,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/release.yml",
         "build",
-    ): "ffde401b1343930965ae6a2a89ca3a81b2996af5821b332f65de7eba874e2be2",
+    ): "7375c7f0f82227e8695aea7fc290631a9d3667dc6674dca10830c53e0a0f4564",
     (
         ".github/workflows/release.yml",
         "verify_npm_published",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -587,6 +587,7 @@ EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
     # census is what would otherwise let a new job's NAME appear unreviewed.
     ".github/workflows/rc-build.yml": {
         "build": "RC Build (${{ matrix.artifact }})",
+        "capability": "RC Capability (${{ matrix.os }})",
     },
     ".github/workflows/registry-index-migrate.yml": {
         "migrate": None,
@@ -666,6 +667,10 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
         ".github/workflows/rc-build.yml",
         "build",
     ): "8dc0699fb69599edbca87492f3f3a895aefa3bea8384c86d8fc11fef99f9d52a",
+    (
+        ".github/workflows/rc-build.yml",
+        "capability",
+    ): "3e7512c3b44ab447531be464599f6237bff7efe798d54728c012676a7c3aed23",
     (
         ".github/workflows/release.yml",
         "build",


### PR DESCRIPTION
## `macos-15-large` is proven schedulable in this org

This opened with a blocker, because nothing in the org had ever used a `-large` label and
a tag run cannot be repaired after the fact. **rc-build run 32275955235** on this branch
settles it: the runner scheduled and every build leg completed green. No API surface said
so in advance, which is why it took a dispatch rather than a reading.

That same run also found a real defect in the new capability leg, fixed below.

## The release build's apt install is bounded, and so is its job

`release.yml` called apt directly while `rc-build.yml`, which mirrors the same step,
already went through `scripts/ci-apt-install.sh`. The candidate build was protected from a
stalled mirror and the release build was not, which is the wrong way round: a candidate can
be re-dispatched, a tag run cannot be repaired. The same shape hung a required kin-db Linux
job for 27 minutes.

A bare `apt-get update && apt-get install` has no ceiling below the job timeout. The hosted
mirrorlist puts `azure.archive.ubuntu.com` first, and a stall there trickles bytes slowly
enough that no per-fetch timeout fires. The helper bounds each call (120s update, 240s
install), retries three times, and rewrites the mirror to `archive.ubuntu.com` from the
second attempt.

`build` also gains `timeout-minutes: 90`, the number `rc-build.yml` already uses for the
identical compile. It had no bound, so it inherited the 360-minute default while holding
`kin-release-promotion` with `cancel-in-progress: false`, and a hung leg could block every
release-channel mutation for six hours. The slowest leg ever measured is 40m03s. This
bounds execution rather than queue time, so it is not a runner-label safety net.

Falsified in an `ubuntu:24.04` container against a stubbed `apt-get`, so the stall is
deterministic and needs no network, with real GNU `timeout` and a real `/etc/apt` layout:

```
stalled   exit=1 elapsed=67s   (2s bounds; ~6s of apt plus the helper's fixed 10+20+30 backoff)
  apt attempt 1 of 3 failed for: musl-tools
  apt attempt 2: dropping the azure mirror in favour of archive.ubuntu.com
  apt attempt 2 of 3 failed for: musl-tools
  apt attempt 3: dropping the azure mirror in favour of archive.ubuntu.com
  apt attempt 3 of 3 failed for: musl-tools
  ::error::apt could not install after 3 bounded attempts: musl-tools
  mirror file after this case: http://archive.ubuntu.com/ubuntu

healthy   exit=0 elapsed=0s    one attempt, no retry, mirror file untouched
```

Ten assertions, all passing: the stalled run exits nonzero, stays bounded, makes all three
attempts, fails over off the azure mirror, and ends with its own error line naming apt and
the package; the healthy run exits 0 in under a second, takes one attempt, and leaves the
mirror alone; and the two transcripts differ. Under production bounds the guaranteed
ceiling is `3*(120+240)+60`, about 19 minutes, against an unbounded call that has no
ceiling below the job timeout at all.

Two assertions failed on the first pass and both were the harness: a `<60s` threshold that
ignored the helper's own documented backoff, and a mirror check that read the file at
verdict time, after the second case had reset it.

The two steps are byte-identical again, so the `apt` entry is removed from the drift
guard's delta list, where an anchor describing a difference that no longer exists fails as
a delta matching nothing. The falsification case that used that anchor now drives the
`archive-docs-version` delta and still requires both complaints.

**Re-proved: rc-build run 32281857025 at `743c58d5` is `completed/success`, all five
jobs.** The two Linux legs are the only ones that run the musl toolchain step, so this is
the healthy path in a real release-shaped build rather than a container:

```
Run ./scripts/ci-apt-install.sh musl-tools
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1216 kB]
17:29:30.86 -> 17:29:44.03   about 13 seconds
```

Zero `apt attempt` lines in the job, so one attempt, no retry, azure mirror left in place.
Both capability legs still printed real verdicts on that run too.

`publish` remains unbounded; that is a separate item.

## The release build no longer writes a cache

The `build` job's Cargo cache never restored, once. GitHub scopes a cache entry to the ref
that wrote it and this workflow runs only on a `v*` tag, so every tag saved into a scope
the next tag cannot read. Measured on the v0.5.41 run: both the exact key and the prefix
restore-key missed, and the step saved anyway. It spent roughly 1.4 GB of the repository's
10 GB budget per release, evicting the CI entries that do restore.

Nothing replaces it, deliberately. `target/` and `kin-vfs/target` hold linked objects that
go straight into the published binary; "Assert clean release source" cannot see them
because `target/` is gitignored; and "Verify native release build provenance" runs the
binary and matches an embedded commit sha, which a poisoned object still reports
correctly. A restore that worked would put unreviewed objects into a released artifact for
the first time, with no guard able to fail. The release now compiles cold as stated policy
rather than by accident, which is what `rc-build.yml` already says about candidates.

The rationale sits in the `build` job header rather than in the step list, so the block
`rc-build.yml` mirrors stays byte-identical. `rc-build.yml`'s header and the drift guard's
omission list drop the entry that described a step `release.yml` no longer has.

## The Intel macOS archive builds on a larger Intel host

`Build (kin-macos-x86_64)` was the critical path: 40m03s of a 45m59s run on v0.5.40,
against 24m46s for the aarch64 row, and 34m15s of it was the one `cargo build --release`
step that takes 9m20s on linux-aarch64. Every step in the job is conditioned on
`runner.os`, `matrix.cross` or `matrix.skip_vfs` and never on architecture, so both macOS
rows run identical commands and the gap is the runner. `macos-15-intel` is 4 vCPU and
14 GB; `macos-15-large` is the same macOS 15 on Intel with 12 vCPU and 30 GB, at $0.077 a
minute against $0.062. Three times the cores for 1.24 times the rate, so a shorter job
also costs less than the one it replaces.

**Why not cross-compile from Apple Silicon.** Signing and notarization are not what
breaks: `codesign` and `notarytool` never execute the binary and work fine on a cross-built
artifact. The execution provenance is what breaks. "Verify native release build
provenance" runs the binary, and its `case "$RUNNER_ARCH:$TARGET"` declines a
cross-architecture artifact and returns before writing `kin-build-meta.json`; "Generate
artifact provenance manifest" then reads that file unconditionally, so the leg fails there
rather than degrading quietly. Making it pass means one of two things. Run the x86_64
binary under Rosetta on the arm64 host, which the `macos-15-arm64` runner image does not
list among its installed software. Or drop the execution proof for a shipped archive,
which retires the version-line commit match, the dirty refusal, the embedded `Cargo.lock`
provenance check, and the `vector`/`embeddings`/`metal` feature assertions for that
artifact. The row's own comment was written to prevent exactly that.

Staying on Intel keeps `RUNNER_ARCH` at `X64`, so that guard's `X64:x86_64-*` arm still
matches and nothing else in the job moves. Artifact naming, provenance manifest fields,
archive inventory, and every publish assertion are byte-unchanged; the `os:` value is the
only line that differs. Where the archive is proven to *install* is unchanged too:
`install-proof.yml` still runs its `macos-15-intel` leg against the published archive.

The reviewed matrix expansion for the `build` job is re-pinned in the authority suite,
which is what made this change visible rather than silent.

## rc-build gains credential-free candidate capability legs

A candidate build proved its archives compiled and packaged. It could not say whether they
survive an install. v0.5.41 built cleanly on all five platforms and then died at the tag's
own doctor health gate, because setup recorded a mount projection it never engaged and
`kin doctor` read the recorded mode against the running state. Nothing pre-tag ever
installed a candidate on a non-Linux platform and asked.

The new `capability` job asks, on the archives this run actually built. On `macos-latest`
it downloads `kin-macos-aarch64`, checks it against its own sha256 sidecar, installs it
through `scripts/install.sh` over a `file://` base URL (the installer's own documented
offline path, the same one the pull-request install proof uses), then runs `kin init`,
`kin setup`, `kin setup status --json` and `kin doctor --json` against a scratch repository
outside the workspace.

It stays inside every property that makes this workflow safe to dispatch on an arbitrary
ref: no secret, no environment, no permission beyond the workflow's `contents: read`, no
caching action, nothing published. The suite that pins those five properties is unchanged
and still passes.

`windows-latest` has no candidate archive, because this workflow deliberately builds no
Windows row, so that leg records the platform as NOT COVERED in the job summary and emits
a warning rather than reporting a pass on nothing. Neither claim is taken on trust: the
first step reads the `build` matrix and refuses a row whose `covered` flag disagrees with
it in either direction, with a parse-sanity control so an empty read cannot masquerade as
an uncovered platform. Add the Windows build row later and this fails until the probe is
enabled.

What it asserts is a named subset a candidate install with no agent clients present can
legitimately satisfy, plus the rollup-consistency invariant over the whole report, which
is the class v0.5.38 was abandoned for. Every other check is printed to the job summary and
marked reported-only. This is deliberately not a fourth hand-maintained copy of the
capability contract; `install-proof.yml` holds that contract and stays the authority.

## What the first proof run caught, and the fix

`RC Capability (windows-latest)` failed in run 32275955235 after 18 seconds with
`rc-build.yml has no build job to read a matrix from`. Windows checks out CRLF, every line
carried a trailing `\r`, and the exact match on `"  build:"` found nothing. The macOS leg
passed on the same run because its checkout is LF.

The parse bug is the smaller half. The reporting was the real defect: a parse failure and
a genuine coverage mismatch both threw, both exited 1, and both printed a sentence about
the build matrix, so a probe that never read the matrix was indistinguishable from a probe
that read it and disagreed. The step existed to stop coverage being faked and its own
failure mode read as a coverage finding.

Both halves are fixed and neither depends on the other. The parser splits on `/\r?\n/`, and
the job runs `core.autocrlf false` before its checkout the way the `build` job already
does. The reconciler now writes its answer to a verdict file and exits 0 for RECONCILED,
20 for MISMATCH, 30 for UNREADABLE; the step reads the file rather than the exit code
alone, so a reconciler that dies before answering leaves no verdict and is reported as
UNREADABLE with an error that says outright that nothing there claims whether the artifact
is built.

Falsified locally against the step extracted from this file, seven paths:

```
reconciled (windows row)        exit=0   RECONCILED kin-windows-x86_64 covered=false built=false
reconciled (macos row)          exit=0   RECONCILED kin-macos-aarch64 covered=true built=true
wrong covered flag, either way  exit=1   ::error::COVERAGE MISMATCH: ...
workflow file absent            exit=1   ::error::UNREADABLE: ... (reconciler exit 30)
parse control tripped           exit=1   ::error::UNREADABLE: ... (reconciler exit 30)
node stubbed to exit 1, silent  exit=1   ::error::UNREADABLE: exited 1 without writing a verdict
CRLF fixture                    exit=0   RECONCILED   (no longer a failure at all)
```

**Re-proved on the fix: rc-build run 32278253080 at `150c023f` is `completed/success`,
all five jobs.** Both capability legs were read for their verdicts rather than their
conclusions, because a job whose purpose is to refuse can go green by skipping:

```
RC Capability (windows-latest)  success
  RECONCILED kin-windows-x86_64 covered=false built=false;
    the build matrix produces kin-linux-x86_64, kin-linux-aarch64, kin-macos-aarch64
  ::warning::windows-latest candidate capability is not covered pre-tag:
    this workflow builds no kin-windows-x86_64 archive
  (the four install and probe steps skipped, as covered: false intends)

RC Capability (macos-latest)    success
  RECONCILED kin-macos-aarch64 covered=true built=true; the build matrix produces ...
  installed candidate 0.5.42 from kin-macos-aarch64
  candidate health surface holds on macos-latest
```

`installed candidate 0.5.42` means the sidecar check, the manifest version read and
`scripts/install.sh` over `file://` all succeeded; `candidate health surface holds` is the
judging step's last line, past its assertion loop.

## Guards run

`test-release-workflow-authority.py`, `test-assertion-reachability.py`,
`check-rc-build-drift.mjs` and its 17 falsification cases, `check-kin-vfs-compat.mjs`,
`test-homebrew-release-gate.py`, `test-install-checksum.py`, the installer
verify/falsify pairs, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, and
164 `node --test` cases across the release script suites. All green, exit codes read
directly rather than through a pipe. `actionlint` is clean on both changed workflows; its
one repo-wide finding is in `registry-index-migrate.yml`, which is byte-identical to
`origin/main` here.

Two guards moved and both moved because they were doing their job: the workflow job census
gained the new `capability` job, and the reviewed matrix expansions gained its entry and
re-pinned the `build` job's after the runner change.

Refs FIR-2459
