### PR TITLE
Put the one verdict on every retrieval answer and stop certifying an unprobed scan

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1775,6 +1775,17 @@ mod tests {
                 },
                 "references": vec![json!({"name": "extract_links"}); returned as usize],
                 "relation_kinds": ["calls", "imports", "references"],
+                // Complete on purpose. Since FIR-2463 a populated answer carries
+                // the response verdict too, and a fixture that reports no
+                // cross-repo authority is not the fully-resolved answer these
+                // cases are about: it would read as a floor for a reason the
+                // test never meant to exercise.
+                "cross_repo": {
+                    "status": "available",
+                    "authority_complete": true,
+                    "authority_revision": "sha256:complete",
+                    "authority_roots": { "local": "local-root" },
+                },
                 "edge_coverage": {
                     "scope": "language",
                     "language": "Python",
@@ -1824,16 +1835,16 @@ mod tests {
             "the limiting class is named rather than left to be inferred: {completeness}"
         );
 
-        // The payload is not empty, so the object that used to be the only trust
-        // signal is absent by design. That asymmetry is the defect this closes:
-        // without the completeness object this response carries nothing.
-        assert!(
-            !annotated_value(&annotated)
-                .as_object()
-                .unwrap()
-                .contains_key(crate::negative::NEGATIVE_KEY),
-            "a populated answer synthesizes no negative, which is why it needed this"
+        // The payload is not empty, and since FIR-2463 it still carries the
+        // response's verdict. What it must never carry is an absence claim, so
+        // the qualifier is present and says so.
+        let negative = &annotated_value(&annotated)[crate::negative::NEGATIVE_KEY];
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a populated answer claims no absence: {negative}"
         );
+        assert_eq!(negative["interpretation"], json!("qualified_answer"));
     }
 
     /// The regression FIR-2357 item 4 bars, held in the opposite direction. A

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -4791,6 +4791,11 @@ mod tests {
             &[],
         )
         .expect("an empty search carries a negative");
+        // The Python half certifies, and FIR-2464 is what earns it: the host
+        // probe found a server for this language, so the observation reports
+        // `available` rather than leaving the question open. What stops a
+        // narrowed name filter certifying a false zero is FIR-2452's own gate on
+        // the name's side, not this one.
         assert_eq!(negative["safe_to_conclude_absent"], true);
         assert_eq!(negative["trust"], "authoritative");
     }
@@ -6013,10 +6018,21 @@ mod tests {
         );
         assert_eq!(coverage["entities_examined"], 0);
 
-        assert!(
-            response.get("negative").is_none(),
-            "a populated answer still synthesizes no negative, which is why the \
-             completeness signal is the one that has to carry this case"
+        // The completeness signal is no longer the only thing carrying this
+        // case: since FIR-2463 the qualifier rides a populated answer too, and
+        // the two say the same thing. What the qualifier must never do here is
+        // claim an absence off an answer holding a row.
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "{}",
+            response["negative"]
+        );
+        assert_eq!(response["negative"]["interpretation"], "qualified_answer");
+        assert_eq!(
+            response["negative"]["trust"], "authoritative",
+            "a complete cross-file answer is the whole set, and the verdict says so on both \
+             surfaces: {}",
+            response["negative"]
         );
     }
 
@@ -6063,10 +6079,14 @@ mod tests {
             response["total_upstream"], 1,
             "the answer itself is unchanged; what changes is what rides beside it"
         );
-        assert!(
-            response.get("negative").is_none(),
-            "non-empty, so the negative object never fires here"
+        // Since FIR-2463 the qualifier rides a populated answer too. What it
+        // must never do there is claim an absence.
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "a populated answer claims no absence: {}",
+            response["negative"]
         );
+        assert_eq!(response["negative"]["interpretation"], "qualified_answer");
 
         let completeness = &response["_kin"]["completeness"];
         assert_eq!(
@@ -6519,8 +6539,14 @@ mod tests {
             response["_kin"]["verdict"]
         );
         assert_eq!(
-            response["_kin"]["completeness"]["status"], "complete",
-            "the substrate observation is kept, not rewritten: {}",
+            response["_kin"]["completeness"]["status"], "partial",
+            "the one-word summary follows the verdict: {}",
+            response["_kin"]["completeness"]
+        );
+        assert_eq!(
+            response["_kin"]["completeness"]["classes"],
+            serde_json::json!({"calls": "present", "imports": "absent", "references": "absent"}),
+            "and the observation it was computed from is published unchanged beside it: {}",
             response["_kin"]["completeness"]
         );
         assert_eq!(
@@ -7140,9 +7166,16 @@ mod tests {
             response["relation_count"], 2,
             "the pre-truncation total still reports the two real edges"
         );
-        assert!(
-            response.get("negative").is_none(),
-            "a truncated edge array is not an absence and must not be qualified as one: {response}"
+        assert_eq!(
+            response["negative"]["safe_to_conclude_absent"], false,
+            "a walk that found two edges must not be reported as an absence when the caller \
+             capped the array: {}",
+            response["negative"]
+        );
+        assert_eq!(
+            response["negative"]["interpretation"], "qualified_answer",
+            "it is a qualified answer rather than an absence: {}",
+            response["negative"]
         );
     }
 

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -594,6 +594,33 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
     (!gaps.is_empty()).then(|| gaps.join("; "))
 }
 
+/// Whether a POPULATED answer from `tool` carries the response's verdict too,
+/// or only its empty answers do.
+///
+/// FIR-2463 asked for one verdict on every retrieval response, and the default
+/// here is yes: an answer that returned rows and says nothing about how far they
+/// can be trusted is the shape that let `graph_neighborhood` frame two inbound
+/// edges as the whole set while `find_references` refused to certify the same
+/// entity over the same edges. An answer with no epistemic claim is not
+/// agreement with the tool beside it, it is a missing claim.
+///
+/// The exemptions are listed rather than left to whichever handler was edited
+/// last, because an accidental exemption is exactly how that shape shipped.
+///
+/// | tool | qualifies a populated answer | why |
+/// |---|---|---|
+/// | `find_references`, `bulk_check_references`, `trace_data_flow`, `graph_neighborhood`, `semantic_search`, `find_dead_code_seeded` | yes | each answers from the graph, and whether its rows are the whole set is exactly the question a caller acts on |
+/// | `semantic_locate` | NO | its page is a bounded ranking rather than an enumeration, so its verdict can never be authoritative at any coverage, and the module already refuses to certify one. Attaching a verdict to every page is the defect FIR-2430 found wearing the opposite costume: a real symbol and a fabricated one came back under the IDENTICAL envelope, so a qualifier there teaches a reader to read a page as a graph claim when it is not one |
+/// | `entity_history` | NO | reads recorded change history, where a populated answer is the history and there is no whole-set question about the graph to answer |
+/// | `dead_code` | NO | its result is the INVERSE claim, and rows are candidates to check rather than an answer whose completeness licenses an action |
+///
+/// An exemption bars the verdict from `negative` only. `_kin.verdict` is still
+/// computed and published for these tools when any input spoke, so the one
+/// verdict is never absent, only carried in one place instead of two.
+fn qualifies_populated_answers(tool: &str) -> bool {
+    !matches!(tool, "semantic_locate" | "entity_history" | "dead_code")
+}
+
 /// Whether `tool` declares anything [`absence_coverage_gap`] can gate, so a
 /// `None` from that gate means "every dependency it declared was observed
 /// present" rather than "it declared none".
@@ -1234,6 +1261,27 @@ fn absence_advice_consequence(
     }
 }
 
+/// The consequence an answer that RETURNED rows carries.
+///
+/// Separate from [`absence_advice_consequence`] because the two say opposite
+/// things about the same verdict. On an empty answer an authoritative verdict
+/// licenses concluding absence; on a populated one it licenses treating the rows
+/// as the whole set and licenses no absence claim at all. Reusing the absence
+/// wording here would put "safe to treat the target as genuinely absent" on an
+/// answer holding results, which is the contradiction one field over.
+fn populated_advice_consequence(trustworthy: bool, trust_reason: &str) -> String {
+    if trustworthy {
+        "These rows are the whole set: every input that could qualify this answer agreed. That \
+         says nothing about anything absent from it."
+            .to_string()
+    } else {
+        format!(
+            "Treat these rows as a lower bound rather than the whole set, and do not conclude \
+             anything from what is missing from them. Limiting factor: {trust_reason}"
+        )
+    }
+}
+
 /// The consequence sentence for a locate page that ranked hits but none the
 /// query named. Distinct from [`absence_consequence`], which speaks about an
 /// empty result: here the rows are real and stay ranked, and what is absent is
@@ -1402,12 +1450,28 @@ fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
     }
 }
 
-/// Build a confidence-qualified negative for `tool`'s `payload`, enriched from
-/// `envelope`, or `None` when the tool is not negative-capable or it returned a
-/// non-empty result (and is not an `always`-qualify tool).
+/// Build the trust qualifier for `tool`'s `payload`, enriched from `envelope`,
+/// or `None` when the tool is not retrieval.
 ///
 /// The returned object is additive: callers attach it under [`NEGATIVE_KEY`]
 /// beside the existing payload keys, never replacing them.
+///
+/// ## Every retrieval answer carries one, not only the empty ones (FIR-2463)
+///
+/// This used to return `None` the moment a collection came back non-empty, on
+/// the reasoning that there was no absence to qualify. The consequence is that
+/// an answer with rows reached an agent with no epistemic claim attached at all,
+/// and a reader cannot tell "this answer is whole" from "nobody said". On
+/// psf/requests, `graph_neighborhood` walked two inbound edges of
+/// `HTTPAdapter.send` and framed them as complete with no qualifier, in the same
+/// session where `find_references` refused to certify the same entity over the
+/// same edges. Whichever tool you reached for first decided what you believed.
+///
+/// So the split is now between what is CLAIMED, not whether an object exists.
+/// `trust` is the response's one verdict either way. `safe_to_conclude_absent`
+/// answers the narrower question and is false whenever the answer returned rows,
+/// because no absence is being claimed there and a reader must never be able to
+/// read one out of a populated answer.
 pub fn negative_for(
     tool: &str,
     payload: &Value,
@@ -1426,7 +1490,12 @@ pub fn negative_for(
     // this reports rather than filters, and a weak-but-real hit is never dropped
     // to hide a wrong one.
     let ranking_names_nothing = tool == "semantic_locate" && locate_ranking_names_nothing(payload);
-    if count != 0 && !spec.always && !ranking_names_nothing {
+    // Whether this response asserts that something is NOT there. An answer with
+    // rows asserts nothing of the kind, and still gets qualified: the gates
+    // below decide how far its rows can be trusted as the whole set, which is
+    // the question `graph_neighborhood` used to leave unanswered.
+    let mut claims_absence = count == 0 || spec.always || ranking_names_nothing;
+    if !claims_absence && !qualifies_populated_answers(tool) {
         return None;
     }
 
@@ -1481,13 +1550,20 @@ pub fn negative_for(
     // repositories, so it is never the reason a local absence could not be
     // certified. Reporting it as that reason is how a miss inside one file came
     // back explained as a cross-repo root mismatch.
-    if tool == "find_references" {
+    //
+    // Scoped to answers that actually claim an absence. The gate exists to stop
+    // "nothing references this" being read as safe-to-delete proof when the
+    // spine could not answer for other repositories. A populated answer claims
+    // no such thing, and applying it there would report every answer on every
+    // repository with no spine configured as a floor forever, which is the
+    // "mark everything uncertain" regression arriving through a side door.
+    if tool == "find_references" && claims_absence {
         if let Some(reason) = cross_repo_references_gap(payload) {
             push_gap(&mut trustworthy, &mut trust_reason, reason);
         }
     }
 
-    if tool == "bulk_check_references" {
+    if tool == "bulk_check_references" && claims_absence {
         if let Some(reason) = cross_repo_bulk_gap(payload) {
             push_gap(&mut trustworthy, &mut trust_reason, reason);
         }
@@ -1539,12 +1615,19 @@ pub fn negative_for(
         // `limit` of zero empties it while the walk still found neighbors. The
         // pre-truncation total is what decides whether anything was there, so a
         // truncated answer is never dressed up as an absence.
+        //
+        // It stops the ABSENCE framing and no longer stops the qualifier. This
+        // returned `None` until FIR-2463, which is why a neighborhood that walked
+        // 16 entities over 15 relations reached an agent carrying no epistemic
+        // claim at all, in the same session where `find_references` refused to
+        // certify the same entity over the same edges. Whichever tool you reached
+        // for first decided what you believed.
         if payload
             .get("relation_count")
             .and_then(Value::as_u64)
             .is_some_and(|total| total > 0)
         {
-            return None;
+            claims_absence = false;
         }
         let neighborhood_gap = if payload.get("entity_count").and_then(Value::as_u64) == Some(0) {
             kind = "focal_not_in_graph";
@@ -1633,13 +1716,22 @@ pub fn negative_for(
         "unnamed_ranking"
     } else if spec.always {
         "qualified_verdicts"
-    } else {
+    } else if claims_absence {
         "absent_as_indexed"
+    } else {
+        "qualified_answer"
     };
+    if !claims_absence {
+        kind = "qualified_answer";
+        subject = "this answer returned rows, so it asserts no absence; the verdict below says \
+                   how far those rows can be trusted as the whole set";
+    }
     let consequence = if ranking_names_nothing {
         unnamed_ranking_consequence().to_string()
-    } else {
+    } else if claims_absence {
         absence_advice_consequence(tool, spec.always, trustworthy, &trust_reason)
+    } else {
+        populated_advice_consequence(trustworthy, &trust_reason)
     };
 
     let degraded_signals = degraded_signals(tool, payload, envelope);
@@ -1650,7 +1742,13 @@ pub fn negative_for(
     negative.insert("subject".to_string(), json!(subject));
     negative.insert("result_count".to_string(), json!(count));
     negative.insert("interpretation".to_string(), json!(interpretation));
-    negative.insert("safe_to_conclude_absent".to_string(), json!(trustworthy));
+    // Never true on a populated answer. The verdict can be authoritative there,
+    // meaning the rows are the whole set, and that is still not a licence to
+    // conclude anything is absent, so the two fields are computed apart.
+    negative.insert(
+        "safe_to_conclude_absent".to_string(),
+        json!(trustworthy && claims_absence),
+    );
     negative.insert(
         "trust".to_string(),
         json!(if trustworthy {
@@ -1988,8 +2086,15 @@ mod tests {
 
     #[test]
     fn non_empty_result_gets_no_negative() {
+        // FIR-2463: a populated answer is qualified rather than unqualified, and
+        // what it must never do is claim an absence. The qualifier says how far
+        // the rows can be trusted; it does not say anything is missing.
         let payload = json!({ "results": [{ "id": "x" }] });
-        assert!(negative_for("semantic_search", &payload, &Envelope::daemon()).is_none());
+        let negative = negative_for("semantic_search", &payload, &Envelope::daemon())
+            .expect("every retrieval answer carries the response verdict");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["interpretation"], json!("qualified_answer"));
+        assert_eq!(negative["result_count"], json!(1));
     }
 
     #[test]
@@ -3499,9 +3604,10 @@ mod tests {
     #[test]
     fn neighborhood_with_a_neighbor_gets_no_negative() {
         let payload = neighborhood_payload("both", 1);
-        assert!(
-            negative_for("graph_neighborhood", &payload, &structural_ready_envelope()).is_none()
-        );
+        let negative = negative_for("graph_neighborhood", &payload, &structural_ready_envelope())
+            .expect("every retrieval answer carries the response verdict");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["interpretation"], json!("qualified_answer"));
     }
 
     /// Since the traversal became directional, an empty walk is empty only on
@@ -3608,10 +3714,15 @@ mod tests {
         let mut payload = neighborhood_payload("both", 3);
         payload["entities"] = json!([]);
         payload["relations"] = json!([]);
-        assert!(
-            negative_for("graph_neighborhood", &payload, &structural_ready_envelope()).is_none(),
-            "a walk that found three edges must not report an absence when the caller capped the output"
+        let negative = negative_for("graph_neighborhood", &payload, &structural_ready_envelope())
+            .expect("every retrieval answer carries the response verdict");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "a walk that found three edges must not report an absence when the caller capped \
+             the output: {negative}"
         );
+        assert_eq!(negative["interpretation"], json!("qualified_answer"));
     }
 
     /// A focal that is not in the graph produces the same empty edge set as an
@@ -3830,7 +3941,10 @@ mod tests {
     fn a_populated_chain_still_gets_no_negative() {
         let mut payload = clean_empty_trace("both");
         payload["chain"] = json!([{ "step": 1, "entity_name": "caller" }]);
-        assert!(negative_for("trace_data_flow", &payload, &structural_ready_envelope()).is_none());
+        let negative = negative_for("trace_data_flow", &payload, &structural_ready_envelope())
+            .expect("every retrieval answer carries the response verdict");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["interpretation"], json!("qualified_answer"));
     }
 
     // ---- resolution misses: the answer with no collection to count ----

--- a/crates/kin-mcp/src/verdict.rs
+++ b/crates/kin-mcp/src/verdict.rs
@@ -113,7 +113,13 @@ impl Verdict {
         envelope: &Envelope,
         negative: Option<&Value>,
     ) -> Option<Self> {
-        let makes_absence_claim = negative.is_some();
+        // A qualifier now rides every retrieval answer, so its presence no longer
+        // means an absence is being claimed. The object says which it is, and
+        // reading that rather than its existence is what keeps
+        // `safe_to_conclude_absent` false on a populated answer.
+        let makes_absence_claim = negative.is_some_and(|negative| {
+            negative.get("interpretation").and_then(Value::as_str) != Some("qualified_answer")
+        });
         let readings = [
             (
                 "absence_gate",
@@ -201,6 +207,27 @@ impl Verdict {
         let Some(completeness) = completeness else {
             return;
         };
+        // `status` follows the verdict too. It reads as a claim that the answer
+        // is whole, whatever it was derived from, and the stranger's report named
+        // it first: `status: "complete"` sat directly above a `classes` map
+        // marking two of three entries absent, and above a `negative` refusing
+        // the same zero. The evidence it was computed from is not lost, because
+        // `classes`, `decided_by` and `limits` are published unchanged beside it;
+        // what changes is that the one-word summary can no longer say "whole"
+        // while the response's verdict says otherwise.
+        //
+        // `partial` when something was actually observed absent, `unknown`
+        // otherwise, because a verdict refused for a reason no class captures is
+        // not evidence that a class was missing.
+        completeness.status = if completeness
+            .classes
+            .values()
+            .any(|state| state.as_str() == Some("absent"))
+        {
+            "partial".to_string()
+        } else {
+            "unknown".to_string()
+        };
         completeness.bound = "at_least".to_string();
         if let Some(counted) = completeness.counted.as_mut().and_then(Value::as_object_mut) {
             counted.insert("exact".to_string(), json!(false));
@@ -253,12 +280,14 @@ impl Verdict {
 /// non-empty answer a floor.
 fn absence_gate_reading(tool: &str, payload: &Value, negative: Option<&Value>) -> Reading {
     if let Some(negative) = negative {
-        return match negative
-            .get("safe_to_conclude_absent")
-            .and_then(Value::as_bool)
-        {
-            Some(true) => Reading::Certified,
-            Some(false) => Reading::Inconclusive(
+        // `trust`, not `safe_to_conclude_absent`. The two answer different
+        // questions and only the first is this response's verdict: a populated
+        // answer sets `safe_to_conclude_absent` false because it claims no
+        // absence, and reading that as the gate refusing made every answer with
+        // rows inconclusive on its own success.
+        return match negative.get("trust").and_then(Value::as_str) {
+            Some("authoritative") => Reading::Certified,
+            Some(_) => Reading::Inconclusive(
                 negative
                     .get("trust_reason")
                     .and_then(Value::as_str)
@@ -297,11 +326,31 @@ fn edge_coverage_reading(tool: &str, payload: &Value) -> Reading {
         .filter(|language| !language.trim().is_empty())
         .unwrap_or("an unreported language");
 
-    if coverage.get("reference_enrichment").and_then(Value::as_str) == Some("unsupported") {
-        return Reading::Inconclusive(format!(
-            "reference_enrichment_unsupported: this build wires no language-server adapter for \
-             {language}, so cross-file reference and override edges cannot exist for it at all"
-        ));
+    // The same reading [`crate::negative::absence_coverage_gap`] takes, on
+    // purpose. `available` is the only enrichment state that licenses a
+    // certification; every other state means nothing established that this host
+    // can produce reference edges for the language, and two inputs that read one
+    // observation differently are the disagreement this module exists to end.
+    match coverage
+        .get("reference_enrichment")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+    {
+        "available" => {}
+        "unsupported" => {
+            return Reading::Inconclusive(format!(
+                "reference_enrichment_unsupported: this build wires no language-server adapter \
+                 for {language}, so cross-file reference and override edges cannot exist for it \
+                 at all"
+            ))
+        }
+        "no_language_server" => {
+            return Reading::Inconclusive(format!(
+                "reference_enrichment_no_language_server: an adapter is wired for {language} but \
+                 no language server for it is installed on this host"
+            ))
+        }
+        _ => {}
     }
     if coverage.get("scope_entities").and_then(Value::as_u64) == Some(0) {
         return Reading::Inconclusive(format!(


### PR DESCRIPTION
kin#966 collapsed the three verdict blocks into one computed field. Two shapes survived it, and `bin/kin-brownfield-repro` found both against the stranger's express and requests trees. They were its checks 5 and 6. Both pass on this branch, along with check 8, and every remaining failure in that suite is FIR-2464.

## graph_neighborhood carried no verdict at all

`negative_for` returned `None` the moment a collection came back non-empty, so a walk of 16 entities over 15 relations reached an agent with no epistemic claim attached, in the same session where `find_references` refused to certify the same entity over the same edges. Whichever tool you reached for first decided what you believed, and an answer with no claim is not agreement with the tool beside it.

Every retrieval answer now carries the verdict. `trust` is the response verdict whether the answer is empty or full, and `safe_to_conclude_absent` is false whenever rows came back, so no absence can be read out of a populated answer. The exemptions are listed and justified in `qualifies_populated_answers` rather than left to whichever handler was edited last. `semantic_locate` is the one worth naming: its page is a bounded ranking rather than an enumeration, and FIR-2430 found that attaching a verdict to every page made a real symbol and a fabricated one come back under identical envelopes.

## completeness.status was still certifying under an inconclusive verdict

kin#966 left `status` as a raw substrate reading, on the argument that "was the substrate whole" is a different question from "can this answer be acted on". That kept the one word a reader is most likely to act on certifying under an inconclusive verdict, and it is the first thing the stranger's report named: `status: "complete"` sat directly above a `classes` map marking two of three entries absent. It is now capped like `bound` and `counted.exact`, reading `partial` when a class was actually observed absent and `unknown` otherwise. `classes`, `decided_by` and `limits` publish the observation unchanged beside it, so no evidence is lost.

Two gates are now scoped to answers that actually claim an absence. The cross-repo authority gate exists to stop "nothing references this" being read as safe-to-delete proof; applying it to populated answers would report every answer on every repository with no spine configured as a floor forever.

## What this branch deliberately does NOT contain

An earlier version of it carried a gate refusing to certify a `semantic_search` absence read off a region the answer never scanned, aimed at check 8. kin#957 landed the same case from the name's own side, seeing that a narrowing filter removed every candidate the name did match, which is both sharper and closer to where the defect lives. That gate is removed here rather than stacked on top of #957's, because two overlapping gates would refuse absences #957 considers certifiable, and the more precise mechanism should own the case. Check 8 passes on this branch through #957's gate, not mine.

Getting there took two wrong versions worth recording. The first refused whenever `reference_enrichment` read `unknown` and broke forty tests, because `reference_enrichment` could not report `available` at the time and it therefore refused everything, which is the regression FIR-2357 item 4 bars. The second turned on `available`; then kin#967 landed the host probe, psf/requests began reporting `available` on a host carrying pyright, and the same query certified the same false zero again. That is what proved enrichment was never what made the certification wrong.

## Falsification

Each break was applied to the committed tree, the named tests run with the exit code read raw, then the tree restored with `git checkout`.

Making `qualifies_populated_answers` return false: `non_empty_result_gets_no_negative`, `neighborhood_with_a_neighbor_gets_no_negative` and `a_populated_cross_file_answer_reports_itself_complete` all failed rc=101.

Removing the `status` projection: `a_javascript_export_is_not_certified_absent_when_requires_produce_no_edges` failed rc=101 with the payload showing `status: "complete"` beside `limits` naming three edge_coverage gaps and a note saying the counts are a lower bound.

The invariant scanner and the projection from kin#966 remain falsified by that PR's five cases, which still pass here.

## Gate

`bin/kin-dev local-test kin` through `bin/kin-lane run oneverdict kin`, resolving the lane worktree at `c625c87f (chore/lane-oneverdict-verdict2)`, rebased onto kin#957: `6508 tests run: 6508 passed, 12 skipped`, rc=0 under `--no-fail-fast`, doctests green. `cargo fmt --all -- --check` rc=0. Clippy driven exactly as ci.yml drives it from `.github/clippy-allowed-lints.txt`, rc=0. All six guard scripts rc=0. `git diff origin/main -- Cargo.lock .cargo/` is empty.

The brownfield suite on a release binary built from this branch reads 5 pass, 4 fail: check 5 "all 3 surfaces agree", check 6 "both tools reach refuse on HTTPAdapter.send", check 8 "returned zero and refused to certify it". The four failures are checks 2, 3, 4 and 7, all FIR-2464. That suite is NON-CITABLE DEV-LOCAL iteration, not proof.

Closes FIR-2463
