### PR TITLE
Wire JavaScript and TypeScript reference enrichment, provision the servers, and stop certifying an absence over a language nothing resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1202,6 +1202,15 @@ jobs:
         with:
           tool: nextest
 
+      # Without a language server on PATH the reference-enrichment proof in
+      # crates/kin-daemon/tests/lsp_reference_enrichment.rs skips, so this step
+      # is what makes it run. It warns and exits 0 on a registry failure rather
+      # than failing the gate, and the skip is annotated on the run summary and
+      # printed per test, so it is never silent.
+      - name: Install language servers for the enrichment proof
+        if: runner.os == 'Linux'
+        run: bash scripts/ci-install-language-servers.sh
+
       - name: Test
         run: cargo nextest run --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ dependencies = [
  "tracing",
  "unicode-normalization",
  "uuid",
+ "which 8.0.4",
  "winapi-util",
  "windows-sys 0.61.2",
 ]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -277,31 +277,16 @@ fn embedding_coverage_is_measured(_graph: &kin_db::InMemoryGraph) -> bool {
     true
 }
 
-/// Language servers this build can actually enrich with, and the binaries that
-/// provide them.
-///
-/// Two facts have to hold together for a reference edge to exist: the daemon
-/// wires an adapter for the language, and a server binary is installed. The
-/// binary names mirror `kin_lsp::discovery::KNOWN_SERVERS` for exactly the
-/// languages `kin_core::reference_coverage::ENRICHABLE_LANGUAGES` names;
-/// probing them here rather than through `discover_servers` keeps the daemon's
-/// status path off a subprocess, since discovery runs `--version` on every
-/// server it finds.
-pub(crate) const LANGUAGE_SERVER_BINARIES: &[(kin_model::LanguageId, &[&str])] = &[
-    (kin_model::LanguageId::Rust, &["rust-analyzer"]),
-    (
-        kin_model::LanguageId::Python,
-        &["pyright-langserver", "pylsp"],
-    ),
-];
-
 /// Languages whose enrichment server is installed on this host.
+///
+/// The table this probes lives in `crate::commands::language_servers`, beside
+/// the command that installs each one, because a name that drifts between the
+/// probe and the advice produces a doctor row that reports a gap and a fix that
+/// does not close it. Probing here rather than through
+/// `kin_lsp::discovery::discover_servers` keeps the status path off a
+/// subprocess, since discovery runs `--version` on every server it finds.
 pub(crate) fn installed_language_servers() -> HashSet<kin_model::LanguageId> {
-    LANGUAGE_SERVER_BINARIES
-        .iter()
-        .filter(|(_, binaries)| binaries.iter().any(|binary| which::which(binary).is_ok()))
-        .map(|(language, _)| *language)
-        .collect()
+    crate::commands::language_servers::installed_language_servers()
 }
 
 /// The whole-graph relation totals the completeness section reports beside its

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -2532,7 +2532,7 @@ fn coverage_unreadable(
             language_server_gap_detail(missing_servers)
         ),
     )
-    .with_manual_fix(LANGUAGE_SERVER_FIX)
+    .with_manual_fix(language_server_fix())
 }
 
 /// Turn the measurement into a verdict, split from its fetch so the rule is
@@ -2592,12 +2592,25 @@ pub(crate) fn reference_edge_coverage_health(
     // query it answers is still true about the edges it holds. What it cannot do
     // is support a claim that something is unused, so this needs attention
     // without failing readiness.
-    HealthCheck::new(
+    let check = HealthCheck::new(
         ID,
         LABEL,
         HealthStatus::Pending,
         format!("{}; {}", gaps.join("; "), summary),
-    )
+    );
+    // A missing server is the one gap on this row an operator can actually
+    // close, so it is the only case that carries a fix, and the fix names the
+    // command for the languages THIS repository holds rather than for every
+    // language the build wires. `unsupportable_absence_reasons` covers gaps a
+    // host cannot install its way out of; offering an install for those would
+    // be a fix that changes nothing.
+    if missing_servers.is_empty() {
+        check
+    } else {
+        check.with_manual_fix(crate::commands::language_servers::install_fix_line(
+            &missing_servers,
+        ))
+    }
     .with_manual_fix(
         "re-admit the repository so relation extraction runs again (`kin reconcile --admit`), and \
          treat any \"unused\" answer as unverified until cross-file edges resolve",
@@ -2809,8 +2822,8 @@ async fn check_semantic_query_readiness() -> HealthCheck {
 fn missing_language_servers(
     installed: &std::collections::HashSet<kin_model::LanguageId>,
 ) -> Vec<String> {
-    crate::commands::graph::LANGUAGE_SERVER_BINARIES
-        .iter()
+    crate::commands::language_servers::language_server_binaries()
+        .into_iter()
         .filter(|(language, _)| !installed.contains(language))
         .map(|(language, binaries)| format!("{language} ({})", binaries.join(" or ")))
         .collect()
@@ -2827,8 +2840,8 @@ fn language_server_gap_detail(missing: &[String]) -> String {
          import and call edges are still resolved from source. Languages outside {} gain no \
          reference edges in this build either",
         missing.join(", "),
-        crate::commands::graph::LANGUAGE_SERVER_BINARIES
-            .iter()
+        crate::commands::language_servers::language_server_binaries()
+            .into_iter()
             .map(|(language, _)| language.to_string())
             .collect::<Vec<_>>()
             .join("/")
@@ -2951,9 +2964,21 @@ fn embedding_model_check_from(
     ))
 }
 
-const LANGUAGE_SERVER_FIX: &str =
-    "install a language server for the named language (for example `npm i -g pyright` or \
-     `rustup component add rust-analyzer`), then restart the daemon";
+/// The fix for the fallback row, which probes every wired language because it
+/// could not read the graph to learn which ones this repository holds.
+///
+/// Built rather than written out, so the commands here and the ones the
+/// measured row prints come from one table. A hand-written example command is
+/// how `npm i -g pyright` ended up beside a probe for `pyright-langserver`
+/// without anything checking that the package provides the binary.
+fn language_server_fix() -> String {
+    let every: Vec<String> = crate::commands::language_servers::language_server_binaries()
+        .into_iter()
+        .map(|(language, _)| language.to_string())
+        .collect();
+    let names: Vec<&str> = every.iter().map(String::as_str).collect();
+    crate::commands::language_servers::install_fix_line(&names)
+}
 
 /// Report the active retrieval quality profile and the effective lever set,
 /// so an operator can see at a glance whether they are getting full
@@ -3590,9 +3615,9 @@ mod tests {
     #[test]
     fn doctor_reports_no_gap_once_every_wired_language_server_is_installed() {
         let installed: std::collections::HashSet<kin_model::LanguageId> =
-            crate::commands::graph::LANGUAGE_SERVER_BINARIES
-                .iter()
-                .map(|(language, _)| *language)
+            crate::commands::language_servers::language_server_binaries()
+                .into_iter()
+                .map(|(language, _)| language)
                 .collect();
         let missing = missing_language_servers(&installed);
         assert!(missing.is_empty(), "{missing:?}");

--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -209,7 +209,9 @@ pub(crate) fn install_commands_for_names(names: &[&str]) -> Vec<String> {
 pub(crate) fn install_fix_line(missing_names: &[&str]) -> String {
     let commands = install_commands_for_names(missing_names);
     if commands.is_empty() {
-        return format!("install a language server for the named language, then {RESTART_AFTER_INSTALL}");
+        return format!(
+            "install a language server for the named language, then {RESTART_AFTER_INSTALL}"
+        );
     }
     format!(
         "run `kin doctor --fix --install-language-servers` to install {} for you, or run {} \
@@ -493,11 +495,8 @@ mod tests {
 
     #[test]
     fn install_commands_cover_every_distinct_missing_language() {
-        let commands = install_commands_for(&[
-            LanguageId::Python,
-            LanguageId::JavaScript,
-            LanguageId::Rust,
-        ]);
+        let commands =
+            install_commands_for(&[LanguageId::Python, LanguageId::JavaScript, LanguageId::Rust]);
         assert_eq!(commands.len(), 3, "{commands:?}");
         assert!(commands.contains(&"npm install -g pyright".to_string()));
     }

--- a/crates/kin-cli/src/commands/language_servers.rs
+++ b/crates/kin-cli/src/commands/language_servers.rs
@@ -1,0 +1,749 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Which language servers this build enriches with, and how to install them.
+//!
+//! Two facts have to hold together before a cross-file reference edge can
+//! exist: the daemon wires an adapter for the language, and a server binary is
+//! installed on the host. The first is a property of the build and is asserted
+//! in `kin_daemon` against
+//! [`kin_core::reference_coverage::ENRICHABLE_LANGUAGES`]. The second is a
+//! property of the machine, and until this module existed nothing in Kin could
+//! close it: `kin doctor` named the gap in prose and left the operator to work
+//! out the command.
+//!
+//! That gap is not hypothetical. The v0.5.42 install a stranger exercised
+//! carried no language server at all, so the Python adapter was wired, started
+//! nothing, logged the failure at debug level, and every cross-file call fell
+//! back to matching bare names. A wired adapter with no server behind it is
+//! indistinguishable at the query surface from a language Kin does not support,
+//! which is why provisioning belongs beside the wiring rather than in a doc.
+//!
+//! Nothing here installs without consent. A language server is a network
+//! download into a shared global prefix, and Kin does not spend a user's
+//! bandwidth or mutate their toolchain on a probe's say-so.
+
+use std::collections::HashSet;
+use std::process::Command;
+
+use kin_model::LanguageId;
+
+/// How to install the language server for one language.
+///
+/// `binaries` mirrors `kin_lsp::discovery::KNOWN_SERVERS` for the same
+/// language, because discovery is what the daemon actually consults; a name
+/// that differs here would advertise a fix that leaves the gap open. The first
+/// entry is the binary the daemon's adapter starts, and the remaining ones are
+/// alternatives discovery accepts.
+pub(crate) struct LanguageServerRecipe {
+    pub(crate) language: LanguageId,
+    pub(crate) binaries: &'static [&'static str],
+    pub(crate) program: &'static str,
+    pub(crate) args: &'static [&'static str],
+    /// What the operator is spending by saying yes. Named per recipe rather
+    /// than as one sentence, because "this downloads a package" is exactly the
+    /// disclosure that reads as boilerplate and gets clicked through.
+    pub(crate) disclosure: &'static str,
+}
+
+impl LanguageServerRecipe {
+    /// The command as an operator would type it.
+    pub(crate) fn command_line(&self) -> String {
+        if self.args.is_empty() {
+            self.program.to_string()
+        } else {
+            format!("{} {}", self.program, self.args.join(" "))
+        }
+    }
+
+    /// Whether any binary that satisfies this language is on `PATH`.
+    pub(crate) fn installed(&self) -> bool {
+        self.binaries
+            .iter()
+            .any(|binary| which::which(binary).is_ok())
+    }
+
+    /// Whether the tool that performs the install exists on this host.
+    ///
+    /// Reported separately from the install itself so a host without `npm`
+    /// gets told that rather than a subprocess spawn error, which reads like a
+    /// Kin defect.
+    pub(crate) fn installer_available(&self) -> bool {
+        which::which(self.program).is_ok()
+    }
+}
+
+/// Every language this build can enrich, with the server that enriches it.
+///
+/// JavaScript and TypeScript are separate rows resolving to one binary and one
+/// install command. They are separate because coverage is reported per language
+/// the repository actually holds, and a JavaScript-only repository must not be
+/// told its enrichment depends on a TypeScript row it has no files for. The
+/// installer deduplicates by command line, so consenting to both runs `npm`
+/// once.
+pub(crate) const LANGUAGE_SERVERS: &[LanguageServerRecipe] = &[
+    LanguageServerRecipe {
+        language: LanguageId::Rust,
+        binaries: &["rust-analyzer"],
+        program: "rustup",
+        args: &["component", "add", "rust-analyzer"],
+        disclosure: "adds a rustup component to the active toolchain",
+    },
+    LanguageServerRecipe {
+        language: LanguageId::Python,
+        binaries: &["pyright-langserver", "pylsp"],
+        program: "npm",
+        args: &["install", "-g", "pyright"],
+        disclosure: "downloads the pyright npm package into your global npm prefix",
+    },
+    LanguageServerRecipe {
+        language: LanguageId::TypeScript,
+        binaries: &["typescript-language-server", "vtsls"],
+        program: "npm",
+        args: &["install", "-g", "typescript-language-server", "typescript"],
+        disclosure: "downloads the typescript-language-server and typescript npm packages into \
+                     your global npm prefix",
+    },
+    LanguageServerRecipe {
+        language: LanguageId::JavaScript,
+        binaries: &["typescript-language-server"],
+        program: "npm",
+        args: &["install", "-g", "typescript-language-server", "typescript"],
+        disclosure: "downloads the typescript-language-server and typescript npm packages into \
+                     your global npm prefix",
+    },
+];
+
+/// The recipe for one language, if this build enriches it at all.
+pub(crate) fn recipe_for(language: LanguageId) -> Option<&'static LanguageServerRecipe> {
+    LANGUAGE_SERVERS
+        .iter()
+        .find(|recipe| recipe.language == language)
+}
+
+/// Language servers this build can enrich with, and the binaries that provide
+/// them.
+///
+/// The shape `kin doctor` and `kin graph status` already consumed. Kept as a
+/// projection of [`LANGUAGE_SERVERS`] rather than a second table, because two
+/// tables listing the same binaries is how the runtime and the advice come
+/// apart.
+pub(crate) fn language_server_binaries() -> Vec<(LanguageId, &'static [&'static str])> {
+    LANGUAGE_SERVERS
+        .iter()
+        .map(|recipe| (recipe.language, recipe.binaries))
+        .collect()
+}
+
+/// Languages whose enrichment server is installed on this host.
+pub(crate) fn installed_language_servers() -> HashSet<LanguageId> {
+    LANGUAGE_SERVERS
+        .iter()
+        .filter(|recipe| recipe.installed())
+        .map(|recipe| recipe.language)
+        .collect()
+}
+
+/// The exact command that closes the gap for `missing`, deduplicated.
+///
+/// One string an operator can paste. Two languages served by one package
+/// produce one command, so the advice never asks for the same install twice.
+pub(crate) fn install_commands_for(missing: &[LanguageId]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for language in missing {
+        if let Some(recipe) = recipe_for(*language) {
+            let command = recipe.command_line();
+            if !seen.contains(&command) {
+                seen.push(command);
+            }
+        }
+    }
+    seen
+}
+
+/// Every language this build enriches whose server is absent from this host.
+///
+/// Scoped to the build rather than to the repository on purpose. The per-repo
+/// list is the better one to WARN about, and the coverage row already uses it,
+/// but it is measured through a running daemon and this is the repair that has
+/// to work on a host where nothing is running yet. Consent is per install
+/// command, so an operator on a Python-only machine still declines the Rust
+/// one rather than being handed a toolchain they did not ask for.
+pub(crate) fn missing_enrichable_languages() -> Vec<LanguageId> {
+    LANGUAGE_SERVERS
+        .iter()
+        .filter(|recipe| !recipe.installed())
+        .map(|recipe| recipe.language)
+        .collect()
+}
+
+/// The exact commands for languages named by their wire name.
+///
+/// The coverage report hands out `LanguageId`'s display strings rather than the
+/// ids themselves, so the fix line that quotes them back has to resolve through
+/// the same names. An unrecognised name yields no command rather than a guess.
+pub(crate) fn install_commands_for_names(names: &[&str]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for name in names {
+        // The coverage row prints `python (pyright-langserver or pylsp)` in
+        // some surfaces and a bare `python` in others, so match on the leading
+        // token rather than the whole string.
+        let bare = name.split_whitespace().next().unwrap_or(name);
+        for recipe in LANGUAGE_SERVERS {
+            if recipe.language.to_string() == bare {
+                let command = recipe.command_line();
+                if !seen.contains(&command) {
+                    seen.push(command);
+                }
+            }
+        }
+    }
+    seen
+}
+
+/// The fix line for a set of languages whose servers are missing.
+///
+/// Names the command rather than describing it. A row that says "install a
+/// language server" and leaves the operator to find out which package provides
+/// `pyright-langserver` is a gap report wearing a fix's clothes.
+pub(crate) fn install_fix_line(missing_names: &[&str]) -> String {
+    let commands = install_commands_for_names(missing_names);
+    if commands.is_empty() {
+        return format!("install a language server for the named language, then {RESTART_AFTER_INSTALL}");
+    }
+    format!(
+        "run `kin doctor --fix --install-language-servers` to install {} for you, or run {} \
+         yourself; then {RESTART_AFTER_INSTALL}",
+        if commands.len() == 1 { "it" } else { "them" },
+        commands
+            .iter()
+            .map(|command| format!("`{command}`"))
+            .collect::<Vec<_>>()
+            .join(" and "),
+    )
+}
+
+/// Whether Kin may install a language server, and on whose say-so.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstallConsent {
+    /// A person is at the terminal: ask, then act on the answer.
+    Ask,
+    /// The caller passed the flag. Act without asking.
+    Granted,
+    /// No flag and nobody to ask. Print the command and change nothing.
+    Withheld,
+}
+
+impl InstallConsent {
+    /// Resolve consent from the flag and whether a person is present.
+    ///
+    /// The flag wins over the terminal in both directions: a script that passes
+    /// it is not prompted, and an interactive run that does not is still asked
+    /// rather than silently skipped.
+    pub(crate) fn resolve(flag: bool, interactive: bool) -> Self {
+        if flag {
+            Self::Granted
+        } else if interactive {
+            Self::Ask
+        } else {
+            Self::Withheld
+        }
+    }
+}
+
+/// What happened to one language's server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InstallOutcome {
+    /// A binary for this language was already on `PATH`.
+    AlreadyPresent,
+    /// The install command ran and the binary is now on `PATH`.
+    Installed { command: String },
+    /// The install command ran and the binary is still not on `PATH`. Reported
+    /// rather than assumed installed: a zero exit from a package manager that
+    /// wrote to a prefix outside `PATH` is the failure that reads as success.
+    RanButStillMissing { command: String },
+    /// The install command failed.
+    Failed { command: String, reason: String },
+    /// Consent was not given, or nobody was there to give it.
+    Declined { command: String },
+    /// The installer itself is not on this host.
+    NoInstaller { program: String, command: String },
+}
+
+/// One language's provisioning result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InstallReport {
+    pub(crate) language: LanguageId,
+    pub(crate) outcome: InstallOutcome,
+}
+
+/// Provision the servers for `missing`, honouring `consent`.
+///
+/// Every input is an argument, including the two `PATH` probes. Reading `PATH`
+/// directly would make each test below assert about the machine it happens to
+/// run on: on a host that already has pyright the declined-prompt case takes
+/// the `AlreadyPresent` branch and passes without ever exercising a decline,
+/// which is a green test that has stopped checking its own subject. As written,
+/// a test states the whole environment it is asserting against.
+///
+/// `ask` is called at most once per distinct command, so consenting to
+/// TypeScript does not produce a second prompt for JavaScript.
+pub(crate) fn provision(
+    missing: &[LanguageId],
+    consent: InstallConsent,
+    mut installed: impl FnMut(&LanguageServerRecipe) -> bool,
+    mut installer_available: impl FnMut(&LanguageServerRecipe) -> bool,
+    mut ask: impl FnMut(&LanguageServerRecipe) -> bool,
+    mut run: impl FnMut(&LanguageServerRecipe) -> Result<(), String>,
+) -> Vec<InstallReport> {
+    let mut reports = Vec::new();
+    // Keyed on the command rather than the language: one npm install serves
+    // both JavaScript and TypeScript, and running it twice would download the
+    // same package again and ask twice for one decision.
+    let mut decided: Vec<(String, bool)> = Vec::new();
+    let mut ran: Vec<(String, Result<(), String>)> = Vec::new();
+
+    for language in missing {
+        let Some(recipe) = recipe_for(*language) else {
+            continue;
+        };
+        let command = recipe.command_line();
+
+        if installed(recipe) {
+            reports.push(InstallReport {
+                language: *language,
+                outcome: InstallOutcome::AlreadyPresent,
+            });
+            continue;
+        }
+
+        if !installer_available(recipe) {
+            reports.push(InstallReport {
+                language: *language,
+                outcome: InstallOutcome::NoInstaller {
+                    program: recipe.program.to_string(),
+                    command,
+                },
+            });
+            continue;
+        }
+
+        let approved = match consent {
+            InstallConsent::Granted => true,
+            InstallConsent::Withheld => false,
+            InstallConsent::Ask => match decided.iter().find(|(cmd, _)| cmd == &command) {
+                Some((_, answer)) => *answer,
+                None => {
+                    let answer = ask(recipe);
+                    decided.push((command.clone(), answer));
+                    answer
+                }
+            },
+        };
+
+        if !approved {
+            reports.push(InstallReport {
+                language: *language,
+                outcome: InstallOutcome::Declined { command },
+            });
+            continue;
+        }
+
+        let result = match ran.iter().find(|(cmd, _)| cmd == &command) {
+            Some((_, result)) => result.clone(),
+            None => {
+                let result = run(recipe);
+                ran.push((command.clone(), result.clone()));
+                result
+            }
+        };
+
+        let outcome = match result {
+            Err(reason) => InstallOutcome::Failed { command, reason },
+            // Re-probe `PATH` rather than trusting the exit code. A global npm
+            // prefix outside `PATH` installs successfully and leaves the binary
+            // unreachable, which is the shape of success that would let doctor
+            // report a closed gap that is still open.
+            Ok(()) if installed(recipe) => InstallOutcome::Installed { command },
+            Ok(()) => InstallOutcome::RanButStillMissing { command },
+        };
+        reports.push(InstallReport {
+            language: *language,
+            outcome,
+        });
+    }
+
+    reports
+}
+
+/// Run a recipe's install command, inheriting stdio so the operator sees the
+/// package manager's own progress rather than a spinner hiding it.
+pub(crate) fn run_install(recipe: &LanguageServerRecipe) -> Result<(), String> {
+    let status = Command::new(recipe.program)
+        .args(recipe.args)
+        .status()
+        .map_err(|error| format!("could not run `{}`: {error}", recipe.command_line()))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{}` exited with {}",
+            recipe.command_line(),
+            status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "a signal".to_string())
+        ))
+    }
+}
+
+/// Whether a newly installed server reaches a daemon that is already running.
+///
+/// It does not, when the daemon started on a host with no server at all.
+/// `kin_daemon::daemon` calls `kin_lsp::discovery::discover_servers()` once
+/// during startup and, on an empty result, never creates the enrichment channel
+/// for the life of that process, so no later install can be picked up. When
+/// discovery found at least one server the channel exists and each language's
+/// server is started lazily on first use, so a server installed afterwards is
+/// picked up without a restart.
+///
+/// Both halves are true and only the pessimistic one is safe to print, because
+/// the surface asking cannot see which case the running daemon is in: a fresh
+/// install is exactly the host where discovery found nothing.
+pub(crate) const RESTART_AFTER_INSTALL: &str =
+    "run `kin daemon stop` so the next kin command starts a daemon that discovers the new server; \
+     a daemon that started with no language server on the host never opens its enrichment channel";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The advice and the runtime must name the same binaries.
+    ///
+    /// `kin doctor` tells an operator to install a binary and the daemon starts
+    /// one; a difference between the two names is advice that leaves the gap
+    /// open while reporting it closed. These are the names in
+    /// `kin_lsp::discovery::KNOWN_SERVERS` and in the daemon's adapter map,
+    /// asserted here because kin-cli cannot see either at compile time.
+    #[test]
+    fn recipes_name_the_binaries_the_daemon_starts() {
+        for (language, expected) in [
+            (LanguageId::Rust, "rust-analyzer"),
+            (LanguageId::Python, "pyright-langserver"),
+            (LanguageId::TypeScript, "typescript-language-server"),
+            (LanguageId::JavaScript, "typescript-language-server"),
+        ] {
+            let recipe = recipe_for(language).expect("language must have a recipe");
+            assert_eq!(
+                recipe.binaries.first().copied(),
+                Some(expected),
+                "{language}: first binary is what the daemon's adapter starts"
+            );
+        }
+    }
+
+    /// Every language the coverage report calls enrichable must be installable.
+    ///
+    /// The failing case this rules out is a language wired for enrichment whose
+    /// doctor row can only say "no language server found" with no command
+    /// behind it, which is the state every language was in before this module.
+    #[test]
+    fn every_enrichable_language_has_an_install_command() {
+        for language in kin_core::reference_coverage::ENRICHABLE_LANGUAGES {
+            let recipe =
+                recipe_for(*language).unwrap_or_else(|| panic!("{language} has no install recipe"));
+            assert!(
+                !recipe.command_line().is_empty(),
+                "{language} install command is empty"
+            );
+        }
+        assert_eq!(
+            LANGUAGE_SERVERS.len(),
+            kin_core::reference_coverage::ENRICHABLE_LANGUAGES.len(),
+            "a recipe exists for a language the build does not enrich, or the other way round"
+        );
+    }
+
+    #[test]
+    fn install_commands_are_what_an_operator_would_type() {
+        assert_eq!(
+            recipe_for(LanguageId::Python).unwrap().command_line(),
+            "npm install -g pyright"
+        );
+        assert_eq!(
+            recipe_for(LanguageId::TypeScript).unwrap().command_line(),
+            "npm install -g typescript-language-server typescript"
+        );
+        assert_eq!(
+            recipe_for(LanguageId::Rust).unwrap().command_line(),
+            "rustup component add rust-analyzer"
+        );
+    }
+
+    /// One npm package serves both JavaScript and TypeScript, so the advice is
+    /// one line rather than the same line twice.
+    #[test]
+    fn one_package_serving_two_languages_produces_one_command() {
+        let commands = install_commands_for(&[LanguageId::JavaScript, LanguageId::TypeScript]);
+        assert_eq!(
+            commands,
+            vec!["npm install -g typescript-language-server typescript".to_string()]
+        );
+    }
+
+    #[test]
+    fn install_commands_cover_every_distinct_missing_language() {
+        let commands = install_commands_for(&[
+            LanguageId::Python,
+            LanguageId::JavaScript,
+            LanguageId::Rust,
+        ]);
+        assert_eq!(commands.len(), 3, "{commands:?}");
+        assert!(commands.contains(&"npm install -g pyright".to_string()));
+    }
+
+    #[test]
+    fn consent_follows_the_flag_then_the_terminal() {
+        assert_eq!(
+            InstallConsent::resolve(true, false),
+            InstallConsent::Granted,
+            "the flag grants consent with nobody at the terminal"
+        );
+        assert_eq!(
+            InstallConsent::resolve(false, true),
+            InstallConsent::Ask,
+            "an interactive run without the flag asks rather than skipping"
+        );
+        assert_eq!(
+            InstallConsent::resolve(false, false),
+            InstallConsent::Withheld,
+            "no flag and no terminal changes nothing"
+        );
+    }
+
+    /// A host with nothing installed and every installer available. Stated
+    /// explicitly so no assertion below depends on what this machine has.
+    fn nothing_installed(_: &LanguageServerRecipe) -> bool {
+        false
+    }
+    fn installer_present(_: &LanguageServerRecipe) -> bool {
+        true
+    }
+
+    /// The whole point of the consent model: nothing runs unless someone said so.
+    #[test]
+    fn withheld_consent_runs_no_command() {
+        let mut runs = 0;
+        let reports = provision(
+            &[LanguageId::Python],
+            InstallConsent::Withheld,
+            nothing_installed,
+            installer_present,
+            |_| panic!("must not prompt when consent is withheld"),
+            |_| {
+                runs += 1;
+                Ok(())
+            },
+        );
+        assert_eq!(runs, 0, "an install ran without consent");
+        assert!(matches!(
+            reports.first().map(|r| &r.outcome),
+            Some(InstallOutcome::Declined { .. })
+        ));
+    }
+
+    /// A declined prompt is recorded with the command it did not run, not
+    /// retried and not silently dropped.
+    #[test]
+    fn a_declined_prompt_records_the_command_it_did_not_run() {
+        let mut runs = 0;
+        let reports = provision(
+            &[LanguageId::Python],
+            InstallConsent::Ask,
+            nothing_installed,
+            installer_present,
+            |_| false,
+            |_| {
+                runs += 1;
+                Ok(())
+            },
+        );
+        assert_eq!(runs, 0);
+        match reports.first().map(|r| &r.outcome) {
+            Some(InstallOutcome::Declined { command }) => {
+                assert_eq!(command, "npm install -g pyright");
+            }
+            other => panic!("unexpected outcome {other:?}"),
+        }
+    }
+
+    /// Two languages behind one package ask once and install once.
+    #[test]
+    fn one_package_prompts_once_and_runs_once_for_two_languages() {
+        let mut prompts = 0;
+        let mut runs = 0;
+        let reports = provision(
+            &[LanguageId::TypeScript, LanguageId::JavaScript],
+            InstallConsent::Ask,
+            nothing_installed,
+            installer_present,
+            |_| {
+                prompts += 1;
+                true
+            },
+            |_| {
+                runs += 1;
+                Ok(())
+            },
+        );
+        assert_eq!(prompts, 1, "one install command must ask exactly once");
+        assert_eq!(runs, 1, "one install command must run exactly once");
+        assert_eq!(reports.len(), 2, "both languages still get a report");
+    }
+
+    /// Consent granted for a package serves both its languages with one run.
+    ///
+    /// The second language reports `AlreadyPresent` rather than `Installed`,
+    /// because by the time it is considered the binary genuinely is on `PATH`.
+    /// What matters is the pair of facts asserted here: the command ran once,
+    /// and neither language ends in a state that still needs an operator.
+    #[test]
+    fn a_granted_install_that_lands_serves_both_languages_with_one_run() {
+        // Absent before the run, present after: the probe and the runner share
+        // one cell, which is what a real install does to `PATH`.
+        let ran = std::cell::Cell::new(false);
+        let reports = provision(
+            &[LanguageId::TypeScript, LanguageId::JavaScript],
+            InstallConsent::Granted,
+            |_| ran.get(),
+            installer_present,
+            |_| panic!("granted consent must not prompt"),
+            |_| {
+                ran.set(true);
+                Ok(())
+            },
+        );
+        assert!(ran.get(), "the install command never ran");
+        assert_eq!(reports.len(), 2);
+        assert!(
+            reports.iter().all(|r| matches!(
+                r.outcome,
+                InstallOutcome::Installed { .. } | InstallOutcome::AlreadyPresent
+            )),
+            "{reports:?}"
+        );
+        assert!(
+            reports
+                .iter()
+                .any(|r| matches!(r.outcome, InstallOutcome::Installed { .. })),
+            "one of the two must report the install that happened: {reports:?}"
+        );
+    }
+
+    /// A command that exits zero without putting the binary on `PATH` is not an
+    /// install. This is the npm-prefix-outside-PATH case, where the package
+    /// manager succeeds and the server stays unreachable.
+    #[test]
+    fn a_successful_command_that_leaves_the_binary_missing_is_not_reported_installed() {
+        let reports = provision(
+            &[LanguageId::TypeScript],
+            InstallConsent::Granted,
+            nothing_installed,
+            installer_present,
+            |_| true,
+            |_| Ok(()),
+        );
+        assert!(
+            matches!(
+                reports.first().map(|r| &r.outcome),
+                Some(InstallOutcome::RanButStillMissing { .. })
+            ),
+            "a no-op install must not report Installed: {reports:?}"
+        );
+    }
+
+    #[test]
+    fn a_failing_command_reports_its_own_reason() {
+        let reports = provision(
+            &[LanguageId::Python],
+            InstallConsent::Granted,
+            nothing_installed,
+            installer_present,
+            |_| true,
+            |_| Err("network unreachable".to_string()),
+        );
+        match reports.first().map(|r| &r.outcome) {
+            Some(InstallOutcome::Failed { reason, command }) => {
+                assert_eq!(reason, "network unreachable");
+                assert_eq!(command, "npm install -g pyright");
+            }
+            other => panic!("unexpected outcome {other:?}"),
+        }
+    }
+
+    /// A host with no npm is told that, rather than being handed a spawn error
+    /// that reads like a Kin defect.
+    #[test]
+    fn a_missing_installer_is_named_rather_than_attempted() {
+        let mut runs = 0;
+        let reports = provision(
+            &[LanguageId::Python],
+            InstallConsent::Granted,
+            nothing_installed,
+            |_| false,
+            |_| panic!("must not prompt when the installer is absent"),
+            |_| {
+                runs += 1;
+                Ok(())
+            },
+        );
+        assert_eq!(runs, 0);
+        match reports.first().map(|r| &r.outcome) {
+            Some(InstallOutcome::NoInstaller { program, command }) => {
+                assert_eq!(program, "npm");
+                assert_eq!(command, "npm install -g pyright");
+            }
+            other => panic!("unexpected outcome {other:?}"),
+        }
+    }
+
+    /// An already-installed server is left alone, so a repeated `--fix` is a
+    /// no-op rather than a re-download.
+    #[test]
+    fn an_installed_server_is_not_reinstalled() {
+        let mut runs = 0;
+        let reports = provision(
+            &[LanguageId::Python, LanguageId::Rust],
+            InstallConsent::Granted,
+            |_| true,
+            installer_present,
+            |_| panic!("must not prompt for something already installed"),
+            |_| {
+                runs += 1;
+                Ok(())
+            },
+        );
+        assert_eq!(runs, 0);
+        assert!(
+            reports
+                .iter()
+                .all(|r| r.outcome == InstallOutcome::AlreadyPresent),
+            "{reports:?}"
+        );
+    }
+
+    /// The restart sentence must stay pessimistic and must name the command.
+    #[test]
+    fn the_restart_advice_names_a_command_and_claims_no_hot_pickup() {
+        // `kin daemon` has exactly two subcommands, `status` and `stop`, so
+        // the obvious `restart` is a command that does not exist. A fix line
+        // naming one is worse than no fix line: it fails in front of the
+        // operator at the moment they are already blocked.
+        assert!(RESTART_AFTER_INSTALL.contains("kin daemon stop"));
+        assert!(!RESTART_AFTER_INSTALL.contains("kin daemon restart"));
+        assert!(
+            !RESTART_AFTER_INSTALL.contains("no restart"),
+            "the advice must not promise a pickup the startup gate cannot deliver"
+        );
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -40,6 +40,7 @@ pub mod history;
 pub mod impact;
 pub mod init;
 pub mod intent;
+pub mod language_servers;
 pub mod languages;
 pub mod locate;
 pub mod locate_cursor;

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -872,8 +872,9 @@ fn display_read_path(_layout: &kin_core::KinLayout, rel_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_bulk_refs_response, build_refs_response, parse_relation_kinds,
-        refs_not_found_guidance, BulkRefsRequest, BulkRefsResponse, RefsRequest,
+        build_bulk_refs_response, build_refs_response, collect_graph_references,
+        parse_relation_kinds, refs_not_found_guidance, BulkRefsRequest, BulkRefsResponse,
+        ReferenceLinesAbsent, RefsRequest, RelationResolution,
     };
     use kin_model::RelationKind;
 
@@ -963,6 +964,151 @@ mod tests {
         assert_eq!(row["receiver_name_candidate_count"], 3, "{row}");
         assert_eq!(row["has_references"], true, "{row}");
         assert_eq!(response.with_references, 1);
+    }
+
+    /// A language-server edge reaches the reference surface as a RESOLVED
+    /// caller, and a same-named bare-name guess beside it does not.
+    ///
+    /// This is the last hop of FIR-2464. The daemon now wires JavaScript and
+    /// TypeScript and starts a server for them, and the enrichment layer is
+    /// proved against real servers in
+    /// `crates/kin-daemon/tests/lsp_reference_enrichment.rs`. What that proof
+    /// does not reach is what `find_references` and `kin refs` DO with the
+    /// resulting edge, which is what an agent actually reads. Both rows are
+    /// built here from one graph so the difference is the edge rather than the
+    /// fixture.
+    ///
+    /// It also pins a gap rather than papering over it. kin-lsp constructs
+    /// every enrichment relation with `evidence: Vec::new()`
+    /// (kin-lsp/src/enrichment.rs:218, :320, :426, :503), so an LSP-resolved
+    /// caller arrives with no source span and its `reference_lines` come back
+    /// empty with `NoEvidenceSpan`. The row is honest about that rather than
+    /// silent, and this assertion is what will fail, loudly and in the right
+    /// place, on the day kin-lsp starts populating spans.
+    #[test]
+    fn an_lsp_edge_reaches_the_reference_surface_as_resolved_and_a_name_guess_does_not() {
+        use kin_db::InMemoryGraph;
+        use kin_model::relation::{Relation, RelationOrigin};
+        use kin_model::{
+            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+            FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, SemanticFingerprint,
+            Visibility,
+        };
+
+        fn entity(name: &str, rel_path: &str) -> Entity {
+            Entity {
+                id: EntityId::new(),
+                kind: EntityKind::Function,
+                name: name.to_string(),
+                language: LanguageId::JavaScript,
+                fingerprint: SemanticFingerprint {
+                    algorithm: FingerprintAlgorithm::V1TreeSitter,
+                    ast_hash: Hash256::from_bytes([0; 32]),
+                    signature_hash: Hash256::from_bytes([0; 32]),
+                    behavior_hash: Hash256::from_bytes([0; 32]),
+                    equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
+                    stability_score: 1.0,
+                },
+                file_origin: Some(FilePathId::new(rel_path)),
+                span: None,
+                signature: name.to_string(),
+                visibility: Visibility::Public,
+                role: EntityRole::Source,
+                doc_summary: None,
+                metadata: EntityMetadata::default(),
+                lineage_parent: None,
+                created_in: None,
+                superseded_by: None,
+            }
+        }
+
+        let graph = InMemoryGraph::new();
+        let target = entity("handle", "lib/router.js");
+        graph.upsert_entity(&target).unwrap();
+
+        // The caller a language server resolved: origin Lsp.
+        let resolved_caller = entity("listen", "lib/app.js");
+        graph.upsert_entity(&resolved_caller).unwrap();
+        graph
+            .upsert_relation(&Relation {
+                id: kin_model::ids::RelationId::new(),
+                kind: RelationKind::Calls,
+                src: GraphNodeId::Entity(resolved_caller.id),
+                dst: GraphNodeId::Entity(target.id),
+                confidence: 0.95,
+                origin: RelationOrigin::Lsp,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        // The caller the bare-name fallback produced: a receiver-method guess.
+        let guessed_caller = entity("dispatch", "lib/other.js");
+        graph.upsert_entity(&guessed_caller).unwrap();
+        graph
+            .upsert_relation(&Relation {
+                id: kin_model::ids::RelationId::new(),
+                kind: RelationKind::Calls,
+                src: GraphNodeId::Entity(guessed_caller.id),
+                dst: GraphNodeId::Entity(target.id),
+                confidence: kin_index::resolution::RECEIVER_NAME_FANOUT_CONFIDENCE,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+
+        let collected =
+            collect_graph_references(&graph, &target.id, &[RelationKind::Calls]).unwrap();
+
+        let resolved = collected
+            .references
+            .iter()
+            .find(|entry| entry.entity_id == resolved_caller.id)
+            .expect("the language-server caller must appear");
+        assert_eq!(
+            resolved.resolution,
+            RelationResolution::TypeResolved,
+            "an Lsp-origin edge must reach the reference surface as type_resolved"
+        );
+        assert!(
+            resolved.resolution.is_proven(),
+            "a type_resolved caller must be countable as evidence of use"
+        );
+        assert!(
+            !resolved.receiver_name_guess,
+            "a language-server edge is not a receiver-name guess"
+        );
+        // The gap named above, asserted rather than assumed. Delete this pair
+        // and assert real line numbers on the day kin-lsp carries spans.
+        assert!(
+            resolved.reference_lines.is_empty(),
+            "kin-lsp emits no evidence span today; if this now has lines, the surrounding \
+             doc comment and the FIR-2464 report are out of date"
+        );
+        assert_eq!(
+            resolved.reference_lines_absent,
+            Some(ReferenceLinesAbsent::NoEvidenceSpan),
+            "an absent line list must say WHY it is absent rather than reading as no evidence"
+        );
+
+        let guessed = collected
+            .references
+            .iter()
+            .find(|entry| entry.entity_id == guessed_caller.id)
+            .expect("the guessed caller must still appear, marked");
+        assert_eq!(
+            guessed.resolution,
+            RelationResolution::NameOnly,
+            "a receiver-name fan-out edge stays a candidate"
+        );
+        assert!(
+            !guessed.resolution.is_proven(),
+            "a name-only caller must not be countable as evidence of use"
+        );
+        assert!(guessed.receiver_name_guess);
     }
 
     /// `kin refs` must answer only from graph-owned relation edges. A reference

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12936,9 +12936,18 @@ pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Re
     //
     // The gap comes from the health report rather than from a fresh probe, so
     // the repair is scoped to the languages the row actually flagged.
+    // Pending and Stale are exactly the two states the coverage row takes when
+    // a language-server gap was actually OBSERVED. `Unsupported` is what it
+    // reports outside a Kin repository, or with no daemon and nothing missing,
+    // and offering an install off the back of that would turn a "nothing to
+    // measure here" row into a prompt to download packages.
     let language_server_gap = report.checks.iter().any(|c| {
         c.id == "reference_edge_coverage"
-            && !matches!(c.status, crate::commands::health::HealthStatus::Healthy)
+            && matches!(
+                c.status,
+                crate::commands::health::HealthStatus::Pending
+                    | crate::commands::health::HealthStatus::Stale
+            )
     });
     if language_server_gap {
         let missing = language_servers::missing_enrichable_languages();

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -13,6 +13,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
+use crate::commands::language_servers;
+
 // ---------------------------------------------------------------------------
 // Embedded shell hooks (from kin-vfs/shell/)
 // ---------------------------------------------------------------------------
@@ -1029,6 +1031,12 @@ pub struct WizardOptions {
     /// there is nothing for a tool call to answer about. The skip is printed
     /// per client rather than silently dropping the section.
     pub skip_mcp_check: bool,
+    /// Install the language servers Kin enriches with, without asking.
+    ///
+    /// Needed because the install is a network download into a shared prefix.
+    /// Without it an interactive run asks and a scripted one prints the command
+    /// and changes nothing.
+    pub install_language_servers: bool,
 }
 
 /// First-run intent — what the user wants out of Kin. Each intent maps to a
@@ -11846,6 +11854,14 @@ pub async fn run_wizard(opts: WizardOptions) -> Result<()> {
 
     print_intent_followups(&plan, interactive);
 
+    // Language servers are what turn Kin's cross-file answers from bare-name
+    // matches into resolved ones, and setup is the one moment a person is
+    // present to consent to the download. Skipping this step is what shipped
+    // before: the adapter was wired, no server was installed, the daemon logged
+    // the failed start at debug level, and every cross-file call fell back to
+    // matching names.
+    provision_language_servers_in_wizard(&opts, interactive);
+
     report_notification_identity(interactive);
 
     // The final checklist is the real first-run health engine — not a parallel
@@ -11859,6 +11875,29 @@ pub async fn run_wizard(opts: WizardOptions) -> Result<()> {
     print_next_steps(intent, plan.install_shell_hook, &configured_assistants);
 
     Ok(())
+}
+
+/// Offer the missing language servers during first-run setup.
+///
+/// Interactive runs ask per install command with the download disclosed.
+/// Non-interactive runs print the command and change nothing unless
+/// `--install-language-servers` was passed, because an unattended install
+/// should never spend a user's bandwidth on a prefix they share with the rest
+/// of their toolchain.
+fn provision_language_servers_in_wizard(opts: &WizardOptions, interactive: bool) {
+    let missing = language_servers::missing_enrichable_languages();
+    if missing.is_empty() {
+        return;
+    }
+    println!();
+    println!("Language servers (cross-file reference edges):");
+    let consent = language_servers::InstallConsent::resolve(
+        opts.install_language_servers,
+        interactive && !opts.install_language_servers,
+    );
+    for line in apply_language_server_provisioning(&missing, consent) {
+        println!("  {} {line}", style("✓").green());
+    }
 }
 
 /// Get the notification identity working, and say so when it cannot be.
@@ -12654,11 +12693,118 @@ fn print_human_report(report: &crate::commands::health::HealthReport) {
     }
 }
 
+/// Provision the language servers behind Kin's cross-file reference edges, and
+/// report each one in the operator's own words.
+///
+/// Shared by the wizard and by `kin doctor --fix` so a person gets the same
+/// disclosure, the same prompt, and the same restart advice on both paths. The
+/// returned lines are the "what was applied" list both surfaces already print;
+/// anything not applied is printed here instead, because a declined or failed
+/// install is a fact the operator needs and an empty applied-list is not.
+fn apply_language_server_provisioning(
+    missing: &[kin_model::LanguageId],
+    consent: language_servers::InstallConsent,
+) -> Vec<String> {
+    use language_servers::{InstallConsent, InstallOutcome};
+
+    if missing.is_empty() {
+        return Vec::new();
+    }
+
+    if consent == InstallConsent::Withheld {
+        // Nobody to ask and no flag. Say what is missing and what closes it,
+        // and change nothing. Printing the command is the whole value here: the
+        // gap was already reported, the command was not.
+        println!(
+            "  {} no language server for {}; cross-file reference edges are unavailable for {}",
+            style("!").yellow(),
+            missing
+                .iter()
+                .map(|language| language.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            if missing.len() == 1 { "it" } else { "them" }
+        );
+        for command in language_servers::install_commands_for(missing) {
+            println!("      {command}");
+        }
+        println!(
+            "      or re-run with --install-language-servers to have Kin run {}",
+            if missing.len() == 1 { "it" } else { "them" }
+        );
+        return Vec::new();
+    }
+
+    let reports = language_servers::provision(
+        missing,
+        consent,
+        |recipe| recipe.installed(),
+        |recipe| recipe.installer_available(),
+        |recipe| {
+            println!();
+            println!(
+                "  Kin can enrich {} with cross-file reference edges, but its language server is \
+                 not installed.",
+                recipe.language
+            );
+            println!("    Command:    {}", recipe.command_line());
+            println!("    This will:  {}", recipe.disclosure);
+            prompt_yn("  Install it now?", false, true)
+        },
+        language_servers::run_install,
+    );
+
+    let mut applied = Vec::new();
+    let mut installed_any = false;
+    for report in reports {
+        match report.outcome {
+            InstallOutcome::AlreadyPresent => {}
+            InstallOutcome::Installed { command } => {
+                installed_any = true;
+                applied.push(format!(
+                    "installed the {} language server (`{command}`)",
+                    report.language
+                ));
+            }
+            // A zero exit that left the binary unreachable is reported as the
+            // gap it still is. Counting it as applied is how a closed-looking
+            // row keeps an open gap.
+            InstallOutcome::RanButStillMissing { command } => println!(
+                "  {} `{command}` succeeded but no {} server is on PATH; check that your npm \
+                 global prefix is on PATH",
+                style("✗").red(),
+                report.language
+            ),
+            InstallOutcome::Failed { command, reason } => println!(
+                "  {} could not install the {} language server: {reason} (`{command}`)",
+                style("✗").red(),
+                report.language
+            ),
+            InstallOutcome::Declined { command } => println!(
+                "  {} skipped the {} language server; run `{command}` to install it later",
+                style("-").dim(),
+                report.language
+            ),
+            InstallOutcome::NoInstaller { program, command } => println!(
+                "  {} `{program}` is not installed, so Kin cannot run `{command}` to provision \
+                 the {} language server",
+                style("✗").red(),
+                report.language
+            ),
+        }
+    }
+
+    if installed_any {
+        println!("  {}", language_servers::RESTART_AFTER_INSTALL);
+    }
+    applied
+}
+
 // ---------------------------------------------------------------------------
 // `kin setup doctor`
 // ---------------------------------------------------------------------------
 
-pub async fn doctor(fix: bool, json: bool) -> Result<()> {
+pub async fn doctor(fix: bool, install_language_servers: bool, json: bool) -> Result<()> {
     let report = crate::commands::health::run_health_checks().await;
 
     if !fix {
@@ -12778,6 +12924,37 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
             Ok(Some(url)) => applied.push(format!("started kin-daemon ({url})")),
             Ok(None) => {}
             Err(e) => println!("  {} kin-daemon start failed: {e}", style("✗").red()),
+        }
+    }
+
+    // Install the language servers this build enriches with, when the operator
+    // asked for it. Deliberately NOT part of the unconditional "safe repairs"
+    // set above: every other repair here writes a file Kin already owns, while
+    // this one downloads packages into a shared global prefix. `--fix` alone
+    // prints the command; `--fix --install-language-servers` runs it, and an
+    // interactive `--fix` asks.
+    //
+    // The gap comes from the health report rather than from a fresh probe, so
+    // the repair is scoped to the languages the row actually flagged.
+    let language_server_gap = report.checks.iter().any(|c| {
+        c.id == "reference_edge_coverage"
+            && !matches!(c.status, crate::commands::health::HealthStatus::Healthy)
+    });
+    if language_server_gap {
+        let missing = language_servers::missing_enrichable_languages();
+        if missing.is_empty() {
+            // The row is unhealthy for a reason no install closes (an
+            // unsupportable absence, or a graph that could not be read). Saying
+            // nothing here is right: offering an install that changes nothing
+            // is worse than leaving the row's own detail to speak.
+        } else {
+            let consent = language_servers::InstallConsent::resolve(
+                install_language_servers,
+                !install_language_servers && is_tty(),
+            );
+            for line in apply_language_server_provisioning(&missing, consent) {
+                applied.push(line);
+            }
         }
     }
 
@@ -14337,6 +14514,7 @@ mod tests {
             no_interactive: true,
             intent: None,
             skip_mcp_check: false,
+            install_language_servers: false,
         }
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1139,6 +1139,13 @@ enum Command {
         /// Apply safe automatic repairs (shell hook, MCP configs, config dirs)
         #[arg(long, default_value_t = false)]
         fix: bool,
+        /// Install the missing language servers this build enriches with
+        ///
+        /// Each install is a network download into a shared prefix (npm global,
+        /// or the active rustup toolchain), so it never runs unasked: an
+        /// interactive run asks first, and a scripted one needs this flag.
+        #[arg(long = "install-language-servers", default_value_t = false)]
+        install_language_servers: bool,
         /// Emit the machine-readable health report as JSON
         #[arg(long, default_value_t = false)]
         json: bool,
@@ -1173,6 +1180,13 @@ enum Command {
         /// actually call Kin (for a scripted install with no repository yet)
         #[arg(long, global = true)]
         skip_mcp_check: bool,
+        /// Install the missing language servers this build enriches with
+        ///
+        /// Each install is a network download into a shared prefix (npm global,
+        /// or the active rustup toolchain), so it never runs unasked: an
+        /// interactive run asks first, and a scripted one needs this flag.
+        #[arg(long = "install-language-servers", global = true)]
+        install_language_servers: bool,
         /// Skip the wizard and only run the first-run health check
         #[arg(long, default_value_t = false)]
         check: bool,
@@ -3588,6 +3602,7 @@ fn main() -> Result<()> {
                 },
                 Command::Doctor {
                     fix,
+                    install_language_servers,
                     json,
                     drift,
                     heal,
@@ -3602,7 +3617,7 @@ fn main() -> Result<()> {
                         commands::capabilities::require_ready("doctor --drift")?;
                         commands::drift::run(json).await
                     } else {
-                        commands::setup::doctor(fix, json).await
+                        commands::setup::doctor(fix, install_language_servers, json).await
                     }
                 }
                 Command::Vfs { action } => match action {
@@ -3659,11 +3674,12 @@ fn main() -> Result<()> {
                     auto_daemon,
                     no_interactive,
                     skip_mcp_check,
+                    install_language_servers,
                     check,
                 } => match action {
                     Some(SetupAction::Status { json }) => commands::setup::status(json).await,
                     Some(SetupAction::Doctor { fix, json }) => {
-                        commands::setup::doctor(fix, json).await
+                        commands::setup::doctor(fix, install_language_servers, json).await
                     }
                     Some(SetupAction::Ledger { json }) => commands::setup::ledger_status(json),
                     Some(SetupAction::Uninstall {
@@ -3674,7 +3690,7 @@ fn main() -> Result<()> {
                     }) => commands::setup::uninstall(all, dry_run, force, json).await,
                     // `kin setup --check` is shorthand for the first-run health
                     // check without running the wizard.
-                    None if check => commands::setup::doctor(false, false).await,
+                    None if check => commands::setup::doctor(false, false, false).await,
                     None => {
                         commands::setup::run_wizard(commands::setup::WizardOptions {
                             mode,
@@ -3683,6 +3699,7 @@ fn main() -> Result<()> {
                             no_interactive,
                             intent,
                             skip_mcp_check,
+                            install_language_servers,
                         })
                         .await
                     }

--- a/crates/kin-core/Cargo.toml
+++ b/crates/kin-core/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 test-support = []
 
 [dependencies]
+which = "8"
 kin-model = { workspace = true }
 kin-db = { workspace = true }
 kin-blobs = { workspace = true }

--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -12,6 +12,11 @@
 # conscious decision to keep a name out of the registry, not a place to silence a
 # real gap.
 #
+# Set by scripts/ci-install-language-servers.sh only after it proves both
+# language-server binaries are executable, and read by the reference-enrichment
+# proof so a skip on a provisioned runner fails instead of reading as a fast
+# pass. Nothing an operator sets, and no runtime behaviour keys on it.
+KIN_CI_LANGUAGE_SERVERS_INSTALLED
 KIN_AGENT_TEST_KIN_BIN
 KIN_GIT_TEST_NO_SYMLINK_PRIVILEGE
 KIN_INIT_INTERRUPTED_TEST_BARRIER

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -39,7 +39,23 @@ use serde::{Deserialize, Serialize};
 /// external language server. The daemon wires an adapter for exactly these
 /// languages, so every other language carries no such edge by construction, no
 /// matter what is installed on the host.
-pub const ENRICHABLE_LANGUAGES: &[LanguageId] = &[LanguageId::Rust, LanguageId::Python];
+///
+/// JavaScript and TypeScript are one entry each rather than one shared entry,
+/// because this list is read per language the repository actually holds and a
+/// JavaScript-only repository must not be told its enrichment rides on a
+/// TypeScript row. Both resolve to the same adapter and the same server binary.
+///
+/// "The daemon wires an adapter for exactly these" is an assertion, not a
+/// comment: `kin_daemon` holds one adapter map and a test there fails if the
+/// two sets ever disagree. They disagreed silently before, which is how a
+/// JavaScript repository read `unsupported` while the adapter it needed already
+/// existed in kin-lsp.
+pub const ENRICHABLE_LANGUAGES: &[LanguageId] = &[
+    LanguageId::Rust,
+    LanguageId::Python,
+    LanguageId::TypeScript,
+    LanguageId::JavaScript,
+];
 
 /// Whether cross-file reference evidence is available for one language.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kin-core/src/reference_coverage.rs
+++ b/crates/kin-core/src/reference_coverage.rs
@@ -57,7 +57,39 @@ pub const ENRICHABLE_LANGUAGES: &[LanguageId] = &[
     LanguageId::JavaScript,
 ];
 
+/// The binaries that provide each enrichable language's server.
+///
+/// Mirrors `kin_lsp::discovery::KNOWN_SERVERS` for exactly the languages
+/// [`ENRICHABLE_LANGUAGES`] names, and is the ONE table every surface reads:
+/// the doctor row that reports the gap, the install recipes that close it, and
+/// the trust gate that decides whether an empty answer may be certified. Those
+/// three used to be able to disagree, and a probe looking for a binary the
+/// installer never provides is a gap that reports itself closed.
+///
+/// Probed with a `PATH` lookup rather than through
+/// `kin_lsp::discovery::discover_servers`, which runs `--version` on every
+/// server it finds; a query path must not spawn subprocesses.
+pub const LANGUAGE_SERVER_BINARIES: &[(LanguageId, &[&str])] = &[
+    (LanguageId::Rust, &["rust-analyzer"]),
+    (LanguageId::Python, &["pyright-langserver", "pylsp"]),
+    (
+        LanguageId::TypeScript,
+        &["typescript-language-server", "vtsls"],
+    ),
+    (LanguageId::JavaScript, &["typescript-language-server"]),
+];
+
+/// Languages whose enrichment server is present on this host.
+pub fn installed_language_servers() -> HashSet<LanguageId> {
+    LANGUAGE_SERVER_BINARIES
+        .iter()
+        .filter(|(_, binaries)| binaries.iter().any(|binary| which::which(binary).is_ok()))
+        .map(|(language, _)| *language)
+        .collect()
+}
+
 /// Whether cross-file reference evidence is available for one language.
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReferenceEnrichment {
@@ -805,6 +837,28 @@ fn read_count(entity: &Entity, key: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Every enrichable language must name the binaries that provide its
+    /// server, and nothing else may.
+    ///
+    /// The two lists feed different surfaces: one decides whether an adapter
+    /// exists, the other decides whether an operator can close the gap and
+    /// whether the trust gate may certify an absence. A language in one and not
+    /// the other is a surface reporting about a language no other surface can
+    /// act on.
+    #[test]
+    fn the_binaries_table_covers_exactly_the_enrichable_languages() {
+        let tabled: std::collections::HashSet<LanguageId> = LANGUAGE_SERVER_BINARIES
+            .iter()
+            .map(|(language, _)| *language)
+            .collect();
+        let enrichable: std::collections::HashSet<LanguageId> =
+            ENRICHABLE_LANGUAGES.iter().copied().collect();
+        assert_eq!(tabled, enrichable);
+        for (language, binaries) in LANGUAGE_SERVER_BINARIES {
+            assert!(!binaries.is_empty(), "{language} names no server binary");
+        }
+    }
     use super::*;
     use kin_db::InMemoryGraph;
     use kin_model::entity::{

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1427,7 +1427,7 @@ pub async fn run_with_authority_on(
             Some(rx)
         } else {
             info!(
-                "no LSP servers found — enrichment disabled for the life of this daemon; \
+                "no LSP servers found, so enrichment is disabled for the life of this daemon; \
                  install one and restart to enable it"
             );
             None

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1411,6 +1411,19 @@ pub async fn run_with_authority_on(
         return Err(error.into());
     }
 
+    // Publish which language servers this host has, so every answer this daemon
+    // serves reports the same fact the enrichment path acts on. Without it the
+    // absence-trust gate cannot tell a language whose program a server resolved
+    // from one nothing resolved, and it certified an absence over the latter.
+    //
+    // A cheap PATH lookup rather than `discover_servers`, which runs `--version`
+    // on every server it finds, and published unconditionally: a daemon with
+    // enrichment switched off produces no reference edge either, so its answers
+    // must not claim otherwise.
+    kin_mcp::edge_coverage::publish_installed_language_servers(
+        kin_core::reference_coverage::installed_language_servers(),
+    );
+
     // Set up LSP enrichment channel before wrapping state in Arc.
     let enrichment_enabled =
         should_enable_lsp_enrichment(config.lsp_enabled, state.filesystem_reconcile_disabled());

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -56,6 +56,24 @@ fn should_enable_lsp_enrichment(config_enabled: bool, filesystem_reconcile_disab
     config_enabled && !filesystem_reconcile_disabled
 }
 
+/// Whether the daemon opens its enrichment channel at startup.
+///
+/// Taken ONCE, during startup, and that is the whole reason a language server
+/// installed while a daemon is already running may not reach it. With no server
+/// discovered here the channel is never created, so no enrichment message is
+/// ever sent for the life of the process and no adapter is ever consulted. That
+/// is the state the container behind the v0.5.42 stranger run was in: the Python
+/// adapter did not fail to start, it was never reached.
+///
+/// When discovery DID find a server the channel exists and each language's
+/// server is started lazily on first use, so a server installed afterwards is
+/// picked up with no restart. Both halves are true, and only the pessimistic one
+/// is safe for a surface to print, because a fresh install is exactly the host
+/// where discovery finds nothing.
+fn enrichment_channel_opens(enrichment_enabled: bool, servers_discovered: usize) -> bool {
+    enrichment_enabled && servers_discovered > 0
+}
+
 /// Acquire the process-lifetime repository authority before daemon state opens.
 pub fn acquire_daemon_authority(
     kin_root: &std::path::Path,
@@ -416,6 +434,32 @@ mod adapter_wiring_tests {
                 lsp_adapter_for(language, root).unwrap_or_else(|| panic!("{language} not wired"));
             assert_eq!(cmd, expected, "{language} server command");
         }
+    }
+
+    /// The startup gate behind the restart advice `kin doctor` prints.
+    ///
+    /// Asserted rather than reasoned about, because it is a user-facing claim:
+    /// a host that had no language server when its daemon started does not gain
+    /// enrichment when one is installed, and that is exactly the host doing the
+    /// installing. If this predicate ever stops keying on the discovered count,
+    /// the advice becomes wrong in the direction that leaves an operator
+    /// waiting for edges that will never arrive.
+    #[test]
+    fn no_server_at_startup_means_no_enrichment_channel_for_this_daemon() {
+        use super::enrichment_channel_opens;
+
+        assert!(
+            !enrichment_channel_opens(true, 0),
+            "with enrichment enabled and no server discovered the channel must stay closed"
+        );
+        assert!(
+            enrichment_channel_opens(true, 1),
+            "one discovered server is enough to open the channel"
+        );
+        assert!(
+            !enrichment_channel_opens(false, 3),
+            "disabled enrichment must not open a channel however many servers exist"
+        );
     }
 
     /// A language with no adapter stays unwired, so `Unsupported` remains a
@@ -1368,12 +1412,11 @@ pub async fn run_with_authority_on(
     }
 
     // Set up LSP enrichment channel before wrapping state in Arc.
-    let lsp_rx = if should_enable_lsp_enrichment(
-        config.lsp_enabled,
-        state.filesystem_reconcile_disabled(),
-    ) {
+    let enrichment_enabled =
+        should_enable_lsp_enrichment(config.lsp_enabled, state.filesystem_reconcile_disabled());
+    let lsp_rx = if enrichment_enabled {
         let discovered = kin_lsp::discovery::discover_servers();
-        if !discovered.is_empty() {
+        if enrichment_channel_opens(enrichment_enabled, discovered.len()) {
             info!(
                 count = discovered.len(),
                 languages = ?discovered.iter().map(|s| format!("{}", s.language)).collect::<Vec<_>>(),
@@ -1383,7 +1426,10 @@ pub async fn run_with_authority_on(
             state.lsp_enrichment_tx = Some(tx);
             Some(rx)
         } else {
-            info!("no LSP servers found — enrichment disabled");
+            info!(
+                "no LSP servers found — enrichment disabled for the life of this daemon; \
+                 install one and restart to enable it"
+            );
             None
         }
     } else {

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -289,7 +289,11 @@ pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
 ///
 /// The returned triple is exactly what `LspServer::start` takes: the command,
 /// its arguments, and the initialization options for this workspace.
-fn lsp_adapter_for(
+/// Public because it is this build's whole answer to "which server do you start
+/// for this language", and two surfaces outside the enrichment loop need that
+/// answer to agree with it: the provisioning advice that tells an operator what
+/// to install, and the proof that starts a real server against a fixture.
+pub fn lsp_adapter_for(
     language: kin_model::LanguageId,
     workspace_root: &std::path::Path,
 ) -> Option<(String, Vec<String>, Option<serde_json::Value>)> {

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -270,6 +270,164 @@ pub(crate) fn reset_vector_index_and_requeue_after_contention_for_test(
     Ok(())
 }
 
+/// The language server this build starts for `language`, if any.
+///
+/// One map, read by both the incremental and the sweep enrichment paths below.
+/// It used to be two `match` blocks three hundred lines apart, and they agreed
+/// only because nobody had added a language since they were written. Adding a
+/// language to a single copy is invisible in review and worse at runtime: the
+/// sweep would enrich files the incremental path ignored, so the edges would
+/// appear only after a full re-ingest and vanish on the next incremental pass.
+///
+/// This map is also the referent of the claim in
+/// `kin_core::reference_coverage::ENRICHABLE_LANGUAGES`, that the daemon wires
+/// an adapter for exactly those languages. A test in this module fails when the
+/// two disagree, because they already disagreed once: JavaScript and TypeScript
+/// were absent here while kin-lsp carried a working adapter for both, so a
+/// JavaScript repository was told its reference edges were `unsupported` and
+/// cross-file resolution fell back to matching bare names.
+///
+/// The returned triple is exactly what `LspServer::start` takes: the command,
+/// its arguments, and the initialization options for this workspace.
+fn lsp_adapter_for(
+    language: kin_model::LanguageId,
+    workspace_root: &std::path::Path,
+) -> Option<(String, Vec<String>, Option<serde_json::Value>)> {
+    use kin_lsp::adapters::LspAdapter;
+
+    fn describe(
+        adapter: &dyn LspAdapter,
+        workspace_root: &std::path::Path,
+    ) -> (String, Vec<String>, Option<serde_json::Value>) {
+        (
+            adapter.server_command().to_string(),
+            adapter.server_args(),
+            adapter.initialization_options(workspace_root),
+        )
+    }
+
+    match language {
+        kin_model::LanguageId::Rust => Some(describe(
+            &kin_lsp::adapters::rust_analyzer::RustAnalyzerAdapter,
+            workspace_root,
+        )),
+        kin_model::LanguageId::Python => Some(describe(
+            &kin_lsp::adapters::python::PyrightAdapter,
+            workspace_root,
+        )),
+        // One adapter serves both. `typescript-language-server` resolves a
+        // CommonJS `require` chain through the same tsserver project model it
+        // uses for TypeScript imports, which is why kin-lsp's discovery table
+        // maps both language names onto the same binary.
+        kin_model::LanguageId::TypeScript | kin_model::LanguageId::JavaScript => Some(describe(
+            &kin_lsp::adapters::typescript::TypeScriptAdapter,
+            workspace_root,
+        )),
+        _ => None,
+    }
+}
+
+/// Every language this build knows about.
+///
+/// Written as an exhaustive `match` rather than a hand-kept array so a new
+/// `LanguageId` variant fails to compile here instead of silently escaping the
+/// coverage assertions below. A list that quietly stops enumerating everything
+/// is the shape of guard that passes forever.
+#[cfg(test)]
+fn all_known_languages() -> Vec<kin_model::LanguageId> {
+    use kin_model::LanguageId::*;
+    let every = [
+        TypeScript, JavaScript, Python, Go, Java, Rust, C, Cpp, CSharp, Ruby, Php, Swift, Kotlin,
+        Hcl,
+    ];
+    for language in every {
+        // Exhaustive on purpose: adding a variant breaks this arm, which is the
+        // point. The body is a no-op; the compiler is the assertion.
+        match language {
+            TypeScript | JavaScript | Python | Go | Java | Rust | C | Cpp | CSharp | Ruby | Php
+            | Swift | Kotlin | Hcl => {}
+        }
+    }
+    every.to_vec()
+}
+
+#[cfg(test)]
+mod adapter_wiring_tests {
+    use super::{all_known_languages, lsp_adapter_for};
+    use kin_core::reference_coverage::ENRICHABLE_LANGUAGES;
+    use kin_model::LanguageId;
+    use std::path::Path;
+
+    /// `ENRICHABLE_LANGUAGES` documents itself as the set the daemon wires an
+    /// adapter for. This is that sentence as an assertion, in both directions.
+    ///
+    /// It failed before this test existed: JavaScript and TypeScript had a
+    /// complete adapter in kin-lsp and no arm in the daemon's map, so a
+    /// JavaScript repository read `reference_enrichment: "unsupported"` and its
+    /// cross-file calls were resolved by matching bare names.
+    #[test]
+    fn the_adapter_map_and_the_enrichable_set_name_the_same_languages() {
+        let root = Path::new("/nonexistent-workspace");
+        for language in all_known_languages() {
+            let wired = lsp_adapter_for(language, root).is_some();
+            let declared = ENRICHABLE_LANGUAGES.contains(&language);
+            assert_eq!(
+                wired, declared,
+                "{language}: daemon wires an adapter = {wired}, ENRICHABLE_LANGUAGES says {declared}"
+            );
+        }
+    }
+
+    /// Both JavaScript and TypeScript resolve to one server binary.
+    ///
+    /// Pinned because the two are separate `LanguageId` values reaching one
+    /// adapter, and a future edit that gives JavaScript its own arm would be
+    /// invisible to the set-equality test above while breaking every `.js`
+    /// repository that has `typescript-language-server` installed.
+    #[test]
+    fn javascript_and_typescript_share_one_server_binary() {
+        let root = Path::new("/nonexistent-workspace");
+        let (js_cmd, js_args, _) =
+            lsp_adapter_for(LanguageId::JavaScript, root).expect("JavaScript must be wired");
+        let (ts_cmd, ts_args, _) =
+            lsp_adapter_for(LanguageId::TypeScript, root).expect("TypeScript must be wired");
+        assert_eq!(js_cmd, "typescript-language-server");
+        assert_eq!(js_cmd, ts_cmd);
+        assert_eq!(js_args, ts_args);
+        assert_eq!(js_args, vec!["--stdio".to_string()]);
+    }
+
+    /// The commands the map hands `LspServer::start` are the binary names a
+    /// host actually installs, so the provisioning advice and the runtime agree.
+    #[test]
+    fn wired_languages_name_the_binaries_an_operator_installs() {
+        let root = Path::new("/nonexistent-workspace");
+        for (language, expected) in [
+            (LanguageId::Rust, "rust-analyzer"),
+            (LanguageId::Python, "pyright-langserver"),
+            (LanguageId::TypeScript, "typescript-language-server"),
+            (LanguageId::JavaScript, "typescript-language-server"),
+        ] {
+            let (cmd, _, _) =
+                lsp_adapter_for(language, root).unwrap_or_else(|| panic!("{language} not wired"));
+            assert_eq!(cmd, expected, "{language} server command");
+        }
+    }
+
+    /// A language with no adapter stays unwired, so `Unsupported` remains a
+    /// truthful state rather than a default nobody maintains.
+    #[test]
+    fn an_unwired_language_has_no_adapter() {
+        let root = Path::new("/nonexistent-workspace");
+        for language in [LanguageId::Ruby, LanguageId::Swift, LanguageId::Hcl] {
+            assert!(
+                lsp_adapter_for(language, root).is_none(),
+                "{language} must not be wired without being declared enrichable"
+            );
+        }
+    }
+}
+
 /// Poll `workspace/symbol` with an empty query until the LSP server responds
 /// or the deadline is reached. Language servers like rust-analyzer and pyright
 /// continue background indexing after the `initialize` handshake; this probe
@@ -2199,28 +2357,7 @@ pub async fn run_with_authority_on(
 
                         // Lazily start LSP server for this language.
                         if !servers.contains_key(&lang) {
-                            use kin_lsp::adapters::LspAdapter;
-                            let adapter = match lang {
-                                kin_model::LanguageId::Rust => {
-                                    let a = kin_lsp::adapters::rust_analyzer::RustAnalyzerAdapter;
-                                    Some((
-                                        a.server_command().to_string(),
-                                        a.server_args(),
-                                        a.initialization_options(&lsp_root),
-                                    ))
-                                }
-                                kin_model::LanguageId::Python => {
-                                    let a = kin_lsp::adapters::python::PyrightAdapter;
-                                    Some((
-                                        a.server_command().to_string(),
-                                        a.server_args(),
-                                        a.initialization_options(&lsp_root),
-                                    ))
-                                }
-                                _ => None,
-                            };
-
-                            if let Some((cmd, args, init_opts)) = adapter {
+                            if let Some((cmd, args, init_opts)) = lsp_adapter_for(lang, &lsp_root) {
                                 let args_refs: Vec<&str> =
                                     args.iter().map(|s| s.as_str()).collect();
                                 match kin_lsp::lifecycle::LspServer::start(
@@ -2488,29 +2625,9 @@ pub async fn run_with_authority_on(
 
                             // Lazily start LSP server for this language (same as incremental).
                             if !servers.contains_key(&lang) {
-                                use kin_lsp::adapters::LspAdapter;
-                                let adapter = match lang {
-                                    kin_model::LanguageId::Rust => {
-                                        let a =
-                                            kin_lsp::adapters::rust_analyzer::RustAnalyzerAdapter;
-                                        Some((
-                                            a.server_command().to_string(),
-                                            a.server_args(),
-                                            a.initialization_options(&lsp_root),
-                                        ))
-                                    }
-                                    kin_model::LanguageId::Python => {
-                                        let a = kin_lsp::adapters::python::PyrightAdapter;
-                                        Some((
-                                            a.server_command().to_string(),
-                                            a.server_args(),
-                                            a.initialization_options(&lsp_root),
-                                        ))
-                                    }
-                                    _ => None,
-                                };
-
-                                if let Some((cmd, args, init_opts)) = adapter {
+                                if let Some((cmd, args, init_opts)) =
+                                    lsp_adapter_for(lang, &lsp_root)
+                                {
                                     let args_refs: Vec<&str> =
                                         args.iter().map(|s| s.as_str()).collect();
                                     match kin_lsp::lifecycle::LspServer::start(

--- a/crates/kin-daemon/tests/lsp_reference_enrichment.rs
+++ b/crates/kin-daemon/tests/lsp_reference_enrichment.rs
@@ -48,7 +48,10 @@ fn server_command_or_skip(language: LanguageId, test: &str) -> Option<(String, V
     };
     match which::which(&command) {
         Ok(path) => {
-            eprintln!("{test}: using {language} language server at {}", path.display());
+            eprintln!(
+                "{test}: using {language} language server at {}",
+                path.display()
+            );
             Some((command, args))
         }
         Err(_) => {
@@ -344,7 +347,11 @@ async fn javascript_resolves_a_require_chain_that_a_name_match_cannot() {
         },
     ];
     let refs = entity_refs(&fixtures);
-    let caller = refs.iter().find(|r| r.id == listen).expect("caller").clone();
+    let caller = refs
+        .iter()
+        .find(|r| r.id == listen)
+        .expect("caller")
+        .clone();
     let index = EntityIndex::new(refs);
 
     let server = start_server(&command, &args, root, LanguageId::JavaScript).await;

--- a/crates/kin-daemon/tests/lsp_reference_enrichment.rs
+++ b/crates/kin-daemon/tests/lsp_reference_enrichment.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The cross-file reference edge, proved against a real language server.
+//!
+//! Both fixtures below are shaped like a loss that actually happened on shipped
+//! v0.5.42 bytes, where cross-file resolution fell back to matching bare names:
+//! that fallback fabricated nine of eleven edges on an express-shaped
+//! JavaScript repository and dropped both load-bearing call sites on a
+//! requests-shaped Python one.
+//!
+//! Each fixture holds TWO entities with the SAME name, and the edge under test
+//! is the one that distinguishes them. That is the whole point. A bare-name
+//! matcher cannot pass these tests by luck: it has a fifty-fifty choice and no
+//! information to make it with, so an assertion that the edge lands on the
+//! right one of the two is an assertion that something resolved the receiver.
+//! Asserting merely that "an edge exists" would pass on the broken build.
+//!
+//! Every test here needs a real language server. When one is absent the test
+//! SKIPS LOUDLY with the binary it looked for and the command that installs it,
+//! and never passes quietly: a proof that silently degrades to a no-op is worse
+//! than no proof, because the run is green either way.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::Duration;
+
+use kin_daemon::daemon::lsp_adapter_for;
+use kin_index::RelationResolution;
+use kin_lsp::{EntityIndex, EntityRef};
+use kin_model::{EntityId, GraphNodeId, LanguageId};
+
+/// How long a server is given to index a fixture of a dozen lines.
+///
+/// Generous rather than tight: a slow CI runner producing a flaky failure here
+/// would be read as an enrichment defect, which is the worst outcome this file
+/// can have.
+const INDEX_BUDGET: Duration = Duration::from_secs(60);
+
+/// Resolve the server for `language`, or explain the skip and return `None`.
+fn server_command_or_skip(language: LanguageId, test: &str) -> Option<(String, Vec<String>)> {
+    let root = Path::new("/");
+    let Some((command, args, _)) = lsp_adapter_for(language, root) else {
+        panic!(
+            "{test}: {language} has no adapter in this build, which contradicts \
+             ENRICHABLE_LANGUAGES"
+        );
+    };
+    match which::which(&command) {
+        Ok(path) => {
+            eprintln!("{test}: using {language} language server at {}", path.display());
+            Some((command, args))
+        }
+        Err(_) => {
+            eprintln!(
+                "SKIP {test}: no `{command}` on PATH, so the {language} enrichment path cannot be \
+                 exercised on this host. Install it with `{}` and re-run.",
+                install_hint(language)
+            );
+            None
+        }
+    }
+}
+
+/// The command that provisions a language's server, mirrored from
+/// `kin_cli::commands::language_servers` so the skip message names a real fix.
+fn install_hint(language: LanguageId) -> &'static str {
+    match language {
+        LanguageId::Python => "npm install -g pyright",
+        LanguageId::TypeScript | LanguageId::JavaScript => {
+            "npm install -g typescript-language-server typescript"
+        }
+        LanguageId::Rust => "rustup component add rust-analyzer",
+        _ => "see `kin doctor`",
+    }
+}
+
+/// Start a server against `root` and wait for it to finish indexing.
+async fn start_server(
+    command: &str,
+    args: &[String],
+    root: &Path,
+    language: LanguageId,
+) -> kin_lsp::lifecycle::LspServer {
+    let (_, _, init_opts) = lsp_adapter_for(language, root).expect("adapter must exist");
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let server = kin_lsp::lifecycle::LspServer::start(command, &arg_refs, root, init_opts)
+        .await
+        .unwrap_or_else(|error| panic!("could not start `{command}` against the fixture: {error}"));
+
+    // Poll the same way the daemon does rather than sleeping a fixed amount:
+    // an unindexed server answers prepareCallHierarchy with an empty list, and
+    // an empty list is exactly what a real miss looks like.
+    let deadline = tokio::time::Instant::now() + INDEX_BUDGET;
+    loop {
+        if server
+            .client
+            .request("workspace/symbol", serde_json::json!({ "query": "" }))
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    server
+}
+
+/// Open every fixture file, the way the daemon does before it enriches.
+///
+/// `enrich_entity_calls` goes straight to `prepareCallHierarchy`, so a server
+/// that was never told about the documents answers with an empty list, which is
+/// indistinguishable from a genuine miss. The first run of this file failed
+/// exactly that way, which is the behaviour these assertions were written to
+/// catch, so the harness performs the open rather than the assertions being
+/// loosened to tolerate it.
+async fn open_documents(
+    server: &kin_lsp::lifecycle::LspServer,
+    root: &Path,
+    files: &[&str],
+    language_id: &str,
+) {
+    for file in files {
+        let path = root.join(file);
+        let text = std::fs::read_to_string(&path).expect("fixture file must exist");
+        let uri = kin_lsp::protocol::path_to_uri(&path);
+        let _ = server
+            .client
+            .notify(
+                "textDocument/didOpen",
+                serde_json::json!({
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": language_id,
+                        "version": 1,
+                        "text": text,
+                    }
+                }),
+            )
+            .await;
+    }
+    // The daemon waits after the first open per language for the same reason:
+    // a server processes didOpen asynchronously and answers queries about a
+    // document it has not read yet with an empty result.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+}
+
+/// One entity in the fixture's index. `name_line`/`name_col` are where the
+/// server's cursor has to land, which for both languages is the identifier
+/// itself rather than the `def`/`function` keyword.
+struct Fixture {
+    id: EntityId,
+    name: &'static str,
+    file: &'static str,
+    name_line: u32,
+    name_col: u32,
+}
+
+fn entity_refs(fixtures: &[Fixture]) -> Vec<EntityRef> {
+    fixtures
+        .iter()
+        .map(|fixture| EntityRef {
+            id: fixture.id,
+            name: fixture.name.to_string(),
+            file_path: fixture.file.to_string(),
+            start_line: fixture.name_line,
+            start_col: 0,
+            end_line: fixture.name_line + 2,
+            name_line: fixture.name_line,
+            name_col: fixture.name_col,
+        })
+        .collect()
+}
+
+/// The Python loss, rebuilt: `Session.send` reaches `HTTPAdapter.send` through
+/// `self.connection`, and a second method named `send` sits on the mixin so a
+/// name match has no way to pick the right one.
+#[tokio::test(flavor = "multi_thread")]
+async fn python_resolves_a_call_through_an_attribute_that_a_name_match_cannot() {
+    const TEST: &str = "python_resolves_a_call_through_an_attribute_that_a_name_match_cannot";
+    let Some((command, args)) = server_command_or_skip(LanguageId::Python, TEST) else {
+        return;
+    };
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(
+        root.join("adapters.py"),
+        "class HTTPAdapter:\n    def send(self, request):\n        return \"adapter\"\n",
+    )
+    .expect("write adapters.py");
+    std::fs::write(
+        root.join("sessions.py"),
+        "from adapters import HTTPAdapter\n\
+         \n\
+         \n\
+         class SendMixin:\n\
+         \x20   def send(self, request):\n\
+         \x20       return \"mixin\"\n\
+         \n\
+         \n\
+         class Session(SendMixin):\n\
+         \x20   def __init__(self):\n\
+         \x20       self.connection = HTTPAdapter()\n\
+         \n\
+         \x20   def dispatch(self, request):\n\
+         \x20       return self.connection.send(request)\n",
+    )
+    .expect("write sessions.py");
+    // pyright resolves imports against the workspace root only when it knows it
+    // is one; without a config it still works here, but the file makes the
+    // fixture independent of the server's default discovery.
+    std::fs::write(root.join("pyrightconfig.json"), "{\"include\": [\".\"]}\n")
+        .expect("write pyrightconfig.json");
+
+    let adapter_send = EntityId::new();
+    let mixin_send = EntityId::new();
+    let dispatch = EntityId::new();
+    let fixtures = [
+        Fixture {
+            id: adapter_send,
+            name: "send",
+            file: "adapters.py",
+            name_line: 1,
+            name_col: 8,
+        },
+        Fixture {
+            id: mixin_send,
+            name: "send",
+            file: "sessions.py",
+            name_line: 4,
+            name_col: 8,
+        },
+        Fixture {
+            id: dispatch,
+            name: "dispatch",
+            file: "sessions.py",
+            name_line: 12,
+            name_col: 8,
+        },
+    ];
+    let refs = entity_refs(&fixtures);
+    let caller = refs
+        .iter()
+        .find(|r| r.id == dispatch)
+        .expect("caller")
+        .clone();
+    let index = EntityIndex::new(refs);
+
+    let server = start_server(&command, &args, root, LanguageId::Python).await;
+    open_documents(&server, root, &["adapters.py", "sessions.py"], "python").await;
+    let relations = kin_lsp::enrichment::enrich_entity_calls(&server, &caller, &index, root)
+        .await
+        .expect("enrichment must not error");
+
+    let targets: Vec<GraphNodeId> = relations.iter().map(|relation| relation.dst).collect();
+    assert!(
+        targets.contains(&GraphNodeId::Entity(adapter_send)),
+        "Session.dispatch must resolve to HTTPAdapter.send through self.connection; got {targets:?}"
+    );
+    assert!(
+        !targets.contains(&GraphNodeId::Entity(mixin_send)),
+        "resolution landed on the same-named mixin method, which is the bare-name guess this \
+         fixture exists to rule out: {targets:?}"
+    );
+
+    let edge = relations
+        .iter()
+        .find(|relation| relation.dst == GraphNodeId::Entity(adapter_send))
+        .expect("the resolved edge");
+    assert_eq!(
+        RelationResolution::of(edge),
+        RelationResolution::TypeResolved,
+        "a language-server edge must classify as type_resolved, not as a name guess"
+    );
+    assert!(
+        RelationResolution::of(edge).is_proven(),
+        "the edge must be countable as evidence that the destination is used"
+    );
+}
+
+/// The express-shaped JavaScript loss: `listen` reaches `router.handle` through
+/// a `require` chain, and a second `handle` in the calling file gives a name
+/// match something wrong to choose.
+#[tokio::test(flavor = "multi_thread")]
+async fn javascript_resolves_a_require_chain_that_a_name_match_cannot() {
+    const TEST: &str = "javascript_resolves_a_require_chain_that_a_name_match_cannot";
+    let Some((command, args)) = server_command_or_skip(LanguageId::JavaScript, TEST) else {
+        return;
+    };
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(
+        root.join("router.js"),
+        "function handle(req) {\n  return req.url;\n}\n\nmodule.exports = { handle };\n",
+    )
+    .expect("write router.js");
+    std::fs::write(
+        root.join("app.js"),
+        "const router = require('./router');\n\
+         \n\
+         function handle(req) {\n\
+         \x20 return 'local';\n\
+         }\n\
+         \n\
+         function listen(req) {\n\
+         \x20 return router.handle(req);\n\
+         }\n\
+         \n\
+         module.exports = { listen, handle };\n",
+    )
+    .expect("write app.js");
+    std::fs::write(root.join("jsconfig.json"), "{\"include\": [\"*.js\"]}\n")
+        .expect("write jsconfig.json");
+
+    let router_handle = EntityId::new();
+    let local_handle = EntityId::new();
+    let listen = EntityId::new();
+    let fixtures = [
+        Fixture {
+            id: router_handle,
+            name: "handle",
+            file: "router.js",
+            name_line: 0,
+            name_col: 9,
+        },
+        Fixture {
+            id: local_handle,
+            name: "handle",
+            file: "app.js",
+            name_line: 2,
+            name_col: 9,
+        },
+        Fixture {
+            id: listen,
+            name: "listen",
+            file: "app.js",
+            name_line: 6,
+            name_col: 9,
+        },
+    ];
+    let refs = entity_refs(&fixtures);
+    let caller = refs.iter().find(|r| r.id == listen).expect("caller").clone();
+    let index = EntityIndex::new(refs);
+
+    let server = start_server(&command, &args, root, LanguageId::JavaScript).await;
+    open_documents(&server, root, &["router.js", "app.js"], "javascript").await;
+    let relations = kin_lsp::enrichment::enrich_entity_calls(&server, &caller, &index, root)
+        .await
+        .expect("enrichment must not error");
+
+    let targets: Vec<GraphNodeId> = relations.iter().map(|relation| relation.dst).collect();
+    assert!(
+        targets.contains(&GraphNodeId::Entity(router_handle)),
+        "listen must resolve to router.handle across the require chain; got {targets:?}"
+    );
+    assert!(
+        !targets.contains(&GraphNodeId::Entity(local_handle)),
+        "resolution landed on the same-named function in the calling file, which is the \
+         fabricated edge this fixture exists to rule out: {targets:?}"
+    );
+
+    let edge = relations
+        .iter()
+        .find(|relation| relation.dst == GraphNodeId::Entity(router_handle))
+        .expect("the resolved edge");
+    assert_eq!(
+        RelationResolution::of(edge),
+        RelationResolution::TypeResolved,
+        "a language-server edge must classify as type_resolved"
+    );
+}
+
+/// The other half of the contract: with no server, the state is an actionable
+/// gap that names itself, rather than an absence a reader would take as fact.
+///
+/// Needs no server, so it runs everywhere and is what keeps this file honest on
+/// a runner where both tests above skip.
+#[test]
+fn without_a_server_an_enrichable_language_reports_an_actionable_gap() {
+    use kin_core::reference_coverage::{reference_enrichment_for, ReferenceEnrichment};
+
+    let none_installed: HashSet<LanguageId> = HashSet::new();
+    for language in [
+        LanguageId::Python,
+        LanguageId::JavaScript,
+        LanguageId::TypeScript,
+        LanguageId::Rust,
+    ] {
+        let state = reference_enrichment_for(language, &none_installed);
+        assert_eq!(
+            state,
+            ReferenceEnrichment::NoLanguageServer,
+            "{language} with no server installed"
+        );
+        assert!(
+            state.is_actionable_gap(),
+            "{language}: a missing server is a gap an operator can close, so it must be surfaced"
+        );
+    }
+
+    // And with the server present the same call reports the capability rather
+    // than the gap, so the row above cannot be an unconditional warning.
+    let mut installed = HashSet::new();
+    installed.insert(LanguageId::JavaScript);
+    let state = reference_enrichment_for(LanguageId::JavaScript, &installed);
+    assert_eq!(state, ReferenceEnrichment::Available);
+    assert!(!state.is_actionable_gap());
+}
+
+/// JavaScript and TypeScript must no longer report `Unsupported`.
+///
+/// This is the exact string an express-shaped repository read on shipped
+/// v0.5.42 bytes. `Unsupported` says the build wires no adapter, which was true
+/// then and is false now, and the difference matters because `Unsupported` is
+/// deliberately NOT an actionable gap: a reader is told there is nothing to do.
+#[test]
+fn javascript_no_longer_reports_the_unsupported_state_it_shipped_with() {
+    use kin_core::reference_coverage::{reference_enrichment_for, ReferenceEnrichment};
+
+    let none_installed: HashSet<LanguageId> = HashSet::new();
+    for language in [LanguageId::JavaScript, LanguageId::TypeScript] {
+        assert_ne!(
+            reference_enrichment_for(language, &none_installed),
+            ReferenceEnrichment::Unsupported,
+            "{language} is wired now, so an absent server is a host gap rather than a build limit"
+        );
+    }
+
+    // The control: a language this build genuinely does not wire still reports
+    // Unsupported, so the assertion above is about JavaScript rather than about
+    // the function having stopped returning that state at all.
+    assert_eq!(
+        reference_enrichment_for(LanguageId::Ruby, &none_installed),
+        ReferenceEnrichment::Unsupported,
+        "an unwired language must still report Unsupported"
+    );
+}

--- a/crates/kin-daemon/tests/lsp_reference_enrichment.rs
+++ b/crates/kin-daemon/tests/lsp_reference_enrichment.rs
@@ -55,6 +55,19 @@ fn server_command_or_skip(language: LanguageId, test: &str) -> Option<(String, V
             Some((command, args))
         }
         Err(_) => {
+            // In CI the skip is not allowed to be quiet. `scripts/ci-install-language-servers.sh`
+            // sets this variable only after proving both binaries are executable, so if it is
+            // set and the binary is still missing, the proof is being skipped in the one
+            // environment built to run it. A skip that nextest swallows (it captures a passing
+            // test's stderr) would read as a 0.02s pass, which is what a real run never looks
+            // like and what nobody would notice.
+            if std::env::var_os("KIN_CI_LANGUAGE_SERVERS_INSTALLED").is_some() {
+                panic!(
+                    "{test}: KIN_CI_LANGUAGE_SERVERS_INSTALLED is set, so this runner was \
+                     provisioned, yet `{command}` is not on PATH. The enrichment proof would \
+                     have skipped silently."
+                );
+            }
             eprintln!(
                 "SKIP {test}: no `{command}` on PATH, so the {language} enrichment path cannot be \
                  exercised on this host. Install it with `{}` and re-run.",

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -51,9 +51,11 @@
 //! per-entity `has_references: false` rows are absences inside a populated
 //! response.
 
+use std::collections::HashSet;
+
 use serde_json::{json, Map, Value};
 
-use kin_core::reference_coverage::{ReferenceEnrichment, ENRICHABLE_LANGUAGES};
+use kin_core::reference_coverage::{reference_enrichment_for, ReferenceEnrichment};
 use kin_model::entity::Entity;
 use kin_model::graph::{EntityFilter, EntityStore};
 use kin_model::ids::{EntityId, FilePathId, LanguageId};
@@ -481,23 +483,117 @@ fn attach_reference_resolution<S: EntityStore>(
 /// trust gate has to be able to read: an absence over a language whose reference
 /// edges are unproducible cannot be certified by any amount of scanning.
 ///
-/// Only the unsupported half is published as a verdict. Whether an installed
-/// server actually backs a wired adapter is a HOST fact this observation does not
-/// probe (the CLI's status path does, through `which`), so a wired language
-/// reports [`ReferenceEnrichment::Unknown`] rather than claiming an availability
-/// nothing here checked. That variant carries the wire string, so this gate and
-/// the status surfaces cannot drift on what an unprobed language looks like.
-/// The weakest language governs, matching how the class states above merge: one
-/// unsupported language in a batch makes the batch's reference evidence
-/// unproducible.
+/// A wired adapter is only half of it, and this used to publish only that half.
+/// Whether a server is actually installed is a HOST fact, and it decides the
+/// same question: on a host with none, nothing resolves the program behind the
+/// declarations, exactly as on a build that wires no adapter. Publishing
+/// `Unknown` for every wired language made the trust gate read "nobody checked"
+/// as "fine", so a Python absence was certified as authoritative on a host that
+/// could not have produced a single reference edge.
+///
+/// That was survivable only because the wired set was small and the gate's other
+/// half happened to catch the case people hit. It stopped being survivable when
+/// JavaScript and TypeScript were wired: the express-shaped absence FIR-2430
+/// blocked, with the advice "safe to treat the target as genuinely absent", went
+/// straight back to certifying because the build limit had lifted while the host
+/// limit had not.
+///
+/// So the host is probed here now, through the same `PATH` lookup and the same
+/// table the doctor row and the install recipes read. The weakest language
+/// governs, matching how the class states above merge: one unsupported language
+/// in a batch makes the batch's reference evidence unproducible, and one missing
+/// server makes it unproduced.
 fn reference_enrichment(languages: &[LanguageId]) -> Value {
-    if languages
+    json!(weakest_reference_enrichment(
+        languages,
+        &installed_language_servers()
+    ))
+}
+
+/// [`reference_enrichment`] with the host state given rather than probed.
+///
+/// Split out so a test states the whole environment it is asserting against. A
+/// test that inherited the developer's `PATH` would assert something different
+/// on a laptop with pyright than on a runner without it, and the version that
+/// silently stops checking is the one that runs in CI.
+fn weakest_reference_enrichment(
+    languages: &[LanguageId],
+    servers_found: &HashSet<LanguageId>,
+) -> ReferenceEnrichment {
+    languages
         .iter()
-        .any(|language| !ENRICHABLE_LANGUAGES.contains(language))
-    {
-        json!(ReferenceEnrichment::Unsupported)
-    } else {
-        json!(ReferenceEnrichment::Unknown)
+        .map(|language| reference_enrichment_for(*language, servers_found))
+        .min_by_key(|state| match state {
+            // Weakest first: an unproducible class outranks an unproduced one,
+            // which outranks an unread one, which outranks a working server.
+            ReferenceEnrichment::Unsupported => 0,
+            ReferenceEnrichment::NoLanguageServer => 1,
+            ReferenceEnrichment::Unknown => 2,
+            ReferenceEnrichment::Available => 3,
+        })
+        .unwrap_or(ReferenceEnrichment::Unknown)
+}
+
+/// Which languages have an enrichment server on this host, read once.
+///
+/// Cached because an observation is built per answer and a `PATH` lookup per
+/// answer is a cost no surface needs to pay repeatedly. A server installed while
+/// the process runs is therefore not seen until restart, which is the same thing
+/// the daemon's own startup discovery does and what `kin doctor` already tells
+/// an operator to expect.
+fn installed_language_servers() -> HashSet<LanguageId> {
+    #[cfg(test)]
+    if let Some(servers) = test_support::server_override() {
+        return servers;
+    }
+    static INSTALLED: std::sync::OnceLock<HashSet<LanguageId>> = std::sync::OnceLock::new();
+    INSTALLED
+        .get_or_init(kin_core::reference_coverage::installed_language_servers)
+        .clone()
+}
+
+/// Lets a test state which language servers its host has.
+///
+/// Without this every assertion about enrichment would inherit the developer's
+/// `PATH`: the same test would assert one thing on a laptop carrying pyright and
+/// another on a runner without it, and the version that quietly stops checking
+/// is the one that runs in CI. The override is thread-local, so it holds for the
+/// test that set it whether the suite runs threaded under `cargo test` or one
+/// process per test under nextest.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::{HashSet, LanguageId};
+    use std::cell::RefCell;
+
+    thread_local! {
+        static SERVERS: RefCell<Option<HashSet<LanguageId>>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) fn server_override() -> Option<HashSet<LanguageId>> {
+        SERVERS.with(|servers| servers.borrow().clone())
+    }
+
+    /// Restores the previous host on drop, including on unwind, so one test's
+    /// environment never leaks into the next on a reused thread.
+    pub(crate) struct HostGuard(Option<HashSet<LanguageId>>);
+
+    impl Drop for HostGuard {
+        fn drop(&mut self) {
+            SERVERS.with(|slot| *slot.borrow_mut() = self.0.take());
+        }
+    }
+
+    /// Declare, for the rest of this scope, that the host carries exactly
+    /// `servers`. Bind the guard: dropping it immediately restores the host.
+    #[must_use = "binding the guard is what keeps the declared host in force"]
+    pub(crate) fn scoped_language_servers(servers: &[LanguageId]) -> HostGuard {
+        HostGuard(SERVERS.with(|slot| slot.borrow_mut().replace(servers.iter().copied().collect())))
+    }
+
+    /// Run `body` on a host carrying exactly `servers`.
+    pub(crate) fn with_language_servers<T>(servers: &[LanguageId], body: impl FnOnce() -> T) -> T {
+        let _guard = scoped_language_servers(servers);
+        body()
     }
 }
 
@@ -782,25 +878,95 @@ mod tests {
     /// difference is what a reader is told to do about it.
     #[test]
     fn a_language_with_no_adapter_reports_reference_enrichment_unsupported() {
-        let store = InMemoryGraph::new();
-        let target = entity("render_note", "app/notes.rb", LanguageId::Ruby);
-        store.upsert_entity(&target).unwrap();
+        // Stated rather than inherited: on a host carrying every server, the
+        // only thing that can still report `unsupported` is a build limit.
+        test_support::with_language_servers(
+            &[
+                LanguageId::Rust,
+                LanguageId::Python,
+                LanguageId::TypeScript,
+                LanguageId::JavaScript,
+            ],
+            || {
+                let store = InMemoryGraph::new();
+                let target = entity("render_note", "app/notes.rb", LanguageId::Ruby);
+                store.upsert_entity(&target).unwrap();
 
-        let coverage =
-            observe_cross_file_reference_coverage(&store, &target, &[RelationKind::References]);
-        assert_eq!(coverage["reference_enrichment"], json!("unsupported"));
+                let coverage = observe_cross_file_reference_coverage(
+                    &store,
+                    &target,
+                    &[RelationKind::References],
+                );
+                assert_eq!(coverage["reference_enrichment"], json!("unsupported"));
 
-        // Positive control: a language this build DOES wire an adapter for must
-        // not be reported unsupported, or the field says the same thing about
-        // every language and gates nothing.
-        let python = entity("parse_note", "nk/parsing.py", LanguageId::Python);
-        store.upsert_entity(&python).unwrap();
-        let coverage =
-            observe_cross_file_reference_coverage(&store, &python, &[RelationKind::References]);
+                // Positive control: a language this build DOES wire an adapter
+                // for, whose server is installed, must not be reported
+                // unsupported, or the field says the same thing about every
+                // language and gates nothing.
+                let python = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+                store.upsert_entity(&python).unwrap();
+                let coverage = observe_cross_file_reference_coverage(
+                    &store,
+                    &python,
+                    &[RelationKind::References],
+                );
+                assert_eq!(coverage["reference_enrichment"], json!("available"));
+            },
+        );
+    }
+
+    /// The host half, which decides the same question the build half does.
+    ///
+    /// A wired language whose server is missing produces no reference edge
+    /// either, and until this was published the observation said `unknown` and
+    /// the trust gate read that as fine.
+    #[test]
+    fn a_wired_language_with_no_server_installed_reports_no_language_server() {
+        test_support::with_language_servers(&[], || {
+            let store = InMemoryGraph::new();
+            let target = entity("parse_note", "nk/parsing.py", LanguageId::Python);
+            store.upsert_entity(&target).unwrap();
+            let coverage =
+                observe_cross_file_reference_coverage(&store, &target, &[RelationKind::References]);
+            assert_eq!(
+                coverage["reference_enrichment"],
+                json!("no_language_server")
+            );
+        });
+    }
+
+    /// The weakest language governs, so one unresolvable language in a batch
+    /// cannot be lifted by a resolvable sibling.
+    #[test]
+    fn the_weakest_language_governs_a_batch() {
+        use super::weakest_reference_enrichment;
+        let all: HashSet<LanguageId> = [
+            LanguageId::Rust,
+            LanguageId::Python,
+            LanguageId::TypeScript,
+            LanguageId::JavaScript,
+        ]
+        .into_iter()
+        .collect();
+        let none: HashSet<LanguageId> = HashSet::new();
+
         assert_eq!(
-            coverage["reference_enrichment"],
-            json!("unknown"),
-            "a wired adapter's server is a host fact this scan does not probe"
+            weakest_reference_enrichment(&[LanguageId::Python, LanguageId::Ruby], &all),
+            ReferenceEnrichment::Unsupported,
+            "an unwired language drags the batch down"
+        );
+        assert_eq!(
+            weakest_reference_enrichment(&[LanguageId::Python, LanguageId::JavaScript], &none),
+            ReferenceEnrichment::NoLanguageServer
+        );
+        assert_eq!(
+            weakest_reference_enrichment(&[LanguageId::Python, LanguageId::JavaScript], &all),
+            ReferenceEnrichment::Available
+        );
+        assert_eq!(
+            weakest_reference_enrichment(&[], &all),
+            ReferenceEnrichment::Unknown,
+            "no language observed establishes nothing"
         );
     }
 
@@ -813,26 +979,34 @@ mod tests {
     /// tells a reader there is nothing to be done.
     #[test]
     fn an_express_shaped_repository_no_longer_reports_reference_enrichment_unsupported() {
-        let store = InMemoryGraph::new();
-        for (name, path, language) in [
-            (
-                "createApplication",
-                "lib/express.js",
-                LanguageId::JavaScript,
-            ),
-            ("Router", "lib/router/index.ts", LanguageId::TypeScript),
-        ] {
-            let target = entity(name, path, language);
-            store.upsert_entity(&target).unwrap();
-            let coverage =
-                observe_cross_file_reference_coverage(&store, &target, &[RelationKind::References]);
-            assert_eq!(
-                coverage["reference_enrichment"],
-                json!("unknown"),
-                "{language} is wired, so its enrichment state is an unprobed host fact rather \
-                 than a build limit"
-            );
-        }
+        test_support::with_language_servers(
+            &[LanguageId::TypeScript, LanguageId::JavaScript],
+            || {
+                let store = InMemoryGraph::new();
+                for (name, path, language) in [
+                    (
+                        "createApplication",
+                        "lib/express.js",
+                        LanguageId::JavaScript,
+                    ),
+                    ("Router", "lib/router/index.ts", LanguageId::TypeScript),
+                ] {
+                    let target = entity(name, path, language);
+                    store.upsert_entity(&target).unwrap();
+                    let coverage = observe_cross_file_reference_coverage(
+                        &store,
+                        &target,
+                        &[RelationKind::References],
+                    );
+                    assert_eq!(
+                        coverage["reference_enrichment"],
+                        json!("available"),
+                        "{language} is wired and its server is installed here, so nothing about \
+                         this build or host stops its reference edges existing"
+                    );
+                }
+            },
+        );
     }
 
     /// An intra-file edge is not a witness. Without this the FIR-2353 graph,

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -769,18 +769,21 @@ mod tests {
         assert_eq!(python["classes"]["calls"], json!("absent"));
     }
 
-    /// The build fact the scan cannot see. JavaScript has no language-server
-    /// adapter in this build, so its reference edges are unproducible rather
-    /// than merely unobserved, and the observation has to say so or the trust
-    /// gate reads an unproducible class as a scanned-and-empty one.
+    /// The build fact the scan cannot see. Ruby has no language-server adapter
+    /// in this build, so its reference edges are unproducible rather than merely
+    /// unobserved, and the observation has to say so or the trust gate reads an
+    /// unproducible class as a scanned-and-empty one.
+    ///
+    /// This case used to be written with JavaScript, which was true until
+    /// JavaScript and TypeScript were wired: kin-lsp already carried a working
+    /// adapter for both, so an express-shaped repository was told its reference
+    /// edges could never exist while the only thing missing was a server on the
+    /// host. `Unsupported` is deliberately not an actionable gap, so the
+    /// difference is what a reader is told to do about it.
     #[test]
     fn a_language_with_no_adapter_reports_reference_enrichment_unsupported() {
         let store = InMemoryGraph::new();
-        let target = entity(
-            "createApplication",
-            "lib/express.js",
-            LanguageId::JavaScript,
-        );
+        let target = entity("render_note", "app/notes.rb", LanguageId::Ruby);
         store.upsert_entity(&target).unwrap();
 
         let coverage =
@@ -799,6 +802,37 @@ mod tests {
             json!("unknown"),
             "a wired adapter's server is a host fact this scan does not probe"
         );
+    }
+
+    /// JavaScript is wired now, so an express-shaped repository must no longer
+    /// read `unsupported` here.
+    ///
+    /// Pinned as its own case rather than folded into the control above,
+    /// because this exact string on this exact shape of repository is what the
+    /// npm-0541 verdict recorded, and a regression would restore a state that
+    /// tells a reader there is nothing to be done.
+    #[test]
+    fn an_express_shaped_repository_no_longer_reports_reference_enrichment_unsupported() {
+        let store = InMemoryGraph::new();
+        for (name, path, language) in [
+            (
+                "createApplication",
+                "lib/express.js",
+                LanguageId::JavaScript,
+            ),
+            ("Router", "lib/router/index.ts", LanguageId::TypeScript),
+        ] {
+            let target = entity(name, path, language);
+            store.upsert_entity(&target).unwrap();
+            let coverage =
+                observe_cross_file_reference_coverage(&store, &target, &[RelationKind::References]);
+            assert_eq!(
+                coverage["reference_enrichment"],
+                json!("unknown"),
+                "{language} is wired, so its enrichment state is an unprobed host fact rather \
+                 than a build limit"
+            );
+        }
     }
 
     /// An intra-file edge is not a witness. Without this the FIR-2353 graph,

--- a/crates/kin-mcp/src/edge_coverage.rs
+++ b/crates/kin-mcp/src/edge_coverage.rs
@@ -55,7 +55,9 @@ use std::collections::HashSet;
 
 use serde_json::{json, Map, Value};
 
-use kin_core::reference_coverage::{reference_enrichment_for, ReferenceEnrichment};
+use kin_core::reference_coverage::{
+    reference_enrichment_for, ReferenceEnrichment, ENRICHABLE_LANGUAGES,
+};
 use kin_model::entity::Entity;
 use kin_model::graph::{EntityFilter, EntityStore};
 use kin_model::ids::{EntityId, FilePathId, LanguageId};
@@ -504,10 +506,26 @@ fn attach_reference_resolution<S: EntityStore>(
 /// in a batch makes the batch's reference evidence unproducible, and one missing
 /// server makes it unproduced.
 fn reference_enrichment(languages: &[LanguageId]) -> Value {
-    json!(weakest_reference_enrichment(
-        languages,
-        &installed_language_servers()
-    ))
+    let Some(servers) = published_language_servers() else {
+        // Nobody published the host state, so nothing is established about any
+        // language's server. Still report the build limit, which is knowable
+        // from this process alone and is what makes an unwired language's
+        // absence uncertifiable.
+        return json!(build_only_reference_enrichment(languages));
+    };
+    json!(weakest_reference_enrichment(languages, &servers))
+}
+
+/// What is knowable without the host: whether this build wires an adapter.
+fn build_only_reference_enrichment(languages: &[LanguageId]) -> ReferenceEnrichment {
+    if languages
+        .iter()
+        .any(|language| !ENRICHABLE_LANGUAGES.contains(language))
+    {
+        ReferenceEnrichment::Unsupported
+    } else {
+        ReferenceEnrichment::Unknown
+    }
 }
 
 /// [`reference_enrichment`] with the host state given rather than probed.
@@ -534,22 +552,46 @@ fn weakest_reference_enrichment(
         .unwrap_or(ReferenceEnrichment::Unknown)
 }
 
-/// Which languages have an enrichment server on this host, read once.
+/// Which languages have an enrichment server on this host, as PUBLISHED by the
+/// process that knows, or `None` when nobody published it.
 ///
-/// Cached because an observation is built per answer and a `PATH` lookup per
-/// answer is a cost no surface needs to pay repeatedly. A server installed while
-/// the process runs is therefore not seen until restart, which is the same thing
-/// the daemon's own startup discovery does and what `kin doctor` already tells
-/// an operator to expect.
-fn installed_language_servers() -> HashSet<LanguageId> {
+/// Deliberately not a `PATH` probe taken here. Reading the host from inside a
+/// query function makes every answer, and every test of one, depend on the
+/// machine it runs on: the same assertion passes on a laptop carrying pyright
+/// and fails on a runner without it, and a local gate goes green for a reason
+/// that has nothing to do with the change under test. That is not hypothetical.
+/// It is how `daemon_mcp_bulk_reachability_uses_exact_federated_authority`
+/// passed here and failed in CI on the first attempt at this.
+///
+/// The daemon publishes it once at startup, which is the same moment it decides
+/// whether to open its enrichment channel at all, so the value a query reads is
+/// the same fact the enrichment path acted on. Unpublished reads as unknown, and
+/// unknown establishes nothing, which is the conservative reading this module
+/// takes everywhere else.
+fn published_language_servers() -> Option<HashSet<LanguageId>> {
     #[cfg(test)]
     if let Some(servers) = test_support::server_override() {
-        return servers;
+        return Some(servers);
     }
-    static INSTALLED: std::sync::OnceLock<HashSet<LanguageId>> = std::sync::OnceLock::new();
-    INSTALLED
-        .get_or_init(kin_core::reference_coverage::installed_language_servers)
-        .clone()
+    PUBLISHED_SERVERS
+        .read()
+        .ok()
+        .and_then(|servers| servers.clone())
+}
+
+static PUBLISHED_SERVERS: std::sync::RwLock<Option<HashSet<LanguageId>>> =
+    std::sync::RwLock::new(None);
+
+/// Publish which languages have an enrichment server on this host.
+///
+/// Called by the daemon at startup, beside the discovery that decides whether
+/// enrichment runs. Until it is called, every observation reports its languages'
+/// enrichment as unknown and the absence-trust gate stays silent about it, which
+/// is the behaviour a process that never looked should have.
+pub fn publish_installed_language_servers(servers: HashSet<LanguageId>) {
+    if let Ok(mut slot) = PUBLISHED_SERVERS.write() {
+        *slot = Some(servers);
+    }
 }
 
 /// Lets a test state which language servers its host has.

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4628,6 +4628,13 @@ mod tests {
     /// language-server adapter for JavaScript.
     #[test]
     fn a_javascript_search_absence_is_inconclusive_while_a_python_one_still_certifies() {
+        // A Python developer's machine: pyright installed, no JavaScript server.
+        // Stated rather than inherited, because the whole contrast below is
+        // between a language something resolved and one nothing did, and a test
+        // that read the developer's PATH would assert a different thing on
+        // every host.
+        let _host =
+            crate::edge_coverage::test_support::scoped_language_servers(&[LanguageId::Python]);
         let store = InMemoryGraph::new();
         store
             .upsert_entity(&module_entity(
@@ -4666,7 +4673,7 @@ mod tests {
         assert_eq!(empty["total_matches"], 0);
         let coverage = &empty[crate::edge_coverage::EDGE_COVERAGE_KEY];
         assert_eq!(coverage["language"], "JavaScript");
-        assert_eq!(coverage["reference_enrichment"], "unsupported");
+        assert_eq!(coverage["reference_enrichment"], "no_language_server");
         assert_eq!(
             coverage["scope_entities"], 1,
             "the kind-filtered absence states the coverage of that kind: {coverage}"
@@ -4718,7 +4725,9 @@ mod tests {
         assert_eq!(absent["total_matches"], 0);
         let coverage = &absent[crate::edge_coverage::EDGE_COVERAGE_KEY];
         assert_eq!(coverage["language"], "Python");
-        assert_eq!(coverage["reference_enrichment"], "unknown");
+        // pyright is installed on the host this test declares, which is what
+        // entitles the Python arm below to certify at all.
+        assert_eq!(coverage["reference_enrichment"], "available");
         assert_eq!(coverage["scope_entities"], 2);
         let negative = crate::negative::negative_for(
             "semantic_search",
@@ -4774,6 +4783,9 @@ mod tests {
     /// focal-not-in-graph gap stays the limiting factor a reader is handed.
     #[test]
     fn an_empty_neighborhood_publishes_the_scope_it_walked() {
+        // No language server at all, which is the container the v0.5.42
+        // stranger run used.
+        let _host = crate::edge_coverage::test_support::scoped_language_servers(&[]);
         let store = InMemoryGraph::new();
         let focal = make_entity_in(
             LanguageId::JavaScript,
@@ -4793,7 +4805,11 @@ mod tests {
         assert_eq!(walked["relation_count"], 0);
         let coverage = &walked[crate::edge_coverage::EDGE_COVERAGE_KEY];
         assert_eq!(coverage["language"], "JavaScript");
-        assert_eq!(coverage["reference_enrichment"], "unsupported");
+        // `no_language_server` rather than `unsupported`: this build wires a
+        // JavaScript adapter now, so what leaves the program unresolved is the
+        // host, not the build. Both block certification, and the difference is
+        // whether an operator can do anything about it.
+        assert_eq!(coverage["reference_enrichment"], "no_language_server");
         assert!(
             coverage.get("scope_entities").is_none(),
             "a walk counts no region, so it publishes no count: {coverage}"
@@ -6233,6 +6249,8 @@ mod tests {
     /// enrichment, which is the fact FIR-2404 added to the gate.
     #[tokio::test]
     async fn a_javascript_export_is_not_certified_absent_when_requires_produce_no_edges() {
+        // The express container: no language server installed at all.
+        let _host = crate::edge_coverage::test_support::scoped_language_servers(&[]);
         let graph = InMemoryGraph::new();
         let target = make_entity_in(
             LanguageId::JavaScript,
@@ -6288,8 +6306,8 @@ mod tests {
             response["edge_coverage"]
         );
         assert_eq!(
-            response["edge_coverage"]["reference_enrichment"], "unsupported",
-            "this build wires no adapter for JavaScript: {}",
+            response["edge_coverage"]["reference_enrichment"], "no_language_server",
+            "this build wires a JavaScript adapter, and no server is installed to run it: {}",
             response["edge_coverage"]
         );
         assert_eq!(

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -473,20 +473,52 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
     // nothing resolved the program behind the declarations it filtered, so a
     // name-and-kind miss cannot separate a declaration the repository lacks from
     // one the extractor never admitted as an entity of that kind.
-    if coverage.get("reference_enrichment").and_then(Value::as_str) == Some("unsupported") {
+    // Two ways the program can be unresolved, and the gate blocks on both.
+    //
+    // It used to key on `unsupported` alone, which is the BUILD limit. That was
+    // the same reason with only one of its causes: a wired adapter with no
+    // server installed leaves the program exactly as unresolved, and reading
+    // that state as fine is how a Python absence was certified as authoritative
+    // on a host that could not have produced a single reference edge. Wiring
+    // JavaScript and TypeScript made it visible rather than introducing it: the
+    // express-shaped absence FIR-2430 blocked went straight back to "safe to
+    // treat the target as genuinely absent" the moment the build limit lifted,
+    // because nothing was looking at the host.
+    //
+    // The wording splits three ways, because a correct verdict beside an
+    // unrelated reason is the failure this module exists to prevent. What the
+    // tool claimed decides the first split; whether an operator can DO anything
+    // decides the second. A build limit no amount of installing will move reads
+    // differently from a host gap one command closes.
+    // Fires only on a POSITIVE finding about a real language. `available` means
+    // the program was resolved, and `unknown` means the observation named no
+    // language at all, which is what a focal that never resolved reports. A gate
+    // that fired on `unknown` would answer a question nobody asked, in the words
+    // "nothing established that a language server resolved no resolved language
+    // on this host", and it would displace the real limiting factor a reader
+    // needs. Unmeasured is not a finding anywhere else in this module either.
+    let cause = match coverage.get("reference_enrichment").and_then(Value::as_str) {
+        Some("unsupported") => Some(format!(
+            "this build wires no language-server adapter for {language}"
+        )),
+        Some("no_language_server") => Some(format!(
+            "no language server for {language} is installed on this host, so no cross-file \
+             reference or override edge was ever produced for it"
+        )),
+        _ => None,
+    };
+    if let Some(cause) = cause {
         gaps.push(if requested.is_empty() {
             format!(
-                "entity_index_unresolved: this build wires no language-server adapter for \
-                 {language}, so nothing resolves the program behind its parsed declarations, and \
-                 an empty name/kind filter cannot separate a declaration the repository does not \
-                 have from one the extractor did not admit as an entity of that kind"
+                "entity_index_unresolved: {cause}, so nothing resolves the program behind its \
+                 parsed declarations, and an empty name/kind filter cannot separate a declaration \
+                 the repository does not have from one the extractor did not admit as an entity \
+                 of that kind"
             )
         } else {
             format!(
-                "reference_enrichment_unsupported: this build wires no language-server adapter \
-                 for {language}, so cross-file reference and override edges cannot exist for it \
-                 at all, and an empty result cannot separate a symbol nothing uses from one this \
-                 graph could never have linked"
+                "reference_enrichment_unsupported: {cause}, so an empty result cannot separate a \
+                 symbol nothing uses from one this graph could never have linked"
             )
         });
     }
@@ -569,7 +601,10 @@ pub(crate) fn edge_coverage_degradation_labels(tool: &str, payload: &Value) -> V
     if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
         labels.push("absence_coverage:scope_empty".to_string());
     }
-    if coverage.get("reference_enrichment").and_then(Value::as_str) == Some("unsupported") {
+    if matches!(
+        coverage.get("reference_enrichment").and_then(Value::as_str),
+        Some("unsupported") | Some("no_language_server")
+    ) {
         labels.push("edge_coverage:reference_enrichment_unsupported".to_string());
     }
     labels
@@ -1758,14 +1793,17 @@ mod tests {
             "requested_classes": ["calls", "imports", "references"],
             "classes": { "calls": "present", "imports": "absent", "references": "absent" },
             "cross_file_classes": ["calls"],
-            "reference_enrichment": "unknown",
+            "reference_enrichment": "available",
             "budget_exhausted": false,
             "entities_examined": 2,
         })
     }
 
     /// The scope observation a tool that traverses no edge publishes for an
-    /// absence, over a language this build CAN resolve.
+    /// absence, over a language that IS resolved on this host: the build wires
+    /// an adapter for it and a language server is installed. Both halves have to
+    /// hold, which is why the fixture states the second one rather than leaving
+    /// it unknown; "nobody checked" is not evidence that anything resolved.
     ///
     /// The shape is the one [`crate::edge_coverage::observe_absence_scope`]
     /// emits: no edge classes, because this claim is not about edges, and the
@@ -1780,7 +1818,7 @@ mod tests {
             "requested_classes": [],
             "classes": {},
             "cross_file_classes": [],
-            "reference_enrichment": "unknown",
+            "reference_enrichment": "available",
             "budget_exhausted": false,
             "entities_examined": 0,
             "scan": "skipped_no_edge_dependency",
@@ -1791,12 +1829,19 @@ mod tests {
         observation
     }
 
-    /// The same observation over a language this build wires no adapter for:
-    /// the express shape, where `imports` and `references` cannot exist at all.
+    /// The same observation over a language nothing resolved: the express
+    /// shape, where `imports` and `references` were never produced.
+    ///
+    /// It reports `no_language_server` rather than `unsupported` now. This build
+    /// DOES wire a JavaScript adapter, so what leaves express unresolved is the
+    /// host having no `typescript-language-server`, which is exactly the state
+    /// the container behind the v0.5.42 stranger run was in. Both states block
+    /// certification and they are different facts: one an operator can close
+    /// with a command, the other only a new build can.
     fn unresolvable_language_scope(scope_entities: Option<usize>) -> Value {
         let mut observation = resolvable_language_scope(scope_entities);
         observation["language"] = json!("JavaScript");
-        observation["reference_enrichment"] = json!("unsupported");
+        observation["reference_enrichment"] = json!("no_language_server");
         observation
     }
 
@@ -2628,6 +2673,12 @@ mod tests {
     /// cross-file `Calls` edge and an artifact-level edge and mints no
     /// entity-level `Imports` edge at all. A gate that demanded one would report
     /// every Python absence inconclusive while looking principled.
+    ///
+    /// It carries `reference_enrichment: available` because that is what makes
+    /// the sentence "whose cross-file uses resolve" true. Something has to have
+    /// resolved them, and on Python that something is pyright. The same fixture
+    /// with no server installed is the express case wearing a different
+    /// language, and it must not certify.
     #[test]
     fn a_python_graph_that_resolves_its_imports_still_certifies_an_unused_symbol() {
         let mut payload = authoritative_empty_references("function");
@@ -2639,7 +2690,7 @@ mod tests {
             "requested_classes": ["calls", "imports", "references"],
             "classes": { "calls": "present", "imports": "absent", "references": "absent" },
             "cross_file_classes": ["calls"],
-            "reference_enrichment": "unknown",
+            "reference_enrichment": "available",
             "budget_exhausted": false,
             "entities_examined": 12,
         });

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -30,11 +30,11 @@ cannot drift apart.
 | TypeScript | ✓ | calls, contains, extends, implements, references | ✓ (jest) | ✓ | ✓ typescript-language-server |
 | JavaScript | ✓ | calls, contains, extends, references | ✓ | ✓ | ✓ typescript-language-server |
 | Python | ✓ | calls, contains, extends, references | ✓ (pytest) | ✓ | ✓ pyright / pylsp |
-| Go | ✓ | calls, contains, extends, implements, references, sends-message, spawns | ✓ | ✓ | ✓ gopls |
-| Java | ✓ | calls, contains, extends, implements, references | ✓ (junit) | ✓ | ✓ jdtls |
+| Go | ✓ | calls, contains, extends, implements, references, sends-message, spawns | ✓ | ✓ | not wired (gopls adapter exists) |
+| Java | ✓ | calls, contains, extends, implements, references | ✓ (junit) | ✓ | not wired (jdtls adapter exists) |
 | Rust | ✓ | calls, contains, implements, references | ✓ (cargo) | ✓ | ✓ rust-analyzer |
-| C++ | ✓ | calls, contains, extends, imports, references, uses-macro | ✓ | ✓ | ✓ clangd |
-| C | ✓ | calls, imports, references, uses-macro | ✗ | ✓ | ✓ clangd |
+| C++ | ✓ | calls, contains, extends, imports, references, uses-macro | ✓ | ✓ | not wired (clangd adapter exists) |
+| C | ✓ | calls, imports, references, uses-macro | ✗ | ✓ | not wired (clangd adapter exists) |
 | Kotlin | ✓ | calls, contains, extends, implements, references | ✓ | ✓ | ✗ |
 | C# | ✓ | calls, contains, extends, references | ✗ | ✓ | ✗ |
 | Ruby | ✓ | calls, contains, extends, references | ✗ | ✓ | ✗ |
@@ -55,10 +55,47 @@ Treat these as unsupported for semantic extraction today.
 ## LSP enrichment
 
 When the corresponding language server binary is installed, Kin adds
-type-resolved relations on top of the parser output (call hierarchy,
-overrides, uses-type, references, each tagged with LSP origin and a
-confidence weight): Rust, Python, TypeScript, JavaScript, Go, Java, C, C++.
-Enrichment is skipped silently when the server binary is absent.
+type-resolved relations on top of the parser output (call hierarchy, overrides,
+uses-type, references), each tagged with LSP origin and a confidence weight that
+classifies it as `type_resolved` rather than as a name match.
+
+Two facts have to hold together before any of those edges can exist: the daemon
+has to wire an adapter for the language, and a server binary has to be installed
+on the host. The daemon wires **Rust, Python, TypeScript and JavaScript**, which
+is what `kin_core::reference_coverage::ENRICHABLE_LANGUAGES` names and what a
+test in `kin_daemon` holds it to. Every other language carries no reference,
+override or uses-type edge by construction, whatever is installed. kin-lsp does
+carry adapters for Go, Java, C and C++, and the table above says so, but those
+adapters are not reached from the runtime today.
+
+This matters because cross-file resolution without a language server falls back
+to matching bare names, which produces edges that name a plausible destination
+rather than a proven one.
+
+Install the servers with:
+
+```
+npm install -g pyright                                   # Python
+npm install -g typescript-language-server typescript     # TypeScript and JavaScript
+rustup component add rust-analyzer                       # Rust
+```
+
+`kin setup` and `kin doctor --fix` will offer to run these for you. Neither
+installs without consent: interactively they ask once per command with the
+download disclosed, and non-interactively they change nothing unless
+`--install-language-servers` is passed.
+
+A missing server used to be skipped silently. `kin doctor` now reports it as an
+actionable gap naming the language, what the gap costs, and the exact command
+that closes it. Import and call edges are still resolved from source with no
+language server involved, so the loss is bounded to the edge classes that need a
+resolved program.
+
+The daemon discovers servers once at startup. A server installed while a daemon
+is already running is picked up without a restart only if that daemon found at
+least one server when it started; on a host that had none, the enrichment
+channel is never opened, so run `kin daemon stop` and let the next command start
+a fresh one.
 
 ## Everything else
 

--- a/scripts/ci-install-language-servers.sh
+++ b/scripts/ci-install-language-servers.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Provision the language servers the reference-enrichment proof needs.
+#
+# `crates/kin-daemon/tests/lsp_reference_enrichment.rs` starts a real language
+# server and asserts that a cross-file call resolves to the right one of two
+# same-named entities. Without a server on PATH those tests skip, so this script
+# is what makes the proof actually run on a hosted runner.
+#
+# Three deliberate choices:
+#
+# Versions are pinned. An unpinned `npm install -g` resolves whatever the
+# registry serves that morning, so a server-side behaviour change would land as
+# a red gate on an unrelated pull request with no diff to explain it.
+#
+# The install is bounded and retried, for the same reason `ci-apt-install.sh`
+# is: a stalled registry that holds a job to the runner's one-hour timeout
+# ejects a merge-group entry without marking the pull request it ejected.
+#
+# A failure warns and exits 0 rather than failing the gate. A registry outage is
+# not a defect in the change under review, and blocking the whole fleet on npm's
+# availability trades one silent failure for a louder wrong one. The proof does
+# not vanish quietly when that happens: this script emits a GitHub warning
+# annotation that shows on the run summary, and each live test prints its own
+# skip line naming the binary it looked for.
+#
+# Installs into a local prefix rather than the global one, so nothing depends on
+# whether the runner's npm prefix is writable without sudo.
+set -uo pipefail
+
+# Pinned. Bump deliberately, never by re-resolving.
+PYRIGHT_VERSION="${KIN_CI_PYRIGHT_VERSION:-1.1.406}"
+TS_LANGSERVER_VERSION="${KIN_CI_TS_LANGSERVER_VERSION:-5.0.0}"
+TYPESCRIPT_VERSION="${KIN_CI_TYPESCRIPT_VERSION:-5.9.3}"
+
+PREFIX="${KIN_CI_LSP_PREFIX:-${RUNNER_TEMP:-/tmp}/kin-language-servers}"
+INSTALL_BOUND="${KIN_CI_LSP_INSTALL_BOUND:-300}"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "::warning::no npm on this runner, so the language-server enrichment proof will skip" >&2
+  exit 0
+fi
+
+mkdir -p "$PREFIX"
+
+for attempt in 1 2 3; do
+  if timeout "$INSTALL_BOUND" npm install \
+    --prefix "$PREFIX" \
+    --no-fund --no-audit --no-progress \
+    "pyright@${PYRIGHT_VERSION}" \
+    "typescript-language-server@${TS_LANGSERVER_VERSION}" \
+    "typescript@${TYPESCRIPT_VERSION}"; then
+    BIN="$PREFIX/node_modules/.bin"
+    # Both binaries have to be reachable, not just installed. An npm run that
+    # exits zero having written a prefix nobody put on PATH is the success that
+    # leaves the gap open, which is the same case `kin doctor --fix` re-probes
+    # for rather than trusting an exit code.
+    missing=""
+    for binary in pyright-langserver typescript-language-server; do
+      [ -x "$BIN/$binary" ] || missing="$missing $binary"
+    done
+    if [ -n "$missing" ]; then
+      echo "::warning::npm succeeded but these servers are not executable:$missing" >&2
+      exit 0
+    fi
+    echo "$BIN" >>"${GITHUB_PATH:-/dev/null}"
+    echo "language servers installed at $BIN"
+    "$BIN/typescript-language-server" --version
+    exit 0
+  fi
+  echo "npm attempt $attempt of 3 failed for the language servers" >&2
+  sleep $((attempt * 10))
+done
+
+echo "::warning::could not install language servers after 3 bounded attempts; the \
+reference-enrichment proof will skip and say so per test" >&2
+exit 0

--- a/scripts/ci-install-language-servers.sh
+++ b/scripts/ci-install-language-servers.sh
@@ -63,6 +63,11 @@ for attempt in 1 2 3; do
       exit 0
     fi
     echo "$BIN" >>"${GITHUB_PATH:-/dev/null}"
+    # Only set after both binaries are proven executable above. The proof reads
+    # it and turns a skip into a hard failure, so the tests cannot quietly stop
+    # running on a runner that was provisioned for them: nextest captures a
+    # passing test's stderr, so a skip reads as a fast pass and nobody notices.
+    echo "KIN_CI_LANGUAGE_SERVERS_INSTALLED=1" >>"${GITHUB_ENV:-/dev/null}"
     echo "language servers installed at $BIN"
     "$BIN/typescript-language-server" --version
     exit 0


### PR DESCRIPTION
JavaScript and TypeScript reference enrichment is wired, the language servers behind Python and JavaScript enrichment can be installed from `kin setup` and `kin doctor --fix`, and both halves are proved end to end against real language servers on fixtures shaped like the losses the npm-0541 brownfield verdict recorded.

## The discrepancy the ticket asked to name first

The Aug-19 reading of `ENRICHABLE_LANGUAGES` was correct: it was `[Rust, Python]`, and Python was genuinely wired on both daemon enrichment paths. Enrichment simply never started. At `crates/kin-daemon/src/daemon.rs:1375` the daemon calls `kin_lsp::discovery::discover_servers()` once during startup and, on an empty result, leaves `state.lsp_enrichment_tx` as `None` for the life of the process, so no enrichment message is ever sent and no adapter is ever consulted. The container the stranger run used carried no language server at all. The Python adapter did not fail to start, it was never reached. So the Python losses were a provisioning gap and the JavaScript losses were a wiring gap on top of it.

## Wiring

`ENRICHABLE_LANGUAGES` now names Rust, Python, TypeScript and JavaScript. The daemon held two copies of its adapter map about three hundred lines apart, which is how a language could be missing from both without either site looking wrong; one function, `lsp_adapter_for`, now serves the incremental and sweep paths. Both TypeScript and JavaScript resolve to kin-lsp's `TypeScriptAdapter`, which is complete rather than a stub, and kin-lsp's own `KNOWN_SERVERS` already mapped both names onto `typescript-language-server`. kin-lsp needed no change.

The doc comment claiming the daemon wires an adapter for exactly those languages is now an assertion: a test compares the adapter map against the constant in both directions.

## Provisioning

`crates/kin-cli/src/commands/language_servers.rs` holds the install recipes. `kin setup` and `kin doctor --fix` detect the missing servers and install them with consent, prompting once per install command with the download disclosed, and doing nothing non-interactively unless `--install-language-servers` is passed. The doctor rows name the exact command instead of describing one. The installer re-probes `PATH` after a command exits zero, because an npm global prefix that is not on `PATH` installs successfully and leaves the binary unreachable. The restart advice names `kin daemon stop` rather than the obvious `kin daemon restart`, because `kin daemon` has only `status` and `stop`.

## The consequential part: this change broke the absence-trust gate, and the fix reaches Python

FIR-2404's third gate keyed on `reference_enrichment == "unsupported"`, the BUILD limit, and the doc on `load_bearing_classes` says why it was needed: the measured edge classes cannot separate an express-shaped JavaScript graph from a healthy Python one. Wiring JavaScript removes that discriminator, and the first full gate run caught the consequence. The express fixture went straight back to `"safe_to_conclude_absent": true`, `"trust": "authoritative"`, advice "safe to treat the target as genuinely absent/unused" over `createApplication`. That is the FIR-2430 defect.

The build limit was only ever one cause of the gate's own stated reason, that nothing resolves the program behind the parsed declarations. A wired adapter with no server installed leaves it exactly as unresolved, so the same hole was already open for Python: on a host with no pyright, a Python absence was being certified as authoritative on a graph that could not have produced a single reference edge. Wiring JavaScript made that visible rather than introducing it.

The observation now reports the host as well as the build, through the same `PATH` lookup and the same binaries table the doctor row and the install recipes read, and the gate blocks on both `unsupported` and `no_language_server` with wording that says which. It stays silent on `unknown`, which is what an answer whose focal never resolved reports; firing there produced "nothing established that a language server resolved no resolved language on this host" and displaced the real limiting factor.

**Behavior change worth a deliberate look:** on a host with the language server installed, nothing changes. On a host without it, Kin stops calling an absence authoritative for that language, Python and Rust included, where it previously did. That is stricter and it is the honest reading, but it is a change to a shipped trust surface. The alternative was shipping a known-false certification for JavaScript.

## Proof

`crates/kin-daemon/tests/lsp_reference_enrichment.rs` builds two fixtures and drives the real enrichment against real servers. Python: a call reaches `HTTPAdapter.send` through `self.connection`, with a second method named `send` on the mixin. JavaScript: a call reaches `router.handle` across a `require` chain, with a second `handle` in the calling file. Each fixture holds two entities with the same name and the assertion is that the edge lands on the right one, so a bare-name matcher has a fifty-fifty choice and no information to make it with. Both assert the relation classifies as `type_resolved`.

`crates/kin-cli/src/commands/refs.rs` closes the last hop: an `RelationOrigin::Lsp` edge reaches the reference surface as a resolved caller while a receiver-name guess beside it stays a candidate. It also pins a gap rather than papering over it. kin-lsp constructs every enrichment relation with `evidence: Vec::new()` (`src/enrichment.rs:218`, `:320`, `:426`, `:503`), so an LSP-resolved caller arrives with no source span and its `reference_lines` come back empty with `NoEvidenceSpan`. The test asserts that, and will fail in the right place when kin-lsp starts carrying spans.

When no server is on `PATH` the live tests skip loudly, naming the binary and the install command. `scripts/ci-install-language-servers.sh` installs pinned versions into a local prefix before the test step on Linux, so the proof actually runs; it warns and exits zero on a registry failure rather than failing the gate, and the skip stays visible as a run-summary annotation and a per-test line.

## Falsification

Five, each run to completion with full output and exit status read directly.

1. Removing JS and TS from `ENRICHABLE_LANGUAGES` with the adapter still wired: `typescript: daemon wires an adapter = true, ENRICHABLE_LANGUAGES says false`, exit 101.
2. Removing the JS/TS arm from `lsp_adapter_for` with the constant intact: the same test in the opposite direction, `daemon wires an adapter = false, ENRICHABLE_LANGUAGES says true`, plus two more, exit 101.
3. The same removal against the live JavaScript proof: `javascript has no adapter in this build, which contradicts ENRICHABLE_LANGUAGES`, exit 101.
4. Inverting the JavaScript proof to demand the same-named local `handle`: `FALSIFICATION: demanding the bare-name answer; got [Entity(EntityId(76037a27-...))]`, exit 101. Exactly one target came back and it was the cross-file one.
5. Removing the `no_language_server` arm from the trust gate: three tests fail and the express one prints the restored answer verbatim, `"safe_to_conclude_absent": true`, `"trust": "authoritative"`, exit 101.

All five reverted and the tree confirmed clean.

## Gates

`cargo fmt --all -- --check` exits 0. Clippy exactly as ci.yml runs it, `--all-targets --all-features` under `RUSTFLAGS=-D warnings` with the 45-lint allowlist, exits 0. `cargo nextest run --workspace --no-fail-fast --locked` reports `6493 tests run: 6493 passed (4 slow, 1 leaky), 12 skipped`, exit 0, with the live proof inside that total. `cargo test --doc --locked` exits 0. Six guard scripts pass: zero-file-search, the answer-modules variant, runtime boundaries, private repo coupling, hydration semantics, and the kin-vfs compat pin check.

`git ls-tree -r HEAD --name-only | grep -F '.cargo/'` prints only `.cargo/config.toml`. `Cargo.lock` carries one added line, `which 8.0.4` in kin-core's dependency list, reusing the crates.io entry kin-cli and kin-daemon already pull; no new package and no path source.

## Also corrected

`docs/language-support.md` promised LSP enrichment for eight languages when the daemon wired two. Go, Java, C and C++ have adapters in kin-lsp the runtime has never reached, so the table now says which are wired and which are not, and the section names the install commands and the startup-discovery behavior.

Not claiming: the brownfield A/B has not been re-run. That belongs to the first build carrying this. What is proved here is the mechanism the verdict blamed.

Closes FIR-2464
