### PR TITLE
Key the release mint off the merge-group-proven sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,16 +522,17 @@ jobs:
     # Deliberately off the pull-request path. This leg cold-builds the whole
     # dependency graph in the release profile for x86_64-pc-windows-msvc and
     # measured 20 to 25 minutes per round, longer than any other job, so it set
-    # the floor for every land-and-iterate cycle. It now runs on each push to
-    # main, which is exactly the commit release proof reads: release-tag.yml
-    # names this check in REQUIRED_CHECKS and refuses to mint a tag unless it is
-    # present and green on the release sha. On a pull request the job reports
-    # skipped, which satisfies the required context the same way the
-    # documentation-only path already relies on.
+    # the floor for every land-and-iterate cycle. Keeping it off pull requests
+    # is what protects that cycle; keeping it off the merge queue protected
+    # nothing and cost the release its evidence. release-tag.yml now keys the
+    # mint off the merge-group-proven sha, and the queue's build is only a
+    # sufficient proof if it runs every leg the mint then trusts, so this job
+    # runs on the queue as well as on the landing push. On a pull request it
+    # still reports skipped, which satisfies the required context the same way
+    # the documentation-only path already relies on.
     if: >-
       ${{ !cancelled()
       && github.event_name != 'pull_request'
-      && github.event_name != 'merge_group'
       && needs.changes.outputs.docs_only != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 60

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -60,11 +60,24 @@ jobs:
     # conclusion veto through it. This trigger therefore decides only when to
     # look, never whether the commit is releasable, which is exactly the
     # division the scheduled path already runs under.
+    #
+    # The queue's CI run is the occasion that matters now that the mint keys
+    # off the merge-group-proven sha. It concludes when the landing does,
+    # roughly half an hour before the landing push's own CI run concludes, and
+    # waiting for the later one was the single largest stretch of pure waiting
+    # in the release chain. Both are kept: a landing that produced no queue
+    # build still has to be looked at, and a merge-group completion that
+    # arrives before main carries the commit resolves to a clean no-op that the
+    # next occasion picks up. The trigger still decides only when to look.
     if: >-
       github.event_name != 'workflow_run' ||
       (
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main'
+      ) ||
+      (
+        github.event.workflow_run.event == 'merge_group' &&
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')
       )
     runs-on: ubuntu-latest
     # The automatic path waits for release-critical checks to settle, so the
@@ -768,13 +781,29 @@ jobs:
         # Evidence is resolved through workflow provenance, not through the
         # context name. A merge-queue landing publishes the same context names
         # twice on one sha, once from the queue's merge_group build and again
-        # from the push build of the commit that landed, and only the push build
-        # runs the legs the queue deliberately skips. Selecting by name alone
-        # would read those two as ambiguous authority, or would accept the
-        # queue's skipped Windows leg as the release proof. Each required context
-        # is therefore matched against its exact workflow id, path, push event,
+        # from the push build of the commit that landed. Selecting by name alone
+        # would read those two as ambiguous authority. Each required context is
+        # therefore matched against its exact workflow id, path, admitted build,
         # and head sha, and must be unique within that provenance, so a rerun of
-        # the push build remains ambiguous authority.
+        # one build remains ambiguous authority.
+        #
+        # The queue's build is the authority when it exists. With SQUASH
+        # merging the queue's speculative commit IS the commit pushed to main,
+        # so the merge-group build and the landing push prove one tree, and the
+        # queue's is the one that actually gated the landing. That identity is
+        # asserted rather than assumed: the queue ref carries the base sha it
+        # was built on, the landing commit's first parent is that same base,
+        # and the parent is read from checked-out protected history rather than
+        # from the endpoint being judged. The landing push stays admissible and
+        # becomes the authority only when no merge-group build exists at this
+        # sha at all, so a commit that reached main without a queue build is
+        # still releasable on exactly the evidence that used to carry it.
+        # Exactly one tier is authority per release; crediting both would make
+        # every duplicated context ambiguous and refuse every queue landing.
+        # The other tier is kept as corroboration: a completed landing-push
+        # build of a required context that failed still refuses, because the
+        # same tree failing a full pass is a verdict, while an unfinished one
+        # is never waited for.
         #
         # The automatic triggers can reach a commit whose release-critical checks
         # are still running, so absent and unfinished evidence is retried. Every
@@ -797,8 +826,35 @@ jobs:
             cargo-deny
             gitleaks (full history)
             Windows installer + vector release build
+          # The reviewed mirror of ruleset 19746451 "Require status checks on
+          # main", which is live GitHub configuration no test in this
+          # repository can read and which is what the merge queue waits on. It
+          # is a superset of REQUIRED_CHECKS: a context it gates but this mint
+          # does not veto on still has to be published by an admitted build, or
+          # the queue waits on a name nobody produces with every visible check
+          # green, which is a silent hang rather than a failure. Reading the
+          # mirror against the check-runs the sha carries turns that hang into
+          # a named refusal here.
+          RULESET_REQUIRED_CHECKS: |
+            Check & Test (ubuntu-latest)
+            Check & Test (macos-latest)
+            DCO Sign-off
+            cargo-deny
+            gitleaks (full history)
+            Windows installer + vector release build
+            PR text hygiene
+            Falsify guards
+            Feature permutation tests (ubuntu-latest)
+            Feature permutation tests (macos-latest)
         run: |
           set -euo pipefail
+          # The landing commit's first parent, read from the protected history
+          # this job checked out rather than from the API answer being judged.
+          # The merge queue names the base it built on inside the queue ref, so
+          # this is the one binding between "the tree the queue proved" and
+          # "the commit being released" that a wrong API answer cannot satisfy.
+          RELEASE_PARENT_SHA="$(git rev-parse "${SHA}^")"
+          export RELEASE_PARENT_SHA
           gh api "repos/$REPO/actions/runs/$CURRENT_RUN_ID" \
             -q '{
               id: .id,
@@ -842,7 +898,7 @@ jobs:
               > workflow_runs.ndjson || { echo "::error::failed to fetch workflow runs for $SHA"; exit 1; }
             set +e
             python3 - <<'PY'
-          import json, os, sys
+          import json, os, re, sys
 
           def read_ndjson(path):
               records = []
@@ -871,41 +927,38 @@ jobs:
               for check in os.environ["REQUIRED_CHECKS"].splitlines()
               if check.strip()
           ]
-          # Workflow id, path, event, and branch. The branch is load-bearing: a
-          # merge-queue landing produces a push run of the same workflow at the
-          # same sha from the queue's own ref as well as from main, and only the
-          # run on main is release evidence.
+          ruleset_required = [
+              check.strip()
+              for check in os.environ["RULESET_REQUIRED_CHECKS"].splitlines()
+              if check.strip()
+          ]
+          # Producer identity only: workflow id and path. Which build proves
+          # this release is a single tier decision made once, below, against
+          # the queue ref and the landing branch together. Binding an event
+          # into this table is what left the mint unable to read the queue
+          # build that actually gated the landing, and made every release wait
+          # on a second full pass of a tree already proven.
           release_branch = "main"
           expected_provenance = {
               "Check & Test (ubuntu-latest)": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
               "Check & Test (macos-latest)": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
               "Falsify guards": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
               "Feature permutation tests (ubuntu-latest)": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
               "Feature permutation tests (macos-latest)": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
               # Uppercase `Sign-off` is the skipped-on-push CI job. The
               # pull_request_target DCO workflow emits lowercase `sign-off`
@@ -913,29 +966,26 @@ jobs:
               "DCO Sign-off": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
               "cargo-deny": (
                   251549972,
                   ".github/workflows/sast.yml",
-                  "push",
-                  release_branch,
               ),
               "gitleaks (full history)": (
                   293452372,
                   ".github/workflows/secret-scan.yml",
-                  "push",
-                  release_branch,
               ),
               "Windows installer + vector release build": (
                   245803170,
                   ".github/workflows/ci.yml",
-                  "push",
-                  release_branch,
               ),
           }
+          # ci.yml is the anchor because it is the workflow the merge queue
+          # builds under a merge_group event, and its run is what names the
+          # queue ref the rest of the queue's evidence was published on.
+          queue_anchor_workflow = (245803170, ".github/workflows/ci.yml")
           expected_sha = os.environ["SHA"]
+          release_parent_sha = os.environ["RELEASE_PARENT_SHA"]
           trigger_sha = os.environ["TRIGGER_SHA"]
           # A required context name is not authority on its own. Only the
           # GitHub Actions App may write one, pinned by numeric id as well as
@@ -963,6 +1013,8 @@ jobs:
           downgraded = []
           discounted = []
           unwaited = []
+          corroborated = []
+          corroboration_unwaited = []
 
           if required != list(expected_provenance):
               errors.append("required check order does not match its provenance contract")
@@ -1024,15 +1076,111 @@ jobs:
                       f"{workflow.get('id')}"
                   )
 
-          for name in required:
-              expected_workflow_id, expected_path, expected_event, expected_branch = (
-                  expected_provenance[name]
+          # Resolve which build proves this release, once, before any context
+          # is judged. The queue ref is taken from the merge_group run of the
+          # anchor workflow rather than guessed from a branch-name shape, so a
+          # branch that merely looks like a queue ref cannot nominate itself.
+          # Then the ref's embedded base sha is required to equal this
+          # release's first parent, which is the assertion that makes crediting
+          # the queue build a proof rather than an assumption.
+          queue_ref_pattern = re.compile(
+              r"^gh-readonly-queue/"
+              + re.escape(release_branch)
+              + r"/pr-[0-9]+-([0-9a-f]{40})$"
+          )
+          queue_anchors = [
+              workflow
+              for workflow in workflow_runs
+              if (
+                  workflow.get("workflow_id"),
+                  workflow.get("path"),
+              ) == queue_anchor_workflow
+              and workflow.get("event") == "merge_group"
+              # A superseded speculative group is cancelled and gated nothing.
+              # It is neither evidence nor a competing authority.
+              and workflow.get("conclusion") != "cancelled"
+          ]
+          queue_ref = None
+          if len(queue_anchors) > 1:
+              errors.append(
+                  "ambiguous merge-group evidence: "
+                  f"{len(queue_anchors)} uncancelled merge_group runs of "
+                  f"{queue_anchor_workflow[1]} at {expected_sha}"
               )
+          elif queue_anchors:
+              anchor = queue_anchors[0]
+              anchor_branch = anchor.get("head_branch") or ""
+              anchor_base = queue_ref_pattern.match(anchor_branch)
+              if anchor_base is None:
+                  errors.append(
+                      "merge-group evidence is not on a merge-queue ref for "
+                      f"{release_branch}: {anchor_branch!r}"
+                  )
+              elif anchor.get("head_sha") != expected_sha:
+                  errors.append(
+                      "merge-group evidence sha mismatch: queue build "
+                      f"{anchor.get('id')} proved {anchor.get('head_sha')}, "
+                      f"release commit is {expected_sha}"
+                  )
+              elif anchor_base.group(1) != release_parent_sha:
+                  errors.append(
+                      "merge-group evidence proved a different tree: queue ref "
+                      f"{anchor_branch} was built on {anchor_base.group(1)}, "
+                      f"release commit {expected_sha} has parent "
+                      f"{release_parent_sha}"
+                  )
+              else:
+                  queue_ref = anchor_branch
+          authority_tier = "merge_group" if queue_ref is not None else "push"
+          # The refs a release may be proved from. A run sitting on one of
+          # these that is still not evidence is an authority conflict rather
+          # than an unrelated build, because it claims a required context name
+          # on a ref this release is being proved from.
+          admitted_branches = {release_branch}
+          if queue_ref is not None:
+              admitted_branches.add(queue_ref)
+
+          def evidence_tier(workflow):
+              if workflow is None:
+                  return None
+              if workflow.get("head_sha") != expected_sha:
+                  return None
+              if workflow.get("conclusion") == "cancelled":
+                  return None
+              if queue_ref is not None and workflow.get("head_branch") == queue_ref:
+                  # secret-scan.yml publishes `gitleaks (full history)` from a
+                  # push to the queue ref rather than from a merge_group event,
+                  # so the admitted ref is the tier and the event name is not.
+                  if workflow.get("event") in ("merge_group", "push"):
+                      return "merge_group"
+                  return None
+              if (
+                  workflow.get("event") == "push"
+                  and workflow.get("head_branch") == release_branch
+              ):
+                  return "push"
+              return None
+
+          def producer_of(run):
+              producers = workflows_by_suite.get(run.get("check_suite_id"), [])
+              return producers[0] if len(producers) == 1 else None
+
+          def origin_of(producer, suite_id):
+              if producer is None:
+                  return f"no unique workflow run for suite {suite_id}"
+              return (
+                  f"{producer.get('path')} run {producer.get('id')} "
+                  f"({producer.get('event')} on {producer.get('head_branch')})"
+              )
+
+          for name in required:
+              expected_workflow_id, expected_path = expected_provenance[name]
+              expected_producer = (expected_workflow_id, expected_path)
               expected_identity = (
                   expected_workflow_id,
                   expected_path,
-                  expected_event,
-                  expected_branch,
+                  authority_tier,
+                  queue_ref if queue_ref is not None else release_branch,
                   expected_sha,
               )
               named_runs = runs_by_name.get(name, [])
@@ -1045,7 +1193,8 @@ jobs:
                       )
 
               matching_runs = []
-              off_release_branch = 0
+              corroborating_runs = []
+              off_admitted_builds = 0
               for run in named_runs:
                   matching_workflows = workflows_by_suite.get(
                       run.get("check_suite_id"), []
@@ -1058,6 +1207,7 @@ jobs:
                       )
                       continue
                   workflow = matching_workflows[0]
+                  tier = evidence_tier(workflow)
                   identity = (
                       workflow.get("workflow_id"),
                       workflow.get("path"),
@@ -1065,28 +1215,48 @@ jobs:
                       workflow.get("head_branch"),
                       workflow.get("head_sha"),
                   )
-                  if identity == expected_identity:
-                      matching_runs.append((run, workflow))
-                  elif workflow.get("head_branch") == expected_branch:
-                      # Produced on the release branch itself, but not by the
-                      # reviewed producer. A second writer of a required context
-                      # name is an authority conflict, never a fallback.
+                  if tier is None:
+                      if (
+                          workflow.get("head_branch") in admitted_branches
+                          and workflow.get("conclusion") != "cancelled"
+                      ):
+                          # Produced on a ref this release is proved from, but
+                          # not by an admitted build. A second writer of a
+                          # required context name is an authority conflict,
+                          # never a fallback. A cancelled run is the exception
+                          # and is counted below: the queue superseded it, so
+                          # it gated nothing and claims nothing.
+                          errors.append(
+                              f"required check workflow provenance mismatch: {name} "
+                              f"expected={expected_identity} actual={identity}"
+                          )
+                      else:
+                          # Produced somewhere neither tier admits, which is
+                          # what an unrelated queue entry's build does at this
+                          # sha. Not this release's evidence, and not an
+                          # anomaly either.
+                          off_admitted_builds += 1
+                      continue
+                  if (
+                      workflow.get("workflow_id"),
+                      workflow.get("path"),
+                  ) != expected_producer:
                       errors.append(
                           f"required check workflow provenance mismatch: {name} "
                           f"expected={expected_identity} actual={identity}"
                       )
+                      continue
+                  if tier == authority_tier:
+                      matching_runs.append((run, workflow))
                   else:
-                      # Produced on another branch, which is what a merge-queue
-                      # build does at this sha before the landing push. Not this
-                      # release's evidence, and not an anomaly either.
-                      off_release_branch += 1
+                      corroborating_runs.append((run, workflow))
 
               if not matching_runs:
                   pending.append(
                       f"missing required check: {name} "
                       f"(expected provenance {expected_identity}, "
                       f"{len(named_runs)} same-named check-runs, "
-                      f"{off_release_branch} produced off the release branch)"
+                      f"{off_admitted_builds} produced off the admitted builds)"
                   )
                   continue
               if len(matching_runs) != 1:
@@ -1095,6 +1265,30 @@ jobs:
                       f"({len(matching_runs)} check-runs under one provenance)"
                   )
                   continue
+
+              # The other tier built the same tree, so its verdict on this
+              # context is a real result even though the mint no longer waits
+              # for it. A completed failure refuses, which is exactly what the
+              # landing-push authority used to do; an unfinished one is
+              # announced and never waited for, because waiting is the cost
+              # this rekey exists to remove.
+              for other_run, other_workflow in corroborating_runs:
+                  other_origin = origin_of(
+                      other_workflow, other_run.get("check_suite_id")
+                  )
+                  if other_run.get("status") != "completed":
+                      corroboration_unwaited.append(
+                          f"{name} (status={other_run.get('status')}, "
+                          f"from {other_origin})"
+                      )
+                  elif other_run.get("conclusion") not in non_failing_optional:
+                      errors.append(
+                          f"corroborating required check not green: {name} "
+                          f"(conclusion={other_run.get('conclusion')}, "
+                          f"from {other_origin})"
+                      )
+                  else:
+                      corroborated.append(name)
 
               run, workflow = matching_runs[0]
               allowed_conclusions = (
@@ -1147,20 +1341,61 @@ jobs:
                       )
                   )
 
-          # A check-run is this release's evidence only when its producing
-          # workflow run is the landing push on the release branch. The merge
-          # queue builds the same workflows at this exact sha on its own ref,
-          # and for a solo queue entry the speculative sha IS the landing sha,
-          # so a queue job the queue never waited for concludes after the merge
-          # on the commit being released, having gated nothing. Gate 1 already
-          # discounts those for required contexts. The sweep discounts them the
-          # same way instead of letting one poison the mint.
+          # Ruleset 19746451 gates the merge queue, and it is live GitHub
+          # configuration this repository cannot read from a test. A context it
+          # requires that no admitted build publishes any more does not fail
+          # anywhere: the queue waits on the name forever with every visible
+          # check green. Judging the reviewed mirror against the check-runs
+          # this sha actually carries is what makes that state a named
+          # refusal. It runs only under queue authority, because the
+          # landing-push fallback does not publish the queue-only contexts and
+          # refusing there would brick the very path that exists so a commit
+          # without a queue build stays releasable.
+          missing_from_ruleset = sorted(set(required) - set(ruleset_required))
+          if missing_from_ruleset:
+              errors.append(
+                  "mint requires a context the reviewed main ruleset does not "
+                  f"gate: {missing_from_ruleset}"
+              )
+          if queue_ref is not None:
+              for name in ruleset_required:
+                  if name in required:
+                      continue
+                  admitted = [
+                      run
+                      for run in runs_by_name.get(name, [])
+                      if evidence_tier(producer_of(run)) == authority_tier
+                  ]
+                  if not admitted:
+                      errors.append(
+                          "ruleset-required context has no admitted build at "
+                          f"this sha: {name}; the merge queue waits on it and "
+                          "nothing published it"
+                      )
+                      continue
+                  for run in admitted:
+                      if run.get("status") != "completed":
+                          pending.append(
+                              f"ruleset-required context not completed: {name} "
+                              f"(status={run.get('status')})"
+                          )
+                      elif run.get("conclusion") not in non_failing_optional:
+                          errors.append(
+                              f"ruleset-required context not green: {name} "
+                              f"(conclusion={run.get('conclusion')})"
+                          )
+
+          # A check-run is this release's evidence when its producing workflow
+          # run is one of the two admitted builds of this exact sha: the queue
+          # build that gated the landing, or the landing push itself. Anything
+          # else at this sha, such as an unrelated queue entry's build, gated
+          # nothing and is discounted rather than allowed to poison the mint.
+          # Both admitted builds feed the sweep even though only one is
+          # authority, so rekeying the gate widened what gets disclosed and
+          # darkened nothing.
           evidence_workflows = set()
           for workflow in workflow_runs:
-              if (
-                  workflow.get("event") == "push"
-                  and workflow.get("head_branch") == release_branch
-              ):
+              if evidence_tier(workflow) is not None:
                   evidence_workflows.add(
                       (workflow.get("workflow_id"), workflow.get("path"))
                   )
@@ -1175,8 +1410,7 @@ jobs:
                   and run.get("check_suite_id") in release_tag_suite_ids
               ):
                   continue
-              producers = workflows_by_suite.get(run.get("check_suite_id"), [])
-              producer = producers[0] if len(producers) == 1 else None
+              producer = producer_of(run)
               if name == "Mint release tag":
                   # The mint's own job name from a producer that is not the
                   # reviewed release-tag workflow. Never release evidence and
@@ -1188,21 +1422,8 @@ jobs:
                       f"conclusion={run.get('conclusion')})"
                   )
                   continue
-              if producer is None:
-                  origin = (
-                      "no unique workflow run for suite "
-                      f"{run.get('check_suite_id')}"
-                  )
-              else:
-                  origin = (
-                      f"{producer.get('path')} run {producer.get('id')} "
-                      f"({producer.get('event')} on {producer.get('head_branch')})"
-                  )
-              is_evidence = (
-                  producer is not None
-                  and producer.get("event") == "push"
-                  and producer.get("head_branch") == release_branch
-              )
+              origin = origin_of(producer, run.get("check_suite_id"))
+              is_evidence = evidence_tier(producer) is not None
               if not is_evidence:
                   discounted.append(
                       {
@@ -1251,6 +1472,12 @@ jobs:
           # nobody was told about. Announcing on the retry passes instead would
           # repeat every line up to sixty times and train the reader to skip it.
           announcements = []
+          if queue_ref is None:
+              announcements.append(
+                  "admitting on landing-push evidence: no merge-group build "
+                  f"exists at {expected_sha}, so the queue proved nothing this "
+                  "mint could key on"
+              )
           for path, run_id, state in sorted(set(degraded_producers)):
               announcements.append(
                   f"admitting over a producing run that {state}: "
@@ -1271,10 +1498,10 @@ jobs:
                       f"evidence: {entry['name']} "
                       f"(conclusion={entry['conclusion']}, from {entry['origin']}); "
                       + (
-                          "the landing push build on the release branch is the "
-                          "evidence"
+                          "an admitted build of that workflow at this sha is "
+                          "the evidence"
                           if entry["twin"]
-                          else "it has no build on the release branch at this sha"
+                          else "it has no admitted build at this sha"
                       )
                   )
           for line in announcements:
@@ -1285,10 +1512,19 @@ jobs:
                   f"not waiting for a check no required context covers: {item}"
               )
               print(f"::notice::{not_waited[-1]}")
+          for item in corroboration_unwaited:
+              not_waited.append(
+                  "not waiting for the other admitted build of a required "
+                  f"context: {item}"
+              )
+              print(f"::notice::{not_waited[-1]}")
 
           verdict = (
               f"verified {len(required)} required checks against their workflow "
-              f"provenance; {len(check_runs)} check-runs on the sha, "
+              f"provenance on the {authority_tier} evidence for {expected_sha}"
+              + (f" (queue ref {queue_ref})" if queue_ref is not None else "")
+              + f"; {len(check_runs)} check-runs on the sha, "
+              f"{len(corroborated)} corroborated by the other admitted build, "
               f"{len(discounted)} not this release's evidence, "
               f"{len(downgraded)} red and covered by no required context, "
               f"{len(unwaited)} unfinished and not waited for"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -26,11 +26,23 @@ concurrency:
 jobs:
   reconcile:
     name: Reconcile release PR
+    # The queue's own CI run concludes when the landing does, roughly half an
+    # hour before the landing push's CI run concludes, so it is the occasion
+    # that removes the wait rather than the one that reports it. Both are kept.
+    # A merge-group completion that arrives before main carries the commit
+    # reconciles a main one commit short, which is not a new class: the branch
+    # is coalescing by construction and every later cycle folds the newer drift
+    # into the same branch well inside the release PR's own queue time.
     if: >-
       github.event_name != 'workflow_run' ||
       (
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.conclusion == 'success'
+      ) ||
+      (
+        github.event.workflow_run.event == 'merge_group' &&
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/') &&
         github.event.workflow_run.conclusion == 'success'
       )
     runs-on: ubuntu-latest
@@ -582,8 +594,16 @@ jobs:
             --json headRefOid \
             --jq .headRefOid)"
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+          # Wait long enough for GitHub to register the run the App's own pull
+          # request already started. The old twelve-second budget expired
+          # before a busy Actions backend answered, and the activation commit
+          # below then rewrote the head and bought a second full pull-request
+          # CI round on a release the merge queue proves anyway. A minute of
+          # polling costs nothing against a twenty-minute job timeout, and it
+          # is the difference between the release pull request paying one
+          # pre-queue pass and paying two.
           needs_activation=true
-          for attempt in 1 2 3 4 5 6; do
+          for attempt in $(seq 1 15); do
             ci_runs="$(gh api \
               "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?event=pull_request&per_page=30")"
             valid_ci="$(jq -r \
@@ -602,7 +622,7 @@ jobs:
               needs_activation=false
               break
             fi
-            [ "$attempt" -eq 6 ] || sleep 2
+            [ "$attempt" -eq 15 ] || sleep 4
           done
           {
             echo "number=$pr"
@@ -622,6 +642,13 @@ jobs:
           # approval-required run a GITHUB_TOKEN-created pull request leaves
           # behind. This App-authored synchronize event is the narrow,
           # unattended handoff into the ordinary protected PR checks.
+          #
+          # It exists to make the required contexts report at all, never to buy
+          # a full pre-queue pass. The merge queue is what proves this branch,
+          # and the release mint now keys off that queue-proven sha, so a
+          # pull-request run whose heavy jobs report skipped satisfies this
+          # step exactly as a full one does. Do not widen this into a way of
+          # re-running the whole suite before the queue does.
           git commit --allow-empty --signoff \
             -m "Activate protected checks for the automated release PR"
           git push origin "HEAD:refs/heads/${BRANCH}"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -715,30 +715,37 @@ REQUIRED_CHECK_JOB_PRODUCERS = {
 # Durable workflow IDs are GitHub's repository-scoped identity, while `path`
 # makes that identity reviewable in source. These values are also exercised
 # against the current REST response shape by the positive fixture below.
+#
+# The third element is the event the producer publishes under INSIDE the merge
+# queue, which is not uniform: ci.yml and sast.yml carry a `merge_group:`
+# trigger, while secret-scan.yml carries only `push: branches: ["**"]` and so
+# publishes `gitleaks (full history)` from a push to the queue ref. That
+# asymmetry is why the mint admits a tier by the ref the queue built rather
+# than by the event name.
 REQUIRED_RELEASE_CHECK_PROVENANCE = {
     "Check & Test (ubuntu-latest)": (
         245_803_170,
         ".github/workflows/ci.yml",
-        "push",
+        "merge_group",
     ),
     "Check & Test (macos-latest)": (
         245_803_170,
         ".github/workflows/ci.yml",
-        "push",
+        "merge_group",
     ),
-    "Falsify guards": (245_803_170, ".github/workflows/ci.yml", "push"),
+    "Falsify guards": (245_803_170, ".github/workflows/ci.yml", "merge_group"),
     "Feature permutation tests (ubuntu-latest)": (
         245_803_170,
         ".github/workflows/ci.yml",
-        "push",
+        "merge_group",
     ),
     "Feature permutation tests (macos-latest)": (
         245_803_170,
         ".github/workflows/ci.yml",
-        "push",
+        "merge_group",
     ),
-    "DCO Sign-off": (245_803_170, ".github/workflows/ci.yml", "push"),
-    "cargo-deny": (251_549_972, ".github/workflows/sast.yml", "push"),
+    "DCO Sign-off": (245_803_170, ".github/workflows/ci.yml", "merge_group"),
+    "cargo-deny": (251_549_972, ".github/workflows/sast.yml", "merge_group"),
     "gitleaks (full history)": (
         293_452_372,
         ".github/workflows/secret-scan.yml",
@@ -747,12 +754,24 @@ REQUIRED_RELEASE_CHECK_PROVENANCE = {
     "Windows installer + vector release build": (
         245_803_170,
         ".github/workflows/ci.yml",
-        "push",
+        "merge_group",
     ),
+}
+# Ruleset 19746451 "Require status checks on main" gates the merge queue and is
+# live GitHub configuration no test here can read. The mint carries a reviewed
+# mirror of it; this is the part of that mirror the mint does not itself veto
+# on, which it still requires an admitted build to have published.
+RULESET_ONLY_RELEASE_CHECKS = {
+    "PR text hygiene": (328_945_626, ".github/workflows/pr-text-hygiene.yml"),
 }
 GITHUB_ACTIONS_APP_ID = 15_368
 RELEASE_TAG_WORKFLOW_ID = 318_521_292
 RELEASE_GATE_FIXTURE_SHA = "1" * 40
+# The landing commit's first parent, and the base sha the queue ref embeds.
+# The mint requires these to be the same value, which is the assertion that
+# binds "the tree the queue proved" to "the commit being released".
+RELEASE_GATE_PARENT_SHA = "2" * 40
+RELEASE_GATE_QUEUE_REF = f"gh-readonly-queue/main/pr-958-{RELEASE_GATE_PARENT_SHA}"
 RELEASE_GATE_CURRENT_RUN_ID = 9000
 EXTERNAL_REQUIRED_CONTEXT_SPOOF = textwrap.dedent(
     """\
@@ -5146,16 +5165,24 @@ def execute_release_check_gate(
         None,
     ]
     | None = None,
+    parent_sha: str = RELEASE_GATE_PARENT_SHA,
 ) -> subprocess.CompletedProcess[str]:
-    """Execute the real gate against a current-API-shaped provenance fixture."""
+    """Execute the real gate against a current-API-shaped provenance fixture.
+
+    The default fixture is a merge-queue landing as the API actually reports
+    one: every required context published once, by the queue's build of the
+    exact sha that landed. That is the mint's authority, so the falsifications
+    below mutate the evidence a release is really minted from rather than a
+    second copy of it. Fixtures that need the landing push add it explicitly.
+    """
 
     workflow_specs = {
         ".github/workflows/ci.yml": {
             "id": 1001,
             "workflow_id": 245_803_170,
             "path": ".github/workflows/ci.yml",
-            "event": "push",
-            "head_branch": "main",
+            "event": "merge_group",
+            "head_branch": RELEASE_GATE_QUEUE_REF,
             "head_sha": RELEASE_GATE_FIXTURE_SHA,
             "status": "completed",
             "conclusion": "success",
@@ -5165,23 +5192,37 @@ def execute_release_check_gate(
             "id": 1002,
             "workflow_id": 251_549_972,
             "path": ".github/workflows/sast.yml",
-            "event": "push",
-            "head_branch": "main",
+            "event": "merge_group",
+            "head_branch": RELEASE_GATE_QUEUE_REF,
             "head_sha": RELEASE_GATE_FIXTURE_SHA,
             "status": "completed",
             "conclusion": "success",
             "check_suite_id": 102,
         },
+        # secret-scan.yml carries no merge_group trigger. Inside the queue it
+        # publishes from the push that creates the queue ref, which is why the
+        # admitted tier is the ref and never the event name.
         ".github/workflows/secret-scan.yml": {
             "id": 1003,
             "workflow_id": 293_452_372,
             "path": ".github/workflows/secret-scan.yml",
             "event": "push",
-            "head_branch": "main",
+            "head_branch": RELEASE_GATE_QUEUE_REF,
             "head_sha": RELEASE_GATE_FIXTURE_SHA,
             "status": "completed",
             "conclusion": "success",
             "check_suite_id": 103,
+        },
+        ".github/workflows/pr-text-hygiene.yml": {
+            "id": 1004,
+            "workflow_id": 328_945_626,
+            "path": ".github/workflows/pr-text-hygiene.yml",
+            "event": "merge_group",
+            "head_branch": RELEASE_GATE_QUEUE_REF,
+            "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            "status": "completed",
+            "conclusion": "success",
+            "check_suite_id": 107,
         },
     }
     workflow_runs = list(workflow_specs.values())
@@ -5198,8 +5239,14 @@ def execute_release_check_gate(
     }
     workflow_runs.append(current_run.copy())
     check_runs = []
-    for index, name in enumerate(REQUIRED_RELEASE_CHECKS, start=1):
-        _, workflow_path, _ = REQUIRED_RELEASE_CHECK_PROVENANCE[name]
+    fixture_contexts = list(REQUIRED_RELEASE_CHECKS) + sorted(
+        RULESET_ONLY_RELEASE_CHECKS
+    )
+    for index, name in enumerate(fixture_contexts, start=1):
+        if name in RULESET_ONLY_RELEASE_CHECKS:
+            workflow_path = RULESET_ONLY_RELEASE_CHECKS[name][1]
+        else:
+            _, workflow_path, _ = REQUIRED_RELEASE_CHECK_PROVENANCE[name]
         check_runs.append(
             {
                 "name": name,
@@ -5247,7 +5294,11 @@ def execute_release_check_gate(
                 "CURRENT_RUN_ID": str(RELEASE_GATE_CURRENT_RUN_ID),
                 "CURRENT_RUN_EVENT": str(current_run["event"]),
                 "REQUIRED_CHECKS": "\n".join(REQUIRED_RELEASE_CHECKS),
+                "RULESET_REQUIRED_CHECKS": "\n".join(
+                    list(REQUIRED_RELEASE_CHECKS) + sorted(RULESET_ONLY_RELEASE_CHECKS)
+                ),
                 "SHA": RELEASE_GATE_FIXTURE_SHA,
+                "RELEASE_PARENT_SHA": parent_sha,
                 "TRIGGER_SHA": RELEASE_GATE_FIXTURE_SHA,
                 "GITHUB_ACTIONS_APP_ID": str(GITHUB_ACTIONS_APP_ID),
                 "GITHUB_ACTIONS_APP_SLUG": "github-actions",
@@ -6584,6 +6635,53 @@ def assert_selector_arguments(
         )
 
 
+RELEASE_PR_HEAD_REF = "automation/release-next"
+
+
+def assert_release_pr_ci_scope_cannot_widen(ci: str) -> None:
+    """A release-PR CI carve-out must be unable to reach the queue or main.
+
+    The release pull request is the one whose whole content is the version
+    bump, and the merge queue is what proves it. A carve-out scoped loosely
+    enough to match `merge_group` would merge that pull request with no full
+    pass anywhere. One that matched `push` would leave a skipped required
+    context on the release sha, which the mint reads as not green and refuses
+    permanently. Neither failure announces itself as a scoping mistake: the
+    first is invisible until something ships broken, and the second looks like
+    a broken mint rather than a broken condition.
+
+    `github.head_ref` is what makes the scoping structural rather than
+    conventional: it is set only on pull-request events and is empty under
+    both `push` and `merge_group`, so a condition written against it cannot
+    match either however the rest of the expression is edited. This assertion
+    passes vacuously today, because ci.yml carries no such carve-out yet, and
+    starts constraining the moment one lands.
+    """
+
+    for job, block in workflow_job_blocks(ci).items():
+        active = "\n".join(active_lines(block))
+        if RELEASE_PR_HEAD_REF not in active:
+            continue
+        if "github.head_ref" not in active:
+            raise AssertionError(
+                f"ci.yml job {job} scopes the release pull request by something "
+                "other than github.head_ref, which is the only selector that is "
+                "empty under push and merge_group"
+            )
+        if "github.event_name == 'pull_request'" not in active:
+            raise AssertionError(
+                f"ci.yml job {job} carves out the release pull request without "
+                "pinning the pull_request event, so the carve-out's reach "
+                "depends on expression evaluation rather than on the event"
+            )
+        for reaching in ("github.ref ", "github.ref=", "github.ref==", "github.base_ref"):
+            if reaching in active:
+                raise AssertionError(
+                    f"ci.yml job {job} scopes the release pull request with a "
+                    f"context that is populated off pull requests: {reaching.strip()}"
+                )
+
+
 def assert_mint_trigger_survives_advisory_flakes(release_tag: str) -> None:
     """The event-driven mint must evaluate on any completed main-push CI run.
 
@@ -6629,12 +6727,25 @@ def assert_mint_trigger_survives_advisory_flakes(release_tag: str) -> None:
     for clause in (
         "github.event.workflow_run.event == 'push'",
         "github.event.workflow_run.head_branch == 'main'",
+        # The queue's own CI run is the occasion that removes the wait: it
+        # concludes when the landing does, roughly half an hour before the
+        # landing push's run concludes, and the mint now keys off exactly the
+        # sha that build proved. Losing this clause does not break a release,
+        # which is what makes it worth pinning: it silently restores the
+        # half-hour of pure waiting the rekey exists to delete.
+        "github.event.workflow_run.event == 'merge_group'",
+        "startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')",
     ):
         if clause not in active:
             raise AssertionError(
-                "the release mint's workflow_run trigger must still pin the "
-                f"reviewed default-branch push it evaluates: {clause}"
+                "the release mint's workflow_run trigger must pin both reviewed "
+                f"occasions it evaluates: {clause}"
             )
+    if "gh-readonly-queue/'" in active or "'gh-readonly-queue/')" in active:
+        raise AssertionError(
+            "the release mint's queue trigger must pin the merge-queue ref for "
+            "main, not any merge-queue ref in the repository"
+        )
 
     # A widened trigger must not widen what the mint may release. The event's
     # own head sha is the only stale-capable input into the candidate: a rerun
@@ -7902,8 +8013,26 @@ def main() -> None:
         "head_branch: .head_branch",
         'release_branch = "main"',
         "expected_provenance = {",
-        "if identity == expected_identity:",
+        "tier = evidence_tier(workflow)",
+        ") != expected_producer:",
+        "if tier == authority_tier:",
         "ambiguous required check",
+        # The rekey onto the merge-group-proven sha. Each of these is one half
+        # of a proof that cannot be dropped on its own: the queue anchor names
+        # the ref, the parent read from checked-out history is what the ref's
+        # embedded base has to equal, and the tier decision is what keeps a
+        # duplicated context from reading as ambiguous authority.
+        'RELEASE_PARENT_SHA="$(git rev-parse "${SHA}^")"',
+        "queue_anchor_workflow = (245803170",
+        'authority_tier = "merge_group" if queue_ref is not None else "push"',
+        "ambiguous merge-group evidence",
+        "merge-group evidence is not on a merge-queue ref",
+        "merge-group evidence sha mismatch",
+        "merge-group evidence proved a different tree",
+        "corroborating required check not green",
+        "RULESET_REQUIRED_CHECKS:",
+        "ruleset-required context has no admitted build at",
+        "mint requires a context the reviewed main ruleset does not",
         'allowed_conclusions = (\n                  {"success", "skipped"}',
         "release_tag_suite_ids",
         "did not settle within 30 minutes",
@@ -7989,6 +8118,11 @@ def main() -> None:
         "github.event.workflow_run.event == 'push'",
         "github.event.workflow_run.head_branch == 'main'",
         "github.event.workflow_run.conclusion == 'success'",
+        # The train reconciles off the queue's CI completion as well, for the
+        # same reason the mint does: it is the occasion that arrives when the
+        # landing does rather than half an hour later.
+        "github.event.workflow_run.event == 'merge_group'",
+        "startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')",
         "environment: release-tag",
         "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
         "repositories: kin",
@@ -10820,12 +10954,19 @@ def main() -> None:
     ):
         require(windows_job, policy, "Windows exact lockfile provenance regression")
 
-    # The Windows installer leg is off the pull-request path, so the only place
-    # it can still prove anything is a push to main. The only reason that is
-    # safe is that release-tag.yml refuses to mint a tag unless this exact
-    # check is present and green on the release sha. Pin both halves together:
-    # dropping either one silently turns a required release gate into a job that
-    # never runs on the commit being released.
+    # The Windows installer leg is off the pull-request path, so the only
+    # places it can prove anything are the queue's build and the landing push.
+    # The only reason that is safe is that release-tag.yml refuses to mint a
+    # tag unless this exact check is present and green on the release sha. Pin
+    # every half together: dropping one silently turns a required release gate
+    # into a job that never runs on the commit being released.
+    #
+    # The merge-queue half is load-bearing now rather than optional. The mint
+    # keys off the merge-group-proven sha, and this leg is the one required
+    # context the queue used to skip, so a build that skips it is a build the
+    # mint must refuse. Restoring a merge_group exclusion here would make the
+    # queue's proof incomplete for exactly the platform that has been killing
+    # tags, and the mint would refuse every release until someone noticed.
     installer_start = ci_workflow.index("  windows-installer:")
     installer_end = ci_workflow.index("\n  changes:", installer_start)
     installer_job = ci_workflow[installer_start:installer_end]
@@ -10835,10 +10976,21 @@ def main() -> None:
         "needs.changes.outputs.docs_only != 'true'",
     ):
         require(installer_job, policy, "main-only Windows installer admission")
+    if "github.event_name != 'merge_group'" in installer_job:
+        raise AssertionError(
+            "the Windows installer leg must run inside the merge queue: the "
+            "release mint keys off the queue-proven sha and refuses a build "
+            "that skipped this required context"
+        )
     require(
         ci_workflow,
         "  push:\n    branches: [main]",
         "Windows installer proof still reaching every main commit",
+    )
+    require(
+        ci_workflow,
+        "  merge_group:",
+        "Windows installer proof reaching the queue build the mint keys off",
     )
 
     # Main's classifier must keep reporting false so the release-critical
@@ -11911,18 +12063,23 @@ def main() -> None:
         add_duplicate_success,
     )
 
-    def add_merge_queue_producer(
+    def add_landing_push_producer(
         check_runs: list[dict[str, object]],
         workflow_runs: list[dict[str, object]],
         _current_run: dict[str, object],
     ) -> None:
-        """A landing through the merge queue publishes the same contexts twice."""
+        """The landing push republishes every context the queue already proved.
 
-        queue_branch = "gh-readonly-queue/main/pr-1-" + "0" * 40
+        Both builds carry the same sha because the queue's speculative commit
+        IS the squash that lands. Crediting both would make every context
+        ambiguous, so the queue build is the authority and this one is
+        corroboration: judged when it has concluded, never waited for.
+        """
+
         for path, suite in (
-            (".github/workflows/ci.yml", 201),
-            (".github/workflows/sast.yml", 202),
-            (".github/workflows/secret-scan.yml", 203),
+            (".github/workflows/ci.yml", 301),
+            (".github/workflows/sast.yml", 302),
+            (".github/workflows/secret-scan.yml", 303),
         ):
             source = workflow_fixture(
                 workflow_runs,
@@ -11935,88 +12092,341 @@ def main() -> None:
             source.update(
                 {
                     "id": suite * 10,
-                    "event": (
-                        "push" if path.endswith("secret-scan.yml") else "merge_group"
-                    ),
-                    "head_branch": queue_branch,
+                    "event": "push",
+                    "head_branch": "main",
                     "check_suite_id": suite,
                 }
             )
             workflow_runs.append(source)
         for name in REQUIRED_RELEASE_CHECKS:
             _, workflow_path, _ = REQUIRED_RELEASE_CHECK_PROVENANCE[name]
-            queue_copy = required_check_fixture(check_runs, name).copy()
-            queue_copy.update(
+            push_copy = required_check_fixture(check_runs, name).copy()
+            push_copy.update(
                 {
                     "id": 20_000 + len(check_runs),
                     "check_suite_id": {
-                        ".github/workflows/ci.yml": 201,
-                        ".github/workflows/sast.yml": 202,
-                        ".github/workflows/secret-scan.yml": 203,
+                        ".github/workflows/ci.yml": 301,
+                        ".github/workflows/sast.yml": 302,
+                        ".github/workflows/secret-scan.yml": 303,
                     }[workflow_path],
-                    # The queue build deliberately skips the legs that only the
-                    # landing push runs for real.
-                    "conclusion": "skipped",
                 }
             )
-            check_runs.append(queue_copy)
+            check_runs.append(push_copy)
 
     merge_queue_fixture = execute_release_check_gate(
         release_gate,
         {},
-        mutate_fixture=add_merge_queue_producer,
+        mutate_fixture=add_landing_push_producer,
     )
     if merge_queue_fixture.returncode != 0:
         raise AssertionError(
             "a merge-queue landing's duplicate contexts blocked the release: "
             f"{merge_queue_fixture.stdout}{merge_queue_fixture.stderr}"
         )
+    if "corroborated by the other admitted build" not in (
+        merge_queue_fixture.stdout + merge_queue_fixture.stderr
+    ):
+        raise AssertionError(
+            "the landing push's verdict on an already-proven tree was neither "
+            "judged nor reported: "
+            f"{merge_queue_fixture.stdout}{merge_queue_fixture.stderr}"
+        )
 
-    def only_merge_queue_producer(
+    def red_landing_push_corroboration(
         check_runs: list[dict[str, object]],
         workflow_runs: list[dict[str, object]],
         current_run: dict[str, object],
     ) -> None:
-        """Before the landing push runs, only queue evidence exists."""
+        """The other build of this exact tree failed the same required context."""
 
-        add_merge_queue_producer(check_runs, workflow_runs, current_run)
-        release_suites = {
-            run["check_suite_id"]
-            for run in workflow_runs
-            if run.get("head_branch") == "main"
-            and run.get("path")
-            in (
-                ".github/workflows/ci.yml",
-                ".github/workflows/sast.yml",
-                ".github/workflows/secret-scan.yml",
-            )
-        }
+        add_landing_push_producer(check_runs, workflow_runs, current_run)
+        for run in check_runs:
+            if run["name"] == "cargo-deny" and run["check_suite_id"] == 302:
+                run["conclusion"] = "failure"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "the landing push failed a context the queue passed",
+        "corroborating required check not green: cargo-deny (conclusion=failure",
+        red_landing_push_corroboration,
+    )
+
+    def unfinished_landing_push_corroboration(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        current_run: dict[str, object],
+    ) -> None:
+        """The usual case: the landing push is still running when the mint fires."""
+
+        add_landing_push_producer(check_runs, workflow_runs, current_run)
+        workflow_fixture(workflow_runs, 301).update(
+            {"status": "in_progress", "conclusion": None}
+        )
+        for run in check_runs:
+            if run["check_suite_id"] == 301:
+                run.update({"status": "in_progress", "conclusion": None})
+
+    assert_release_gate_admits(
+        release_gate,
+        "the landing push is still running when the queue's proof is complete",
+        (
+            "not waiting for the other admitted build of a required context: "
+            "Check & Test (ubuntu-latest) (status=in_progress",
+        ),
+        unfinished_landing_push_corroboration,
+    )
+
+    def skipped_queue_leg(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """The queue build skipped a leg the mint now keys off.
+
+        This is the pre-rekey shape of the merge_group build, and it is the
+        defect the rekey would reintroduce if the Windows leg were admitted as
+        proof while the queue kept skipping it.
+        """
+
+        required_check_fixture(
+            check_runs,
+            "Windows installer + vector release build",
+        )["conclusion"] = "skipped"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "the queue's skipped Windows leg is admitted as release evidence",
+        (
+            "required check not green: Windows installer + vector release build "
+            "(conclusion=skipped)"
+        ),
+        skipped_queue_leg,
+    )
+
+    def absent_queue_leg(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """The queue build published no such context at all."""
+
         check_runs[:] = [
-            run for run in check_runs if run["check_suite_id"] not in release_suites
+            run
+            for run in check_runs
+            if run["name"] != "Windows installer + vector release build"
+        ]
+
+    absent_leg_fixture = execute_release_check_gate(
+        release_gate,
+        {},
+        mutate_fixture=absent_queue_leg,
+    )
+    if absent_leg_fixture.returncode != 2:
+        raise AssertionError(
+            "a required context the admitted build never published no longer "
+            "holds the mint for retry: "
+            f"rc={absent_leg_fixture.returncode} "
+            f"{absent_leg_fixture.stdout}{absent_leg_fixture.stderr}"
+        )
+    if "missing required check: Windows installer + vector release build" not in (
+        absent_leg_fixture.stdout + absent_leg_fixture.stderr
+    ):
+        raise AssertionError(
+            "absent queue evidence was held without naming the missing "
+            f"producer: {absent_leg_fixture.stdout}{absent_leg_fixture.stderr}"
+        )
+
+    def queue_ref_names_another_base(
+        _check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """The queue built a tree whose parent is not this release's parent."""
+
+        workflow_fixture(workflow_runs, 101)["head_branch"] = (
+            "gh-readonly-queue/main/pr-958-" + "9" * 40
+        )
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "the queue build credited to this release was built on another base",
+        "merge-group evidence proved a different tree",
+        queue_ref_names_another_base,
+    )
+
+    # The other half of that equality, mutated on the git side. The parent is
+    # read from the protected history this job checked out rather than from the
+    # endpoint being judged, so this proves the assertion consults it at all
+    # instead of comparing the API's answer with itself.
+    wrong_parent_fixture = execute_release_check_gate(
+        release_gate,
+        {},
+        parent_sha="9" * 40,
+    )
+    if wrong_parent_fixture.returncode == 0:
+        raise AssertionError(
+            "a queue build was credited to a release whose first parent is not "
+            "the base that build was made on"
+        )
+    if "merge-group evidence proved a different tree" not in (
+        wrong_parent_fixture.stdout + wrong_parent_fixture.stderr
+    ):
+        raise AssertionError(
+            "the sha-identity refusal fired for the wrong reason: "
+            f"{wrong_parent_fixture.stdout}{wrong_parent_fixture.stderr}"
+        )
+
+    def queue_build_proved_another_sha(
+        _check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        workflow_fixture(workflow_runs, 101)["head_sha"] = "7" * 40
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "the queue build credited to this release proved another sha",
+        "merge-group evidence sha mismatch",
+        queue_build_proved_another_sha,
+    )
+
+    def queue_ref_is_an_ordinary_branch(
+        _check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """A branch that merely looks like queue evidence cannot nominate itself."""
+
+        workflow_fixture(workflow_runs, 101)["head_branch"] = "attacker/queue-lookalike"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "an ordinary branch claims to be the queue build",
+        "merge-group evidence is not on a merge-queue ref",
+        queue_ref_is_an_ordinary_branch,
+    )
+
+    def two_uncancelled_queue_builds(
+        _check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        rebuild = workflow_fixture(workflow_runs, 101).copy()
+        rebuild.update({"id": 1_101, "check_suite_id": 401})
+        workflow_runs.append(rebuild)
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "two uncancelled queue builds of one sha are collapsed by recency",
+        "ambiguous merge-group evidence",
+        two_uncancelled_queue_builds,
+    )
+
+    def superseded_queue_build(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """A speculative group the queue cancelled and rebatched gated nothing."""
+
+        cancelled = workflow_fixture(workflow_runs, 101).copy()
+        cancelled.update(
+            {"id": 1_102, "check_suite_id": 402, "conclusion": "cancelled"}
+        )
+        workflow_runs.append(cancelled)
+        check_runs.append(
+            {
+                "name": "Check & Test (ubuntu-latest)",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "id": 40_201,
+                "app_id": GITHUB_ACTIONS_APP_ID,
+                "app_slug": "github-actions",
+                "check_suite_id": 402,
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            }
+        )
+
+    superseded_fixture = execute_release_check_gate(
+        release_gate,
+        {},
+        mutate_fixture=superseded_queue_build,
+    )
+    if superseded_fixture.returncode != 0:
+        raise AssertionError(
+            "a cancelled superseded queue group was read as a competing "
+            f"authority: {superseded_fixture.stdout}{superseded_fixture.stderr}"
+        )
+
+    def no_queue_build_at_all(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        current_run: dict[str, object],
+    ) -> None:
+        """A commit that reached main without a queue build is still releasable.
+
+        The landing push is the fallback authority, which is exactly the
+        evidence the mint used before it was rekeyed. Removing that path would
+        make one queue outage an unreleasable repository.
+        """
+
+        add_landing_push_producer(check_runs, workflow_runs, current_run)
+        queue_suites = {101, 102, 103, 107}
+        check_runs[:] = [
+            run for run in check_runs if run["check_suite_id"] not in queue_suites
         ]
         workflow_runs[:] = [
             run
             for run in workflow_runs
-            if run.get("check_suite_id") not in release_suites
+            if run.get("check_suite_id") not in queue_suites
         ]
 
-    queue_only_fixture = execute_release_check_gate(
+    assert_release_gate_admits(
         release_gate,
-        {},
-        mutate_fixture=only_merge_queue_producer,
+        "a landing with no queue build at all",
+        (
+            "admitting on landing-push evidence: no merge-group build exists at",
+        ),
+        no_queue_build_at_all,
     )
-    if queue_only_fixture.returncode == 0:
-        raise AssertionError(
-            "the merge queue's skipped build was admitted as release evidence"
-        )
-    for name in REQUIRED_RELEASE_CHECKS:
-        expected = f"missing required check: {name}"
-        if expected not in queue_only_fixture.stdout + queue_only_fixture.stderr:
-            raise AssertionError(
-                "queue-only evidence was refused without naming the missing "
-                f"producer: {name}: {queue_only_fixture.stdout}"
-                f"{queue_only_fixture.stderr}"
-            )
+
+    def ruleset_context_nothing_publishes(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        """Ruleset 19746451 still gates a context no producer publishes.
+
+        Nothing in this repository can read that ruleset, and the queue's own
+        symptom is a wait with every visible check green, so the mint reading
+        its reviewed mirror against the sha is the only place this becomes a
+        stated failure.
+        """
+
+        check_runs[:] = [
+            run for run in check_runs if run["name"] != "PR text hygiene"
+        ]
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "a ruleset-gated context that no admitted build published",
+        "ruleset-required context has no admitted build at this sha: PR text hygiene",
+        ruleset_context_nothing_publishes,
+    )
+
+    def ruleset_context_is_red(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        required_check_fixture(check_runs, "PR text hygiene")["conclusion"] = "failure"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "a ruleset-gated context that the admitted build failed",
+        "ruleset-required context not green: PR text hygiene (conclusion=failure)",
+        ruleset_context_is_red,
+    )
 
     def non_required_check(
         name: str,
@@ -12037,32 +12447,33 @@ def main() -> None:
             "head_sha": RELEASE_GATE_FIXTURE_SHA,
         }
 
-    def add_red_queue_job_after_landing(
+    def add_red_advisory_in_the_queue_build(
         check_runs: list[dict[str, object]],
-        workflow_runs: list[dict[str, object]],
-        current_run: dict[str, object],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
     ) -> None:
-        """The queue's own build reds on the landing sha, after the merge.
+        """An advisory job reds inside the build the mint now keys off.
 
-        A solo queue entry's speculative sha IS the landing sha, so a
-        merge_group job no ruleset required keeps running past the merge and
-        concludes on the exact commit being released.
+        Before the rekey this was discounted, because a merge_group job the
+        queue never waited for concluded after the merge having gated nothing.
+        The queue's build is now this release's evidence, so a red in it is
+        the same class of fact as a red in the landing push: admitted over,
+        and announced. The disclosure got wider here rather than darker, which
+        is the property the rekey had to preserve.
         """
 
-        add_merge_queue_producer(check_runs, workflow_runs, current_run)
         check_runs.append(
-            non_required_check("Windows authority tests", 201, 30_001)
+            non_required_check("Windows authority tests", 101, 30_001)
         )
 
     assert_release_gate_admits(
         release_gate,
-        "a merge_group job the queue never waited for concluded red",
+        "an advisory job reds inside the admitted queue build",
         (
-            "discounting a red check that is not this release's evidence: "
-            "Windows authority tests",
-            "the landing push build on the release branch is the evidence",
+            "admitting over a red check no required context covers: "
+            "Windows authority tests (conclusion=failure",
         ),
-        add_red_queue_job_after_landing,
+        add_red_advisory_in_the_queue_build,
     )
 
     def add_red_queue_only_job(
@@ -12070,7 +12481,7 @@ def main() -> None:
         workflow_runs: list[dict[str, object]],
         _current_run: dict[str, object],
     ) -> None:
-        """A red job from a workflow that never builds the release branch."""
+        """A red job from another queue entry's build of this same sha."""
 
         workflow_runs.append(
             {
@@ -12089,11 +12500,11 @@ def main() -> None:
 
     assert_release_gate_admits(
         release_gate,
-        "a red job that only ever runs inside the queue",
+        "a red job from a build neither tier admits",
         (
             "discounting a red check that is not this release's evidence: "
             "Queue-only smoke",
-            "it has no build on the release branch at this sha",
+            "it has no admitted build at this sha",
         ),
         add_red_queue_only_job,
     )
@@ -12297,17 +12708,19 @@ def main() -> None:
         workflow_runs: list[dict[str, object]],
         _current_run: dict[str, object],
     ) -> None:
-        check = required_check_fixture(
-            check_runs,
-            "Check & Test (macos-latest)",
-        )
+        # Deliberately not a ci.yml context. ci.yml's run is the queue anchor,
+        # and moving its head sha is refused earlier and more specifically by
+        # the sha-identity assertion, which `queue_build_proved_another_sha`
+        # covers. This case is the per-context provenance path, which every
+        # non-anchor producer still has to be judged against.
+        check = required_check_fixture(check_runs, "cargo-deny")
         workflow = workflow_fixture(workflow_runs, check["check_suite_id"])
         workflow["head_sha"] = "3" * 40
 
     assert_release_gate_fixture_rejected(
         release_gate,
         "required workflow run is attached to the wrong head sha",
-        "required check workflow provenance mismatch: Check & Test (macos-latest)",
+        "required check workflow provenance mismatch: cargo-deny",
         change_required_workflow_head,
     )
 
@@ -12353,6 +12766,39 @@ def main() -> None:
         RELEASE_RECOVERY.read_text(encoding="utf-8")
     )
     assert_mint_trigger_survives_advisory_flakes(release_tag)
+    assert_release_pr_ci_scope_cannot_widen(ci_workflow)
+    # This guard has to be able to fail before it is worth carrying, and it
+    # currently constrains nothing in the tree, so falsify it against the two
+    # shapes a loose carve-out actually takes.
+    release_pr_job_start = ci_workflow.index("  npm-launchers:")
+    release_pr_job_end = ci_workflow.index("\n  windows-authority-tests:")
+    release_pr_job = ci_workflow[release_pr_job_start:release_pr_job_end]
+    for label, condition, expected in (
+        (
+            "a release-PR carve-out written against github.ref",
+            "    if: >-\n      ${{ github.ref != 'refs/heads/automation/release-next' }}\n",
+            "other than github.head_ref",
+        ),
+        (
+            "a release-PR carve-out that never pins the pull_request event",
+            "    if: >-\n      ${{ github.head_ref != 'automation/release-next' }}\n",
+            "without pinning the pull_request event",
+        ),
+    ):
+        mutated_ci = (
+            ci_workflow[:release_pr_job_start]
+            + release_pr_job.replace(
+                "    name: npm launcher tests\n",
+                "    name: npm launcher tests\n" + condition,
+                1,
+            )
+            + ci_workflow[release_pr_job_end:]
+        )
+        expect_assertion(
+            label,
+            expected,
+            lambda source=mutated_ci: assert_release_pr_ci_scope_cannot_widen(source),
+        )
 
     with tempfile.TemporaryDirectory() as directory:
         fixture_directory = Path(directory)


### PR DESCRIPTION
Every release waits for a second full CI pass of a tree the merge queue already
proved. The mint bound all nine required contexts to push-event provenance on
main, so it could not read the build that actually gated the landing. On the
v0.5.42 landing the queue's CI run concluded at 14:48:06Z, the landing push's
run at 15:16:20Z, and the mint fired at 15:16:25Z. Run against that landing's
real API payload, the rekeyed gate admits at the earlier point with every
unfinished landing-push context announced rather than waited for.

## Land this as one change

Half of it bricks the mint. Widen the mint's provenance without running the
Windows leg in the queue and every release refuses terminally with `required
check not green: Windows installer + vector release build (conclusion=skipped)`,
which is reproduced below against the live payload rather than predicted. Run
the Windows leg in the queue without the rekey and nothing breaks, but the queue
pays a 20 to 25 minute leg per speculative entry for a proof nothing reads.

## What changed

**ci.yml, one job condition.** `windows-installer` loses `github.event_name !=
'merge_group'` and keeps `!= 'pull_request'`. Off the pull-request path is what
protected the land-and-iterate cycle; off the queue protected nothing and cost
the release its evidence. This is the only ci.yml edit here, isolated in its own
commit so it composes cleanly with the ci.yml lane.

**release-tag.yml, the mint.** `expected_provenance` now binds producer identity
only, workflow id and path, and which build proves a release is one tier
decision made before any context is judged.

The queue ref is taken from the `merge_group` run of ci.yml at the release sha,
never guessed from a branch-name shape, so a branch that merely looks like a
queue ref cannot nominate itself. Sha identity is then asserted rather than
assumed: the queue ref carries the base sha it was built on, the release
commit's first parent is that same base, and the parent is read with `git
rev-parse "${SHA}^"` from the checked-out protected history rather than from the
endpoint being judged. Verified across three consecutive landings, `pr-958-64c7c8c5`
for `5aa184d9`, `pr-955-0b8767c8` for `64c7c8c5`, `pr-953-14efb5a7` for `0b8767c8`.

The tier is the ref, never the event name. `secret-scan.yml` carries only `push:
branches: ["**"]`, so inside the queue it publishes `gitleaks (full history)`
from a push to the queue ref while ci.yml and sast.yml publish under
`merge_group`. Keying on the event would have lost a required context.

Exactly one tier is authority per release, because crediting both would make
every duplicated context ambiguous and refuse every queue landing. The landing
push stays admissible and becomes the authority only when no merge-group build
exists at the sha at all, announced when it happens, so one queue outage is not
an unreleasable repository. The other tier is judged as corroboration: a
completed build that failed a required context still refuses, which is what the
landing-push authority used to do, while an unfinished one is announced and
never waited for. A superseded cancelled speculative group gated nothing and is
neither evidence nor a competing authority; two uncancelled queue builds of one
sha are refused as ambiguous rather than collapsed by recency.

The red-disclosure sweep now treats both admitted builds as evidence instead of
only the landing push. Measured on the v0.5.42 payload it discounts 62
check-runs where the current mint discounts 84, so 22 more moved into the judged
and announced set. The disclosure got wider; nothing went dark.

The mint also carries a reviewed mirror of ruleset 19746451 as
`RULESET_REQUIRED_CHECKS`. A context that ruleset gates and no admitted build
published is refused by name, because the queue's own symptom for that state is
waiting forever with every visible check green and no check saying why.

**Both mints go event-driven on the queue's CI completion.** release-tag.yml and
release-train.yml already fired on the landing push's CI completion, which
arrives about half an hour after the occasion that matters. Both gain the
`merge_group` arm pinned to `gh-readonly-queue/main/`, and both keep their crons
as the backstop. 100 of 100 `workflow_run` runs of the mint carry `head_branch:
main`, so a queue-triggered run does not inherit the queue ref and the mint's own
identity assertion is unaffected. A merge-group completion arriving before main
carries the commit resolves to a clean no-op: the resolve step reads main HEAD,
reports `needed=false`, and never touches the decline ledger.

**The release train stops buying a second pre-queue pass.** Its activation poll
was six attempts two seconds apart. Expiring early pushes an empty commit, which
rewrites the release head and buys another full pull-request CI round on a branch
the queue proves anyway. The poll is now fifteen attempts four seconds apart
against a twenty-minute job timeout, and the step's comment states that it exists
to make the required contexts report at all, never to buy a full pre-queue pass.

## Not in this branch

The ci.yml half of the release-PR skip is owned by the ci.yml lane. This branch
adds the guard that makes it safe to land: `assert_release_pr_ci_scope_cannot_widen`
requires any release-PR carve-out to select on `github.head_ref`, which is empty
under both `push` and `merge_group`, and to pin `github.event_name ==
'pull_request'`, and to avoid `github.ref` and `github.base_ref`. It passes
vacuously today and starts constraining the moment the carve-out lands. The shape
it admits, for that lane to use on each heavy job:

```
    if: >-
      ${{ !cancelled()
      && needs.changes.outputs.docs_only != 'true'
      && !(github.event_name == 'pull_request'
           && github.head_ref == 'automation/release-next') }}
```

Not on `dco` or `pr-text-hygiene`, which are the pull-request-only contexts the
ruleset still requires.

## Falsification

Fifteen negative cases run against the real extracted gate, all behaving as
specified, plus five guard falsifications that mutate the tree and confirm the
authority suite goes red naming the mutation. The three the rekey turns on:

* **sha mismatch.** A queue ref naming a base that is not this commit's parent
  refuses with `merge-group evidence proved a different tree`, in both
  directions, mutating the ref and mutating the git-side parent separately. A
  queue build carrying another head sha refuses with `merge-group evidence sha
  mismatch`.
* **missing merge_group context.** An absent one is `missing required check` and
  exits 2 for retry; a `skipped` one is `required check not green` and exits 1.
  Neither is ever a silent pass.
* **red disclosure.** An advisory red inside the admitted queue build is
  announced as `admitting over a red check no required context covers`, one in
  the landing push the same way, and a red from a build neither tier admits is
  announced as discounted with `it has no admitted build at this sha`.

Also covered: an ordinary branch claiming to be the queue build, two uncancelled
queue builds at one sha, a cancelled superseded group, a landing push that failed
a context the queue passed, a landing push still running, a ruleset-gated context
nothing published, a ruleset-gated context that is red, and no queue build at all.

Against the live v0.5.42 payload, 112 check-runs and 34 workflow runs pulled with
the mint's own queries: the rekeyed gate refuses today with the Windows leg
skipped and admits with only that one conclusion flipped to success, which is
exactly what the ci.yml hunk changes. The current mint on `main` admits the same
payload, so the payload is a genuinely admissible release and the difference is
this change rather than the data. Repeated on the `64c7c8c5` landing with the
same result.

The release-order, hold-alarm and release-notes node tests needed no changes and
pass unchanged at 7, 18 and 22 assertions. The wider node gate passes 97 of 97,
and `check-rc-build-drift`, `test-assertion-reachability` and
`test-homebrew-release-gate` are green.

## Assertions that moved

None deleted without an equivalent replacement. The default gate fixture becomes
a queue landing as the API reports one, because that is the evidence a release is
minted from, so every existing falsification now mutates real authority instead of
a second copy. `add_merge_queue_producer` inverts into `add_landing_push_producer`.
The old queue-only refusal, which asserted `missing required check` for all nine
contexts, splits into two sharper cases: a skipped queue leg refused as not green,
an absent one held for retry. `add_red_queue_job_after_landing` asserted that a red
advisory in the queue's build was discounted; it is now announced as admitted-over,
the louder half of the same disclosure. `add_red_queue_only_job` keeps its intent
with the message changed to `it has no admitted build at this sha`.
`change_required_workflow_head` retargets from a ci.yml context to `cargo-deny`,
because ci.yml's run is the queue anchor and moving its head sha is refused earlier
by the sha-identity assertion, which a new case covers; the per-context provenance
path still needs a non-anchor producer and keeps one.
`assert_mint_trigger_survives_advisory_flakes` gains the queue clauses and refuses a
queue trigger not scoped to `gh-readonly-queue/main/`.
`REQUIRED_RELEASE_CHECK_PROVENANCE`'s third element moves from `push` to the event
each producer publishes under inside the queue, which is the asymmetry that made
ref-keyed tiers necessary.

## Land-together checklist

1. Land only after v0.5.42 is Latest.
2. Land with the merge queue empty, and with no untagged release commit sitting
   on main. Two conditions, one hazard: any sha whose queue build predates this
   landing has a skipped Windows leg, and the rekeyed mint refuses such a sha
   terminally. A pull request already queued against a pre-landing base builds
   one, and so does a version-bump squash that landed earlier and has not been
   tagged yet. Confirm the workspace version is already tagged and Latest first.
3. Run the ruleset motion below and record the output.
4. Watch this pull request's own `merge_group` run and confirm `Windows installer
   + vector release build` concludes `success` there rather than `skipped`.
   Actions resolves workflow files from the merge-group ref, so this pull request
   is its own canary for the enablement. Read the `merge_group` runs, not the PR
   checks: an ejection marks nothing on the PR.
5. On the next release, read the mint's summary and confirm it names `merge_group
   evidence` and a queue ref.

### Ruleset 19746451

This change renames, shards and relocates nothing, so it requires no ruleset
mutation. The motion is a verification, and the mirror the mint now carries has to
match it or the mint refuses:

```
gh api repos/firelock-ai/kin/rulesets/19746451 \
  --jq '[.rules[] | select(.type=="required_status_checks")
         | .parameters.required_status_checks[].context] | sort'
```

Expected, and the exact contents of `RULESET_REQUIRED_CHECKS`: `Check & Test
(macos-latest)`, `Check & Test (ubuntu-latest)`, `DCO Sign-off`, `Falsify guards`,
`Feature permutation tests (macos-latest)`, `Feature permutation tests
(ubuntu-latest)`, `PR text hygiene`, `cargo-deny`, `gitleaks (full history)`,
`Windows installer + vector release build`.

If that read ever drifts, this is the idempotent re-assert that restores it:

```
gh api --method PUT repos/firelock-ai/kin/rulesets/19746451 --input - <<'JSON'
{
  "name": "Require status checks on main",
  "target": "branch",
  "enforcement": "active",
  "conditions": {"ref_name": {"include": ["refs/heads/main"], "exclude": []}},
  "rules": [
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": true,
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          {"context": "Check & Test (ubuntu-latest)"},
          {"context": "Check & Test (macos-latest)"},
          {"context": "DCO Sign-off"},
          {"context": "cargo-deny"},
          {"context": "gitleaks (full history)"},
          {"context": "Windows installer + vector release build"},
          {"context": "PR text hygiene"},
          {"context": "Falsify guards"},
          {"context": "Feature permutation tests (ubuntu-latest)"},
          {"context": "Feature permutation tests (macos-latest)"}
        ]
      }
    }
  ]
}
JSON
```

A PUT replaces the ruleset wholesale and drops the one bypass actor the live
ruleset carries. Read `.bypass_actors` first and put it back in the same body.

## Known costs, stated rather than hidden

The queue now pays the Windows leg, 20 to 25 minutes, per speculative entry, and
`max_entries_to_build` is 5. `check_response_timeout_minutes` is 90, so a hung
Windows job ejects a queue entry that previously did not contain that job at all.

The leg's `actions/cache@v6` step writes about 1.5 GB under
`windows-vector-cargo-`, and a write from a `gh-readonly-queue/` ref lands in a
scope nothing later reads. The repository cache sits at 9.99 of 10 GB, so this
evicts entries that do restore. The fix is `actions/cache/restore` plus a
conditional `actions/cache/save`, a second hunk in a job this branch only holds
the conditional of, so it belongs to the ci.yml lane and should follow closely.

`docs/release-bot.md` lists six of the nine required contexts and never described
push-event provenance, so this change does not make it wrong; it was already
incomplete. `sast.yml` and `secret-scan.yml` carry comments saying release-tag
demands their context with push-event provenance, which becomes imprecise here.
All three are owned elsewhere.

Refs FIR-2459
