### PR TITLE
Pin kin-lsp to =0.6.14 so runtime resolution carries the enrichment fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.6.12"
+version = "0.6.14"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "bb2026d10f41f36fad8fad9709195e587611507a885d0956e6e6fea28adb97f4"
+checksum = "6d926f6fdf0445ce64ef10fdc01c02f9a9905bafdc16e9417160183130a861b0"
 dependencies = [
  "kin-model",
  "serde",
@@ -6644,7 +6644,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "0.6.5", registry = "kin" }
+kin-lsp = { version = "=0.6.14", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled


### PR DESCRIPTION
The workspace floor of 0.6.5 let a fresh registry resolve pick 0.6.12, which predates the override-producer and sweep-observability work the enrichment milestone depends on: on a 0.6.12 resolution, kin refs BaseAdapter.send still reads no incoming callers, which is exactly the gap kin#974's branch shows. Sibling registry deps already use exact pins; this brings kin-lsp in line at =0.6.14.

The lock entry moved 0.6.12 -> 0.6.14 with the sparse registry source and checksum intact, one package changed. Per the pin-change rule the DEV-LOCAL gate says nothing about this PR (it path-patches the very crate under test), so the gates that count are this PR's own hosted CI on the registry resolution and a registry-only release-check running beside it.

Lands as part of the FIR-2469 one-train landing behind kin#973 and kin#974.

Refs FIR-2464