### PR TITLE
Carry the planned repository authority into the commit that publishes it

### DIFF
--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -48,6 +48,8 @@ impl LocalRepositoryAuthorityContext {
     pub(crate) fn open(
         &self,
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
+        #[cfg(test)]
+        record_authority_open();
         self.binding.open_manager()
     }
 
@@ -56,6 +58,37 @@ impl LocalRepositoryAuthorityContext {
     ) -> std::result::Result<(), kin_core::PinnedNamespaceRefusal> {
         self.binding.revalidate_pinned_namespace()
     }
+}
+
+// How many repository authorities this thread has opened.
+//
+// Opening one is O(store) and not a cheap handle: kin-db decodes the whole
+// persisted authority and then re-verifies every body in repository CAS against
+// its content address, unconditionally, on every open. How many a single
+// operation pays for is therefore a cost invariant worth pinning, and nothing
+// else in this process can observe it. The count is per thread because a test
+// owns its thread and the commit path it drives is synchronous, so a concurrent
+// test can neither inflate nor deflate another's reading.
+#[cfg(test)]
+thread_local! {
+    static AUTHORITY_OPENS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_authority_open() {
+    AUTHORITY_OPENS.with(|count| count.set(count.get() + 1));
+}
+
+/// Start counting authority opens on this thread from zero.
+#[cfg(test)]
+pub(crate) fn reset_authority_open_count() {
+    AUTHORITY_OPENS.with(|count| count.set(0));
+}
+
+/// Authority opens on this thread since the last reset.
+#[cfg(test)]
+pub(crate) fn authority_open_count() -> usize {
+    AUTHORITY_OPENS.with(std::cell::Cell::get)
 }
 
 /// Why a command refused to bind this daemon's local repository authority.

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -33,6 +33,16 @@ type ProjectionEntry = (kin_model::RepoPath, kin_model::TreeEntry, Arc<[u8]>);
 /// `source_hashes` name bodies already present in the daemon's admitted blob
 /// CAS. They are copied into repository-owned CAS immediately before the
 /// authority compare-and-swap; raw checkout bytes are never consulted.
+///
+/// The plan also carries the repository authority it was read from, still open.
+/// Opening one is O(store): it decodes the whole persisted authority and then
+/// re-verifies every body in repository CAS against its content address, which
+/// kin-db does unconditionally on every open. A commit that planned against one
+/// open authority and then published through a second paid that twice for one
+/// change. Carrying it is what makes the plan and the publication the same
+/// authority rather than two reads of the same generation, so the roots the
+/// transaction expects and the roots the publication compare-and-swaps against
+/// are the same in-memory state.
 pub struct NativeCommitPlan {
     pub change: SemanticChange,
     pub transaction: RepositoryTransaction,
@@ -51,6 +61,7 @@ pub struct NativeCommitPlan {
     previous_tree: kin_model::ResolvedTree,
     target_tree: kin_model::ResolvedTree,
     source_hashes: Vec<Hash256>,
+    authority: RepositoryAuthorityManager<LocalFileBackend>,
 }
 
 #[derive(Debug)]
@@ -934,6 +945,9 @@ fn plan_native_commit_inner(
     }
     source_hashes.extend(shared_policy.sources.iter().map(|source| source.body_hash));
 
+    // The lease is a read of this authority and the plan carries the authority
+    // itself, so the read ends here and the open does not.
+    drop(lease);
     Ok(NativeCommitPlan {
         change,
         transaction,
@@ -945,6 +959,7 @@ fn plan_native_commit_inner(
         previous_tree: workspace.tree,
         target_tree: deltas.expected_tree,
         source_hashes: source_hashes.into_iter().collect(),
+        authority,
     })
 }
 
@@ -1086,7 +1101,7 @@ pub(crate) fn commit_native_plan(
             plan.transaction.repository_id, repository_id
         )));
     }
-    let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    let authority = plan.authority;
     for hash in &plan.source_hashes {
         if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish() {
             authority.save_source_blob(*hash, body)?;
@@ -1205,10 +1220,14 @@ fn commit_native_plan_with_working_copy_proof(
             plan.transaction.repository_id, repository_id
         )));
     }
-    let authority = crate::mcp_commit::timed_commit_phase("open_repository_authority", || {
-        authority_context.open()
-    })
-    .map_err(DaemonError::Graph)?;
+    // The plan carries the authority it planned against, still open. The phase
+    // keeps its name and its place in the table so a reader can compare a trace
+    // against an older one; what it now measures is the handoff, and a commit
+    // whose plan and publication share one authority reports it as the near-zero
+    // span it is. A second open here would decode the whole persisted authority
+    // and re-verify every body in repository CAS a second time for one change.
+    let authority =
+        crate::mcp_commit::timed_commit_phase("open_repository_authority", || plan.authority);
     crate::mcp_commit::timed_commit_phase("stage_changed_source_blobs", || {
         for hash in &plan.source_hashes {
             if let Some(body) = read_publishable_source(blobs, &authority, *hash)?.body_to_publish()
@@ -1521,6 +1540,60 @@ mod tests {
             &test_authority_context(layout),
             plan,
         )
+    }
+
+    /// One commit opens the repository authority exactly once.
+    ///
+    /// An open is O(store) rather than a cheap handle: kin-db decodes the whole
+    /// persisted authority and then re-verifies every body in repository CAS
+    /// against its content address, unconditionally, on every one. A commit that
+    /// planned against one open authority and then published through a second
+    /// paid that whole cost twice to record one change, so the plan carries the
+    /// authority it planned against and the publication consumes it.
+    ///
+    /// The count is the invariant, not the timing. A publication that opens its
+    /// own authority again fails the second assertion here whatever the store
+    /// costs to open, including on a fixture small enough for the duplicate to
+    /// be invisible in wall time.
+    #[test]
+    fn one_commit_opens_the_repository_authority_once() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        add_artifact(
+            &graph,
+            &blobs,
+            b"api.py",
+            b"def get():\n    pass\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+
+        crate::local_repository_authority::reset_authority_open_count();
+        let plan = plan_native_commit(
+            &init.layout,
+            &graph,
+            &blobs,
+            OperationId::new(),
+            fixed_timestamp(),
+            AuthorId::new("commitwall"),
+            "publish one artifact".to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            crate::local_repository_authority::authority_open_count(),
+            1,
+            "planning must open the repository authority exactly once"
+        );
+
+        commit_native_plan_with_projection(&init.layout, &blobs, plan).unwrap();
+        assert_eq!(
+            crate::local_repository_authority::authority_open_count(),
+            1,
+            "the publication opened a second repository authority instead of consuming the \
+             one the plan carries; every open decodes the whole persisted authority and \
+             re-verifies every body in repository CAS, so this commit paid that twice"
+        );
     }
 
     /// A desired tree describes one transition out of one observed prior tree.

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -2355,8 +2355,20 @@ mod tests {
         )
         .unwrap();
         commit_native_plan(&init.layout, &blobs, winner).unwrap();
+        // The refusal comes from the durable compare-and-swap. A plan carries
+        // the authority it planned against, so publishing a stale plan no
+        // longer re-reads authority first and cannot notice the move before
+        // preparing its successor; kin-db refuses the write itself because the
+        // persisted base generation is not the one the successor was built on.
+        // The refusal is what matters and it is unconditional: the successor
+        // exists only in memory, and nothing durable moved, which the state
+        // assertions below check rather than assume.
         let error = commit_native_plan(&init.layout, &blobs, stale).unwrap_err();
-        assert!(error.to_string().contains("authority moved"));
+        let refusal = error.to_string();
+        assert!(
+            refusal.contains("generation mismatch") && refusal.contains("another writer committed"),
+            "a stale plan must be refused naming the generation conflict, got: {refusal}"
+        );
 
         let authority = reopen(&init);
         let lease = authority.read_authority();


### PR DESCRIPTION
A commit opened the repository authority three times. Opening one is O(store):
kin-db decodes the whole persisted authority and then re-verifies every body in
repository CAS against its content address, unconditionally, on every open. Its
own comment says so at kin-db 0.7.35 `storage/repository.rs:1912`.

Two of the three were a plan and the publication of that same plan, one function
call apart, on the same generation, inside one held coordination gate. The plan
now carries the authority it planned against, still open, and the publication
consumes it. That is one whole-store decode and one whole-store body
re-verification removed from every commit.

Measured on 45 authority opens against a converted psf/requests store (6491
commits, 887 MB), one open costs a median of 10.8 s, range 6.3 s to 19.6 s, and
70% of that is the CAS body re-verification.

## What the commit wall actually looks like today

FIR-2347 describes a commit that prepares the authority successor twice and
writes a full ~150 MB snapshot twice. That is no longer what happens. kin#854
collapsed the double preparation and kin-db#198's journaled authority frames
replaced the full-snapshot write. Counted off the labeled kin-db events, a
one-line commit performs one successor preparation and one durable write, and on
the 887 MB fixture that write is a 142 KB frame taking 105 ms.

The duplication that remained was the authority opens, which the ticket never
named:

| # | call site | commit phase |
|---|---|---|
| 1 | `crates/kin-daemon/src/loop_runner.rs:521` | `forced_filesystem_admission` |
| 2 | `crates/kin-daemon/src/repository_commit.rs:737` | `plan_transaction` |
| 3 | `crates/kin-daemon/src/repository_commit.rs:1209` | `open_repository_authority` |

This change removes #3. #1 needs `crates/kin-daemon/src/api.rs`, which another
open pull request owns, so it is left for a follow-up rather than raced.

## Before and after

Same instrument on both sides: the labeled kin-db publication events counted out
of the daemon log window the commit itself wrote, bounded by the log's byte
offset captured immediately before the commit rather than by timestamp
arithmetic, with ANSI stripped before matching. Fixtures built identically on
both arms. NON-CITABLE: shared dev box, DEV binaries, one fresh-init run per arm.

| fixture | store | wall s | daemon peak RSS MB | authority opens | successor preparations | snapshot writes | frame writes |
|---|---|---|---|---|---|---|---|
| express (1 commit) | 5.2 MB | 1.36 → 0.93 | 110.1 → 123.6 | 3 → 2 | 1 → 1 | 0 → 0 | 1 → 1 |
| requests (1 commit) | 20.2 MB | 0.98 → 0.80 | 275.6 → 273.7 | 3 → 2 | 1 → 1 | 0 → 0 | 1 → 1 |
| requests (6491 commits) | 887 MB | 163.3 → 137.1 | 4005.8 → 3825.0 | 3 → 2 | 1 → 1 | 0 → 0 | 1 → 1 |

Total time inside authority opens on the 887 MB fixture went from 54,740 ms to
22,716 ms in that pair.

The product's own commit phase table says the same thing without the harness. On
the 887 MB fixture the daemon logged:

```
before:  commit phase phase="open_repository_authority" elapsed_ms=18245
after:   (absent: the phase completed under the 500 ms slow-phase threshold)
```

The phase keeps its name and its place in the table on purpose, so a trace stays
comparable with an older one. What it measures is now the handoff.

The count is the claim. The wall column is reported as observed, not as a proven
speedup: run-to-run spread on this fixture is large enough to swamp a single
open, and a second commit on the same store walled 62.9 s. What does not vary is
that a commit performs one fewer O(store) operation, and that one such operation
has a median measured cost of 10.8 s on a real converted repository. The small
fixtures move the count and not the clock, which is expected at 85 ms per open,
and they are in the table because the invariant has to hold at both scales.

## Durability

Unchanged. The same transaction reaches the same compare-and-swap through the
same `persist_successor` path, and the fsync discipline behind it is untouched.
Nothing about what is written, or how, moved.

Two facts make carrying the authority safe rather than merely cheaper:

- `RepositoryAuthorityManager` holds no lock guard. Its fields are
  `repository_id`, `backend`, `publication`, `opened_by_history_validation` and
  `prepared` (kin-db 0.7.35 `storage/repository.rs:1659`). Cross-process
  exclusion lives in `LocalRepositoryAuthorityFreeze` at `:1682`, a separate type
  this path never constructs, so holding the manager longer holds no lock longer.
- Coherence improves rather than loosens. `AuthorityPublication::commit` prepares
  against its own in-memory current state, and the transaction's
  `expected_generation` and `expected_roots` were read from that same state.
  Before this change they were read from a different manager's copy of the same
  generation.

One observable behavior does change, and it is the reason
`stale_plan_cannot_split_change_workspace_and_ref_authority` moved with this
commit. A plan built before another writer commits used to be refused early: the
publication opened authority again, read the newer generation, and rejected the
transaction's expectation. It now carries its own authority and cannot see the
move before preparing a successor, so kin-db refuses the durable write instead,
with `authority frame base generation mismatch ... (another writer committed
since last load)`. The refusal is unconditional and nothing durable moves; the
successor exists only in memory. The test keeps every post-condition it had, and
those assertions are what prove the store was not split: generation still 2, the
default ref still naming the winner, one change in the store. What the conflict
costs changed shape too. It used to waste one authority open and now wastes one
successor preparation, on a path that only runs when two writers race the same
generation.

## Test

`one_commit_opens_the_repository_authority_once` counts opens through a
thread-local counter behind `cfg(test)`, per thread because a test owns its
thread and the commit path it drives is synchronous.

Falsified by restoring the second open and re-running, which fails with
`left: 2, right: 1` and a message naming the duplicate. It fails on a fixture
small enough that the duplicate costs no measurable wall time, which is the point
of counting rather than timing.

The first full run of the workspace gate is what caught the stale-plan change
above. The gate now reads 6509 tests run, 6509 passed, 12 skipped, run
registry-resolved with `--locked --no-fail-fast`, plus `cargo test --doc
--locked --workspace` clean, `cargo fmt --check` clean, the CI clippy allowlist
clean, and the ci.yml guard scripts `verify-zero-file-search.py`,
`zero_file_search_guard.sh`, `verify-hydration-semantics.py`,
`check_runtime_boundaries.sh`, `check_private_repo_coupling.sh` and
`test-assertion-reachability.py` all passing.

Refs FIR-2347
Refs FIR-2459
