### PR TITLE
Collapse a retrieval response's three verdict blocks into one

### DIFF
--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -233,13 +233,31 @@ pub fn build_refs_response(
         ));
     };
 
+    // FIR-2463. The count and the held rows are one reading, so they are printed
+    // as one line. A reader who stops at "No resolved incoming calls relations."
+    // and never reaches the candidates paragraph below has read a zero the same
+    // response is contradicting, which is the shape that made an MCP
+    // `total_upstream: 0` deletable while the one real caller sat in the payload
+    // beside it.
+    let unconfirmed = if candidates.is_empty() {
+        String::new()
+    } else {
+        format!(
+            ", plus {} unconfirmed candidate{} not in that count",
+            candidates.len(),
+            if candidates.len() == 1 { "" } else { "s" }
+        )
+    };
     if resolved.is_empty() {
         lines.push(format!(
-            "No resolved incoming {} relations.",
+            "No resolved incoming {} relations{unconfirmed}.",
             relation_kinds_label(&relation_kinds)
         ));
     } else {
-        lines.push(format!("referenced by {} entities:", resolved.len()));
+        lines.push(format!(
+            "referenced by {} entities{unconfirmed}:",
+            resolved.len()
+        ));
         for entry in &resolved {
             render(&mut lines, entry);
         }

--- a/crates/kin-cli/src/output_style.rs
+++ b/crates/kin-cli/src/output_style.rs
@@ -89,9 +89,25 @@ fn paint_refs(line: &str) -> String {
         );
     }
 
-    let count = compiled(&COUNT, r"^referenced by (\d+) entities:$");
+    // The headline carries the unconfirmed candidates it held out of itself, so
+    // the count and the rows it is not counting are read together (FIR-2463).
+    // The suffix is optional and the literal tail is captured rather than
+    // rebuilt, because an unmatched line here prints as plain text and loses its
+    // color silently.
+    let count = compiled(
+        &COUNT,
+        r"^referenced by (\d+) entities(?:, plus (\d+)( unconfirmed candidates? not in that count))?:$",
+    );
     if let Some(caps) = count.captures(line) {
-        return format!("referenced by {ACCENT_BOLD}{}{RESET} entities:", &caps[1]);
+        return match (caps.get(2), caps.get(3)) {
+            (Some(unconfirmed), Some(tail)) => format!(
+                "referenced by {ACCENT_BOLD}{}{RESET} entities, plus {ACCENT_BOLD}{}{RESET}{}:",
+                &caps[1],
+                unconfirmed.as_str(),
+                tail.as_str()
+            ),
+            _ => format!("referenced by {ACCENT_BOLD}{}{RESET} entities:", &caps[1]),
+        };
     }
 
     // A row's location omits `:line` when the entity carries no span, the
@@ -405,7 +421,23 @@ mod tests {
             .iter()
             .find(|line| line.starts_with("referenced by "))
             .unwrap_or_else(|| panic!("no count line in {lines:?}"));
-        assert_painted(&paint_refs(count), count, &format!("{ACCENT_BOLD}1"));
+        let painted_count = paint_refs(count);
+        assert_painted(&painted_count, count, &format!("{ACCENT_BOLD}1"));
+        // FIR-2463: the headline names the row it is not counting, on the same
+        // line, and both numbers are painted. An unmatched count line prints as
+        // plain text, so widening the sentence without widening the rule is a
+        // silent regression.
+        assert_eq!(
+            count, "referenced by 1 entities, plus 1 unconfirmed candidate not in that count:",
+            "the headline carries its unconfirmed candidates: {lines:?}"
+        );
+        assert_eq!(
+            painted_count
+                .matches(&format!("{ACCENT_BOLD}1{RESET}"))
+                .count(),
+            2,
+            "both the counted and the unconfirmed number are painted: {painted_count:?}"
+        );
         assert!(
             lines
                 .iter()

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13060,6 +13060,7 @@ mod tests {
             "semantic_locate",
             &empty,
             &kin_mcp::Envelope::daemon(),
+            &[],
         )
         .expect("an empty cosine page must carry a negative");
         assert_eq!(negative["kind"], json!("no_ranked_match"));
@@ -13471,9 +13472,13 @@ mod tests {
             "an empty fused page omits `entities` entirely: {body}"
         );
         assert_eq!(body["files"], json!([]));
-        let negative =
-            kin_mcp::negative::negative_for("semantic_locate", &body, &kin_mcp::Envelope::daemon())
-                .expect("an empty fused page must carry a negative");
+        let negative = kin_mcp::negative::negative_for(
+            "semantic_locate",
+            &body,
+            &kin_mcp::Envelope::daemon(),
+            &[],
+        )
+        .expect("an empty fused page must carry a negative");
         assert_eq!(negative["kind"], json!("no_ranked_match"));
         assert_eq!(negative["result_count"], json!(0));
     }
@@ -13491,9 +13496,13 @@ mod tests {
         };
         let body = fused_locate_body(result, "zzqqxx_nonexistent_symbol_9f3a");
         assert_eq!(body["all_fallback"], json!(true));
-        let negative =
-            kin_mcp::negative::negative_for("semantic_locate", &body, &kin_mcp::Envelope::daemon())
-                .expect("a ranking that names nothing must be qualified");
+        let negative = kin_mcp::negative::negative_for(
+            "semantic_locate",
+            &body,
+            &kin_mcp::Envelope::daemon(),
+            &[],
+        )
+        .expect("a ranking that names nothing must be qualified");
         assert_eq!(negative["kind"], json!("no_named_match"));
         assert_eq!(negative["interpretation"], json!("unnamed_ranking"));
         assert_eq!(negative["result_count"], json!(1));
@@ -13513,7 +13522,8 @@ mod tests {
         assert!(kin_mcp::negative::negative_for(
             "semantic_locate",
             &body,
-            &kin_mcp::Envelope::daemon()
+            &kin_mcp::Envelope::daemon(),
+            &[],
         )
         .is_none());
     }

--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -578,7 +578,7 @@ impl Completeness {
             .cloned();
 
         Some(Completeness {
-            note: completeness_note(status, bound, substrate, &limits),
+            note: completeness_note(status, bound, substrate, &decided_by, &limits),
             status: status.to_string(),
             bound: bound.to_string(),
             substrate: substrate.as_str().to_string(),
@@ -785,10 +785,17 @@ fn counted_for(tool: &str, payload: &Value) -> Option<Value> {
 
 /// One line an agent can act on. Says what the answer is worth and, when it is
 /// worth less than it looks, what limited it.
+///
+/// The deciding classes are NAMED rather than described as "every class this
+/// answer depended on". That phrasing was accurate about `decided_by` and read
+/// as a claim about `classes`, which sat directly below it in the same object
+/// with two of three entries marked `absent`. A reader cannot be expected to
+/// know which subset a sentence means when the superset is printed beside it.
 fn completeness_note(
     status: &str,
     bound: &str,
     substrate: CoverageSubstrate,
+    decided_by: &[String],
     limits: &[String],
 ) -> String {
     let named = if limits.is_empty() {
@@ -796,16 +803,22 @@ fn completeness_note(
     } else {
         format!(" Limited by: {}.", limits.join(", "))
     };
+    let deciding = if decided_by.is_empty() {
+        format!("no {} class", substrate.noun())
+    } else {
+        format!(
+            "the {} {} class(es)",
+            decided_by.join(", "),
+            substrate.noun()
+        )
+    };
     match (status, bound) {
-        ("complete", "exact") => format!(
-            "Every {} class this answer depended on was observed present, so the counts here are \
-             the whole set.",
-            substrate.noun()
-        ),
+        ("complete", "exact") => {
+            format!("This answer rested on {deciding}, and each was observed present, so the counts here are the whole set.")
+        }
         ("complete", _) => format!(
-            "Every {} class this answer depended on was observed present, but the counts are a \
-             lower bound.{named}",
-            substrate.noun()
+            "This answer rested on {deciding}, and each was observed present, but the counts are \
+             a lower bound.{named}"
         ),
         ("partial", _) => format!(
             "One of the {} classes this answer depended on was observed absent, so what came back \
@@ -856,6 +869,15 @@ pub struct Envelope {
     /// partial one, which is the case an agent cannot see.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completeness: Option<Completeness>,
+    /// The response's one verdict (FIR-2463): the single field a reader acts on,
+    /// computed from every block that would otherwise publish a verdict-shaped
+    /// claim of its own, with the most pessimistic input winning.
+    ///
+    /// `negative` and `completeness` beside it are inputs to this and are
+    /// projections of it, never independent answers. Present on every retrieval
+    /// response at least one input spoke about, absent on everything else.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verdict: Option<Value>,
     /// What the response budget did to this payload: the budget applied and what
     /// the response measured before it. Present only on the retrieval tools the
     /// budget governs, and written by [`finalize_bounded`] AFTER this struct is
@@ -881,6 +903,7 @@ impl Envelope {
                 ..Degraded::default()
             },
             completeness: None,
+            verdict: None,
             response: None,
         }
     }
@@ -898,6 +921,7 @@ impl Envelope {
             graph_state: GraphState::default(),
             degraded: Degraded::default(),
             completeness: None,
+            verdict: None,
             response: None,
         }
     }
@@ -962,6 +986,7 @@ impl Envelope {
                 ..Degraded::default()
             },
             completeness: None,
+            verdict: None,
             response: None,
         }
     }
@@ -987,6 +1012,7 @@ impl Envelope {
                 ..Degraded::default()
             },
             completeness: None,
+            verdict: None,
             response: None,
         }
     }
@@ -1268,12 +1294,30 @@ pub fn finalize_bounded(
         envelope.completeness = Completeness::for_tool(tool_name, payload, &envelope);
     }
     let negative = match &payload {
-        Some(payload) => crate::negative::negative_for(tool_name, payload, &envelope),
+        Some(payload) => crate::negative::negative_for(
+            tool_name,
+            payload,
+            &envelope,
+            &crate::verdict::Verdict::pre_negative_gaps(payload),
+        ),
         None if result.is_error == Some(true) => first_message_text(&result).and_then(|message| {
             crate::negative::resolution_miss_for(tool_name, message, &envelope)
         }),
         None => None,
     };
+    // The one verdict is computed last, because every block it reads has to
+    // exist first, and then projected back over the blocks that would otherwise
+    // answer the same question differently. Projection only ever downgrades: the
+    // completeness signal is itself an input, so a certified verdict is one it
+    // already agreed with.
+    if let Some(payload) = &payload {
+        if let Some(verdict) =
+            crate::verdict::Verdict::compute(tool_name, payload, &envelope, negative.as_ref())
+        {
+            verdict.project_onto_completeness(&mut envelope.completeness);
+            envelope.verdict = Some(verdict.to_value());
+        }
+    }
     annotate_inner(result, &envelope, negative.as_ref(), tool_name, budget)
 }
 
@@ -1316,6 +1360,15 @@ fn annotate_block(
     };
     let mut annotated = annotated;
     apply_response_budget(&mut annotated, tool_name, budget);
+    // The invariant that keeps the collapse from being undone one block at a
+    // time. It reads what a client will read, after the budget has had its say,
+    // so a block added later cannot reintroduce a second verdict without this
+    // firing in every debug build and every test.
+    debug_assert!(
+        crate::verdict::disagreements(&annotated).is_empty(),
+        "response for {tool_name} contradicts its own verdict: {:?}",
+        crate::verdict::disagreements(&annotated)
+    );
     let rendered =
         serde_json::to_string_pretty(&annotated).unwrap_or_else(|_| annotated.to_string());
     ContentBlock::Text { text: rendered }
@@ -1355,6 +1408,10 @@ fn apply_response_budget(annotated: &mut Value, tool_name: &str, budget: &Respon
         {
             Completeness::mark_response_bounded(completeness);
         }
+        // The verdict and the absence object are downgraded with it. A budget
+        // that removed rows on purpose is the one cut that cannot leave a
+        // response certifying what it no longer carries.
+        crate::verdict::mark_response_bounded(annotated);
     }
 }
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -6034,34 +6034,25 @@ mod tests {
         );
     }
 
-    /// FIR-2463 case (a), the shape a stranger hit on shipped v0.5.42 bytes.
+    /// The one call site of `send` in the psf/requests shape, at whatever
+    /// resolution confidence the caller chooses, answered on the daemon
+    /// authority path so no cross-repo gap can stand in for the thing under
+    /// test.
     ///
-    /// `find_references(HTTPAdapter.send)` on psf/requests answered
-    /// `total_upstream: 0` and `counts.referencing_entities: 0` while the same
-    /// payload carried the one real caller, `Session.send` at
-    /// `sessions.py:784`, in `candidates` as `resolution: name_only`. A reader
-    /// of the headline deletes working code and a reader of the array keeps it,
-    /// off one response.
-    ///
-    /// The fixture is Rust on a graph that links calls across files, so the
-    /// coverage gate and the enrichment gate both clear and the WITHHELD ROW is
-    /// the only thing left that can move the verdict. That is what makes this
-    /// discriminating rather than a fixture that is inconclusive for four
-    /// reasons at once.
-    #[tokio::test]
-    async fn a_withheld_caller_refuses_the_zero_it_was_held_out_of() {
+    /// `Session.send` calls `HTTPAdapter.send` at `sessions.py:784` through a
+    /// receiver whose type nothing at the site settles. At the receiver-name
+    /// tier that row is withheld from the headline; at the parser-certain tier
+    /// the identical row is an ordinary caller. Nothing else about the graph
+    /// changes between the two, which is what makes the pair a discriminator
+    /// rather than two fixtures that happen to differ.
+    async fn requests_shape_response(confidence: f32) -> serde_json::Value {
         let store = InMemoryGraph::new();
         let target = make_entity("send", "src/requests/adapters.rs");
         let caller = make_entity("Session.send", "src/requests/sessions.rs");
         store.upsert_entity(&target).unwrap();
         store.upsert_entity(&caller).unwrap();
 
-        let mut relation = make_relation_at(
-            caller.id,
-            target.id,
-            RelationKind::Calls,
-            kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
-        );
+        let mut relation = make_relation_at(caller.id, target.id, RelationKind::Calls, confidence);
         relation.evidence = vec![RelationEvidence {
             source_span: Some(kin_model::entity::SourceSpan {
                 file: FilePathId::new("src/requests/sessions.rs"),
@@ -6075,16 +6066,91 @@ mod tests {
             ..RelationEvidence::default()
         }];
         store.upsert_relation(&relation).unwrap();
+        let registered_root = graph_root(&store);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "requests",
+            vec![spine_entry("requests", &target)],
+            &registered_root,
+        );
+        spine.refresh_cross_repo_edges("requests", &[], &[], &["requests".to_string()]);
 
         let args = HashMap::from([(
             "entity_id".to_string(),
             serde_json::json!(target.id.to_string()),
         )]);
-        let response = parsed_response(&crate::finalize_with_envelope(
-            handle_find_references(&args, &store, None).await.unwrap(),
+        parsed_response(&crate::finalize_with_envelope(
+            handle_find_references_with_authority(
+                &args,
+                &store,
+                FindReferencesAuthority {
+                    repo_id: "requests",
+                    graph_root: &registered_root,
+                    spine: Some(&spine),
+                },
+                None,
+            )
+            .await
+            .unwrap(),
             structurally_ready_envelope(),
             "find_references",
-        ));
+        ))
+    }
+
+    /// The control for [`a_withheld_caller_refuses_the_zero_it_was_held_out_of`]:
+    /// the same fixture with the one relation at the parser-certain tier. The
+    /// row is counted, nothing is withheld, and the one verdict certifies.
+    ///
+    /// Without this the refusal above proves only that the verdict CAN say
+    /// inconclusive on this fixture, which a hardcoded refusal would satisfy
+    /// too.
+    #[tokio::test]
+    async fn a_proven_caller_on_the_same_fixture_certifies() {
+        let response = requests_shape_response(1.0).await;
+
+        assert_eq!(response["total_upstream"], 1, "{response:#}");
+        assert_eq!(response["unconfirmed_candidates"], 0, "{response:#}");
+        assert!(response["candidates"].as_array().unwrap().is_empty());
+        assert_eq!(
+            response["_kin"]["verdict"]["state"], "certified",
+            "one confidence value apart from the refusal above: {}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(
+            response["_kin"]["verdict"]["inputs"]["withheld_candidates"], "certified",
+            "{}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(response["_kin"]["completeness"]["bound"], "exact");
+        assert!(
+            crate::verdict::disagreements(&response).is_empty(),
+            "{:?}",
+            crate::verdict::disagreements(&response)
+        );
+    }
+
+    /// FIR-2463 case (a), the shape a stranger hit on shipped v0.5.42 bytes.
+    ///
+    /// `find_references(HTTPAdapter.send)` on psf/requests answered
+    /// `total_upstream: 0` and `counts.referencing_entities: 0` while the same
+    /// payload carried the one real caller, `Session.send` at
+    /// `sessions.py:784`, in `candidates` as `resolution: name_only`. A reader
+    /// of the headline deletes working code and a reader of the array keeps it,
+    /// off one response.
+    ///
+    /// The fixture is Rust on a graph that links calls across files, on the
+    /// daemon authority path with a registered spine, so the coverage gate, the
+    /// enrichment gate and the cross-repo gate all clear. The CONFIDENCE on the
+    /// one relation is the only input left that can move the verdict, and
+    /// [`a_proven_caller_on_the_same_fixture_certifies`] runs the identical
+    /// fixture at the parser-certain tier and gets the opposite verdict. A
+    /// hardcoded `inconclusive` fails there and a hardcoded `certified` fails
+    /// here.
+    #[tokio::test]
+    async fn a_withheld_caller_refuses_the_zero_it_was_held_out_of() {
+        let response =
+            requests_shape_response(kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE).await;
 
         assert_eq!(
             response["total_upstream"], 0,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1022,6 +1022,11 @@ module was known and the symbol selected inside it), or `name_only` (a bare same
 match across the repo, with nothing at the reference site proving it). A `name_only` row \
 is a candidate, not a fact; do not count it as use, and do not conclude something is \
 unused from the absence of anything but `name_only` rows without confirming. \
+`name_only` rows are held out of `total_upstream` and travel in `candidates`, and \
+`unconfirmed_candidates` beside the headline says how many were held, so a \
+`total_upstream` of 0 with `unconfirmed_candidates` above 0 means this answer is holding \
+rows it could not confirm and the zero may not be read alone. \
+`_kin.verdict` is the one verdict for the whole response and outranks every count in it. \
 The response bounds its own size (max_chars, default 30000 serialized characters): a symbol \
 with hundreds of call sites sheds its inline snippets before it withholds any row, and any cut \
 is reported in `degradations` and in `_kin.response` with the size the response had before the \
@@ -1693,6 +1698,19 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         // infer it, and `counts.reference_sites` carries the finer number when
         // every row could be located.
         "total_upstream": references.len(),
+        // FIR-2463. The headline may not be readable alone when the same
+        // response is holding evidence that contradicts it. `HTTPAdapter.send`
+        // on psf/requests answered `total_upstream: 0` while carrying its one
+        // real caller, `Session.send` at `sessions.py:784`, in `candidates`: a
+        // reader of the number deletes working code and a reader of the array
+        // keeps it, off one response. This is the same withheld count
+        // `counts.receiver_name_candidates` and
+        // `_kin.completeness.counted.withheld_candidates` publish, from the same
+        // partition, placed where a reader of the headline cannot miss it rather
+        // than as a fourth accounting of it. Emitted at zero as well, because a
+        // field that appears only when it is nonzero is one no reader learns to
+        // look for.
+        "unconfirmed_candidates": candidates.len(),
         "counts": counts,
         "references": references,
         // Same row shape as `references`, held apart because these are not
@@ -4653,9 +4671,13 @@ mod tests {
             coverage["scope_entities"], 1,
             "the kind-filtered absence states the coverage of that kind: {coverage}"
         );
-        let negative =
-            crate::negative::negative_for("semantic_search", &empty, &ready_daemon_envelope(2))
-                .expect("an empty search carries a negative");
+        let negative = crate::negative::negative_for(
+            "semantic_search",
+            &empty,
+            &ready_daemon_envelope(2),
+            &[],
+        )
+        .expect("an empty search carries a negative");
         assert_eq!(negative["safe_to_conclude_absent"], false);
         assert_eq!(negative["trust"], "inconclusive");
         assert!(
@@ -4698,9 +4720,13 @@ mod tests {
         assert_eq!(coverage["language"], "Python");
         assert_eq!(coverage["reference_enrichment"], "unknown");
         assert_eq!(coverage["scope_entities"], 2);
-        let negative =
-            crate::negative::negative_for("semantic_search", &absent, &ready_daemon_envelope(2))
-                .expect("an empty search carries a negative");
+        let negative = crate::negative::negative_for(
+            "semantic_search",
+            &absent,
+            &ready_daemon_envelope(2),
+            &[],
+        )
+        .expect("an empty search carries a negative");
         assert_eq!(negative["safe_to_conclude_absent"], true);
         assert_eq!(negative["trust"], "authoritative");
     }
@@ -4726,9 +4752,13 @@ mod tests {
             0,
             "this graph holds no module entity at all: {empty}"
         );
-        let negative =
-            crate::negative::negative_for("semantic_search", &empty, &ready_daemon_envelope(1))
-                .expect("an empty search carries a negative");
+        let negative = crate::negative::negative_for(
+            "semantic_search",
+            &empty,
+            &ready_daemon_envelope(1),
+            &[],
+        )
+        .expect("an empty search carries a negative");
         assert_eq!(negative["safe_to_conclude_absent"], false);
         assert!(
             negative["trust_reason"]
@@ -4768,9 +4798,13 @@ mod tests {
             coverage.get("scope_entities").is_none(),
             "a walk counts no region, so it publishes no count: {coverage}"
         );
-        let negative =
-            crate::negative::negative_for("graph_neighborhood", &walked, &ready_daemon_envelope(1))
-                .expect("an empty walk carries a negative");
+        let negative = crate::negative::negative_for(
+            "graph_neighborhood",
+            &walked,
+            &ready_daemon_envelope(1),
+            &[],
+        )
+        .expect("an empty walk carries a negative");
         assert_eq!(negative["safe_to_conclude_absent"], false);
 
         let mut missing = HashMap::new();
@@ -4787,6 +4821,7 @@ mod tests {
             "graph_neighborhood",
             &unresolved,
             &ready_daemon_envelope(1),
+            &[],
         )
         .expect("an unresolved focal carries a negative");
         assert!(
@@ -5962,6 +5997,161 @@ mod tests {
             response["negative"]
         );
         assert_eq!(response["negative"]["trust"], "authoritative");
+
+        // FIR-2463 case (b). The collapse must not degrade into refusing
+        // everything: where every input agrees, the one verdict certifies, and a
+        // hardcoded `inconclusive` in the verdict fails right here.
+        assert_eq!(
+            response["_kin"]["verdict"]["state"], "certified",
+            "every input agreed, so the one verdict certifies: {}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(
+            response["_kin"]["verdict"]["safe_to_conclude_absent"], true,
+            "{}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(
+            response["_kin"]["verdict"]["limiting_factor"],
+            serde_json::Value::Null,
+            "a certified verdict names no limiting factor: {}",
+            response["_kin"]["verdict"]
+        );
+        assert!(
+            response["_kin"]["verdict"]["inputs"]
+                .as_object()
+                .unwrap()
+                .values()
+                .all(|state| state == "certified" || state == "not_applicable"),
+            "certification requires every input that spoke to agree: {}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(response["_kin"]["completeness"]["bound"], "exact");
+        assert!(
+            crate::verdict::disagreements(&response).is_empty(),
+            "{:?}",
+            crate::verdict::disagreements(&response)
+        );
+    }
+
+    /// FIR-2463 case (a), the shape a stranger hit on shipped v0.5.42 bytes.
+    ///
+    /// `find_references(HTTPAdapter.send)` on psf/requests answered
+    /// `total_upstream: 0` and `counts.referencing_entities: 0` while the same
+    /// payload carried the one real caller, `Session.send` at
+    /// `sessions.py:784`, in `candidates` as `resolution: name_only`. A reader
+    /// of the headline deletes working code and a reader of the array keeps it,
+    /// off one response.
+    ///
+    /// The fixture is Rust on a graph that links calls across files, so the
+    /// coverage gate and the enrichment gate both clear and the WITHHELD ROW is
+    /// the only thing left that can move the verdict. That is what makes this
+    /// discriminating rather than a fixture that is inconclusive for four
+    /// reasons at once.
+    #[tokio::test]
+    async fn a_withheld_caller_refuses_the_zero_it_was_held_out_of() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("send", "src/requests/adapters.rs");
+        let caller = make_entity("Session.send", "src/requests/sessions.rs");
+        store.upsert_entity(&target).unwrap();
+        store.upsert_entity(&caller).unwrap();
+
+        let mut relation = make_relation_at(
+            caller.id,
+            target.id,
+            RelationKind::Calls,
+            kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+        );
+        relation.evidence = vec![RelationEvidence {
+            source_span: Some(kin_model::entity::SourceSpan {
+                file: FilePathId::new("src/requests/sessions.rs"),
+                start_byte: 0,
+                end_byte: 1,
+                start_line: 783,
+                start_col: 0,
+                end_line: 783,
+                end_col: 1,
+            }),
+            ..RelationEvidence::default()
+        }];
+        store.upsert_relation(&relation).unwrap();
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let response = parsed_response(&crate::finalize_with_envelope(
+            handle_find_references(&args, &store, None).await.unwrap(),
+            structurally_ready_envelope(),
+            "find_references",
+        ));
+
+        assert_eq!(
+            response["total_upstream"], 0,
+            "the headline still counts only what resolved: {response:#}"
+        );
+        assert_eq!(response["counts"]["referencing_entities"], 0);
+        let candidates = response["candidates"].as_array().unwrap();
+        assert_eq!(candidates.len(), 1, "{response:#}");
+        assert_eq!(
+            candidates[0]["reference_lines"],
+            serde_json::json!([784]),
+            "the held row carries the real call site: {response:#}"
+        );
+
+        // The count may not be read alone.
+        assert_eq!(
+            response["unconfirmed_candidates"], 1,
+            "the zero has to name the row it is holding, at the count: {response:#}"
+        );
+        assert_eq!(response["counts"]["receiver_name_candidates"], 1);
+        assert_eq!(
+            response["_kin"]["completeness"]["counted"]["withheld_candidates"], 1,
+            "one withheld number, three placements: {}",
+            response["_kin"]["completeness"]
+        );
+
+        // And the one verdict refuses.
+        assert_eq!(
+            response["_kin"]["verdict"]["state"], "inconclusive",
+            "{}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(
+            response["_kin"]["verdict"]["safe_to_conclude_absent"], false,
+            "{}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(
+            response["_kin"]["verdict"]["inputs"]["withheld_candidates"], "inconclusive",
+            "the withheld row is the input that decided: {}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(response["negative"]["safe_to_conclude_absent"], false);
+        assert_eq!(response["negative"]["trust"], "inconclusive");
+        assert_eq!(
+            response["_kin"]["completeness"]["bound"], "at_least",
+            "{}",
+            response["_kin"]["completeness"]
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["counted"]["exact"], false,
+            "{}",
+            response["_kin"]["completeness"]
+        );
+        assert!(
+            !response["_kin"]["completeness"]["note"]
+                .as_str()
+                .unwrap()
+                .contains("the whole set"),
+            "no block may call this the whole set: {}",
+            response["_kin"]["completeness"]
+        );
+        assert!(
+            crate::verdict::disagreements(&response).is_empty(),
+            "{:?}",
+            crate::verdict::disagreements(&response)
+        );
     }
 
     /// FIR-2404 end to end, on a real store rather than a hand-written payload,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -6317,6 +6317,61 @@ mod tests {
             ]),
             "the shortfalls the observation names are disclosed beside the verdict"
         );
+
+        // FIR-2463, and the exact three-verdict shape a stranger quoted off
+        // shipped v0.5.42 bytes. `decided_by` here is `calls` alone, which IS
+        // present, so the completeness signal reached `complete` and `exact`
+        // over the same zero the negative beside it refused to certify, and its
+        // note called that zero the whole set. The substrate reading stays as
+        // measured, because it is the evidence; what a reader acts on follows
+        // the one verdict.
+        assert_eq!(
+            response["_kin"]["verdict"]["state"], "inconclusive",
+            "{}",
+            response["_kin"]["verdict"]
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["status"], "complete",
+            "the substrate observation is kept, not rewritten: {}",
+            response["_kin"]["completeness"]
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["decided_by"],
+            serde_json::json!(["calls"]),
+            "{}",
+            response["_kin"]["completeness"]
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["bound"], "at_least",
+            "a complete substrate cannot make this zero exact while the verdict refuses it: {}",
+            response["_kin"]["completeness"]
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["counted"]["exact"], false,
+            "{}",
+            response["_kin"]["completeness"]
+        );
+        assert!(
+            !response["_kin"]["completeness"]["note"]
+                .as_str()
+                .unwrap()
+                .contains("the whole set"),
+            "the note that called four wrong dead-code rows the whole set: {}",
+            response["_kin"]["completeness"]
+        );
+        assert!(
+            response["_kin"]["completeness"]["limits"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!("verdict_inconclusive")),
+            "the downgrade names itself: {}",
+            response["_kin"]["completeness"]
+        );
+        assert!(
+            crate::verdict::disagreements(&response).is_empty(),
+            "{:?}",
+            crate::verdict::disagreements(&response)
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -13,6 +13,7 @@ pub mod session;
 pub mod startup_binding;
 pub mod tools;
 pub mod types;
+pub mod verdict;
 
 pub use budget::{
     is_budgeted as is_budgeted_tool, BudgetAccounting, ResponseBudget, RESPONSE_DEFAULT_MAX_CHARS,
@@ -42,3 +43,4 @@ pub use tools::{
 pub use types::{
     ContentBlock, JsonRpcRequest, JsonRpcResponse, ToolCallParams, ToolCallResult, ToolDefinition,
 };
+pub use verdict::{disagreements as verdict_disagreements, Verdict, VERDICT_KEY};

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -373,7 +373,7 @@ pub(crate) fn load_bearing_classes(requested: &[String]) -> Vec<String> {
 /// `absent` for every class and a language's zero to `absent` for that language;
 /// [`crate::edge_coverage`] can then be retired, since it is called from exactly
 /// three payload builders.
-fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
+pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
     let requested = absence_cross_file_classes(tool, payload);
     let language_scoped = absence_is_language_scoped(tool);
     if requested.is_empty() && !language_scoped {
@@ -492,6 +492,18 @@ fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String> {
     }
 
     (!gaps.is_empty()).then(|| gaps.join("; "))
+}
+
+/// Whether `tool` declares anything [`absence_coverage_gap`] can gate, so a
+/// `None` from that gate means "every dependency it declared was observed
+/// present" rather than "it declared none".
+///
+/// The distinction is what stops [`crate::verdict`] certifying a response on no
+/// evidence. A tool that reads neither cross-file edges nor a language's
+/// extracted graph has nothing for this gate to say, and silence is not
+/// agreement.
+pub(crate) fn declares_absence_dependency(tool: &str, payload: &Value) -> bool {
+    !absence_cross_file_classes(tool, payload).is_empty() || absence_is_language_scoped(tool)
 }
 
 /// One class's observed state, defaulting to `unknown` for a class the
@@ -900,7 +912,7 @@ fn describes_the_store_not_the_run(label: &str) -> bool {
 /// is not one.
 ///
 /// [`Degraded`]: crate::envelope::Degraded
-fn payload_degradation_labels(payload: &Value) -> Vec<String> {
+pub(crate) fn payload_degradation_labels(payload: &Value) -> Vec<String> {
     let Some(entries) = payload.get("degradations").and_then(Value::as_array) else {
         return Vec::new();
     };
@@ -1262,7 +1274,12 @@ fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
 ///
 /// The returned object is additive: callers attach it under [`NEGATIVE_KEY`]
 /// beside the existing payload keys, never replacing them.
-pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<Value> {
+pub fn negative_for(
+    tool: &str,
+    payload: &Value,
+    envelope: &Envelope,
+    response_gaps: &[String],
+) -> Option<Value> {
     let spec = spec_for(tool)?;
     let count = if tool == "semantic_locate" {
         locate_result_count(payload)?
@@ -1291,6 +1308,15 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // if it were.
     if let Some(gap) = absence_coverage_gap(tool, payload) {
         push_gap(&mut trustworthy, &mut trust_reason, gap);
+    }
+
+    // Gaps the response carries that this function cannot observe from the
+    // payload's collections alone, contributed by [`crate::verdict`] so the one
+    // verdict and the advice a reader acts on are built from the same list.
+    // Threading them in here rather than patching the finished object is what
+    // keeps `trust`, `trust_reason` and `advice` one consistent sentence.
+    for gap in response_gaps {
+        push_gap(&mut trustworthy, &mut trust_reason, gap.clone());
     }
 
     // Receiver-method calls (`x.method()`) are resolved by bare name in
@@ -1671,6 +1697,18 @@ pub fn resolution_miss_for(tool: &str, message: &str, envelope: &Envelope) -> Op
 mod tests {
     use super::*;
     use crate::envelope::{Degraded, Envelope, SemanticCoverage};
+
+    /// The absence object for a response carrying no gaps beyond the ones this
+    /// module computes for itself.
+    ///
+    /// Shadows [`super::negative_for`] so the cases below keep asserting on the
+    /// gates that live here. The response-scoped gaps the real signature takes
+    /// are contributed by [`crate::verdict`] and are exercised where they are
+    /// computed; passing an empty list here is what makes a failure in this
+    /// module a failure of this module.
+    fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<Value> {
+        super::negative_for(tool, payload, envelope, &[])
+    }
 
     /// A daemon envelope whose SEMANTIC substrate is complete — full embedding
     /// coverage, no degraded signals: the only state in which a *semantic* tool's

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -1057,9 +1057,12 @@ const SUPPORTED_PROTOCOL_VERSION: &str = "2024-11-05";
 const SERVER_INSTRUCTIONS: &str = "Kin answers repository questions from a semantic graph rather than raw file search. \
 Prefer semantic_locate to find symbols and behavior by meaning, get_context_pack for a structured context bundle \
 around an entity or file, and trace_data_flow for cross-file data lineage; reach for grep only when no graph-backed \
-tool answers the question. Every tool response carries a `_kin` envelope reporting graph freshness and coverage. An \
-empty retrieval result also carries a `negative` object whose `safe_to_conclude_absent` field says whether the \
-absence can be trusted; when it is false, treat the answer as unknown rather than absent.";
+tool answers the question. Every tool response carries a `_kin` envelope reporting graph freshness and coverage. \
+Read `_kin.verdict` first: it is the ONE verdict for the response, computed from every block that qualifies the \
+answer, with the most pessimistic input winning. When its `state` is `inconclusive`, treat the counts as a lower \
+bound and do not act on an absence in the answer, whatever any single count or block says on its own; \
+`limiting_factor` names what stopped it. `negative` and `_kin.completeness` beside it are the evidence that verdict \
+was computed from, never independent answers.";
 
 fn handle_initialize(
     id: Option<serde_json::Value>,
@@ -1672,7 +1675,10 @@ mod tests {
         // The spec's instructions field must reach the wire with usable content.
         let instructions = result["instructions"].as_str().unwrap();
         assert!(instructions.contains("semantic_locate"));
-        assert!(instructions.contains("safe_to_conclude_absent"));
+        // The one verdict has to be named on the wire, or an agent learns the
+        // contract from whichever block it happens to read first.
+        assert!(instructions.contains("_kin.verdict"));
+        assert!(instructions.contains("most pessimistic input"));
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -173,7 +173,9 @@ impl Verdict {
                     .to_string(),
             );
         }
-        if withheld_candidate_count(payload) > 0 && !discloses_withheld_candidates(payload) {
+        if withheld_candidate_count(payload).is_some_and(|withheld| withheld > 0)
+            && !discloses_withheld_candidates(payload)
+        {
             gaps.push(
                 "withheld_candidates: same-name candidates were held out of the counts here, \
                  so the headline is a floor and the withheld rows may belong in it"
@@ -353,8 +355,14 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
 /// keeps.
 fn withheld_candidates_reading(payload: &Value) -> Reading {
     match withheld_candidate_count(payload) {
-        0 => Reading::Certified,
-        withheld => Reading::Inconclusive(format!(
+        // A payload carrying no candidate accounting at all has nothing to say
+        // here, which is not the same as saying nothing was withheld. Answering
+        // `certified` for a concept the payload does not carry is how a mutation
+        // response, whose every other input is silent, came to ship a certified
+        // verdict about nothing.
+        None => Reading::Silent,
+        Some(0) => Reading::Certified,
+        Some(withheld) => Reading::Inconclusive(format!(
             "withheld_candidates: {withheld} same-name candidate(s) are carried in `candidates` \
              and are not in the counts here, so the headline is a floor and each withheld row \
              may belong in it"
@@ -364,6 +372,9 @@ fn withheld_candidates_reading(payload: &Value) -> Reading {
 
 /// This query's own reported degradations.
 fn degradations_reading(payload: &Value) -> Reading {
+    if payload.get("degradations").is_none() {
+        return Reading::Silent;
+    }
     let labels = crate::negative::payload_degradation_labels(payload);
     if labels.is_empty() {
         Reading::Certified
@@ -401,7 +412,7 @@ fn completeness_reading(envelope: &Envelope) -> Reading {
 
 /// How many same-name candidates the payload held out of its counts, read from
 /// the one number the withheld plumbing already publishes.
-fn withheld_candidate_count(payload: &Value) -> u64 {
+fn withheld_candidate_count(payload: &Value) -> Option<u64> {
     payload
         .get("counts")
         .and_then(|counts| counts.get("receiver_name_candidates"))
@@ -412,7 +423,6 @@ fn withheld_candidate_count(payload: &Value) -> u64 {
                 .and_then(Value::as_array)
                 .map(|rows| rows.len() as u64)
         })
-        .unwrap_or(0)
 }
 
 /// Whether the payload already names its withheld candidates as a degradation,
@@ -776,6 +786,49 @@ mod tests {
             disagreements(&response).is_empty(),
             "{:?}",
             disagreements(&response)
+        );
+    }
+
+    /// A response no retrieval input spoke about must carry no verdict at all.
+    ///
+    /// Certification on no evidence is the failure this module would otherwise
+    /// introduce. A mutation payload has no absence gate, no edge coverage and
+    /// no completeness signal, so an input that answers `certified` for a
+    /// concept the payload does not carry would put a certified verdict on every
+    /// commit response. Both remaining inputs stay silent instead.
+    #[test]
+    fn a_non_retrieval_payload_carries_no_verdict() {
+        let payload = json!({"committed": true, "change_id": "abc"});
+        let envelope = Envelope::daemon();
+        assert!(
+            Verdict::compute("kin_transaction_commit", &payload, &envelope, None).is_none(),
+            "a payload no input spoke about must not be certified"
+        );
+    }
+
+    /// The other direction: a retrieval payload that genuinely withheld nothing
+    /// and reported no degradation still certifies, so the silence above is not
+    /// a blanket refusal.
+    #[test]
+    fn a_clean_retrieval_payload_still_certifies() {
+        let payload = json!({
+            "references": [{"name": "caller"}],
+            "relation_kinds": ["calls"],
+            "counts": {"receiver_name_candidates": 0},
+            "degradations": [],
+            "edge_coverage": {
+                "language": "Rust",
+                "classes": {"calls": "present"},
+                "reference_enrichment": "supported",
+            },
+        });
+        let verdict = Verdict::compute("find_references", &payload, &Envelope::daemon(), None)
+            .expect("a retrieval payload carries a verdict");
+        assert_eq!(
+            verdict.to_value()["state"],
+            json!(CERTIFIED),
+            "{}",
+            verdict.to_value()
         );
     }
 

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -1,0 +1,811 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! One verdict per response (FIR-2463).
+//!
+//! A retrieval response used to carry up to three verdict-shaped claims that
+//! were computed independently and could disagree with each other. The
+//! `negative` object certified or refused an absence, `edge_coverage` reported
+//! whether the graph could hold the edges the answer was read off, and
+//! `_kin.completeness` reported `status`, `bound` and `counted.exact`. Which one
+//! an agent acted on depended on which key it happened to read.
+//!
+//! The shape is not hypothetical. A shipped v0.5.42 `find_references` response
+//! carried `completeness.status: "complete"`, `bound: "exact"`,
+//! `counted.exact: true` and a note reading "the counts here are the whole set"
+//! directly above `classes: {"imports": "absent", "references": "absent"}` and
+//! `negative.safe_to_conclude_absent: false`. In the same session on the same
+//! repository, `graph_neighborhood` walked the same two inbound edges and framed
+//! them as `"complete"` with no `negative` object at all, because a non-empty
+//! answer synthesizes none.
+//!
+//! ## The contract
+//!
+//! [`Verdict::compute`] is the one authority. Every block that publishes a
+//! verdict-shaped claim is an INPUT to it, the most pessimistic input wins, and
+//! certification requires every input that spoke to agree. The blocks keep
+//! publishing their raw observations, because those are the evidence a reader
+//! needs to act, but the fields a reader acts ON are projections of this one
+//! verdict:
+//!
+//! - `negative.safe_to_conclude_absent` / `negative.trust` / `negative.advice`
+//!   are built from the gap list this module contributes to, so they are correct
+//!   by construction rather than patched afterwards.
+//! - `_kin.completeness.bound`, `counted.exact` and `note` are capped by
+//!   [`Verdict::project_onto_completeness`].
+//! - `_kin.completeness.status`, `classes`, `decided_by` and `limits` stay raw
+//!   observation. `status` answers "was the substrate whole", which is a
+//!   different question from "can this answer be acted on", and collapsing the
+//!   two would throw away the evidence rather than reconcile it.
+//!
+//! [`disagreements`] is the invariant that holds this together. It scans a fully
+//! built response for any block whose verdict language contradicts
+//! `_kin.verdict`, and it runs under `debug_assert!` on every annotated response
+//! so a future block cannot reintroduce a second verdict silently.
+
+use serde_json::{json, Map, Value};
+
+use crate::envelope::Envelope;
+
+/// Reserved key under `_kin` holding the single verdict for the response.
+pub const VERDICT_KEY: &str = "verdict";
+
+/// Wire words for a verdict state and for one input's reading.
+const CERTIFIED: &str = "certified";
+const INCONCLUSIVE: &str = "inconclusive";
+const NOT_APPLICABLE: &str = "not_applicable";
+
+/// Machine-stable label recorded in `_kin.completeness.limits` when the single
+/// verdict, rather than this answer's own substrate reading, is what stopped the
+/// counts being called whole.
+const VERDICT_LIMIT: &str = "verdict_inconclusive";
+
+/// The limiting factor a response bounded by the size budget carries.
+const RESPONSE_BOUNDED_FACTOR: &str = "response_bounded: the response budget withheld part of \
+                                       this answer, so its counts are a lower bound and its \
+                                       absence claims are not authoritative";
+
+/// One input's reading of the same answer.
+enum Reading {
+    /// The input observed nothing that stops this answer being acted on.
+    Certified,
+    /// The input refuses, and says why in the reason it carries.
+    Inconclusive(String),
+    /// The input has nothing to say about this response, which is different from
+    /// saying it is fine. A silent input never certifies anything.
+    Silent,
+}
+
+impl Reading {
+    fn state(&self) -> &'static str {
+        match self {
+            Reading::Certified => CERTIFIED,
+            Reading::Inconclusive(_) => INCONCLUSIVE,
+            Reading::Silent => NOT_APPLICABLE,
+        }
+    }
+}
+
+/// The single verdict for one response, plus the inputs it was computed from.
+pub struct Verdict {
+    certified: bool,
+    safe_to_conclude_absent: bool,
+    limiting_factor: Option<String>,
+    inputs: Map<String, Value>,
+}
+
+impl Verdict {
+    /// Compute the response's one verdict, or `None` for a response no input
+    /// spoke about (a mutation, a session call, anything that is not retrieval).
+    ///
+    /// `negative` is the already-built absence object when one was synthesized.
+    /// It is an input rather than the authority: it exists only for an answer
+    /// that came back empty, and the contradiction this module exists to end was
+    /// found on a NON-empty answer whose only verdict-shaped claim was
+    /// `completeness`.
+    ///
+    /// Certification requires every input that spoke to agree, and an input that
+    /// stayed silent never contributes agreement. A response where no input
+    /// spoke returns `None` rather than a certified verdict on no evidence.
+    pub fn compute(
+        tool: &str,
+        payload: &Value,
+        envelope: &Envelope,
+        negative: Option<&Value>,
+    ) -> Option<Self> {
+        let makes_absence_claim = negative.is_some();
+        let readings = [
+            (
+                "absence_gate",
+                absence_gate_reading(tool, payload, negative),
+            ),
+            ("edge_coverage", edge_coverage_reading(tool, payload)),
+            ("withheld_candidates", withheld_candidates_reading(payload)),
+            ("degradations", degradations_reading(payload)),
+            ("completeness", completeness_reading(envelope)),
+        ];
+
+        if readings
+            .iter()
+            .all(|(_, reading)| matches!(reading, Reading::Silent))
+        {
+            return None;
+        }
+
+        let limiting_factor = readings.iter().find_map(|(_, reading)| match reading {
+            Reading::Inconclusive(reason) => Some(reason.clone()),
+            _ => None,
+        });
+        let certified = limiting_factor.is_none();
+        let inputs = readings
+            .iter()
+            .map(|(name, reading)| ((*name).to_string(), json!(reading.state())))
+            .collect();
+
+        Some(Verdict {
+            certified,
+            safe_to_conclude_absent: certified && makes_absence_claim,
+            limiting_factor,
+            inputs,
+        })
+    }
+
+    /// Gaps this response carries that [`crate::negative::negative_for`] cannot
+    /// observe on its own, in the order they should lead the composed reason.
+    ///
+    /// These are threaded INTO the absence object rather than patched onto it
+    /// afterwards, so its `trust`, `trust_reason` and `advice` are one
+    /// consistent sentence. Patching a built advice string is how a verdict and
+    /// the reason a reader acts on come apart again.
+    ///
+    /// Only gaps the absence gates structurally cannot reach are listed here.
+    /// Withheld same-name candidates are already disclosed as a payload
+    /// degradation by every tool that withholds them today, and the absence gate
+    /// consumes `degradations`, so repeating them would put the same fact in one
+    /// reason twice.
+    pub fn pre_negative_gaps(payload: &Value) -> Vec<String> {
+        let mut gaps = Vec::new();
+        if payload.get("truncated").and_then(Value::as_bool) == Some(true) {
+            gaps.push(
+                "answer_truncated: this answer stopped early and returned part of what it \
+                 found, so its counts are a floor and an absence in it is a fact about where \
+                 the walk stopped"
+                    .to_string(),
+            );
+        }
+        if withheld_candidate_count(payload) > 0 && !discloses_withheld_candidates(payload) {
+            gaps.push(
+                "withheld_candidates: same-name candidates were held out of the counts here, \
+                 so the headline is a floor and the withheld rows may belong in it"
+                    .to_string(),
+            );
+        }
+        gaps
+    }
+
+    /// Cap the completeness signal's verdict-shaped fields at this verdict.
+    ///
+    /// Only ever downgrades. `bound`, `counted.exact` and `note` are what a
+    /// reader acts on, so they follow the one verdict; `status`, `classes`,
+    /// `decided_by` and `limits` are the observation the verdict was computed
+    /// from and stay exactly as measured.
+    pub fn project_onto_completeness(
+        &self,
+        completeness: &mut Option<crate::envelope::Completeness>,
+    ) {
+        if self.certified {
+            return;
+        }
+        let Some(completeness) = completeness else {
+            return;
+        };
+        completeness.bound = "at_least".to_string();
+        if let Some(counted) = completeness.counted.as_mut().and_then(Value::as_object_mut) {
+            counted.insert("exact".to_string(), json!(false));
+        }
+        if !completeness
+            .limits
+            .iter()
+            .any(|limit| limit == VERDICT_LIMIT)
+        {
+            completeness.limits.push(VERDICT_LIMIT.to_string());
+        }
+        completeness.note = format!(
+            "The counts here are a lower bound, because this response's one verdict is \
+             inconclusive. Limiting factor: {}.",
+            self.limiting_factor.as_deref().unwrap_or("unreported")
+        );
+    }
+
+    /// Serialize for embedding under `_kin.verdict`.
+    pub fn to_value(&self) -> Value {
+        let note = if self.certified {
+            "Every input that could qualify this answer agreed, so the counts here are the whole \
+             set and an absence in it is authoritative."
+                .to_string()
+        } else {
+            format!(
+                "Treat this answer as a lower bound and do not act on an absence in it. Limiting \
+                 factor: {}.",
+                self.limiting_factor.as_deref().unwrap_or("unreported")
+            )
+        };
+        json!({
+            "state": if self.certified { CERTIFIED } else { INCONCLUSIVE },
+            "safe_to_conclude_absent": self.safe_to_conclude_absent,
+            "limiting_factor": self.limiting_factor.clone().map(Value::String).unwrap_or(Value::Null),
+            "inputs": Value::Object(self.inputs.clone()),
+            "note": note,
+        })
+    }
+}
+
+/// The absence gate's reading: the composed verdict
+/// [`crate::negative::negative_for`] already reached, when it built one.
+///
+/// When it did not, the gate is run here against the same payload rather than
+/// skipped. That is the whole point of computing this once: a non-empty answer
+/// and a tool with no absence spec are exactly the routes that used to reach a
+/// reader with no gate applied at all, and the missing dependency that stops an
+/// absence being certified is the same missing dependency that makes a
+/// non-empty answer a floor.
+fn absence_gate_reading(tool: &str, payload: &Value, negative: Option<&Value>) -> Reading {
+    if let Some(negative) = negative {
+        return match negative
+            .get("safe_to_conclude_absent")
+            .and_then(Value::as_bool)
+        {
+            Some(true) => Reading::Certified,
+            Some(false) => Reading::Inconclusive(
+                negative
+                    .get("trust_reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("the absence gate refused and reported no reason")
+                    .to_string(),
+            ),
+            None => Reading::Silent,
+        };
+    }
+    match crate::negative::absence_coverage_gap(tool, payload) {
+        Some(gap) => Reading::Inconclusive(gap),
+        None if crate::negative::declares_absence_dependency(tool, payload) => Reading::Certified,
+        None => Reading::Silent,
+    }
+}
+
+/// The raw `edge_coverage` observation's own reading, independent of whichever
+/// route consumed it.
+///
+/// It repeats what the absence gate reads on the tools that declare edge
+/// classes, and that repetition is deliberate: recording both as named inputs is
+/// what makes the verdict auditable, and the two come apart exactly where the
+/// contradiction lived. A tool that declares no edge class still publishes this
+/// observation, and `reference_enrichment: "unsupported"` is a fact about what
+/// the build can resolve that no coverage number can override.
+fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
+    let Some(coverage) = payload
+        .get(crate::edge_coverage::EDGE_COVERAGE_KEY)
+        .and_then(Value::as_object)
+    else {
+        return Reading::Silent;
+    };
+    let language = coverage
+        .get("language")
+        .and_then(Value::as_str)
+        .filter(|language| !language.trim().is_empty())
+        .unwrap_or("an unreported language");
+
+    if coverage.get("reference_enrichment").and_then(Value::as_str) == Some("unsupported") {
+        return Reading::Inconclusive(format!(
+            "reference_enrichment_unsupported: this build wires no language-server adapter for \
+             {language}, so cross-file reference and override edges cannot exist for it at all"
+        ));
+    }
+    if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
+        return Reading::Inconclusive(format!(
+            "absence_scope_empty: the graph holds no entity at all under the filter this query \
+             applied for {language}"
+        ));
+    }
+    if coverage.get("budget_exhausted").and_then(Value::as_bool) == Some(true) {
+        return Reading::Inconclusive(format!(
+            "edge_coverage_budget_exhausted: the coverage scan for {language} stopped before it \
+             could establish what the graph holds"
+        ));
+    }
+
+    let requested = crate::negative::absence_cross_file_classes(tool, payload);
+    if requested.is_empty() {
+        return Reading::Certified;
+    }
+    let states = coverage.get("classes").and_then(Value::as_object);
+    let deciding = crate::negative::load_bearing_classes(&requested);
+    let unhealthy: Vec<&str> = deciding
+        .iter()
+        .filter(|class| {
+            states
+                .and_then(|states| states.get(class.as_str()))
+                .and_then(Value::as_str)
+                != Some("present")
+        })
+        .map(String::as_str)
+        .collect();
+    if unhealthy.is_empty() {
+        Reading::Certified
+    } else {
+        Reading::Inconclusive(format!(
+            "cross_file_edges_not_present: the graph was not observed to hold cross-file {} \
+             edges for {language}, so a use that reaches the target through {} could not have \
+             been found",
+            unhealthy.join(", "),
+            unhealthy.join(", ")
+        ))
+    }
+}
+
+/// Same-name candidates this answer held out of its headline.
+///
+/// A withheld row is evidence the answer already has and did not count, which is
+/// the one shape where the count and the payload beside it disagree about the
+/// same repository. `find_references(HTTPAdapter.send)` on psf/requests answered
+/// `total_upstream: 0` while carrying `Session.send` at `sessions.py:784` in
+/// `candidates`, and a reader of the headline deletes code a reader of the array
+/// keeps.
+fn withheld_candidates_reading(payload: &Value) -> Reading {
+    match withheld_candidate_count(payload) {
+        0 => Reading::Certified,
+        withheld => Reading::Inconclusive(format!(
+            "withheld_candidates: {withheld} same-name candidate(s) are carried in `candidates` \
+             and are not in the counts here, so the headline is a floor and each withheld row \
+             may belong in it"
+        )),
+    }
+}
+
+/// This query's own reported degradations.
+fn degradations_reading(payload: &Value) -> Reading {
+    let labels = crate::negative::payload_degradation_labels(payload);
+    if labels.is_empty() {
+        Reading::Certified
+    } else {
+        Reading::Inconclusive(format!(
+            "retrieval_degraded: this query reported degradations [{}], so it did not run at \
+             full capability",
+            labels.join(", ")
+        ))
+    }
+}
+
+/// The completeness signal's own reading of the substrate and the numbers.
+fn completeness_reading(envelope: &Envelope) -> Reading {
+    let Some(completeness) = &envelope.completeness else {
+        return Reading::Silent;
+    };
+    if completeness.status != "complete" {
+        return Reading::Inconclusive(format!(
+            "substrate_{}: the coverage classes this answer depended on were not all observed \
+             present ({})",
+            completeness.status,
+            completeness.decided_by.join(", ")
+        ));
+    }
+    if completeness.bound != "exact" {
+        return Reading::Inconclusive(
+            "counts_are_a_floor: this answer's own accounting reports its numbers as a lower \
+             bound"
+                .to_string(),
+        );
+    }
+    Reading::Certified
+}
+
+/// How many same-name candidates the payload held out of its counts, read from
+/// the one number the withheld plumbing already publishes.
+fn withheld_candidate_count(payload: &Value) -> u64 {
+    payload
+        .get("counts")
+        .and_then(|counts| counts.get("receiver_name_candidates"))
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            payload
+                .get("candidates")
+                .and_then(Value::as_array)
+                .map(|rows| rows.len() as u64)
+        })
+        .unwrap_or(0)
+}
+
+/// Whether the payload already names its withheld candidates as a degradation,
+/// which the absence gate consumes on its own.
+fn discloses_withheld_candidates(payload: &Value) -> bool {
+    crate::negative::payload_degradation_labels(payload)
+        .iter()
+        .any(|label| label.ends_with(":receiver_name_candidates"))
+}
+
+/// Downgrade every verdict surface on an already-built response that the size
+/// budget then shortened.
+///
+/// The budget runs after the verdict is serialized, so the cut cannot be known
+/// when the verdict is computed. Downgrading only `_kin.completeness` here, as
+/// this path used to, would leave `_kin.verdict` and `negative` certifying an
+/// answer whose rows were removed on purpose.
+pub fn mark_response_bounded(annotated: &mut Value) {
+    if let Some(verdict) = annotated
+        .get_mut(crate::envelope::ENVELOPE_KEY)
+        .and_then(Value::as_object_mut)
+        .and_then(|envelope| envelope.get_mut(VERDICT_KEY))
+        .and_then(Value::as_object_mut)
+    {
+        verdict.insert("state".to_string(), json!(INCONCLUSIVE));
+        verdict.insert("safe_to_conclude_absent".to_string(), json!(false));
+        verdict.insert(
+            "limiting_factor".to_string(),
+            json!(RESPONSE_BOUNDED_FACTOR),
+        );
+        verdict.insert(
+            "note".to_string(),
+            json!(format!(
+                "Treat this answer as a lower bound and do not act on an absence in it. Limiting \
+                 factor: {RESPONSE_BOUNDED_FACTOR}."
+            )),
+        );
+        if let Some(inputs) = verdict.get_mut("inputs").and_then(Value::as_object_mut) {
+            inputs.insert("response_budget".to_string(), json!(INCONCLUSIVE));
+        }
+    }
+    if let Some(negative) = annotated
+        .get_mut(crate::negative::NEGATIVE_KEY)
+        .and_then(Value::as_object_mut)
+    {
+        negative.insert("safe_to_conclude_absent".to_string(), json!(false));
+        negative.insert("trust".to_string(), json!(INCONCLUSIVE));
+        let reason = match negative.get("trust_reason").and_then(Value::as_str) {
+            Some(existing) if !existing.is_empty() => {
+                format!("{RESPONSE_BOUNDED_FACTOR}; {existing}")
+            }
+            _ => RESPONSE_BOUNDED_FACTOR.to_string(),
+        };
+        negative.insert("trust_reason".to_string(), json!(reason.clone()));
+        if let Some(advice) = negative.get("advice").and_then(Value::as_str) {
+            let head = advice.split(". Limiting factor:").next().unwrap_or(advice);
+            negative.insert(
+                "advice".to_string(),
+                json!(format!("{head}. Limiting factor: {reason}")),
+            );
+        }
+    }
+}
+
+/// Every way a built response contradicts its own single verdict, as one message
+/// per disagreement.
+///
+/// This is the guard that keeps the collapse from being undone one block at a
+/// time. It reads the fully built response, so it sees what a client sees rather
+/// than what any producer intended, and an empty result is the only shape that
+/// may ship.
+///
+/// Only fields a reader ACTS on are checked. `_kin.completeness.status` and
+/// `classes` are raw observation and may legitimately read `complete` and
+/// `present` under an inconclusive verdict, because the substrate being whole is
+/// not the same claim as the answer being whole.
+pub fn disagreements(response: &Value) -> Vec<String> {
+    let Some(verdict) = response
+        .get(crate::envelope::ENVELOPE_KEY)
+        .and_then(|envelope| envelope.get(VERDICT_KEY))
+    else {
+        return Vec::new();
+    };
+    let certified = verdict.get("state").and_then(Value::as_str) == Some(CERTIFIED);
+    let verdict_absent = verdict
+        .get("safe_to_conclude_absent")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let mut found = Vec::new();
+
+    if let Some(negative) = response.get(crate::negative::NEGATIVE_KEY) {
+        let negative_absent = negative
+            .get("safe_to_conclude_absent")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if negative_absent != verdict_absent {
+            found.push(format!(
+                "negative.safe_to_conclude_absent is {negative_absent} while \
+                 _kin.verdict.safe_to_conclude_absent is {verdict_absent}"
+            ));
+        }
+        if negative.get("trust").and_then(Value::as_str) == Some("authoritative") && !certified {
+            found.push(
+                "negative.trust reads authoritative under an inconclusive _kin.verdict".to_string(),
+            );
+        }
+        if let Some(advice) = negative.get("advice").and_then(Value::as_str) {
+            if advice.contains("Absence is authoritative") && !certified {
+                found.push(
+                    "negative.advice certifies an absence under an inconclusive _kin.verdict"
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    if let Some(completeness) = response
+        .get(crate::envelope::ENVELOPE_KEY)
+        .and_then(|envelope| envelope.get("completeness"))
+    {
+        if completeness.get("bound").and_then(Value::as_str) == Some("exact") && !certified {
+            found.push(
+                "_kin.completeness.bound reads exact under an inconclusive _kin.verdict"
+                    .to_string(),
+            );
+        }
+        if completeness
+            .get("counted")
+            .and_then(|counted| counted.get("exact"))
+            .and_then(Value::as_bool)
+            == Some(true)
+            && !certified
+        {
+            found.push(
+                "_kin.completeness.counted.exact is true under an inconclusive _kin.verdict"
+                    .to_string(),
+            );
+        }
+        if let Some(note) = completeness.get("note").and_then(Value::as_str) {
+            if note.contains("the whole set") && !certified {
+                found.push(
+                    "_kin.completeness.note claims the whole set under an inconclusive \
+                     _kin.verdict"
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    found.extend(headline_count_disagreements(response));
+    found
+}
+
+/// Where a headline count a reader acts on contradicts evidence the same
+/// response is holding.
+///
+/// The count and the withheld rows are one accounting with one source, so the
+/// three places it surfaces have to carry the same number. A `total_upstream` of
+/// zero beside a populated `candidates` array is the exact shape that made a
+/// reader delete working code, and it may not ship without
+/// `unconfirmed_candidates` naming the held rows at the count.
+fn headline_count_disagreements(response: &Value) -> Vec<String> {
+    let Some(candidates) = response.get("candidates").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let withheld = candidates.len() as u64;
+    if withheld == 0 {
+        return Vec::new();
+    }
+    let mut found = Vec::new();
+    match response
+        .get("unconfirmed_candidates")
+        .and_then(Value::as_u64)
+    {
+        None => found.push(format!(
+            "the response carries {withheld} candidate row(s) and no unconfirmed_candidates \
+             beside its headline count"
+        )),
+        Some(reported) if reported != withheld => found.push(format!(
+            "unconfirmed_candidates reads {reported} against {withheld} candidate row(s)"
+        )),
+        Some(_) => {}
+    }
+    if let Some(counted) = response
+        .get("counts")
+        .and_then(|counts| counts.get("receiver_name_candidates"))
+        .and_then(Value::as_u64)
+    {
+        if counted != withheld {
+            found.push(format!(
+                "counts.receiver_name_candidates reads {counted} against {withheld} candidate \
+                 row(s)"
+            ));
+        }
+    }
+    if let Some(reported) = response
+        .get(crate::envelope::ENVELOPE_KEY)
+        .and_then(|envelope| envelope.get("completeness"))
+        .and_then(|completeness| completeness.get("counted"))
+        .and_then(|counted| counted.get("withheld_candidates"))
+        .and_then(Value::as_u64)
+    {
+        if reported != withheld {
+            found.push(format!(
+                "_kin.completeness.counted.withheld_candidates reads {reported} against \
+                 {withheld} candidate row(s)"
+            ));
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A response whose blocks all agree with a certified verdict.
+    fn agreeing_response() -> Value {
+        json!({
+            "total_upstream": 2,
+            "unconfirmed_candidates": 0,
+            "candidates": [],
+            "_kin": {
+                "verdict": {
+                    "state": CERTIFIED,
+                    "safe_to_conclude_absent": true,
+                    "limiting_factor": Value::Null,
+                },
+                "completeness": {
+                    "status": "complete",
+                    "bound": "exact",
+                    "counted": {"reported": 2, "exact": true},
+                    "note": "the counts here are the whole set.",
+                },
+            },
+            "negative": {
+                "safe_to_conclude_absent": true,
+                "trust": "authoritative",
+                "advice": "Absence is authoritative: safe to treat the target as genuinely absent/unused.",
+            },
+        })
+    }
+
+    /// The scanner must be able to say "no disagreement", or every assertion
+    /// built on it passes for the wrong reason.
+    #[test]
+    fn an_agreeing_response_reports_no_disagreement() {
+        assert!(
+            disagreements(&agreeing_response()).is_empty(),
+            "{:?}",
+            disagreements(&agreeing_response())
+        );
+    }
+
+    /// A response with no verdict at all is not a disagreement: mutations,
+    /// session calls and everything else that is not retrieval carry none.
+    #[test]
+    fn a_response_without_a_verdict_is_not_scanned() {
+        assert!(disagreements(&json!({"committed": true})).is_empty());
+    }
+
+    /// FIR-2463 case (c). The old two-verdict shape, verbatim from the shipped
+    /// v0.5.42 payload the stranger quoted: `completeness` calling an answer
+    /// complete, exact and "the whole set" while `negative` on the same object
+    /// refuses to certify it. Forcing that shape back has to be caught at every
+    /// field a reader acts on, not just the first.
+    #[test]
+    fn the_old_two_verdict_shape_cannot_serialize() {
+        let mut response = agreeing_response();
+        response["_kin"]["verdict"]["state"] = json!(INCONCLUSIVE);
+        response["_kin"]["verdict"]["safe_to_conclude_absent"] = json!(false);
+
+        let found = disagreements(&response);
+        for expected in [
+            "negative.safe_to_conclude_absent is true while _kin.verdict.safe_to_conclude_absent \
+             is false",
+            "negative.trust reads authoritative under an inconclusive _kin.verdict",
+            "negative.advice certifies an absence under an inconclusive _kin.verdict",
+            "_kin.completeness.bound reads exact under an inconclusive _kin.verdict",
+            "_kin.completeness.counted.exact is true under an inconclusive _kin.verdict",
+            "_kin.completeness.note claims the whole set under an inconclusive _kin.verdict",
+        ] {
+            assert!(
+                found.iter().any(|message| message == expected),
+                "the scanner missed `{expected}`: {found:?}"
+            );
+        }
+    }
+
+    /// The headline-count half of the same invariant. A zero beside a populated
+    /// `candidates` array may not ship without `unconfirmed_candidates` naming
+    /// the held rows at the count.
+    #[test]
+    fn a_headline_that_hides_its_held_rows_cannot_serialize() {
+        let mut response = agreeing_response();
+        response["total_upstream"] = json!(0);
+        response["candidates"] = json!([{"name": "Session.send", "reference_lines": [784]}]);
+        response
+            .as_object_mut()
+            .unwrap()
+            .remove("unconfirmed_candidates");
+
+        let missing = disagreements(&response);
+        assert!(
+            missing.iter().any(|message| message
+                == "the response carries 1 candidate row(s) and no unconfirmed_candidates beside \
+                    its headline count"),
+            "{missing:?}"
+        );
+
+        // Present but wrong is caught too, at each of the three placements the
+        // one withheld number surfaces at.
+        response["unconfirmed_candidates"] = json!(0);
+        response["counts"] = json!({"receiver_name_candidates": 0});
+        response["_kin"]["completeness"]["counted"]["withheld_candidates"] = json!(4);
+        let skewed = disagreements(&response);
+        for expected in [
+            "unconfirmed_candidates reads 0 against 1 candidate row(s)",
+            "counts.receiver_name_candidates reads 0 against 1 candidate row(s)",
+            "_kin.completeness.counted.withheld_candidates reads 4 against 1 candidate row(s)",
+        ] {
+            assert!(
+                skewed.iter().any(|message| message == expected),
+                "the scanner missed `{expected}`: {skewed:?}"
+            );
+        }
+
+        // And the agreeing form clears, so the check is not simply always-on.
+        response["unconfirmed_candidates"] = json!(1);
+        response["counts"] = json!({"receiver_name_candidates": 1});
+        response["_kin"]["completeness"]["counted"]["withheld_candidates"] = json!(1);
+        assert!(
+            headline_count_disagreements(&response).is_empty(),
+            "{:?}",
+            headline_count_disagreements(&response)
+        );
+    }
+
+    /// The substrate reading stays raw. `status: "complete"` and a `classes` map
+    /// are the evidence the verdict was computed FROM, so an inconclusive
+    /// verdict beside them is the intended shape rather than a contradiction.
+    /// Scanning them would force the fix to throw the evidence away.
+    #[test]
+    fn a_raw_substrate_observation_is_not_a_competing_verdict() {
+        let mut response = agreeing_response();
+        response["_kin"]["verdict"]["state"] = json!(INCONCLUSIVE);
+        response["_kin"]["verdict"]["safe_to_conclude_absent"] = json!(false);
+        response["negative"] = json!({
+            "safe_to_conclude_absent": false,
+            "trust": INCONCLUSIVE,
+            "advice": "Absence is NOT authoritative: do not conclude the target is unused.",
+        });
+        response["_kin"]["completeness"] = json!({
+            "status": "complete",
+            "classes": {"calls": "present", "imports": "absent"},
+            "bound": "at_least",
+            "counted": {"reported": 2, "exact": false},
+            "note": "The counts here are a lower bound.",
+        });
+        assert!(
+            disagreements(&response).is_empty(),
+            "{:?}",
+            disagreements(&response)
+        );
+    }
+
+    /// The budget path downgrades every verdict surface together. Leaving
+    /// `negative` or `_kin.verdict` certifying an answer whose rows were removed
+    /// is the same defect arriving through the one path that removes answers on
+    /// purpose.
+    #[test]
+    fn a_budget_cut_downgrades_the_verdict_and_the_absence_together() {
+        let mut response = agreeing_response();
+        response["negative"]["trust_reason"] = json!("structural_authoritative");
+        mark_response_bounded(&mut response);
+
+        assert_eq!(response["_kin"]["verdict"]["state"], json!(INCONCLUSIVE));
+        assert_eq!(
+            response["_kin"]["verdict"]["safe_to_conclude_absent"],
+            json!(false)
+        );
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"],
+            json!(false)
+        );
+        assert_eq!(response["negative"]["trust"], json!(INCONCLUSIVE));
+        assert!(response["negative"]["trust_reason"]
+            .as_str()
+            .unwrap()
+            .starts_with("response_bounded"));
+        assert!(response["negative"]["advice"]
+            .as_str()
+            .unwrap()
+            .contains("Limiting factor: response_bounded"));
+    }
+}


### PR DESCRIPTION
A single retrieval response could carry three verdict-shaped claims that were computed on separate routes and could disagree with each other, so which one an agent acted on depended on which key it happened to read. The npm-0541 stranger run on shipped v0.5.42 bytes quoted a `find_references` response carrying `_kin.completeness.status: "complete"`, `bound: "exact"`, `counted.exact: true` and a note reading "the counts here are the whole set", directly above a `classes` map marking two of three edge classes absent and `negative.safe_to_conclude_absent: false`. In the same session on the same repository, `graph_neighborhood` walked the same two inbound edges and framed them as `"complete"` with no `negative` object at all, because a non-empty answer synthesizes none.

## Mechanism

`Completeness::for_tool` decides `status` from `load_bearing_classes`, which narrows to `calls` alone, and it files `edge_coverage:reference_enrichment_unsupported` under `limits`, which by design does not decide `status` (`crates/kin-mcp/src/envelope.rs:512`). The absence gate reads that same enrichment fact and refuses on it (`crates/kin-mcp/src/negative.rs:481`). Both were right about their own question and the response published them side by side. Separately, `negative_for` returns `None` the moment a collection is non-empty (`crates/kin-mcp/src/negative.rs:1277`), so any answer that returned rows reached a reader with no gate applied at all.

## The fix

`crates/kin-mcp/src/verdict.rs` is the one authority. Every block that publishes a verdict-shaped claim is an input to it, the most pessimistic input wins, and certification requires every input that spoke to agree. A silent input never contributes agreement, so a response no input spoke about carries no verdict rather than a certified one. The absence gate runs for a non-empty answer too, which is the route that used to skip it.

`envelope::finalize_bounded` computes it after completeness and negative both exist, then projects it back. `negative_for` takes the response-scoped gaps as an argument so its `trust`, `trust_reason` and `advice` are built consistently rather than patched after the fact. `_kin.completeness` has `bound`, `counted.exact` and `note` capped. `status`, `classes`, `decided_by` and `limits` stay raw observation, because whether the substrate was whole is a different claim from whether the answer can be acted on, and collapsing the two would throw the evidence away rather than reconcile it.

For the headline counts, `find_references` publishes `unconfirmed_candidates` beside `total_upstream`, from the same partition that already feeds `counts.receiver_name_candidates` and `_kin.completeness.counted.withheld_candidates`. One number, three placements, one source, and the invariant below asserts they agree. `kin refs` prints the held count on the same line as the headline instead of leaving it to a paragraph further down, and the count painter was widened with it, since an unmatched line prints as plain text and would have lost its color silently.

`verdict::disagreements` scans a fully built response for any block contradicting the verdict and runs under `debug_assert!` on every annotated response, so a future block cannot reintroduce a second verdict quietly. The MCP server instructions and the `find_references` tool description now name `_kin.verdict` as the field to read first.

## Falsification

Each break was applied to the committed tree, the named test run with its exit code read raw, then the tree restored with `git checkout`.

Breaking `withheld_candidates_reading` to always certify: `a_withheld_caller_refuses_the_zero_it_was_held_out_of` failed rc=101 with "the withheld row is the input that decided", the payload showing `withheld_candidates: certified`. Removing `unconfirmed_candidates` from the payload: the same test failed rc=101 inside the response-construction assertion. Forcing `certified = false`: `a_proven_caller_on_the_same_fixture_certifies` and `find_references_certifies_absence_once_the_graph_links_calls_across_files` both failed rc=101, which is the lazy regression FIR-2357 item 4 bars. Removing the `project_onto_completeness` call: `a_javascript_export_is_not_certified_absent_when_requires_produce_no_edges` failed rc=101 with `["_kin.completeness.bound reads exact under an inconclusive _kin.verdict", "_kin.completeness.counted.exact is true under an inconclusive _kin.verdict", "_kin.completeness.note claims the whole set under an inconclusive _kin.verdict"]`, which is the stranger's quoted shape caught at construction. Blinding `disagreements` to return an empty vec: `the_old_two_verdict_shape_cannot_serialize` and `a_headline_that_hides_its_held_rows_cannot_serialize` both failed rc=101.

The first form of the task-2 fixture answered on the offline path with no spine, so it was also inconclusive for `cross_repo_unavailable` and proved less than it claimed. It now runs on the daemon authority path with a registered spine, and `a_proven_caller_on_the_same_fixture_certifies` runs the identical fixture with the one relation moved to the parser-certain tier and asserts the opposite verdict. One confidence value separates the two outcomes, so a hardcoded verdict in either direction fails one of the pair.

A second-pass review of the finished diff found one more hole and it is fixed here. The withheld-candidate and degradation inputs answered `certified` when the payload carried no candidate accounting and no `degradations` array at all, so a mutation response, whose every other input is silent, reached a certified verdict on no evidence. Silence is not agreement, which the module's own contract said and those two did not do. Both now return `Silent` when the concept is absent. `a_non_retrieval_payload_carries_no_verdict` fails rc=101 against the old behavior, and `a_clean_retrieval_payload_still_certifies` is the control proving the change is not a blanket refusal.

## Gate

`bin/kin-dev local-test kin` through `bin/kin-lane run oneverdict kin`, resolving the lane worktree on `chore/lane-oneverdict-kin`: `6474 tests run: 6474 passed (3 slow, 4 leaky), 12 skipped`, rc=0 with `--no-fail-fast`, plus green doctests. `cargo fmt --all -- --check` rc=0. Clippy driven exactly as ci.yml now drives it, reading the 45 allows from `.github/clippy-allowed-lints.txt`, rc=0. `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `verify-hydration-semantics.py`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh` and `test-private-repo-coupling.py` all rc=0. The `--no-default-features` permutation over kin-mcp, kin-cli and kin-daemon with the same allow list is rc=0. `git ls-tree -r HEAD --name-only` prints only `.cargo/config.toml` under `.cargo/`, and `git diff origin/main -- Cargo.lock .cargo/` is empty.

The Windows cross-compile legs could not run on this host: `cargo clippy --target x86_64-pc-windows-msvc` fails building `ring`, whose C sources need Windows headers this machine does not have. Nothing in this change is platform gated, and every item added is reachable unconditionally from `finalize_bounded`, but the Windows legs are proven by CI here rather than locally.

Closes FIR-2463
