### PR TITLE
Decide a context pack's dependents with the authority find_references reads

### DIFF
--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -726,9 +726,19 @@ edge leaving the focal, `relation: \"dependent_edge\"` is an edge arriving at it
 `relation: \"same_file_neighbor\"` means the focal had no dependency edge in either \
 direction, so the row is a neighbour sharing the focal's file rather than anything the \
 focal depends on. That last one is the usual shape for a class whose only edges are \
-containment, and those rows sort after the real edges. `dependency_selection` names \
-which of the two filled the list, how many rows each group returned, and, for the \
-fallback, how many same-file candidates there were and how many were dropped to fit. \
+containment, and those rows sort after the real edges. A row carrying \
+`bidirectional: true` is joined to the focal BOTH ways; it is grouped by the arriving \
+edge because that is the one that decides whether changing the focal breaks it. \
+`dependents` is assembled by the same collector `find_references` uses, on the same \
+graph, so the two tools cannot answer differently about one entity: a caller that tool \
+returns is in this group, and a bare-name receiver guess it declines to certify is in \
+neither. `dependency_selection` names which selection filled the dependency list, how \
+many rows each group returned, how many dependents the reference authority certified, \
+how many were withheld to stay inside the pack's budget, and, for the fallback, how many \
+same-file candidates there were and how many were dropped to fit. Read `edge_coverage` \
+and the response's `negative` verdict before acting on an EMPTY `dependents`: a graph \
+that does not link this language's calls across files returns the same `[]` for a symbol \
+with twenty callers as for one with none. \
 If get_entity_source is available to you it is cheaper for a raw \
 body alone; if you need to follow an actual call chain step by step, use trace_data_flow.";
 

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -691,6 +691,18 @@ pub fn handle_get_entity_sources<G: GraphStore>(
     Ok(assemble_entity_sources_response(resolved, &opts))
 }
 
+/// Certified dependents a pack will recover into its `dependents` group beyond
+/// the rows its own section already carried.
+///
+/// The group's membership must not depend on how much token budget was left,
+/// which is the whole point of recovering them, but a focal with hundreds of
+/// callers must not turn a budgeted pack into an unbudgeted one either. Past
+/// this the count is still exact: `certified_dependents` reports what the
+/// reference authority proved and `dependents_withheld` reports what did not
+/// fit, so a caller reading a short group knows to ask `find_references` for
+/// the rest rather than reading the group as the whole set.
+const CERTIFIED_DEPENDENTS_MAX: usize = 24;
+
 pub const GET_CONTEXT_PACK_DESC: &str = "\
 Assemble a focused, ready-to-read context bundle around one entity, fitted to a token \
 budget. Starting from a focal entity ID, Kin walks the relation graph to gather the \
@@ -861,6 +873,68 @@ pub fn handle_get_context_pack<G: GraphStore>(
         }
     };
 
+    // Membership of the `dependents` group is decided by the edge authority
+    // `find_references` reads, on the same store, in the same request. The two
+    // surfaces answer the same question about the same entity, so a pack that
+    // decided it independently could disagree with the tool beside it, and it
+    // did: on expressjs/express `res.sendFile` packed `dependents: []` while
+    // `find_references` on that id returned `res.download`, which calls it.
+    //
+    // This is the same call `handle_find_references` makes, not a second
+    // implementation of it. Everything that decides what counts as a reference
+    // -- the allowed edge classes, the self-edge exclusion, composition over
+    // proven overrides, and dropping a caller the workspace no longer contains
+    // -- is that function's, so the two cannot drift apart by being edited
+    // separately.
+    let reference_kinds = default_reference_kinds();
+    let reference_rows = collect_graph_reference_rows(
+        store,
+        &entity_id,
+        &reference_kinds,
+        repository_authority,
+    )?;
+    // Observed before the partition, because a candidate row still witnesses the
+    // edge class it arrived on. Same rule as the reference tool's, so the
+    // coverage the pack publishes is the coverage that tool would publish.
+    let witnessed = match &focal_entity {
+        Some(entity) => answer_witnessed_classes(store, entity, &reference_rows),
+        None => Vec::new(),
+    };
+    // FIR-1552 again, in the direction that matters here: a row matched on a
+    // bare receiver name with nothing at the site proving the destination is a
+    // candidate, not a caller. `find_references` withholds it from its count,
+    // so a pack that promoted it to a dependent would be certifying what the
+    // reference surface declined to.
+    let mut certified_rows: Vec<ReferenceRow> = reference_rows
+        .into_iter()
+        .filter(|row| !row.receiver_name_guess)
+        .collect();
+    certified_rows.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.entity_id.cmp(&right.entity_id))
+    });
+    let certified_ids: Vec<kin_model::ids::EntityId> = certified_rows
+        .iter()
+        .filter_map(|row| row.entity_id.as_deref())
+        .filter_map(|id| parse_entity_id(id).ok())
+        .collect();
+    let certified: std::collections::HashSet<kin_model::ids::EntityId> = certified_ids.iter().copied().collect();
+    // What the graph can structurally answer over the classes the group was
+    // built from. An empty `dependents` is only evidence about the code when
+    // this says the focal's language links those classes across files, and
+    // nothing else in a pack reports it.
+    let edge_coverage = match &focal_entity {
+        Some(entity) => crate::edge_coverage::observe_cross_file_reference_coverage_witnessed(
+            store,
+            entity,
+            &reference_kinds,
+            &witnessed,
+        ),
+        None => serde_json::Value::Null,
+    };
+
     // The dependency section carries both directions, so it is served as two
     // groups named for what they are. Serving it as one list called
     // `dependencies` reported a focal's callers as things the focal depends on,
@@ -870,15 +944,63 @@ pub fn handle_get_context_pack<G: GraphStore>(
     // order survives the partition.
     let mut dependencies: Vec<serde_json::Value> = Vec::new();
     let mut dependents: Vec<serde_json::Value> = Vec::new();
+    let mut packed: std::collections::HashSet<kin_model::ids::EntityId> =
+        std::collections::HashSet::new();
     for entry in &pack.dependency_signatures {
-        let relation = selection.relation_for(&entry.entity_id);
-        let row = project_dep(entry, Some(relation))?;
+        let packed_relation = selection.relation_for(&entry.entity_id);
+        // The union, never the intersection. A certified caller is a dependent
+        // whatever the pack's own section made of it, and an arriving edge of a
+        // class the reference surface does not read -- `UsesType`, `Implements`,
+        // `Extends` -- is still a dependent the pack can see and that surface
+        // cannot. Taking either one alone would drop real blast radius.
+        let relation = if certified.contains(&entry.entity_id) {
+            DependencyRelation::DependentEdge
+        } else {
+            packed_relation
+        };
+        let mut row = project_dep(entry, Some(relation))?;
         match relation {
-            DependencyRelation::DependentEdge => dependents.push(row),
+            DependencyRelation::DependentEdge => {
+                // Nothing is lost when a pair is joined both ways. The pack used
+                // to resolve that by calling the neighbour a dependency, which
+                // on a JavaScript object literal spends a weak leaving
+                // `References` edge to erase a real arriving `Calls` -- and
+                // every sibling method has that shape, so a focal lost its whole
+                // caller set at once. The group is decided by the arriving edge
+                // and the other direction is stated on the row.
+                if packed_relation == DependencyRelation::DependencyEdge {
+                    row["bidirectional"] = serde_json::json!(true);
+                }
+                packed.insert(entry.entity_id);
+                dependents.push(row);
+            }
             DependencyRelation::DependencyEdge | DependencyRelation::SameFileNeighbor => {
                 dependencies.push(row)
             }
         }
+    }
+    // A certified caller the pack's own section never reached -- shed by the
+    // builder's token budget, or missed by its subgraph walk -- is exactly the
+    // shape this defect had. Recovering it here is what makes the group's
+    // membership a property of the answer rather than of how much budget was
+    // left, and the recovered rows carry the same shape as the projected ones so
+    // a reader cannot tell which path produced them.
+    let mut dependents_withheld = 0usize;
+    for id in &certified_ids {
+        if packed.contains(id) {
+            continue;
+        }
+        if dependents.len() >= CERTIFIED_DEPENDENTS_MAX {
+            dependents_withheld += 1;
+            continue;
+        }
+        let entry = kin_model::context::ContextEntry {
+            entity_id: *id,
+            projection_level: kin_model::context::ProjectionLevel::SignatureOnly,
+            content: String::new(),
+        };
+        dependents.push(project_dep(&entry, Some(DependencyRelation::DependentEdge))?);
+        packed.insert(*id);
     }
     let transitive: Vec<_> = pack
         .transitive_deps
@@ -898,15 +1020,30 @@ pub fn handle_get_context_pack<G: GraphStore>(
         "dependencies": dependencies,
         // Always present, empty included. "no dependents" and "this build does
         // not report dependents" are different answers, and a group that
-        // appears only when populated cannot tell them apart.
+        // appears only when populated cannot tell them apart. What separates
+        // them now is `edge_coverage` and the response's `negative` verdict:
+        // an empty group on a graph that demonstrably links this language's
+        // edges across files is an answer, and an empty group on one that does
+        // not is a gap, and both used to serialize as `[]`.
         "dependents": dependents,
         "dependency_selection": {
             "source": selection.source().as_str(),
             "returned": returned,
             "dependents_returned": dependents_returned,
+            // What the reference authority certified, stated beside what the
+            // group returned so the two can be compared. They differ when the
+            // pack sees an arriving edge of a class that authority does not
+            // read, and when the cap below withholds one.
+            "certified_dependents": certified_ids.len(),
+            "dependents_withheld": dependents_withheld,
             "same_file_candidates": selection.same_file_candidates(),
             "same_file_dropped": selection.same_file_dropped(),
         },
+        // The substrate behind the `dependents` group, so an empty group is
+        // read against what this graph can structurally answer for the focal's
+        // language rather than as a bare fact. Computed by the same observer
+        // `find_references` uses, from the same witnesses.
+        crate::edge_coverage::EDGE_COVERAGE_KEY: edge_coverage,
         "token_budget": budget.max_tokens(),
         "tokens_used": pack.actual_tokens,
     });

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -897,12 +897,8 @@ pub fn handle_get_context_pack<G: GraphStore>(
     // -- is that function's, so the two cannot drift apart by being edited
     // separately.
     let reference_kinds = default_reference_kinds();
-    let reference_rows = collect_graph_reference_rows(
-        store,
-        &entity_id,
-        &reference_kinds,
-        repository_authority,
-    )?;
+    let reference_rows =
+        collect_graph_reference_rows(store, &entity_id, &reference_kinds, repository_authority)?;
     // Observed before the partition, because a candidate row still witnesses the
     // edge class it arrived on. Same rule as the reference tool's, so the
     // coverage the pack publishes is the coverage that tool would publish.
@@ -930,7 +926,8 @@ pub fn handle_get_context_pack<G: GraphStore>(
         .filter_map(|row| row.entity_id.as_deref())
         .filter_map(|id| parse_entity_id(id).ok())
         .collect();
-    let certified: std::collections::HashSet<kin_model::ids::EntityId> = certified_ids.iter().copied().collect();
+    let certified: std::collections::HashSet<kin_model::ids::EntityId> =
+        certified_ids.iter().copied().collect();
     // What the graph can structurally answer over the classes the group was
     // built from. An empty `dependents` is only evidence about the code when
     // this says the focal's language links those classes across files, and
@@ -1009,7 +1006,10 @@ pub fn handle_get_context_pack<G: GraphStore>(
             projection_level: kin_model::context::ProjectionLevel::SignatureOnly,
             content: String::new(),
         };
-        dependents.push(project_dep(&entry, Some(DependencyRelation::DependentEdge))?);
+        dependents.push(project_dep(
+            &entry,
+            Some(DependencyRelation::DependentEdge),
+        )?);
         packed.insert(*id);
     }
     let transitive: Vec<_> = pack

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3314,6 +3314,14 @@ mod tests {
                 serde_json::json!("dependent_edge"),
                 "an arriving edge must say which way it points (compact={compact}): {value}"
             );
+            // The control for the marker: this caller reaches the focal one way
+            // only, so claiming both would be a fabrication rather than a label.
+            assert_eq!(
+                dependents[0]["bidirectional"],
+                serde_json::Value::Null,
+                "a one-way caller must not be marked as joined both ways \
+                 (compact={compact}): {value}"
+            );
 
             let dependencies = value["dependencies"]
                 .as_array()
@@ -3392,9 +3400,28 @@ mod tests {
             let dependents = value["dependents"].as_array().unwrap_or_else(|| {
                 panic!("the pack must name the group holding what depends on the focal: {value}")
             });
-            assert!(
-                dependents.iter().any(|row| row["id"] == caller_id),
-                "the caller find_references reports must reach the pack's dependents \
+            let caller = dependents
+                .iter()
+                .find(|row| row["id"] == caller_id)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "the caller find_references reports must reach the pack's dependents \
+                         (compact={compact}): {value}"
+                    )
+                });
+            assert_eq!(
+                caller["relation"],
+                serde_json::json!("dependent_edge"),
+                "an arriving edge must say which way it points (compact={compact}): {value}"
+            );
+            // The fixture's pair IS joined both ways, so the marker has to be
+            // here. Without this the group could be right for the wrong reason:
+            // a build that simply relabelled every neighbour a dependent would
+            // pass every other assertion in this test.
+            assert_eq!(
+                caller["bidirectional"],
+                serde_json::json!(true),
+                "a pair joined both ways must keep the other direction on the row \
                  (compact={compact}): {value}"
             );
             assert_eq!(

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3414,6 +3414,42 @@ mod tests {
         }
     }
 
+    /// The gate in `negative` that separates "nothing depends on this" from
+    /// "this graph could not have found a dependent" reads `edge_coverage` off
+    /// the payload. A pack that did not publish one would leave that gate
+    /// silent, and a silent gate reports the same trustworthy-looking answer for
+    /// both cases, which is the defect wearing the fix's clothes. So the pack
+    /// has to carry the object, and it has to be the observation the reference
+    /// surface publishes rather than a second one.
+    #[test]
+    fn a_context_pack_publishes_the_coverage_its_dependents_claim_rests_on() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        for compact in [false, true] {
+            let value = context_pack_json(&fixture, &fixture.sender, compact);
+            let coverage = value[crate::edge_coverage::EDGE_COVERAGE_KEY]
+                .as_object()
+                .unwrap_or_else(|| {
+                    panic!("the pack must report what its dependents claim rests on: {value}")
+                });
+            assert!(
+                coverage.contains_key("classes"),
+                "the observation must name the per-class states the gate reads \
+                 (compact={compact}): {value}"
+            );
+            assert_eq!(
+                coverage.get("scope").and_then(serde_json::Value::as_str),
+                Some("language"),
+                "extraction gaps are per-language, so the observation is too \
+                 (compact={compact}): {value}"
+            );
+        }
+    }
+
     /// The other half of FIR-2474, and the reason an empty group was readable as
     /// an answer at all: the two surfaces must not be able to disagree in EITHER
     /// direction. `find_references` withholds a row whose only edge is a

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -210,11 +210,26 @@ mod tests {
         /// Wire `caller` as calling `callee`, indexed under BOTH endpoints so an
         /// impact walk finds it from either direction.
         pub(super) fn insert_test_calls_relation(&mut self, caller: &Entity, callee: &Entity) {
+            self.insert_test_relation(RelationKind::Calls, caller, callee);
+        }
+
+        /// Wire one `src -> dst` edge of `kind`, indexed under BOTH endpoints.
+        ///
+        /// The kind is a parameter because direction alone does not decide what
+        /// a row answers: a pair joined by an arriving `Calls` and a leaving
+        /// `References` is a caller, and a fixture that can only build `Calls`
+        /// cannot express that pair at all.
+        pub(super) fn insert_test_relation(
+            &mut self,
+            kind: RelationKind,
+            src: &Entity,
+            dst: &Entity,
+        ) {
             let relation = Relation {
                 id: RelationId::new(),
-                kind: RelationKind::Calls,
-                src: kin_model::GraphNodeId::Entity(caller.id),
-                dst: kin_model::GraphNodeId::Entity(callee.id),
+                kind,
+                src: kin_model::GraphNodeId::Entity(src.id),
+                dst: kin_model::GraphNodeId::Entity(dst.id),
                 confidence: 1.0,
                 origin: kin_model::relation::RelationOrigin::Parsed,
                 created_in: None,
@@ -222,11 +237,11 @@ mod tests {
                 evidence: vec![],
             };
             self.relations_by_entity
-                .entry(callee.id)
+                .entry(dst.id)
                 .or_default()
                 .push(relation.clone());
             self.relations_by_entity
-                .entry(caller.id)
+                .entry(src.id)
                 .or_default()
                 .push(relation);
         }
@@ -2984,9 +2999,15 @@ mod tests {
         note_store: Entity,
         reader: Entity,
         renderer: Entity,
+        sender: Entity,
+        downloader: Entity,
     }
 
     const NOTES_SOURCE: &str = "export class NoteStore {\n  open(): void {}\n  close(): void {}\n  stats(): number { return 0; }\n}\n";
+    const SEND_SOURCE: &str =
+        "export function sendFile(path: string): void {\n  void path;\n}\n";
+    const DOWNLOAD_SOURCE: &str =
+        "export function download(path: string): void {\n  sendFile(path);\n}\n";
 
     fn pack_provenance_fixture() -> PackProvenanceFixture {
         let dir = tempdir().unwrap();
@@ -3083,6 +3104,20 @@ mod tests {
             EntityKind::Function,
             0,
         );
+        let sender = file_entity(
+            "send.ts",
+            SEND_SOURCE,
+            "res.sendFile",
+            EntityKind::Method,
+            0,
+        );
+        let downloader = file_entity(
+            "download.ts",
+            DOWNLOAD_SOURCE,
+            "res.download",
+            EntityKind::Method,
+            0,
+        );
 
         // The class's only edges are containment, which is the shape that sends
         // the builder to its same-file fallback: edges exist, none of them is a
@@ -3116,6 +3151,16 @@ mod tests {
         // `reader` is what breaks it.
         store.insert_test_calls_relation(&renderer, &reader);
 
+        // FIR-2474, measured on expressjs/express at a3714473feb3. `res.download`
+        // calls `res.sendFile`, and `res.sendFile` names `res.download` back
+        // because both are methods assigned onto the same object literal, so the
+        // pair carries an arriving `Calls` and a leaving `References`. Every
+        // `res.*` sibling has that shape, which is why the focal's whole caller
+        // set went missing at once rather than one row at a time.
+        store.insert_test_calls_relation(&downloader, &sender);
+        store.insert_test_relation(RelationKind::References, &downloader, &sender);
+        store.insert_test_relation(RelationKind::References, &sender, &downloader);
+
         install_empty_store_exact_tree(&mut store, dir.path());
         let authority = test_repository_authority(dir.path());
 
@@ -3127,6 +3172,8 @@ mod tests {
             note_store,
             reader,
             renderer,
+            sender,
+            downloader,
         }
     }
 
@@ -3288,6 +3335,126 @@ mod tests {
                 value["dependency_selection"]["dependents_returned"],
                 serde_json::json!(1),
                 "the selection must count both groups (compact={compact}): {value}"
+            );
+        }
+    }
+
+    /// FIR-2474. A pack served `dependents: []` for `res.sendFile` while
+    /// `find_references` on the SAME entity in the SAME store answered with
+    /// `res.download`, which calls it at `lib/response.js:483`. Measured on
+    /// expressjs/express at a3714473feb3 against kin 0.5.42.
+    ///
+    /// The cause is not the token budget: raising it to 200k left the group
+    /// empty and put `res.download` under `dependencies` instead. Both methods
+    /// hang off one object literal, so the graph holds an arriving `Calls` AND a
+    /// leaving `References` for the pair, and a rule that reported any
+    /// both-directions neighbour as a dependency spent the weaker leaving edge
+    /// to erase the stronger arriving one. Every `res.*` sibling has that shape,
+    /// so the focal's entire caller set disappeared at once and the answer an
+    /// agent read was the opposite of the truth: nothing depends on me, and the
+    /// thing that does is something I depend on.
+    ///
+    /// The reference surface is the control. A pack that agreed with it by
+    /// returning nothing on a graph holding nothing would prove nothing, so this
+    /// asserts the caller is reachable through `find_references` first.
+    #[tokio::test]
+    async fn a_context_pack_reports_the_caller_that_find_references_finds() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+        let caller_id = serde_json::json!(fixture.downloader.id.to_string());
+
+        let references = tool_result_json(
+            entities::handle_find_references_with_ambient_binding(
+                &HashMap::from([(
+                    "entity_id".to_string(),
+                    serde_json::json!(fixture.sender.id.to_string()),
+                )]),
+                &fixture.store,
+                entities::AmbientCrossRepoBinding::new(None, None),
+                Some(&fixture.authority),
+            )
+            .await
+            .unwrap(),
+        );
+        let rows = references["references"].as_array().unwrap_or_else(|| {
+            panic!("the control must reach the references surface: {references}")
+        });
+        assert!(
+            rows.iter().any(|row| row["entity_id"] == caller_id),
+            "control: the caller must be reachable through find_references, or this test \
+             cannot fail when the pack is wrong: {references}"
+        );
+
+        for compact in [false, true] {
+            let value = context_pack_json(&fixture, &fixture.sender, compact);
+            let dependents = value["dependents"].as_array().unwrap_or_else(|| {
+                panic!("the pack must name the group holding what depends on the focal: {value}")
+            });
+            assert!(
+                dependents.iter().any(|row| row["id"] == caller_id),
+                "the caller find_references reports must reach the pack's dependents \
+                 (compact={compact}): {value}"
+            );
+            assert_eq!(
+                value["dependency_selection"]["dependents_returned"],
+                serde_json::json!(dependents.len()),
+                "the selection must count the group it describes (compact={compact}): {value}"
+            );
+            let dependencies = value["dependencies"].as_array().unwrap_or_else(|| {
+                panic!("the pack must carry a dependencies group: {value}")
+            });
+            assert!(
+                dependencies.iter().all(|row| row["id"] != caller_id),
+                "a caller must not also be served as something the focal depends on \
+                 (compact={compact}): {value}"
+            );
+        }
+    }
+
+    /// The other half of FIR-2474, and the reason an empty group was readable as
+    /// an answer at all: the two surfaces must not be able to disagree in EITHER
+    /// direction. `find_references` withholds a row whose only edge is a
+    /// bare-name receiver guess, reporting it as a candidate instead. A pack
+    /// that promoted the same edge to a dependent would be handing an agent a
+    /// caller the reference surface declined to certify.
+    #[tokio::test]
+    async fn a_context_pack_withholds_a_dependent_find_references_declines_to_certify() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let fixture = pack_provenance_fixture();
+
+        let references = tool_result_json(
+            entities::handle_find_references_with_ambient_binding(
+                &HashMap::from([(
+                    "entity_id".to_string(),
+                    serde_json::json!(fixture.sender.id.to_string()),
+                )]),
+                &fixture.store,
+                entities::AmbientCrossRepoBinding::new(None, None),
+                Some(&fixture.authority),
+            )
+            .await
+            .unwrap(),
+        );
+        let certified: HashSet<String> = references["references"]
+            .as_array()
+            .unwrap_or_else(|| panic!("the control must reach the references surface: {references}"))
+            .iter()
+            .filter_map(|row| row["entity_id"].as_str().map(str::to_string))
+            .collect();
+
+        let value = context_pack_json(&fixture, &fixture.sender, false);
+        for row in value["dependents"].as_array().unwrap() {
+            let id = row["id"].as_str().unwrap().to_string();
+            assert!(
+                certified.contains(&id),
+                "the pack must not certify a dependent the reference surface withheld: \
+                 {row} not in {certified:?}"
             );
         }
     }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3004,8 +3004,7 @@ mod tests {
     }
 
     const NOTES_SOURCE: &str = "export class NoteStore {\n  open(): void {}\n  close(): void {}\n  stats(): number { return 0; }\n}\n";
-    const SEND_SOURCE: &str =
-        "export function sendFile(path: string): void {\n  void path;\n}\n";
+    const SEND_SOURCE: &str = "export function sendFile(path: string): void {\n  void path;\n}\n";
     const DOWNLOAD_SOURCE: &str =
         "export function download(path: string): void {\n  sendFile(path);\n}\n";
 
@@ -3403,9 +3402,9 @@ mod tests {
                 serde_json::json!(dependents.len()),
                 "the selection must count the group it describes (compact={compact}): {value}"
             );
-            let dependencies = value["dependencies"].as_array().unwrap_or_else(|| {
-                panic!("the pack must carry a dependencies group: {value}")
-            });
+            let dependencies = value["dependencies"]
+                .as_array()
+                .unwrap_or_else(|| panic!("the pack must carry a dependencies group: {value}"));
             assert!(
                 dependencies.iter().all(|row| row["id"] != caller_id),
                 "a caller must not also be served as something the focal depends on \
@@ -3479,7 +3478,9 @@ mod tests {
         );
         let certified: HashSet<String> = references["references"]
             .as_array()
-            .unwrap_or_else(|| panic!("the control must reach the references surface: {references}"))
+            .unwrap_or_else(|| {
+                panic!("the control must reach the references surface: {references}")
+            })
             .iter()
             .filter_map(|row| row["entity_id"].as_str().map(str::to_string))
             .collect();

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -755,6 +755,23 @@ fn push_gap(trustworthy: &mut bool, trust_reason: &mut String, gap: String) {
 /// Number of items in the tool's result collection within `payload`, or `None`
 /// when the expected collection is absent or not an array (in which case no
 /// negative is synthesized — we never guess emptiness).
+/// Whether `payload` is a real answer from `tool` that simply left its answer
+/// group out, as opposed to a payload this module has no business qualifying.
+///
+/// Absence of the key is not enough on its own: an error object is also missing
+/// it, and qualifying one would report a verdict about a graph nobody queried.
+/// The gate is the marker that the tool did produce an answer. For a context
+/// pack that is `focal_entity`, which is the pack's whole reason to exist and is
+/// present in every mode.
+fn omits_its_answer_group(tool: &str, payload: &Value) -> bool {
+    match tool {
+        "get_context_pack" => payload
+            .get("focal_entity")
+            .is_some_and(|focal| !focal.is_null()),
+        _ => false,
+    }
+}
+
 fn collection_len(payload: &Value, field: &str) -> Option<usize> {
     if field.is_empty() {
         payload.as_array().map(Vec::len)
@@ -1498,7 +1515,19 @@ pub fn negative_for(
     let count = if tool == "semantic_locate" {
         locate_result_count(payload)?
     } else {
-        collection_len(payload, spec.field)?
+        match collection_len(payload, spec.field) {
+            Some(count) => count,
+            // An omitted group makes the same claim as an empty one, and it is
+            // the more dangerous of the two: `[]` at least names the question,
+            // while a missing key reads as a question the tool does not answer.
+            // Bailing out here would leave the shape with no verdict at all,
+            // which is the defect this module exists to prevent wearing its
+            // sharpest costume. `get_context_pack` shipped exactly that in
+            // 0.5.42, where the pack carried no `dependents` key, and nothing
+            // qualified it.
+            None if omits_its_answer_group(tool, payload) => 0,
+            None => return None,
+        }
     };
     // A locate page has a second way of being a negative: it came back full, and
     // not one hit is the symbol the query named. Qualifying that page is the
@@ -2993,6 +3022,51 @@ mod tests {
                 .unwrap()
                 .contains("method_call_resolution_incomplete"),
             "the method gap must be named: {negative}"
+        );
+    }
+
+    /// The shipped 0.5.42 pack carried NO `dependents` key at all, not an empty
+    /// one, and the agentadopt lane hit that shape on flask. A missing key is the
+    /// worse of the two: `[]` at least names the question and can be qualified,
+    /// while an absent key reads as a question this tool does not answer, and the
+    /// gate that would have refused to certify it never ran.
+    ///
+    /// The two-group split has since made the key unconditional, so this is a
+    /// regression guard rather than a live bug. It is worth its cost because the
+    /// regression is invisible: dropping the key silently disables the verdict
+    /// instead of failing anything.
+    #[test]
+    fn a_pack_that_omits_its_dependents_group_is_qualified_like_an_empty_one() {
+        let mut payload = empty_pack_dependents("function", cross_file_edges_observed());
+        payload
+            .as_object_mut()
+            .unwrap()
+            .remove("dependents")
+            .expect("the fixture carries the group to remove");
+        let negative = negative_for("get_context_pack", &payload, &structural_ready_envelope())
+            .expect("an omitted dependents group is still an absence claim");
+        assert_eq!(negative["kind"], json!("no_dependents"));
+        assert_eq!(negative["result_count"], json!(0));
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "the omitted shape must be qualified exactly as the empty one is: {negative}"
+        );
+    }
+
+    /// The control that keeps the case above from swallowing payloads it has no
+    /// business judging. A pack that failed before producing a focal has no
+    /// answer to qualify, and inventing a verdict for it would report on a graph
+    /// nobody queried.
+    #[test]
+    fn a_pack_payload_with_no_focal_gets_no_verdict() {
+        let mut payload = empty_pack_dependents("function", cross_file_edges_observed());
+        let map = payload.as_object_mut().unwrap();
+        map.remove("dependents");
+        map.remove("focal_entity");
+        assert!(
+            negative_for("get_context_pack", &payload, &structural_ready_envelope()).is_none(),
+            "a payload carrying no answer must not be handed a verdict about one"
         );
     }
 

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -2894,6 +2894,126 @@ mod tests {
         );
     }
 
+    /// A context pack with an empty `dependents` group, over `coverage`.
+    ///
+    /// The group is the reference surface's answer (FIR-2474), so the payload
+    /// carries the same observation `find_references` publishes beside its own
+    /// empty list. A pack that shipped the group without it would be claiming an
+    /// absence with no evidence the query could have found anything, which is
+    /// the FIR-2353 failure arriving through a second tool.
+    fn empty_pack_dependents(kind: &str, coverage: Value) -> Value {
+        json!({
+            "focal_entity": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "kind": kind,
+                "name": "sendFile",
+            },
+            "dependencies": [{ "id": "00000000-0000-0000-0000-000000000002" }],
+            "dependents": [],
+            "dependency_selection": {
+                "source": "dependency_edges",
+                "returned": 1,
+                "dependents_returned": 0,
+                "certified_dependents": 0,
+                "dependents_withheld": 0,
+                "same_file_candidates": 0,
+                "same_file_dropped": 0,
+            },
+            "edge_coverage": coverage,
+        })
+    }
+
+    /// FIR-2474, the half an agent acts on. `get_context_pack` published
+    /// `dependents: []` with no verdict of any kind, so "nothing depends on
+    /// this" and "this graph links none of this language's edges across files"
+    /// serialized identically, and the empty list was the readable one.
+    ///
+    /// The express shape is the case: JavaScript, no cross-file class produced.
+    #[test]
+    fn a_pack_with_no_dependents_is_inconclusive_when_the_language_links_no_edges() {
+        let payload = empty_pack_dependents(
+            "function",
+            json!({
+                "scope": "language",
+                "language": "JavaScript",
+                "requested_classes": ["calls", "imports", "references"],
+                "classes": { "calls": "absent", "imports": "absent", "references": "absent" },
+                "cross_file_classes": [],
+                "budget_exhausted": false,
+                "entities_examined": 66,
+            }),
+        );
+        let negative = negative_for("get_context_pack", &payload, &structural_ready_envelope())
+            .expect("an empty dependents group yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.starts_with("cross_file_edges_absent"),
+            "the limiting factor must lead the reason: {reason}"
+        );
+        assert!(
+            reason.contains("JavaScript"),
+            "the reason names the language whose edges are missing: {reason}"
+        );
+    }
+
+    /// The control that makes the case above mean something. A gate that
+    /// answered "inconclusive" for every pack would pass it and would be just as
+    /// useless: an empty group on a graph that demonstrably links this
+    /// language's calls across files IS an answer, and it has to read as one.
+    #[test]
+    fn a_pack_with_no_dependents_is_authoritative_when_the_graph_links_them() {
+        let payload = empty_pack_dependents("function", cross_file_edges_observed());
+        let negative = negative_for("get_context_pack", &payload, &structural_ready_envelope())
+            .expect("an empty dependents group yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "a graph that links this language's calls across files can answer: {negative}"
+        );
+        assert_eq!(negative["trust"], json!("authoritative"));
+    }
+
+    /// The pack inherits the reference surface's gap along with its authority.
+    /// A receiver-method call is linked by bare name, so a method's incoming
+    /// edges are routinely unresolved, and `find_references` has always refused
+    /// to certify an empty answer for one. A pack reading the same edges must
+    /// refuse identically, or the two tools disagree about one entity in one
+    /// store, which is the defect this ticket is.
+    #[test]
+    fn a_pack_with_no_dependents_is_inconclusive_for_a_method_focal() {
+        let payload = empty_pack_dependents("method", cross_file_edges_observed());
+        let negative = negative_for("get_context_pack", &payload, &structural_ready_envelope())
+            .expect("an empty dependents group yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(
+            negative["trust_reason"]
+                .as_str()
+                .unwrap()
+                .contains("method_call_resolution_incomplete"),
+            "the method gap must be named: {negative}"
+        );
+    }
+
+    /// A pack that returned dependents is qualified too, because FIR-2463 asks
+    /// every retrieval answer for one verdict rather than only the empty ones.
+    /// What it must never do is claim an absence it is not making.
+    #[test]
+    fn a_populated_pack_is_qualified_without_claiming_an_absence() {
+        let mut payload = empty_pack_dependents("function", cross_file_edges_observed());
+        payload["dependents"] = json!([{ "id": "00000000-0000-0000-0000-000000000003" }]);
+        payload["dependency_selection"]["dependents_returned"] = json!(1);
+        payload["dependency_selection"]["certified_dependents"] = json!(1);
+        let negative = negative_for("get_context_pack", &payload, &structural_ready_envelope())
+            .expect("a populated pack still carries the response's one verdict");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(false),
+            "an answer with rows claims no absence: {negative}"
+        );
+    }
+
     /// A payload that reports no observation at all is the unknown case. This is
     /// the shape every retrieval tool had before FIR-2353, and reading it as
     /// healthy is precisely how absence was certified on a graph that could not

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -118,6 +118,21 @@ fn spec_for(tool: &str) -> Option<RetrievalSpec> {
             always: false,
             class: NegativeClass::Structural,
         },
+        // A pack's `dependents` group is the reference surface's answer,
+        // assembled by the same collector on the same store (FIR-2474), so the
+        // absence it can claim is the same absence and it is qualified by the
+        // same gates. `dependencies` is not the field here: an empty one says
+        // the focal calls nothing, which is an ordinary fact about a leaf and
+        // not a claim any agent acts on. The claim that decides whether a
+        // contract is safe to change is "nothing depends on this", and that is
+        // the one a pack used to publish as a bare `[]`.
+        "get_context_pack" => RetrievalSpec {
+            field: "dependents",
+            kind: "no_dependents",
+            subject: "nothing was found depending on the focal entity",
+            always: false,
+            class: NegativeClass::Structural,
+        },
         // The neighborhood always returns the focal itself, so an empty
         // `entities` says the focal is not in the graph rather than that it has
         // no neighbors, and for an indexed entity the list is never empty at
@@ -247,7 +262,7 @@ pub(crate) fn absence_cross_file_classes(tool: &str, payload: &Value) -> Vec<Str
                     .collect()
             })
             .unwrap_or_else(reference_classes),
-        "trace_data_flow" | "impact_analysis" => reference_classes(),
+        "trace_data_flow" | "impact_analysis" | "get_context_pack" => reference_classes(),
         _ => Vec::new(),
     }
 }
@@ -287,6 +302,7 @@ fn absence_is_language_scoped(tool: &str) -> bool {
             | "semantic_search"
             | "find_dead_code_seeded"
             | "graph_neighborhood"
+            | "get_context_pack"
     )
 }
 
@@ -609,7 +625,7 @@ pub(crate) fn absence_coverage_gap(tool: &str, payload: &Value) -> Option<String
 ///
 /// | tool | qualifies a populated answer | why |
 /// |---|---|---|
-/// | `find_references`, `bulk_check_references`, `trace_data_flow`, `graph_neighborhood`, `semantic_search`, `find_dead_code_seeded` | yes | each answers from the graph, and whether its rows are the whole set is exactly the question a caller acts on |
+/// | `find_references`, `bulk_check_references`, `trace_data_flow`, `graph_neighborhood`, `semantic_search`, `find_dead_code_seeded`, `get_context_pack` | yes | each answers from the graph, and whether its rows are the whole set is exactly the question a caller acts on |
 /// | `semantic_locate` | NO | its page is a bounded ranking rather than an enumeration, so its verdict can never be authoritative at any coverage, and the module already refuses to certify one. Attaching a verdict to every page is the defect FIR-2430 found wearing the opposite costume: a real symbol and a fabricated one came back under the IDENTICAL envelope, so a qualifier there teaches a reader to read a page as a graph claim when it is not one |
 /// | `entity_history` | NO | reads recorded change history, where a populated answer is the history and there is no whole-set question about the graph to answer |
 /// | `dead_code` | NO | its result is the INVERSE claim, and rows are candidates to check rather than an answer whose completeness licenses an action |
@@ -1529,7 +1545,14 @@ pub fn negative_for(
     // verdict — the calls may simply never have been linked. Never let an agent
     // read "safe to delete" off an incomplete call graph: downgrade to
     // inconclusive so the absence is flagged as possibly-unresolved, not certain.
-    if tool == "find_references" && focal_is_method(payload) {
+    //
+    // A pack's `dependents` group is built by the same collector over the same
+    // edges (FIR-2474), so the gap it inherits is the same one and it has to be
+    // reported the same way. Gating this on the tool name alone was how the two
+    // surfaces were able to disagree about one entity in one store: the tool
+    // that refused to certify and the tool that published `[]` were reading the
+    // identical incomplete call graph.
+    if matches!(tool, "find_references" | "get_context_pack") && focal_is_method(payload) {
         push_gap(
             &mut trustworthy,
             &mut trust_reason,


### PR DESCRIPTION
`get_context_pack` and `find_references` answered the same question about the same entity on
the same store and disagreed. The pack decided its `dependents` group from the context
builder's edge labelling, whose rule reports any neighbour joined in both directions as a
dependency. That rule spends the weaker leaving edge to erase the stronger arriving one.

On expressjs/express, `res.sendFile` and `res.download` carry an arriving `Calls`, an arriving
`References`, and a leaving `References`, because both are methods assigned onto one object
literal. Every `res.*` sibling has that shape, so the focal did not lose one caller, it lost
its whole caller set at once, and the callers came back under `dependencies` as things the
focal depends on. That is the opposite claim, and it is the one an agent acts on when deciding
what it may safely change. The token budget is not the cause: at `token_budget: 200000` the
group was still empty and `res.download` was still a dependency.

The group is now assembled by `collect_graph_reference_rows`, the same call
`handle_find_references` makes, with the same edge classes and the same repository authority.
Everything that decides what counts as a reference stays in that one function, so the two
surfaces cannot drift apart by being edited separately. Rows are partitioned on
`receiver_name_guess` exactly as that tool partitions them, so a bare-name receiver guess is a
dependent in neither.

Membership is the union of what the reference authority certifies and what the pack's own
section labelled arriving, because an arriving `UsesType` or `Implements` edge is real blast
radius that surface does not read. A pair joined both ways is grouped by the arriving edge and
carries `bidirectional: true`, so nothing the old rule expressed is lost. Certified callers the
pack's section never reached, shed by the builder's token budget or missed by its subgraph
walk, are recovered up to a cap; `dependency_selection` gains `certified_dependents` and
`dependents_withheld` so a short group is never readable as the whole set.

An empty group also carried no verdict of any kind, so "nothing depends on this" and "this
graph links none of this language's edges across files" serialized identically as `[]`.
`get_context_pack` is registered in the existing one-verdict machinery rather than given a
parallel marker: it declares its reference classes for the absence gates, publishes the
`edge_coverage` observation `find_references` publishes, computed from the same witnesses, and
inherits the same method-resolution gate, since a receiver-method call is linked by bare name
and an empty answer for a method is not an authoritative absence on either surface.

One shape had to be covered beyond the empty list. The 0.5.42 pack carried no `dependents`
key at all, which the agentadopt lane hit on flask, and a missing key made the negative module
bail out before it could refuse to certify. That is the worse of the two shapes: an empty list
at least names the question, while an absent key reads as a question the tool does not answer.
The two-group split has since made the key unconditional, so the guard here is a regression
guard, and it is worth its cost because the regression is invisible: dropping the key silently
disables the verdict rather than breaking anything. It is gated on the payload carrying a
focal, so a pack that failed before producing one is still not handed a verdict about a graph
nobody queried.

Two behaviour changes a reviewer should rule on rather than discover. A test entity that calls
the focal now appears in `dependents` as well as in `tests`; it does break when the focal
changes and `find_references` has always reported it, so the pack agreeing is the point, and
the duplicate row is bounded by the recovery cap and absent in compact mode. And a pack now
propagates a hard body-read failure on a referencing entity where it previously only
propagated one on its own rows; that is the loud-failure half of the graph-gap rule and it can
only fire on a store whose blobs or authority are already broken.

Verified live over MCP against a lane-built daemon on an isolated copy of the express store:
`dependents: [res.download]`, `dependencies: [pathIsAbsolute, sendfile, app.enabled, send]`,
and the reference surface and the pack agree in both directions with nothing in one and not
the other. The failing test was written first from the measured shape and calls
`find_references` on the same fixture as its control, so it cannot pass vacuously on a graph
holding nothing.

Closes FIR-2474
