### PR TITLE
Count what a find_references query could have meant, and let the verdict read it

### DIFF
--- a/crates/kin-mcp/src/envelope.rs
+++ b/crates/kin-mcp/src/envelope.rs
@@ -1797,6 +1797,18 @@ mod tests {
                     "reference_enrichment": "unknown",
                     "budget_exhausted": false,
                 },
+                // Unambiguous on purpose, and present on purpose. The handler
+                // publishes this block on every answer, and since FIR-2475 the
+                // verdict reads it: an answer that does not say how its focal
+                // was resolved cannot be certified, because it may describe a
+                // same-named sibling. A fixture omitting it is not a smaller
+                // response, it is one the handler cannot produce.
+                "focal_resolution": {
+                    "addressed_by": "entity_id",
+                    "same_name_candidates": 1,
+                    "matched": "exact_focal_name",
+                    "other_candidates": [],
+                },
             })
             .to_string(),
         )

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -1752,6 +1752,10 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     };
 
     let addressed_by_name = get_optional_string_param(args, "entity_id").is_none();
+    // Kept for the resolution accounting below. The count that answers "how
+    // ambiguous was what I typed" can only be taken against the caller's own
+    // string, and the resolver consumes it and hands back a winner.
+    let resolution_query = get_optional_string_param(args, "query");
     let target = if let Some(entity_id_str) = get_optional_string_param(args, "entity_id") {
         let entity_id = parse_entity_id(&entity_id_str)?;
         store.get_entity(&entity_id).map_err(McpError::graph)?
@@ -1950,19 +1954,50 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
     // rename driven by an unannounced guess. `trace_data_flow` already reports
     // this as `focal_resolution`; the shape is copied deliberately so the two
     // tools answer the same question with the same key.
-    let same_name_candidates = same_name_entity_count(store, &target.name)?;
+    //
+    // The count has to be taken against what the CALLER addressed, not against
+    // what the resolver returned. Taking it against the winner's own name made
+    // it structurally unable to count on any language that qualifies a method:
+    // `find_references(query: "dispatch_request")` on pallets/flask resolved
+    // `Flask.dispatch_request` and reported one candidate, while the graph held
+    // `View.dispatch_request` and `MethodView.dispatch_request` beside it and
+    // `semantic_search` for the same string returned six. An ambiguity counter
+    // pinned at one is worse than no counter: a reader who checks it is handed
+    // an explicit assurance that there was nothing to disambiguate (FIR-2475).
+    let (same_name_candidates, other_candidates, matched_by) = match resolution_query.as_deref() {
+        Some(query) if addressed_by_name => {
+            let (count, others) = query_resolution_candidates(store, query, &target.id)?;
+            (count, others, "query_name_pattern")
+        }
+        // A pinned entity_id resolved nothing by name, so there is no query
+        // ambiguity to report. What still applies is the twin question: a name
+        // the graph holds twice (two cfg arms admitted as distinct entities)
+        // means an edge the extractor could not attribute sits on neither.
+        _ => {
+            let count = same_name_entity_count(store, &target.name)?;
+            (count, Vec::new(), "exact_focal_name")
+        }
+    };
     result["focal_resolution"] = serde_json::json!({
         "addressed_by": if addressed_by_name { "name" } else { "entity_id" },
         "same_name_candidates": same_name_candidates,
+        // Which rule produced the number. Without it the same field means two
+        // different things depending on how the call was addressed, and a
+        // reader cannot tell which answer they are holding.
+        "matched": matched_by,
+        // A count alone says the tool guessed and leaves no way to ask again.
+        // These are addressable by id, bounded, and never include the winner.
+        "other_candidates": other_candidates,
     });
     if addressed_by_name && same_name_candidates > 1 {
         let entry = serde_json::json!({
             "component": "focal_resolution",
             "reason": "ambiguous_name",
             "detail": format!(
-                "{same_name_candidates} entities are named '{}', and this answer describes the \
-                 one reported as focal_entity. Address it by entity_id to pin the choice.",
-                target.name
+                "{same_name_candidates} entities match the name '{}' that was queried, and this \
+                 answer describes the one reported as focal_entity. Address it by entity_id, \
+                 from focal_resolution.other_candidates, to pin the choice.",
+                resolution_query.as_deref().unwrap_or(target.name.as_str())
             ),
         });
         match result
@@ -3841,6 +3876,72 @@ pub fn handle_trace_data_flow<G: GraphStore>(
 ///
 /// Never reports zero: the focal was resolved from this store, so it is its own
 /// first candidate whatever the pattern query matched.
+/// Rejected candidates a resolution will name before it stops listing them.
+///
+/// The count beside them is exact whatever this is, so a caller reading a short
+/// list still knows how many it is choosing between. The cap exists because a
+/// short query is a substring: `find_references(query: "get")` matches every
+/// getter in the repository, and a resolution note is not the place to
+/// enumerate them.
+const RESOLUTION_CANDIDATES_LISTED_MAX: usize = 10;
+
+/// How many entities the caller's QUERY could have meant, and which ones the
+/// resolver did not pick.
+///
+/// This mirrors what `kin_ranking::select_best_entity` filters on, because the
+/// number is only honest if it counts the set that resolver actually chose
+/// among: the same `name_pattern` match, which is a case-insensitive substring
+/// unless the caller wrote a wildcard, and the same exclusion of external
+/// reference targets the repository does not define. A count taken with a
+/// different rule than the choice it describes is a different question wearing
+/// the same field name, which is the whole of FIR-2475.
+fn query_resolution_candidates<G: GraphStore>(
+    store: &G,
+    query: &str,
+    chosen: &kin_model::ids::EntityId,
+) -> Result<(usize, Vec<serde_json::Value>)> {
+    let filter = EntityFilter {
+        name_pattern: Some(query.to_string()),
+        ..Default::default()
+    };
+    let mut matched: Vec<_> = store
+        .query_entities(&filter)
+        .map_err(McpError::graph)?
+        .into_iter()
+        .filter(|entity| {
+            entity.file_origin.is_some() || entity.role != kin_model::entity::EntityRole::External
+        })
+        .collect();
+    // A total order, so two runs of one store list the same candidates. The rows
+    // come off a query whose order is the store's, and several entities can
+    // share a file and a name.
+    matched.sort_by(|left, right| {
+        left.file_origin
+            .as_ref()
+            .map(|path| path.0.as_str())
+            .cmp(&right.file_origin.as_ref().map(|path| path.0.as_str()))
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    // A resolved focal proves at least one match, so a zero here would be the
+    // count disagreeing with the answer it travels with rather than a fact.
+    let count = matched.len().max(1);
+    let others = matched
+        .into_iter()
+        .filter(|entity| entity.id != *chosen)
+        .take(RESOLUTION_CANDIDATES_LISTED_MAX)
+        .map(|entity| {
+            serde_json::json!({
+                "id": entity.id,
+                "name": entity.name,
+                "kind": entity.kind,
+                "file_path": entity.file_origin.as_ref().map(|path| path.to_string()),
+            })
+        })
+        .collect();
+    Ok((count, others))
+}
+
 fn same_name_entity_count<G: GraphStore>(store: &G, name: &str) -> Result<usize> {
     let filter = EntityFilter {
         name_pattern: Some(name.to_string()),
@@ -5397,6 +5498,160 @@ mod tests {
         // blob-backed body to project).
         assert!(verbose_refs[0].as_object().unwrap().contains_key("snippet"));
         assert_eq!(verbose_refs[0]["signature"], "fn caller()");
+    }
+
+    /// FIR-2475. The ambiguity counter above cannot count ambiguity on any
+    /// language that qualifies a method name, which is most of them.
+    ///
+    /// Measured on pallets/flask at d318b683 with npm `@kinlab/kin@0.5.42`:
+    /// `find_references(query: "dispatch_request")` resolved
+    /// `Flask.dispatch_request` and reported `same_name_candidates: 1`, while
+    /// `semantic_search` for the same string in the same session returned
+    /// `total_matches: 6`. Three of those are source-role methods whose
+    /// unqualified name is exactly `dispatch_request`, in two files.
+    ///
+    /// Two bugs stack. The count is taken against the RESOLVED focal's qualified
+    /// name rather than against the query the caller typed, and it is taken with
+    /// exact string equality rather than the substring rule the resolver ranked
+    /// with. So for a qualified-name language the answer is pinned at one
+    /// whatever the caller asked, the `ambiguous_name` degradation can never
+    /// fire, and a reader following FIR-2439's own advice gets an explicit
+    /// assurance that there was nothing to disambiguate. The fixture above
+    /// passes only because its two entities carry bare identical names.
+    #[tokio::test]
+    async fn find_references_counts_what_the_query_could_have_meant() {
+        let store = InMemoryGraph::new();
+        let app = make_entity_in(
+            LanguageId::Python,
+            "Flask.dispatch_request",
+            "src/flask/app.py",
+        );
+        let base = make_entity_in(
+            LanguageId::Python,
+            "View.dispatch_request",
+            "src/flask/views.py",
+        );
+        let derived = make_entity_in(
+            LanguageId::Python,
+            "MethodView.dispatch_request",
+            "src/flask/views.py",
+        );
+        for entity in [&app, &base, &derived] {
+            store.upsert_entity(entity).unwrap();
+        }
+
+        // The control. Three distinct entities really do answer to this query in
+        // this store, so a response reporting one candidate is reporting a fact
+        // the store contradicts rather than a small repository.
+        let matched = store
+            .query_entities(&kin_model::graph::EntityFilter {
+                name_pattern: Some("dispatch_request".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            matched.len(),
+            3,
+            "control: the query must be genuinely ambiguous in this store, or this test \
+             cannot fail"
+        );
+
+        let mut args = HashMap::new();
+        args.insert("query".to_string(), serde_json::json!("dispatch_request"));
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+
+        assert_eq!(body["focal_resolution"]["addressed_by"], "name");
+        assert_eq!(
+            body["focal_resolution"]["same_name_candidates"], 3,
+            "the count must answer what the QUERY could have meant, not how many \
+             entities carry the winner's qualified name: {body}"
+        );
+        assert_eq!(
+            body["focal_resolution"]["matched"], "query_name_pattern",
+            "the response must name the rule it counted by, or the number is unreadable: {body}"
+        );
+
+        // A count alone tells an agent it guessed and leaves it no way to ask
+        // again. The rejected candidates travel with it, addressable by id.
+        let others = body["focal_resolution"]["other_candidates"]
+            .as_array()
+            .unwrap_or_else(|| {
+                panic!("an ambiguous resolution must name what it did not pick: {body}")
+            });
+        assert_eq!(others.len(), 2, "two candidates were not chosen: {body}");
+        let focal_id = body["focal_entity"]["id"].as_str().unwrap().to_string();
+        for other in others {
+            assert_ne!(
+                other["id"].as_str().unwrap(),
+                focal_id,
+                "the chosen entity is not one of the rejected ones: {body}"
+            );
+            assert!(
+                other["name"].is_string() && other["file_path"].is_string(),
+                "a rejected candidate must be re-askable: {other}"
+            );
+        }
+
+        let degradations = body["degradations"]
+            .as_array()
+            .unwrap_or_else(|| panic!("an ambiguous resolution must degrade: {body}"));
+        assert!(
+            degradations
+                .iter()
+                .any(|entry| entry["reason"] == "ambiguous_name"),
+            "the ambiguity must be named: {body}"
+        );
+
+        // The verdict half of this is asserted where `negative_for` is callable
+        // directly, in `negative::tests`. This handler returns its payload
+        // before the envelope layer attaches one, so asserting it here would be
+        // asserting on a key this call never produces.
+    }
+
+    /// The control for the case above, and the reason the field cannot simply be
+    /// redefined as "everything the pattern matched". Addressing by entity_id
+    /// resolves nothing by name, so there is no query ambiguity to report, and
+    /// the count must stay the exact-name twin count that protects the cfg-twin
+    /// shape rather than inheriting a substring's fan-out.
+    #[tokio::test]
+    async fn find_references_addressed_by_id_counts_exact_name_twins() {
+        let store = InMemoryGraph::new();
+        let app = make_entity_in(
+            LanguageId::Python,
+            "Flask.dispatch_request",
+            "src/flask/app.py",
+        );
+        let base = make_entity_in(
+            LanguageId::Python,
+            "View.dispatch_request",
+            "src/flask/views.py",
+        );
+        for entity in [&app, &base] {
+            store.upsert_entity(entity).unwrap();
+        }
+
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(app.id.to_string()),
+        );
+        let body = parsed_response(&handle_find_references(&args, &store, None).await.unwrap());
+
+        assert_eq!(body["focal_resolution"]["addressed_by"], "entity_id");
+        assert_eq!(
+            body["focal_resolution"]["same_name_candidates"], 1,
+            "one entity carries this exact name, and the caller pinned it: {body}"
+        );
+        assert_eq!(
+            body["focal_resolution"]["matched"], "exact_focal_name",
+            "a pinned address must say it counted twins, not query matches: {body}"
+        );
+        assert!(
+            body["degradations"]
+                .as_array()
+                .is_none_or(|entries| entries.iter().all(|e| e["reason"] != "ambiguous_name")),
+            "a pinned address is not an ambiguous one: {body}"
+        );
     }
 
     /// A bare name that matches several entities is resolved to one of them and

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -974,6 +974,57 @@ fn trace_absence_subject(payload: &Value) -> Option<&'static str> {
 /// `trace_data_flow` used to skip all of them and certify absence on nothing but
 /// the substrate gate, which is how an entity with a live caller came back
 /// authoritative-absent.
+/// The gap a response's own `focal_resolution` names, phrased for the shape of
+/// answer that carries it.
+///
+/// Shared, because two tools resolve a focal the same way and must not qualify
+/// it differently. `trace_data_flow` has always refused to certify a walk whose
+/// focal name the graph holds twice; `find_references` published the identical
+/// resolution block and read nothing from it, so on pallets/flask it stamped an
+/// answer describing one of three same-named methods as complete and exact
+/// (FIR-2475). One resolution, one verdict about it.
+///
+/// `subject` names what the answer is, so the sentence reads about a chain or a
+/// reference list rather than about "the answer" in both.
+fn focal_resolution_gap(payload: &Value, subject: &str) -> Option<String> {
+    // A missing block is the `None` arm, not an exemption. Both tools publish
+    // one on every answer, so its absence means the resolution went unreported
+    // rather than that this response has no focal to resolve, and reading it as
+    // an exemption would let exactly the answers that say least certify most.
+    let resolution = payload.get("focal_resolution").unwrap_or(&Value::Null);
+    match resolution
+        .get("same_name_candidates")
+        .and_then(Value::as_u64)
+    {
+        None => Some(format!(
+            "focal_resolution_unreported: this answer did not report how many entities the \
+             focal could have been resolved from, so {subject} may describe a same-named \
+             sibling rather than the entity that was asked about"
+        )),
+        Some(candidates) if candidates > 1 => {
+            // Which rule produced the count decides what the gap is ABOUT: a
+            // query that matched several entities is an ambiguous question,
+            // while several entities carrying one exact name is an ambiguous
+            // graph. Reporting either as the other sends a reader to fix the
+            // wrong end.
+            let counted = resolution
+                .get("matched")
+                .and_then(Value::as_str)
+                .unwrap_or("exact_focal_name");
+            let clause = if counted == "query_name_pattern" {
+                "match the name that was queried"
+            } else {
+                "share the focal's name"
+            };
+            Some(format!(
+                "focal_resolution_ambiguous: {candidates} entities {clause} and only one was \
+                 answered for, so {subject} is not evidence about the others"
+            ))
+        }
+        Some(_) => None,
+    }
+}
+
 fn trace_flow_gaps(payload: &Value) -> Vec<String> {
     let mut gaps = Vec::new();
 
@@ -997,22 +1048,8 @@ fn trace_flow_gaps(payload: &Value) -> Vec<String> {
     // one of them, and an edge the extractor could not attribute to a single
     // candidate sits on neither. Certifying that as absence answers for every
     // twin a question that was asked of one.
-    match payload
-        .get("focal_resolution")
-        .and_then(|resolution| resolution.get("same_name_candidates"))
-        .and_then(Value::as_u64)
-    {
-        None => gaps.push(
-            "focal_resolution_unreported: the walk did not report how many entities share the \
-             focal's name, so an empty chain may describe a same-named sibling rather than the \
-             entity that was asked about"
-                .to_string(),
-        ),
-        Some(candidates) if candidates > 1 => gaps.push(format!(
-            "focal_resolution_ambiguous: {candidates} entities share the focal's name and only \
-             one was walked, so an empty chain is not evidence about the others"
-        )),
-        Some(_) => {}
+    if let Some(gap) = focal_resolution_gap(payload, "an empty chain") {
+        gaps.push(gap);
     }
 
     // A walk cut short by its own caps or work ceilings stopped before it could
@@ -1581,6 +1618,26 @@ pub fn negative_for(
     // surfaces were able to disagree about one entity in one store: the tool
     // that refused to certify and the tool that published `[]` were reading the
     // identical incomplete call graph.
+    //
+    // The resolution the answer rode in on. `find_references` published a
+    // `focal_resolution` block and never read it back, so an answer describing
+    // one of several same-named entities was certified as the whole set
+    // (FIR-2475).
+    //
+    // Scoped to `find_references` on purpose, and the asymmetry with the method
+    // gate below is the point rather than an oversight: `get_context_pack` is
+    // addressed by `entity_id` and resolves no name, so it publishes no
+    // `focal_resolution` and has no resolution to qualify. Extending this to it
+    // would report `focal_resolution_unreported` on every pack, which is a gap
+    // about a step that tool never takes. The method gate is shared because both
+    // tools read the same edges; this one is not because only one of them
+    // resolves a name.
+    if tool == "find_references" {
+        if let Some(gap) = focal_resolution_gap(payload, "this reference list") {
+            push_gap(&mut trustworthy, &mut trust_reason, gap);
+        }
+    }
+
     if matches!(tool, "find_references" | "get_context_pack") && focal_is_method(payload) {
         push_gap(
             &mut trustworthy,
@@ -2127,7 +2184,84 @@ mod tests {
                 "authority_roots": { "provider": "provider-root" },
             },
             "edge_coverage": cross_file_edges_observed(),
+            // Every real find_references answer carries this block, so a
+            // fixture without one is not a smaller response, it is a shape the
+            // handler cannot produce. Leaving it out exercised the absence
+            // gates against a payload that never says how it resolved its
+            // focal, which is the gap FIR-2475 found unread.
+            "focal_resolution": {
+                "addressed_by": "entity_id",
+                "same_name_candidates": 1,
+                "matched": "exact_focal_name",
+                "other_candidates": [],
+            },
         })
+    }
+
+    /// FIR-2475, the verdict half. `find_references` published a
+    /// `focal_resolution` block on every answer and read nothing back from it,
+    /// so an answer describing one of several same-named entities was stamped
+    /// complete and exact. `trace_data_flow` has refused to certify that shape
+    /// since it was built; one resolution deserves one verdict whichever tool
+    /// carries it.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_the_query_matched_several_entities() {
+        let mut payload = authoritative_empty_references("function");
+        payload["focal_resolution"] = json!({
+            "addressed_by": "name",
+            "same_name_candidates": 3,
+            "matched": "query_name_pattern",
+            "other_candidates": [
+                {"id": "00000000-0000-0000-0000-000000000002", "name": "View.dispatch_request"},
+                {"id": "00000000-0000-0000-0000-000000000003", "name": "MethodView.dispatch_request"},
+            ],
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("an empty reference list yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        let reason = negative["trust_reason"].as_str().unwrap();
+        assert!(
+            reason.contains("focal_resolution_ambiguous"),
+            "the ambiguous resolution must be named: {reason}"
+        );
+        assert!(
+            reason.contains("match the name that was queried"),
+            "an ambiguous QUERY and an ambiguous graph send a reader to different \
+             places, so the gap must say which one this is: {reason}"
+        );
+    }
+
+    /// The control. The gate must not fire on an unambiguous resolution, or it
+    /// would mark every answer uncertain and say nothing at all.
+    #[test]
+    fn find_references_absence_stays_authoritative_when_its_resolution_was_exact() {
+        let payload = authoritative_empty_references("function");
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("an empty reference list yields a negative");
+        assert_eq!(
+            negative["safe_to_conclude_absent"],
+            json!(true),
+            "one candidate is not an ambiguity: {negative}"
+        );
+    }
+
+    /// An answer that does not report its resolution at all is the shape that
+    /// let this through: absent said nothing, and nothing read as fine.
+    #[test]
+    fn find_references_absence_is_inconclusive_when_the_resolution_went_unreported() {
+        let mut payload = authoritative_empty_references("function");
+        payload
+            .as_object_mut()
+            .unwrap()
+            .remove("focal_resolution")
+            .expect("the fixture carries the block to remove");
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("an empty reference list yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("focal_resolution_unreported"));
     }
 
     #[test]


### PR DESCRIPTION
`find_references` publishes a `focal_resolution` block whose job is to say how ambiguous the
caller's question was. On any language that qualifies a method name it was structurally unable
to say anything.

The count came from `same_name_entity_count(store, &target.name)`: taken against the RESOLVED
focal's own qualified name rather than against the query the caller typed, and taken with exact
string equality rather than the case-insensitive substring rule the resolver ranked with. Two
bugs that stack into a constant. On pallets/flask, `find_references(query: "dispatch_request")`
resolved `Flask.dispatch_request` and reported `same_name_candidates: 1` while the graph held
`View.dispatch_request` and `MethodView.dispatch_request` beside it and `semantic_search` for
the same string in the same session returned six. The `ambiguous_name` degradation is gated on
that count, so it could never fire either.

An ambiguity counter pinned at one is worse than no counter. FIR-2439 asked for this field
precisely so a reader could check before trusting a reference list, and a reader who follows
that advice now gets an explicit assurance that there was nothing to disambiguate.

When the focal was resolved from a name, the count is now taken against that name under the
resolver's own rule: the same `name_pattern` match and the same exclusion of external targets
the repository does not define, because a count taken with a different rule than the choice it
describes is a different question wearing the same field name. The rejected candidates travel
with it, addressable by id and bounded, so an agent told it guessed has a way to ask again. The
block says which rule produced the number, so one field cannot mean two things depending on how
the call was addressed. A pinned `entity_id` resolved nothing by name and keeps the exact-name
twin count, which is what protects the cfg-twin shape where two arms of one declaration are
admitted as distinct entities.

The verdict had the same hole from the other side. `trace_data_flow` has always refused to
certify a walk whose focal name the graph holds more than once. `find_references` published the
identical block and read nothing back from it, so the flask answer was stamped
`status: "complete"`, `bound: "exact"`, "the counts here are the whole set". That gate is now
shared, phrased for the answer that carries it, and an answer reporting no resolution at all
cannot be certified either.

Two test fixtures gained a `focal_resolution` block, in `negative.rs` and `envelope.rs`. That is
not fitting the tests to the change: the handler emits the block on every answer, so a fixture
without one is not a smaller response, it is a shape the handler cannot produce, and its absence
was letting the absence gates be exercised against a payload that never says how it resolved its
focal.

The failing tests were written first from the measured shape, with a control that asserts the
store really holds three entities answering to the query, so they cannot pass on a graph holding
nothing. The pinned-by-id case is its own control: it must keep reporting one, or the field
would have been redefined into a substring's fan-out.

This branch is rebased onto current main, which carries #973, #976 and #978, rather than sitting
beside them. #973 produces `Overrides` edges and the reference collector composes over proven
override bases, so this change reads edges #973 now mints. The full workspace gate ran on top of
all three: 6566 tests, all passing.

#976 landed first and touches the same two files, so the rebase carried one real conflict, in
`negative.rs`, where both changes add a gate to the same spot. Both survive. The method-resolution
gate keeps #976's widening to `find_references` and `get_context_pack`, because both tools read
the same edges and inherit the same bare-name linking gap. The focal-resolution gate added here
stays scoped to `find_references` alone, and that asymmetry is deliberate rather than an
oversight: `get_context_pack` is addressed by `entity_id`, resolves no name, and publishes no
`focal_resolution`, so extending this gate to it would report `focal_resolution_unreported` on
every pack, a gap about a step that tool never takes. The reason is written at the call site so
the asymmetry is not later "fixed" into a defect.

Closes FIR-2475
