### PR TITLE
Pin that a repeated receiver does not pull the query column back

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -4594,6 +4594,18 @@ mod lsp_query_column_tests {
         );
     }
 
+    /// A signature that repeats the receiver must not pull the cursor back to
+    /// it.
+    ///
+    /// `app.app = function app(` carries the token `app` three times. Anchoring
+    /// on the whole dotted name and then stepping to its last segment lands on
+    /// the member at 4. Searching for the segment on its own would return 0,
+    /// the receiver, which is this same defect wearing a different disguise.
+    #[test]
+    fn a_signature_that_repeats_the_receiver_still_addresses_the_member() {
+        assert_eq!(lsp_query_column("app.app = function app(", "app.app", 0), 4);
+    }
+
     /// And a name the signature does not carry at all keeps the old answer
     /// rather than inventing a position.
     #[test]


### PR DESCRIPTION
One unit case, completing the falsification FIR-2472 asked for.

That ticket named two conditions: the express fan must stop being counted, and "a unit case with a dotted name whose signature repeats the receiver must place the query on the final segment." kin#980 shipped the fix and the first condition; this is the second. It could not ride with 980 because the branch was already in the merge queue, which locks it.

`app.app = function app(` carries the receiver token three times. Anchoring on the whole dotted name and then stepping to its last segment lands on the member at column 4. Searching for the segment on its own returns 0, the receiver, which is the original defect wearing a different disguise, and no other test in the module distinguishes those two implementations.

Falsified: replacing the anchored search with a segment-only search fails exactly this case and leaves the other six passing.

Test-only, twelve lines, no production change. Targeted tests, all six ci.yml guard scripts, `cargo fmt -- --check`, and the ci.yml clippy invocation with its debt allow-list under `-D warnings`: green.

Follow-on to FIR-2472, which kin#980 already closed.
