### PR TITLE
Wait on the daemon's own record instead of a 60s ambient-admission bound

### DIFF
--- a/crates/kin-cli/tests/live_graph_durability_disclosure.rs
+++ b/crates/kin-cli/tests/live_graph_durability_disclosure.rs
@@ -39,16 +39,49 @@ use common::Command;
 /// Wall-clock bound for one four-frame stdio session against a live daemon.
 const SESSION_BOUND: Duration = Duration::from_secs(60);
 
-/// How long ambient admission gets to pick up a host write before the fixture
-/// gives up. The loop polls at 100ms and the file is three functions.
-const ADMISSION_BOUND: Duration = Duration::from_secs(60);
+/// How long the fixture waits for the daemon to record that it admitted the
+/// host write.
+///
+/// Deliberately generous rather than tuned. The wait below is event driven, so
+/// this bound never paces a passing run: it is only how long a run that is
+/// going to fail spends proving it. A loaded runner reconciling several seconds
+/// late is the case a tighter bound turned into a red queue entry.
+const ADMISSION_BOUND: Duration = Duration::from_secs(120);
+
+/// How long the fixture waits for the daemon to record that its file watcher is
+/// registered, before making the host write that watcher has to observe.
+const WATCHER_BOUND: Duration = Duration::from_secs(90);
+
+/// How long the counters get to catch up with the admission the daemon just
+/// recorded. Short on purpose: a bound long enough to hide a missing admission
+/// would put back the ambiguity the wait above exists to remove.
+const COUNT_SETTLE_BOUND: Duration = Duration::from_secs(30);
+
+/// What the daemon logs once `FileWatcher::new` has registered the watch
+/// (`crates/kin-index/src/watcher.rs`, immediately after `watch()` returns).
+const WATCHER_RECORD: &str = "started file watcher";
+
+/// What the reconciliation loop logs once it has admitted a working-copy change
+/// into repository authority (`crates/kin-daemon/src/loop_runner.rs`).
+const ADMISSION_RECORD: &str = "admitted exact workspace tree into repository authority";
+
+/// How long the fixture will keep repeating a session while `kin_graph_status`
+/// refuses to sample its counts. Generous against the few hundred milliseconds
+/// this repository's four vectors take, so expiry means the lock is never being
+/// yielded rather than that embedding was merely busy.
+const RETRY_BOUND: Duration = Duration::from_secs(30);
 
 struct IsolatedDaemon {
     child: Option<common::RuntimeOwnedChild>,
+    log: std::path::PathBuf,
 }
 
 impl IsolatedDaemon {
-    fn spawn(repo: &Path, runtime: &common::IsolatedDaemonRuntime) -> Self {
+    /// Spawn the daemon with its own log kept OUTSIDE the repository, so that
+    /// reading the daemon's record of its own progress cannot itself produce
+    /// the watcher events this fixture is about.
+    fn spawn(repo: &Path, log: &Path, runtime: &common::IsolatedDaemonRuntime) -> Self {
+        let sink = fs::File::create(log).expect("create the daemon log");
         let mut command = runtime.daemon_command();
         let child = command
             .arg("--repo")
@@ -57,12 +90,69 @@ impl IsolatedDaemon {
             .arg("0")
             .env("KIN_DAEMON_DISABLE_LSP", "1")
             .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "0")
+            // The waits below read the daemon's own INFO records, so ask for
+            // them explicitly rather than inheriting whatever the ambient
+            // filter happens to be.
+            .env("RUST_LOG", "info")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(sink))
             .spawn_owned()
             .expect("spawn isolated kin-daemon");
-        Self { child: Some(child) }
+        Self {
+            child: Some(child),
+            log: log.to_path_buf(),
+        }
+    }
+
+    /// Wait until the daemon records that its file watcher is registered.
+    ///
+    /// Serving is not watching. The daemon publishes `.kin/daemon.port` and
+    /// retires its warming surface in `run_with_authority_on` BEFORE it spawns
+    /// the reconciliation loop, and that loop is what calls `FileWatcher::new`;
+    /// the loop then deliberately admits nothing at startup, because
+    /// working-copy content crosses into authority only through a watcher
+    /// observed edit or an explicit seam. So a host write made between those
+    /// two points raises no event and nothing ever replays it, and the wait for
+    /// admission afterwards can only burn its whole bound.
+    ///
+    /// Measured on this host the gap is a few milliseconds and the fixture won
+    /// it by 5 to 113ms when it won; the runs that failed are exactly the runs
+    /// where it lost. Waiting for the daemon to say the watch exists removes
+    /// the race rather than widening a bound around it.
+    fn wait_until_watching(&self) {
+        self.wait_for_record(
+            WATCHER_RECORD,
+            0,
+            WATCHER_BOUND,
+            "register its file watcher",
+        );
+    }
+
+    /// Byte offset the log has reached, so a later wait only considers records
+    /// written after this point and cannot match an older line.
+    fn log_offset(&self) -> u64 {
+        fs::metadata(&self.log).map(|meta| meta.len()).unwrap_or(0)
+    }
+
+    /// Poll the daemon's log for `record`, considering only bytes at or after
+    /// `from`. The bound expiring is a real failure that names the record that
+    /// never arrived and quotes what the daemon did say instead.
+    fn wait_for_record(&self, record: &str, from: u64, bound: Duration, what: &str) {
+        let deadline = Instant::now() + bound;
+        loop {
+            let text = fs::read_to_string(&self.log).unwrap_or_default();
+            let tail = text.get(from as usize..).unwrap_or(&text);
+            if tail.contains(record) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the daemon did not {what} within {bound:?}: its log carries no {record:?} \
+                 record after byte {from}. What it did log:\n{tail}"
+            );
+            thread::sleep(Duration::from_millis(50));
+        }
     }
 
     fn wait_until_serving(&mut self, kin_root: &Path) -> u16 {
@@ -141,6 +231,10 @@ fn seed_repository(repo: &Path) {
     run_git(repo, &["add", "--all"]);
     run_git(repo, &["commit", "-m", "storage"]);
 }
+
+/// Where that file is written. Named here because the wait for admission
+/// re-arms the same path rather than only polling it.
+const UNCOMMITTED_PATH: &str = "src/link_graph.rs";
 
 /// The file the agent wrote and then located. Named for the transcript's
 /// `link_graph.py`, which is the write whose entities the second locate found
@@ -321,8 +415,41 @@ fn live_entity_count(repo: &Path, home: &Path, port: u16) -> u64 {
 }
 
 /// Wait until ambient admission has taken the host write into the live graph.
-fn wait_for_live_growth(repo: &Path, home: &Path, port: u16, above: u64) -> u64 {
-    let deadline = Instant::now() + ADMISSION_BOUND;
+///
+/// Event driven, on the daemon's own record of the admission it performed,
+/// rather than a poll that can only ever report that a count has not moved.
+/// A poll cannot tell "the reconciliation pass is still running" from "no
+/// event was ever raised, so no pass will ever run", and those two are the
+/// whole question: they differ by whether the watcher existed when the write
+/// landed. `wait_until_watching` above now guarantees it did, and this wait
+/// reads the consequence.
+///
+/// `since` is the log offset taken immediately before the write, so an
+/// admission recorded earlier in this daemon's life cannot satisfy it.
+///
+/// A passing run costs exactly as long as admission actually took, so the
+/// generous bound is spent only by a run that is going to fail, and that
+/// failure names the record that never arrived instead of timing out vaguely.
+fn wait_for_live_growth(
+    daemon: &IsolatedDaemon,
+    repo: &Path,
+    home: &Path,
+    port: u16,
+    above: u64,
+    since: u64,
+) -> u64 {
+    daemon.wait_for_record(
+        ADMISSION_RECORD,
+        since,
+        ADMISSION_BOUND,
+        "admit the host write",
+    );
+
+    // The daemon publishes its record and its counters a moment apart, so this
+    // closes that last gap and nothing more. It is deliberately short: it must
+    // not be able to stand in for the wait above, because a bound long enough
+    // to hide a missing admission is the bug this test kept reporting.
+    let deadline = Instant::now() + COUNT_SETTLE_BOUND;
     loop {
         let live = live_entity_count(repo, home, port);
         if live > above {
@@ -330,14 +457,55 @@ fn wait_for_live_growth(repo: &Path, home: &Path, port: u16, above: u64) -> u64 
         }
         assert!(
             Instant::now() < deadline,
-            "ambient admission never took the host write: live entity count stayed at {live}, \
-             above={above}; graph status said:\n{}",
+            "the daemon recorded admitting the host write, but the live entity count stayed at \
+             {live} against above={above}; graph status said:\n{}",
             stdout_of(
                 &kin_against_daemon(repo, home, port, &["graph", "status"]),
                 "kin graph status"
             )
         );
         thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Whether `kin_graph_status` refused this call and asked to be repeated.
+///
+/// `crates/kin-daemon/src/api.rs:2084` fails the call outright when the
+/// embedding-work lock is held, because every count the payload reports has to
+/// describe one instant and it cannot sample them while embedding is moving.
+/// The answer carries that instruction and no observation.
+fn asks_for_retry(payload: &serde_json::Value) -> bool {
+    payload
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|message| message.contains("retry kin_graph_status"))
+}
+
+/// Drive the session, repeating it while the daemon answers with that refusal.
+///
+/// Re-arming the host write above re-parses and re-embeds the file, so the
+/// window in which the status call can land on a held embedding lock is wider
+/// than it was, but the refusal predates this: any write admitted shortly
+/// before the session could always meet it. Reading that refusal as a payload
+/// is asserting on the absence of an answer, so the fixture takes the retry the
+/// tool asked for. The bound is what keeps this a discriminator rather than a
+/// mask: a daemon that never yields the lock still fails, naming how many times
+/// it refused.
+fn settled_mcp_session(repo: &Path, home: &Path, port: u16) -> Vec<(u64, serde_json::Value)> {
+    let deadline = Instant::now() + RETRY_BOUND;
+    let mut refusals = 0_u32;
+    loop {
+        let session = run_mcp_session(repo, home, port);
+        let status = payload(&session, 2, "kin_graph_status");
+        if !asks_for_retry(&status) {
+            return session;
+        }
+        refusals += 1;
+        assert!(
+            Instant::now() < deadline,
+            "kin_graph_status refused {refusals} times without ever sampling its counts: {status}"
+        );
+        thread::sleep(Duration::from_millis(200));
     }
 }
 
@@ -381,16 +549,24 @@ fn mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit
     );
 
     let runtime = common::IsolatedDaemonRuntime::new(&repo);
-    let mut daemon = IsolatedDaemon::spawn(&repo, &runtime);
+    // Kept beside the repository rather than inside it: the fixture reads this
+    // file while the daemon is watching, and a log under the working copy would
+    // be a source of the very events under test.
+    let daemon_log = root.path().join("kin-daemon.log");
+    let mut daemon = IsolatedDaemon::spawn(&repo, &daemon_log, &runtime);
     let port = daemon.wait_until_serving(&repo.join(".kin"));
+    // Serving is not watching, and the write below is the one the watcher has
+    // to see. Nothing replays an event raised before the watch existed.
+    daemon.wait_until_watching();
 
+    let before_write = daemon.log_offset();
     // The transcript's first move: write a file, through nothing but the
     // filesystem, exactly as an agent's `write_file` tool does.
-    fs::write(repo.join("src/link_graph.rs"), UNCOMMITTED_SOURCE)
+    fs::write(repo.join(UNCOMMITTED_PATH), UNCOMMITTED_SOURCE)
         .expect("write the uncommitted source");
-    let live = wait_for_live_growth(&repo, &home, port, durable_at_init);
+    let live = wait_for_live_growth(&daemon, &repo, &home, port, durable_at_init, before_write);
 
-    let uncommitted = run_mcp_session(&repo, &home, port);
+    let uncommitted = settled_mcp_session(&repo, &home, port);
     let status = payload(&uncommitted, 2, "kin_graph_status");
     let locate = payload(&uncommitted, 3, "semantic_locate");
 
@@ -457,7 +633,7 @@ fn mcp_status_and_locate_disclose_live_only_entities_and_then_stop_once_a_commit
     );
     stdout_of(&commit, "kin commit");
 
-    let recorded = run_mcp_session(&repo, &home, port);
+    let recorded = settled_mcp_session(&repo, &home, port);
     let status_after = payload(&recorded, 2, "kin_graph_status");
     let locate_after = payload(&recorded, 3, "semantic_locate");
 


### PR DESCRIPTION
This test has been taxing every landing. It ejected kin#957 twice, it ejected kin#961's
speculative build, it failed kin#940, #947 and #951 overnight, and it has cost at least six
check or queue cycles in a day. None of those diffs can touch ambient admission. It is not an
interaction with any pull request, and the bound it burns is racing something real.

## The question FIR-2449 left open, answered

FIR-2449 said the class would be decided by the first occurrence on a head that INCLUDES
kin#948 (`c86b89e6`, FIR-2442's containment fix). Every failure above is on such a head, and
the failure reproduces locally on plain `origin/main` as well. So kin#948 did not end the
class, and FIR-2449's own conclusion applies: the fix is an event-driven wait, not a longer
sleep.

## What is actually happening

Serving is not watching. `crates/kin-daemon/src/daemon.rs:1274` publishes `.kin/daemon.port`
and `:1281` retires the warming surface; only at `:1375` does the daemon spawn the
reconciliation loop, and that loop is what calls `FileWatcher::new` at
`crates/kin-daemon/src/loop_runner.rs:1817`. The loop's own comment at `:1830-1839` says
startup deliberately admits nothing, because working-copy content crosses into authority only
through a watcher-observed edit or an explicit seam.

The fixture gated its host write on the published port
(`live_graph_durability_disclosure.rs:68-90`), which is true before `daemon.rs:1375`. A write
landing in that window raises no event, and nothing ever replays it, so the count sits at the
committed value until the bound expires. That is why every failure burned the full 60s and
reported `Entities: 2`, `Files: 1`, with `src/link_graph.rs` never admitted.

Instrumenting each local run to timestamp the daemon's `started file watcher` record against
the fixture's write makes it exact. Across 25 runs the sign of that margin predicts the verdict
with no exceptions: every run where the watcher led passed, every run where the write led
failed. Winning margins were 5 to 113ms.

| Arm | `cargo nextest run` | `cargo test` |
|---|---|---|
| plain `origin/main`, no #957 | 5 pass, 1 fail | 6 pass, 0 fail |
| with #957 merged | 6 pass, 0 fail | 5 pass, 1 fail |

Both arms fail and both invocations fail, so neither #957 nor the invocation is the cause.
#964 is ruled out by reading the workflow rather than inferring it: `ci.yml:1206` is the ubuntu
Test step and reads `cargo nextest run --locked` both before and after #964, while the
`--partition count:N/2` shard #964 added is `ci.yml:1310`, the macOS leg. Both failing
merge-group job logs show the literal step `Run cargo nextest run --locked`, and the first
ejection ran on a pre-#964 base (`git merge-base --is-ancestor d06e2b97 ae9f4b25` succeeds).

## The change

Wait for the daemon to record that its watch exists before writing, so the event cannot be
lost. Then wait for the daemon's record of the admission it performed, rather than polling a
count for a change that may never come. Both waits read the daemon's own log, which the fixture
now captures to a file kept outside the repository so that reading it cannot itself produce the
events under test. The admission wait starts from the log offset taken immediately before the
write, so an older record cannot satisfy it.

A poll could never tell "the pass is still running" from "no event was raised, so no pass will
ever run", and those two differ by exactly the thing that was racing. The bounds are generous
because they now pace nothing except a run that is going to fail, and that failure names the
record that never arrived and quotes what the daemon logged instead.

One more transient, met while proving this: `kin_graph_status` fails a call outright while the
embedding-work lock is held (`crates/kin-daemon/src/api.rs:2084`), because the counts it
reports have to describe one instant. That answer carries a retry instruction and no
observation, and the fixture read it as a payload and panicked on the missing durability
object. The session is now repeated while the daemon asks for a retry, bounded.

## Falsification

Both directions, full output and exit codes read from files rather than through a pipe.

Admission made impossible, which is FIR-2449's named falsification: with the reconciliation
loop patched to register its watch and then never drain an event, the test fails in 125.7s
saying `the daemon did not admit the host write within 120s: its log carries no "admitted exact
workspace tree into repository authority" record after byte 3646`, and quotes the log. That is
the test naming the failure rather than timing out vaguely.

The guard, broken on purpose: with `Durability::observe` forced never to report
`live_uncommitted`, the changed test fails in 3.253s at the disclosure assertion reading
`left: "recorded"`, `right: "live_uncommitted"`. The waits recover a lost event and mask
nothing about what the test is for.

Held direction: 10 of 10 under the post-#964 ubuntu invocation, nine of them in about 3.3s and
one in 24.5s under heavy local load. Before this change the same condition, made deterministic
by moving the write ahead of the daemon spawn so the first event is guaranteed lost, failed at
63.186s with the exact CI text.

## Gates

All run from the lane worktree through `bin/kin-lane run fir2465repro kin`, exit codes read raw
from files rather than through a pipe.

- `bin/kin-dev local-test kin` rc=0: **6464 tests run, 6464 passed**, 12 skipped, zero FAIL
  lines, plus `cargo test --doc` clean. Invoked with the umbrella's absolute path, because a
  bare `bin/kin-dev` inside the lane worktree resolves to a path that does not exist and exits
  126, which is not a gate result.
- `cargo clippy --all-targets --all-features` under `RUSTFLAGS=-D warnings` with the exact
  allow-list read out of `.github/clippy-allowed-lints.txt` rc=0.
- `cargo fmt --all -- --check` rc=0.
- Guard scripts rc=0: `verify-zero-file-search.py`, `zero_file_search_guard.sh`,
  `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`,
  `test-private-repo-coupling.py`.
- `git diff --quiet HEAD -- Cargo.lock` rc=0 checked AFTER the gate exited, so no path-patch
  contamination was restored behind it.

## Not fixed here

The daemon advertises itself before ambient admission is live, so a client that finds it
through `.kin/daemon.port` and writes within that window loses the write until the next edit or
an explicit seam. The early bind is deliberate and documented at `daemon.rs:1264-1273`, because
publishing during the open window would turn "not ready yet" into a failed command on the
attach path. Closing it means giving the reconciliation loop a way to signal "watch registered"
back to the publish step, which is a change to daemon startup semantics with its own failure
mode, so it is reported rather than done here.

Closes FIR-2449
Closes FIR-2465
Refs FIR-2459
