### PR TITLE
Carry a removed entity's record into the diff so review names what was deleted

### DIFF
--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -17,8 +17,18 @@ use crate::error::ReviewError;
 #[allow(clippy::large_enum_variant)]
 pub enum EntityChangeKind {
     Added(Entity),
-    Modified { old: Entity, new: Entity },
-    Removed(EntityId),
+    Modified {
+        old: Entity,
+        new: Entity,
+    },
+    /// The base-side record of a removed entity. The delta that produced the
+    /// removal already carries this entity, so a review can name what was
+    /// deleted instead of printing an opaque id. `None` only when no version of
+    /// the entity is recoverable from the graph or its history, which a renderer
+    /// must report as an unresolved removal rather than as a bare id.
+    Removed {
+        old: Option<Entity>,
+    },
 }
 
 /// A single entity-level diff entry.
@@ -32,8 +42,15 @@ pub struct EntityChange {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RelationChangeKind {
     Added(Relation),
-    Modified { old: Relation, new: Relation },
-    Removed(RelationId),
+    Modified {
+        old: Relation,
+        new: Relation,
+    },
+    /// The base-side record of a removed relation, which carries both endpoints
+    /// and the edge kind. Every producer holds it, so it is not optional.
+    Removed {
+        old: Relation,
+    },
 }
 
 /// A single relation-level diff entry.
@@ -76,7 +93,21 @@ impl SemanticDiff {
         self.entity_changes
             .iter()
             .filter_map(|c| match &c.kind {
-                EntityChangeKind::Removed(id) => Some(id),
+                EntityChangeKind::Removed { .. } => Some(&c.entity_id),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Removed entities paired with the id they were recorded under. The entity
+    /// is `None` only for a removal whose base-side record could not be
+    /// recovered; a caller must render that case as unresolved rather than
+    /// falling back to the id alone as if it were a name.
+    pub fn removed_entities(&self) -> Vec<(&EntityId, Option<&Entity>)> {
+        self.entity_changes
+            .iter()
+            .filter_map(|c| match &c.kind {
+                EntityChangeKind::Removed { old } => Some((&c.entity_id, old.as_ref())),
                 _ => None,
             })
             .collect()
@@ -101,7 +132,7 @@ fn relation_change_key(change: &RelationChange) -> String {
     match &change.kind {
         RelationChangeKind::Added(rel) => rel.id.to_string(),
         RelationChangeKind::Modified { new, .. } => new.id.to_string(),
-        RelationChangeKind::Removed(id) => id.to_string(),
+        RelationChangeKind::Removed { old } => old.id.to_string(),
     }
 }
 
@@ -157,7 +188,7 @@ pub fn compute_diff_scoped<G: GraphStore>(
                 EntityDelta::Added { new: entity } => {
                     let id = entity.id;
                     match entity_states.get(&id) {
-                        Some(EntityChangeKind::Removed(_)) => {
+                        Some(EntityChangeKind::Removed { .. }) => {
                             // The model delta carries the removed payload, but
                             // the public review summary remains ID-shaped for
                             // now. Treat a reintroduction as an add rather than
@@ -196,7 +227,12 @@ pub fn compute_diff_scoped<G: GraphStore>(
                             entity_states.remove(&id);
                         }
                         _ => {
-                            entity_states.insert(id, EntityChangeKind::Removed(id));
+                            entity_states.insert(
+                                id,
+                                EntityChangeKind::Removed {
+                                    old: Some(old.clone()),
+                                },
+                            );
                         }
                     }
                 }
@@ -262,9 +298,9 @@ pub fn compute_diff_scoped<G: GraphStore>(
             kind: RelationChangeKind::Modified { old, new },
         });
     }
-    for (id, _) in relation_removed {
+    for (_, old) in relation_removed {
         diff.relation_changes.push(RelationChange {
-            kind: RelationChangeKind::Removed(id),
+            kind: RelationChangeKind::Removed { old },
         });
     }
     diff.relation_changes.sort_by_key(relation_change_key);
@@ -291,7 +327,12 @@ pub fn diff_from_change(change: &SemanticChange) -> SemanticDiff {
                     new: new.clone(),
                 },
             ),
-            EntityDelta::Removed { old } => (old.id, EntityChangeKind::Removed(old.id)),
+            EntityDelta::Removed { old } => (
+                old.id,
+                EntityChangeKind::Removed {
+                    old: Some(old.clone()),
+                },
+            ),
         };
         diff.entity_changes.push(EntityChange { entity_id, kind });
     }
@@ -303,7 +344,7 @@ pub fn diff_from_change(change: &SemanticChange) -> SemanticDiff {
                 old: old.clone(),
                 new: new.clone(),
             },
-            RelationDelta::Removed { old } => RelationChangeKind::Removed(old.id),
+            RelationDelta::Removed { old } => RelationChangeKind::Removed { old: old.clone() },
         };
         diff.relation_changes.push(RelationChange { kind });
     }
@@ -360,7 +401,12 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
                         entity_states.remove(&old.id);
                     }
                     _ => {
-                        entity_states.insert(old.id, EntityChangeKind::Removed(old.id));
+                        entity_states.insert(
+                            old.id,
+                            EntityChangeKind::Removed {
+                                old: Some(old.clone()),
+                            },
+                        );
                     }
                 },
             }
@@ -423,9 +469,9 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
             kind: RelationChangeKind::Modified { old, new },
         });
     }
-    for (id, _) in relation_removed {
+    for (_, old) in relation_removed {
         diff.relation_changes.push(RelationChange {
-            kind: RelationChangeKind::Removed(id),
+            kind: RelationChangeKind::Removed { old },
         });
     }
     diff.relation_changes.sort_by_key(relation_change_key);
@@ -479,10 +525,23 @@ pub fn diff_from_entity_ids<G: GraphStore>(
                 });
             }
             None => {
-                // Entity not in graph — treat as removed
+                // Entity not in graph, so treat as removed. The entity is absent
+                // at head by definition here, but its history still holds the
+                // last version that existed, and that record is what lets a
+                // review name what was deleted. Prefer the payload the removal
+                // delta itself carried, then the newest surviving version.
+                let history = store.get_entity_history(&eid).map_err(ReviewError::graph)?;
+                let old = history.iter().rev().find_map(|change| {
+                    change.entity_deltas.iter().find_map(|delta| match delta {
+                        EntityDelta::Removed { old } if old.id == eid => Some(old.clone()),
+                        EntityDelta::Modified { new, .. } if new.id == eid => Some(new.clone()),
+                        EntityDelta::Added { new } if new.id == eid => Some(new.clone()),
+                        _ => None,
+                    })
+                });
                 diff.entity_changes.push(EntityChange {
                     entity_id: eid,
-                    kind: EntityChangeKind::Removed(eid),
+                    kind: EntityChangeKind::Removed { old },
                 });
             }
         }

--- a/crates/kin-review/src/format.rs
+++ b/crates/kin-review/src/format.rs
@@ -42,6 +42,29 @@ pub fn format_review(review: &Review) -> String {
     out
 }
 
+/// Convert a graph-owned 0-based line index to the 1-based line number every
+/// editor, `file:line` reference, and diff hunk uses.
+///
+/// A review renders locations a reader clicks or greps, so emitting the raw
+/// graph row sends them one line above the declaration. The agent-facing
+/// surfaces convert at one seam per surface for this reason; this is that seam
+/// for the review renderers.
+pub(crate) fn presentation_line(graph_line: u32) -> u32 {
+    graph_line.saturating_add(1)
+}
+
+/// `file:line` for an entity, or just the file when no span was captured.
+fn entity_location(entity: &kin_model::entity::Entity) -> Option<String> {
+    if let Some(span) = entity.span.as_ref() {
+        return Some(format!(
+            "{}:{}",
+            span.file,
+            presentation_line(span.start_line)
+        ));
+    }
+    entity.file_origin.as_ref().map(|origin| origin.to_string())
+}
+
 /// Format entity-level diff.
 pub fn format_diff(diff: &SemanticDiff) -> String {
     let mut out = String::new();
@@ -55,7 +78,7 @@ pub fn format_diff(diff: &SemanticDiff) -> String {
 
     let added = diff.added_entities();
     let modified = diff.modified_entities();
-    let removed = diff.removed_entity_ids();
+    let removed = diff.removed_entities();
 
     if !added.is_empty() {
         writeln!(out, "\nAdded ({}):", added.len()).unwrap();
@@ -95,8 +118,31 @@ pub fn format_diff(diff: &SemanticDiff) -> String {
 
     if !removed.is_empty() {
         writeln!(out, "\nRemoved ({}):", removed.len()).unwrap();
-        for id in &removed {
-            writeln!(out, "  - {}", id).unwrap();
+        for (id, entity) in &removed {
+            match entity {
+                Some(entity) => {
+                    writeln!(
+                        out,
+                        "  - {} ({:?}) — {}",
+                        entity.name, entity.kind, entity.signature,
+                    )
+                    .unwrap();
+                    if let Some(location) = entity_location(entity) {
+                        writeln!(out, "    file: {}", location).unwrap();
+                    }
+                }
+                // An unresolved removal is reported as one. Printing the id
+                // alone would read as a name and hide that the base-side record
+                // was unrecoverable.
+                None => {
+                    writeln!(out, "  - <unresolved removal> id {}", id).unwrap();
+                    writeln!(
+                        out,
+                        "    no base-side record for this entity; its name, kind and location are unknown"
+                    )
+                    .unwrap();
+                }
+            }
         }
     }
 
@@ -116,8 +162,8 @@ pub fn format_diff(diff: &SemanticDiff) -> String {
                     )
                     .unwrap();
                 }
-                RelationChangeKind::Removed(id) => {
-                    writeln!(out, "  - relation {}", id).unwrap();
+                RelationChangeKind::Removed { old } => {
+                    writeln!(out, "  - {:?}: {} -> {}", old.kind, old.src, old.dst).unwrap();
                 }
             }
         }

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -392,7 +392,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
             EntityChangeKind::Modified { old, new } => {
                 vec![entity_identity_key(old), entity_identity_key(new)]
             }
-            EntityChangeKind::Removed(_) => Vec::new(),
+            EntityChangeKind::Removed { .. } => Vec::new(),
         })
         .collect();
 

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -829,8 +829,12 @@ pub fn collect_inline_comments(diff: &SemanticDiff, impact: &ImpactReport) -> Ve
             EntityChangeKind::Modified { old, new } => {
                 collect_modified_comments(old, new, impact, &mut comments);
             }
-            EntityChangeKind::Removed(_) => {
-                // Removed entities have no span data — nothing to anchor.
+            EntityChangeKind::Removed { .. } => {
+                // The base-side record now travels with the removal, so a span
+                // usually exists, but it describes a line that is gone at head.
+                // Anchoring a head-side comment there would point at whatever
+                // now occupies it, so removals stay in the diff and findings
+                // surfaces, which name the entity and its file directly.
             }
         }
     }

--- a/crates/kin-review/src/risk.rs
+++ b/crates/kin-review/src/risk.rs
@@ -1,10 +1,147 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use crate::diff::{EntityChangeKind, SemanticDiff};
+use std::collections::BTreeMap;
+
+use crate::diff::{EntityChangeKind, RelationChangeKind, SemanticDiff};
 use crate::impact::ImpactReport;
-use kin_model::entity::{EntityKind, EntityRole, Visibility};
+use kin_model::entity::{Entity, EntityKind, EntityRole, Visibility};
+use kin_model::ids::EntityId;
+use kin_model::relation::GraphNodeId;
 use kin_model::review::{RiskLevel, RiskSummary};
+
+/// `name (Kind) at file:line` for a removed entity, so a finding reads as code.
+fn describe_entity(entity: &Entity) -> String {
+    let kind = format!("{:?}", entity.kind);
+    match entity.span.as_ref() {
+        Some(span) => format!(
+            "`{}` ({}) at {}:{}",
+            entity.name,
+            kind,
+            span.file,
+            crate::format::presentation_line(span.start_line)
+        ),
+        None => match entity.file_origin.as_ref() {
+            Some(origin) => format!("`{}` ({}) in {}", entity.name, kind, origin),
+            None => format!("`{}` ({})", entity.name, kind),
+        },
+    }
+}
+
+/// Names for every entity this diff and impact report can see, keyed by id.
+///
+/// A relation note carries two node ids. Both are usually entities the same
+/// review already describes, so this index turns them back into names. An id
+/// with no entry stays an id: a note must not invent a name it cannot support.
+fn known_entity_names(diff: &SemanticDiff, impact: &ImpactReport) -> BTreeMap<EntityId, String> {
+    let mut names = BTreeMap::new();
+    for entity in impact
+        .affected_callers
+        .iter()
+        .chain(impact.affected_dependents.iter())
+        .chain(impact.affected_contract_consumers.iter())
+        .chain(impact.affected_tests.iter())
+    {
+        names
+            .entry(entity.id)
+            .or_insert_with(|| entity.name.clone());
+    }
+    for change in &diff.entity_changes {
+        let named = match &change.kind {
+            EntityChangeKind::Added(entity) => Some(entity),
+            EntityChangeKind::Modified { new, .. } => Some(new),
+            EntityChangeKind::Removed { old } => old.as_ref(),
+        };
+        if let Some(entity) = named {
+            names
+                .entry(change.entity_id)
+                .or_insert_with(|| entity.name.clone());
+        }
+    }
+    names
+}
+
+/// One endpoint of a relation, named where the review can name it.
+fn describe_node(node: &GraphNodeId, names: &BTreeMap<EntityId, String>) -> String {
+    match node.as_entity().and_then(|id| names.get(&id)) {
+        Some(name) => format!("`{name}`"),
+        None => node.to_string(),
+    }
+}
+
+/// How many dependents a removal finding names before summarising the rest. A
+/// deleted helper can have dozens of callers; naming the first few and counting
+/// the remainder keeps the finding readable without hiding the size.
+const MAX_LISTED_DEPENDENTS: usize = 5;
+
+/// Dependents of a removed entity, named and carrying the edge kind that joined
+/// them to it.
+///
+/// The edge kinds come from the relations this diff removed alongside the
+/// entity: a relation whose `dst` was the removed entity names its consumer in
+/// `src`. Names come from the impact report's entity lists, which hold whole
+/// entities. Both inputs are already in hand, so no graph lookup is needed and
+/// this is safe to call from a pure formatting path.
+///
+/// Returns the rendered dependents and the total found, which may exceed the
+/// rendered count. Production consumers sort ahead of tests so a cap never
+/// drops the callers that decide whether the deletion is safe.
+fn removed_entity_dependents(
+    diff: &SemanticDiff,
+    impact: &ImpactReport,
+    removed_id: &EntityId,
+) -> (Vec<String>, usize) {
+    let mut edge_kinds: BTreeMap<EntityId, String> = BTreeMap::new();
+    for relation_change in &diff.relation_changes {
+        let RelationChangeKind::Removed { old } = &relation_change.kind else {
+            continue;
+        };
+        if old.dst != GraphNodeId::Entity(*removed_id) {
+            continue;
+        }
+        if let Some(src) = old.src.as_entity() {
+            // A pair can carry more than one edge kind; keep the first in the
+            // relation set's stable order rather than picking arbitrarily.
+            edge_kinds
+                .entry(src)
+                .or_insert_with(|| format!("{:?}", old.kind));
+        }
+    }
+    if edge_kinds.is_empty() {
+        return (Vec::new(), 0);
+    }
+
+    // A test consumer is real blast radius but it is not what decides whether a
+    // deletion is safe, so it sorts after production consumers and yields the
+    // listed slots to them.
+    let mut described: BTreeMap<EntityId, (bool, String)> = BTreeMap::new();
+    let candidates = impact
+        .affected_callers
+        .iter()
+        .chain(impact.affected_dependents.iter())
+        .chain(impact.affected_contract_consumers.iter())
+        .chain(impact.affected_tests.iter());
+    for entity in candidates {
+        if let Some(edge_kind) = edge_kinds.get(&entity.id) {
+            described.entry(entity.id).or_insert_with(|| {
+                (
+                    entity.role == EntityRole::Test,
+                    format!("{} via {}", describe_entity(entity), edge_kind),
+                )
+            });
+        }
+    }
+
+    let mut ordered: Vec<(bool, String)> = described.into_values().collect();
+    ordered.sort();
+    let total = ordered.len();
+    let listed = ordered
+        .into_iter()
+        .take(MAX_LISTED_DEPENDENTS)
+        .map(|(_, description)| description)
+        .collect();
+    (listed, total)
+}
 
 /// Assess risk given a diff and its impact report.
 ///
@@ -68,11 +205,37 @@ pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
                     }
                 }
             }
-            EntityChangeKind::Removed(id) => {
+            EntityChangeKind::Removed { old } => {
                 let has_dependents =
                     !impact.affected_dependents.is_empty() || !impact.affected_callers.is_empty();
                 if has_dependents {
-                    breaking_changes.push(format!("Removed entity `{}` still has dependents", id,));
+                    let subject = match old {
+                        Some(entity) => describe_entity(entity),
+                        // An unrecoverable base-side record is reported as one.
+                        // An id rendered bare would read as a name.
+                        None => format!(
+                            "<unresolved removal> id {} (no base-side record)",
+                            change.entity_id
+                        ),
+                    };
+                    let (dependents, total) =
+                        removed_entity_dependents(diff, impact, &change.entity_id);
+                    if dependents.is_empty() {
+                        breaking_changes
+                            .push(format!("Removed entity {subject} still has dependents"));
+                    } else {
+                        // The overflow is counted rather than dropped: a reader
+                        // must be able to tell five of five from five of forty.
+                        let more = total
+                            .checked_sub(dependents.len())
+                            .filter(|remaining| *remaining > 0)
+                            .map(|remaining| format!(", and {remaining} more"))
+                            .unwrap_or_default();
+                        breaking_changes.push(format!(
+                            "Removed entity {subject} still has {total} dependent(s): {}{more}",
+                            dependents.join(", ")
+                        ));
+                    }
                 }
             }
             EntityChangeKind::Added(entity) => {
@@ -91,9 +254,15 @@ pub fn assess_risk(diff: &SemanticDiff, impact: &ImpactReport) -> RiskSummary {
     }
 
     // Removed relations that break contracts
+    let relation_note_names = known_entity_names(diff, impact);
     for rel_change in &diff.relation_changes {
-        if let crate::diff::RelationChangeKind::Removed(id) = &rel_change.kind {
-            notes.push(format!("Relation {} removed", id));
+        if let RelationChangeKind::Removed { old } = &rel_change.kind {
+            notes.push(format!(
+                "Relation removed: {:?} {} -> {}",
+                old.kind,
+                describe_node(&old.src, &relation_note_names),
+                describe_node(&old.dst, &relation_note_names)
+            ));
         }
     }
 
@@ -229,6 +398,244 @@ mod tests {
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    /// `test_entity` with a real span, so a rendered finding can be checked for
+    /// the file and line a reviewer needs.
+    fn placed_entity(name: &str, file: &str, start_line: u32) -> Entity {
+        let mut entity = test_entity(name);
+        entity.span = Some(kin_model::entity::SourceSpan {
+            file: kin_model::ids::FilePathId::new(file),
+            start_byte: 0,
+            end_byte: 1,
+            // `placed_entity` takes the 1-based line a reader would see, so the
+            // graph row stored here is one less.
+            start_line: start_line.saturating_sub(1),
+            start_col: 0,
+            end_line: start_line,
+            end_col: 0,
+        });
+        entity
+    }
+
+    fn calls_relation(src: &Entity, dst: &Entity) -> kin_model::relation::Relation {
+        kin_model::relation::Relation {
+            id: kin_model::ids::RelationId::new(),
+            kind: kin_model::relation::RelationKind::Calls,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: kin_model::relation::RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    /// Deleting a consumed helper is the canonical review catch. The finding has
+    /// to say what was deleted and who still calls it, in words a reviewer can
+    /// act on. This mirrors the `utils.super_len` case from the reviewprobe
+    /// assessment, where the finding named a bare id and nothing else.
+    #[test]
+    fn removed_entity_finding_names_the_entity_and_its_dependents() {
+        use crate::diff::{RelationChange, RelationChangeKind};
+
+        let removed = placed_entity("super_len", "src/requests/utils.py", 160);
+        let caller_a = placed_entity(
+            "PreparedRequest.prepare_body",
+            "src/requests/models.py",
+            576,
+        );
+        let caller_b = placed_entity(
+            "PreparedRequest.prepare_content_length",
+            "src/requests/models.py",
+            654,
+        );
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: removed.id,
+                kind: EntityChangeKind::Removed {
+                    old: Some(removed.clone()),
+                },
+            }],
+            relation_changes: vec![
+                RelationChange {
+                    kind: RelationChangeKind::Removed {
+                        old: calls_relation(&caller_a, &removed),
+                    },
+                },
+                RelationChange {
+                    kind: RelationChangeKind::Removed {
+                        old: calls_relation(&caller_b, &removed),
+                    },
+                },
+            ],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: vec![caller_a.clone(), caller_b.clone()],
+            ..Default::default()
+        };
+
+        let summary = assess_risk(&diff, &impact);
+        let finding = summary
+            .breaking_changes
+            .iter()
+            .find(|f| f.contains("still has") && f.contains("dependent"))
+            .expect("a removal with dependents is a breaking change");
+
+        assert!(
+            finding.contains("super_len"),
+            "names the deleted entity: {finding}"
+        );
+        assert!(
+            finding.contains("src/requests/utils.py:160"),
+            "names where it lived: {finding}"
+        );
+        assert!(
+            finding.contains("PreparedRequest.prepare_body")
+                && finding.contains("src/requests/models.py:576"),
+            "names the first dependent and its location: {finding}"
+        );
+        assert!(
+            finding.contains("PreparedRequest.prepare_content_length")
+                && finding.contains("src/requests/models.py:654"),
+            "names the second dependent and its location: {finding}"
+        );
+        assert!(finding.contains("Calls"), "names the edge kind: {finding}");
+        assert!(
+            !contains_uuid(finding),
+            "a reviewer cannot act on an opaque id: {finding}"
+        );
+    }
+
+    /// A widely-called helper has more dependents than a finding should print.
+    /// The cap must count what it omits, and must spend its slots on production
+    /// callers rather than tests.
+    #[test]
+    fn dependent_list_is_capped_but_counts_the_remainder_and_prefers_production() {
+        use crate::diff::{RelationChange, RelationChangeKind};
+
+        let removed = placed_entity("super_len", "src/requests/utils.py", 160);
+        let production = placed_entity(
+            "PreparedRequest.prepare_body",
+            "src/requests/models.py",
+            576,
+        );
+        let mut tests: Vec<Entity> = (0..12)
+            .map(|i| {
+                let mut test = placed_entity(
+                    &format!("TestSuperLen.test_case_{i:02}"),
+                    "tests/test_utils.py",
+                    60 + i,
+                );
+                test.role = EntityRole::Test;
+                test
+            })
+            .collect();
+        let mut consumers = vec![production.clone()];
+        consumers.append(&mut tests);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: removed.id,
+                kind: EntityChangeKind::Removed {
+                    old: Some(removed.clone()),
+                },
+            }],
+            relation_changes: consumers
+                .iter()
+                .map(|consumer| RelationChange {
+                    kind: RelationChangeKind::Removed {
+                        old: calls_relation(consumer, &removed),
+                    },
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: consumers.clone(),
+            ..Default::default()
+        };
+
+        let summary = assess_risk(&diff, &impact);
+        let finding = summary
+            .breaking_changes
+            .iter()
+            .find(|f| f.contains("still has") && f.contains("dependent"))
+            .expect("a removal with dependents is a breaking change");
+
+        assert!(
+            finding.contains("still has 13 dependent(s)"),
+            "the total is stated, not just the listed few: {finding}"
+        );
+        assert!(
+            finding.contains("and 8 more"),
+            "the omitted remainder is counted, never silently dropped: {finding}"
+        );
+        assert!(
+            finding.contains("PreparedRequest.prepare_body"),
+            "a production caller must not be crowded out by tests: {finding}"
+        );
+        assert!(
+            !contains_uuid(finding),
+            "a reviewer cannot act on an opaque id: {finding}"
+        );
+    }
+
+    /// A removal whose base-side record is unrecoverable must say so. Printing
+    /// the id alone would read as a name and hide the gap.
+    #[test]
+    fn unresolvable_removal_is_reported_as_unresolved_not_as_a_name() {
+        let dependent = placed_entity("caller", "src/lib.rs", 10);
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: EntityId::new(),
+                kind: EntityChangeKind::Removed { old: None },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: vec![dependent],
+            ..Default::default()
+        };
+
+        let summary = assess_risk(&diff, &impact);
+        let finding = summary
+            .breaking_changes
+            .iter()
+            .find(|f| f.contains("still has") && f.contains("dependent"))
+            .expect("a removal with dependents is a breaking change");
+        assert!(
+            finding.contains("unresolved removal"),
+            "an unrecoverable record is named as one: {finding}"
+        );
+    }
+
+    /// A 36-character hyphenated hex id. Used to assert a rendered finding does
+    /// not fall back to one where a name is required.
+    fn contains_uuid(text: &str) -> bool {
+        text.split(|c: char| !(c.is_ascii_hexdigit() || c == '-'))
+            .any(|token| {
+                let parts: Vec<&str> = token.split('-').collect();
+                parts.len() == 5
+                    && [8, 4, 4, 4, 12]
+                        .iter()
+                        .zip(&parts)
+                        .all(|(want, part)| part.len() == *want)
+            })
+    }
+
+    #[test]
+    fn uuid_detector_catches_the_shape_it_is_guarding_against() {
+        // The guard above is only evidence if it can fail, so pin both ways.
+        assert!(contains_uuid(
+            "Removed entity `1c5c4764-ef10-4cb7-b2b3-e1512d0b578d` still has dependents"
+        ));
+        assert!(!contains_uuid(
+            "Removed entity `super_len` (Function) at src/requests/utils.py:160"
+        ));
     }
 
     #[test]
@@ -400,7 +807,7 @@ mod tests {
         let diff = SemanticDiff {
             entity_changes: vec![EntityChange {
                 entity_id,
-                kind: EntityChangeKind::Removed(entity_id),
+                kind: EntityChangeKind::Removed { old: None },
             }],
             ..Default::default()
         };
@@ -423,7 +830,7 @@ mod tests {
         let diff = SemanticDiff {
             entity_changes: vec![EntityChange {
                 entity_id,
-                kind: EntityChangeKind::Removed(entity_id),
+                kind: EntityChangeKind::Removed { old: None },
             }],
             ..Default::default()
         };
@@ -629,19 +1036,71 @@ mod tests {
     #[test]
     fn removed_relation_generates_note() {
         use crate::diff::{RelationChange, RelationChangeKind};
-        use kin_model::ids::RelationId;
 
-        let rel_id = RelationId::new();
+        let src = test_entity("caller");
+        let dst = test_entity("callee");
         let diff = SemanticDiff {
             relation_changes: vec![RelationChange {
-                kind: RelationChangeKind::Removed(rel_id),
+                kind: RelationChangeKind::Removed {
+                    old: calls_relation(&src, &dst),
+                },
             }],
             ..Default::default()
         };
 
-        let impact = ImpactReport::default();
+        // The endpoints are entities the review can see, so the note must name
+        // them rather than printing node ids.
+        let impact = ImpactReport {
+            affected_callers: vec![src.clone()],
+            affected_dependents: vec![dst.clone()],
+            ..Default::default()
+        };
         let summary = assess_risk(&diff, &impact);
-        assert!(summary.notes.iter().any(|n| n.contains("Relation")));
+        let note = summary
+            .notes
+            .iter()
+            .find(|n| n.contains("Relation removed"))
+            .expect("removed relation emits a note");
+        assert!(
+            note.contains("Calls"),
+            "note should name the edge kind: {note}"
+        );
+        assert!(
+            note.contains("`caller`") && note.contains("`callee`"),
+            "note should name both endpoints: {note}"
+        );
+        assert!(
+            !contains_uuid(note),
+            "a named endpoint must not fall back to a node id: {note}"
+        );
+    }
+
+    /// An endpoint the review cannot name keeps its id. Inventing a name would
+    /// be worse than showing the id, so the fallback is pinned.
+    #[test]
+    fn unknown_relation_endpoint_keeps_its_id() {
+        use crate::diff::{RelationChange, RelationChangeKind};
+
+        let src = test_entity("stranger");
+        let dst = test_entity("also_stranger");
+        let diff = SemanticDiff {
+            relation_changes: vec![RelationChange {
+                kind: RelationChangeKind::Removed {
+                    old: calls_relation(&src, &dst),
+                },
+            }],
+            ..Default::default()
+        };
+        let summary = assess_risk(&diff, &ImpactReport::default());
+        let note = summary
+            .notes
+            .iter()
+            .find(|n| n.contains("Relation removed"))
+            .expect("removed relation emits a note");
+        assert!(
+            contains_uuid(note),
+            "an unnameable endpoint shows its id rather than a guess: {note}"
+        );
     }
 
     // ── API endpoint contract tests ─────────────────────────────────────

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -474,7 +474,7 @@ fn overlay_removed_entity_impact_from_base<G: GraphStore>(
         .entity_changes
         .iter()
         .filter_map(|change| match &change.kind {
-            EntityChangeKind::Removed(id) => Some(*id),
+            EntityChangeKind::Removed { .. } => Some(change.entity_id),
             _ => None,
         })
         .collect();
@@ -891,17 +891,20 @@ fn collect_changed_entities<G: GraphStore>(
                     role: new.role,
                 });
             }
-            EntityChangeKind::Removed(id) => {
-                // The diff carries only the removed entity's id, and the entity
-                // is absent at head. Resolve its name/kind/file where it still
-                // exists — the base ref — so findings and the entity list read
-                // as code, not opaque ids, and the breaking-removal rule keeps
-                // demotion only for a surface the BASE graph also cannot name.
-                // Fall back to the live store, then to the id string when the
-                // graph has genuinely forgotten the entity.
-                let removed = match at_base {
-                    Some(base) => base.get_entity(id)?,
-                    None => None,
+            EntityChangeKind::Removed { old } => {
+                let id = &change.entity_id;
+                // The diff now carries the removed entity's base-side record, so
+                // prefer it. The base ref and then the live store remain as
+                // fallbacks for a diff built before the payload existed, or for
+                // a removal whose record was genuinely unrecoverable, and the
+                // breaking-removal rule keeps demotion only for a surface none
+                // of the three can name.
+                let removed = match old {
+                    Some(entity) => Some(entity.clone()),
+                    None => match at_base {
+                        Some(base) => base.get_entity(id)?,
+                        None => None,
+                    },
                 };
                 let removed = match removed {
                     Some(entity) => Some(entity),
@@ -1244,8 +1247,8 @@ fn derive_policy(
                             rename_neutral,
                         )
                     }
-                    EntityChangeKind::Removed(id) => {
-                        let id_string = id.to_string();
+                    EntityChangeKind::Removed { .. } => {
+                        let id_string = change.entity_id.to_string();
                         let unresolvable = unresolvable_removed.contains(id_string.as_str());
                         let name = resolved_names
                             .get(id_string.as_str())
@@ -2556,7 +2559,7 @@ mod tests {
                 .iter()
                 .map(|&i| EntityChange {
                     entity_id: ids[i],
-                    kind: EntityChangeKind::Removed(ids[i]),
+                    kind: EntityChangeKind::Removed { old: None },
                 })
                 .collect();
             Review {
@@ -3638,7 +3641,7 @@ mod tests {
                 entity_changes: vec![
                     EntityChange {
                         entity_id: moved_old_id,
-                        kind: EntityChangeKind::Removed(moved_old_id),
+                        kind: EntityChangeKind::Removed { old: None },
                     },
                     EntityChange {
                         entity_id: readded.id,
@@ -4358,7 +4361,7 @@ mod tests {
                 head: None,
                 entity_changes: vec![EntityChange {
                     entity_id: removed_id,
-                    kind: EntityChangeKind::Removed(removed_id),
+                    kind: EntityChangeKind::Removed { old: None },
                 }],
                 relation_changes: vec![],
             },


### PR DESCRIPTION
`kin review` printed a deleted entity as a bare id, and its breaking finding read ``Removed entity `1c5c4764-...` still has dependents``, naming neither what was deleted nor who still called it. Deleting a consumed helper is the review catch that matters most, and the graph already held the answer: the same report's impact section named the real callers. This was a formatter defect over a working analysis.

## Why the formatter could not do better

`EntityChangeKind::Removed` carried only an `EntityId`, discarding the base-side entity its own delta already held. The plainest case was `diff.rs`:

```rust
EntityDelta::Removed { old } => (old.id, EntityChangeKind::Removed(old.id)),
```

The debt was recorded in a comment at `diff.rs:160`: "The model delta carries the removed payload, but the public review summary remains ID-shaped for now." `RelationChangeKind::Removed` did the same to a `Relation` carrying both endpoints and the edge kind, and two drain loops read `for (id, _) in relation_removed`, destructuring that value away.

Both variants now carry the record. Dropping the id from the entity variant loses nothing, because `EntityChange.entity_id` already holds it at every construction site.

## What changed

Removals render like additions: name, kind, signature, file and line. The breaking finding names the entity and the dependents joined to it, each carrying the edge kind that joined them, by correlating the relations the same diff removed against the impact report's entity lists. Both are already arguments to `assess_risk`, so this stays a pure formatting path with no graph handle added. Removed relations render `Calls: <src> -> <dst>` with endpoints named where the review can name them.

Two judgement calls worth stating:

The dependent list is capped at five with the total stated and the remainder counted (`still has 14 dependent(s): ..., and 9 more`). An uncapped list was the first version and it was wrong for the same reason an unbounded repair context is: a helper with forty callers produces a finding nobody reads. Nothing is dropped silently.

Production consumers sort ahead of tests, so the cap never spends its five slots on `TestSuperLen.test_case_07` while `PreparedRequest.prepare_body` falls off the end.

Lines convert at one seam through `presentation_line`. Spans are 0-based graph rows and a review renders locations a reader clicks, so emitting the raw row sent them one line above the declaration. This was caught by checking the rendered output against `grep -n` rather than by a test.

`diff_from_entity_ids` builds a removal for an id absent from the graph, where no entity exists to carry. It now recovers the last version from history and reports unresolved only when history has nothing either. An unresolved removal says so, because printing the id alone is what made the original output read as if a name had been supplied.

## Scope correction

`review shadow` was never broken here. `shadow.rs:894` already resolved removed names from the base ref, and its comment says why. The original ticket overstated the blast radius and was corrected on the ticket before this work started. Shadow now prefers the carried payload and keeps the base-ref and live-store fallbacks, so a diff built before the payload existed still resolves. `shadow::tests::removed_entity_names_resolve_from_graph` and `shadow::tests::unresolvable_removed_downstream_risk_is_attention_not_would_block` both still pass, which is what proves the fallback was not regressed.

No `kin-cli` change was needed: the CLI renders through `format_review`, so fixing the shared formatter fixed the command.

## Verification

End to end on psf/requests at upstream `8f8b212d`, deleting `utils.super_len` and leaving its three call sites intact.

Before:

```
Removed (1):
  - 1c5c4764-ef10-4cb7-b2b3-e1512d0b578d
  ! Removed entity `1c5c4764-ef10-4cb7-b2b3-e1512d0b578d` still has dependents
```

After:

```
Removed (1):
  - super_len (Function) — def super_len(o: Any) -> int
    file: src/requests/utils.py:160

  ! Removed entity `super_len` (Function) at src/requests/utils.py:160 still has 14 dependent(s):
    `PreparedRequest.prepare_body` (Method) at src/requests/models.py:576 via Calls,
    `PreparedRequest.prepare_content_length` (Method) at src/requests/models.py:654 via Calls, ...
    and 9 more
```

Those line numbers match `grep -n` on the source exactly. The Removed section and the breaking finding now contain no ids at all. Three of nineteen removed-relation notes still show an id: they are outbound `References` edges to targets that are neither inbound consumers nor changed entities, so they are genuinely unnameable from what `assess_risk` holds, and the fallback shows the id rather than guessing a name.

Six new tests in `risk.rs`. The one that matters mirrors the case above and asserts the finding names the entity, its file and line, both production dependents with their files and lines, the `Calls` edge kind, and that it contains no id. The id detector is itself pinned in both directions, because a detector that cannot fail is not evidence.

## Gates

Run through `bin/kin-lane run reviewprobe kin --` from the lane worktree, never piped.

- `cargo nextest run --workspace --no-fail-fast --locked`: 6521 passed, 0 failed, 12 skipped
- `cargo test --doc --locked`: pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features` with the 90-entry ci.yml allowlist: pass
- `verify-zero-file-search.py`, `zero_file_search_guard.sh`, `verify-hydration-semantics.py`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`, `test-private-repo-coupling.py`: all pass

## Not fixed here

The same deletion review still shows `Modified (51)` and four fabricated `@overload` breaking changes on functions the deletion never touched. Those are FIR-2479. The impact-walk contradiction and the `--json` not_found resolution are FIR-2478. Both are untouched and parked.

The removal finding's firing condition is also unchanged: `assess_risk` decides `has_dependents` from the diff-global impact buckets, so it fires when any entity in the diff has dependents rather than when the removed one does. This change names the correlated dependents when the correlation yields them and keeps the generic phrasing when it does not, so gate behaviour is identical. Narrowing that condition would change what blocks a merge and belongs in its own ticket.

Closes FIR-2477
