### PR TITLE
Cut CI wall clock: build Windows legs once, shard the macOS gate, route release-policy failures

### DIFF
--- a/.github/clippy-allowed-lints.txt
+++ b/.github/clippy-allowed-lints.txt
@@ -1,0 +1,62 @@
+# TEMPORARY debt allow-list; burn entries down and delete each allow once its
+# lint is clean. No additions without lead sign-off.
+#
+# Enumerated from `cargo clippy --all-targets --all-features` on main against
+# the CI toolchain (rustc/clippy 1.96.0, the channel in rust-toolchain.toml):
+# 45 distinct clippy lints (the 1.96 bump from 1.94 added collapsible_match,
+# manual_checked_ops, useless_conversion). Every consumer passes these AFTER a
+# `--`, which is what keeps each specific allow overriding the
+# RUSTFLAGS=-Dwarnings group. (The ArtifactId deprecation is now enforced. Its
+# `-A deprecated` rustc allow was removed once the graph-assigned ArtifactId
+# migration landed.)
+#
+# The list lives in a file rather than inline in ci.yml because two jobs now run
+# clippy, one per platform, and macOS-gated code is linted only by the macOS
+# one. Two inline copies would drift, and the drift would be invisible: the
+# platform whose copy still allowed a lint would stay green while the other went
+# red for a lint nobody meant to enforce yet.
+-A clippy::await_holding_lock
+-A clippy::bool_assert_comparison
+-A clippy::clone_on_copy
+-A clippy::collapsible_if
+-A clippy::collapsible_match
+-A clippy::derivable_impls
+-A clippy::doc_lazy_continuation
+-A clippy::doc_overindented_list_items
+-A clippy::field_reassign_with_default
+-A clippy::filter_map_bool_then
+-A clippy::for_kv_map
+-A clippy::format_in_format_args
+-A clippy::if_same_then_else
+-A clippy::int_plus_one
+-A clippy::io_other_error
+-A clippy::items_after_test_module
+-A clippy::large_enum_variant
+-A clippy::len_zero
+-A clippy::manual_checked_ops
+-A clippy::manual_contains
+-A clippy::manual_is_multiple_of
+-A clippy::manual_map
+-A clippy::manual_pattern_char_comparison
+-A clippy::manual_strip
+-A clippy::map_entry
+-A clippy::match_single_binding
+-A clippy::missing_const_for_thread_local
+-A clippy::needless_borrow
+-A clippy::needless_option_as_deref
+-A clippy::needless_question_mark
+-A clippy::needless_return
+-A clippy::new_without_default
+-A clippy::only_used_in_recursion
+-A clippy::ptr_arg
+-A clippy::redundant_closure
+-A clippy::redundant_field_names
+-A clippy::regex_creation_in_loops
+-A clippy::result_large_err
+-A clippy::too_many_arguments
+-A clippy::type_complexity
+-A clippy::unnecessary_cast
+-A clippy::unnecessary_map_or
+-A clippy::unnecessary_sort_by
+-A clippy::unnecessary_unwrap
+-A clippy::useless_conversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
           bash -n ./scripts/verify-npm-release.sh
           bash -n ./scripts/assert-windows-init-contract.sh
           bash -n ./scripts/windows-authority-legs.sh
+          bash -n ./scripts/test-windows-authority-legs.sh
+          bash -n ./scripts/release-policy-gate.sh
+          bash -n ./scripts/test-release-policy-gate.sh
           bash -n ./scripts/verify-base-image-pins.sh
           # install.sh is the public installer users pipe straight into a shell,
           # and the one with no pull-request syntax check. Its only `sh -n` runs
@@ -796,6 +799,14 @@ jobs:
       - name: Report the documentation-only fast path
         run: echo "documentation-only diff; build and test validation not applicable"
 
+  # The macOS half of this job moved to `check-macos` + `check-macos-aggregate`
+  # below, so this one now carries the ubuntu-latest context alone. The matrix
+  # stays, with one value, because it is what makes the display name expand to
+  # `Check & Test (ubuntu-latest)`, the exact required context name, and what
+  # keeps a SKIPPED job from expanding at all. The `runner.os == 'Linux'`
+  # conditions further down are now always true and are kept rather than
+  # deleted: they document which steps are Linux-only by intent, and they are
+  # what would keep this job honest if a platform were ever added back.
   check:
     name: Check & Test
     needs: changes
@@ -812,7 +823,7 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: "0"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v7
 
@@ -957,9 +968,30 @@ jobs:
       - name: Validate mandatory Homebrew release outcome gate
         run: python3 scripts/test-homebrew-release-gate.py
 
+      # Every validator below polices a repo-global invariant, so a break in one
+      # is a property of the tree rather than of the change under test and the
+      # identical failure lands on every open pull request and every queue entry
+      # at once. On 2026-08-19 a kin-vfs pin that had drifted between
+      # release.yml and rc-build.yml failed this step 70 times and ejected 32
+      # queue entries; four of the seven pull requests it ejected touched
+      # nothing release-related and could neither have caused the drift nor
+      # fixed it. The gate runs the same validators and routes their failure:
+      # hard for anything reaching release machinery, for the release pull
+      # request, for a push, and for a diff it cannot read, and a warning
+      # annotation otherwise. The invocations stay here rather than moving into
+      # the gate because the assertion-reachability gate reads this file to
+      # prove each suite still runs on pull requests.
       - name: Validate automatic release policy
         if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KIN_POLICY_EVENT: ${{ github.event_name }}
+          KIN_POLICY_HEAD_REF: ${{ github.head_ref }}
+          KIN_POLICY_REPOSITORY: ${{ github.repository }}
+          KIN_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          KIN_POLICY_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
+          bash scripts/release-policy-gate.sh <<'RELEASE_POLICY'
           python3 scripts/test-release-workflow-authority.py
           node --test \
             scripts/check-glibc-floor.test.mjs \
@@ -972,6 +1004,7 @@ jobs:
           node --check scripts/check-release-version.mjs
           node --check scripts/prepare-release.mjs
           node --check scripts/release-intent.mjs
+          RELEASE_POLICY
 
       # rc-build.yml builds release-candidate archives from a copy of
       # release.yml's build job, so the archive stranger and the preflight Linux
@@ -1052,63 +1085,41 @@ jobs:
           # nothing.
           python3 scripts/falsify-hydration-semantics.py "$poisoned"
 
-      # TEMPORARY debt allow-list; burn entries down and delete each allow once its
-      # lint is clean. No additions without lead sign-off.
-      # Enumerated from `cargo clippy --all-targets --all-features` on main against
-      # the CI toolchain (rustc/clippy 1.96.0, the channel in rust-toolchain.toml):
-      # 45 distinct clippy lints (the 1.96 bump from 1.94 added collapsible_match,
-      # manual_checked_ops, useless_conversion). The `--` keeps these allows AFTER the
-      # RUSTFLAGS=-Dwarnings group so each specific lint overrides it. (The ArtifactId
-      # deprecation is now enforced. Its `-A deprecated` rustc allow was removed once the
-      # graph-assigned ArtifactId migration landed.)
+      # Two gates that ROUTE a failure rather than merely reporting one: the
+      # release-policy gate decides whether a repo-global break belongs to the
+      # change under test, and the Windows leg helpers decide whether a leg's
+      # test selection was real. Each is driven in both directions here, the arm
+      # it must accept and the arm it must refuse, because a routing gate that
+      # only ever passes is indistinguishable from one that has stopped
+      # deciding. Both run after the toolchain step because the leg helpers
+      # resolve a compilation unit through cargo.
+      - name: Falsify the release policy and Windows leg gates
+        if: runner.os == 'Linux'
+        run: |
+          bash scripts/test-release-policy-gate.sh
+          bash scripts/test-windows-authority-legs.sh
+
+      # The debt allow-list lives in .github/clippy-allowed-lints.txt, with its
+      # own provenance note. Two jobs run clippy now, one per platform, and only
+      # the macOS one lints macOS-gated code; two inline copies of a 45-entry
+      # list would drift, and the drift would be invisible until the platform
+      # whose copy lost an allow went red for a lint nobody meant to enforce.
       - name: Clippy
-        run: >
-          cargo clippy --all-targets --all-features --
-          -A clippy::await_holding_lock
-          -A clippy::bool_assert_comparison
-          -A clippy::clone_on_copy
-          -A clippy::collapsible_if
-          -A clippy::collapsible_match
-          -A clippy::derivable_impls
-          -A clippy::doc_lazy_continuation
-          -A clippy::doc_overindented_list_items
-          -A clippy::field_reassign_with_default
-          -A clippy::filter_map_bool_then
-          -A clippy::for_kv_map
-          -A clippy::format_in_format_args
-          -A clippy::if_same_then_else
-          -A clippy::int_plus_one
-          -A clippy::io_other_error
-          -A clippy::items_after_test_module
-          -A clippy::large_enum_variant
-          -A clippy::len_zero
-          -A clippy::manual_checked_ops
-          -A clippy::manual_contains
-          -A clippy::manual_is_multiple_of
-          -A clippy::manual_map
-          -A clippy::manual_pattern_char_comparison
-          -A clippy::manual_strip
-          -A clippy::map_entry
-          -A clippy::match_single_binding
-          -A clippy::missing_const_for_thread_local
-          -A clippy::needless_borrow
-          -A clippy::needless_option_as_deref
-          -A clippy::needless_question_mark
-          -A clippy::needless_return
-          -A clippy::new_without_default
-          -A clippy::only_used_in_recursion
-          -A clippy::ptr_arg
-          -A clippy::redundant_closure
-          -A clippy::redundant_field_names
-          -A clippy::regex_creation_in_loops
-          -A clippy::result_large_err
-          -A clippy::too_many_arguments
-          -A clippy::type_complexity
-          -A clippy::unnecessary_cast
-          -A clippy::unnecessary_map_or
-          -A clippy::unnecessary_sort_by
-          -A clippy::unnecessary_unwrap
-          -A clippy::useless_conversion
+        shell: bash
+        run: |
+          set -euo pipefail
+          allows="$(grep -Ev '^(#|$)' .github/clippy-allowed-lints.txt | tr '\n' ' ')"
+          words="$(printf '%s\n' "$allows" | wc -w | tr -d ' ')"
+          if [ "$words" -lt 2 ]; then
+            echo "::error title=Empty clippy debt list::.github/clippy-allowed-lints.txt carries no allows"
+            echo "Clippy would run with the RUSTFLAGS -D warnings group and nothing" >&2
+            echo "overriding it, so every entry on the debt list would go red at once." >&2
+            exit 1
+          fi
+          echo "clippy debt allow-list: $((words / 2)) lints"
+          # The allow list is a word list, and splitting it is the point.
+          # shellcheck disable=SC2086
+          cargo clippy --all-targets --all-features -- $allows
 
       - name: Check Runtime Boundaries
         run: bash scripts/check_runtime_boundaries.sh
@@ -1195,6 +1206,160 @@ jobs:
       - name: Doc tests
         # nextest does not run doctests; keep them covered explicitly.
         run: cargo test --doc --locked
+
+  # The macOS half of Check & Test, sharded.
+  #
+  # `Check & Test (macos-latest)` was the last required check to report on 83%
+  # of merge_group runs and 73% of pull-request runs, at ~21.9 min. Of that,
+  # 14.2 min is the `Test` step alone: 6454 tests in 801.6s, against 7.5 min for
+  # the identical suite on ubuntu-latest, because macos-latest is a three-core
+  # arm64 runner and nextest ran the suite as a single partition. Splitting the
+  # partition is the whole point of this job.
+  #
+  # What this job carries is what macOS can answer differently from ubuntu:
+  # clippy over macOS-gated code, the build, the tests, and the doctests. The
+  # steps it does not carry are the source-reading gates whose result cannot
+  # depend on the runner at all, from the README language count through the
+  # zero-file-search and hydration guards. `Check & Test (ubuntu-latest)` is a
+  # required context and runs every one of them, so none is lost; running them a
+  # second time bought nothing but macOS minutes at ten times the billing rate.
+  #
+  # Within that set, shard 1 runs everything and shard 2 runs its own build and
+  # its own partition. Nothing before `Test` can differ between the shards, so
+  # repeating it would only pay twice for one answer, and the build is the one
+  # thing a partition genuinely needs of its own.
+  #
+  # This job publishes no required context. `check-macos-aggregate` below does,
+  # and it fails unless every shard here succeeded.
+  check-macos:
+    name: Check & Test macOS shard
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    strategy:
+      # A shard that dies must not take its sibling with it. With fail-fast on,
+      # one red shard cancels the other, the aggregate reads `cancelled` for a
+      # partition that was passing, and the run reports one cause where there
+      # may be two.
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/rust-toolchain
+        with:
+          components: clippy, rustfmt
+
+      - name: Verify kin cargo registry config
+        run: |
+          test -f .cargo/config.toml
+          grep -q '^\[registries\.kin\]' .cargo/config.toml
+          if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed. kin-* resolve from the Kin registry"; exit 1; fi
+
+      # Same trusted-ref scoping as every other cached job: restore always, save
+      # only from main. Both shards restore the same main entry, so the second
+      # one is not paying for the first one's warmth.
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # See .github/clippy-allowed-lints.txt. This is the only clippy pass over
+      # macOS-gated code, which is why it stays on the macOS side rather than
+      # being left to the ubuntu leg.
+      - name: Clippy
+        if: matrix.shard == 1
+        shell: bash
+        run: |
+          set -euo pipefail
+          allows="$(grep -Ev '^(#|$)' .github/clippy-allowed-lints.txt | tr '\n' ' ')"
+          words="$(printf '%s\n' "$allows" | wc -w | tr -d ' ')"
+          if [ "$words" -lt 2 ]; then
+            echo "::error title=Empty clippy debt list::.github/clippy-allowed-lints.txt carries no allows"
+            echo "Clippy would run with the RUSTFLAGS -D warnings group and nothing" >&2
+            echo "overriding it, so every entry on the debt list would go red at once." >&2
+            exit 1
+          fi
+          echo "clippy debt allow-list: $((words / 2)) lints"
+          # The allow list is a word list, and splitting it is the point.
+          # shellcheck disable=SC2086
+          cargo clippy --all-targets --all-features -- $allows
+
+      - name: Build
+        run: cargo build --all-targets --locked
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # `--partition count:N/M` splits the suite by test, deterministically, so
+      # the two shards together run exactly the set one unpartitioned run ran.
+      # The aggregate below is what makes "together" enforceable: a shard that
+      # never reported cannot leave its partition silently unrun.
+      - name: Test
+        run: cargo nextest run --locked --partition count:${{ matrix.shard }}/2
+
+      # nextest does not run doctests, so partitioning cannot cover them and one
+      # shard has to. They are a 0.9 min step and splitting them would cost more
+      # in a second cold `cargo test --doc` than it could save.
+      - name: Doc tests
+        if: matrix.shard == 1
+        run: cargo test --doc --locked
+
+  # The required context for macOS. Its display name plus its one matrix value
+  # compose to `Check & Test (macos-latest)`, byte for byte what ruleset
+  # 19746451, release-tag.yml's REQUIRED_CHECKS and expected_provenance tables,
+  # scripts/test-release-workflow-authority.py, and docs/release-bot.md all name.
+  # Nothing about that string changes; only the job producing it does.
+  #
+  # The matrix is not decoration. A skipped matrix job never expands, so on a
+  # documentation-only diff this publishes the bare `Check & Test` name and
+  # leaves `check-docs-only` as the sole producer of the expanded one, exactly
+  # as the real and stub `check` jobs already behave. Without the matrix, a
+  # skipped aggregate would publish `Check & Test (macos-latest)` as `skipped`
+  # beside the stub's success, and two check runs under one required name is the
+  # ambiguity the release mint refuses on.
+  #
+  # It runs on ubuntu-latest deliberately: it compiles nothing and spends
+  # seconds, and macOS bills at ten times the rate. The matrix value names the
+  # platform this context speaks for, not the platform it runs on.
+  check-macos-aggregate:
+    name: Check & Test
+    needs: [changes, check-macos]
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        os: [macos-latest]
+    steps:
+      # `needs.<job>.result` for a matrix job is the roll-up of every leg, so
+      # this is `success` only when both shards succeeded. Requiring exactly
+      # `success` is what makes a SKIPPED or CANCELLED shard fail this check
+      # rather than pass it: a shard that never ran left half the macOS suite
+      # unexecuted, and a required context that goes green on that is worse than
+      # no context at all.
+      - name: Require every macOS shard to have succeeded
+        env:
+          SHARDS: ${{ needs.check-macos.result }}
+        run: |
+          set -euo pipefail
+          if [ "$SHARDS" != "success" ]; then
+            echo "::error title=macOS shards did not pass::the sharded macOS Check & Test legs reported '$SHARDS'"
+            echo "Every partition of the macOS suite has to report success for this" >&2
+            echo "context to be evidence that the suite ran. 'skipped' and 'cancelled'" >&2
+            echo "mean a partition did not run at all." >&2
+            exit 1
+          fi
+          echo "every macOS Check & Test shard succeeded"
 
   # Two sets of steps used to run inside Check & Test and gate nothing that
   # needed them to be there. Both sat on the merge queue's critical path: five

--- a/scripts/release-policy-gate.sh
+++ b/scripts/release-policy-gate.sh
@@ -225,6 +225,18 @@ main() {
   # shellcheck disable=SC2064
   [ -z "$cleanup" ] || trap "rm -f '$cleanup'" EXIT
 
+  # Printed on EVERY run, not only a failing one. The routing inputs are read
+  # from event payloads that differ per event type, and if one of them arrives
+  # empty the gate resolves the diff as unreadable and hard-fails, which is
+  # indistinguishable from the behaviour this step had before. That is the safe
+  # direction, and it is also invisible: the soft path would simply never fire
+  # and nobody would learn why. This line is what makes the wiring checkable
+  # from a green run.
+  echo "release-policy gate: event=${KIN_POLICY_EVENT:-unset}" \
+    "head_ref=${KIN_POLICY_HEAD_REF:-none}" \
+    "base_sha=${KIN_POLICY_BASE_SHA:-unset}" \
+    "head_sha=${KIN_POLICY_HEAD_SHA:-unset}"
+
   if run_validators "$commands"; then
     echo "release policy validators passed"
     return 0

--- a/scripts/release-policy-gate.sh
+++ b/scripts/release-policy-gate.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Run the automatic release-policy validators, and decide who a failure belongs
+# to before turning it into a red required context.
+#
+# These validators police repo-global invariants: that rc-build.yml still
+# mirrors release.yml's build job, that the version files agree, that the mint's
+# authority tables match the workflow that produces them. A break in any of
+# them is a property of the tree, not of the change under test, so the identical
+# failure appears on every open pull request and every merge-queue entry at
+# once. On 2026-08-19 one such break, a kin-vfs pin that had drifted between
+# release.yml and rc-build.yml, failed this step 70 times and ejected 32 queue
+# entries in a morning. Four of the seven pull requests it ejected touched
+# nothing release-related, could not have caused the drift, and could not have
+# fixed it. Each ejection cost a full requeue, and the queue lost roughly
+# thirteen hours of serialized wall clock to a defect none of those changes
+# introduced.
+#
+# So the failure is routed rather than softened:
+#
+#   - A change that touches release machinery still HARD-FAILS. Workflows,
+#     version manifests, the changelog, the abandoned-tag ledger, and the
+#     scripts these validators read are exactly where a real regression comes
+#     from, and the release pull request itself is always in this class.
+#   - Any event that is not a pull request or a merge-queue entry HARD-FAILS.
+#     The push build on main is the one release-tag.yml reads for provenance, so
+#     a broken invariant must be red there and must stop a mint.
+#   - Anything else fails SOFT: the validators still run, the failure is still
+#     printed in full and raised as a warning annotation, and the entry is not
+#     ejected for a defect it did not bring.
+#
+# Everything unknown resolves to HARD. An unreadable diff, an unclassifiable
+# event, a missing input: each of those is the state where the gate cannot prove
+# the change is unrelated, and the safe reading of "cannot prove" is the
+# behaviour this step had before.
+#
+# Transient refusals get a bounded retry ahead of that decision, because a
+# network stumble inside a validator is neither a real break nor a reason to
+# eject. The retry is keyed on the failure text: a deterministic assertion
+# reproduces identically and is never retried past its first attempt beyond the
+# bounded count, which costs seconds and cannot mask anything.
+#
+# Usage: release-policy-gate.sh [commands-file]
+# With no argument the commands are read from stdin, which is how ci.yml passes
+# them: the validator invocations stay visible in the workflow, where the
+# assertion-reachability gate can see that they run.
+
+set -euo pipefail
+
+RELEASE_POLICY_ATTEMPTS="${KIN_POLICY_ATTEMPTS:-3}"
+RELEASE_POLICY_BACKOFF="${KIN_POLICY_BACKOFF:-10}"
+RELEASE_BRANCH="automation/release-next"
+
+# Paths whose change can plausibly cause, or fix, one of these validators.
+# Deliberately wide: over-including a path costs the old behaviour, which is a
+# hard failure, while under-including one lets a real release regression land
+# behind a warning. `*` matches `/` in a bash case pattern, so a directory
+# prefix covers its whole subtree.
+release_relevant_path() {
+  case "$1" in
+    .github/*) return 0 ;;
+    scripts/*) return 0 ;;
+    packages/*) return 0 ;;
+    Cargo.toml | Cargo.lock | rust-toolchain.toml) return 0 ;;
+    crates/*/Cargo.toml) return 0 ;;
+    CHANGELOG.md) return 0 ;;
+    docs/release-bot.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Read paths on stdin, print `touched` or `untouched`. Blank input is not
+# "untouched": a diff that produced no paths is a diff this gate failed to read.
+classify_paths() {
+  local seen=0
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    seen=1
+    if release_relevant_path "$path"; then
+      printf 'touched\n'
+      return 0
+    fi
+  done
+  if [ "$seen" -eq 0 ]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  printf 'untouched\n'
+}
+
+# The whole routing decision, as one pure function so it can be driven directly
+# by the falsification test. `relevance` is touched / untouched / unknown.
+release_policy_severity() {
+  local event="$1"
+  local head_ref="$2"
+  local relevance="$3"
+
+  if [ "$head_ref" = "$RELEASE_BRANCH" ]; then
+    printf 'hard\n'
+    return 0
+  fi
+  case "$event" in
+    pull_request | merge_group) ;;
+    *)
+      printf 'hard\n'
+      return 0
+      ;;
+  esac
+  if [ "$relevance" = "untouched" ]; then
+    printf 'soft\n'
+    return 0
+  fi
+  printf 'hard\n'
+}
+
+# A failure worth trying again. Matched against the validators' own output, so
+# a deterministic assertion never matches and never spends the budget.
+transient_failure() {
+  case "$1" in
+    *"Could not resolve host"*) return 0 ;;
+    *"Temporary failure in name resolution"*) return 0 ;;
+    *"EAI_AGAIN"*) return 0 ;;
+    *"ECONNRESET"*) return 0 ;;
+    *"ETIMEDOUT"*) return 0 ;;
+    *"Connection reset"*) return 0 ;;
+    *"Connection timed out"*) return 0 ;;
+    *"TLS connect error"*) return 0 ;;
+    *"502 Bad Gateway"*) return 0 ;;
+    *"503 Service Unavailable"*) return 0 ;;
+    *"504 Gateway"*) return 0 ;;
+    *"rate limit exceeded"*) return 0 ;;
+    *"secondary rate limit"*) return 0 ;;
+    *"server error"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# The changed-path list for this event, or nothing at all. The compare endpoint
+# caps `files` at 300 and says nothing when it truncates, so a diff at the cap
+# is reported as unreadable rather than as a partial answer that could classify
+# a release-touching change as unrelated.
+changed_paths() {
+  local repo="${KIN_POLICY_REPOSITORY:-}"
+  local base="${KIN_POLICY_BASE_SHA:-}"
+  local head="${KIN_POLICY_HEAD_SHA:-}"
+  if [ -z "$repo" ] || [ -z "$base" ] || [ -z "$head" ]; then
+    return 1
+  fi
+
+  local attempt=1
+  local response=""
+  local status=0
+  while [ "$attempt" -le "$RELEASE_POLICY_ATTEMPTS" ]; do
+    status=0
+    response="$(gh api "repos/$repo/compare/$base...$head" 2>&1)" || status=$?
+    if [ "$status" -eq 0 ]; then
+      break
+    fi
+    echo "release-policy gate: compare attempt $attempt failed" >&2
+    printf '%s\n' "$response" >&2
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le "$RELEASE_POLICY_ATTEMPTS" ]; then
+      sleep "$RELEASE_POLICY_BACKOFF"
+    fi
+  done
+  if [ "$status" -ne 0 ]; then
+    return 1
+  fi
+
+  local count
+  count="$(printf '%s' "$response" | jq '.files | length')" || return 1
+  if [ "$count" -ge 300 ]; then
+    echo "release-policy gate: compare returned $count files and may be truncated" >&2
+    return 1
+  fi
+  printf '%s' "$response" | jq -r '.files[].filename'
+}
+
+resolve_relevance() {
+  local paths
+  if ! paths="$(changed_paths)"; then
+    printf 'unknown\n'
+    return 0
+  fi
+  printf '%s\n' "$paths" | classify_paths
+}
+
+run_validators() {
+  local commands="$1"
+  local attempt=1
+  local status=0
+  local output=""
+  while [ "$attempt" -le "$RELEASE_POLICY_ATTEMPTS" ]; do
+    status=0
+    output="$(bash -euo pipefail "$commands" 2>&1)" || status=$?
+    printf '%s\n' "$output"
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+    if ! transient_failure "$output"; then
+      break
+    fi
+    echo "release-policy gate: attempt $attempt failed on a transient refusal" >&2
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le "$RELEASE_POLICY_ATTEMPTS" ]; then
+      sleep "$RELEASE_POLICY_BACKOFF"
+    fi
+  done
+  return "${status:-1}"
+}
+
+main() {
+  local commands
+  local cleanup=""
+  if [ "$#" -ge 1 ]; then
+    commands="$1"
+  else
+    commands="$(mktemp)"
+    cleanup="$commands"
+    cat > "$commands"
+  fi
+  # shellcheck disable=SC2064
+  [ -z "$cleanup" ] || trap "rm -f '$cleanup'" EXIT
+
+  if run_validators "$commands"; then
+    echo "release policy validators passed"
+    return 0
+  fi
+
+  local event="${KIN_POLICY_EVENT:-}"
+  local head_ref="${KIN_POLICY_HEAD_REF:-}"
+  local relevance
+  relevance="$(resolve_relevance)"
+  local severity
+  severity="$(release_policy_severity "$event" "$head_ref" "$relevance")"
+
+  echo "release-policy gate: event=$event head_ref=${head_ref:-<none>} release-paths=$relevance severity=$severity" >&2
+
+  if [ "$severity" = "hard" ]; then
+    echo "::error title=Automatic release policy::the release-policy validators failed on a change that reaches release machinery"
+    return 1
+  fi
+
+  echo "::warning title=Automatic release policy::the release-policy validators are failing on a repository-wide invariant this change does not touch. The failure is real and is reported above; it is not attributed to this entry, which is why this check is not red. Fix it in a change that touches release machinery, where this gate hard-fails."
+  return 0
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/scripts/test-release-policy-gate.sh
+++ b/scripts/test-release-policy-gate.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Falsify scripts/release-policy-gate.sh.
+#
+# The gate decides whether a failing release-policy validator turns a required
+# context red. Both of its mistakes are silent. Routed too softly, a real
+# release regression lands behind a warning nobody reads, and the next tag is
+# the one that finds out. Routed too harshly, the gate is what it replaced and
+# the next repo-global break ejects the queue again.
+#
+# So every arm is driven here, in both directions: the soft path is proven to
+# exist, and it is proven NOT to exist for a release-touching change, for the
+# release pull request, for a push, or for a diff the gate could not read. The
+# routing decision is a pure function precisely so it can be driven without a
+# network, and the end-to-end arms replace `changed_paths` after sourcing rather
+# than giving the production script an injection point that a workflow edit
+# could aim at itself.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT/scripts/release-policy-gate.sh"
+
+if [ ! -f "$GATE" ]; then
+  echo "missing gate under test: $GATE" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export KIN_POLICY_BACKOFF=0
+export KIN_POLICY_ATTEMPTS=3
+
+# shellcheck source=scripts/release-policy-gate.sh
+source "$GATE"
+
+failures=0
+
+report() { echo "  $1"; }
+
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+expect_equal() {
+  local label="$1"
+  local want="$2"
+  local got="$3"
+  if [ "$want" = "$got" ]; then
+    report "$label"
+  else
+    fail "$label: wanted '$want', got '$got'"
+  fi
+}
+
+echo "path classification"
+
+for path in \
+  ".github/workflows/ci.yml" \
+  ".github/workflows/release.yml" \
+  "scripts/check-rc-build-drift.mjs" \
+  "scripts/abandoned-release-tags.json" \
+  "Cargo.toml" \
+  "Cargo.lock" \
+  "rust-toolchain.toml" \
+  "crates/kin-cli/Cargo.toml" \
+  "packages/kin/package.json" \
+  "CHANGELOG.md" \
+  "docs/release-bot.md"; do
+  expect_equal "release path '$path' classifies as touched" \
+    "touched" "$(printf '%s\n' "$path" | classify_paths)"
+done
+
+for path in \
+  "crates/kin-cli/src/commands/setup.rs" \
+  "crates/kin-core/src/init.rs" \
+  "README.md" \
+  "docs/architecture.md" \
+  "src/main.rs"; do
+  expect_equal "unrelated path '$path' classifies as untouched" \
+    "untouched" "$(printf '%s\n' "$path" | classify_paths)"
+done
+
+expect_equal "one release path among many decides the whole diff" \
+  "touched" \
+  "$(printf '%s\n' "crates/kin-core/src/init.rs" "README.md" "Cargo.lock" | classify_paths)"
+
+expect_equal "an empty path list is unknown, not untouched" \
+  "unknown" "$(printf '' | classify_paths)"
+
+echo "routing decision"
+
+expect_equal "a merge-queue entry touching release machinery hard-fails" \
+  "hard" "$(release_policy_severity merge_group "" touched)"
+expect_equal "a merge-queue entry touching nothing release-related fails soft" \
+  "soft" "$(release_policy_severity merge_group "" untouched)"
+expect_equal "a pull request touching nothing release-related fails soft" \
+  "soft" "$(release_policy_severity pull_request "some/branch" untouched)"
+expect_equal "a pull request touching release machinery hard-fails" \
+  "hard" "$(release_policy_severity pull_request "some/branch" touched)"
+expect_equal "the release pull request hard-fails even on an unrelated diff" \
+  "hard" "$(release_policy_severity pull_request "automation/release-next" untouched)"
+expect_equal "a push to main hard-fails" \
+  "hard" "$(release_policy_severity push "" untouched)"
+expect_equal "a repository_dispatch hard-fails" \
+  "hard" "$(release_policy_severity repository_dispatch "" untouched)"
+expect_equal "an unreadable diff hard-fails" \
+  "hard" "$(release_policy_severity merge_group "" unknown)"
+
+echo "transient classification"
+
+for text in \
+  "curl: (6) Could not resolve host: github.com" \
+  "Error: connect ETIMEDOUT 140.82.121.6:443" \
+  "read ECONNRESET" \
+  "HTTP 503 Service Unavailable" \
+  "API rate limit exceeded for 1.2.3.4"; do
+  if transient_failure "$text"; then
+    report "retryable: ${text:0:40}"
+  else
+    fail "did not classify as transient: $text"
+  fi
+done
+
+for text in \
+  "AssertionError: rc-build.yml no longer mirrors release.yml" \
+  "not ok 27 - the workflows in the tree agree" \
+  "assertion reachability gate failed: missing call site"; do
+  if transient_failure "$text"; then
+    fail "classified a deterministic failure as transient: $text"
+  else
+    report "not retryable: ${text:0:40}"
+  fi
+done
+
+echo "end to end"
+
+COUNTER="$WORK/attempts"
+
+# `main` is invoked in a subshell so its EXIT trap and its exit status stay its
+# own. Output is captured whole; nothing here is judged through a pipe.
+drive() {
+  local label="$1"
+  local want_status="$2"
+  local want_needle="$3"
+  local commands="$4"
+  local want_paths="$5"
+  local event="$6"
+  local head_ref="$7"
+
+  : > "$COUNTER"
+  local output
+  local status=0
+  output="$(
+    changed_paths() { printf '%s\n' $want_paths; }
+    KIN_POLICY_EVENT="$event" KIN_POLICY_HEAD_REF="$head_ref" \
+      main "$commands" 2>&1
+  )" || status=$?
+
+  if [ "$status" -ne "$want_status" ]; then
+    fail "$label: wanted exit $want_status, got $status"
+    printf '%s\n' "$output" >&2
+    return
+  fi
+  case "$output" in
+    *"$want_needle"*) report "$label" ;;
+    *)
+      fail "$label: output did not carry '$want_needle'"
+      printf '%s\n' "$output" >&2
+      ;;
+  esac
+}
+
+cat > "$WORK/passing.sh" <<EOF
+printf 'x' >> "$COUNTER"
+echo "all validators agree"
+EOF
+
+cat > "$WORK/deterministic.sh" <<EOF
+printf 'x' >> "$COUNTER"
+echo "AssertionError: rc-build.yml no longer mirrors release.yml" >&2
+exit 1
+EOF
+
+cat > "$WORK/transient-then-passing.sh" <<EOF
+printf 'x' >> "$COUNTER"
+if [ "\$(wc -c < "$COUNTER" | tr -d ' ')" -lt 3 ]; then
+  echo "curl: (6) Could not resolve host: github.com" >&2
+  exit 1
+fi
+echo "all validators agree on the third attempt"
+EOF
+
+attempts() { wc -c < "$COUNTER" | tr -d ' '; }
+
+drive "passing validators exit clean" 0 "release policy validators passed" \
+  "$WORK/passing.sh" "README.md" merge_group ""
+expect_equal "a passing run costs one attempt" "1" "$(attempts)"
+
+drive "a real failure on a release-touching entry is an error" 1 \
+  "::error title=Automatic release policy" \
+  "$WORK/deterministic.sh" "Cargo.lock" merge_group ""
+
+drive "a real failure on an unrelated entry is a warning" 0 \
+  "::warning title=Automatic release policy" \
+  "$WORK/deterministic.sh" "crates/kin-core/src/init.rs" merge_group ""
+expect_equal "a deterministic failure is not retried" "1" "$(attempts)"
+
+drive "the failure text is still printed on the soft path" 0 \
+  "rc-build.yml no longer mirrors release.yml" \
+  "$WORK/deterministic.sh" "crates/kin-core/src/init.rs" merge_group ""
+
+drive "the release pull request never takes the soft path" 1 \
+  "::error title=Automatic release policy" \
+  "$WORK/deterministic.sh" "crates/kin-core/src/init.rs" \
+  pull_request "automation/release-next"
+
+drive "a push to main never takes the soft path" 1 \
+  "::error title=Automatic release policy" \
+  "$WORK/deterministic.sh" "crates/kin-core/src/init.rs" push ""
+
+drive "a transient refusal is retried and then passes" 0 \
+  "release policy validators passed" \
+  "$WORK/transient-then-passing.sh" "crates/kin-core/src/init.rs" merge_group ""
+expect_equal "the transient arm took three attempts" "3" "$(attempts)"
+
+# An unreadable diff must not become a soft pass. `changed_paths` returning
+# non-zero is what the real one does when the compare call or its inputs fail.
+: > "$COUNTER"
+unreadable_status=0
+unreadable_output="$(
+  changed_paths() { return 1; }
+  KIN_POLICY_EVENT=merge_group KIN_POLICY_HEAD_REF="" \
+    main "$WORK/deterministic.sh" 2>&1
+)" || unreadable_status=$?
+if [ "$unreadable_status" -eq 1 ]; then
+  case "$unreadable_output" in
+    *"::error title=Automatic release policy"*)
+      report "an unreadable diff hard-fails end to end" ;;
+    *)
+      fail "an unreadable diff failed without the error annotation"
+      printf '%s\n' "$unreadable_output" >&2 ;;
+  esac
+else
+  fail "an unreadable diff did not hard-fail (exit $unreadable_status)"
+  printf '%s\n' "$unreadable_output" >&2
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "release policy gate: $failures assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "release policy gate: routing, retry, and both failure directions hold"

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -495,10 +495,43 @@ REAL_CHECK_JOB_AUTHORITY = textwrap.dedent(
         CARGO_PROFILE_TEST_DEBUG: "0"
       strategy:
         matrix:
-          os: [ubuntu-latest, macos-latest]
+          os: [ubuntu-latest]
       steps:
     """
 ).rstrip()
+# The macOS shards publish `Check & Test macOS shard (1)` and `(2)`, which no
+# ruleset requires, and the aggregate is what publishes the required
+# `Check & Test (macos-latest)`. Two properties make that safe and both are
+# pinned here, because neither is observable from the required context's name:
+# the aggregate carries a one-value matrix, without which a SKIPPED aggregate
+# would publish the expanded name beside the documentation-only stub's and put
+# two check runs under one required name; and it admits only `success` from the
+# shard roll-up, without which a skipped or cancelled shard would leave half the
+# macOS suite unrun behind a green required context.
+MACOS_SHARD_AGGREGATE_AUTHORITY = textwrap.dedent(
+    """\
+    check-macos-aggregate:
+      name: Check & Test
+      needs: [changes, check-macos]
+      if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      strategy:
+        matrix:
+          os: [macos-latest]
+      steps:
+    """
+).rstrip()
+# Indented as `classifier_active_job_source` renders a dedented job block, which
+# is the form these are matched against.
+MACOS_SHARD_RUNNER = "  runs-on: macos-latest"
+MACOS_SHARD_INDEPENDENT_LEGS = "    fail-fast: false"
+MACOS_SHARD_MATRIX = "      shard: [1, 2]"
+MACOS_SHARD_PARTITION = (
+    "      run: cargo nextest run --locked --partition count:${{ matrix.shard }}/2"
+)
+MACOS_SHARD_DOCTESTS = "      run: cargo test --doc --locked"
+MACOS_SHARD_SUCCESS_GATE = 'if [ "$SHARDS" != "success" ]; then'
 CI_JOB_DISPLAY_NAMES = {
     "dco": "DCO Sign-off",
     "npm-launchers": "npm launcher tests",
@@ -509,6 +542,13 @@ CI_JOB_DISPLAY_NAMES = {
     "changes": "Classify diff scope",
     "check-docs-only": "Check & Test",
     "check": "Check & Test",
+    # The macOS half of Check & Test, split so its 14.2-minute test step can run
+    # as two nextest partitions. The shard job publishes a name of its own and
+    # is required by nothing; the aggregate publishes `Check & Test` with a
+    # one-value matrix, which expands to the release-required
+    # `Check & Test (macos-latest)` and is what the ruleset names.
+    "check-macos": "Check & Test macOS shard",
+    "check-macos-aggregate": "Check & Test",
     # Both were steps inside `check` and are jobs so they stop sitting on the
     # merge queue's critical path. Neither is a required context until the
     # branch ruleset names it, so each is listed here to be reviewed as a
@@ -680,9 +720,16 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     ): "495829aee07c97dfd59924fcac7ff3ddb57be574ffd0bf741adc93a37425b492",
 }
 REQUIRED_CHECK_JOB_PRODUCERS = {
+    # Three producers, one per required expansion plus the documentation-only
+    # stub. `check` carries ubuntu-latest, `check-macos-aggregate` carries
+    # macos-latest and is green only when every `check-macos` shard succeeded,
+    # and `check-docs-only` publishes both names on a documentation-only diff.
+    # The real jobs and the stub stay mutually exclusive by condition, so no two
+    # of them ever publish the same expanded name on one event.
     "Check & Test": {
         (".github/workflows/ci.yml", "check-docs-only"),
         (".github/workflows/ci.yml", "check"),
+        (".github/workflows/ci.yml", "check-macos-aggregate"),
     },
     "Falsify guards": {
         (".github/workflows/ci.yml", "falsify-guards"),
@@ -4156,6 +4203,54 @@ def assert_check_consumer_authority(workflow: str) -> None:
             "Check & Test consumer authority requires the exact real check admission "
             "and matrix contract"
         )
+
+
+def assert_macos_shard_authority(workflow: str) -> None:
+    """Pin the sharded macOS producer of `Check & Test (macos-latest)`.
+
+    Sharding a required context is the cheapest possible way to lose half a test
+    suite. The shards publish names no ruleset requires, so nothing outside this
+    file notices what they run; the aggregate publishes the name the ruleset
+    does require, and it is a five-second job that compiles nothing. Everything
+    that makes it evidence rather than decoration is asserted here, because none
+    of it is visible from the context name:
+
+    the aggregate admits only `success` from the shard roll-up, so a SKIPPED or
+    CANCELLED shard fails it instead of passing it; it carries a one-value matrix,
+    so a skipped aggregate publishes the bare name and cannot put a second check
+    run under the required expanded one beside the documentation-only stub; the
+    shards run the partitions, which together are the suite one unpartitioned run
+    ran; one shard still runs the doctests nextest does not run; and fail-fast is
+    off, so a red shard cannot cancel a sibling that was passing.
+    """
+
+    blocks = workflow_job_blocks(workflow)
+    shards = blocks.get("check-macos")
+    aggregate = blocks.get("check-macos-aggregate")
+    if shards is None or aggregate is None:
+        raise AssertionError(
+            "macOS shard authority requires both the shard job and its aggregate"
+        )
+    if real_check_job_authority_source(aggregate) != MACOS_SHARD_AGGREGATE_AUTHORITY:
+        raise AssertionError(
+            "macOS shard authority requires the exact reviewed aggregate admission "
+            "and matrix contract"
+        )
+
+    active_shards = classifier_active_job_source(shards)
+    for policy in (
+        MACOS_SHARD_RUNNER,
+        MACOS_SHARD_INDEPENDENT_LEGS,
+        MACOS_SHARD_MATRIX,
+        MACOS_SHARD_PARTITION,
+        MACOS_SHARD_DOCTESTS,
+    ):
+        require(active_shards, policy, "macOS shard authority")
+    require(
+        classifier_active_job_source(aggregate),
+        MACOS_SHARD_SUCCESS_GATE,
+        "macOS shard authority",
+    )
 
 
 def execute_docs_only_classifier(
@@ -11129,9 +11224,92 @@ def main() -> None:
         ),
     )
     assert_check_consumer_authority(ci_workflow)
+    assert_macos_shard_authority(ci_workflow)
     consumer_blocks = workflow_job_blocks(ci_workflow)
     docs_only_check = consumer_blocks["check-docs-only"]
     real_check = consumer_blocks["check"]
+    macos_shards = consumer_blocks["check-macos"]
+    macos_aggregate = consumer_blocks["check-macos-aggregate"]
+
+    for label, old, new in (
+        (
+            "the aggregate accepts a shard result that is not success",
+            'if [ "$SHARDS" != "success" ]; then',
+            'if [ "$SHARDS" = "failure" ]; then',
+        ),
+        (
+            "the aggregate loses the matrix that keeps a skip from expanding",
+            "        os: [macos-latest]",
+            "        os: []",
+        ),
+        (
+            "the aggregate stops waiting on the shards",
+            "    needs: [changes, check-macos]",
+            "    needs: changes",
+        ),
+        (
+            "the aggregate takes the display name of the shard job",
+            "    name: Check & Test",
+            "    name: Check & Test macOS aggregate",
+        ),
+    ):
+        if macos_aggregate.count(old) != 1:
+            raise AssertionError(
+                f"macOS shard falsification could not identify {label}"
+            )
+        mutant_workflow = ci_workflow.replace(
+            macos_aggregate, macos_aggregate.replace(old, new, 1), 1
+        )
+        expect_assertion(
+            label,
+            "macOS shard authority",
+            lambda mutant_workflow=mutant_workflow: assert_macos_shard_authority(
+                mutant_workflow
+            ),
+        )
+
+    for label, old, new in (
+        (
+            "a shard stops partitioning and both legs run the whole suite",
+            "        run: cargo nextest run --locked "
+            "--partition count:${{ matrix.shard }}/2",
+            "        run: cargo nextest run --locked",
+        ),
+        (
+            "the doctest pass nextest cannot run disappears",
+            "        run: cargo test --doc --locked",
+            "        run: echo doctests skipped",
+        ),
+        (
+            "one red shard is allowed to cancel its passing sibling",
+            "      fail-fast: false",
+            "      fail-fast: true",
+        ),
+        (
+            "the shards leave macOS",
+            "    runs-on: macos-latest",
+            "    runs-on: ubuntu-latest",
+        ),
+        (
+            "the shard count changes without the partition denominator",
+            "        shard: [1, 2]",
+            "        shard: [1, 2, 3]",
+        ),
+    ):
+        if macos_shards.count(old) != 1:
+            raise AssertionError(
+                f"macOS shard falsification could not identify {label}"
+            )
+        mutant_workflow = ci_workflow.replace(
+            macos_shards, macos_shards.replace(old, new, 1), 1
+        )
+        expect_assertion(
+            label,
+            "macOS shard authority",
+            lambda mutant_workflow=mutant_workflow: assert_macos_shard_authority(
+                mutant_workflow
+            ),
+        )
 
     docs_only_condition = (
         "    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}"
@@ -11228,9 +11406,13 @@ def main() -> None:
             "    runs-on: ubuntu-latest",
         ),
         (
+            # Restoring the two-platform matrix is the specific regression to
+            # catch: `check` would publish `Check & Test (macos-latest)` again,
+            # beside the aggregate's, and put two check runs under one required
+            # context name.
             "real Check & Test matrix changed",
-            "        os: [ubuntu-latest, macos-latest]",
             "        os: [ubuntu-latest]",
+            "        os: [ubuntu-latest, macos-latest]",
         ),
     ):
         if real_check.count(old) != 1:
@@ -12366,10 +12548,11 @@ def main() -> None:
 
     ci_path = WORKFLOWS / "ci.yml"
     check_start = ci_workflow.index("\n  check:")
-    # `falsify-guards` and `feature-tests` sit between `check` and `coverage`,
-    # so slicing to `coverage:` would hand this falsification three jobs and
-    # count save lines that are not the check job's.
-    check_end = ci_workflow.index("\n  falsify-guards:", check_start)
+    # The slice has to stop at the very next job. `check-macos` follows `check`
+    # and caches too, and `falsify-guards` and `feature-tests` follow that, so
+    # slicing to any of them would hand this falsification several jobs and count
+    # save lines that are not the check job's.
+    check_end = ci_workflow.index("\n  check-macos:", check_start)
     check_job = ci_workflow[check_start:check_end]
     save_line = f"          {MAIN_ONLY_CACHE_SAVE}\n"
     if check_job.count(save_line) != 1:

--- a/scripts/test-windows-authority-legs.sh
+++ b/scripts/test-windows-authority-legs.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+#
+# Drive scripts/windows-authority-legs.sh against a real cargo package.
+#
+# The helpers under test decide what the three native Windows authority jobs
+# prove, and they now resolve a compilation unit once and execute the compiled
+# test binary for every leg after that. Two classes of breakage are invisible
+# without this file. A memo that silently misses re-enters cargo for every leg
+# and gives back the minutes the change was made to save, while reporting a
+# perfectly green job. An emptiness guard that stops firing reports success for
+# a test that was renamed away, which is the exact condition the helpers were
+# written to catch.
+#
+# So this runs both arms. It proves the helpers pass a real selection, and it
+# proves each guard still FAILS on the input it exists to reject. It also counts
+# cargo entries through a PATH shim, because "built once" is a claim about
+# process count that no assertion on the test result can see.
+#
+# The fixture is a throwaway package outside the repository: a lib with unit
+# tests, a bin, and an integration test. That shape is what makes the artifact
+# selector falsifiable, because `cargo test --no-run` for an integration test
+# also builds the package binary and that binary carries an `executable` of its
+# own.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPERS="$ROOT/scripts/windows-authority-legs.sh"
+
+if [ ! -f "$HELPERS" ]; then
+  echo "missing helpers under test: $HELPERS" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FIXTURE="$WORK/legfixture"
+mkdir -p "$FIXTURE/src" "$FIXTURE/tests" "$WORK/bin"
+
+cat > "$FIXTURE/Cargo.toml" <<'EOF'
+[package]
+name = "legfixture"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "legfixture"
+path = "src/lib.rs"
+
+[[bin]]
+name = "legfixture"
+path = "src/main.rs"
+EOF
+
+# `runs_where_cargo_would_run_it` is the cwd and environment assertion. Cargo
+# runs a test binary with the working directory at the package root and
+# CARGO_MANIFEST_DIR exported; a bare execution from the repository root does
+# neither, and a test reading either would change behaviour for a reason having
+# nothing to do with the test.
+cat > "$FIXTURE/src/lib.rs" <<'EOF'
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn unit_addition() {
+        assert_eq!(super::add(1, 1), 2);
+    }
+
+    #[test]
+    fn unit_identity() {
+        assert_eq!(super::add(2, 0), 2);
+    }
+
+    #[test]
+    fn runs_where_cargo_would_run_it() {
+        let cwd = std::env::current_dir().expect("a working directory");
+        assert!(
+            cwd.join("Cargo.toml").is_file(),
+            "working directory is not the package root: {cwd:?}"
+        );
+        let manifest_dir =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is exported");
+        let manifest_dir =
+            std::fs::canonicalize(manifest_dir).expect("CARGO_MANIFEST_DIR resolves");
+        let cwd = std::fs::canonicalize(cwd).expect("the working directory resolves");
+        assert_eq!(manifest_dir, cwd);
+    }
+}
+EOF
+
+cat > "$FIXTURE/src/main.rs" <<'EOF'
+fn main() {
+    println!("legfixture");
+}
+EOF
+
+cat > "$FIXTURE/tests/integration.rs" <<'EOF'
+#[test]
+fn integration_reaches_the_library() {
+    assert_eq!(legfixture::add(3, 4), 7);
+}
+EOF
+
+CARGO_BIN="$(command -v cargo)"
+CALLS="$WORK/cargo-calls"
+: > "$CALLS"
+
+cat > "$WORK/bin/cargo" <<EOF
+#!/usr/bin/env bash
+printf 'x' >> "$CALLS"
+exec "$CARGO_BIN" "\$@"
+EOF
+chmod +x "$WORK/bin/cargo"
+
+export PATH="$WORK/bin:$PATH"
+export CARGO_TARGET_DIR="$WORK/target"
+export KIN_WINDOWS_LEG_CACHE_DIR="$WORK/leg-cache"
+mkdir -p "$KIN_WINDOWS_LEG_CACHE_DIR"
+
+cd "$FIXTURE"
+
+# shellcheck source=scripts/windows-authority-legs.sh
+source "$HELPERS"
+
+failures=0
+
+report() {
+  echo "  $1"
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+cargo_entries() {
+  wc -c < "$CALLS" | tr -d ' '
+}
+
+# Every helper call runs in a subshell, positive arm included, because the
+# helpers `exit` rather than return. A bare call that trips a guard would take
+# this file down with it, and the run would end mid-arm having reported nothing
+# about which assertion was reached: exit 1 with a truncated log reads the same
+# whether the guard fired correctly or the harness broke. Output is captured
+# whole and printed on an unexpected result. A pipeline's status is its last
+# stage's, so nothing here is judged through `head`, `tail`, or a pipe.
+LAST_OUTPUT=""
+
+expect_pass() {
+  local label="$1"
+  shift
+  local status=0
+  LAST_OUTPUT="$( "$@" 2>&1 )" || status=$?
+  if [ "$status" -ne 0 ]; then
+    fail "$label did not pass (exit $status)"
+    printf '%s\n' "$LAST_OUTPUT" >&2
+    return 1
+  fi
+  report "$label"
+  return 0
+}
+
+expect_refusal() {
+  local label="$1"
+  local needle="$2"
+  shift 2
+  local output
+  local status=0
+  output="$( "$@" 2>&1 )" || status=$?
+  if [ "$status" -eq 0 ]; then
+    fail "$label was accepted; the guard cannot fire"
+    printf '%s\n' "$output" >&2
+    return
+  fi
+  case "$output" in
+    *"$needle"*) report "refused $label" ;;
+    *)
+      fail "$label was refused for the wrong reason (wanted '$needle')"
+      printf '%s\n' "$output" >&2
+      ;;
+  esac
+}
+
+echo "positive arm"
+
+before="$(cargo_entries)"
+if expect_pass "ran a filtered library leg" \
+  run_required_filter "fixture library units" "unit_" --lib; then
+  case "$LAST_OUTPUT" in
+    *"filter 'unit_' matched 2 test(s)"*) : ;;
+    *)
+      fail "the filtered leg did not report its match count"
+      printf '%s\n' "$LAST_OUTPUT" >&2
+      ;;
+  esac
+fi
+after_first="$(cargo_entries)"
+if [ "$((after_first - before))" -ne 1 ]; then
+  fail "resolving one unit took $((after_first - before)) cargo entries, expected 1"
+fi
+
+# The cwd and environment assertion lives in the fixture's own test, so a
+# regression there fails the run rather than this file's bookkeeping.
+expect_pass "ran the compiled binary the way cargo runs it" \
+  run_required_exact "cargo-equivalent execution" \
+  "tests::runs_where_cargo_would_run_it" --lib || true
+
+after_second="$(cargo_entries)"
+if [ "$after_second" -ne "$after_first" ]; then
+  fail "a second leg on the same unit entered cargo again ($after_first -> $after_second)"
+else
+  report "a second leg on the same unit entered cargo zero more times"
+fi
+
+# A different argument vector is a different compilation unit and must build.
+expect_pass "ran a whole integration target" \
+  run_required_target "fixture integration binary" \
+  "integration_reaches_the_library" --test integration || true
+after_third="$(cargo_entries)"
+if [ "$((after_third - after_second))" -ne 1 ]; then
+  fail "a distinct unit took $((after_third - after_second)) cargo entries, expected 1"
+fi
+
+# `cargo test --no-run --test integration` also builds the package binary, and
+# that binary carries an `executable` of its own. Resolving to it instead of the
+# harness would run the fixture's main and report success having tested nothing.
+if expect_pass "resolved a single integration unit" \
+  resolve_leg_unit --test integration; then
+  resolved="${LAST_OUTPUT%%$'\t'*}"
+  case "$(basename "$resolved")" in
+    integration-*) report "selected the test harness, not the package binary" ;;
+    *) fail "resolved the wrong artifact: $resolved" ;;
+  esac
+fi
+
+expect_pass "compiled and listed without running" \
+  compile_required_target "fixture compile-only" \
+  "integration_reaches_the_library" --test integration || true
+
+echo "falsification arm"
+
+expect_refusal "a filter matching nothing" \
+  "matched zero listed tests" \
+  run_required_filter "renamed away" "no_such_test_name" --lib
+
+expect_refusal "an exact name that does not exist" \
+  "expected exactly one" \
+  run_required_exact "renamed away" "tests::no_such_test" --lib
+
+expect_refusal "a required name absent from a whole target" \
+  "expected exactly one" \
+  run_required_target "renamed away" "no_such_test" --test integration
+
+expect_refusal "a compile target whose required test is gone" \
+  "expected exactly one" \
+  compile_required_target "renamed away" "no_such_test" --test integration
+
+# No target selector at all builds the lib harness AND the integration harness,
+# so the leg names two compilation units and cannot say which one it drives.
+expect_refusal "a selection naming more than one test binary" \
+  "Ambiguous native Windows test binary" \
+  resolve_leg_unit
+
+# An empty listing is the condition the original guards were written for: a
+# target that builds and lists nothing must not read as a passing leg.
+mkdir -p "$WORK/emptyfixture/src"
+cat > "$WORK/emptyfixture/Cargo.toml" <<'EOF'
+[package]
+name = "emptyfixture"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "emptyfixture"
+path = "src/lib.rs"
+EOF
+cat > "$WORK/emptyfixture/src/lib.rs" <<'EOF'
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+EOF
+cd "$WORK/emptyfixture"
+expect_refusal "a target that lists zero tests" \
+  "listed zero tests" \
+  run_nonempty_target "no tests at all" --lib
+cd "$FIXTURE"
+
+if [ "$failures" -ne 0 ]; then
+  echo "windows authority leg helpers: $failures assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "windows authority leg helpers: positive and falsification arms both hold"

--- a/scripts/test-windows-authority-legs.sh
+++ b/scripts/test-windows-authority-legs.sh
@@ -120,8 +120,14 @@ chmod +x "$WORK/bin/cargo"
 
 export PATH="$WORK/bin:$PATH"
 export CARGO_TARGET_DIR="$WORK/target"
-export KIN_WINDOWS_LEG_CACHE_DIR="$WORK/leg-cache"
-mkdir -p "$KIN_WINDOWS_LEG_CACHE_DIR"
+
+# KIN_WINDOWS_LEG_CACHE_DIR is deliberately NOT set. Pinning it here was how the
+# memo's own assertion came to prove nothing: the helpers create the directory
+# themselves when the variable is empty, that is the path CI takes, and an
+# earlier version created a fresh one per call and missed every time. A test
+# that supplies the directory exercises neither. The override is covered
+# separately at the end.
+unset KIN_WINDOWS_LEG_CACHE_DIR
 
 cd "$FIXTURE"
 
@@ -152,14 +158,23 @@ cargo_entries() {
 # stage's, so nothing here is judged through `head`, `tail`, or a pipe.
 LAST_OUTPUT=""
 
+# The positive arm calls the helpers DIRECTLY, in this shell, because that is
+# how ci.yml calls them and because the memo depends on it: the helpers export
+# their cache directory, and an export made inside a command substitution dies
+# with the subshell. Running the positive arm through substitutions is what let
+# a memo that missed every single time read as a passing assertion. The cost is
+# that a helper's hard `exit` takes this file with it, so the label is printed
+# BEFORE the call and the run's last line names where it stopped.
 expect_pass() {
   local label="$1"
   shift
+  echo "  running: $label"
   local status=0
-  LAST_OUTPUT="$( "$@" 2>&1 )" || status=$?
+  "$@" > "$WORK/last.log" 2>&1 || status=$?
+  LAST_OUTPUT="$(cat "$WORK/last.log")"
   if [ "$status" -ne 0 ]; then
     fail "$label did not pass (exit $status)"
-    printf '%s\n' "$LAST_OUTPUT" >&2
+    cat "$WORK/last.log" >&2
     return 1
   fi
   report "$label"
@@ -290,6 +305,39 @@ expect_refusal "a target that lists zero tests" \
   "listed zero tests" \
   run_nonempty_target "no tests at all" --lib
 cd "$FIXTURE"
+
+echo "cache directory arm"
+
+# The helpers must have created the directory themselves, in THIS shell, which
+# is what makes the memo survive between legs. If they created it inside a
+# command substitution the variable would be unset here and every leg would have
+# built its own.
+if [ -n "${KIN_WINDOWS_LEG_CACHE_DIR:-}" ] && [ -d "$KIN_WINDOWS_LEG_CACHE_DIR" ]; then
+  report "the helpers created and exported one cache directory"
+else
+  fail "no cache directory survived the legs; the memo cannot persist"
+fi
+
+entries="$(find "$KIN_WINDOWS_LEG_CACHE_DIR" -type f | wc -l | tr -d ' ')"
+if [ "$entries" -ge 2 ]; then
+  report "the cache holds $entries resolved units"
+else
+  fail "the cache holds $entries entries after several distinct units"
+fi
+
+# The override still works, and a caller-supplied directory is used rather than
+# a fresh one.
+override="$WORK/explicit-cache"
+mkdir -p "$override"
+(
+  export KIN_WINDOWS_LEG_CACHE_DIR="$override"
+  run_required_filter "override cache" "unit_" --lib > /dev/null 2>&1
+)
+if [ "$(find "$override" -type f | wc -l | tr -d ' ')" -ge 1 ]; then
+  report "an explicit cache directory is honoured"
+else
+  fail "an explicit KIN_WINDOWS_LEG_CACHE_DIR was ignored"
+fi
 
 if [ "$failures" -ne 0 ]; then
   echo "windows authority leg helpers: $failures assertion(s) failed" >&2

--- a/scripts/windows-authority-legs.sh
+++ b/scripts/windows-authority-legs.sh
@@ -83,12 +83,23 @@ _leg_count_lines() {
 # current directory, so the same arguments in two directories are two units; and
 # without the prefix an empty argument vector keys the cache DIRECTORY itself,
 # which `-s` reports as non-empty and `cat` then reads as a resolved unit.
-_leg_cache_dir() {
+#
+# Where the directory is created is what decides whether the memo works at all.
+# A command substitution runs in a subshell, so an export made inside one is
+# discarded the moment it returns. The first version of this returned the
+# directory on stdout and every caller read it as `$(_leg_cache_dir)`, so each
+# call minted a FRESH mktemp directory the next call could not see. The memo
+# missed every time, the helpers fell back to one cargo entry per leg, and the
+# job stayed green while giving the saving back. Measured on run 32276720780:
+# eight `Finished test profile` lines in a job whose eight legs name a single
+# compilation unit. This is why the initialiser sets a variable instead of
+# printing one, and why the bottom of this file calls it at source time, in the
+# shell that sourced it.
+_leg_cache_dir_init() {
   if [ -z "${KIN_WINDOWS_LEG_CACHE_DIR:-}" ]; then
     KIN_WINDOWS_LEG_CACHE_DIR="$(mktemp -d)"
     export KIN_WINDOWS_LEG_CACHE_DIR
   fi
-  printf '%s\n' "$KIN_WINDOWS_LEG_CACHE_DIR"
 }
 
 _leg_cache_key() {
@@ -103,7 +114,8 @@ _leg_cache_key() {
 # instead of being swallowed by the capture.
 resolve_leg_unit() {
   local cache artifacts executables manifests count
-  cache="$(_leg_cache_dir)/$(_leg_cache_key "$@")"
+  _leg_cache_dir_init
+  cache="$KIN_WINDOWS_LEG_CACHE_DIR/$(_leg_cache_key "$@")"
   if [ -f "$cache" ] && [ -s "$cache" ]; then
     cat "$cache"
     return 0
@@ -277,3 +289,12 @@ compile_required_target() {
   fi
   echo "$label: compiled and listed required test '$required_test'"
 }
+
+# Initialise the memo HERE, at source time, in the shell that sourced this file.
+# `resolve_leg_unit` is always reached through a command substitution, because
+# every helper reads its stdout, and an export made inside a substitution dies
+# with the subshell that made it. Initialising there produced a fresh directory
+# per call and a memo that missed every time, which is invisible: the helpers
+# fall back to one cargo entry per leg and the job stays green. A `source` runs
+# in the caller's shell, so this is the one place the export survives.
+_leg_cache_dir_init

--- a/scripts/windows-authority-legs.sh
+++ b/scripts/windows-authority-legs.sh
@@ -19,10 +19,139 @@
 # reviewable workflow policy, and the release authority test asserts against it
 # there.
 #
+# BUILD ONCE, DRIVE THE BINARY. Every helper used to enter cargo twice, once for
+# `cargo test -- --list` and again for the filtered run, and the three jobs
+# between them made 51 cargo entries to execute 39 seconds of tests. On
+# windows-latest each entry costs roughly a minute of freshness and link
+# accounting even when nothing recompiles: one sampled CLI job spent 23.5 min in
+# 16 entries whose test binary hash was identical every time, against a
+# rust-cache reporting a full hit. So the compilation unit is resolved once per
+# distinct argument vector through `cargo test --no-run`, memoised, and both the
+# listing and the run are then driven from the compiled test binary. Repeating a
+# leg against a unit already built costs a process, not a cargo entry.
+#
+# What that preserves, deliberately:
+#
+#   - The cargo invocation shape is unchanged. `--no-run` takes the same
+#     arguments the run used to take, so feature resolution, target selection,
+#     and the built binary are the same ones the old form produced. Grouping
+#     several packages into one cargo entry would be faster still and is NOT
+#     done here, because a wider `-p` selection unifies features across the
+#     selected packages and would change what each leg proves.
+#   - The listing is the same listing. `<binary> --list` is what
+#     `cargo test -- --list` shells out to, so the emptiness and exactness
+#     guards read identical text.
+#   - The binary runs the way cargo runs it: working directory at the package
+#     root, `CARGO_MANIFEST_DIR` exported, and the artifact directory ahead of
+#     PATH so a colocated dependency resolves. Cargo sets those, a bare
+#     execution does not, and a test that reads any of them would otherwise
+#     change behaviour for a reason having nothing to do with the test.
+#
 # Source this file from a `bash` step that has already set `-euo pipefail`.
 
+# `cargo test --no-run` reports every artifact it built, including the package
+# binaries an integration test links against through CARGO_BIN_EXE_*. Those
+# carry an `executable` too, so selecting on `executable` alone picks up a
+# `kin.exe` beside the test harness. Only a test-harness artifact carries
+# `"test":true` INSIDE its profile object, which is what this selects on: the
+# profile object holds scalars only, so `[^}]*` cannot run past its closing
+# brace into the rest of the record. Verified against real cargo output for a
+# package with a lib, a bin and an integration test: three artifact records, one
+# match.
+_leg_test_executables() {
+  sed -n 's/.*"profile":{[^}]*"test":true}.*"executable":"\([^"]*\)".*/\1/p' \
+    | sed 's|\\\\|/|g'
+}
+
+_leg_test_manifests() {
+  sed -n 's/.*"manifest_path":"\([^"]*\)".*"profile":{[^}]*"test":true}.*"executable":"[^"]*".*/\1/p' \
+    | sed 's|\\\\|/|g'
+}
+
+_leg_count_lines() {
+  awk 'NF { count += 1 } END { print count + 0 }'
+}
+
+# A memo keyed on the argument vector, held in files rather than an associative
+# array so the script still parses and runs under the bash 3.2 a developer may
+# have locally. Non-alphanumeric bytes collapse to underscores, which is
+# injective enough here: two legs collide only if their arguments differ solely
+# in punctuation, and such a pair would name the same compilation unit anyway.
+#
+# The working directory is part of the key and the key carries a fixed prefix.
+# Cargo resolves a package selection against the manifest it finds from the
+# current directory, so the same arguments in two directories are two units; and
+# without the prefix an empty argument vector keys the cache DIRECTORY itself,
+# which `-s` reports as non-empty and `cat` then reads as a resolved unit.
+_leg_cache_dir() {
+  if [ -z "${KIN_WINDOWS_LEG_CACHE_DIR:-}" ]; then
+    KIN_WINDOWS_LEG_CACHE_DIR="$(mktemp -d)"
+    export KIN_WINDOWS_LEG_CACHE_DIR
+  fi
+  printf '%s\n' "$KIN_WINDOWS_LEG_CACHE_DIR"
+}
+
+_leg_cache_key() {
+  local joined="$PWD|$*"
+  printf '%s\n' "unit-${joined//[^A-Za-z0-9]/_}"
+}
+
+# Resolve one compilation unit to "<executable>\t<package root>", building it at
+# most once per distinct argument vector. Diagnostics are rendered to stderr by
+# `json-render-diagnostics` rather than folded into the JSON on stdout, so a
+# compile failure under `-D warnings` still reports itself as compiler output
+# instead of being swallowed by the capture.
+resolve_leg_unit() {
+  local cache artifacts executables manifests count
+  cache="$(_leg_cache_dir)/$(_leg_cache_key "$@")"
+  if [ -f "$cache" ] && [ -s "$cache" ]; then
+    cat "$cache"
+    return 0
+  fi
+
+  artifacts="$(cargo test --no-run --message-format=json-render-diagnostics "$@")"
+  executables="$(printf '%s\n' "$artifacts" | _leg_test_executables)"
+  manifests="$(printf '%s\n' "$artifacts" | _leg_test_manifests)"
+  count="$(printf '%s\n' "$executables" | _leg_count_lines)"
+  if [ "$count" -ne 1 ]; then
+    echo "::error title=Ambiguous native Windows test binary::cargo test --no-run built $count test binaries for: $*"
+    echo "Each Windows authority leg must name exactly one compilation unit, because" >&2
+    echo "the leg then drives that binary directly. Narrow the target selection." >&2
+    printf '%s\n' "$executables" >&2
+    exit 1
+  fi
+  count="$(printf '%s\n' "$manifests" | _leg_count_lines)"
+  if [ "$count" -ne 1 ]; then
+    echo "::error title=Unresolvable native Windows package root::cargo test --no-run reported $count manifests for: $*"
+    exit 1
+  fi
+
+  printf '%s\t%s\n' \
+    "$(printf '%s\n' "$executables" | head -n 1)" \
+    "$(dirname "$(printf '%s\n' "$manifests" | head -n 1)")" \
+    > "$cache"
+  cat "$cache"
+}
+
+# Run a resolved unit's binary the way cargo would have run it.
+_leg_exec() {
+  local unit="$1"
+  shift
+  local executable package_root
+  executable="${unit%%$'\t'*}"
+  package_root="${unit#*$'\t'}"
+  (
+    cd "$package_root" || exit 1
+    CARGO_MANIFEST_DIR="$package_root" \
+    PATH="$(dirname "$executable"):$PATH" \
+      "$executable" "$@"
+  )
+}
+
 list_tests() {
-  CARGO_TERM_COLOR=never cargo test "$@" -- --list | tr -d '\r'
+  local unit
+  unit="$(resolve_leg_unit "$@")"
+  _leg_exec "$unit" --list | tr -d '\r'
 }
 
 assert_nonempty_listing() {
@@ -42,19 +171,23 @@ assert_nonempty_listing() {
 run_nonempty_target() {
   local label="$1"
   shift
+  local unit
   local listing
-  listing="$(list_tests "$@")"
+  unit="$(resolve_leg_unit "$@")"
+  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
   assert_nonempty_listing "$label" "$listing"
-  cargo test "$@" -- --test-threads=1
+  _leg_exec "$unit" --test-threads=1
 }
 
 run_required_filter() {
   local label="$1"
   local filter="$2"
   shift 2
+  local unit
   local listing
   local matches
-  listing="$(list_tests "$@")"
+  unit="$(resolve_leg_unit "$@")"
+  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
   matches="$(printf '%s\n' "$listing" \
     | awk -v needle="$filter" \
       'index($0, needle) > 0 && /: test$/ { count += 1 } END { print count + 0 }')"
@@ -64,16 +197,18 @@ run_required_filter() {
     exit 1
   fi
   echo "$label: filter '$filter' matched $matches test(s)"
-  cargo test "$@" "$filter" -- --test-threads=1
+  _leg_exec "$unit" "$filter" --test-threads=1
 }
 
 run_required_exact() {
   local label="$1"
   local test_name="$2"
   shift 2
+  local unit
   local listing
   local matches
-  listing="$(list_tests "$@")"
+  unit="$(resolve_leg_unit "$@")"
+  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
   matches="$(printf '%s\n' "$listing" \
     | awk -v expected="$test_name: test" \
       '$0 == expected { count += 1 } END { print count + 0 }')"
@@ -82,16 +217,18 @@ run_required_exact() {
     printf '%s\n' "$listing"
     exit 1
   fi
-  cargo test "$@" "$test_name" -- --exact --test-threads=1
+  _leg_exec "$unit" "$test_name" --exact --test-threads=1
 }
 
 run_required_target() {
   local label="$1"
   local required_test="$2"
   shift 2
+  local unit
   local listing
   local matches
-  listing="$(list_tests "$@")"
+  unit="$(resolve_leg_unit "$@")"
+  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
   assert_nonempty_listing "$label" "$listing"
   matches="$(printf '%s\n' "$listing" \
     | awk -v expected="$required_test: test" \
@@ -101,16 +238,18 @@ run_required_target() {
     printf '%s\n' "$listing"
     exit 1
   fi
-  cargo test "$@" -- --test-threads=1
+  _leg_exec "$unit" --test-threads=1
 }
 
 compile_required_target() {
   local label="$1"
   local required_test="$2"
   shift 2
+  local unit
   local listing
   local matches
-  listing="$(list_tests "$@")"
+  unit="$(resolve_leg_unit "$@")"
+  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
   assert_nonempty_listing "$label" "$listing"
   matches="$(printf '%s\n' "$listing" \
     | awk -v expected="$required_test: test" \

--- a/scripts/windows-authority-legs.sh
+++ b/scripts/windows-authority-legs.sh
@@ -163,10 +163,11 @@ _leg_exec() {
   )
 }
 
-list_tests() {
-  local unit
-  unit="$(resolve_leg_unit "$@")"
-  _leg_exec "$unit" --list | tr -d '\r'
+# The listing a leg's guards read. It is the same text `cargo test -- --list`
+# produced, because that is what cargo shells out to. `tr -d` strips the CRs a
+# native Windows binary writes, so the awk matches below see plain lines.
+_leg_listing() {
+  _leg_exec "$1" --list | tr -d '\r'
 }
 
 assert_nonempty_listing() {
@@ -189,7 +190,7 @@ run_nonempty_target() {
   local unit
   local listing
   unit="$(resolve_leg_unit "$@")"
-  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
+  listing="$(_leg_listing "$unit")"
   assert_nonempty_listing "$label" "$listing"
   _leg_exec "$unit" --test-threads=1
 }
@@ -202,7 +203,7 @@ run_required_filter() {
   local listing
   local matches
   unit="$(resolve_leg_unit "$@")"
-  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
+  listing="$(_leg_listing "$unit")"
   matches="$(printf '%s\n' "$listing" \
     | awk -v needle="$filter" \
       'index($0, needle) > 0 && /: test$/ { count += 1 } END { print count + 0 }')"
@@ -223,7 +224,7 @@ run_required_exact() {
   local listing
   local matches
   unit="$(resolve_leg_unit "$@")"
-  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
+  listing="$(_leg_listing "$unit")"
   matches="$(printf '%s\n' "$listing" \
     | awk -v expected="$test_name: test" \
       '$0 == expected { count += 1 } END { print count + 0 }')"
@@ -243,7 +244,7 @@ run_required_target() {
   local listing
   local matches
   unit="$(resolve_leg_unit "$@")"
-  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
+  listing="$(_leg_listing "$unit")"
   assert_nonempty_listing "$label" "$listing"
   matches="$(printf '%s\n' "$listing" \
     | awk -v expected="$required_test: test" \
@@ -264,7 +265,7 @@ compile_required_target() {
   local listing
   local matches
   unit="$(resolve_leg_unit "$@")"
-  listing="$(_leg_exec "$unit" --list | tr -d '\r')"
+  listing="$(_leg_listing "$unit")"
   assert_nonempty_listing "$label" "$listing"
   matches="$(printf '%s\n' "$listing" \
     | awk -v expected="$required_test: test" \

--- a/scripts/windows-authority-legs.sh
+++ b/scripts/windows-authority-legs.sh
@@ -112,9 +112,13 @@ resolve_leg_unit() {
   artifacts="$(cargo test --no-run --message-format=json-render-diagnostics "$@")"
   executables="$(printf '%s\n' "$artifacts" | _leg_test_executables)"
   manifests="$(printf '%s\n' "$artifacts" | _leg_test_manifests)"
+  # These annotations go to stderr, not stdout. Callers read this function
+  # through a command substitution, which captures stdout, so an `::error` line
+  # written there would be swallowed into the caller's variable and never reach
+  # the log. GitHub reads workflow commands off either stream.
   count="$(printf '%s\n' "$executables" | _leg_count_lines)"
   if [ "$count" -ne 1 ]; then
-    echo "::error title=Ambiguous native Windows test binary::cargo test --no-run built $count test binaries for: $*"
+    echo "::error title=Ambiguous native Windows test binary::cargo test --no-run built $count test binaries for: $*" >&2
     echo "Each Windows authority leg must name exactly one compilation unit, because" >&2
     echo "the leg then drives that binary directly. Narrow the target selection." >&2
     printf '%s\n' "$executables" >&2
@@ -122,7 +126,7 @@ resolve_leg_unit() {
   fi
   count="$(printf '%s\n' "$manifests" | _leg_count_lines)"
   if [ "$count" -ne 1 ]; then
-    echo "::error title=Unresolvable native Windows package root::cargo test --no-run reported $count manifests for: $*"
+    echo "::error title=Unresolvable native Windows package root::cargo test --no-run reported $count manifests for: $*" >&2
     exit 1
   fi
 
@@ -134,16 +138,27 @@ resolve_leg_unit() {
 }
 
 # Run a resolved unit's binary the way cargo would have run it.
+#
+# The artifact directory goes on PATH through `cygpath -u` where that exists.
+# PATH is a COLON-separated list, and a `D:/a/kin/...` component in one is
+# ambiguous to the MSYS conversion that runs when bash spawns a native Windows
+# process: the drive letter can be read as its own entry. A single path argument
+# has no such ambiguity, which is why the executable and the package root are
+# passed through as they are and only the list is converted.
 _leg_exec() {
   local unit="$1"
   shift
-  local executable package_root
+  local executable package_root artifact_dir
   executable="${unit%%$'\t'*}"
   package_root="${unit#*$'\t'}"
+  artifact_dir="$(dirname "$executable")"
+  if command -v cygpath > /dev/null 2>&1; then
+    artifact_dir="$(cygpath -u "$artifact_dir")"
+  fi
   (
     cd "$package_root" || exit 1
     CARGO_MANIFEST_DIR="$package_root" \
-    PATH="$(dirname "$executable"):$PATH" \
+    PATH="$artifact_dir:$PATH" \
       "$executable" "$@"
   )
 }


### PR DESCRIPTION
Three CI changes that give back runner minutes and stop one class of merge-queue ejection. No required status context changes name, so no ruleset, no release-tag.yml table, and no docs edit rides along.

## Windows authority legs build once and drive the compiled binary

Every helper in `scripts/windows-authority-legs.sh` entered cargo twice per leg, once for `cargo test -- --list` and again for the filtered run. Across the three Windows jobs that is 26 legs and 51 cargo entries to execute 39 seconds of tests. It was never compilation: a sampled CLI job spent 23.5 minutes in 16 entries whose test binary hash was identical every time, against a rust-cache reporting a full hit, so each entry was paying roughly 88 seconds of freshness and link accounting on windows-latest.

The helpers now resolve a compilation unit once per distinct argument vector through `cargo test --no-run`, memoise the resolved test binary and its package root, and drive that binary for both the listing and the run.

| job | legs | cargo entries before | after |
|---|---:|---:|---:|
| Windows authority tests | 11 | 22 | 6 |
| Windows authority CLI tests | 8 | 16 | 1 |
| Windows authority runtime tests | 7 | 13 | 5 |
| total | 26 | 51 | 12 |

Measured on this branch's own run 32279143527, reading the entry counts out of the job logs: one entry for the CLI job's eight legs, six for the core job's eleven, five for the runtime job's seven. The CLI job is the clean read, because its eight legs are one compilation unit, and it came in at 7.2 minutes against 24.8 on main.

The other two moved less, and that is the honest shape of the win rather than a disappointment. This run had no rust-cache entry to restore, so every unit paid a real build and a repeat entry on an already-built tree cost 0.26 to 0.58 seconds. The 65 to 88 seconds per entry the profile measured is what cargo pays re-fingerprinting a RESTORED target directory, which is the warm case and the normal one, and that is where the other sixteen avoided entries land. None of these three jobs is a required context, so this buys billable minutes and full-run wall clock, not gating wall clock.

Three things are preserved deliberately. The cargo invocation shape is unchanged, so `--no-run` takes the same arguments the run took and feature resolution and the built binary are identical. The listing is the same text, because `<binary> --list` is what `cargo test -- --list` shells out to. And the binary runs the way cargo runs it, with the working directory at the package root, `CARGO_MANIFEST_DIR` exported, and the artifact directory ahead of PATH.

Grouping several packages into one cargo entry would be faster still and is not done here, because a wider `-p` selection unifies features across the selected packages and would change what each leg proves.

The sharp part is which artifact to drive. `cargo test --no-run --test X` also builds the package binary an integration test links through `CARGO_BIN_EXE_*`, and that binary carries an `executable` of its own, so selecting on `executable` alone runs the fixture's `main` and reports success having tested nothing. Only a test-harness artifact carries `"test":true` inside its `profile` object, which is what the selector keys on, verified against real cargo output for a package with a lib, a bin and an integration test.

## The macOS half of Check & Test is sharded two ways

`Check & Test (macos-latest)` was the last required check to report on 83 percent of merge_group runs and 73 percent of pull-request runs, at about 21.9 minutes. Of that, 14.2 minutes is the Test step alone: 6454 tests in 801.6 seconds, against 7.5 minutes for the identical suite on ubuntu-latest, because macos-latest is a three-core arm64 runner and nextest ran the suite as a single partition.

`check` now carries `os: [ubuntu-latest]` alone. The macOS work moved to `check-macos`, a two-shard matrix running `cargo nextest run --locked --partition count:N/2`, and `check-macos-aggregate` publishes the required context. Shard 1 is today's macOS leg with its Test step partitioned; shard 2 runs the other partition and nothing else.

The required context name is byte identical. The aggregate is `name: Check & Test` with a one-value `os: [macos-latest]` matrix, which composes to exactly `Check & Test (macos-latest)`. Ruleset 19746451, release-tag.yml's `REQUIRED_CHECKS` and `expected_provenance` tables, and `docs/release-bot.md` are untouched and need no edit.

Two properties make the aggregate evidence rather than decoration, and the release-authority suite pins both. It admits only `success` from `needs.check-macos.result`, which for a matrix job is the roll-up of every leg, so a skipped or cancelled shard fails it instead of passing it. And it carries that one-value matrix, because a skipped matrix job never expands: on a documentation-only diff the aggregate publishes the bare `Check & Test` name and leaves `check-docs-only` as the sole producer of the expanded one. Without the matrix, a skipped aggregate would publish `Check & Test (macos-latest)` as skipped beside the stub's success, and two check runs under one required name is the ambiguity the release mint refuses on.

nextest does not run doctests, so `cargo test --doc --locked` still runs on shard 1 and the authority suite pins that it exists.

What the macOS side no longer carries is the source-reading gates whose result cannot differ by platform: the README language count, the installer checksum fixtures, assertion reachability, the Homebrew gate, both zero-file-search guards, both hydration guards, runtime boundaries, private repo coupling, and fmt. `Check & Test (ubuntu-latest)` is a required context and runs every one of them, so no gate is lost. macOS keeps what macOS can answer differently, which is clippy over macOS-gated code, the build, the tests and the doctests.

Honest about what this buys, with the measurement. The Test step went from 14.2 minutes to 8.9 and 8.3 on the two shards, about 39 percent off rather than 50, because a `count` partition splits tests but each shard still loads every test binary and the slow tail does not divide evenly. Shard 2 pays its own build, so this costs about three extra macOS minutes per event, and at the 10x macOS rate it buys latency rather than cost.

And it does not reach a 15.5-minute gating wall. `Feature permutation tests (macos-latest)` is the next required check, at 18.6 minutes warm and 17.8 on this run, so the wall lands there instead. Sharding feature permutations the same way is the next lever and is not in this change.

The clippy debt allow-list moved to `.github/clippy-allowed-lints.txt`, read by both platform jobs, because two inline copies of a 45-entry list would drift and the drift would be invisible until one platform went red for a lint nobody meant to enforce yet.

## Release-policy validators route their failure instead of ejecting the queue

These validators police repository-wide invariants, so a break in one is a property of the tree rather than of the change under test, and the identical failure appears on every open pull request and every queue entry at once. On 2026-08-19 a kin-vfs commit that had drifted between release.yml and rc-build.yml failed this step 70 times and ejected 32 queue entries in a morning. Four of the seven pull requests it ejected touched nothing release related, could not have caused the drift, and could not have fixed it. Each ejection cost a full requeue, and the queue lost roughly thirteen hours of serialized wall clock to a defect none of those changes introduced.

`scripts/release-policy-gate.sh` runs the same validators, retries a bounded number of times when the failure text matches a transient signature, and then routes the failure. It hard-fails when the diff touches release machinery, when the head ref is `automation/release-next`, when the event is anything other than a pull request or a merge-queue entry, and when it could not read the diff. Everything else fails soft: the validator output is still printed in full and raised as a warning annotation, and the entry is not ejected for a defect it did not bring.

Push on main still hard-fails, which matters because that is the build release-tag.yml reads for provenance, so a broken invariant still stops a mint. Everything unknown resolves to hard, which is the behaviour this step had before.

The validator invocations stay written in ci.yml and are fed to the gate over a heredoc, so `scripts/test-assertion-reachability.py` can still see that each suite runs on pull requests. The changed-path list comes from the compare API with the same bounded retry, and a compare at the 300-file cap is reported as unreadable rather than as a partial answer that could classify a release-touching change as unrelated.

## Falsification

Both new gates ship with suites that drive every arm in both directions, wired into Check & Test on Linux, because a routing gate that only ever passes is indistinguishable from one that has stopped deciding.

The Windows leg helpers were mutated seven ways and every mutant is caught with a named failure: the artifact selector losing its test-profile clause, the binary running without cargo's working directory and environment, the memo never hitting, and each of the four emptiness and exactness guards disabled. Writing that suite found two real bugs before any of this shipped. An empty argument vector sanitised to an empty cache key, so the cache path was the cache directory itself, `-s` reported a non-empty directory as a hit, and `cat` read it as a resolved unit. And the memo was keyed on the argument vector alone, so the same arguments in two directories resolved to one unit, which is wrong because cargo resolves a package selection from the current directory.

The release-policy gate was mutated five ways, all caught: severity always soft, workflow paths no longer release relevant, an empty diff reading as untouched, every failure classified transient, and the release branch losing its carve-out.

The release-authority suite gained a macOS shard assertion and nine falsification cases. Five were also driven externally against the real ci.yml, each confirmed to make the suite exit 1 with the expected message: `check` regaining the macOS matrix leg, the aggregate accepting a non-success roll-up, the aggregate losing its one-value matrix, the shards no longer partitioning, and the shards losing `fail-fast: false`.

A defect this change introduced, found by its own first run and fixed here. The memo missed every single time: the cache directory was created inside a command substitution, so the export died with the subshell and each call minted a fresh temporary directory. The helpers fell back to one cargo entry per leg, which is still half of the two-per-leg form, so the job ran faster and stayed green while giving most of the saving back. The initialiser now sets a variable instead of printing one, and the file calls it at source time, in the shell that sourced it, because `resolve_leg_unit` is always reached through a substitution and can never export to its caller.

The test could not have caught that, twice over. It exported the cache directory before sourcing, so the helpers never took the path CI takes, and it drove its positive arm through command substitutions of its own, which would have discarded the export anyway. It now leaves the variable unset, calls the helpers directly the way ci.yml does, and asserts both that a cache directory survived the legs and that it holds one entry per distinct unit. Reverting the helpers to the substitution form fails the suite on exactly those two assertions.

Refs FIR-2459
